### PR TITLE
[doc][core] add missing public core actor APIs

### DIFF
--- a/doc/source/ray-core/api/core.rst
+++ b/doc/source/ray-core/api/core.rst
@@ -30,7 +30,12 @@ Actors
     :toctree: doc/
 
     ray.remote
+    ray.actor.ActorClass
     ray.actor.ActorClass.options
+    ray.actor.ActorMethod
+    ray.actor.ActorHandle
+    ray.actor.ActorClassInheritanceException
+    ray.actor.exit_actor
     ray.method
     ray.get_actor
     ray.kill


### PR DESCRIPTION
Document missing public core actor APIs (found in this list https://docs.google.com/spreadsheets/d/1wQALnsUuFN4dMgmGITfiVX41fCc6P6FEjYVO6jDWGtM/edit?gid=1577233649#gid=1577233649)

Test:
- CI