### PR TITLE
[py312] ml cpu tests

### DIFF
--- a/.buildkite/ml.rayci.yml
+++ b/.buildkite/ml.rayci.yml
@@ -17,6 +17,18 @@ steps:
       IMAGE_TO: mlbuild
       RAYCI_IS_GPU_BUILD: "false"
 
+  - name: mlbuild-multipy
+    label: "wanda: mlbuild-py{{matrix}}"
+    wanda: ci/docker/ml.build.wanda.yaml
+    depends_on: oss-ci-base_ml-multipy
+    env:
+      IMAGE_FROM: cr.ray.io/rayproject/oss-ci-base_ml-py{{matrix}}
+      IMAGE_TO: mlbuild-py{{matrix}}
+      PYTHON: "{{matrix}}"
+      RAYCI_IS_GPU_BUILD: "false"
+    matrix:
+      - "3.12"
+
   - name: mllightning2gpubuild
     wanda: ci/docker/mllightning2gpu.build.wanda.yaml
     depends_on: oss-ci-base_gpu
@@ -39,6 +51,29 @@ steps:
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --except-tags gpu_only,gpu,minimal,tune,doctest,needs_credentials 
     depends_on: [ "mlbuild", "forge" ]
+
+  - label: ":train: ml: {{matrix.python}} tests ({{matrix.worker_id}})"
+    key: ml_python_tests
+    if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
+    tags: 
+      - python
+      - train
+      - tune
+      - ml
+    instance_type: large
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/train/... //python/ray/tune/... //python/ray/air/... ml
+        --workers 4 --worker-id {{matrix.worker_id}} --parallelism-per-worker 3
+        --python-version {{matrix.python}}
+        --except-tags gpu_only,gpu,minimal,doctest,needs_credentials,soft_imports,rllib,multinode
+    depends_on: 
+      - mlbuild-multipy
+      - forge
+    job_env: 
+    matrix:
+      setup:
+        python: ["3.12"]
+        worker_id: ["0", "1", "2", "3"]
 
   - label: ":train: ml: train gpu tests"
     tags: 

--- a/python/ray/air/tests/test_keras_callback.py
+++ b/python/ray/air/tests/test_keras_callback.py
@@ -1,21 +1,28 @@
 import os
+import sys
 from typing import Dict, Tuple
 from unittest.mock import patch
 
 import numpy as np
 import pytest
-import tensorflow as tf
 
 import ray
 from ray import train
-from ray.air.integrations.keras import ReportCheckpointCallback
 from ray.train import ScalingConfig
 from ray.train.constants import TRAIN_DATASET_KEY
-from ray.train.tensorflow import (
-    TensorflowCheckpoint,
-    TensorflowPredictor,
-    TensorflowTrainer,
-)
+
+if sys.version_info >= (3, 12):
+    # Tensorflow is not installed for Python 3.12 because of keras compatibility.
+    sys.exit(0)
+else:
+    import tensorflow as tf
+
+    from ray.air.integrations.keras import ReportCheckpointCallback
+    from ray.train.tensorflow import (
+        TensorflowCheckpoint,
+        TensorflowPredictor,
+        TensorflowTrainer,
+    )
 
 
 class TestReportCheckpointCallback:

--- a/python/ray/train/examples/experiment_tracking/lightning_exp_tracking_mlflow.py
+++ b/python/ray/train/examples/experiment_tracking/lightning_exp_tracking_mlflow.py
@@ -6,7 +6,11 @@ import tempfile
 tempdir = tempfile.TemporaryDirectory()
 os.environ["SHARED_STORAGE_PATH"] = tempdir.name
 
-from lightning_exp_tracking_model_dl import DummyModel, dataloader
+from ray.train.examples.experiment_tracking.lightning_exp_tracking_model_dl import (
+    DummyModel,
+    dataloader,
+)
+
 
 # __lightning_experiment_tracking_mlflow_start__
 import os

--- a/python/ray/train/examples/experiment_tracking/lightning_exp_tracking_tensorboard.py
+++ b/python/ray/train/examples/experiment_tracking/lightning_exp_tracking_tensorboard.py
@@ -7,7 +7,10 @@ import tempfile
 tempdir = tempfile.TemporaryDirectory()
 os.environ["SHARED_STORAGE_PATH"] = tempdir.name
 
