### PR TITLE
[doc][build] Skip loading cache if build is recent

### DIFF
--- a/ci/ray_ci/doc/cmd_load_doc_cache.py
+++ b/ci/ray_ci/doc/cmd_load_doc_cache.py
@@ -6,6 +6,8 @@ import os
 import click
 from botocore import UNSIGNED
 from botocore.client import Config
+import time
+from ci.ray_ci.doc.build_cache import ENVIRONMENT_PICKLE
 
 S3_BUCKET = "ray-ci-results"
 DOC_BUILD_DIR_S3 = "doc_build"
@@ -102,9 +104,31 @@ def list_changed_and_added_files(ray_dir: str, latest_master_commit: str):
     return filenames
 
 
+def should_load_cache(ray_dir: str):
+    """
+    Check if cache should be loaded based on the timestamp of last build.
+    """
+    ray_doc_dir = os.path.join(ray_dir, "doc")
+    if not os.path.exists(f"{ray_doc_dir}/{ENVIRONMENT_PICKLE}"):
+        print("Doc build environment pickle file does not exist.")
+        return True
+    last_build_time = os.path.getmtime(f"{ray_doc_dir}/{ENVIRONMENT_PICKLE}")
+    current_time = time.time()
+    # Load cache if last build was more than 3 days ago
+    print("time diff: ", current_time - last_build_time)
+    if current_time - last_build_time > 3 * 60 * 60 * 24:
+        print("Last build was more than 3 days ago.")
+        return True
+    return False
+
+
 @click.command()
 @click.option("--ray-dir", default="/ray", help="Path to Ray repo")
 def main(ray_dir: str) -> None:
+    if not should_load_cache(ray_dir):
+        print("Skip loading global cache...")
+        return
+    print("Loading global cache ...")
     latest_master_commit = find_latest_master_commit()
     # List all changed and added files in the repo
     filenames = list_changed_and_added_files(ray_dir, latest_master_commit)

--- a/ci/ray_ci/doc/cmd_load_doc_cache.py
+++ b/ci/ray_ci/doc/cmd_load_doc_cache.py
@@ -11,7 +11,7 @@ from ci.ray_ci.doc.build_cache import ENVIRONMENT_PICKLE
 
 S3_BUCKET = "ray-ci-results"
 DOC_BUILD_DIR_S3 = "doc_build"
-
+LAST_BUILD_CUTOFF = 3  # how many days ago to consider a build outdated
 PENDING_FILES_PATH = "pending_files.txt"
 
 
@@ -114,10 +114,10 @@ def should_load_cache(ray_dir: str):
         return True
     last_build_time = os.path.getmtime(f"{ray_doc_dir}/{ENVIRONMENT_PICKLE}")
     current_time = time.time()
-    # Load cache if last build was more than 3 days ago
+    # Load cache if last build was more than LAST_BUILD_CUTOFF days ago
     print("time diff: ", current_time - last_build_time)
-    if current_time - last_build_time > 3 * 60 * 60 * 24:
-        print("Last build was more than 3 days ago.")
+    if current_time - last_build_time > LAST_BUILD_CUTOFF * 60 * 60 * 24:
+        print(f"Last build was more than {LAST_BUILD_CUTOFF} days ago.")
         return True
     return False
 
@@ -142,6 +142,7 @@ def main(ray_dir: str) -> None:
     fetch_cache_from_s3(latest_master_commit, cache_path)
     # Extract cache to override ray/doc directory
     extract_cache(cache_path, f"{ray_dir}/doc")
+    os.remove(cache_path)
 
 
 if __name__ == "__main__":

--- a/ci/ray_ci/doc/cmd_update_cache_env.py
+++ b/ci/ray_ci/doc/cmd_update_cache_env.py
@@ -16,6 +16,7 @@ def list_pending_files(ray_dir: str) -> List[str]:
     with open(f"{ray_dir}/{PENDING_FILES_PATH}", "r") as f:
         pending_files = f.readlines()
         pending_files = [file.strip() for file in pending_files]
+    os.remove(f"{ray_dir}/{PENDING_FILES_PATH}")
     return pending_files
 
 
@@ -82,6 +83,10 @@ def update_file_timestamp(ray_dir: str) -> None:
 @click.command()
 @click.option("--ray-dir", required=True, type=str, help="Path to the Ray repository.")
 def main(ray_dir: str) -> None:
+    if not os.path.exists(f"{ray_dir}/{PENDING_FILES_PATH}"):
+        print("Global cache was not loaded. Skip updating cache environment.")
+        return
+    print("Updating cache environment ...")
     pending_files = list_pending_files(ray_dir)
     update_environment_pickle(ray_dir, pending_files)
     update_file_timestamp(ray_dir)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -82,9 +82,7 @@ develop: html
 RAY_DIR := $(shell pwd | rev | cut -d'/' -f2- | rev)
 
 local:
-	@echo "Loading cache"
 	bazel run //ci/ray_ci/doc:cmd_load_doc_cache -- --ray-dir=$(RAY_DIR)
-	@echo "Updating cache environment"
 	bazel run //ci/ray_ci/doc:cmd_update_cache_env -- --ray-dir=$(RAY_DIR)
 	$(SPHINXBUILD) -W --keep-going -b html $(ALLLOCALSPHINXOPTS) $(BUILDDIR)/html
 


### PR DESCRIPTION
- Skip loading global cache if `environment.pickle` is last modified less than 3 days ago
- Skip updating cache environment if global cache was not loaded (determine by whether `pending_files.txt` is there, which is created from loading global cache)