### PR TITLE
[doc] fix readthedocs build

### DIFF
--- a/doc/source/_templates/main-sidebar-readthedocs.html
+++ b/doc/source/_templates/main-sidebar-readthedocs.html
@@ -1,0 +1,3 @@
+<nav id="main-sidebar" class="bd-docs-nav bd-links" aria-label="{{ _('Section Navigation') }}">
+  <div class="bd-toc-item navbar-nav">{{ cached_toctree }}</div>
+</nav>

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -322,7 +322,11 @@ html_context = {
 }
 
 html_sidebars = {
-    "**": ["main-sidebar"],
+    "**": [
+        "main-sidebar-readthedocs"
+        if os.getenv("READTHEDOCS") == "True"
+        else "main-sidebar"
+    ],
     "ray-overview/examples": [],
 }
 


### PR DESCRIPTION
The main sidebar without caching version exceeds timed out limit on readthedocs, but the caching version makes it more complicated for local build.

Use the cache version of the sidebar for now to unblock. I'm requesting bigger machines from readthedocs in the mean time, to unify the build going forward.

Test:
- CI