### PR TITLE
[data] refactor fetching total resources

### DIFF
--- a/python/ray/data/_internal/execution/autoscaler/autoscaler.py
+++ b/python/ray/data/_internal/execution/autoscaler/autoscaler.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
+from ray.data._internal.execution.interfaces.execution_options import ExecutionResources
 from ray.util.annotations import DeveloperAPI
 
 if TYPE_CHECKING:
@@ -35,4 +36,9 @@ class Autoscaler(ABC):
     @abstractmethod
     def on_executor_shutdown(self):
         """Callback when the StreamingExecutor is shutting down."""
+        ...
+
+    @abstractmethod
+    def get_total_resources(self) -> ExecutionResources:
+        """Get the total resources that are available to this data execution."""
         ...

--- a/python/ray/data/_internal/execution/autoscaler/default_autoscaler.py
+++ b/python/ray/data/_internal/execution/autoscaler/default_autoscaler.py
@@ -2,6 +2,7 @@ import math
 import time
 from typing import TYPE_CHECKING, Dict
 
+import ray
 from .autoscaler import Autoscaler
 from .autoscaling_actor_pool import AutoscalingActorPool
 from ray.data._internal.execution.autoscaling_requester import (
@@ -182,3 +183,6 @@ class DefaultAutoscaler(Autoscaler):
         # Make request for zero resources to autoscaler for this execution.
         actor = get_or_create_autoscaling_requester_actor()
         actor.request_resources.remote({}, self._execution_id)
+
+    def get_total_resources(self) -> ExecutionResources:
+        return ExecutionResources.from_resource_dict(ray.cluster_resources())

--- a/python/ray/data/_internal/execution/interfaces/execution_options.py
+++ b/python/ray/data/_internal/execution/interfaces/execution_options.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from .common import NodeIdStr
 from ray.data._internal.execution.util import memory_string
@@ -34,6 +34,20 @@ class ExecutionResources:
         self._gpu = gpu
         self._object_store_memory = object_store_memory
         self._default_to_inf = default_to_inf
+
+    @classmethod
+    def from_resource_dict(
+        cls,
+        resource_dict: Dict[str, float],
+        default_to_inf: bool = False,
+    ):
+        """Create an ExecutionResources object from a resource dict."""
+        return ExecutionResources(
+            cpu=resource_dict.get("CPU", None),
+            gpu=resource_dict.get("GPU", None),
+            object_store_memory=resource_dict.get("object_store_memory", None),
+            default_to_inf=default_to_inf,
+        )
 
     @classmethod
     def for_limits(

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -112,7 +112,11 @@ class StreamingExecutor(Executor, threading.Thread):
 
         # Setup the streaming DAG topology and start the runner thread.
         self._topology, _ = build_streaming_topology(dag, self._options)
-        self._resource_manager = ResourceManager(self._topology, self._options)
+        self._resource_manager = ResourceManager(
+            self._topology,
+            self._options,
+            lambda: self._autoscaler.get_total_resources(),
+        )
         self._backpressure_policies = get_backpressure_policies(self._topology)
         self._autoscaler = create_autoscaler(
             self._topology,

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -266,7 +266,11 @@ def test_debug_dump_topology():
         make_map_transformer(lambda block: [b * 2 for b in block]), o2
     )
     topo, _ = build_streaming_topology(o3, opt)
-    resource_manager = ResourceManager(topo, ExecutionOptions())
+    resource_manager = ResourceManager(
+        topo,
+        ExecutionOptions(),
+        MagicMock(return_value=ExecutionResources.zero()),
+    )
     resource_manager.update_usages()
     # Just a sanity check to ensure it doesn't crash.
     _debug_dump_topology(topo, resource_manager)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently Ray Data's ResourceManager uses the total cluster resources as available resources. This is problematic when running multiple datasets or when running Data together with Train. This PR abstracts fetching total resources as a method in the `Autoscaler` class. So the concrete Autoscaler implementation can better handle allocating resources. 
Also removes the `ignore_extra_tasks` logic in `assert_task_metrics`. This is not very helpful and can be broken if an Autoscaler implementation introduces new tasks. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
