### PR TITLE
[POC] A Reactor style GCS. #1: GcsNodeManager

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -28,6 +28,16 @@
 namespace ray {
 namespace gcs {
 
+namespace {
+rpc::Address RayletAddressFromNodeInfo(const rpc::GcsNodeInfo &node_info) {
+  rpc::Address address;
+  address.set_raylet_id(node_info.node_id());
+  address.set_ip_address(node_info.node_manager_address());
+  address.set_port(node_info.node_manager_port());
+  return address;
+}
+}  // namespace
+
 //////////////////////////////////////////////////////////////////////////////////////////
 GcsNodeManager::GcsNodeManager(
     std::shared_ptr<GcsPublisher> gcs_publisher,
@@ -37,7 +47,117 @@ GcsNodeManager::GcsNodeManager(
     : gcs_publisher_(std::move(gcs_publisher)),
       gcs_table_storage_(std::move(gcs_table_storage)),
       raylet_client_pool_(std::move(raylet_client_pool)),
-      cluster_id_(cluster_id) {}
+      cluster_id_(cluster_id) {
+  gcs_table_storage_->NodeTable().AddPutCallback(
+      [this](const NodeID &node_id, const rpc::GcsNodeInfo &node_info) {
+        this->ReactorOnNodeChanged(node_id, node_info);
+      });
+}
+
+void GcsNodeManager::ReactorOnNodeChanged(const NodeID &node_id,
+                                          const rpc::GcsNodeInfo &node_info) {
+  // A node has updated. It can be added, updated, or removed.
+  // No matter what, publish it.
+  // TODO: only publish delta vs alive_node_, a la
+  // https://github.com/ray-project/ray/pull/13364
+  RAY_CHECK_OK(gcs_publisher_->PublishNodeInfo(node_id, node_info, nullptr));
+
+  switch (node_info.state()) {
+  case rpc::GcsNodeInfo::ALIVE:
+    ReactorOnNodeAlive(node_id, node_info);
+    break;
+  case rpc::GcsNodeInfo::DEAD:
+    ReactorOnNodeDead(node_id, node_info);
+    break;
+  default:
+    RAY_LOG(FATAL) << "Unknown node state " << node_info.state();
+  }
+}
+
+// Idempotent!
+// Reactions:
+// - erase from all data structures
+// - AddDeadNodeToCache(node);
+// - publish the error
+//
+// Can be called regardless of alive_node_ status, i.e. can from Initialize.
+// TODO: add a knob of AddDeadNodeToCache to not evict cache, as Initialize may evict
+// after all ingestion.
+void GcsNodeManager::ReactorOnNodeDead(const NodeID &node_id,
+                                       const rpc::GcsNodeInfo &info) {
+  RAY_CHECK(info.state() == rpc::GcsNodeInfo::DEAD);
+  // Remove from alive nodes, if any.
+  auto iter = alive_nodes_.find(node_id);
+  if (iter != alive_nodes_.end()) {
+    // Record stats that there's a new removed node.
+    stats::NodeFailureTotal.Record(1);
+    // Remove from alive nodes.
+    alive_nodes_.erase(iter);
+    node_map_.left.erase(node_id);
+    // Remove from draining nodes if present.
+    draining_nodes_.erase(node_id);
+
+    const auto &death_info = info.death_info();
+
+    RAY_LOG(INFO).WithField(node_id)
+        << "Removing node, node name = " << info.node_name()
+        << ", death reason = " << rpc::NodeDeathInfo_Reason_Name(death_info.reason())
+        << ", death message = " << death_info.reason_message();
+
+    if (death_info.reason() == rpc::NodeDeathInfo::UNEXPECTED_TERMINATION) {
+      // Broadcast a warning to all of the drivers indicating that the node
+      // has been marked as dead.
+      // TODO(rkn): Define this constant somewhere else.
+      std::string type = "node_removed";
+      std::ostringstream error_message;
+      error_message << "The node with node id: " << node_id
+                    << " and address: " << info.node_manager_address()
+                    << " and node name: " << info.node_name()
+                    << " has been marked dead because the detector"
+                    << " has missed too many heartbeats from it. This can happen when a "
+                       "\t(1) raylet crashes unexpectedly (OOM, etc.) \n"
+                    << "\t(2) raylet has lagging heartbeats due to slow network or busy "
+                       "workload.";
+      RAY_EVENT(ERROR, EL_RAY_NODE_REMOVED)
+              .WithField("node_id", node_id.Hex())
+              .WithField("ip", info.node_manager_address())
+          << error_message.str();
+      RAY_LOG(WARNING) << error_message.str();
+      auto error_data_ptr =
+          gcs::CreateErrorTableData(type, error_message.str(), current_time_ms());
+      RAY_CHECK_OK(gcs_publisher_->PublishError(node_id.Hex(), *error_data_ptr, nullptr));
+    }
+  }
+
+  // Adds to dead nodes, no matter if it was in alive_nodes_.
+  if (dead_nodes_.find(node_id) == dead_nodes_.end()) {
+    AddDeadNodeToCache(std::make_shared<rpc::GcsNodeInfo>(info));
+    for (auto &listener : node_removed_listeners_) {
+      // DO NOT SUBMIT TODO: change listeners to accept &.
+      listener(std::make_shared<rpc::GcsNodeInfo>(info));
+    }
+  }
+}
+
+// Idempotent!
+// Reactions:
+// - Add to alive_nodes_ and all data structures
+void GcsNodeManager::ReactorOnNodeAlive(const NodeID &node_id,
+                                        const rpc::GcsNodeInfo &info) {
+  RAY_CHECK(info.state() == rpc::GcsNodeInfo::ALIVE);
+  auto iter = alive_nodes_.find(node_id);
+  if (iter == alive_nodes_.end()) {
+    auto node_addr =
+        absl::StrCat(info.node_manager_address(), ":", info.node_manager_port());
+    node_map_.insert(NodeIDAddrBiMap::value_type(node_id, node_addr));
+    alive_nodes_.emplace(node_id, std::make_shared<rpc::GcsNodeInfo>(info));
+
+    for (auto &listener : node_added_listeners_) {
+      // DO NOT SUBMIT TODO: change listeners to accept &.
+      listener(std::make_shared<rpc::GcsNodeInfo>(info));
+    }
+  }
+}
 
 // Note: ServerCall will populate the cluster_id.
 void GcsNodeManager::HandleGetClusterId(rpc::GetClusterIdRequest request,
@@ -55,16 +175,14 @@ void GcsNodeManager::HandleRegisterNode(rpc::RegisterNodeRequest request,
   RAY_LOG(INFO) << "Registering node info, node id = " << node_id
                 << ", address = " << request.node_info().node_manager_address()
                 << ", node name = " << request.node_info().node_name();
-  auto on_done = [this, node_id, request, reply, send_reply_callback](
-                     const Status &status) {
+  auto on_done = [node_id, request, reply, send_reply_callback](const Status &status) {
     RAY_CHECK_OK(status);
     RAY_LOG(INFO) << "Finished registering node info, node id = " << node_id
                   << ", address = " << request.node_info().node_manager_address()
                   << ", node name = " << request.node_info().node_name();
-    RAY_CHECK_OK(gcs_publisher_->PublishNodeInfo(node_id, request.node_info(), nullptr));
-    AddNode(std::make_shared<rpc::GcsNodeInfo>(request.node_info()));
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
   };
+
   if (request.node_info().is_head_node()) {
     // mark all old head nodes as dead if exists:
     // 1. should never happen when HA is not used
@@ -79,12 +197,11 @@ void GcsNodeManager::HandleRegisterNode(rpc::RegisterNodeRequest request,
 
     assert(head_nodes.size() <= 1);
     if (head_nodes.size() == 1) {
-      OnNodeFailure(head_nodes[0],
-                    [this, request, on_done, node_id](const Status &status) {
-                      RAY_CHECK_OK(status);
-                      RAY_CHECK_OK(gcs_table_storage_->NodeTable().Put(
-                          node_id, request.node_info(), on_done));
-                    });
+      OnNodeDead(head_nodes[0], [this, request, on_done, node_id](const Status &status) {
+        RAY_CHECK_OK(status);
+        RAY_CHECK_OK(
+            gcs_table_storage_->NodeTable().Put(node_id, request.node_info(), on_done));
+      });
     } else {
       RAY_CHECK_OK(
           gcs_table_storage_->NodeTable().Put(node_id, request.node_info(), on_done));
@@ -112,29 +229,13 @@ void GcsNodeManager::HandleUnregisterNode(rpc::UnregisterNodeRequest request,
                                           rpc::UnregisterNodeReply *reply,
                                           rpc::SendReplyCallback send_reply_callback) {
   NodeID node_id = NodeID::FromBinary(request.node_id());
-  RAY_LOG(DEBUG) << "HandleUnregisterNode() for node id = " << node_id;
-  auto node = RemoveNode(node_id, request.node_death_info());
-  if (!node) {
-    RAY_LOG(INFO) << "Node " << node_id << " is already removed";
-    return;
-  }
-
-  node->set_state(rpc::GcsNodeInfo::DEAD);
-  node->set_end_time_ms(current_sys_time_ms());
-
-  AddDeadNodeToCache(node);
-
-  auto node_info_delta = std::make_shared<rpc::GcsNodeInfo>();
-  node_info_delta->set_node_id(node->node_id());
-  node_info_delta->mutable_death_info()->CopyFrom(request.node_death_info());
-  node_info_delta->set_state(node->state());
-  node_info_delta->set_end_time_ms(node->end_time_ms());
-
-  auto on_put_done = [=](const Status &status) {
-    RAY_CHECK_OK(gcs_publisher_->PublishNodeInfo(node_id, *node_info_delta, nullptr));
-  };
-  RAY_CHECK_OK(gcs_table_storage_->NodeTable().Put(node_id, *node, on_put_done));
-  GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
+  RAY_LOG(DEBUG).WithField(node_id) << "HandleUnregisterNode() for node id";
+  OnNodeDead(
+      node_id,
+      [send_reply_callback, reply](Status status) {
+        GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
+      },
+      request.mutable_node_death_info());
 }
 
 void GcsNodeManager::HandleDrainNode(rpc::DrainNodeRequest request,
@@ -163,12 +264,8 @@ void GcsNodeManager::DrainNode(const NodeID &node_id) {
   auto node = maybe_node.value();
 
   // Set the address.
-  rpc::Address remote_address;
-  remote_address.set_raylet_id(node->node_id());
-  remote_address.set_ip_address(node->node_manager_address());
-  remote_address.set_port(node->node_manager_port());
-
-  auto raylet_client = raylet_client_pool_->GetOrConnectByAddress(remote_address);
+  auto raylet_client =
+      raylet_client_pool_->GetOrConnectByAddress(RayletAddressFromNodeInfo(*node));
   RAY_CHECK(raylet_client);
   // NOTE(sang): Drain API is not supposed to kill the raylet, but we are doing
   // this until the proper "drain" behavior is implemented.
@@ -223,7 +320,7 @@ absl::optional<std::shared_ptr<rpc::GcsNodeInfo>> GcsNodeManager::GetAliveNode(
   return iter->second;
 }
 
-rpc::NodeDeathInfo GcsNodeManager::InferDeathInfo(const NodeID &node_id) {
+rpc::NodeDeathInfo GcsNodeManager::InferDeathInfo(const NodeID &node_id) const {
   auto iter = draining_nodes_.find(node_id);
   rpc::NodeDeathInfo death_info;
   bool expect_force_termination;
@@ -251,21 +348,6 @@ rpc::NodeDeathInfo GcsNodeManager::InferDeathInfo(const NodeID &node_id) {
   return death_info;
 }
 
-void GcsNodeManager::AddNode(std::shared_ptr<rpc::GcsNodeInfo> node) {
-  auto node_id = NodeID::FromBinary(node->node_id());
-  auto iter = alive_nodes_.find(node_id);
-  if (iter == alive_nodes_.end()) {
-    auto node_addr =
-        node->node_manager_address() + ":" + std::to_string(node->node_manager_port());
-    node_map_.insert(NodeIDAddrBiMap::value_type(node_id, node_addr));
-    alive_nodes_.emplace(node_id, node);
-    // Notify all listeners.
-    for (auto &listener : node_added_listeners_) {
-      listener(node);
-    }
-  }
-}
-
 void GcsNodeManager::SetNodeDraining(
     const NodeID &node_id,
     std::shared_ptr<rpc::autoscaler::DrainNodeRequest> drain_request) {
@@ -288,93 +370,35 @@ void GcsNodeManager::SetNodeDraining(
   }
 }
 
-std::shared_ptr<rpc::GcsNodeInfo> GcsNodeManager::RemoveNode(
-    const ray::NodeID &node_id, const rpc::NodeDeathInfo &node_death_info) {
-  std::shared_ptr<rpc::GcsNodeInfo> removed_node;
-  auto iter = alive_nodes_.find(node_id);
-  if (iter != alive_nodes_.end()) {
-    removed_node = std::move(iter->second);
-
-    // Set node death info.
-    auto death_info = removed_node->mutable_death_info();
-    death_info->CopyFrom(node_death_info);
-
-    RAY_LOG(INFO) << "Removing node, node id = " << node_id
-                  << ", node name = " << removed_node->node_name() << ", death reason = "
-                  << rpc::NodeDeathInfo_Reason_Name(death_info->reason())
-                  << ", death message = " << death_info->reason_message();
-    // Record stats that there's a new removed node.
-    stats::NodeFailureTotal.Record(1);
-    // Remove from alive nodes.
-    alive_nodes_.erase(iter);
-    node_map_.left.erase(node_id);
-    // Remove from draining nodes if present.
-    draining_nodes_.erase(node_id);
-    if (death_info->reason() == rpc::NodeDeathInfo::UNEXPECTED_TERMINATION) {
-      // Broadcast a warning to all of the drivers indicating that the node
-      // has been marked as dead.
-      // TODO(rkn): Define this constant somewhere else.
-      std::string type = "node_removed";
-      std::ostringstream error_message;
-      error_message
-          << "The node with node id: " << node_id
-          << " and address: " << removed_node->node_manager_address()
-          << " and node name: " << removed_node->node_name()
-          << " has been marked dead because the detector"
-          << " has missed too many heartbeats from it. This can happen when a "
-             "\t(1) raylet crashes unexpectedly (OOM, etc.) \n"
-          << "\t(2) raylet has lagging heartbeats due to slow network or busy workload.";
-      RAY_EVENT(ERROR, EL_RAY_NODE_REMOVED)
-              .WithField("node_id", node_id.Hex())
-              .WithField("ip", removed_node->node_manager_address())
-          << error_message.str();
-      RAY_LOG(WARNING) << error_message.str();
-      auto error_data_ptr =
-          gcs::CreateErrorTableData(type, error_message.str(), current_time_ms());
-      RAY_CHECK_OK(gcs_publisher_->PublishError(node_id.Hex(), *error_data_ptr, nullptr));
-    }
-
-    // Notify all listeners.
-    for (auto &listener : node_removed_listeners_) {
-      listener(removed_node);
-    }
-  }
-  return removed_node;
-}
-
-void GcsNodeManager::OnNodeFailure(const NodeID &node_id,
-                                   const StatusCallback &node_table_updated_callback) {
+void GcsNodeManager::OnNodeDead(const NodeID &node_id,
+                                const StatusCallback &node_table_updated_callback,
+                                rpc::NodeDeathInfo *death_info) {
   auto maybe_node = GetAliveNode(node_id);
-  if (maybe_node.has_value()) {
-    rpc::NodeDeathInfo death_info = InferDeathInfo(node_id);
-    auto node = RemoveNode(node_id, death_info);
-    node->set_state(rpc::GcsNodeInfo::DEAD);
-    node->set_end_time_ms(current_sys_time_ms());
-
-    AddDeadNodeToCache(node);
-    auto node_info_delta = std::make_shared<rpc::GcsNodeInfo>();
-    node_info_delta->set_node_id(node->node_id());
-    node_info_delta->set_state(node->state());
-    node_info_delta->set_end_time_ms(node->end_time_ms());
-    node_info_delta->mutable_death_info()->CopyFrom(node->death_info());
-
-    auto on_done = [this, node_id, node_table_updated_callback, node_info_delta](
-                       const Status &status) {
-      if (node_table_updated_callback != nullptr) {
-        node_table_updated_callback(Status::OK());
-      }
-      RAY_CHECK_OK(gcs_publisher_->PublishNodeInfo(node_id, *node_info_delta, nullptr));
-    };
-    RAY_CHECK_OK(gcs_table_storage_->NodeTable().Put(node_id, *node, on_done));
-  } else if (node_table_updated_callback != nullptr) {
-    node_table_updated_callback(Status::OK());
+  if (!maybe_node.has_value()) {
+    RAY_LOG(INFO).WithField(node_id) << "Node is already removed";
+    if (node_table_updated_callback != nullptr) {
+      node_table_updated_callback(Status::OK());
+    }
+    return;
   }
+  auto &node = maybe_node.value();
+
+  if (death_info == nullptr) {
+    *node->mutable_death_info() = InferDeathInfo(node_id);
+  } else {
+    *node->mutable_death_info() = std::move(*death_info);
+  }
+  node->set_state(rpc::GcsNodeInfo::DEAD);
+  node->set_end_time_ms(current_sys_time_ms());
+
+  RAY_CHECK_OK(
+      gcs_table_storage_->NodeTable().Put(node_id, *node, node_table_updated_callback));
 }
 
 void GcsNodeManager::Initialize(const GcsInitData &gcs_init_data) {
   for (const auto &[node_id, node_info] : gcs_init_data.Nodes()) {
     if (node_info.state() == rpc::GcsNodeInfo::ALIVE) {
-      AddNode(std::make_shared<rpc::GcsNodeInfo>(node_info));
+      ReactorOnNodeAlive(node_id, node_info);
 
       // Ask the raylet to do initialization in case of GCS restart.
       // The protocol is correct because when a new node joined, Raylet will do:
@@ -383,15 +407,11 @@ void GcsNodeManager::Initialize(const GcsInitData &gcs_init_data) {
       // With this, it means we only need to ask the node registered to do resubscription.
       // And for the node failed to register, they will crash on the client side due to
       // registeration failure.
-      rpc::Address remote_address;
-      remote_address.set_raylet_id(node_info.node_id());
-      remote_address.set_ip_address(node_info.node_manager_address());
-      remote_address.set_port(node_info.node_manager_port());
-      auto raylet_client = raylet_client_pool_->GetOrConnectByAddress(remote_address);
+      auto raylet_client = raylet_client_pool_->GetOrConnectByAddress(
+          RayletAddressFromNodeInfo(node_info));
       raylet_client->NotifyGCSRestart(nullptr);
     } else if (node_info.state() == rpc::GcsNodeInfo::DEAD) {
-      dead_nodes_.emplace(node_id, std::make_shared<rpc::GcsNodeInfo>(node_info));
-      sorted_dead_node_list_.emplace_back(node_id, node_info.end_time_ms());
+      ReactorOnNodeDead(node_id, node_info);
     }
   }
   sorted_dead_node_list_.sort(

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -87,14 +87,20 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
                         rpc::CheckAliveReply *reply,
                         rpc::SendReplyCallback send_reply_callback) override;
 
-  /// Handle a node failure. This will mark the failed node as dead in gcs
-  /// node table.
+  void ReactorOnNodeChanged(const NodeID &node_id, const rpc::GcsNodeInfo &node_info);
+  void ReactorOnNodeDead(const NodeID &node_id, const rpc::GcsNodeInfo &info);
+  void ReactorOnNodeAlive(const NodeID &node_id, const rpc::GcsNodeInfo &info);
+
+  /// Handle a node death. This will mark the failed node as dead in gcs node table.
   ///
   /// \param node_id The ID of the failed node.
   /// \param node_table_updated_callback The status callback function after
   /// faled node info is updated to gcs node table.
-  void OnNodeFailure(const NodeID &node_id,
-                     const StatusCallback &node_table_updated_callback);
+  /// \param death_info The death info of the node. If it is nullptr, the manager infers
+  /// the death info based on existing draining requests.
+  void OnNodeDead(const NodeID &node_id,
+                  const StatusCallback &node_table_updated_callback,
+                  rpc::NodeDeathInfo *death_info = nullptr);
 
   /// Add an alive node.
   ///
@@ -182,7 +188,7 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   /// \param node_id The ID of the node. The node must not be removed
   /// from alive nodes yet.
   /// \return The inferred death info of the node.
-  rpc::NodeDeathInfo InferDeathInfo(const NodeID &node_id);
+  rpc::NodeDeathInfo InferDeathInfo(const NodeID &node_id) const;
 
   /// Alive nodes.
   absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>> alive_nodes_;

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -282,6 +282,8 @@ void GcsServer::Stop() {
     // Shutdown the rpc server
     rpc_server_.Shutdown();
 
+    // Clean all Table callbacks...
+
     kv_manager_.reset();
 
     is_stopped_ = true;
@@ -311,7 +313,9 @@ void GcsServer::InitGcsHealthCheckManager(const GcsInitData &gcs_init_data) {
   RAY_CHECK(gcs_node_manager_);
   auto node_death_callback = [this](const NodeID &node_id) {
     main_service_.post(
-        [this, node_id] { return gcs_node_manager_->OnNodeFailure(node_id, nullptr); },
+        [this, node_id] {
+          return gcs_node_manager_->OnNodeDead(node_id, nullptr, nullptr);
+        },
         "GcsServer.NodeDeathCallback");
   };
 

--- a/src/ray/gcs/gcs_server/gcs_table_storage.h
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.h
@@ -50,6 +50,14 @@ class GcsTable {
 
   virtual ~GcsTable() = default;
 
+  void AddPutCallback(std::function<void(const Key &, const Data &)> callback) {
+    put_callbacks_.push_back(std::move(callback));
+  }
+
+  void AddDeleteCallback(std::function<void(const Key &)> callback) {
+    delete_callbacks_.push_back(std::move(callback));
+  }
+
   /// Write data to the table asynchronously.
   ///
   /// \param key The key that will be written to the table.
@@ -89,6 +97,8 @@ class GcsTable {
  protected:
   std::string table_name_;
   std::shared_ptr<StoreClient> store_client_;
+  std::vector<std::function<void(const Key &, const Data &)>> put_callbacks_;
+  std::vector<std::function<void(const Key &)>> delete_callbacks_;
 };
 
 /// \class GcsTableWithJobId


### PR DESCRIPTION
tldr:

1. `gcs_table_storage_` is the source of truth. Any manager's data structure is just view.
2. Single direction of info flow: updated table -> updated data structures.
3. `OnNode(Dead|Alive)` is what invokes Put().
4. `ReactorOnNode(Dead|Alive)` is what invoked after the Put(), updating data structures. Idempotent.

This is meant to be a PoC. Issues:
- The table callbacks are passing const&, while existing listeners accept shared_ptr.
- `sorted_dead_node_list_` needs an overhaul.