### PR TITLE
[Core] Rename CoreWorkerDirectTaskReceiver to TaskReceiver

### DIFF
--- a/src/ray/core_worker/actor_manager.h
+++ b/src/ray/core_worker/actor_manager.h
@@ -20,7 +20,7 @@
 #include "ray/core_worker/actor_creator.h"
 #include "ray/core_worker/actor_handle.h"
 #include "ray/core_worker/reference_count.h"
-#include "ray/core_worker/transport/direct_actor_transport.h"
+#include "ray/core_worker/transport/task_receiver.h"
 #include "ray/gcs/gcs_client/gcs_client.h"
 namespace ray {
 namespace core {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -28,7 +28,7 @@
 #include "ray/common/runtime_env_common.h"
 #include "ray/common/task/task_util.h"
 #include "ray/core_worker/context.h"
-#include "ray/core_worker/transport/direct_actor_transport.h"
+#include "ray/core_worker/transport/task_receiver.h"
 #include "ray/gcs/gcs_client/gcs_client.h"
 #include "ray/gcs/pb_util.h"
 #include "ray/stats/metric_defs.h"
@@ -181,7 +181,7 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
                                   std::placeholders::_6,
                                   std::placeholders::_7,
                                   std::placeholders::_8);
-    direct_task_receiver_ = std::make_unique<CoreWorkerDirectTaskReceiver>(
+    task_receiver_ = std::make_unique<TaskReceiver>(
         worker_context_, task_execution_service_, execute_task, [this] {
           return local_raylet_client_->ActorCreationTaskDone();
         });
@@ -569,10 +569,9 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
                                             rpc_address_));
 
   // Unfortunately the raylet client has to be constructed after the receivers.
-  if (direct_task_receiver_ != nullptr) {
+  if (task_receiver_ != nullptr) {
     task_argument_waiter_.reset(new DependencyWaiterImpl(*local_raylet_client_));
-    direct_task_receiver_->Init(
-        core_worker_client_pool_, rpc_address_, task_argument_waiter_);
+    task_receiver_->Init(core_worker_client_pool_, rpc_address_, task_argument_waiter_);
   }
 
   actor_manager_ = std::make_unique<ActorManager>(
@@ -729,7 +728,7 @@ void CoreWorker::Shutdown() {
     if (worker_context_.CurrentActorIsAsync()) {
       options_.terminate_asyncio_thread();
     }
-    direct_task_receiver_->Stop();
+    task_receiver_->Stop();
     task_execution_service_.stop();
   }
   if (options_.on_worker_shutdown) {
@@ -3516,13 +3515,13 @@ void CoreWorker::HandlePushTask(rpc::PushTaskRequest request,
                           << " won't be executed because the worker already exited.";
             return;
           }
-          direct_task_receiver_->HandleTask(request, reply, send_reply_callback);
+          task_receiver_->HandleTask(request, reply, send_reply_callback);
         },
         "CoreWorker.HandlePushTaskActor");
   } else {
     // Normal tasks are enqueued here, and we post a RunNormalTasksFromQueue instance to
     // the task execution service.
-    direct_task_receiver_->HandleTask(request, reply, send_reply_callback);
+    task_receiver_->HandleTask(request, reply, send_reply_callback);
     task_execution_service_.post(
         [this, func_name] {
           // We have posted an exit task onto the main event loop,
@@ -3532,7 +3531,7 @@ void CoreWorker::HandlePushTask(rpc::PushTaskRequest request,
                           << " won't be executed because the worker already exited.";
             return;
           }
-          direct_task_receiver_->RunNormalTasksFromQueue();
+          task_receiver_->RunNormalTasksFromQueue();
         },
         "CoreWorker.HandlePushTask");
   }
