### PR TITLE
[ci] fix ml flaky test job

### DIFF
--- a/.buildkite/ml.rayci.yml
+++ b/.buildkite/ml.rayci.yml
@@ -199,7 +199,7 @@ steps:
     tags: 
       - train
       - skip-on-premerge
-    instance_type: medium
+    instance_type: large
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //... ml --run-flaky-tests
         --parallelism-per-worker 2


### PR DESCRIPTION
The ml flaky test job is using medium machines so those tests in the flaky job even become flakier than the main job. Use large machine instead (the non-flaky job uses large machine)

Test:
- CI