### PR TITLE
Add perf metrics for 2.34.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 500.719616,
+    "_dashboard_memory_usage_mb": 459.20256,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.74,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1219\t8.56GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3654\t1.82GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4487\t0.87GiB\tpython distributed/test_many_actors.py\n2212\t0.39GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3769\t0.34GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n3935\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4285\t0.07GiB\tray::JobSupervisor\n2863\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4080\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3933\t0.06GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
-    "actors_per_second": 554.2728005409015,
+    "_peak_memory": 3.76,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3447\t1.74GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5206\t0.93GiB\tpython distributed/test_many_actors.py\n3564\t0.37GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2845\t0.32GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1249\t0.23GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3737\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n2771\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3884\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n4986\t0.07GiB\tray::JobSupervisor\n3735\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "actors_per_second": 627.338335492887,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 554.2728005409015
+            "perf_metric_value": 627.338335492887
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 92.76
+            "perf_metric_value": 178.601
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4891.92
+            "perf_metric_value": 3542.989
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4891.92
+            "perf_metric_value": 3933.547
         }
     ],
     "success": "1",
-    "time": 18.04165744781494
+    "time": 15.940361738204956
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 198.520832,
+    "_dashboard_memory_usage_mb": 193.712128,
     "_dashboard_test_success": true,
-    "_peak_memory": 1.67,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3600\t0.55GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2958\t0.31GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1243\t0.28GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3715\t0.17GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4952\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n5163\t0.08GiB\tray::StateAPIGeneratorActor.start\n4746\t0.07GiB\tray::JobSupervisor\n3884\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3008\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3882\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "_peak_memory": 1.65,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3461\t0.54GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1255\t0.25GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2918\t0.23GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3578\t0.18GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4426\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n4642\t0.08GiB\tray::StateAPIGeneratorActor.start\n2822\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4216\t0.07GiB\tray::JobSupervisor\n3750\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3748\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 352.05295620792083
+            "perf_metric_value": 342.8427005545737
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4.162
+            "perf_metric_value": 3.87
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 44.529
+            "perf_metric_value": 34.039
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 122.298
+            "perf_metric_value": 119.573
         }
     ],
     "success": "1",
-    "tasks_per_second": 352.05295620792083,
-    "time": 302.8404817581177,
+    "tasks_per_second": 342.8427005545737,
+    "time": 302.91678953170776,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 162.418688,
+    "_dashboard_memory_usage_mb": 120.446976,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.21,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1292\t10.12GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3612\t1.01GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4695\t0.4GiB\tpython distributed/test_many_pgs.py\n2601\t0.28GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3727\t0.11GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n3890\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n2968\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4494\t0.07GiB\tray::JobSupervisor\n4042\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3888\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "_peak_memory": 2.12,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3438\t0.92GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5718\t0.4GiB\tpython distributed/test_many_pgs.py\n2536\t0.35GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1206\t0.24GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3560\t0.12GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2784\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3734\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n5507\t0.07GiB\tray::JobSupervisor\n3877\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3732\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22.61454883772771
+            "perf_metric_value": 22.249430148995714
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.461
+            "perf_metric_value": 3.722
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 10.003
+            "perf_metric_value": 12.055
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 213.243
+            "perf_metric_value": 358.789
         }
     ],
-    "pgs_per_second": 22.61454883772771,
+    "pgs_per_second": 22.249430148995714,
     "success": "1",
-    "time": 44.21932125091553
+    "time": 44.944971323013306
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 1251.663872,
+    "_dashboard_memory_usage_mb": 1263.501312,
     "_dashboard_test_success": true,
-    "_peak_memory": 5.42,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3604\t2.91GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3721\t0.97GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4584\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1262\t0.29GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2330\t0.27GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4842\t0.09GiB\tray::StateAPIGeneratorActor.start\n4788\t0.08GiB\tray::DashboardTester.run\n4377\t0.07GiB\tray::JobSupervisor\n2641\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3886\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
+    "_peak_memory": 5.45,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3382\t3.09GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3499\t0.83GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4186\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1117\t0.24GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2858\t0.22GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4397\t0.08GiB\tray::DashboardTester.run\n4472\t0.08GiB\tray::StateAPIGeneratorActor.start\n2725\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3674\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3984\t0.07GiB\tray::JobSupervisor",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 582.2528587251263
+            "perf_metric_value": 557.3705625276606
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 274.662
+            "perf_metric_value": 167.38
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3995.805
+            "perf_metric_value": 3170.14
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5377.161
+            "perf_metric_value": 5042.844
         }
     ],
     "success": "1",