-from lightning_exp_tracking_model_dl import DummyModel, dataloader
+from ray.train.examples.experiment_tracking.lightning_exp_tracking_model_dl import (
+    DummyModel,
+    dataloader,
+)
 
 # __lightning_experiment_tracking_tensorboard_start__
 import os

--- a/python/ray/train/examples/pytorch/tune_torch_regression_example.py
+++ b/python/ray/train/examples/pytorch/tune_torch_regression_example.py
@@ -1,10 +1,9 @@
 import argparse
 
-from torch_regression_example import get_datasets, train_func
-
 import ray
 from ray import tune
 from ray.train import DataConfig, ScalingConfig
+from ray.train.examples.pytorch.torch_regression_example import get_datasets, train_func
 from ray.train.torch import TorchTrainer
 from ray.tune.tune_config import TuneConfig
 from ray.tune.tuner import Tuner

--- a/python/ray/train/examples/tf/tensorflow_quick_start.py
+++ b/python/ray/train/examples/tf/tensorflow_quick_start.py
@@ -3,8 +3,14 @@
 # isort: skip_file
 
 # __tf_setup_begin__
+import sys
 import numpy as np
-import tensorflow as tf
+
+if sys.version_info >= (3, 12):
+    # Tensorflow is not installed for Python 3.12 because of keras compatibility.
+    sys.exit(0)
+else:
+    import tensorflow as tf
 
 def mnist_dataset(batch_size):
     (x_train, y_train), _ = tf.keras.datasets.mnist.load_data()

--- a/python/ray/train/examples/tf/tensorflow_regression_example.py
+++ b/python/ray/train/examples/tf/tensorflow_regression_example.py
@@ -1,13 +1,19 @@
 import argparse
-
-import tensorflow as tf
+import sys
 
 import ray
 from ray import train
-from ray.air.integrations.keras import ReportCheckpointCallback
 from ray.data.preprocessors import Concatenator
 from ray.train import Result, ScalingConfig
-from ray.train.tensorflow import TensorflowTrainer
+
+if sys.version_info >= (3, 12):
+    # Skip this test in Python 3.12+ because TensorFlow is not supported.
+    sys.exit(0)
+else:
+    import tensorflow as tf
+
+    from ray.air.integrations.keras import ReportCheckpointCallback
+    from ray.train.tensorflow import TensorflowTrainer
 
 
 def build_model() -> tf.keras.Model:

--- a/python/ray/train/examples/tf/tune_tensorflow_mnist_example.py
+++ b/python/ray/train/examples/tf/tune_tensorflow_mnist_example.py
@@ -1,12 +1,18 @@
 import argparse
+import sys
 
 import ray
 from ray import tune
 from ray.train import ScalingConfig
-from ray.train.examples.tf.tensorflow_mnist_example import train_func
-from ray.train.tensorflow import TensorflowTrainer
 from ray.tune.tune_config import TuneConfig
 from ray.tune.tuner import Tuner
+
+if sys.version_info >= (3, 12):
+    # Skip this test in Python 3.12+ because TensorFlow is not supported.
+    exit(0)
+else:
+    from ray.train.examples.tf.tensorflow_mnist_example import train_func
+    from ray.train.tensorflow import TensorflowTrainer
 
 
 def tune_tensorflow_mnist(

--- a/python/ray/train/tests/test_backend.py
+++ b/python/ray/train/tests/test_backend.py
@@ -1,5 +1,6 @@
 import math
 import os
+import sys
 import tempfile
 import time
 from unittest.mock import patch
@@ -28,7 +29,6 @@ from ray.train.constants import (
     ENABLE_SHARE_NEURON_CORES_ACCELERATOR_ENV,
     TRAIN_ENABLE_WORKER_SPREAD_ENV,
 )
-from ray.train.tensorflow import TensorflowConfig
 from ray.train.torch import TorchConfig
 from ray.util.placement_group import get_current_placement_group
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
@@ -311,7 +311,12 @@ def test_single_worker_actor_failure(ray_start_2_cpus):
         e.get_next_results()
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12), reason="tensorflow is not supported in python 3.12+"
+)
 def test_tensorflow_start(ray_start_2_cpus):
+    from ray.train.tensorflow import TensorflowConfig
+
     num_workers = 2
     tensorflow_config = TensorflowConfig()
     e = BackendExecutor(tensorflow_config, num_workers=num_workers)

