### PR TITLE
[dashboard] restrict aiohttp version

### DIFF
--- a/ci/docker/base.test.Dockerfile
+++ b/ci/docker/base.test.Dockerfile
@@ -53,7 +53,6 @@ RUN echo "ulimit -c 0" >> /root/.bashrc
 RUN mkdir /ray
 WORKDIR /ray
 
-# Below should be re-run each time
 COPY . .
 
 RUN ./ci/env/install-miniconda.sh

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -48,7 +48,7 @@ scikit-image==0.21.0
 prometheus_client>=0.7.1
 pandas
 tensorboardX
-aiohttp>=3.7,!=3.9.0
+aiohttp>=3.7,<3.10.0
 starlette
 typer
 fsspec

--- a/python/setup.py
+++ b/python/setup.py
@@ -238,7 +238,7 @@ if setup_spec.type == SetupType.RAY:
         "default": [
             # If adding dependencies necessary to launch the dashboard api server,
             # please add it to dashboard/optional_deps.py as well.
-            "aiohttp >= 3.7",
+            "aiohttp >= 3.7,<3.10.0",
             "aiohttp_cors",
             "colorful",
             "py-spy >= 0.2.0",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

aiohttp's new 3.10.0 stops supporting creating `ClientSession` in non async context any more.

https://github.com/aio-libs/aiohttp/issues/8555#issuecomment-2261456957

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
