### PR TITLE
[doc][core] turn on api policy check for core

### DIFF
--- a/.buildkite/lint.rayci.yml
+++ b/.buildkite/lint.rayci.yml
@@ -32,6 +32,7 @@ steps:
       - ./ci/lint/lint.sh {{matrix}}
     matrix:
       - api_annotations
+      - api_policy_check core
       - api_policy_check serve
       - api_policy_check data
 

--- a/ci/ray_ci/doc/cmd_check_api_discrepancy.py
+++ b/ci/ray_ci/doc/cmd_check_api_discrepancy.py
@@ -23,6 +23,25 @@ TEAM_API_CONFIGS = {
         "head_doc_file": "doc/source/serve/api/index.md",
         "white_list_apis": {},
     },
+    "core": {
+        "head_modules": {"ray"},
+        "head_doc_file": "doc/source/ray-core/api/index.rst",
+        "white_list_apis": {
+            # These APIs will be documented in near future
+            "ray.util.scheduling_strategies.DoesNotExist",
+            "ray.util.scheduling_strategies.Exists",
+            "ray.util.scheduling_strategies.NodeLabelSchedulingStrategy",
+            "ray.util.scheduling_strategies.In",
+            "ray.util.scheduling_strategies.NotIn",
+            # TODO(jjyao): document or deprecate these APIs
+            "ray.experimental.compiled_dag_ref.CompiledDAGFuture",
+            "ray.experimental.compiled_dag_ref.CompiledDAGRef",
+            "ray.cross_language.cpp_actor_class",
+            "ray.cross_language.cpp_function",
+            "ray.client_builder.ClientContext",
+            "ray.remote_function.RemoteFunction",
+        },
+    },
 }
 
 

--- a/doc/source/ray-core/api/exceptions.rst
+++ b/doc/source/ray-core/api/exceptions.rst
@@ -33,6 +33,7 @@ Exceptions
     ray.exceptions.ObjectReconstructionFailedMaxAttemptsExceededError
     ray.exceptions.ObjectReconstructionFailedLineageEvictedError
     ray.exceptions.RayChannelError
+    ray.exceptions.RayChannelTimeoutError
     ray.exceptions.RuntimeEnvSetupError
     ray.exceptions.CrossLanguageError
     ray.exceptions.RaySystemError


### PR DESCRIPTION
Turn on api policy check (https://docs.google.com/document/d/1Wl452te8sxXC29u4JU0Afxm5aiZenO4PcEl2RpuiV_M/edit#heading=h.dmktkxvkc4io) for core; this will block anyone from adding or removing an API that violate the policies.

I added a few whitelisted APIs for core team to help correct as a follow up.

Test:
- CI
- all good: https://buildkite.com/ray-project/microcheck/builds/3621#01910b3a-96cb-48a0-b1f9-fe44d5a7f97c/178-411