--- a/python/ray/train/tests/test_examples.py
+++ b/python/ray/train/tests/test_examples.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from ray.air.constants import TRAINING_ITERATION
@@ -11,18 +13,22 @@ from ray.train.examples.pytorch.torch_linear_example import (
 from ray.train.examples.pytorch.torch_quick_start import (
     train_func as torch_quick_start_train_func,
 )
-from ray.train.examples.tf.tensorflow_mnist_example import (
-    train_func as tensorflow_mnist_train_func,
-)
 from ray.train.examples.tf.tensorflow_quick_start import (
     train_func as tf_quick_start_train_func,
 )
-from ray.train.tensorflow.tensorflow_trainer import TensorflowTrainer
 from ray.train.torch.torch_trainer import TorchTrainer
 
 
 @pytest.mark.parametrize("num_workers", [1, 2])
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12), reason="tensorflow is not supported in python 3.12+"
+)
 def test_tensorflow_mnist(ray_start_4_cpus, num_workers):
+    from ray.train.examples.tf.tensorflow_mnist_example import (
+        train_func as tensorflow_mnist_train_func,
+    )
+    from ray.train.tensorflow.tensorflow_trainer import TensorflowTrainer
+
     num_workers = num_workers
     epochs = 3
 
@@ -43,8 +49,13 @@ def test_tensorflow_mnist(ray_start_4_cpus, num_workers):
     assert loss[-1] < loss[0]
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12), reason="tensorflow is not supported in python 3.12+"
+)
 def test_tf_non_distributed(ray_start_4_cpus):
     """Make sure Ray Train works without TF MultiWorkerMirroredStrategy."""
+
+    from ray.train.tensorflow.tensorflow_trainer import TensorflowTrainer
 
     trainer = TensorflowTrainer(
         tf_quick_start_train_func, scaling_config=ScalingConfig(num_workers=1)

--- a/python/ray/train/tests/test_tensorflow_checkpoint.py
+++ b/python/ray/train/tests/test_tensorflow_checkpoint.py
@@ -1,16 +1,23 @@
 import os.path
+import sys
 import tempfile
 import unittest
 from typing import List
 
 import pytest
-import tensorflow as tf
 from numpy import ndarray
 
 from ray import train
 from ray.data import Preprocessor
 from ray.train import ScalingConfig
-from ray.train.tensorflow import TensorflowCheckpoint, TensorflowTrainer
+
+if sys.version_info >= (3, 12):
+    # Tensorflow is not installed for Python 3.12 because of keras compatibility.
+    sys.exit(0)
+else:
+    import tensorflow as tf
+
+    from ray.train.tensorflow import TensorflowCheckpoint, TensorflowTrainer
 
 
 class DummyPreprocessor(Preprocessor):

--- a/python/ray/train/tests/test_tensorflow_trainer.py
+++ b/python/ray/train/tests/test_tensorflow_trainer.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import tempfile
 
 import pytest
@@ -8,10 +9,15 @@ from ray import train
 from ray.data.preprocessors import Concatenator
 from ray.train import ScalingConfig
 from ray.train.constants import TRAIN_DATASET_KEY
-from ray.train.examples.tf.tensorflow_regression_example import (
-    train_func as tensorflow_linear_train_func,
-)
-from ray.train.tensorflow import TensorflowCheckpoint, TensorflowTrainer
+
+if sys.version_info >= (3, 12):
+    # Tensorflow is not installed for Python 3.12 because of keras compatibility.
+    sys.exit(0)
+else:
+    from ray.train.examples.tf.tensorflow_regression_example import (
+        train_func as tensorflow_linear_train_func,
+    )
+    from ray.train.tensorflow import TensorflowCheckpoint, TensorflowTrainer
 
 
 @pytest.fixture

--- a/python/ray/train/tests/test_training_iterator.py
+++ b/python/ray/train/tests/test_training_iterator.py
@@ -1,4 +1,5 @@
 import functools
+import sys
 import time
 from contextlib import nullcontext
 from unittest.mock import patch
@@ -16,9 +17,6 @@ from ray.train._internal.worker_group import WorkerGroup
 from ray.train.backend import BackendConfig
 from ray.train.examples.pytorch.torch_linear_example import (
     train_func as linear_train_func,
-)
-from ray.train.examples.tf.tensorflow_mnist_example import (
-    train_func as tensorflow_mnist_train_func,
 )
 from ray.train.tests.util import mock_storage_context
 from ray.train.trainer import TrainingIterator
@@ -285,7 +283,10 @@ class KillCallback:
         self.counter += 1
 
 
-@pytest.mark.parametrize("backend", ["test", "torch", "tf"])
+@pytest.mark.parametrize(
+    "backend",
+    ["test", "torch", "tf"] if sys.version_info < (3, 12) else ["test", "torch"],
+)
 def test_worker_kill(ray_start_4_cpus, backend):
     if backend == "test":
         test_config = BackendConfig()
@@ -325,11 +326,17 @@ def test_worker_kill(ray_start_4_cpus, backend):
     assert kill_callback.counter == 4
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12), reason="tensorflow is not installed in python 3.12+"
+)
 def test_tensorflow_mnist_fail(ray_start_4_cpus):
     """Tests if tensorflow example works even with worker failure."""
     epochs = 3
     num_workers = 2
 