-    "tasks_per_second": 582.2528587251263,
-    "time": 317.1746687889099,
+    "tasks_per_second": 557.3705625276606,
+    "time": 317.94138526916504,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.33.0"}
+{"release_version": "2.34.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        9089.554836685598,
-        248.04186524328813
+        9060.701663275304,
+        118.69740715773278
     ],
     "1_1_actor_calls_concurrent": [
-        5417.434493378696,
-        124.35218516682983
+        5167.9800954515,
+        141.99267026522367
     ],
     "1_1_actor_calls_sync": [
-        2130.918760045077,
-        63.88949262425519
+        2055.7051275912527,
+        54.594914220148404
     ],
     "1_1_async_actor_calls_async": [
-        4984.024768215769,
-        203.5406701867711
+        4456.606860484332,
+        300.0483750432424
     ],
     "1_1_async_actor_calls_sync": [
-        1498.0246714553275,
-        34.850293170313556
+        1486.2327104183764,
+        35.32117622112775
     ],
     "1_1_async_actor_calls_with_args_async": [
-        3146.5764172550494,
-        54.100329844822454
+        3038.941703794114,
+        225.62938703844412
     ],
     "1_n_actor_calls_async": [
-        8619.17554203447,
-        183.22254158143645
+        8786.234839177117,
+        155.79705585932524
     ],
     "1_n_async_actor_calls_async": [
-        7688.844331638531,
-        173.03007749476023
+        7804.984752431155,
+        207.2088124010455
     ],
     "client__1_1_actor_calls_async": [
-        995.0481100035444,
-        8.31562300997794
+        963.1902909183787,
+        7.024139165271597
     ],
     "client__1_1_actor_calls_concurrent": [
-        998.230670582613,
-        9.82808610026736
+        947.6614978210325,
+        6.215662216629677
     ],
     "client__1_1_actor_calls_sync": [
-        520.1986351829904,
-        10.298920473666511
+        519.725991336052,
+        5.524396654486067
     ],
     "client__get_calls": [
-        1111.7945170817964,
-        69.14025902831608
+        1119.7725751916082,
+        22.31873036313672
     ],
     "client__put_calls": [
-        813.0590293747532,
-        5.480470279957046
+        801.476709529905,
+        24.90986781791733
     ],
     "client__put_gigabytes": [
-        0.1374322283958248,
-        0.001227703724483899
+        0.13929452807454937,
+        0.0004893965578803182
     ],
     "client__tasks_and_get_batch": [
-        0.9436564669925184,
-        0.00729535146912279
+        0.911263457119588,
+        0.009582733256630546
     ],
     "client__tasks_and_put_batch": [
-        11331.335480466743,
-        75.76791617643977
+        11004.98249042869,
+        406.99702282940336
     ],
     "multi_client_put_calls_Plasma_Store": [
-        12887.278980942054,
-        368.22075531306916
+        12455.514706383783,
+        82.98752196297701
     ],
     "multi_client_put_gigabytes": [
-        37.486165484657576,
-        1.7916027512903987
+        38.4735559860673,
+        1.895531621126946
     ],
     "multi_client_tasks_async": [
-        22970.98779525776,
-        1910.7851737390622
+        23311.858831941317,
+        2350.5613878864333
     ],
     "n_n_actor_calls_async": [
-        26680.036638509766,
-        988.5399124919908
+        26545.931713712664,
+        526.4393166387501
     ],
     "n_n_actor_calls_with_arg_async": [
-        2706.5919733776227,
-        38.25614650279406
+        2699.08314274893,
+        34.72492860665786
     ],
     "n_n_async_actor_calls_async": [
-        23108.484424180868,
-        479.60987709728556
+        22710.046003881216,
+        682.7591872434975
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 9953.300735952664
+            "perf_metric_value": 10303.517743023112
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5329.421150658071
+            "perf_metric_value": 5241.163782117501
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12887.278980942054
+            "perf_metric_value": 12455.514706383783
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 20.286051717751697
+            "perf_metric_value": 20.184014305625574
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8.032581753745204
+            "perf_metric_value": 7.900197666889211
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 37.486165484657576
+            "perf_metric_value": 38.4735559860673
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13.923467935755424
+            "perf_metric_value": 13.679337230724197
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.5725098263282975
+            "perf_metric_value": 5.485273551888224
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1005.4990392468012
+            "perf_metric_value": 986.5998779605792
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8191.316149029263
+            "perf_metric_value": 8011.455682416454
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22970.98779525776
+            "perf_metric_value": 23311.858831941317
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2130.918760045077
+            "perf_metric_value": 2055.7051275912527
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 9089.554836685598
+            "perf_metric_value": 9060.701663275304
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5417.434493378696
+            "perf_metric_value": 5167.9800954515
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8619.17554203447
+            "perf_metric_value": 8786.234839177117
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 26680.036638509766
+            "perf_metric_value": 26545.931713712664
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2706.5919733776227
+            "perf_metric_value": 2699.08314274893
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1498.0246714553275
+            "perf_metric_value": 1486.2327104183764
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4984.024768215769
+            "perf_metric_value": 4456.606860484332
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3146.5764172550494
+            "perf_metric_value": 3038.941703794114
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7688.844331638531
+            "perf_metric_value": 7804.984752431155
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23108.484424180868
+            "perf_metric_value": 22710.046003881216
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 868.0323927376729
+            "perf_metric_value": 824.4108502776797
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1111.7945170817964
+            "perf_metric_value": 1119.7725751916082
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 813.0590293747532
+            "perf_metric_value": 801.476709529905
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.1374322283958248
+            "perf_metric_value": 0.13929452807454937
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 11331.335480466743
+            "perf_metric_value": 11004.98249042869
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 520.1986351829904
+            "perf_metric_value": 519.725991336052
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 995.0481100035444
+            "perf_metric_value": 963.1902909183787
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 998.230670582613
+            "perf_metric_value": 947.6614978210325
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.9436564669925184
+            "perf_metric_value": 0.911263457119588
         }
     ],
     "placement_group_create/removal": [
-        868.0323927376729,
-        13.255102196866675
+        824.4108502776797,
+        17.72810428024577
     ],
     "single_client_get_calls_Plasma_Store": [
-        9953.300735952664,
-        852.2693665348787
+        10303.517743023112,
+        277.61596662520196
     ],
     "single_client_get_object_containing_10k_refs": [
-        13.923467935755424,
-        0.21147472135446713
+        13.679337230724197,
+        0.3123070691705992
     ],
     "single_client_put_calls_Plasma_Store": [
-        5329.421150658071,
-        59.418471384708326
+        5241.163782117501,
+        47.53421003771766
     ],
     "single_client_put_gigabytes": [
-        20.286051717751697,
-        5.578372207610081
+        20.184014305625574,
+        5.646629723807168
     ],
     "single_client_tasks_and_get_batch": [
-        8.032581753745204,
-        0.5527545237782773
+        7.900197666889211,
+        0.39150208385232466
     ],
     "single_client_tasks_async": [
-        8191.316149029263,
-        481.35667160598746
+        8011.455682416454,
+        468.6887008054221
     ],
     "single_client_tasks_sync": [
-        1005.4990392468012,
-        10.263240079707185
+        986.5998779605792,
+        16.522476248712984
     ],
     "single_client_wait_1k_refs": [
-        5.5725098263282975,
-        0.12061844035414801
+        5.485273551888224,
+        0.07839577116526375
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 19.648705655000015,
+    "broadcast_time": 18.28579454300001,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 19.648705655000015
+            "perf_metric_value": 18.28579454300001
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 18.025089421000004,
-    "get_time": 24.442244895,
+    "args_time": 18.382605733000005,
+    "get_time": 23.411743029999997,
     "large_object_size": 107374182400,
-    "large_object_time": 29.384843175999947,
+    "large_object_time": 32.98956875599998,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 18.025089421000004
+            "perf_metric_value": 18.382605733000005
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.781148879999989
+            "perf_metric_value": 5.741477676000002
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 24.442244895
+            "perf_metric_value": 23.411743029999997
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 195.866151365
+            "perf_metric_value": 186.319367591
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 29.384843175999947
+            "perf_metric_value": 32.98956875599998
         }
     ],
