### PR TITLE
[doc] print good+bad apis in the api policy lint check

### DIFF
--- a/ci/ray_ci/doc/api.py
+++ b/ci/ray_ci/doc/api.py
@@ -4,7 +4,7 @@ import inspect
 
 from enum import Enum
 from dataclasses import dataclass
-from typing import Optional, List
+from typing import Optional, List, Tuple, Set, Dict
 
 
 _SPHINX_AUTOSUMMARY_HEADER = ".. autosummary::"
@@ -151,3 +151,29 @@ class API:
         deprecated.
         """
         return self.annotation_type == AnnotationType.DEPRECATED
+
+    @staticmethod
+    def split_good_and_bad_apis(
+        api_in_codes: Dict[str, "API"], api_in_docs: Set[str], white_list_apis: Set[str]
+    ) -> Tuple[List[str]]:
+        """
+        Given the APIs in the codebase and the documentation, split the APIs into good
+        and bad APIs. Good APIs are those that are public and documented, bad APIs are
+        those that are public but NOT documented.
+        """
+        good_apis = []
+        bad_apis = []
+
+        for name, api in api_in_codes.items():
+            if not api.is_public():
+                continue
+
+            if name in white_list_apis:
+                continue
+
+            if name in api_in_docs:
+                good_apis.append(name)
+            else:
+                bad_apis.append(name)
+
+        return good_apis, bad_apis

--- a/ci/ray_ci/doc/cmd_check_api_discrepancy.py
+++ b/ci/ray_ci/doc/cmd_check_api_discrepancy.py
@@ -1,9 +1,9 @@
 import click
-from typing import Dict, Set
 
 from ci.ray_ci.doc.module import Module
 from ci.ray_ci.doc.autodoc import Autodoc
 from ci.ray_ci.doc.api import API
+from ci.ray_ci.utils import logger
 
 TEAM_API_CONFIGS = {
     "data": {
@@ -70,27 +70,22 @@ def main(ray_checkout_dir: str, team: str) -> None:
     white_list_apis = TEAM_API_CONFIGS[team]["white_list_apis"]
 
     # Policy 01: all public APIs should be documented
-    print("Validating that public APIs should be documented...")
-    _validate_documented_public_apis(api_in_codes, api_in_docs, white_list_apis)
+    logger.info("Validating that public APIs should be documented...")
+    good_apis, bad_apis = API.split_good_and_bad_apis(
+        api_in_codes, api_in_docs, white_list_apis
+    )
+
+    logger.info("Public APIs that are documented:")
+    for api in good_apis:
+        logger.info(f"\t{api}")
+
+    logger.info("Public APIs that are NOT documented:")
+    for api in bad_apis:
+        logger.info(f"\t{api}")
+
+    assert not bad_apis, "Some public APIs are not documented. Please document them."
 
     return
-
-
-def _validate_documented_public_apis(
-    api_in_codes: Dict[str, API], api_in_docs: Set[str], white_list_apis: Set[str]
-) -> None:
-    """
-    Validate APIs that are public and documented.
-    """
-    for name, api in api_in_codes.items():
-        if not api.is_public():
-            continue
-
-        if name in white_list_apis:
-            continue
-
-        assert name in api_in_docs, f"\tAPI {api.name} is public but not documented."
-        print(f"\tAPI {api.name} is public and documented.")
 
 
 if __name__ == "__main__":

--- a/ci/ray_ci/doc/test_api.py
+++ b/ci/ray_ci/doc/test_api.py
@@ -177,5 +177,37 @@ def test_is_deprecated():
     ).is_deprecated()
 
 
+def test_split_good_and_bad_apis():
+    good_apis, bad_apis = API.split_good_and_bad_apis(
+        {
+            "a.b.public_function": API(
+                name="a.b.public_function",
+                annotation_type=AnnotationType.PUBLIC_API,
+                code_type=CodeType.FUNCTION,
+            ),
+            "a.b._private_function": API(
+                name="a.b._private_function",
+                annotation_type=AnnotationType.PUBLIC_API,
+                code_type=CodeType.FUNCTION,
+            ),
+            "a.b.deprecated_function_01": API(
+                name="a.b.deprecated_function_01",
+                annotation_type=AnnotationType.PUBLIC_API,
+                code_type=CodeType.FUNCTION,
+            ),
+            "a.b.deprecated_function_02": API(
+                name="a.b.deprecated_function_02",
+                annotation_type=AnnotationType.PUBLIC_API,
+                code_type=CodeType.FUNCTION,
+            ),
+        },
+        {"a.b.public_function"},
+        {"a.b._private_function"},
+    )
+
+    assert good_apis == ["a.b.public_function"]
+    assert bad_apis == ["a.b.deprecated_function_01", "a.b.deprecated_function_02"]
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
Currently the api policy lint check will fail immediately on the first violation. This updates so that it will print all violations out, if any, before failing.

Test:
- CI