+    from ray.train.examples.tf.tensorflow_mnist_example import (
+        train_func as tensorflow_mnist_train_func,
+    )
     from ray.train.tensorflow import TensorflowConfig
 
     test_config = TensorflowConfig()

--- a/python/ray/train/tests/test_tune.py
+++ b/python/ray/train/tests/test_tune.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 import pytest
 
@@ -12,10 +13,6 @@ from ray.train.data_parallel_trainer import DataParallelTrainer
 from ray.train.examples.pytorch.torch_fashion_mnist_example import (
     train_func_per_worker as fashion_mnist_train_func,
 )
-from ray.train.examples.tf.tensorflow_mnist_example import (
-    train_func as tensorflow_mnist_train_func,
-)
-from ray.train.tensorflow.tensorflow_trainer import TensorflowTrainer
 from ray.train.tests.util import create_dict_checkpoint, load_dict_checkpoint
 from ray.train.torch.torch_trainer import TorchTrainer
 from ray.tune.tune_config import TuneConfig
@@ -81,7 +78,15 @@ def test_tune_torch_fashion_mnist(ray_start_8_cpus):
     torch_fashion_mnist(num_workers=2, use_gpu=False, num_samples=2)
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12), reason="tensorflow is not installed in python 3.12+"
+)
 def tune_tensorflow_mnist(num_workers, use_gpu, num_samples):
+    from ray.train.examples.tf.tensorflow_mnist_example import (
+        train_func as tensorflow_mnist_train_func,
+    )
+    from ray.train.tensorflow.tensorflow_trainer import TensorflowTrainer
+
     trainer = TensorflowTrainer(
         tensorflow_mnist_train_func,
         scaling_config=ScalingConfig(num_workers=num_workers, use_gpu=use_gpu),
@@ -106,6 +111,9 @@ def tune_tensorflow_mnist(num_workers, use_gpu, num_samples):
         assert df.loc[1, "loss"] < df.loc[0, "loss"]
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12), reason="tensorflow is not installed in python 3.12+"
+)
 def test_tune_tensorflow_mnist(ray_start_8_cpus):
     tune_tensorflow_mnist(num_workers=2, use_gpu=False, num_samples=2)
 

--- a/python/ray/tune/examples/bohb_example.py
+++ b/python/ray/tune/examples/bohb_example.py
@@ -52,10 +52,9 @@ class MyTrainableClass(Trainable):
 if __name__ == "__main__":
     import sys
 
-    import pytest
-
     if sys.version_info >= (3, 12):
-        pytest.skip("TuneBOHB is not compatible with Python 3.12")
+        # TuneBOHB is not compatible with Python 3.12
+        sys.exit(0)
 
     ray.init(num_cpus=8)
 

--- a/python/ray/tune/examples/pbt_dcgan_mnist/pbt_dcgan_mnist_trainable.py
+++ b/python/ray/tune/examples/pbt_dcgan_mnist/pbt_dcgan_mnist_trainable.py
@@ -13,7 +13,11 @@ import torch.nn as nn
 import torch.nn.parallel
 import torch.optim as optim
 import torch.utils.data
