### PR TITLE
[Dashboard]. Map logic resource data to row node

### DIFF
--- a/python/ray/dashboard/client/src/pages/node/hook/useNodeList.ts
+++ b/python/ray/dashboard/client/src/pages/node/hook/useNodeList.ts
@@ -50,7 +50,7 @@ export const useNodeList = () => {
   const nodeListWithAdditionalInfo = nodeList.map((e) => ({
     ...e,
     state: e.raylet.state,
-    logicalResources: nodeLogicalResources[e.raylet.nodeId],
+    logicalResources: nodeLogicalResources[e.ip],
   }));
 
   const sortedList = _.sortBy(nodeListWithAdditionalInfo, (node) => {


### PR DESCRIPTION
## Why are these changes needed?

This is a bug which causes the UI Cluster part not to show Logical Resources.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
