### PR TITLE
[doc] add a function to check if an api is deprecated

### DIFF
--- a/ci/ray_ci/doc/api.py
+++ b/ci/ray_ci/doc/api.py
@@ -144,3 +144,10 @@ class API:
             self.annotation_type == AnnotationType.PUBLIC_API
             and not self._is_private_name()
         )
+
+    def is_deprecated(self) -> bool:
+        """
+        Check if this API is deprecated. Deprecated APIs are those that are annotated as
+        deprecated.
+        """
+        return self.annotation_type == AnnotationType.DEPRECATED

--- a/ci/ray_ci/doc/test_api.py
+++ b/ci/ray_ci/doc/test_api.py
@@ -163,5 +163,19 @@ def test_is_public():
     ).is_public()
 
 
+def test_is_deprecated():
+    assert not API(
+        name="a.b._private_function",
+        annotation_type=AnnotationType.PUBLIC_API,
+        code_type=CodeType.FUNCTION,
+    ).is_deprecated()
+
+    assert API(
+        name="a.b.function",
+        annotation_type=AnnotationType.DEPRECATED,
+        code_type=CodeType.FUNCTION,
+    ).is_deprecated()
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
Add a function to check if an API is deprecated. I'll use this later to check if deprecated APIs are documented.

Test:
- CI