### PR TITLE
[doc][core] add missing public ray exception APIs

### DIFF
--- a/doc/source/ray-core/api/exceptions.rst
+++ b/doc/source/ray-core/api/exceptions.rst
@@ -22,14 +22,18 @@ Exceptions
     ray.exceptions.ActorPlacementGroupRemoved
     ray.exceptions.ObjectStoreFullError
     ray.exceptions.OutOfDiskError
+    ray.exceptions.OutOfMemoryError
     ray.exceptions.ObjectLostError
     ray.exceptions.ObjectFetchTimedOutError
     ray.exceptions.GetTimeoutError
     ray.exceptions.OwnerDiedError
+    ray.exceptions.PendingCallsLimitExceeded
     ray.exceptions.PlasmaObjectNotAvailable
     ray.exceptions.ObjectReconstructionFailedError
     ray.exceptions.ObjectReconstructionFailedMaxAttemptsExceededError
     ray.exceptions.ObjectReconstructionFailedLineageEvictedError
+    ray.exceptions.RayChannelError
     ray.exceptions.RuntimeEnvSetupError
     ray.exceptions.CrossLanguageError
     ray.exceptions.RaySystemError
+    ray.exceptions.NodeDiedError


### PR DESCRIPTION
Document missing public ray exception APIs (found in this list https://docs.google.com/spreadsheets/d/1wQALnsUuFN4dMgmGITfiVX41fCc6P6FEjYVO6jDWGtM/edit?gid=1577233649#gid=1577233649)

Test:

CI