-    "queued_time": 195.866151365,
-    "returns_time": 5.781148879999989,
+    "queued_time": 186.319367591,
+    "returns_time": 5.741477676000002,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.1202176332473754,
-    "max_iteration_time": 2.7064244747161865,
-    "min_iteration_time": 0.12006998062133789,
+    "avg_iteration_time": 1.0309033346176149,
+    "max_iteration_time": 3.268310546875,
+    "min_iteration_time": 0.07307100296020508,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.1202176332473754
+            "perf_metric_value": 1.0309033346176149
         }
     ],
     "success": 1,
-    "total_time": 112.02198362350464
+    "total_time": 103.0905613899231
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 10.469495058059692
+            "perf_metric_value": 8.773437261581421
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 25.46910936832428
+            "perf_metric_value": 23.938837790489195
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 67.55193538665772
+            "perf_metric_value": 61.69442081451416
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2.7512922286987305
+            "perf_metric_value": 2.573246955871582
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3257.0328571796417
+            "perf_metric_value": 3035.906775712967
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.48565336003962284
+            "perf_metric_value": 0.5129273527822178
         }
     ],
-    "stage_0_time": 10.469495058059692,
-    "stage_1_avg_iteration_time": 25.46910936832428,
-    "stage_1_max_iteration_time": 27.362030506134033,
-    "stage_1_min_iteration_time": 24.83807682991028,
-    "stage_1_time": 254.69121026992798,
-    "stage_2_avg_iteration_time": 67.55193538665772,
-    "stage_2_max_iteration_time": 70.03894901275635,
-    "stage_2_min_iteration_time": 62.81902503967285,
-    "stage_2_time": 337.7604937553406,
-    "stage_3_creation_time": 2.7512922286987305,
-    "stage_3_time": 3257.0328571796417,
-    "stage_4_spread": 0.48565336003962284,
+    "stage_0_time": 8.773437261581421,
+    "stage_1_avg_iteration_time": 23.938837790489195,
+    "stage_1_max_iteration_time": 24.63253116607666,
+    "stage_1_min_iteration_time": 23.625248670578003,
+    "stage_1_time": 239.38846349716187,
+    "stage_2_avg_iteration_time": 61.69442081451416,
+    "stage_2_max_iteration_time": 62.908058643341064,
+    "stage_2_min_iteration_time": 59.646355867385864,
+    "stage_2_time": 308.4730384349823,
+    "stage_3_creation_time": 2.573246955871582,
+    "stage_3_time": 3035.906775712967,
+    "stage_4_spread": 0.5129273527822178,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 0.9454739759751765,
-    "avg_pg_remove_time_ms": 0.9134947552545347,
+    "avg_pg_create_time_ms": 0.9371462897900398,
+    "avg_pg_remove_time_ms": 0.9081441951950084,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9454739759751765
+            "perf_metric_value": 0.9371462897900398
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9134947552545347
+            "perf_metric_value": 0.9081441951950084
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 10.58%: 1_1_async_actor_calls_async (THROUGHPUT) regresses from 4984.024768215769 to 4456.606860484332 in microbenchmark.json
REGRESSION 5.07%: client__1_1_actor_calls_concurrent (THROUGHPUT) regresses from 998.230670582613 to 947.6614978210325 in microbenchmark.json
REGRESSION 5.03%: placement_group_create/removal (THROUGHPUT) regresses from 868.0323927376729 to 824.4108502776797 in microbenchmark.json
REGRESSION 4.60%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 5417.434493378696 to 5167.9800954515 in microbenchmark.json
REGRESSION 4.27%: tasks_per_second (THROUGHPUT) regresses from 582.2528587251263 to 557.3705625276606 in benchmarks/many_tasks.json
REGRESSION 3.53%: 1_1_actor_calls_sync (THROUGHPUT) regresses from 2130.918760045077 to 2055.7051275912527 in microbenchmark.json
REGRESSION 3.43%: client__tasks_and_get_batch (THROUGHPUT) regresses from 0.9436564669925184 to 0.911263457119588 in microbenchmark.json
REGRESSION 3.42%: 1_1_async_actor_calls_with_args_async (THROUGHPUT) regresses from 3146.5764172550494 to 3038.941703794114 in microbenchmark.json
REGRESSION 3.35%: multi_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 12887.278980942054 to 12455.514706383783 in microbenchmark.json
REGRESSION 3.20%: client__1_1_actor_calls_async (THROUGHPUT) regresses from 995.0481100035444 to 963.1902909183787 in microbenchmark.json
REGRESSION 2.88%: client__tasks_and_put_batch (THROUGHPUT) regresses from 11331.335480466743 to 11004.98249042869 in microbenchmark.json
REGRESSION 2.62%: tasks_per_second (THROUGHPUT) regresses from 352.05295620792083 to 342.8427005545737 in benchmarks/many_nodes.json
REGRESSION 2.20%: single_client_tasks_async (THROUGHPUT) regresses from 8191.316149029263 to 8011.455682416454 in microbenchmark.json
REGRESSION 1.88%: single_client_tasks_sync (THROUGHPUT) regresses from 1005.4990392468012 to 986.5998779605792 in microbenchmark.json
REGRESSION 1.75%: single_client_get_object_containing_10k_refs (THROUGHPUT) regresses from 13.923467935755424 to 13.679337230724197 in microbenchmark.json
REGRESSION 1.72%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 23108.484424180868 to 22710.046003881216 in microbenchmark.json
REGRESSION 1.66%: single_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 5329.421150658071 to 5241.163782117501 in microbenchmark.json
REGRESSION 1.65%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 8.032581753745204 to 7.900197666889211 in microbenchmark.json
REGRESSION 1.61%: pgs_per_second (THROUGHPUT) regresses from 22.61454883772771 to 22.249430148995714 in benchmarks/many_pgs.json
REGRESSION 1.57%: single_client_wait_1k_refs (THROUGHPUT) regresses from 5.5725098263282975 to 5.485273551888224 in microbenchmark.json
REGRESSION 1.42%: client__put_calls (THROUGHPUT) regresses from 813.0590293747532 to 801.476709529905 in microbenchmark.json
REGRESSION 0.79%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1498.0246714553275 to 1486.2327104183764 in microbenchmark.json
REGRESSION 0.50%: single_client_put_gigabytes (THROUGHPUT) regresses from 20.286051717751697 to 20.184014305625574 in microbenchmark.json
REGRESSION 0.50%: n_n_actor_calls_async (THROUGHPUT) regresses from 26680.036638509766 to 26545.931713712664 in microbenchmark.json
REGRESSION 0.32%: 1_1_actor_calls_async (THROUGHPUT) regresses from 9089.554836685598 to 9060.701663275304 in microbenchmark.json
REGRESSION 0.28%: n_n_actor_calls_with_arg_async (THROUGHPUT) regresses from 2706.5919733776227 to 2699.08314274893 in microbenchmark.json
REGRESSION 0.09%: client__1_1_actor_calls_sync (THROUGHPUT) regresses from 520.1986351829904 to 519.725991336052 in microbenchmark.json
REGRESSION 92.54%: dashboard_p50_latency_ms (LATENCY) regresses from 92.76 to 178.601 in benchmarks/many_actors.json
REGRESSION 68.25%: dashboard_p99_latency_ms (LATENCY) regresses from 213.243 to 358.789 in benchmarks/many_pgs.json
REGRESSION 20.51%: dashboard_p95_latency_ms (LATENCY) regresses from 10.003 to 12.055 in benchmarks/many_pgs.json
REGRESSION 12.27%: 107374182400_large_object_time (LATENCY) regresses from 29.384843175999947 to 32.98956875599998 in scalability/single_node.json
REGRESSION 7.54%: dashboard_p50_latency_ms (LATENCY) regresses from 3.461 to 3.722 in benchmarks/many_pgs.json
REGRESSION 5.62%: stage_4_spread (LATENCY) regresses from 0.48565336003962284 to 0.5129273527822178 in stress_tests/stress_test_many_tasks.json
REGRESSION 1.98%: 10000_args_time (LATENCY) regresses from 18.025089421000004 to 18.382605733000005 in scalability/single_node.json
```