### PR TITLE
[spark] Fix Ray-on-Spark cluster crashing bug when user cancels cell execution

### DIFF
--- a/python/ray/tests/spark/test_basic.py
+++ b/python/ray/tests/spark/test_basic.py
@@ -517,9 +517,12 @@ class TestSparkLocalCluster:
 
         ray.init(address=local_addr)
 
-        # send a SIGINT signal to current process group,
+        head_proc_pid = ray.util.spark.cluster_init._active_ray_cluster.head_proc.pid
+
+        # send a SIGINT signal to head process (i.e. the `start_ray_node` process),
         # then test the Ray node is not killed by the SIGINT signal.
-        os.killpg(os.getpgid(0), signal.SIGINT)
+        # See https://github.com/ray-project/ray/pull/46899 for details
+        os.kill(head_proc_pid, signal.SIGINT)
 
         time.sleep(1)
 

--- a/python/ray/util/spark/start_ray_node.py
+++ b/python/ray/util/spark/start_ray_node.py
@@ -185,7 +185,15 @@ if __name__ == "__main__":
             os._exit(143)
 
         signal.signal(signal.SIGTERM, sigterm_handler)
-        ret_code = process.wait()
+        while True:
+            try:
+                ret_code = process.wait()
+                break
+            except KeyboardInterrupt:
+                # Jupyter notebook interrupt button triggers SIGINT signal and
+                # `start_ray_node` (subprocess) will receive SIGINT signal and it
+                # causes KeyboardInterrupt exception being raised.
+                pass
         try_clean_temp_dir_at_exit()
         sys.exit(ret_code)
     except Exception:

--- a/python/ray/util/spark/start_ray_node.py
+++ b/python/ray/util/spark/start_ray_node.py
@@ -62,6 +62,15 @@ if __name__ == "__main__":
     # same temp directory, adding a shared lock representing current ray node is
     # using the temp directory.
     fcntl.flock(lock_fd, fcntl.LOCK_SH)
+
+    def preexec_function():
+        # Make Ray node process runs in a separate group,
+        # otherwise Ray node will be in the same group of parent process,
+        # if parent process is a Jupyter notebook kernel, when user
+        # clicks interrupt cell button, SIGINT signal is sent, then Ray node will
+        # receive SIGINT signal and it causes Ray node process dies.
+        os.setpgrp()
+
     process = subprocess.Popen(
         # 'ray start ...' command uses python that is set by
         # Shebang #! ..., the Shebang line is hardcoded in ray script,
@@ -71,6 +80,7 @@ if __name__ == "__main__":
         # '`sys.executable` `which ray` start ...'
         [sys.executable, shutil.which(ray_cli_cmd), "start", *arg_list],
         text=True,
+        preexec_fn=preexec_function,
     )
 
     def try_clean_temp_dir_at_exit():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Fix Ray-on-Spark cluster crashing bug when user cancels cell execution:

When interrupting ray.get calls inside Databricks notebooks, this crashes the entire notebook session. Quick repro: on a ML 15.3 cluster, run this cell to kick off a bunch of async Ray tasks:

```
import ray
from ray.util.spark import setup_ray_cluster

setup_ray_cluster(min_worker_nodes=1, max_worker_nodes=1)

@ray.remote
def f():
  import time
  time.sleep(100)

pending = [f.remote() for _ in range(10)]
```
Then, run the following cell. After it starts, interrupt the cell execution and re-run the cell:

```
ray.get(f.remote())
```
The second call will hang and if you try to interrupt / retry you’ll get Fatal error: The Python kernel is unresponsive. This causes the notebook to lose all session state / restarts the Ray cluster.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
