### PR TITLE
[doc][data] auto-gen GroupedData api

### DIFF
--- a/doc/source/_templates/autosummary/class_v2.rst
+++ b/doc/source/_templates/autosummary/class_v2.rst
@@ -3,7 +3,9 @@
 
 .. currentmodule:: {{ module }}
 
+{% if name | has_public_constructor(module) %}
 .. autoclass:: {{ objname }}
+{% endif %}
 
 {% block methods %}
 {% if methods %}

--- a/doc/source/_templates/autosummary/class_v2.rst
+++ b/doc/source/_templates/autosummary/class_v2.rst
@@ -1,9 +1,9 @@
-{{ name }}
-{{ '-' * name | length }}
-
 .. currentmodule:: {{ module }}
 
 {% if name | has_public_constructor(module) %}
+{{ name }}
+{{ '-' * name | length }}
+
 .. autoclass:: {{ objname }}
 {% endif %}
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -448,6 +448,7 @@ def _is_api_group(obj, group):
 FILTERS["filter_out_undoc_class_members"] = filter_out_undoc_class_members
 FILTERS["get_api_groups"] = get_api_groups
 FILTERS["select_api_group"] = select_api_group
+FILTERS["has_public_constructor"] = has_public_constructor
 
 
 def add_custom_assets(

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -406,6 +406,11 @@ def filter_out_undoc_class_members(member_name, class_name, module_name):
         return ""
 
 
+def has_public_constructor(class_name, module_name):
+    cls = getattr(import_module(module_name), class_name)
+    return _is_public_api(cls)
+
+
 def get_api_groups(method_names, class_name, module_name):
     api_groups = set()
     cls = getattr(import_module(module_name), class_name)

--- a/doc/source/data/api/_autogen.rst
+++ b/doc/source/data/api/_autogen.rst
@@ -18,3 +18,5 @@
     DataIterator
     Dataset
     Schema
+    grouped_data.GroupedData
+    aggregate.AggregateFn

--- a/doc/source/data/api/grouped_data.rst
+++ b/doc/source/data/api/grouped_data.rst
@@ -8,44 +8,5 @@ GroupedData API
 GroupedData objects are returned by groupby call: 
 :meth:`Dataset.groupby() <ray.data.Dataset.groupby>`.
 
-Constructor
------------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   grouped_data.GroupedData
-
-Computations / Descriptive Stats
---------------------------------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   grouped_data.GroupedData.count
-   grouped_data.GroupedData.sum
-   grouped_data.GroupedData.min
-   grouped_data.GroupedData.max
-   grouped_data.GroupedData.mean
-   grouped_data.GroupedData.std
-
-Function Application
---------------------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   grouped_data.GroupedData.aggregate
-   grouped_data.GroupedData.map_groups
-
-Aggregate Function
-------------------
-
-.. autosummary::
-   :nosignatures:
-   :toctree: doc/
-
-   aggregate.AggregateFn
+.. include:: ray.data.grouped_data.GroupedData.rst
+.. include:: ray.data.aggregate.AggregateFn.rst

--- a/python/ray/data/grouped_data.py
+++ b/python/ray/data/grouped_data.py
@@ -9,6 +9,9 @@ from ray.data.block import BlockAccessor, CallableClass, UserDefinedFunction
 from ray.data.dataset import DataBatch, Dataset
 from ray.util.annotations import PublicAPI
 
+CDS_API_GROUP = "Computations or Descriptive Stats"
+FA_API_GROUP = "Function Application"
+
 
 class _MultiColumnSortedKey:
     """Represents a tuple of group keys with a ``__lt__`` method
@@ -32,7 +35,6 @@ class _MultiColumnSortedKey:
         return "T" + self.data.__repr__()
 
 
-@PublicAPI
 class GroupedData:
     """Represents a grouped dataset created by calling ``Dataset.groupby()``.
 
@@ -57,6 +59,7 @@ class GroupedData:
             f"{self.__class__.__name__}(dataset={self._dataset}, " f"key={self._key!r})"
         )
 
+    @PublicAPI(api_group=FA_API_GROUP)
     def aggregate(self, *aggs: AggregateFn) -> Dataset:
         """Implements an accumulator-based aggregation.
 
@@ -102,6 +105,7 @@ class GroupedData:
         )
         return self.aggregate(*aggs)
 
+    @PublicAPI(api_group=FA_API_GROUP)
     def map_groups(
         self,
         fn: UserDefinedFunction[DataBatch, DataBatch],
@@ -272,6 +276,7 @@ class GroupedData:
             **ray_remote_args,
         )
 
+    @PublicAPI(api_group=CDS_API_GROUP)
     def count(self) -> Dataset:
         """Compute count aggregation.
 
@@ -288,6 +293,7 @@ class GroupedData:
         """
         return self.aggregate(Count())
 
+    @PublicAPI(api_group=CDS_API_GROUP)
     def sum(
         self, on: Union[str, List[str]] = None, ignore_nulls: bool = True
     ) -> Dataset:
@@ -331,6 +337,7 @@ class GroupedData:
         """
         return self._aggregate_on(Sum, on, ignore_nulls)
 
+    @PublicAPI(api_group=CDS_API_GROUP)
     def min(
         self, on: Union[str, List[str]] = None, ignore_nulls: bool = True
     ) -> Dataset:
@@ -369,6 +376,7 @@ class GroupedData:
         """
         return self._aggregate_on(Min, on, ignore_nulls)
 
+    @PublicAPI(api_group=CDS_API_GROUP)
     def max(
         self, on: Union[str, List[str]] = None, ignore_nulls: bool = True
     ) -> Dataset:
@@ -407,6 +415,7 @@ class GroupedData:
         """
         return self._aggregate_on(Max, on, ignore_nulls)
 
+    @PublicAPI(api_group=CDS_API_GROUP)
     def mean(
         self, on: Union[str, List[str]] = None, ignore_nulls: bool = True
     ) -> Dataset:
@@ -445,6 +454,7 @@ class GroupedData:
         """
         return self._aggregate_on(Mean, on, ignore_nulls)
 
+    @PublicAPI(api_group=CDS_API_GROUP)
     def std(
         self,
         on: Union[str, List[str]] = None,


### PR DESCRIPTION
Use `_autogen` to auto-generate `GroupedData` api documentation, so that we don't need to enumerate the list of public APIs anymore. Note that in the new look, constructor is un-folded by default. This is to be consistent with how we document classes elsewhere (e.g. https://docs.ray.io/en/latest/data/api/dataset.html)

readthedoc is currently broken on master which is unrelated to this change

Before:

<img width="1542" alt="Screenshot 2024-08-01 at 3 22 50 PM" src="https://github.com/user-attachments/assets/a323e897-dd0b-4051-8174-1a7aa8ea9d0c">



After:

<img width="1633" alt="Screenshot 2024-08-01 at 3 22 40 PM" src="https://github.com/user-attachments/assets/1270a0dd-0239-49e0-ae1e-46d0c591f03f">

Test:
- CI


