### PR TITLE
[Azure][Cluster] Only set evictionPolicy to Delete when spot is used

### DIFF
--- a/python/ray/autoscaler/_private/_azure/azure-vm-template.json
+++ b/python/ray/autoscaler/_private/_azure/azure-vm-template.json
@@ -253,7 +253,7 @@
                     }
                 },
                 "priority": "[parameters('priority')]",
-                "evictionPolicy": "[parameters('evictionPolicy')]",
+                "evictionPolicy": "[if(equals(parameters('priority'), 'Spot'), parameters('evictionPolicy'), '')]",
                 "billingProfile": "[parameters('billingProfile')]"
             },
             "identity": {


### PR DESCRIPTION
previous update assumed evictionPolicy on all nodes as 'Delete', which yields error for those azure users that do not launch a Spot instance.  

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
@gramhagen , @eisber , @ijrsvt 

## Why are these changes needed?

Since Spot instance availability is low in azure, many users will launch with regular instance and encounter error.  

<!-- Please give a short summary of the change and the problem this solves. -->
added conditional logic in master azure json file to check if priority is indeed Spot , if so, then yield evictionPolicy as 'Delete', otherwise yield json('null') to skip this policy.

## Related issue number
fixes #46198

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
