### PR TITLE
[doc] minimize dependencies of cmd_load/update_cache

### DIFF
--- a/ci/ray_ci/doc/BUILD.bazel
+++ b/ci/ray_ci/doc/BUILD.bazel
@@ -17,14 +17,22 @@ py_binary(
 py_binary(
     name = "cmd_load_doc_cache",
     srcs = ["cmd_load_doc_cache.py"],
-    deps = [":doc"],
+    deps = [
+        ci_require("boto3"),
+        ci_require("click"),
+    ],
     exec_compatible_with = ["//:hermetic_python"],
 )
 
 py_binary(
     name = "cmd_update_cache_env",
     srcs = ["cmd_update_cache_env.py"],
-    deps = [":doc"],
+    deps = [
+        ci_require("sphinx"),
+        ci_require("myst-parser"),
+        ci_require("myst-nb"),
+        ci_require("click"),
+    ],
     exec_compatible_with = ["//:hermetic_python"],
 )
 

--- a/ci/ray_ci/doc/cmd_update_cache_env.py
+++ b/ci/ray_ci/doc/cmd_update_cache_env.py
@@ -5,9 +5,9 @@ import time
 from typing import List
 from datetime import datetime, timezone
 import click
-from ci.ray_ci.doc.build_cache import ENVIRONMENT_PICKLE
 
 PENDING_FILES_PATH = "pending_files.txt"
+ENVIRONMENT_PICKLE = "_build/doctrees/environment.pickle"
 
 
 def list_pending_files(ray_dir: str) -> List[str]:


### PR DESCRIPTION
Minimize the dependencies of cmd_load/update_cache so we can use bazel to run these two commands; without worry about bazel download the whole world as its dependencies

Test:
- CI
- make local