### PR TITLE
[Data] Try get `size_bytes` from metadata and consolidate metadata methods 

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -454,22 +454,6 @@ class ParquetDatasource(Datasource):
     def supports_distributed_reads(self) -> bool:
         return self._supports_distributed_reads
 
-    def num_rows(self) -> Optional[int]:
-        # If there is a filter operation, the total row count is unknown.
-        if self._to_batches_kwargs.get("filter") is not None:
-            return None
-
-        if not self._metadata:
-            return None
-
-        return sum(metadata.num_rows for metadata in self._metadata)
-
-    def schema(self) -> "pyarrow.Schema":
-        return self._inferred_schema
-
-    def input_files(self) -> Optional[List[str]]:
-        return self._pq_paths
-
 
 def _read_fragments(
     block_udf,

--- a/python/ray/data/_internal/datasource/range_datasource.py
+++ b/python/ray/data/_internal/datasource/range_datasource.py
@@ -96,7 +96,7 @@ class RangeDatasource(Datasource):
             meta = BlockMetadata(
                 num_rows=count,
                 size_bytes=8 * count * element_size,
-                schema=copy(self.schema()),
+                schema=copy(self._schema()),
                 input_files=None,
                 exec_stats=None,
             )
@@ -113,7 +113,7 @@ class RangeDatasource(Datasource):
         return read_tasks
 
     @functools.cache
-    def schema(self):
+    def _schema(self):
         if self._n == 0:
             return None
 
@@ -137,6 +137,3 @@ class RangeDatasource(Datasource):
         else:
             raise ValueError("Unsupported block type", self._block_format)
         return schema
-
-    def num_rows(self):
-        return self._n

--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -58,26 +58,6 @@ class LogicalOperator(Operator):
     def post_order_iter(self) -> Iterator["LogicalOperator"]:
         return super().post_order_iter()  # type: ignore
 
-    def schema(self) -> Optional[Union[type, "pyarrow.lib.Schema"]]:
-        """The schema of operator outputs, or ``None`` if not known.
-
-        This method is used to get the dataset schema without performing actual
-        computation.
-        """
-        return None
-
-    def num_rows(self) -> Optional[int]:
-        """The number of rows outputted by this operator, or ``None`` if not known.
-
-        This method is used to count the number of rows in a dataset without performing
-        actual computation.
-        """
-        return None
-
-    def input_files(self) -> Optional[List[str]]:
-        """The input files of this operator, or ``None`` if not known."""
-        return None
-
     def output_data(self) -> Optional[List["RefBundle"]]:
         """The output data of this operator, or ``None`` if not known."""
         return None

--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Iterator, List, Optional, Union
 
 from .operator import Operator
+from ray.data.block import BlockMetadata
 
 if TYPE_CHECKING:
     import pyarrow
@@ -80,6 +81,9 @@ class LogicalOperator(Operator):
     def output_data(self) -> Optional[List["RefBundle"]]:
         """The output data of this operator, or ``None`` if not known."""
         return None
+
+    def aggregate_output_metadata(self) -> BlockMetadata:
+        return BlockMetadata(None, None, None, None, None)
 
     def is_lineage_serializable(self) -> bool:
         """Returns whether the lineage of this operator can be serialized.

--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -61,7 +61,11 @@ class LogicalOperator(Operator):
         return None
 
     def aggregate_output_metadata(self) -> BlockMetadata:
-        """A ``BlockMetadata`` that represents the aggregate metadata of the outputs."""
+        """A ``BlockMetadata`` that represents the aggregate metadata of the outputs.
+
+        This method is used by methods like :meth:`~ray.data.Dataset.schema` to
+        efficiently return metadata.
+        """
         return BlockMetadata(None, None, None, None, None)
 
     def is_lineage_serializable(self) -> bool:

--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -1,11 +1,9 @@
-from typing import TYPE_CHECKING, Iterator, List, Optional, Union
+from typing import TYPE_CHECKING, Iterator, List, Optional
 
 from .operator import Operator
 from ray.data.block import BlockMetadata
 
 if TYPE_CHECKING:
-    import pyarrow
-
     from ray.data._internal.execution.interfaces import RefBundle
 
 

--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -61,6 +61,7 @@ class LogicalOperator(Operator):
         return None
 
     def aggregate_output_metadata(self) -> BlockMetadata:
+        """A ``BlockMetadata`` that represents the aggregate metadata of the outputs."""
         return BlockMetadata(None, None, None, None, None)
 
     def is_lineage_serializable(self) -> bool:

--- a/python/ray/data/_internal/logical/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/logical/operators/all_to_all_operator.py
@@ -53,7 +53,7 @@ class RandomizeBlocks(AbstractAllToAll):
 
     def aggregate_output_metadata(self) -> BlockMetadata:
         assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        return self._input_dependencies[0].aggregete_output_metadata()
+        return self._input_dependencies[0].aggregate_output_metadata()
 
 
 class RandomShuffle(AbstractAllToAll):
@@ -79,7 +79,7 @@ class RandomShuffle(AbstractAllToAll):
 
     def aggregate_output_metadata(self) -> BlockMetadata:
         assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        return self._input_dependencies[0].aggregete_output_metadata()
+        return self._input_dependencies[0].aggregate_output_metadata()
 
 
 class Repartition(AbstractAllToAll):
@@ -110,7 +110,7 @@ class Repartition(AbstractAllToAll):
 
     def aggregate_output_metadata(self) -> BlockMetadata:
         assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        return self._input_dependencies[0].aggregete_output_metadata()
+        return self._input_dependencies[0].aggregate_output_metadata()
 
 
 class Sort(AbstractAllToAll):
@@ -134,7 +134,7 @@ class Sort(AbstractAllToAll):
 
     def aggregate_output_metadata(self) -> BlockMetadata:
         assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        return self._input_dependencies[0].aggregete_output_metadata()
+        return self._input_dependencies[0].aggregate_output_metadata()
 
 
 class Aggregate(AbstractAllToAll):

--- a/python/ray/data/_internal/logical/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/logical/operators/all_to_all_operator.py
@@ -5,6 +5,7 @@ from ray.data._internal.planner.exchange.interfaces import ExchangeTaskSpec
 from ray.data._internal.planner.exchange.shuffle_task_spec import ShuffleTaskSpec
 from ray.data._internal.planner.exchange.sort_task_spec import SortKey, SortTaskSpec
 from ray.data.aggregate import AggregateFn
+from ray.data.block import BlockMetadata
 
 
 class AbstractAllToAll(LogicalOperator):
@@ -50,13 +51,9 @@ class RandomizeBlocks(AbstractAllToAll):
         )
         self._seed = seed
 
-    def schema(self):
+    def aggregate_output_metadata(self) -> BlockMetadata:
         assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        return self._input_dependencies[0].schema()
-
-    def num_rows(self):
-        assert len(self._input_dependencies) == 1, len(self._input_dependencies)
-        return self._input_dependencies[0].num_rows()
+        return self._input_dependencies[0].aggregete_output_metadata()
 
 
 class RandomShuffle(AbstractAllToAll):
@@ -79,6 +76,10 @@ class RandomShuffle(AbstractAllToAll):
             ray_remote_args=ray_remote_args,
         )
         self._seed = seed
+
+    def aggregate_output_metadata(self) -> BlockMetadata:
+        assert len(self._input_dependencies) == 1, len(self._input_dependencies)
+        return self._input_dependencies[0].aggregete_output_metadata()
 
 
 class Repartition(AbstractAllToAll):
@@ -107,6 +108,10 @@ class Repartition(AbstractAllToAll):
         )
         self._shuffle = shuffle
 
+    def aggregate_output_metadata(self) -> BlockMetadata:
+        assert len(self._input_dependencies) == 1, len(self._input_dependencies)
+        return self._input_dependencies[0].aggregete_output_metadata()
+
 
 class Sort(AbstractAllToAll):
     """Logical operator for sort."""
@@ -126,6 +131,10 @@ class Sort(AbstractAllToAll):
             ],
         )
         self._sort_key = sort_key
+
+    def aggregate_output_metadata(self) -> BlockMetadata:
+        assert len(self._input_dependencies) == 1, len(self._input_dependencies)
+        return self._input_dependencies[0].aggregete_output_metadata()
 
 
 class Aggregate(AbstractAllToAll):

--- a/python/ray/data/_internal/logical/operators/from_operators.py
+++ b/python/ray/data/_internal/logical/operators/from_operators.py
@@ -1,4 +1,5 @@
 import abc
+import functools
 from typing import TYPE_CHECKING, List, Optional, Union
 
 from ray.data._internal.execution.interfaces import RefBundle
@@ -39,6 +40,7 @@ class AbstractFrom(LogicalOperator, metaclass=abc.ABCMeta):
     def output_data(self) -> Optional[List[RefBundle]]:
         return self._input_data
 
+    @functools.cache
     def aggregate_output_metadata(self) -> BlockMetadata:
         return BlockMetadata(
             num_rows=self._num_rows(),

--- a/python/ray/data/_internal/logical/operators/from_operators.py
+++ b/python/ray/data/_internal/logical/operators/from_operators.py
@@ -36,18 +36,34 @@ class AbstractFrom(LogicalOperator, metaclass=abc.ABCMeta):
     def input_data(self) -> List[RefBundle]:
         return self._input_data
 
-    def schema(self):
-        metadata = [m for bundle in self._input_data for m in bundle.metadata]
-        return unify_block_metadata_schema(metadata)
+    def output_data(self) -> Optional[List[RefBundle]]:
+        return self._input_data
 
-    def num_rows(self):
+    def aggregate_output_metadata(self) -> BlockMetadata:
+        return BlockMetadata(
+            num_rows=self._num_rows(),
+            size_bytes=self._size_bytes(),
+            schema=self._schema(),
+            input_files=None,
+            exec_stats=None,
+        )
+
+    def _num_rows(self):
         if all(bundle.num_rows() is not None for bundle in self._input_data):
             return sum(bundle.num_rows() for bundle in self._input_data)
         else:
             return None
 
-    def output_data(self) -> Optional[List[RefBundle]]:
-        return self._input_data
+    def _size_bytes(self):
+        metadata = [m for bundle in self._input_data for m in bundle.metadata]
+        if all(m.size_bytes is not None for m in metadata):
+            return sum(m.size_bytes for m in metadata)
+        else:
+            return None
+
+    def _schema(self):
+        metadata = [m for bundle in self._input_data for m in bundle.metadata]
+        return unify_block_metadata_schema(metadata)
 
     def is_lineage_serializable(self) -> bool:
         # This operator isn't serializable because it contains ObjectRefs.

--- a/python/ray/data/_internal/logical/operators/input_data_operator.py
+++ b/python/ray/data/_internal/logical/operators/input_data_operator.py
@@ -1,3 +1,4 @@
+import functools
 from typing import Callable, List, Optional
 
 from ray.data._internal.execution.interfaces import RefBundle
@@ -32,6 +33,7 @@ class InputData(LogicalOperator):
             return None
         return self.input_data
 
+    @functools.cache
     def aggregate_output_metadata(self) -> BlockMetadata:
         if self.input_data is None:
             return BlockMetadata(None, None, None, None, None)

--- a/python/ray/data/_internal/logical/operators/input_data_operator.py
+++ b/python/ray/data/_internal/logical/operators/input_data_operator.py
@@ -3,6 +3,7 @@ from typing import Callable, List, Optional
 from ray.data._internal.execution.interfaces import RefBundle
 from ray.data._internal.logical.interfaces import LogicalOperator
 from ray.data._internal.util import unify_block_metadata_schema
+from ray.data.block import BlockMetadata
 
 
 class InputData(LogicalOperator):
@@ -26,25 +27,42 @@ class InputData(LogicalOperator):
         self.input_data = input_data
         self.input_data_factory = input_data_factory
 
-    def schema(self):
-        if self.input_data is None:
-            return None
-
-        metadata = [m for bundle in self.input_data for m in bundle.metadata]
-        return unify_block_metadata_schema(metadata)
-
-    def num_rows(self):
-        if self.input_data is None:
-            return None
-        elif all(bundle.num_rows() is not None for bundle in self.input_data):
-            return sum(bundle.num_rows() for bundle in self.input_data)
-        else:
-            return None
-
     def output_data(self) -> Optional[List[RefBundle]]:
         if self.input_data is None:
             return None
         return self.input_data
+
+    def aggregate_output_metadata(self) -> BlockMetadata:
+        if self.input_data is None:
+            return BlockMetadata(None, None, None, None, None)
+
+        return BlockMetadata(
+            num_rows=self._num_rows(),
+            size_bytes=self._size_bytes(),
+            schema=self._schema(),
+            input_files=None,
+            exec_stats=None,
+        )
+
+    def _num_rows(self):
+        assert self.input_data is not None
+        if all(bundle.num_rows() is not None for bundle in self.input_data):
+            return sum(bundle.num_rows() for bundle in self.input_data)
+        else:
+            return None
+
+    def _size_bytes(self):
+        assert self.input_data is not None
+        metadata = [m for bundle in self.input_data for m in bundle.metadata]
+        if all(m.size_bytes is not None for m in metadata):
+            return sum(m.size_bytes for m in metadata)
+        else:
+            return None
+
+    def _schema(self):
+        assert self.input_data is not None
+        metadata = [m for bundle in self.input_data for m in bundle.metadata]
+        return unify_block_metadata_schema(metadata)
 
     def is_lineage_serializable(self) -> bool:
         # This operator isn't serializable because it contains ObjectRefs.

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List, Optional, Union
 
 from ray.data._internal.logical.operators.map_operator import AbstractMap
+from ray.data.block import BlockMetadata
 from ray.data.datasource.datasource import Datasource, Reader
 
 
@@ -43,11 +44,5 @@ class Read(AbstractMap):
         """
         return self._detected_parallelism
 
-    def schema(self):
-        return self._datasource.schema()
-
-    def num_rows(self):
-        return self._datasource.num_rows()
-
-    def input_files(self) -> Optional[List[str]]:
-        return self._datasource.input_files()
+    def aggregate_output_metadata(self) -> BlockMetadata:
+        return self._datasource.aggregate_output_metadata()

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -47,6 +47,11 @@ class Read(AbstractMap):
 
     @functools.cache
     def aggregate_output_metadata(self) -> BlockMetadata:
+        """A ``BlockMetadata`` that represents the aggregate metadata of the outputs.
+
+        This method gets metadata from the read tasks. It doesn't trigger any actual
+        execution.
+        """
         # Legacy datasources might not implement `get_read_tasks`.
         if self._datasource.should_create_reader:
             return BlockMetadata(None, None, None, None, None)

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -45,6 +45,7 @@ class Read(AbstractMap):
         """
         return self._detected_parallelism
 
+    @functools.cache
     def aggregate_output_metadata(self) -> BlockMetadata:
         # Legacy datasources might not implement `get_read_tasks`.
         if self._datasource.should_create_reader:

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from ray.data._internal.logical.operators.map_operator import AbstractMap
 from ray.data.block import BlockMetadata

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -1,3 +1,4 @@
+import functools
 from typing import Any, Dict, Optional, Union
 
 from ray.data._internal.logical.operators.map_operator import AbstractMap

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Optional, Union
 
 from ray.data._internal.logical.operators.map_operator import AbstractMap
+from ray.data._internal.util import unify_block_metadata_schema
 from ray.data.block import BlockMetadata
 from ray.data.datasource.datasource import Datasource, Reader
 
@@ -45,4 +46,37 @@ class Read(AbstractMap):
         return self._detected_parallelism
 
     def aggregate_output_metadata(self) -> BlockMetadata:
-        return self._datasource.aggregate_output_metadata()
+        # Legacy datasources might not implement `get_read_tasks`.
+        if self._datasource.should_create_reader:
+            return BlockMetadata(None, None, None, None, None)
+
+        # HACK: Try to get a single read task to get the metadata.
+        read_tasks = self._datasource.get_read_tasks(1)
+        assert len(read_tasks) > 0, "Datasource must return at least one read task"
+        # `get_read_tasks` isn't guaranteed to return exactly one read task.
+        metadata = [read_task.get_metadata() for read_task in read_tasks]
+
+        if all(meta.num_rows is not None for meta in metadata):
+            num_rows = sum(meta.num_rows for meta in metadata)
+        else:
+            num_rows = None
+
+        if all(meta.size_bytes is not None for meta in metadata):
+            size_bytes = sum(meta.size_bytes for meta in metadata)
+        else:
+            size_bytes = None
+
+        schema = unify_block_metadata_schema(metadata)
+
+        input_files = []
+        for meta in metadata:
+            if meta.input_files is not None:
+                input_files.extend(meta.input_files)
+
+        return BlockMetadata(
+            num_rows=num_rows,
+            size_bytes=size_bytes,
+            schema=schema,
+            input_files=input_files,
+            exec_stats=None,
+        )

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -52,7 +52,10 @@ class Read(AbstractMap):
 
         # HACK: Try to get a single read task to get the metadata.
         read_tasks = self._datasource.get_read_tasks(1)
-        assert len(read_tasks) > 0, "Datasource must return at least one read task"
+        if len(read_tasks) == 0:
+            # If there are no read tasks, the dataset is probably empty.
+            return BlockMetadata(None, None, None, None, None)
+
         # `get_read_tasks` isn't guaranteed to return exactly one read task.
         metadata = [read_task.get_metadata() for read_task in read_tasks]
 

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -343,8 +343,8 @@ class ExecutionPlan:
         schema = None
         if self.has_computed_output():
             schema = unify_block_metadata_schema(self._snapshot_bundle.metadata)
-        elif self._logical_plan.dag.schema() is not None:
-            schema = self._logical_plan.dag.schema()
+        elif self._logical_plan.dag.aggregate_output_metadata().schema is not None:
+            schema = self._logical_plan.dag.aggregate_output_metadata().schema
         elif fetch_if_missing:
             iter_ref_bundles, _, _ = self.execute_to_iterator()
             for ref_bundle in iter_ref_bundles:
@@ -375,7 +375,7 @@ class ExecutionPlan:
 
     def input_files(self) -> Optional[List[str]]:
         """Get the input files of the dataset, if available."""
-        return self._logical_plan.dag.input_files()
+        return self._logical_plan.dag.aggregate_output_metadata().input_files
 
     def meta_count(self) -> Optional[int]:
         """Get the number of rows after applying all plan optimizations, if possible.
@@ -387,8 +387,8 @@ class ExecutionPlan:
         """
         if self.has_computed_output():
             num_rows = sum(m.num_rows for m in self._snapshot_bundle.metadata)
-        elif self._logical_plan.dag.num_rows() is not None:
-            num_rows = self._logical_plan.dag.num_rows()
+        elif self._logical_plan.dag.aggregate_output_metadata().num_rows is not None:
+            num_rows = self._logical_plan.dag.aggregate_output_metadata().num_rows
         else:
             num_rows = None
         return num_rows

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2653,6 +2653,10 @@ class Dataset:
             The in-memory size of the dataset in bytes, or None if the
             in-memory size is not known.
         """
+        # If the size is known from metadata, return it.
+        if self._logical_plan.dag.aggregate_output_metadata().size_bytes is not None:
+            return self._logical_plan.dag.aggregate_output_metadata().size_bytes
+
         metadata = self._plan.execute().metadata
         if not metadata or metadata[0].size_bytes is None:
             return None

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -1,13 +1,10 @@
-from typing import TYPE_CHECKING, Callable, Iterable, List, Optional, Union
+from typing import Callable, Iterable, List, Optional
 
 import numpy as np
 
 from ray.data._internal.util import _check_pyarrow_version, unify_block_metadata_schema
 from ray.data.block import Block, BlockMetadata
 from ray.util.annotations import Deprecated, DeveloperAPI, PublicAPI
-
-if TYPE_CHECKING:
-    import pyarrow
 
 
 @PublicAPI

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -2,7 +2,7 @@ from typing import Callable, Iterable, List, Optional
 
 import numpy as np
 
-from ray.data._internal.util import _check_pyarrow_version, unify_block_metadata_schema
+from ray.data._internal.util import _check_pyarrow_version
 from ray.data.block import Block, BlockMetadata
 from ray.util.annotations import Deprecated, DeveloperAPI, PublicAPI
 

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -79,41 +79,6 @@ class Datasource:
         """If ``False``, only launch read tasks on the driver's node."""
         return True
 
-    def aggregate_output_metadata(self) -> BlockMetadata:
-        # Legacy datasources might not implement `get_read_tasks`.
-        if self.should_create_reader:
-            return BlockMetadata(None, None, None, None, None)
-
-        read_tasks = self.get_read_tasks(1)
-        assert len(read_tasks) > 0, "Datasource must return at least one read task"
-        # `get_read_tasks` isn't guaranteed to return exactly one read task.
-        metadata = [read_task.get_metadata() for read_task in read_tasks]
-
-        if all(meta.num_rows is not None for meta in metadata):
-            num_rows = sum(meta.num_rows for meta in metadata)
-        else:
-            num_rows = None
-
-        if all(meta.size_bytes is not None for meta in metadata):
-            size_bytes = sum(meta.size_bytes for meta in metadata)
-        else:
-            size_bytes = None
-
-        schema = unify_block_metadata_schema(metadata)
-
-        input_files = []
-        for meta in metadata:
-            if meta.input_files is not None:
-                input_files.extend(meta.input_files)
-
-        return BlockMetadata(
-            num_rows=num_rows,
-            size_bytes=size_bytes,
-            schema=schema,
-            input_files=input_files,
-            exec_stats=None,
-        )
-
 
 @Deprecated
 class Reader:

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -367,9 +367,6 @@ class FileBasedDatasource(Datasource):
     def supports_distributed_reads(self) -> bool:
         return self._supports_distributed_reads
 
-    def input_files(self) -> Optional[List[str]]:
-        return self._paths()
-
 
 def _add_partitions(
     data: Union["pyarrow.Table", "pd.DataFrame"], partitions: Dict[str, Any]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`LogicalOperator` and `Datasource` expose methods like `schema()` to make metadata efficiently available to Dataset APIs like `Dataset.schema()`. Currently, `LogicalOperator` exposes three such methds: `num_rows()`, `schema()`, and `input_files()`. 

This PR adds `size_bytes()` because it was missing. To simplify the interface, it also consolidates the metadata methods into a single `aggregate_output_metadata()` method. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
