### PR TITLE
[Data] Make Parquet tests more robust and expose Parquet logic

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -95,7 +95,7 @@ class _SampleInfo:
 
 # TODO(ekl) this is a workaround for a pyarrow serialization bug, where serializing a
 # raw pyarrow file fragment causes S3 network calls.
-class _SerializedFragment:
+class SerializedFragment:
     def __init__(self, frag: "ParquetFileFragment"):
         self._data = cloudpickle.dumps(
             (frag.format, frag.path, frag.filesystem, frag.partition_expression)
@@ -114,12 +114,12 @@ class _SerializedFragment:
 
 # Visible for test mocking.
 def _deserialize_fragments(
-    serialized_fragments: List[_SerializedFragment],
+    serialized_fragments: List[SerializedFragment],
 ) -> List["pyarrow._dataset.ParquetFileFragment"]:
     return [p.deserialize() for p in serialized_fragments]
 
 
-def _check_for_legacy_tensor_type(schema):
+def check_for_legacy_tensor_type(schema):
     """Check for the legacy tensor extension type and raise an error if found.
 
     Ray Data uses an extension type to represent tensors in Arrow tables. Previously,
@@ -171,7 +171,6 @@ class ParquetDatasource(Datasource):
         _check_pyarrow_version()
 
         import pyarrow as pa
-        import pyarrow.parquet as pq
 
         self._supports_distributed_reads = not _is_local_scheme(paths)
         if not self._supports_distributed_reads and ray.util.client.ray.is_connected():
@@ -211,30 +210,12 @@ class ParquetDatasource(Datasource):
             filtered_paths = set(expanded_paths) - set(paths)
             if filtered_paths:
                 logger.info(f"Filtered out {len(filtered_paths)} paths")
-        else:
-            if len(paths) == 1:
-                paths = paths[0]
 
         if dataset_kwargs is None:
             dataset_kwargs = {}
 
-        try:
-            # The `use_legacy_dataset` parameter is deprecated in Arrow 15.
-            if parse_version(_get_pyarrow_version()) >= parse_version("15.0.0"):
-                pq_ds = pq.ParquetDataset(
-                    paths,
-                    **dataset_kwargs,
-                    filesystem=filesystem,
-                )
-            else:
-                pq_ds = pq.ParquetDataset(
-                    paths,
-                    **dataset_kwargs,
-                    filesystem=filesystem,
-                    use_legacy_dataset=False,
-                )
-        except OSError as e:
-            _handle_read_os_error(e, paths)
+        pq_ds = get_parquet_dataset(paths, filesystem, dataset_kwargs)
+
         if schema is None:
             schema = pq_ds.schema
         if columns:
@@ -242,7 +223,7 @@ class ParquetDatasource(Datasource):
                 [schema.field(column) for column in columns], schema.metadata
             )
 
-        _check_for_legacy_tensor_type(schema)
+        check_for_legacy_tensor_type(schema)
 
         if _block_udf is not None:
             # Try to infer dataset schema by passing dummy table through UDF.
@@ -289,7 +270,7 @@ class ParquetDatasource(Datasource):
         # NOTE: Store the custom serialized `ParquetFileFragment` to avoid unexpected
         # network calls when `_ParquetDatasourceReader` is serialized. See
         # `_SerializedFragment()` implementation for more details.
-        self._pq_fragments = [_SerializedFragment(p) for p in pq_ds.fragments]
+        self._pq_fragments = [SerializedFragment(p) for p in pq_ds.fragments]
         self._pq_paths = [p.path for p in pq_ds.fragments]
         self._meta_provider = meta_provider
         self._inferred_schema = inferred_schema
@@ -302,9 +283,15 @@ class ParquetDatasource(Datasource):
         if shuffle == "files":
             self._file_metadata_shuffler = np.random.default_rng()
 
-        sample_infos = self._sample_fragments()
-        self._encoding_ratio = _estimate_files_encoding_ratio(sample_infos)
-        self._default_read_batch_size_rows = _estimate_default_read_batch_size_rows(
+        sample_infos = sample_fragments(
+            self._pq_fragments,
+            to_batches_kwargs=to_batch_kwargs,
+            columns=columns,
+            schema=schema,
+            local_scheduling=self._local_scheduling,
+        )
+        self._encoding_ratio = estimate_files_encoding_ratio(sample_infos)
+        self._default_read_batch_size_rows = estimate_default_read_batch_size_rows(
             sample_infos
         )
 
@@ -381,7 +368,7 @@ class ParquetDatasource(Datasource):
             )
             read_tasks.append(
                 ReadTask(
-                    lambda f=fragments: _read_fragments(
+                    lambda f=fragments: read_fragments(
                         block_udf,
                         to_batches_kwargs,
                         default_read_batch_size_rows,
@@ -396,53 +383,6 @@ class ParquetDatasource(Datasource):
 
         return read_tasks
 
-    def _sample_fragments(self) -> List[_SampleInfo]:
-        # Sample a few rows from Parquet files to estimate the encoding ratio.
-        # Launch tasks to sample multiple files remotely in parallel.
-        # Evenly distributed to sample N rows in i-th row group in i-th file.
-        # TODO(ekl/cheng) take into account column pruning.
-        num_files = len(self._pq_fragments)
-        num_samples = int(num_files * PARQUET_ENCODING_RATIO_ESTIMATE_SAMPLING_RATIO)
-        min_num_samples = min(
-            PARQUET_ENCODING_RATIO_ESTIMATE_MIN_NUM_SAMPLES, num_files
-        )
-        max_num_samples = min(
-            PARQUET_ENCODING_RATIO_ESTIMATE_MAX_NUM_SAMPLES, num_files
-        )
-        num_samples = max(min(num_samples, max_num_samples), min_num_samples)
-
-        # Evenly distributed to choose which file to sample, to avoid biased prediction
-        # if data is skewed.
-        file_samples = [
-            self._pq_fragments[idx]
-            for idx in np.linspace(0, num_files - 1, num_samples).astype(int).tolist()
-        ]
-
-        sample_fragment = cached_remote_fn(_sample_fragment)
-        futures = []
-        scheduling = self._local_scheduling or "SPREAD"
-        for sample in file_samples:
-            # Sample the first rows batch in i-th file.
-            # Use SPREAD scheduling strategy to avoid packing many sampling tasks on
-            # same machine to cause OOM issue, as sampling can be memory-intensive.
-            futures.append(
-                sample_fragment.options(
-                    scheduling_strategy=scheduling,
-                    # Retry in case of transient errors during sampling.
-                    retry_exceptions=[OSError],
-                ).remote(
-                    self._to_batches_kwargs,
-                    self._columns,
-                    self._schema,
-                    sample,
-                )
-            )
-        sample_bar = ProgressBar("Parquet Files Sample", len(futures), unit="file")
-        sample_infos = sample_bar.fetch_until_complete(futures)
-        sample_bar.close()
-
-        return sample_infos
-
     def get_name(self):
         """Return a human-readable name for this datasource.
 
@@ -455,13 +395,13 @@ class ParquetDatasource(Datasource):
         return self._supports_distributed_reads
 
 
-def _read_fragments(
+def read_fragments(
     block_udf,
     to_batches_kwargs,
     default_read_batch_size_rows,
     columns,
     schema,
-    serialized_fragments: List[_SerializedFragment],
+    serialized_fragments: List[SerializedFragment],
     include_paths: bool,
 ) -> Iterator["pyarrow.Table"]:
     # This import is necessary to load the tensor extension type.
@@ -527,7 +467,7 @@ def _sample_fragment(
     to_batches_kwargs,
     columns,
     schema,
-    file_fragment: _SerializedFragment,
+    file_fragment: SerializedFragment,
 ) -> _SampleInfo:
     # Sample the first rows batch from file fragment `serialized_fragment`.
     fragment = _deserialize_fragments_with_retry([file_fragment])[0]
@@ -570,7 +510,7 @@ def _sample_fragment(
     return sample_data
 
 
-def _estimate_files_encoding_ratio(sample_infos: List[_SampleInfo]) -> float:
+def estimate_files_encoding_ratio(sample_infos: List[_SampleInfo]) -> float:
     """Return an estimate of the Parquet files encoding ratio.
 
     To avoid OOMs, it is safer to return an over-estimate than an underestimate.
@@ -594,7 +534,7 @@ def _estimate_files_encoding_ratio(sample_infos: List[_SampleInfo]) -> float:
     return max(ratio, PARQUET_ENCODING_RATIO_ESTIMATE_LOWER_BOUND)
 
 
-def _estimate_default_read_batch_size_rows(sample_infos: List[_SampleInfo]) -> int:
+def estimate_default_read_batch_size_rows(sample_infos: List[_SampleInfo]) -> int:
     def compute_batch_size_rows(sample_info: _SampleInfo) -> int:
         if sample_info.actual_bytes_per_row is None:
             return PARQUET_READER_ROW_BATCH_SIZE
@@ -612,3 +552,84 @@ def _estimate_default_read_batch_size_rows(sample_infos: List[_SampleInfo]) -> i
             )
 
     return np.mean(list(map(compute_batch_size_rows, sample_infos)))
+
+
+def get_parquet_dataset(paths, filesystem, dataset_kwargs):
+    import pyarrow.parquet as pq
+
+    # If you pass a list containing a single directory path to `ParquetDataset`, PyArrow
+    # errors with 'IsADirectoryError: Path ... points to a directory, but only file
+    # paths are supported'. To avoid this, we pass the directory path directly.
+    if len(paths) == 1:
+        paths = paths[0]
+
+    try:
+        # The `use_legacy_dataset` parameter is deprecated in Arrow 15.
+        if parse_version(_get_pyarrow_version()) >= parse_version("15.0.0"):
+            dataset = pq.ParquetDataset(
+                paths,
+                **dataset_kwargs,
+                filesystem=filesystem,
+            )
+        else:
+            dataset = pq.ParquetDataset(
+                paths,
+                **dataset_kwargs,
+                filesystem=filesystem,
+                use_legacy_dataset=False,
+            )
+    except OSError as e:
+        _handle_read_os_error(e, paths)
+
+    return dataset
+
+
+def sample_fragments(
+    serialized_fragments,
+    *,
+    to_batches_kwargs,
+    columns,
+    schema,
+    local_scheduling=None,
+) -> List[_SampleInfo]:
+    # Sample a few rows from Parquet files to estimate the encoding ratio.
+    # Launch tasks to sample multiple files remotely in parallel.
+    # Evenly distributed to sample N rows in i-th row group in i-th file.
+    # TODO(ekl/cheng) take into account column pruning.
+    num_files = len(serialized_fragments)
+    num_samples = int(num_files * PARQUET_ENCODING_RATIO_ESTIMATE_SAMPLING_RATIO)
+    min_num_samples = min(PARQUET_ENCODING_RATIO_ESTIMATE_MIN_NUM_SAMPLES, num_files)
+    max_num_samples = min(PARQUET_ENCODING_RATIO_ESTIMATE_MAX_NUM_SAMPLES, num_files)
+    num_samples = max(min(num_samples, max_num_samples), min_num_samples)
+
+    # Evenly distributed to choose which file to sample, to avoid biased prediction
+    # if data is skewed.
+    file_samples = [
+        serialized_fragments[idx]
+        for idx in np.linspace(0, num_files - 1, num_samples).astype(int).tolist()
+    ]
+
+    sample_fragment = cached_remote_fn(_sample_fragment)
+    futures = []
+    scheduling = local_scheduling or "SPREAD"
+    for sample in file_samples:
+        # Sample the first rows batch in i-th file.
+        # Use SPREAD scheduling strategy to avoid packing many sampling tasks on
+        # same machine to cause OOM issue, as sampling can be memory-intensive.
+        futures.append(
+            sample_fragment.options(
+                scheduling_strategy=scheduling,
+                # Retry in case of transient errors during sampling.
+                retry_exceptions=[OSError],
+            ).remote(
+                to_batches_kwargs,
+                columns,
+                schema,
+                sample,
+            )
+        )
+    sample_bar = ProgressBar("Parquet Files Sample", len(futures), unit="file")
+    sample_infos = sample_bar.fetch_until_complete(futures)
+    sample_bar.close()
+
+    return sample_infos

--- a/python/ray/data/datasource/parquet_meta_provider.py
+++ b/python/ray/data/datasource/parquet_meta_provider.py
@@ -12,7 +12,7 @@ from ray.util.annotations import DeveloperAPI
 if TYPE_CHECKING:
     import pyarrow
 
-    from ray.data._internal.datasource.parquet_datasource import _SerializedFragment
+    from ray.data._internal.datasource.parquet_datasource import SerializedFragment
 
 
 FRAGMENTS_PER_META_FETCH = 6
@@ -131,11 +131,11 @@ class ParquetMetadataProvider(FileMetadataProvider):
             must be returned in the same order as all input file fragments, such
             that `metadata[i]` always contains the metadata for `fragments[i]`.
         """
-        from ray.data._internal.datasource.parquet_datasource import _SerializedFragment
+        from ray.data._internal.datasource.parquet_datasource import SerializedFragment
 
         if len(fragments) > PARALLELIZE_META_FETCH_THRESHOLD:
             # Wrap Parquet fragments in serialization workaround.
-            fragments = [_SerializedFragment(fragment) for fragment in fragments]
+            fragments = [SerializedFragment(fragment) for fragment in fragments]
             # Fetch Parquet metadata in parallel using Ray tasks.
 
             def fetch_func(fragments):
@@ -162,7 +162,7 @@ class ParquetMetadataProvider(FileMetadataProvider):
 
 
 def _fetch_metadata_serialization_wrapper(
-    fragments: List["_SerializedFragment"],
+    fragments: List["SerializedFragment"],
     retry_match: Optional[List[str]],
     retry_max_attempts: int,
     retry_max_interval: int,

--- a/python/ray/data/tests/test_formats.py
+++ b/python/ray/data/tests/test_formats.py
@@ -133,10 +133,14 @@ def test_fsspec_filesystem(ray_start_regular_shared, tmp_path):
     ds._set_uuid("data")
     ds.write_parquet(out_path)
 
-    ds_df1 = pd.read_parquet(os.path.join(out_path, "data_000000_000000.parquet"))
-    ds_df2 = pd.read_parquet(os.path.join(out_path, "data_000001_000000.parquet"))
-    ds_df = pd.concat([ds_df1, ds_df2])
-    df = pd.concat([df1, df2])
+    ds_dfs = []
+    # `write_parquet` writes an unspecified number of files.
+    for path in os.listdir(out_path):
+        assert path.startswith("data_") and path.endswith(".parquet")
+        ds_dfs.append(pd.read_parquet(os.path.join(out_path, path)))
+
+    ds_df = pd.concat(ds_dfs).reset_index(drop=True)
+    df = pd.concat([df1, df2]).reset_index(drop=True)
     assert ds_df.equals(df)
 
 

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -15,8 +15,8 @@ from ray.data._internal.datasource.parquet_bulk_datasource import ParquetBulkDat
 from ray.data._internal.datasource.parquet_datasource import (
     NUM_CPUS_FOR_META_FETCH_TASK,
     ParquetDatasource,
+    SerializedFragment,
     _deserialize_fragments_with_retry,
-    _SerializedFragment,
 )
 from ray.data._internal.execution.interfaces.ref_bundle import (
     _ref_bundles_iterator_to_block_refs_list,
@@ -66,7 +66,7 @@ def test_parquet_deserialize_fragments_with_retry(
     pq_ds = pq.ParquetDataset(
         data_path, **dataset_kwargs, filesystem=fs, use_legacy_dataset=False
     )
-    serialized_fragments = [_SerializedFragment(p) for p in pq_ds.fragments]
+    serialized_fragments = [SerializedFragment(p) for p in pq_ds.fragments]
 
     # test 1st attempt succeed
     fragments = _deserialize_fragments_with_retry(serialized_fragments)
@@ -1111,15 +1111,20 @@ def test_parquet_concurrency(ray_start_regular_shared, fs, data_path):
 # tests should only be carefully reordered to retain this invariant!
 
 
-def test_parquet_read_spread(ray_start_cluster, tmp_path):
+def test_parquet_read_spread(ray_start_cluster, tmp_path, restore_data_context):
     ray.shutdown()
     cluster = ray_start_cluster
     cluster.add_node(
         resources={"bar:1": 100},
         num_cpus=10,
+        object_store_memory=2 * 1024 * 1024 * 1024,
         _system_config={"max_direct_call_object_size": 0},
     )
-    cluster.add_node(resources={"bar:2": 100}, num_cpus=10)
+    cluster.add_node(
+        resources={"bar:2": 100},
+        num_cpus=10,
+        object_store_memory=2 * 1024 * 1024 * 1024,
+    )
     cluster.add_node(resources={"bar:3": 100}, num_cpus=0)
 
     ray.init(cluster.address)
@@ -1139,6 +1144,9 @@ def test_parquet_read_spread(ray_start_cluster, tmp_path):
     path2 = os.path.join(data_path, "test2.parquet")
     df2.to_parquet(path2)
 
+    # Minimize the block size to prevent Ray Data from reading multiple fragments in a
+    # single task.
+    ray.data.DataContext.get_current().target_max_block_size = 1
     ds = ray.data.read_parquet(data_path)
 
     # Force reads.
@@ -1149,7 +1157,7 @@ def test_parquet_read_spread(ray_start_cluster, tmp_path):
     locations = []
     for block in block_refs:
         locations.extend(location_data[block]["node_ids"])
-    assert set(locations) == {node1_id, node2_id}
+    assert set(locations) == {node1_id, node2_id}, set(locations)
 
 
 def test_parquet_bulk_columns(ray_start_regular_shared):

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -910,13 +910,11 @@ def test_dataset_stats_from_items(ray_start_regular_shared):
     assert "FromItems" in stats, stats
 
 
-def test_dataset_stats_read_parquet(ray_start_regular_shared, tmp_path):
-    ds = ray.data.range(1000, override_num_blocks=10)
-    ds.write_parquet(str(tmp_path))
-    ds = ray.data.read_parquet(str(tmp_path)).map(lambda x: x)
+def test_dataset_stats_range(ray_start_regular_shared, tmp_path):
+    ds = ray.data.range(1000, override_num_blocks=10).map(lambda x: x)
     stats = canonicalize(ds.materialize().stats())
     assert stats == (
-        f"Operator N ReadParquet->Map(<lambda>): {EXECUTION_STRING}\n"
+        f"Operator N ReadRange->Map(<lambda>): {EXECUTION_STRING}\n"
         f"* Remote wall time: T min, T max, T mean, T total\n"
         f"* Remote cpu time: T min, T max, T mean, T total\n"
         f"* UDF time: T min, T max, T mean, T total\n"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR makes the following changes:
* Rewrites `test_dataset_stats_read_parquet` as `test_dataset_stats_range` to make the test independent of the Parquet implementation (the intent of the test isn't Parquet-specific)
* Makes `test_parquet_read_spread` robust to different Parquet implementations (the test makes assumptions about how tasks are launched)
* Makes `test_fsspec_filesystem` not depend on the number of files written by Ray Data (the test assumes `write_parquet` writes exactly two files)
* Exposes Parquet-specific logic to other modules
  * Removes underscores from `SerializedFragment` and `check_for_legacy_tensor_type`
  * Refactors `ParquetDatasource._sample_fragments` as `sample_fragments`
  * Introduces `get_parquet_dataset`
 
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