-from common import (
+from filelock import FileLock
+
+import ray
+from ray import train, tune
+from ray.tune.examples.pbt_dcgan_mnist.common import (
     MODEL_PATH,
     Discriminator,
     Generator,
@@ -25,10 +29,6 @@ from common import (
     train_func,
     weights_init,
 )
-from filelock import FileLock
-
-import ray
-from ray import train, tune
 from ray.tune.schedulers import PopulationBasedTraining
 
 

--- a/python/ray/tune/examples/pbt_memnn_example.py
+++ b/python/ray/tune/examples/pbt_memnn_example.py
@@ -8,28 +8,34 @@ from __future__ import print_function
 import argparse
 import os
 import re
+import sys
 import tarfile
 
 import numpy as np
 from filelock import FileLock
-from tensorflow.keras.layers import (
-    LSTM,
-    Activation,
-    Dense,
-    Dropout,
-    Embedding,
-    Input,
-    Permute,
-    add,
-    concatenate,
-    dot,
-)
-from tensorflow.keras.models import Model, Sequential, load_model
-from tensorflow.keras.optimizers import RMSprop
-from tensorflow.keras.preprocessing.sequence import pad_sequences
-from tensorflow.keras.utils import get_file
 
 from ray import train, tune
+
+if sys.version_info >= (3, 12):
+    # Skip this test in Python 3.12+ because TensorFlow is not supported.
+    sys.exit(0)
+else:
+    from tensorflow.keras.layers import (
+        LSTM,
+        Activation,
+        Dense,
+        Dropout,
+        Embedding,
+        Input,
+        Permute,
+        add,
+        concatenate,
+        dot,
+    )
+    from tensorflow.keras.models import Model, Sequential, load_model
+    from tensorflow.keras.optimizers import RMSprop
+    from tensorflow.keras.preprocessing.sequence import pad_sequences
+    from tensorflow.keras.utils import get_file
 
 
 def tokenize(sent):

--- a/python/ray/tune/examples/tf_mnist_example.py
+++ b/python/ray/tune/examples/tf_mnist_example.py
@@ -11,15 +11,21 @@
 
 import argparse
 import os
+import sys
 
 from filelock import FileLock
-from tensorflow.keras import Model
-from tensorflow.keras.datasets.mnist import load_data
-from tensorflow.keras.layers import Conv2D, Dense, Flatten
 
 from ray import train, tune
 
 MAX_TRAIN_BATCH = 10
+
+if sys.version_info >= (3, 12):
+    # Tensorflow is not installed for Python 3.12 because of keras compatibility.
+    sys.exit(0)
+else:
+    from tensorflow.keras import Model
+    from tensorflow.keras.datasets.mnist import load_data
+    from tensorflow.keras.layers import Conv2D, Dense, Flatten
 
 
 class MyModel(Model):

--- a/python/ray/tune/examples/tune_mnist_keras.py
+++ b/python/ray/tune/examples/tune_mnist_keras.py
@@ -1,13 +1,20 @@
 import argparse
 import os
+import sys
 
 from filelock import FileLock
-from tensorflow.keras.datasets import mnist
 
 import ray
 from ray import train, tune
-from ray.air.integrations.keras import ReportCheckpointCallback
 from ray.tune.schedulers import AsyncHyperBandScheduler
+
+if sys.version_info >= (3, 12):
+    # Tensorflow is not installed for Python 3.12 because of keras compatibility.
+    sys.exit(0)
+else:
+    from tensorflow.keras.datasets import mnist
+
+    from ray.air.integrations.keras import ReportCheckpointCallback
 
 
 def train_mnist(config):

--- a/python/ray/tune/tests/test_sample.py
+++ b/python/ray/tune/tests/test_sample.py
@@ -689,6 +689,10 @@ class SearchSpaceTest(unittest.TestCase):
 
         self._testTuneSampleAPI(config_generator(), ignore=ignore)
 
+    @pytest.mark.skipif(
+        sys.version_info >= (3, 12),
+        reason="BOHB not yet supported for python 3.12+",
+    )
     def testConvertBOHB(self):
         import ConfigSpace
 
@@ -750,6 +754,9 @@ class SearchSpaceTest(unittest.TestCase):
         self.assertTrue(5 <= config["a"] <= 6)
         self.assertTrue(8 <= config["b"] <= 9)
 
+    @pytest.mark.skipif(
+        sys.version_info >= (3, 12), reason="BOHB doesn't support py312"
+    )
     def testSampleBoundsBOHB(self):
         from ray.tune.search.bohb import TuneBOHB
 
@@ -1529,6 +1536,9 @@ class SearchSpaceTest(unittest.TestCase):
 
         return self._testPointsToEvaluate(BayesOptSearch, config)
 
+    @pytest.mark.skipif(
+        sys.version_info >= (3, 12), reason="BOHB not yet supported for python 3.12+"
+    )
     def testPointsToEvaluateBOHB(self):
         config = {
             "metric": ray.tune.search.sample.Categorical([1, 2, 3, 4]).uniform(),
@@ -1846,6 +1856,10 @@ class SearchSpaceTest(unittest.TestCase):
         self.assertNotEqual(configs[0]["rand"], configs[3]["rand"])
 
     @patch.object(logger, "warning")
+    @pytest.mark.skipif(
+        sys.version_info >= (3, 12),
+        reason="TODO(justinvyu): not working for python 3.12 yet",
+    )
     def testSetSearchPropertiesBackwardsCompatibility(self, mocked_warning_method):
         from ray.tune.search import Searcher
 

--- a/python/ray/tune/tests/test_searchers.py
+++ b/python/ray/tune/tests/test_searchers.py
@@ -148,6 +148,10 @@ class InvalidValuesTest(unittest.TestCase):
             )
         self.assertCorrectExperimentOutput(out)
 
+    @pytest.mark.skipif(
+        sys.version_info >= (3, 12),
+        reason="BOHB not yet supported for python 3.12+",
+    )
     def testBOHB(self):
         from ray.tune.search.bohb import TuneBOHB
 
@@ -536,6 +540,10 @@ class SaveRestoreCheckpointTest(unittest.TestCase):
         searcher = BayesOptSearch()
         self._restore(searcher)
 
+    @pytest.mark.skipif(
+        sys.version_info >= (3, 12),
+        reason="BOHB not yet supported for python 3.12+",
+    )
     def testBOHB(self):
         from ray.tune.search.bohb import TuneBOHB
 

--- a/python/ray/tune/tests/test_tune_restore_warm_start.py
+++ b/python/ray/tune/tests/test_tune_restore_warm_start.py
@@ -329,6 +329,7 @@ class AxWarmStartTest(AbstractWarmStartTest, unittest.TestCase):
         return search_alg, cost
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 12), reason="BOHB doesn't support py312")
 class BOHBWarmStartTest(AbstractWarmStartTest, unittest.TestCase):
     def set_basic_conf(self):
         space = {"width": tune.uniform(0, 20), "height": tune.uniform(-100, 100)}

