### PR TITLE
[Core] Fix build issue with ignoring attributes on template argument

### DIFF
--- a/src/ray/util/process.cc
+++ b/src/ray/util/process.cc
@@ -407,8 +407,7 @@ std::string Process::Exec(const std::string command) {
 #ifdef _WIN32
   std::unique_ptr<FILE, decltype(&_pclose)> pipe(_popen(command.c_str(), "r"), _pclose);
 #else
-  std::unique_ptr<FILE, void (*)(FILE *)> pipe(popen(command.c_str(), "r"),
-                                               [](FILE *f) -> void { pclose(f); });
+  std::unique_ptr<FILE, int (*)(FILE *)> pipe(popen(command.c_str(), "r"), pclose);
 #endif
   RAY_CHECK(pipe) << "popen() failed for command: " + command;
   while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {

--- a/src/ray/util/process.cc
+++ b/src/ray/util/process.cc
@@ -407,7 +407,8 @@ std::string Process::Exec(const std::string command) {
 #ifdef _WIN32
   std::unique_ptr<FILE, decltype(&_pclose)> pipe(_popen(command.c_str(), "r"), _pclose);
 #else
-  std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(command.c_str(), "r"), pclose);
+  std::unique_ptr<FILE, void (*)(FILE *)> pipe(popen(command.c_str(), "r"),
+                                               [](FILE *f) -> void { pclose(f); });
 #endif
   RAY_CHECK(pipe) << "popen() failed for command: " + command;
   while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes an issue where a structure with attributes is used as a template argument, triggering `-Wignored-attributes` and causing a build error on my system. The fix here is to just wrap `pclose` in a lambda expression.

## Related issue number

Closes #46804.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