@@ -4059,7 +4058,7 @@ void CoreWorker::CancelTaskOnExecutor(TaskID task_id,
         << "Cancelling a task that's not running. Tasks will be removed from a queue.";
     // If the task is not currently running, check if it is in the worker's queue of
     // normal tasks, and remove it if found.
-    success = direct_task_receiver_->CancelQueuedNormalTask(task_id);
+    success = task_receiver_->CancelQueuedNormalTask(task_id);
   }
   if (recursive) {
     auto recursive_cancel = CancelChildren(task_id, force_kill);
@@ -4090,7 +4089,7 @@ void CoreWorker::CancelActorTaskOnExecutor(WorkerID caller_worker_id,
     std::string concurrency_group_name;
 
     bool is_task_queued_or_executing =
-        direct_task_receiver_->CancelQueuedActorTask(caller_worker_id, task_id);
+        task_receiver_->CancelQueuedActorTask(caller_worker_id, task_id);
 
     // If a task is already running, we send a cancel request.
     // Right now, we can only cancel async actor tasks.
@@ -4565,8 +4564,8 @@ void CoreWorker::SetActorTitle(const std::string &title) {
 }
 
 void CoreWorker::SetActorReprName(const std::string &repr_name) {
-  RAY_CHECK(direct_task_receiver_ != nullptr);
-  direct_task_receiver_->SetActorReprName(repr_name);
+  RAY_CHECK(task_receiver_ != nullptr);
+  task_receiver_->SetActorReprName(repr_name);
 
   absl::MutexLock lock(&mutex_);
   actor_repr_name_ = repr_name;

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -37,8 +37,8 @@
 #include "ray/core_worker/store_provider/memory_store/memory_store.h"
 #include "ray/core_worker/store_provider/plasma_store_provider.h"
 #include "ray/core_worker/task_event_buffer.h"
-#include "ray/core_worker/transport/direct_actor_transport.h"
 #include "ray/core_worker/transport/normal_task_submitter.h"
+#include "ray/core_worker/transport/task_receiver.h"
 #include "ray/gcs/gcs_client/gcs_client.h"
 #include "ray/pubsub/publisher.h"
 #include "ray/pubsub/subscriber.h"
@@ -1906,7 +1906,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   std::shared_ptr<DependencyWaiterImpl> task_argument_waiter_;
 
   // Interface that receives tasks from direct actor calls.
-  std::unique_ptr<CoreWorkerDirectTaskReceiver> direct_task_receiver_;
+  std::unique_ptr<TaskReceiver> task_receiver_;
 
   /// Event loop where tasks are processed.
   /// task_execution_service_ should be destructed first to avoid

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.h
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.h
@@ -39,7 +39,7 @@ class CoreWorkerMemoryStore;
 
 /// The class provides implementations for local process memory store.
 /// An example usage for this is to retrieve the returned objects from direct
-/// actor call (see direct_actor_transport.cc).
+/// actor call (see task_receiver.cc).
 class CoreWorkerMemoryStore {
  public:
   /// Create a memory store.

--- a/src/ray/core_worker/test/actor_manager_test.cc
+++ b/src/ray/core_worker/test/actor_manager_test.cc
@@ -19,7 +19,7 @@
 #include "ray/common/task/task_spec.h"
 #include "ray/common/test_util.h"
 #include "ray/core_worker/reference_count.h"
-#include "ray/core_worker/transport/direct_actor_transport.h"
+#include "ray/core_worker/transport/task_receiver.h"
 #include "ray/gcs/gcs_client/accessor.h"
 #include "ray/gcs/gcs_client/gcs_client.h"
 

--- a/src/ray/core_worker/test/concurrency_group_manager_test.cc
+++ b/src/ray/core_worker/test/concurrency_group_manager_test.cc
@@ -17,7 +17,7 @@
 #include "gtest/gtest.h"
 #include "ray/common/asio/instrumented_io_context.h"
 #include "ray/common/test_util.h"
-#include "ray/core_worker/transport/direct_actor_transport.h"
+#include "ray/core_worker/transport/task_receiver.h"
 
 namespace ray {
 namespace core {

--- a/src/ray/core_worker/test/direct_actor_transport_mock_test.cc
+++ b/src/ray/core_worker/test/direct_actor_transport_mock_test.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // clang-format off
-#include "ray/core_worker/transport/direct_actor_transport.h"
+#include "ray/core_worker/transport/task_receiver.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "ray/core_worker/actor_creator.h"

--- a/src/ray/core_worker/test/direct_actor_transport_test.cc
+++ b/src/ray/core_worker/test/direct_actor_transport_test.cc
@@ -102,9 +102,9 @@ class MockWorkerClient : public rpc::CoreWorkerClientInterface {
   int64_t acked_seqno = 0;
 };
 
-class DirectActorSubmitterTest : public ::testing::TestWithParam<bool> {
+class ActorTaskSubmitterTest : public ::testing::TestWithParam<bool> {
  public:
-  DirectActorSubmitterTest()
+  ActorTaskSubmitterTest()
       : client_pool_(
             std::make_shared<rpc::CoreWorkerClientPool>([&](const rpc::Address &addr) {
               num_clients_connected_++;
@@ -144,7 +144,7 @@ class DirectActorSubmitterTest : public ::testing::TestWithParam<bool> {
   }
 };
 
-TEST_P(DirectActorSubmitterTest, TestSubmitTask) {
+TEST_P(ActorTaskSubmitterTest, TestSubmitTask) {
   auto execute_out_of_order = GetParam();
   rpc::Address addr;
   auto worker_id = WorkerID::FromRandom();
@@ -178,7 +178,7 @@ TEST_P(DirectActorSubmitterTest, TestSubmitTask) {
   ASSERT_THAT(worker_client_->received_seq_nos, ElementsAre(0, 1));
 }
 
-TEST_P(DirectActorSubmitterTest, TestQueueingWarning) {
+TEST_P(ActorTaskSubmitterTest, TestQueueingWarning) {
   auto execute_out_of_order = GetParam();
   rpc::Address addr;
   auto worker_id = WorkerID::FromRandom();
@@ -209,7 +209,7 @@ TEST_P(DirectActorSubmitterTest, TestQueueingWarning) {
   ASSERT_EQ(last_queue_warning_, 20000);
 }
 
-TEST_P(DirectActorSubmitterTest, TestDependencies) {
+TEST_P(ActorTaskSubmitterTest, TestDependencies) {
   auto execute_out_of_order = GetParam();
   rpc::Address addr;
   auto worker_id = WorkerID::FromRandom();
@@ -244,7 +244,7 @@ TEST_P(DirectActorSubmitterTest, TestDependencies) {
   ASSERT_THAT(worker_client_->received_seq_nos, ElementsAre(0, 1));
 }
 
-TEST_P(DirectActorSubmitterTest, TestOutOfOrderDependencies) {
+TEST_P(ActorTaskSubmitterTest, TestOutOfOrderDependencies) {
   auto execute_out_of_order = GetParam();
   rpc::Address addr;
   auto worker_id = WorkerID::FromRandom();
@@ -294,7 +294,7 @@ TEST_P(DirectActorSubmitterTest, TestOutOfOrderDependencies) {
   }
 }
 
-TEST_P(DirectActorSubmitterTest, TestActorDead) {
+TEST_P(ActorTaskSubmitterTest, TestActorDead) {
   auto execute_out_of_order = GetParam();
   rpc::Address addr;
   auto worker_id = WorkerID::FromRandom();
@@ -330,7 +330,7 @@ TEST_P(DirectActorSubmitterTest, TestActorDead) {
   submitter_.DisconnectActor(actor_id, 2, /*dead=*/true, death_cause);
 }
 
-TEST_P(DirectActorSubmitterTest, TestActorRestartNoRetry) {
+TEST_P(ActorTaskSubmitterTest, TestActorRestartNoRetry) {
   auto execute_out_of_order = GetParam();
   rpc::Address addr;
   auto worker_id = WorkerID::FromRandom();
@@ -383,7 +383,7 @@ TEST_P(DirectActorSubmitterTest, TestActorRestartNoRetry) {
   }
 }
 
-TEST_P(DirectActorSubmitterTest, TestActorRestartRetry) {
+TEST_P(ActorTaskSubmitterTest, TestActorRestartRetry) {
   auto execute_out_of_order = GetParam();
   rpc::Address addr;
   auto worker_id = WorkerID::FromRandom();
@@ -444,7 +444,7 @@ TEST_P(DirectActorSubmitterTest, TestActorRestartRetry) {
   }
 }
 
-TEST_P(DirectActorSubmitterTest, TestActorRestartOutOfOrderRetry) {
+TEST_P(ActorTaskSubmitterTest, TestActorRestartOutOfOrderRetry) {
   auto execute_out_of_order = GetParam();
   rpc::Address addr;
   auto worker_id = WorkerID::FromRandom();
@@ -505,7 +505,7 @@ TEST_P(DirectActorSubmitterTest, TestActorRestartOutOfOrderRetry) {
   }
 }
 
-TEST_P(DirectActorSubmitterTest, TestActorRestartOutOfOrderGcs) {
+TEST_P(ActorTaskSubmitterTest, TestActorRestartOutOfOrderGcs) {
   auto execute_out_of_order = GetParam();
   rpc::Address addr;
   auto worker_id = WorkerID::FromRandom();
@@ -579,7 +579,7 @@ TEST_P(DirectActorSubmitterTest, TestActorRestartOutOfOrderGcs) {
   ASSERT_FALSE(CheckSubmitTask(task));
 }
 
-TEST_P(DirectActorSubmitterTest, TestActorRestartFailInflightTasks) {
+TEST_P(ActorTaskSubmitterTest, TestActorRestartFailInflightTasks) {
   auto execute_out_of_order = GetParam();
   rpc::Address addr;
   auto worker_id = WorkerID::FromRandom();
@@ -626,7 +626,7 @@ TEST_P(DirectActorSubmitterTest, TestActorRestartFailInflightTasks) {
   ASSERT_TRUE(worker_client_->ReplyPushTask(Status::IOError("")));
 }
 
-TEST_P(DirectActorSubmitterTest, TestActorRestartFastFail) {
+TEST_P(ActorTaskSubmitterTest, TestActorRestartFastFail) {
   auto execute_out_of_order = GetParam();
   rpc::Address addr;
   auto worker_id = WorkerID::FromRandom();
@@ -657,7 +657,7 @@ TEST_P(DirectActorSubmitterTest, TestActorRestartFastFail) {
   ASSERT_EQ(io_context.poll_one(), 1);
 }
 
-TEST_P(DirectActorSubmitterTest, TestPendingTasks) {
+TEST_P(ActorTaskSubmitterTest, TestPendingTasks) {
   auto execute_out_of_order = GetParam();
   int32_t max_pending_calls = 10;
   rpc::Address addr;
@@ -698,7 +698,7 @@ TEST_P(DirectActorSubmitterTest, TestPendingTasks) {
 }
 
 INSTANTIATE_TEST_SUITE_P(ExecuteOutOfOrder,
-                         DirectActorSubmitterTest,
+                         ActorTaskSubmitterTest,
                          ::testing::Values(true, false));
 
 class MockDependencyWaiter : public DependencyWaiter {
@@ -718,14 +718,13 @@ class MockWorkerContext : public WorkerContext {
   }
 };
 
-class MockCoreWorkerDirectTaskReceiver : public CoreWorkerDirectTaskReceiver {
+class MockTaskReceiver : public TaskReceiver {
  public:
-  MockCoreWorkerDirectTaskReceiver(
-      WorkerContext &worker_context,
-      instrumented_io_context &main_io_service,
-      const TaskHandler &task_handler,
-      const OnActorCreationTaskDone &actor_creation_task_done_)
-      : CoreWorkerDirectTaskReceiver(
+  MockTaskReceiver(WorkerContext &worker_context,
+                   instrumented_io_context &main_io_service,
+                   const TaskHandler &task_handler,
+                   const OnActorCreationTaskDone &actor_creation_task_done_)
+      : TaskReceiver(
             worker_context, main_io_service, task_handler, actor_creation_task_done_) {}
 
   void UpdateConcurrencyGroupsCache(const ActorID &actor_id,
@@ -734,13 +733,13 @@ class MockCoreWorkerDirectTaskReceiver : public CoreWorkerDirectTaskReceiver {
   }
 };
 
-class DirectActorReceiverTest : public ::testing::Test {
+class TaskReceiverTest : public ::testing::Test {
  public:
-  DirectActorReceiverTest()
+  TaskReceiverTest()
       : worker_context_(WorkerType::WORKER, JobID::FromInt(0)),
         worker_client_(std::shared_ptr<MockWorkerClient>(new MockWorkerClient())),
         dependency_waiter_(std::make_shared<MockDependencyWaiter>()) {
-    auto execute_task = std::bind(&DirectActorReceiverTest::MockExecuteTask,
+    auto execute_task = std::bind(&TaskReceiverTest::MockExecuteTask,
                                   this,
                                   std::placeholders::_1,
                                   std::placeholders::_2,
@@ -748,7 +747,7 @@ class DirectActorReceiverTest : public ::testing::Test {
                                   std::placeholders::_4,
                                   std::placeholders::_5,
                                   std::placeholders::_6);
-    receiver_ = std::make_unique<MockCoreWorkerDirectTaskReceiver>(
+    receiver_ = std::make_unique<MockTaskReceiver>(
         worker_context_, main_io_service_, execute_task, [] { return Status::OK(); });
     receiver_->Init(std::make_shared<rpc::CoreWorkerClientPool>(
                         [&](const rpc::Address &addr) { return worker_client_; }),
@@ -776,7 +775,7 @@ class DirectActorReceiverTest : public ::testing::Test {
     main_io_service_.stop();
   }
 
-  std::unique_ptr<MockCoreWorkerDirectTaskReceiver> receiver_;
+  std::unique_ptr<MockTaskReceiver> receiver_;
 
  private:
   rpc::Address rpc_address_;
@@ -786,7 +785,7 @@ class DirectActorReceiverTest : public ::testing::Test {
   std::shared_ptr<DependencyWaiter> dependency_waiter_;
 };
 
-TEST_F(DirectActorReceiverTest, TestNewTaskFromDifferentWorker) {
+TEST_F(TaskReceiverTest, TestNewTaskFromDifferentWorker) {
   TaskID current_task_id = TaskID::Nil();
   ActorID actor_id = ActorID::Of(JobID::FromInt(0), TaskID::Nil(), 0);
   WorkerID worker_id = WorkerID::FromRandom();

--- a/src/ray/core_worker/test/scheduling_queue_test.cc
+++ b/src/ray/core_worker/test/scheduling_queue_test.cc
@@ -17,7 +17,7 @@
 #include "gtest/gtest.h"
 #include "ray/common/asio/instrumented_io_context.h"
 #include "ray/common/test_util.h"
-#include "ray/core_worker/transport/direct_actor_transport.h"
+#include "ray/core_worker/transport/task_receiver.h"
 
 namespace ray {
 namespace core {

--- a/src/ray/core_worker/transport/normal_task_submitter.h
+++ b/src/ray/core_worker/transport/normal_task_submitter.h
@@ -26,7 +26,7 @@
 #include "ray/core_worker/store_provider/memory_store/memory_store.h"
 #include "ray/core_worker/task_manager.h"
 #include "ray/core_worker/transport/dependency_resolver.h"
-#include "ray/core_worker/transport/direct_actor_transport.h"
+#include "ray/core_worker/transport/task_receiver.h"
 #include "ray/raylet_client/raylet_client.h"
 #include "ray/rpc/worker/core_worker_client.h"
 #include "ray/rpc/worker/core_worker_client_pool.h"

--- a/src/ray/core_worker/transport/task_receiver.cc
+++ b/src/ray/core_worker/transport/task_receiver.cc
@@ -25,7 +25,7 @@ using namespace ray::gcs;
 namespace ray {
 namespace core {
 
-void CoreWorkerDirectTaskReceiver::Init(
+void TaskReceiver::Init(
     std::shared_ptr<rpc::CoreWorkerClientPool> client_pool,
     rpc::Address rpc_address,
     std::shared_ptr<DependencyWaiter> dependency_waiter) {
@@ -34,7 +34,7 @@ void CoreWorkerDirectTaskReceiver::Init(
   client_pool_ = client_pool;
 }
 
-void CoreWorkerDirectTaskReceiver::HandleTask(
+void TaskReceiver::HandleTask(
     const rpc::PushTaskRequest &request,
     rpc::PushTaskReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
@@ -289,7 +289,7 @@ void CoreWorkerDirectTaskReceiver::HandleTask(
   }
 }
 
-void CoreWorkerDirectTaskReceiver::RunNormalTasksFromQueue() {
+void TaskReceiver::RunNormalTasksFromQueue() {
   // If the scheduling queue is empty, return.
   if (normal_scheduling_queue_->TaskQueueEmpty()) {
     return;
@@ -299,7 +299,7 @@ void CoreWorkerDirectTaskReceiver::RunNormalTasksFromQueue() {
   normal_scheduling_queue_->ScheduleRequests();
 }
 
-bool CoreWorkerDirectTaskReceiver::CancelQueuedActorTask(const WorkerID &caller_worker_id,
+bool TaskReceiver::CancelQueuedActorTask(const WorkerID &caller_worker_id,
                                                          const TaskID &task_id) {
   auto it = actor_scheduling_queues_.find(caller_worker_id);
   if (it != actor_scheduling_queues_.end()) {
@@ -310,14 +310,14 @@ bool CoreWorkerDirectTaskReceiver::CancelQueuedActorTask(const WorkerID &caller_
   }
 }
 
-bool CoreWorkerDirectTaskReceiver::CancelQueuedNormalTask(TaskID task_id) {
+bool TaskReceiver::CancelQueuedNormalTask(TaskID task_id) {
   // Look up the task to be canceled in the queue of normal tasks. If it is found and
   // removed successfully, return true.
   return normal_scheduling_queue_->CancelTaskIfFound(task_id);
 }
 
 /// Note that this method is only used for asyncio actor.
-void CoreWorkerDirectTaskReceiver::SetupActor(bool is_asyncio,
+void TaskReceiver::SetupActor(bool is_asyncio,
                                               int fiber_max_concurrency,
                                               bool execute_out_of_order) {
   RAY_CHECK(fiber_max_concurrency_ == 0)
@@ -327,13 +327,13 @@ void CoreWorkerDirectTaskReceiver::SetupActor(bool is_asyncio,
   execute_out_of_order_ = execute_out_of_order;
 }
 
-void CoreWorkerDirectTaskReceiver::Stop() {
+void TaskReceiver::Stop() {
   for (const auto &[_, scheduling_queue] : actor_scheduling_queues_) {
     scheduling_queue->Stop();
   }
 }
 
-void CoreWorkerDirectTaskReceiver::SetActorReprName(const std::string &repr_name) {
+void TaskReceiver::SetActorReprName(const std::string &repr_name) {
   actor_repr_name_ = repr_name;
 }
 

--- a/src/ray/core_worker/transport/task_receiver.cc
+++ b/src/ray/core_worker/transport/task_receiver.cc
@@ -25,19 +25,17 @@ using namespace ray::gcs;
 namespace ray {
 namespace core {
 
-void TaskReceiver::Init(
-    std::shared_ptr<rpc::CoreWorkerClientPool> client_pool,
-    rpc::Address rpc_address,
-    std::shared_ptr<DependencyWaiter> dependency_waiter) {
+void TaskReceiver::Init(std::shared_ptr<rpc::CoreWorkerClientPool> client_pool,
+                        rpc::Address rpc_address,
+                        std::shared_ptr<DependencyWaiter> dependency_waiter) {
   waiter_ = std::move(dependency_waiter);
   rpc_address_ = rpc_address;
   client_pool_ = client_pool;
 }
 
-void TaskReceiver::HandleTask(
-    const rpc::PushTaskRequest &request,
-    rpc::PushTaskReply *reply,
-    rpc::SendReplyCallback send_reply_callback) {
+void TaskReceiver::HandleTask(const rpc::PushTaskRequest &request,
+                              rpc::PushTaskReply *reply,
+                              rpc::SendReplyCallback send_reply_callback) {
   RAY_CHECK(waiter_ != nullptr) << "Must call init() prior to use";
   // Use `mutable_task_spec()` here as `task_spec()` returns a const reference
   // which doesn't work with std::move.
@@ -300,7 +298,7 @@ void TaskReceiver::RunNormalTasksFromQueue() {
 }
 
 bool TaskReceiver::CancelQueuedActorTask(const WorkerID &caller_worker_id,
-                                                         const TaskID &task_id) {
+                                         const TaskID &task_id) {
   auto it = actor_scheduling_queues_.find(caller_worker_id);
   if (it != actor_scheduling_queues_.end()) {
     return it->second->CancelTaskIfFound(task_id);
@@ -318,8 +316,8 @@ bool TaskReceiver::CancelQueuedNormalTask(TaskID task_id) {
 
 /// Note that this method is only used for asyncio actor.
 void TaskReceiver::SetupActor(bool is_asyncio,
-                                              int fiber_max_concurrency,
-                                              bool execute_out_of_order) {
+                              int fiber_max_concurrency,
+                              bool execute_out_of_order) {
   RAY_CHECK(fiber_max_concurrency_ == 0)
       << "SetupActor should only be called at most once.";
   is_asyncio_ = is_asyncio;

--- a/src/ray/core_worker/transport/task_receiver.cc
+++ b/src/ray/core_worker/transport/task_receiver.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "ray/core_worker/transport/direct_actor_transport.h"
+#include "ray/core_worker/transport/task_receiver.h"
 
 #include <thread>
 

--- a/src/ray/core_worker/transport/task_receiver.h
+++ b/src/ray/core_worker/transport/task_receiver.h
@@ -48,7 +48,7 @@
 namespace ray {
 namespace core {
 
-class CoreWorkerDirectTaskReceiver {
+class TaskReceiver {
  public:
   using TaskHandler = std::function<Status(
       const TaskSpecification &task_spec,
@@ -63,7 +63,7 @@ class CoreWorkerDirectTaskReceiver {
 
   using OnActorCreationTaskDone = std::function<Status()>;
 
-  CoreWorkerDirectTaskReceiver(WorkerContext &worker_context,
+  TaskReceiver(WorkerContext &worker_context,
                                instrumented_io_context &main_io_service,
                                const TaskHandler &task_handler,
                                const OnActorCreationTaskDone &actor_creation_task_done_)

--- a/src/ray/core_worker/transport/task_receiver.h
+++ b/src/ray/core_worker/transport/task_receiver.h
@@ -64,9 +64,9 @@ class TaskReceiver {
   using OnActorCreationTaskDone = std::function<Status()>;
 
   TaskReceiver(WorkerContext &worker_context,
-                               instrumented_io_context &main_io_service,
-                               const TaskHandler &task_handler,
-                               const OnActorCreationTaskDone &actor_creation_task_done_)
+               instrumented_io_context &main_io_service,
+               const TaskHandler &task_handler,
+               const OnActorCreationTaskDone &actor_creation_task_done_)
       : worker_context_(worker_context),
         task_handler_(task_handler),
         task_main_io_service_(main_io_service),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There is no indirect task call anymore
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