--- a/python/requirements/ml/tune-requirements.txt
+++ b/python/requirements/ml/tune-requirements.txt
@@ -7,6 +7,7 @@ bayesian-optimization==1.4.3
 ConfigSpace==0.7.1; python_version < "3.12"
 hpbandster==0.7.4; python_version < "3.12"
 
-hyperopt==0.2.7
+hyperopt @ git+https://github.com/hyperopt/hyperopt.git@2504ee61419737e814e2dec2961b15d12775529c
+future
 nevergrad==0.4.3.post7
 optuna==3.2.0

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -579,8 +579,8 @@ fugue==0.8.7
     # via statsforecast
 fugue-sql-antlr==0.2.0
     # via fugue
-future==0.18.3
-    # via hyperopt
+future==1.0.0
+    # via -r /ray/ci/../python/requirements/ml/tune-requirements.txt
 gast==0.4.0
     # via
     #   tensorflow
@@ -760,7 +760,7 @@ humanfriendly==10.0
     # via
     #   azure-cli-core
     #   coloredlogs
-hyperopt==0.2.7
+hyperopt @ git+https://github.com/hyperopt/hyperopt.git@2504ee61419737e814e2dec2961b15d12775529c
     # via -r /ray/ci/../python/requirements/ml/tune-requirements.txt
 idna==3.7
     # via
@@ -1591,9 +1591,7 @@ py-spy==0.3.14
 py3nvml==0.2.7
     # via aim
 py4j==0.10.9.7
-    # via
-    #   hyperopt
-    #   pyspark
+    # via pyspark
 pyarrow==14.0.2
     # via
     #   -r /ray/ci/../python/requirements.txt
@@ -2058,7 +2056,6 @@ six==1.16.0
     #   google-pasta
     #   gpy
     #   gsutil
-    #   hyperopt
     #   isodate
     #   junit-xml
     #   kubernetes


### PR DESCRIPTION
Add ml-cpu tests for python 3.12. Skip those tests that are relying on tensorflow, we won't suppport tensorflow for python 3.12 (for now).

Way less tests to skip compared to https://github.com/ray-project/ray/pull/46820, thanks to @justinvyu 

Test:
- CI