### PR TITLE
[Core] Rename CoreWorkerDirectTaskSubmitter to NormalTaskSubmitter

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -856,9 +856,9 @@ ray_cc_test(
 )
 
 ray_cc_test(
-    name = "direct_task_transport_test",
+    name = "normal_task_submitter_test",
     size = "small",
-    srcs = ["src/ray/core_worker/test/direct_task_transport_test.cc"],
+    srcs = ["src/ray/core_worker/test/normal_task_submitter_test.cc"],
     tags = ["team:core"],
     deps = [
         ":core_worker_lib",

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -38,7 +38,7 @@
 #include "ray/core_worker/store_provider/plasma_store_provider.h"
 #include "ray/core_worker/task_event_buffer.h"
 #include "ray/core_worker/transport/direct_actor_transport.h"
-#include "ray/core_worker/transport/direct_task_transport.h"
+#include "ray/core_worker/transport/normal_task_submitter.h"
 #include "ray/gcs/gcs_client/gcs_client.h"
 #include "ray/pubsub/publisher.h"
 #include "ray/pubsub/subscriber.h"
@@ -1112,11 +1112,11 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
       const std::string &event_name);
 
   int64_t GetNumTasksSubmitted() const {
-    return direct_task_submitter_->GetNumTasksSubmitted();
+    return normal_task_submitter_->GetNumTasksSubmitted();
   }
 
   int64_t GetNumLeasesRequested() const {
-    return direct_task_submitter_->GetNumLeasesRequested();
+    return normal_task_submitter_->GetNumLeasesRequested();
   }
 
  public:
@@ -1851,7 +1851,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   std::shared_ptr<LeaseRequestRateLimiter> lease_request_rate_limiter_;
 
   // Interface to submit non-actor tasks directly to leased workers.
-  std::unique_ptr<CoreWorkerDirectTaskSubmitter> direct_task_submitter_;
+  std::unique_ptr<NormalTaskSubmitter> normal_task_submitter_;
 
   /// Manages recovery of objects stored in remote plasma nodes.
   std::unique_ptr<ObjectRecoveryManager> object_recovery_manager_;

--- a/src/ray/core_worker/test/direct_actor_transport_test.cc
+++ b/src/ray/core_worker/test/direct_actor_transport_test.cc
@@ -19,7 +19,7 @@
 #include "ray/common/task/task_spec.h"
 #include "ray/common/test_util.h"
 #include "ray/core_worker/store_provider/memory_store/memory_store.h"
-#include "ray/core_worker/transport/direct_task_transport.h"
+#include "ray/core_worker/transport/normal_task_submitter.h"
 #include "ray/raylet_client/raylet_client.h"
 #include "ray/rpc/worker/core_worker_client.h"
 #include "mock/ray/core_worker/actor_creator.h"

--- a/src/ray/core_worker/test/direct_task_transport_mock_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_mock_test.cc
@@ -36,20 +36,20 @@ class DirectTaskTransportTest : public ::testing::Test {
         [&](const rpc::Address &) { return nullptr; });
     static std::shared_ptr<LeaseRequestRateLimiter> kRateLimiter =
         std::make_shared<StaticLeaseRequestRateLimiter>(1);
-    task_submitter = std::make_unique<NormalTaskSubmitter>(
-        rpc::Address(), /* rpc_address */
-        raylet_client,  /* lease_client */
-        client_pool,    /* core_worker_client_pool */
-        nullptr,        /* lease_client_factory */
-        lease_policy,   /* lease_policy */
-        std::make_shared<CoreWorkerMemoryStore>(),
-        task_finisher,
-        NodeID::Nil(),      /* local_raylet_id */
-        WorkerType::WORKER, /* worker_type */
-        0,                  /* lease_timeout_ms */
-        actor_creator,
-        JobID::Nil() /* job_id */,
-        kRateLimiter);
+    task_submitter =
+        std::make_unique<NormalTaskSubmitter>(rpc::Address(), /* rpc_address */
+                                              raylet_client,  /* lease_client */
+                                              client_pool,  /* core_worker_client_pool */
+                                              nullptr,      /* lease_client_factory */
+                                              lease_policy, /* lease_policy */
+                                              std::make_shared<CoreWorkerMemoryStore>(),
+                                              task_finisher,
+                                              NodeID::Nil(),      /* local_raylet_id */
+                                              WorkerType::WORKER, /* worker_type */
+                                              0,                  /* lease_timeout_ms */
+                                              actor_creator,
+                                              JobID::Nil() /* job_id */,
+                                              kRateLimiter);
   }
 
   TaskSpecification GetCreatingTaskSpec(const ActorID &actor_id) {

--- a/src/ray/core_worker/test/direct_task_transport_mock_test.cc
+++ b/src/ray/core_worker/test/direct_task_transport_mock_test.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // clang-format off
-#include "ray/core_worker/transport/direct_task_transport.h"
+#include "ray/core_worker/transport/normal_task_submitter.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "mock/ray/core_worker/actor_creator.h"
@@ -36,7 +36,7 @@ class DirectTaskTransportTest : public ::testing::Test {
         [&](const rpc::Address &) { return nullptr; });
     static std::shared_ptr<LeaseRequestRateLimiter> kRateLimiter =
         std::make_shared<StaticLeaseRequestRateLimiter>(1);
-    task_submitter = std::make_unique<CoreWorkerDirectTaskSubmitter>(
+    task_submitter = std::make_unique<NormalTaskSubmitter>(
         rpc::Address(), /* rpc_address */
         raylet_client,  /* lease_client */
         client_pool,    /* core_worker_client_pool */
@@ -62,7 +62,7 @@ class DirectTaskTransportTest : public ::testing::Test {
     return TaskSpecification(task_spec);
   }
 
-  std::unique_ptr<CoreWorkerDirectTaskSubmitter> task_submitter;
+  std::unique_ptr<NormalTaskSubmitter> task_submitter;
   std::shared_ptr<MockRayletClientInterface> raylet_client;
   std::shared_ptr<MockTaskFinisherInterface> task_finisher;
   std::shared_ptr<MockActorCreatorInterface> actor_creator;

--- a/src/ray/core_worker/test/normal_task_submitter_test.cc
+++ b/src/ray/core_worker/test/normal_task_submitter_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "ray/core_worker/transport/direct_task_transport.h"
+#include "ray/core_worker/transport/normal_task_submitter.h"
 
 #include "gtest/gtest.h"
 #include "ray/common/task/task_spec.h"
@@ -386,7 +386,7 @@ TaskSpecification BuildEmptyTaskSpec() {
   return BuildTaskSpec(empty_resources, empty_descriptor);
 }
 
-TEST(DirectTaskTransportTest, TestLocalityAwareSubmitOneTask) {
+TEST(NormalTaskSubmitterTest, TestLocalityAwareSubmitOneTask) {
   rpc::Address address;
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
@@ -397,7 +397,7 @@ TEST(DirectTaskTransportTest, TestLocalityAwareSubmitOneTask) {
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
   lease_policy->is_locality_aware = true;
-  CoreWorkerDirectTaskSubmitter submitter(address,
+  NormalTaskSubmitter submitter(address,
                                           raylet_client,
                                           client_pool,
                                           nullptr,
@@ -439,7 +439,7 @@ TEST(DirectTaskTransportTest, TestLocalityAwareSubmitOneTask) {
   ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
-TEST(DirectTaskTransportTest, TestSubmitOneTask) {
+TEST(NormalTaskSubmitterTest, TestSubmitOneTask) {
   rpc::Address address;
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
@@ -449,7 +449,7 @@ TEST(DirectTaskTransportTest, TestSubmitOneTask) {
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
-  CoreWorkerDirectTaskSubmitter submitter(address,
+  NormalTaskSubmitter submitter(address,
                                           raylet_client,
                                           client_pool,
                                           nullptr,
@@ -491,7 +491,7 @@ TEST(DirectTaskTransportTest, TestSubmitOneTask) {
   ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
-TEST(DirectTaskTransportTest, TestRetryTaskApplicationLevelError) {
+TEST(NormalTaskSubmitterTest, TestRetryTaskApplicationLevelError) {
   rpc::Address address;
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
@@ -501,7 +501,7 @@ TEST(DirectTaskTransportTest, TestRetryTaskApplicationLevelError) {
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
-  CoreWorkerDirectTaskSubmitter submitter(address,
+  NormalTaskSubmitter submitter(address,
                                           raylet_client,
                                           client_pool,
                                           nullptr,
@@ -548,7 +548,7 @@ TEST(DirectTaskTransportTest, TestRetryTaskApplicationLevelError) {
   ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
-TEST(DirectTaskTransportTest, TestHandleTaskFailure) {
+TEST(NormalTaskSubmitterTest, TestHandleTaskFailure) {
   rpc::Address address;
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
@@ -558,7 +558,7 @@ TEST(DirectTaskTransportTest, TestHandleTaskFailure) {
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
-  CoreWorkerDirectTaskSubmitter submitter(address,
+  NormalTaskSubmitter submitter(address,
                                           raylet_client,
                                           client_pool,
                                           nullptr,
@@ -591,7 +591,7 @@ TEST(DirectTaskTransportTest, TestHandleTaskFailure) {
   ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
-TEST(DirectTaskTransportTest, TestHandleUnschedulableTask) {
+TEST(NormalTaskSubmitterTest, TestHandleUnschedulableTask) {
   rpc::Address address;
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
@@ -601,7 +601,7 @@ TEST(DirectTaskTransportTest, TestHandleUnschedulableTask) {
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
-  CoreWorkerDirectTaskSubmitter submitter(address,
+  NormalTaskSubmitter submitter(address,
                                           raylet_client,
                                           client_pool,
                                           nullptr,
@@ -661,7 +661,7 @@ TEST(DirectTaskTransportTest, TestHandleUnschedulableTask) {
   ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
-TEST(DirectTaskTransportTest, TestHandleRuntimeEnvSetupFailed) {
+TEST(NormalTaskSubmitterTest, TestHandleRuntimeEnvSetupFailed) {
   rpc::Address address;
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
@@ -671,7 +671,7 @@ TEST(DirectTaskTransportTest, TestHandleRuntimeEnvSetupFailed) {
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
-  CoreWorkerDirectTaskSubmitter submitter(address,
+  NormalTaskSubmitter submitter(address,
                                           raylet_client,
                                           client_pool,
                                           nullptr,
@@ -731,7 +731,7 @@ TEST(DirectTaskTransportTest, TestHandleRuntimeEnvSetupFailed) {
   ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
-TEST(DirectTaskTransportTest, TestWorkerHandleLocalRayletDied) {
+TEST(NormalTaskSubmitterTest, TestWorkerHandleLocalRayletDied) {
   rpc::Address address;
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
@@ -741,7 +741,7 @@ TEST(DirectTaskTransportTest, TestWorkerHandleLocalRayletDied) {
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
-  CoreWorkerDirectTaskSubmitter submitter(address,
+  NormalTaskSubmitter submitter(address,
                                           raylet_client,
                                           client_pool,
                                           nullptr,
@@ -760,7 +760,7 @@ TEST(DirectTaskTransportTest, TestWorkerHandleLocalRayletDied) {
   ASSERT_DEATH(raylet_client->FailWorkerLeaseDueToGrpcUnavailable(), "");
 }
 
-TEST(DirectTaskTransportTest, TestDriverHandleLocalRayletDied) {
+TEST(NormalTaskSubmitterTest, TestDriverHandleLocalRayletDied) {
   rpc::Address address;
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
@@ -770,7 +770,7 @@ TEST(DirectTaskTransportTest, TestDriverHandleLocalRayletDied) {
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
-  CoreWorkerDirectTaskSubmitter submitter(address,
+  NormalTaskSubmitter submitter(address,
                                           raylet_client,
                                           client_pool,
                                           nullptr,
@@ -814,7 +814,7 @@ TEST(DirectTaskTransportTest, TestDriverHandleLocalRayletDied) {
   ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
-TEST(DirectTaskTransportTest, TestConcurrentWorkerLeases) {
+TEST(NormalTaskSubmitterTest, TestConcurrentWorkerLeases) {
   rpc::Address address;
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
@@ -827,7 +827,7 @@ TEST(DirectTaskTransportTest, TestConcurrentWorkerLeases) {
 
   int64_t concurrency = 10;
   auto rateLimiter = std::make_shared<StaticLeaseRequestRateLimiter>(concurrency);
-  CoreWorkerDirectTaskSubmitter submitter(address,
+  NormalTaskSubmitter submitter(address,
                                           raylet_client,
                                           client_pool,
                                           nullptr,
@@ -892,7 +892,7 @@ TEST(DirectTaskTransportTest, TestConcurrentWorkerLeases) {
   ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
-TEST(DirectTaskTransportTest, TestConcurrentWorkerLeasesDynamic) {
+TEST(NormalTaskSubmitterTest, TestConcurrentWorkerLeasesDynamic) {
   rpc::Address address;
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
@@ -905,7 +905,7 @@ TEST(DirectTaskTransportTest, TestConcurrentWorkerLeasesDynamic) {
 
   int64_t concurrency = 10;
   auto rateLimiter = std::make_shared<DynamicRateLimiter>(1);
-  CoreWorkerDirectTaskSubmitter submitter(address,
+  NormalTaskSubmitter submitter(address,
                                           raylet_client,
                                           client_pool,
                                           nullptr,
@@ -996,7 +996,7 @@ TEST(DirectTaskTransportTest, TestConcurrentWorkerLeasesDynamic) {
   ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
-TEST(DirectTaskTransportTest, TestConcurrentWorkerLeasesDynamicWithSpillback) {
+TEST(NormalTaskSubmitterTest, TestConcurrentWorkerLeasesDynamicWithSpillback) {
   rpc::Address address;
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
@@ -1012,7 +1012,7 @@ TEST(DirectTaskTransportTest, TestConcurrentWorkerLeasesDynamicWithSpillback) {
 
   int64_t concurrency = 10;
   auto rateLimiter = std::make_shared<DynamicRateLimiter>(1);
-  CoreWorkerDirectTaskSubmitter submitter(address,
+  NormalTaskSubmitter submitter(address,
                                           raylet_client,
                                           client_pool,
                                           lease_client_factory,
@@ -1106,7 +1106,7 @@ TEST(DirectTaskTransportTest, TestConcurrentWorkerLeasesDynamicWithSpillback) {
   ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
-TEST(DirectTaskTransportTest, TestSubmitMultipleTasks) {
+TEST(NormalTaskSubmitterTest, TestSubmitMultipleTasks) {
   rpc::Address address;
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
@@ -1116,7 +1116,7 @@ TEST(DirectTaskTransportTest, TestSubmitMultipleTasks) {
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
-  CoreWorkerDirectTaskSubmitter submitter(address,
+  NormalTaskSubmitter submitter(address,
                                           raylet_client,
                                           client_pool,
                                           nullptr,
@@ -1178,7 +1178,7 @@ TEST(DirectTaskTransportTest, TestSubmitMultipleTasks) {
   ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
-TEST(DirectTaskTransportTest, TestReuseWorkerLease) {
+TEST(NormalTaskSubmitterTest, TestReuseWorkerLease) {
   rpc::Address address;
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
@@ -1188,7 +1188,7 @@ TEST(DirectTaskTransportTest, TestReuseWorkerLease) {
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
-  CoreWorkerDirectTaskSubmitter submitter(address,
+  NormalTaskSubmitter submitter(address,
                                           raylet_client,
                                           client_pool,
                                           nullptr,
@@ -1251,7 +1251,7 @@ TEST(DirectTaskTransportTest, TestReuseWorkerLease) {
   ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
-TEST(DirectTaskTransportTest, TestRetryLeaseCancellation) {
+TEST(NormalTaskSubmitterTest, TestRetryLeaseCancellation) {
   rpc::Address address;
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
@@ -1261,7 +1261,7 @@ TEST(DirectTaskTransportTest, TestRetryLeaseCancellation) {
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
-  CoreWorkerDirectTaskSubmitter submitter(address,
+  NormalTaskSubmitter submitter(address,
                                           raylet_client,
                                           client_pool,
                                           nullptr,
@@ -1319,7 +1319,7 @@ TEST(DirectTaskTransportTest, TestRetryLeaseCancellation) {
   ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
-TEST(DirectTaskTransportTest, TestConcurrentCancellationAndSubmission) {
+TEST(NormalTaskSubmitterTest, TestConcurrentCancellationAndSubmission) {
   rpc::Address address;
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
@@ -1329,7 +1329,7 @@ TEST(DirectTaskTransportTest, TestConcurrentCancellationAndSubmission) {
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
-  CoreWorkerDirectTaskSubmitter submitter(address,
+  NormalTaskSubmitter submitter(address,
                                           raylet_client,
                                           client_pool,
                                           nullptr,
@@ -1384,7 +1384,7 @@ TEST(DirectTaskTransportTest, TestConcurrentCancellationAndSubmission) {
   ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
-TEST(DirectTaskTransportTest, TestWorkerNotReusedOnError) {
+TEST(NormalTaskSubmitterTest, TestWorkerNotReusedOnError) {
   rpc::Address address;
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
@@ -1394,7 +1394,7 @@ TEST(DirectTaskTransportTest, TestWorkerNotReusedOnError) {
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
-  CoreWorkerDirectTaskSubmitter submitter(address,
+  NormalTaskSubmitter submitter(address,
                                           raylet_client,
                                           client_pool,
                                           nullptr,
@@ -1440,7 +1440,7 @@ TEST(DirectTaskTransportTest, TestWorkerNotReusedOnError) {
   ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
-TEST(DirectTaskTransportTest, TestWorkerNotReturnedOnExit) {
+TEST(NormalTaskSubmitterTest, TestWorkerNotReturnedOnExit) {
   rpc::Address address;
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
@@ -1450,7 +1450,7 @@ TEST(DirectTaskTransportTest, TestWorkerNotReturnedOnExit) {
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
-  CoreWorkerDirectTaskSubmitter submitter(address,
+  NormalTaskSubmitter submitter(address,
                                           raylet_client,
                                           client_pool,
                                           nullptr,
@@ -1487,7 +1487,7 @@ TEST(DirectTaskTransportTest, TestWorkerNotReturnedOnExit) {
   ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
-TEST(DirectTaskTransportTest, TestSpillback) {
+TEST(NormalTaskSubmitterTest, TestSpillback) {
   rpc::Address address;
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
@@ -1506,7 +1506,7 @@ TEST(DirectTaskTransportTest, TestSpillback) {
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
-  CoreWorkerDirectTaskSubmitter submitter(address,
+  NormalTaskSubmitter submitter(address,
                                           raylet_client,
                                           client_pool,
                                           lease_client_factory,
@@ -1560,7 +1560,7 @@ TEST(DirectTaskTransportTest, TestSpillback) {
   ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
-TEST(DirectTaskTransportTest, TestSpillbackRoundTrip) {
+TEST(NormalTaskSubmitterTest, TestSpillbackRoundTrip) {
   rpc::Address address;
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
@@ -1580,7 +1580,7 @@ TEST(DirectTaskTransportTest, TestSpillbackRoundTrip) {
   auto local_raylet_id = NodeID::FromRandom();
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>(local_raylet_id);
-  CoreWorkerDirectTaskSubmitter submitter(address,
+  NormalTaskSubmitter submitter(address,
                                           raylet_client,
                                           client_pool,
                                           lease_client_factory,
@@ -1658,7 +1658,7 @@ void TestSchedulingKey(const std::shared_ptr<CoreWorkerMemoryStore> store,
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
-  CoreWorkerDirectTaskSubmitter submitter(address,
+  NormalTaskSubmitter submitter(address,
                                           raylet_client,
                                           client_pool,
                                           nullptr,
@@ -1719,7 +1719,7 @@ void TestSchedulingKey(const std::shared_ptr<CoreWorkerMemoryStore> store,
   ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
-TEST(DirectTaskTransportTest, TestSchedulingKeys) {
+TEST(NormalTaskSubmitterTest, TestSchedulingKeys) {
   auto store = std::make_shared<CoreWorkerMemoryStore>();
 
   std::unordered_map<std::string, double> resources1({{"a", 1.0}});
@@ -1801,7 +1801,7 @@ TEST(DirectTaskTransportTest, TestSchedulingKeys) {
   TestSchedulingKey(store, same_deps_1, same_deps_2, different_deps);
 }
 
-TEST(DirectTaskTransportTest, TestBacklogReport) {
+TEST(NormalTaskSubmitterTest, TestBacklogReport) {
   rpc::Address address;
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
@@ -1811,7 +1811,7 @@ TEST(DirectTaskTransportTest, TestBacklogReport) {
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
-  CoreWorkerDirectTaskSubmitter submitter(address,
+  NormalTaskSubmitter submitter(address,
                                           raylet_client,
                                           client_pool,
                                           nullptr,
@@ -1870,7 +1870,7 @@ TEST(DirectTaskTransportTest, TestBacklogReport) {
   ASSERT_EQ(raylet_client->reported_backlogs[task4.GetSchedulingClass()], 1);
 }
 
-TEST(DirectTaskTransportTest, TestWorkerLeaseTimeout) {
+TEST(NormalTaskSubmitterTest, TestWorkerLeaseTimeout) {
   rpc::Address address;
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
@@ -1880,7 +1880,7 @@ TEST(DirectTaskTransportTest, TestWorkerLeaseTimeout) {
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
-  CoreWorkerDirectTaskSubmitter submitter(address,
+  NormalTaskSubmitter submitter(address,
                                           raylet_client,
                                           client_pool,
                                           nullptr,
@@ -1936,7 +1936,7 @@ TEST(DirectTaskTransportTest, TestWorkerLeaseTimeout) {
   ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
-TEST(DirectTaskTransportTest, TestKillExecutingTask) {
+TEST(NormalTaskSubmitterTest, TestKillExecutingTask) {
   rpc::Address address;
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
@@ -1947,7 +1947,7 @@ TEST(DirectTaskTransportTest, TestKillExecutingTask) {
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
-  CoreWorkerDirectTaskSubmitter submitter(address,
+  NormalTaskSubmitter submitter(address,
                                           raylet_client,
                                           client_pool,
                                           nullptr,
@@ -1999,7 +1999,7 @@ TEST(DirectTaskTransportTest, TestKillExecutingTask) {
   ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
-TEST(DirectTaskTransportTest, TestKillPendingTask) {
+TEST(NormalTaskSubmitterTest, TestKillPendingTask) {
   rpc::Address address;
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
@@ -2009,7 +2009,7 @@ TEST(DirectTaskTransportTest, TestKillPendingTask) {
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
-  CoreWorkerDirectTaskSubmitter submitter(address,
+  NormalTaskSubmitter submitter(address,
                                           raylet_client,
                                           client_pool,
                                           nullptr,
@@ -2044,7 +2044,7 @@ TEST(DirectTaskTransportTest, TestKillPendingTask) {
   ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
 }
 
-TEST(DirectTaskTransportTest, TestKillResolvingTask) {
+TEST(NormalTaskSubmitterTest, TestKillResolvingTask) {
   rpc::Address address;
   auto raylet_client = std::make_shared<MockRayletClient>();
   auto worker_client = std::make_shared<MockWorkerClient>();
@@ -2054,7 +2054,7 @@ TEST(DirectTaskTransportTest, TestKillResolvingTask) {
   auto task_finisher = std::make_shared<MockTaskFinisher>();
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
-  CoreWorkerDirectTaskSubmitter submitter(address,
+  NormalTaskSubmitter submitter(address,
                                           raylet_client,
                                           client_pool,
                                           nullptr,

--- a/src/ray/core_worker/test/normal_task_submitter_test.cc
+++ b/src/ray/core_worker/test/normal_task_submitter_test.cc
@@ -398,18 +398,18 @@ TEST(NormalTaskSubmitterTest, TestLocalityAwareSubmitOneTask) {
   auto lease_policy = std::make_shared<MockLeasePolicy>();
   lease_policy->is_locality_aware = true;
   NormalTaskSubmitter submitter(address,
-                                          raylet_client,
-                                          client_pool,
-                                          nullptr,
-                                          lease_policy,
-                                          store,
-                                          task_finisher,
-                                          NodeID::Nil(),
-                                          WorkerType::WORKER,
-                                          kLongTimeout,
-                                          actor_creator,
-                                          JobID::Nil(),
-                                          kOneRateLimiter);
+                                raylet_client,
+                                client_pool,
+                                nullptr,
+                                lease_policy,
+                                store,
+                                task_finisher,
+                                NodeID::Nil(),
+                                WorkerType::WORKER,
+                                kLongTimeout,
+                                actor_creator,
+                                JobID::Nil(),
+                                kOneRateLimiter);
 
   TaskSpecification task = BuildEmptyTaskSpec();
 
@@ -450,18 +450,18 @@ TEST(NormalTaskSubmitterTest, TestSubmitOneTask) {
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
   NormalTaskSubmitter submitter(address,
-                                          raylet_client,
-                                          client_pool,
-                                          nullptr,
-                                          lease_policy,
-                                          store,
-                                          task_finisher,
-                                          NodeID::Nil(),
-                                          WorkerType::WORKER,
-                                          kLongTimeout,
-                                          actor_creator,
-                                          JobID::Nil(),
-                                          kOneRateLimiter);
+                                raylet_client,
+                                client_pool,
+                                nullptr,
+                                lease_policy,
+                                store,
+                                task_finisher,
+                                NodeID::Nil(),
+                                WorkerType::WORKER,
+                                kLongTimeout,
+                                actor_creator,
+                                JobID::Nil(),
+                                kOneRateLimiter);
 
   TaskSpecification task = BuildEmptyTaskSpec();
 
@@ -502,18 +502,18 @@ TEST(NormalTaskSubmitterTest, TestRetryTaskApplicationLevelError) {
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
   NormalTaskSubmitter submitter(address,
-                                          raylet_client,
-                                          client_pool,
-                                          nullptr,
-                                          lease_policy,
-                                          store,
-                                          task_finisher,
-                                          NodeID::Nil(),
-                                          WorkerType::WORKER,
-                                          kLongTimeout,
-                                          actor_creator,
-                                          JobID::Nil(),
-                                          kOneRateLimiter);
+                                raylet_client,
+                                client_pool,
+                                nullptr,
+                                lease_policy,
+                                store,
+                                task_finisher,
+                                NodeID::Nil(),
+                                WorkerType::WORKER,
+                                kLongTimeout,
+                                actor_creator,
+                                JobID::Nil(),
+                                kOneRateLimiter);
   TaskSpecification task = BuildEmptyTaskSpec();
   task.GetMutableMessage().set_retry_exceptions(true);
 
@@ -559,18 +559,18 @@ TEST(NormalTaskSubmitterTest, TestHandleTaskFailure) {
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
   NormalTaskSubmitter submitter(address,
-                                          raylet_client,
-                                          client_pool,
-                                          nullptr,
-                                          lease_policy,
-                                          store,
-                                          task_finisher,
-                                          NodeID::Nil(),
-                                          WorkerType::WORKER,
-                                          kLongTimeout,
-                                          actor_creator,
-                                          JobID::Nil(),
-                                          kOneRateLimiter);
+                                raylet_client,
+                                client_pool,
+                                nullptr,
+                                lease_policy,
+                                store,
+                                task_finisher,
+                                NodeID::Nil(),
+                                WorkerType::WORKER,
+                                kLongTimeout,
+                                actor_creator,
+                                JobID::Nil(),
+                                kOneRateLimiter);
   TaskSpecification task = BuildEmptyTaskSpec();
 
   ASSERT_TRUE(submitter.SubmitTask(task).ok());
@@ -602,18 +602,18 @@ TEST(NormalTaskSubmitterTest, TestHandleUnschedulableTask) {
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
   NormalTaskSubmitter submitter(address,
-                                          raylet_client,
-                                          client_pool,
-                                          nullptr,
-                                          lease_policy,
-                                          store,
-                                          task_finisher,
-                                          NodeID::Nil(),
-                                          WorkerType::WORKER,
-                                          kLongTimeout,
-                                          actor_creator,
-                                          JobID::Nil(),
-                                          kTwoRateLimiter);
+                                raylet_client,
+                                client_pool,
+                                nullptr,
+                                lease_policy,
+                                store,
+                                task_finisher,
+                                NodeID::Nil(),
+                                WorkerType::WORKER,
+                                kLongTimeout,
+                                actor_creator,
+                                JobID::Nil(),
+                                kTwoRateLimiter);
 
   TaskSpecification task1 = BuildEmptyTaskSpec();
   TaskSpecification task2 = BuildEmptyTaskSpec();
@@ -672,18 +672,18 @@ TEST(NormalTaskSubmitterTest, TestHandleRuntimeEnvSetupFailed) {
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
   NormalTaskSubmitter submitter(address,
-                                          raylet_client,
-                                          client_pool,
-                                          nullptr,
-                                          lease_policy,
-                                          store,
-                                          task_finisher,
-                                          NodeID::Nil(),
-                                          WorkerType::WORKER,
-                                          kLongTimeout,
-                                          actor_creator,
-                                          JobID::Nil(),
-                                          kTwoRateLimiter);
+                                raylet_client,
+                                client_pool,
+                                nullptr,
+                                lease_policy,
+                                store,
+                                task_finisher,
+                                NodeID::Nil(),
+                                WorkerType::WORKER,
+                                kLongTimeout,
+                                actor_creator,
+                                JobID::Nil(),
+                                kTwoRateLimiter);
 
   TaskSpecification task1 = BuildEmptyTaskSpec();
   TaskSpecification task2 = BuildEmptyTaskSpec();
@@ -742,18 +742,18 @@ TEST(NormalTaskSubmitterTest, TestWorkerHandleLocalRayletDied) {
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
   NormalTaskSubmitter submitter(address,
-                                          raylet_client,
-                                          client_pool,
-                                          nullptr,
-                                          lease_policy,
-                                          store,
-                                          task_finisher,
-                                          NodeID::Nil(),
-                                          WorkerType::WORKER,
-                                          kLongTimeout,
-                                          actor_creator,
-                                          JobID::Nil(),
-                                          kTwoRateLimiter);
+                                raylet_client,
+                                client_pool,
+                                nullptr,
+                                lease_policy,
+                                store,
+                                task_finisher,
+                                NodeID::Nil(),
+                                WorkerType::WORKER,
+                                kLongTimeout,
+                                actor_creator,
+                                JobID::Nil(),
+                                kTwoRateLimiter);
 
   TaskSpecification task1 = BuildEmptyTaskSpec();
   ASSERT_TRUE(submitter.SubmitTask(task1).ok());
@@ -771,18 +771,18 @@ TEST(NormalTaskSubmitterTest, TestDriverHandleLocalRayletDied) {
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
   NormalTaskSubmitter submitter(address,
-                                          raylet_client,
-                                          client_pool,
-                                          nullptr,
-                                          lease_policy,
-                                          store,
-                                          task_finisher,
-                                          NodeID::Nil(),
-                                          WorkerType::DRIVER,
-                                          kLongTimeout,
-                                          actor_creator,
-                                          JobID::Nil(),
-                                          kTwoRateLimiter);
+                                raylet_client,
+                                client_pool,
+                                nullptr,
+                                lease_policy,
+                                store,
+                                task_finisher,
+                                NodeID::Nil(),
+                                WorkerType::DRIVER,
+                                kLongTimeout,
+                                actor_creator,
+                                JobID::Nil(),
+                                kTwoRateLimiter);
 
   TaskSpecification task1 = BuildEmptyTaskSpec();
   TaskSpecification task2 = BuildEmptyTaskSpec();
@@ -828,18 +828,18 @@ TEST(NormalTaskSubmitterTest, TestConcurrentWorkerLeases) {
   int64_t concurrency = 10;
   auto rateLimiter = std::make_shared<StaticLeaseRequestRateLimiter>(concurrency);
   NormalTaskSubmitter submitter(address,
-                                          raylet_client,
-                                          client_pool,
-                                          nullptr,
-                                          lease_policy,
-                                          store,
-                                          task_finisher,
-                                          NodeID::Nil(),
-                                          WorkerType::WORKER,
-                                          kLongTimeout,
-                                          actor_creator,
-                                          JobID::Nil(),
-                                          rateLimiter);
+                                raylet_client,
+                                client_pool,
+                                nullptr,
+                                lease_policy,
+                                store,
+                                task_finisher,
+                                NodeID::Nil(),
+                                WorkerType::WORKER,
+                                kLongTimeout,
+                                actor_creator,
+                                JobID::Nil(),
+                                rateLimiter);
 
   std::vector<TaskSpecification> tasks;
   for (int i = 0; i < 2 * concurrency; i++) {
@@ -906,18 +906,18 @@ TEST(NormalTaskSubmitterTest, TestConcurrentWorkerLeasesDynamic) {
   int64_t concurrency = 10;
   auto rateLimiter = std::make_shared<DynamicRateLimiter>(1);
   NormalTaskSubmitter submitter(address,
-                                          raylet_client,
-                                          client_pool,
-                                          nullptr,
-                                          lease_policy,
-                                          store,
-                                          task_finisher,
-                                          NodeID::Nil(),
-                                          WorkerType::WORKER,
-                                          kLongTimeout,
-                                          actor_creator,
-                                          JobID::Nil(),
-                                          rateLimiter);
+                                raylet_client,
+                                client_pool,
+                                nullptr,
+                                lease_policy,
+                                store,
+                                task_finisher,
+                                NodeID::Nil(),
+                                WorkerType::WORKER,
+                                kLongTimeout,
+                                actor_creator,
+                                JobID::Nil(),
+                                rateLimiter);
 
   std::vector<TaskSpecification> tasks;
   for (int i = 0; i < 2 * concurrency; i++) {
@@ -1013,18 +1013,18 @@ TEST(NormalTaskSubmitterTest, TestConcurrentWorkerLeasesDynamicWithSpillback) {
   int64_t concurrency = 10;
   auto rateLimiter = std::make_shared<DynamicRateLimiter>(1);
   NormalTaskSubmitter submitter(address,
-                                          raylet_client,
-                                          client_pool,
-                                          lease_client_factory,
-                                          lease_policy,
-                                          store,
-                                          task_finisher,
-                                          NodeID::Nil(),
-                                          WorkerType::WORKER,
-                                          kLongTimeout,
-                                          actor_creator,
-                                          JobID::Nil(),
-                                          rateLimiter);
+                                raylet_client,
+                                client_pool,
+                                lease_client_factory,
+                                lease_policy,
+                                store,
+                                task_finisher,
+                                NodeID::Nil(),
+                                WorkerType::WORKER,
+                                kLongTimeout,
+                                actor_creator,
+                                JobID::Nil(),
+                                rateLimiter);
 
   std::vector<TaskSpecification> tasks;
   for (int i = 0; i < 2 * concurrency; i++) {
@@ -1117,18 +1117,18 @@ TEST(NormalTaskSubmitterTest, TestSubmitMultipleTasks) {
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
   NormalTaskSubmitter submitter(address,
-                                          raylet_client,
-                                          client_pool,
-                                          nullptr,
-                                          lease_policy,
-                                          store,
-                                          task_finisher,
-                                          NodeID::Nil(),
-                                          WorkerType::WORKER,
-                                          kLongTimeout,
-                                          actor_creator,
-                                          JobID::Nil(),
-                                          kOneRateLimiter);
+                                raylet_client,
+                                client_pool,
+                                nullptr,
+                                lease_policy,
+                                store,
+                                task_finisher,
+                                NodeID::Nil(),
+                                WorkerType::WORKER,
+                                kLongTimeout,
+                                actor_creator,
+                                JobID::Nil(),
+                                kOneRateLimiter);
 
   TaskSpecification task1 = BuildEmptyTaskSpec();
   TaskSpecification task2 = BuildEmptyTaskSpec();
@@ -1189,18 +1189,18 @@ TEST(NormalTaskSubmitterTest, TestReuseWorkerLease) {
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
   NormalTaskSubmitter submitter(address,
-                                          raylet_client,
-                                          client_pool,
-                                          nullptr,
-                                          lease_policy,
-                                          store,
-                                          task_finisher,
-                                          NodeID::Nil(),
-                                          WorkerType::WORKER,
-                                          kLongTimeout,
-                                          actor_creator,
-                                          JobID::Nil(),
-                                          kOneRateLimiter);
+                                raylet_client,
+                                client_pool,
+                                nullptr,
+                                lease_policy,
+                                store,
+                                task_finisher,
+                                NodeID::Nil(),
+                                WorkerType::WORKER,
+                                kLongTimeout,
+                                actor_creator,
+                                JobID::Nil(),
+                                kOneRateLimiter);
 
   TaskSpecification task1 = BuildEmptyTaskSpec();
   TaskSpecification task2 = BuildEmptyTaskSpec();
@@ -1262,18 +1262,18 @@ TEST(NormalTaskSubmitterTest, TestRetryLeaseCancellation) {
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
   NormalTaskSubmitter submitter(address,
-                                          raylet_client,
-                                          client_pool,
-                                          nullptr,
-                                          lease_policy,
-                                          store,
-                                          task_finisher,
-                                          NodeID::Nil(),
-                                          WorkerType::WORKER,
-                                          kLongTimeout,
-                                          actor_creator,
-                                          JobID::Nil(),
-                                          kOneRateLimiter);
+                                raylet_client,
+                                client_pool,
+                                nullptr,
+                                lease_policy,
+                                store,
+                                task_finisher,
+                                NodeID::Nil(),
+                                WorkerType::WORKER,
+                                kLongTimeout,
+                                actor_creator,
+                                JobID::Nil(),
+                                kOneRateLimiter);
   TaskSpecification task1 = BuildEmptyTaskSpec();
   TaskSpecification task2 = BuildEmptyTaskSpec();
   TaskSpecification task3 = BuildEmptyTaskSpec();
@@ -1330,18 +1330,18 @@ TEST(NormalTaskSubmitterTest, TestConcurrentCancellationAndSubmission) {
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
   NormalTaskSubmitter submitter(address,
-                                          raylet_client,
-                                          client_pool,
-                                          nullptr,
-                                          lease_policy,
-                                          store,
-                                          task_finisher,
-                                          NodeID::Nil(),
-                                          WorkerType::WORKER,
-                                          kLongTimeout,
-                                          actor_creator,
-                                          JobID::Nil(),
-                                          kOneRateLimiter);
+                                raylet_client,
+                                client_pool,
+                                nullptr,
+                                lease_policy,
+                                store,
+                                task_finisher,
+                                NodeID::Nil(),
+                                WorkerType::WORKER,
+                                kLongTimeout,
+                                actor_creator,
+                                JobID::Nil(),
+                                kOneRateLimiter);
   TaskSpecification task1 = BuildEmptyTaskSpec();
   TaskSpecification task2 = BuildEmptyTaskSpec();
   TaskSpecification task3 = BuildEmptyTaskSpec();
@@ -1395,18 +1395,18 @@ TEST(NormalTaskSubmitterTest, TestWorkerNotReusedOnError) {
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
   NormalTaskSubmitter submitter(address,
-                                          raylet_client,
-                                          client_pool,
-                                          nullptr,
-                                          lease_policy,
-                                          store,
-                                          task_finisher,
-                                          NodeID::Nil(),
-                                          WorkerType::WORKER,
-                                          kLongTimeout,
-                                          actor_creator,
-                                          JobID::Nil(),
-                                          kOneRateLimiter);
+                                raylet_client,
+                                client_pool,
+                                nullptr,
+                                lease_policy,
+                                store,
+                                task_finisher,
+                                NodeID::Nil(),
+                                WorkerType::WORKER,
+                                kLongTimeout,
+                                actor_creator,
+                                JobID::Nil(),
+                                kOneRateLimiter);
   TaskSpecification task1 = BuildEmptyTaskSpec();
   TaskSpecification task2 = BuildEmptyTaskSpec();
 
@@ -1451,18 +1451,18 @@ TEST(NormalTaskSubmitterTest, TestWorkerNotReturnedOnExit) {
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
   NormalTaskSubmitter submitter(address,
-                                          raylet_client,
-                                          client_pool,
-                                          nullptr,
-                                          lease_policy,
-                                          store,
-                                          task_finisher,
-                                          NodeID::Nil(),
-                                          WorkerType::WORKER,
-                                          kLongTimeout,
-                                          actor_creator,
-                                          JobID::Nil(),
-                                          kOneRateLimiter);
+                                raylet_client,
+                                client_pool,
+                                nullptr,
+                                lease_policy,
+                                store,
+                                task_finisher,
+                                NodeID::Nil(),
+                                WorkerType::WORKER,
+                                kLongTimeout,
+                                actor_creator,
+                                JobID::Nil(),
+                                kOneRateLimiter);
   TaskSpecification task1 = BuildEmptyTaskSpec();
 
   ASSERT_TRUE(submitter.SubmitTask(task1).ok());
@@ -1507,18 +1507,18 @@ TEST(NormalTaskSubmitterTest, TestSpillback) {
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
   NormalTaskSubmitter submitter(address,
-                                          raylet_client,
-                                          client_pool,
-                                          lease_client_factory,
-                                          lease_policy,
-                                          store,
-                                          task_finisher,
-                                          NodeID::Nil(),
-                                          WorkerType::WORKER,
-                                          kLongTimeout,
-                                          actor_creator,
-                                          JobID::Nil(),
-                                          kOneRateLimiter);
+                                raylet_client,
+                                client_pool,
+                                lease_client_factory,
+                                lease_policy,
+                                store,
+                                task_finisher,
+                                NodeID::Nil(),
+                                WorkerType::WORKER,
+                                kLongTimeout,
+                                actor_creator,
+                                JobID::Nil(),
+                                kOneRateLimiter);
   TaskSpecification task = BuildEmptyTaskSpec();
 
   ASSERT_TRUE(submitter.SubmitTask(task).ok());
@@ -1581,18 +1581,18 @@ TEST(NormalTaskSubmitterTest, TestSpillbackRoundTrip) {
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>(local_raylet_id);
   NormalTaskSubmitter submitter(address,
-                                          raylet_client,
-                                          client_pool,
-                                          lease_client_factory,
-                                          lease_policy,
-                                          store,
-                                          task_finisher,
-                                          local_raylet_id,
-                                          WorkerType::WORKER,
-                                          kLongTimeout,
-                                          actor_creator,
-                                          JobID::Nil(),
-                                          kOneRateLimiter);
+                                raylet_client,
+                                client_pool,
+                                lease_client_factory,
+                                lease_policy,
+                                store,
+                                task_finisher,
+                                local_raylet_id,
+                                WorkerType::WORKER,
+                                kLongTimeout,
+                                actor_creator,
+                                JobID::Nil(),
+                                kOneRateLimiter);
   TaskSpecification task = BuildEmptyTaskSpec();
 
   ASSERT_TRUE(submitter.SubmitTask(task).ok());
@@ -1659,18 +1659,18 @@ void TestSchedulingKey(const std::shared_ptr<CoreWorkerMemoryStore> store,
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
   NormalTaskSubmitter submitter(address,
-                                          raylet_client,
-                                          client_pool,
-                                          nullptr,
-                                          lease_policy,
-                                          store,
-                                          task_finisher,
-                                          NodeID::Nil(),
-                                          WorkerType::WORKER,
-                                          kLongTimeout,
-                                          actor_creator,
-                                          JobID::Nil(),
-                                          kOneRateLimiter);
+                                raylet_client,
+                                client_pool,
+                                nullptr,
+                                lease_policy,
+                                store,
+                                task_finisher,
+                                NodeID::Nil(),
+                                WorkerType::WORKER,
+                                kLongTimeout,
+                                actor_creator,
+                                JobID::Nil(),
+                                kOneRateLimiter);
 
   ASSERT_TRUE(submitter.SubmitTask(same1).ok());
   ASSERT_TRUE(submitter.SubmitTask(same2).ok());
@@ -1812,18 +1812,18 @@ TEST(NormalTaskSubmitterTest, TestBacklogReport) {
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
   NormalTaskSubmitter submitter(address,
-                                          raylet_client,
-                                          client_pool,
-                                          nullptr,
-                                          lease_policy,
-                                          store,
-                                          task_finisher,
-                                          NodeID::Nil(),
-                                          WorkerType::WORKER,
-                                          kLongTimeout,
-                                          actor_creator,
-                                          JobID::Nil(),
-                                          kOneRateLimiter);
+                                raylet_client,
+                                client_pool,
+                                nullptr,
+                                lease_policy,
+                                store,
+                                task_finisher,
+                                NodeID::Nil(),
+                                WorkerType::WORKER,
+                                kLongTimeout,
+                                actor_creator,
+                                JobID::Nil(),
+                                kOneRateLimiter);
 
   TaskSpecification task1 = BuildEmptyTaskSpec();
 
@@ -1881,18 +1881,18 @@ TEST(NormalTaskSubmitterTest, TestWorkerLeaseTimeout) {
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
   NormalTaskSubmitter submitter(address,
-                                          raylet_client,
-                                          client_pool,
-                                          nullptr,
-                                          lease_policy,
-                                          store,
-                                          task_finisher,
-                                          NodeID::Nil(),
-                                          WorkerType::WORKER,
-                                          /*lease_timeout_ms=*/5,
-                                          actor_creator,
-                                          JobID::Nil(),
-                                          kOneRateLimiter);
+                                raylet_client,
+                                client_pool,
+                                nullptr,
+                                lease_policy,
+                                store,
+                                task_finisher,
+                                NodeID::Nil(),
+                                WorkerType::WORKER,
+                                /*lease_timeout_ms=*/5,
+                                actor_creator,
+                                JobID::Nil(),
+                                kOneRateLimiter);
   TaskSpecification task1 = BuildEmptyTaskSpec();
   TaskSpecification task2 = BuildEmptyTaskSpec();
   TaskSpecification task3 = BuildEmptyTaskSpec();
@@ -1948,18 +1948,18 @@ TEST(NormalTaskSubmitterTest, TestKillExecutingTask) {
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
   NormalTaskSubmitter submitter(address,
-                                          raylet_client,
-                                          client_pool,
-                                          nullptr,
-                                          lease_policy,
-                                          store,
-                                          task_finisher,
-                                          NodeID::Nil(),
-                                          WorkerType::WORKER,
-                                          kLongTimeout,
-                                          actor_creator,
-                                          JobID::Nil(),
-                                          kOneRateLimiter);
+                                raylet_client,
+                                client_pool,
+                                nullptr,
+                                lease_policy,
+                                store,
+                                task_finisher,
+                                NodeID::Nil(),
+                                WorkerType::WORKER,
+                                kLongTimeout,
+                                actor_creator,
+                                JobID::Nil(),
+                                kOneRateLimiter);
   TaskSpecification task = BuildEmptyTaskSpec();
 
   ASSERT_TRUE(submitter.SubmitTask(task).ok());
@@ -2010,18 +2010,18 @@ TEST(NormalTaskSubmitterTest, TestKillPendingTask) {
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
   NormalTaskSubmitter submitter(address,
-                                          raylet_client,
-                                          client_pool,
-                                          nullptr,
-                                          lease_policy,
-                                          store,
-                                          task_finisher,
-                                          NodeID::Nil(),
-                                          WorkerType::WORKER,
-                                          kLongTimeout,
-                                          actor_creator,
-                                          JobID::Nil(),
-                                          kOneRateLimiter);
+                                raylet_client,
+                                client_pool,
+                                nullptr,
+                                lease_policy,
+                                store,
+                                task_finisher,
+                                NodeID::Nil(),
+                                WorkerType::WORKER,
+                                kLongTimeout,
+                                actor_creator,
+                                JobID::Nil(),
+                                kOneRateLimiter);
   TaskSpecification task = BuildEmptyTaskSpec();
 
   ASSERT_TRUE(submitter.SubmitTask(task).ok());
@@ -2055,18 +2055,18 @@ TEST(NormalTaskSubmitterTest, TestKillResolvingTask) {
   auto actor_creator = std::make_shared<MockActorCreator>();
   auto lease_policy = std::make_shared<MockLeasePolicy>();
   NormalTaskSubmitter submitter(address,
-                                          raylet_client,
-                                          client_pool,
-                                          nullptr,
-                                          lease_policy,
-                                          store,
-                                          task_finisher,
-                                          NodeID::Nil(),
-                                          WorkerType::WORKER,
-                                          kLongTimeout,
-                                          actor_creator,
-                                          JobID::Nil(),
-                                          kOneRateLimiter);
+                                raylet_client,
+                                client_pool,
+                                nullptr,
+                                lease_policy,
+                                store,
+                                task_finisher,
+                                NodeID::Nil(),
+                                WorkerType::WORKER,
+                                kLongTimeout,
+                                actor_creator,
+                                JobID::Nil(),
+                                kOneRateLimiter);
   TaskSpecification task = BuildEmptyTaskSpec();
   ObjectID obj1 = ObjectID::FromRandom();
   task.GetMutableMessage().add_args()->mutable_object_ref()->set_object_id(obj1.Binary());

--- a/src/ray/core_worker/test/object_recovery_manager_test.cc
+++ b/src/ray/core_worker/test/object_recovery_manager_test.cc
@@ -22,7 +22,7 @@
 #include "ray/common/task/task_util.h"
 #include "ray/common/test_util.h"
 #include "ray/core_worker/store_provider/memory_store/memory_store.h"
-#include "ray/core_worker/transport/direct_task_transport.h"
+#include "ray/core_worker/transport/normal_task_submitter.h"
 #include "ray/raylet_client/raylet_client.h"
 
 namespace ray {

--- a/src/ray/core_worker/transport/normal_task_submitter.cc
+++ b/src/ray/core_worker/transport/normal_task_submitter.cc
@@ -161,10 +161,10 @@ void NormalTaskSubmitter::AddWorkerLeaseClient(
 }
 
 void NormalTaskSubmitter::ReturnWorker(const rpc::Address addr,
-                                                 bool was_error,
-                                                 const std::string &error_detail,
-                                                 bool worker_exiting,
-                                                 const SchedulingKey &scheduling_key) {
+                                       bool was_error,
+                                       const std::string &error_detail,
+                                       bool worker_exiting,
+                                       const SchedulingKey &scheduling_key) {
   RAY_LOG(DEBUG) << "Returning worker " << WorkerID::FromBinary(addr.worker_id())
                  << " to raylet " << NodeID::FromBinary(addr.raylet_id());
   auto &scheduling_key_entry = scheduling_key_entries_[scheduling_key];
@@ -247,8 +247,7 @@ void NormalTaskSubmitter::OnWorkerIdle(
   RequestNewWorkerIfNeeded(scheduling_key);
 }
 
-void NormalTaskSubmitter::CancelWorkerLeaseIfNeeded(
-    const SchedulingKey &scheduling_key) {
+void NormalTaskSubmitter::CancelWorkerLeaseIfNeeded(const SchedulingKey &scheduling_key) {
   auto &scheduling_key_entry = scheduling_key_entries_[scheduling_key];
   auto &task_queue = scheduling_key_entry.task_queue;
   if (!task_queue.empty()) {
@@ -283,8 +282,7 @@ void NormalTaskSubmitter::CancelWorkerLeaseIfNeeded(
   }
 }
 
-std::shared_ptr<WorkerLeaseInterface>
-NormalTaskSubmitter::GetOrConnectLeaseClient(
+std::shared_ptr<WorkerLeaseInterface> NormalTaskSubmitter::GetOrConnectLeaseClient(
     const rpc::Address *raylet_address) {
   std::shared_ptr<WorkerLeaseInterface> lease_client;
   RAY_CHECK(raylet_address != nullptr);
@@ -350,8 +348,8 @@ void NormalTaskSubmitter::ReportWorkerBacklogIfNeeded(
   }
 }
 
-void NormalTaskSubmitter::RequestNewWorkerIfNeeded(
-    const SchedulingKey &scheduling_key, const rpc::Address *raylet_address) {
+void NormalTaskSubmitter::RequestNewWorkerIfNeeded(const SchedulingKey &scheduling_key,
+                                                   const rpc::Address *raylet_address) {
   auto &scheduling_key_entry = scheduling_key_entries_[scheduling_key];
 
   const size_t kMaxPendingLeaseRequestsPerSchedulingCategory =
@@ -753,8 +751,8 @@ void NormalTaskSubmitter::HandleGetTaskFailureCause(
 }
 
 Status NormalTaskSubmitter::CancelTask(TaskSpecification task_spec,
-                                                 bool force_kill,
-                                                 bool recursive) {
+                                       bool force_kill,
+                                       bool recursive) {
   RAY_LOG(INFO) << "Cancelling a task: " << task_spec.TaskId()
                 << " force_kill: " << force_kill << " recursive: " << recursive;
   const SchedulingKey scheduling_key(
@@ -860,9 +858,9 @@ Status NormalTaskSubmitter::CancelTask(TaskSpecification task_spec,
 }
 
 Status NormalTaskSubmitter::CancelRemoteTask(const ObjectID &object_id,
-                                                       const rpc::Address &worker_addr,
-                                                       bool force_kill,
-                                                       bool recursive) {
+                                             const rpc::Address &worker_addr,
+                                             bool force_kill,
+                                             bool recursive) {
   auto client = client_cache_->GetOrConnect(worker_addr);
   auto request = rpc::RemoteCancelTaskRequest();
   request.set_force_kill(force_kill);

--- a/src/ray/core_worker/transport/normal_task_submitter.h
+++ b/src/ray/core_worker/transport/normal_task_submitter.h
@@ -72,9 +72,9 @@ class StaticLeaseRequestRateLimiter : public LeaseRequestRateLimiter {
 };
 
 // This class is thread-safe.
-class CoreWorkerDirectTaskSubmitter {
+class NormalTaskSubmitter {
  public:
-  explicit CoreWorkerDirectTaskSubmitter(
+  explicit NormalTaskSubmitter(
       rpc::Address rpc_address,
       std::shared_ptr<WorkerLeaseInterface> lease_client,
       std::shared_ptr<rpc::CoreWorkerClientPool> core_worker_client_pool,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There is no more indirect task calls.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
