### PR TITLE
[release] Upload the binary without `.zip` extension

### DIFF
--- a/.buildkite/release-automation/pre_release.rayci.yml
+++ b/.buildkite/release-automation/pre_release.rayci.yml
@@ -23,7 +23,7 @@ steps:
     instance_type: default
     commands:
       - bazel build --build_python_zip --incompatible_use_python_toolchains=false --python_path=python //ci/ray_ci/automation:update_version
-      - cp bazel-bin/ci/ray_ci/automation/update_version.zip /artifact-mount/
+      - cp bazel-bin/ci/ray_ci/automation/update_version /artifact-mount/
 
   - label: "Trigger Postmerge test"
     if: build.env("RAYCI_WEEKLY_RELEASE_NIGHTLY") != "1"


### PR DESCRIPTION
- Upload `update_version` to Buildkite artifact instead of `update_version.zip` 