### PR TITLE
[doc][build] Lower max depth when building sidebar

### DIFF
--- a/doc/source/_templates/main-sidebar.html
+++ b/doc/source/_templates/main-sidebar.html
@@ -1,3 +1,3 @@
 <nav id="main-sidebar" class="bd-docs-nav bd-links" aria-label="{{ _('Section Navigation') }}">
-  <div class="bd-toc-item navbar-nav">{{ generate_toctree_html("sidebar", show_nav_level=0, startdepth=0, maxdepth=4, collapse=False, includehidden=True, titles_only=True) }}</div>
+  <div class="bd-toc-item navbar-nav">{{ generate_toctree_html("sidebar", show_nav_level=0, startdepth=0, maxdepth=3, collapse=False, includehidden=True, titles_only=True) }}</div>
 </nav>


### PR DESCRIPTION
- Change `max_depth` to 3 from 4 to see if build time on readthedoc gets better