### PR TITLE
[release-automation] Command to check whether all release wheels exist on S3

### DIFF
--- a/ci/ray_ci/automation/BUILD.bazel
+++ b/ci/ray_ci/automation/BUILD.bazel
@@ -209,6 +209,16 @@ py_binary(
     ],
 )
 
+py_binary(
+    name = "check_s3_wheels_exist",
+    srcs = ["check_s3_wheels_exist.py"],
+    exec_compatible_with = ["//:hermetic_python"],
+    deps = [
+        ":ray_wheels_lib",
+        ci_require("click"),
+    ],
+)
+
 py_test(
     name = "test_determine_microcheck_tests",
     srcs = ["test_determine_microcheck_tests.py"],

--- a/ci/ray_ci/automation/check_s3_wheels_exist.py
+++ b/ci/ray_ci/automation/check_s3_wheels_exist.py
@@ -1,0 +1,22 @@
+import click
+import time
+import sys
+from ci.ray_ci.automation.ray_wheels_lib import check_wheels_exist_on_s3
+
+
+@click.command()
+@click.option("--ray_version", required=True, type=str)
+@click.option("--commit_hash", required=True, type=str)
+def main(ray_version, commit_hash):
+    all_wheels_exist = False
+    start_time = time.time()
+    while not all_wheels_exist:
+        current_time = time.time()
+        # If the check takes more than 2 hours, fail job
+        if current_time - start_time > 7200:
+            sys.exit(42)
+        time.sleep(300)
+        all_wheels_exist = check_wheels_exist_on_s3(commit_hash=commit_hash, ray_version=ray_version)
+
+if __name__ == "__main__":
+    main()

--- a/ci/ray_ci/automation/check_s3_wheels_exist.py
+++ b/ci/ray_ci/automation/check_s3_wheels_exist.py
@@ -8,15 +8,15 @@ from ci.ray_ci.automation.ray_wheels_lib import check_wheels_exist_on_s3
 @click.option("--ray_version", required=True, type=str)
 @click.option("--commit_hash", required=True, type=str)
 def main(ray_version, commit_hash):
-    all_wheels_exist = False
     start_time = time.time()
-    while not all_wheels_exist:
+    while not check_wheels_exist_on_s3(commit_hash=commit_hash, ray_version=ray_version):
         current_time = time.time()
         # If the check takes more than 2 hours, fail job
         if current_time - start_time > 7200:
             sys.exit(42)
+        print("Wheels are not yet on S3. Sleeping for 5 minutes...")
         time.sleep(300)
-        all_wheels_exist = check_wheels_exist_on_s3(commit_hash=commit_hash, ray_version=ray_version)
+    print("All release wheels are on S3")
 
 if __name__ == "__main__":
     main()

--- a/ci/ray_ci/automation/ray_wheels_lib.py
+++ b/ci/ray_ci/automation/ray_wheels_lib.py
@@ -109,6 +109,6 @@ def check_wheels_exist_on_s3(commit_hash: str, ray_version: str) -> bool:
         try:
             s3_client.head_object(Bucket=RAY_WHEELS_BUCKET, Key=wheel_s3_key)
         except Exception as e:
-            logger.error(f"Wheel {wheel_s3_key} does not exist on S3: {e}")
+            logger.info(f"Wheel {wheel_s3_key} does not exist on S3: {e}")
             return False
     return True

--- a/ci/ray_ci/automation/ray_wheels_lib.py
+++ b/ci/ray_ci/automation/ray_wheels_lib.py
@@ -15,6 +15,7 @@ ALL_PLATFORMS = [
     "win_amd64",
 ]
 RAY_TYPES = ["ray", "ray_cpp"]
+RAY_WHEELS_BUCKET = "ray-wheels"
 
 
 def _check_downloaded_wheels(directory_path: str, wheels: List[str]) -> None:
@@ -60,14 +61,15 @@ def download_wheel_from_s3(key: str, directory_path: str) -> None:
         key: The key of the wheel in S3.
         directory_path: The directory to download the wheel to.
     """
-    bucket = "ray-wheels"
     s3_client = boto3.client("s3", region_name="us-west-2")
     wheel_name = key.split("/")[-1]  # Split key to get the wheel file name
 
     logger.info(
-        f"Downloading {bucket}/{key} to {directory_path}/{wheel_name} ........."
+        f"Downloading {RAY_WHEELS_BUCKET}/{key} to {directory_path}/{wheel_name} ..."
     )
-    s3_client.download_file(bucket, key, os.path.join(directory_path, wheel_name))
+    s3_client.download_file(
+        RAY_WHEELS_BUCKET, key, os.path.join(directory_path, wheel_name)
+    )
 
 
 def download_ray_wheels_from_s3(
@@ -90,3 +92,23 @@ def download_ray_wheels_from_s3(
         download_wheel_from_s3(s3_key, full_directory_path)
 
     _check_downloaded_wheels(full_directory_path, wheels)
+
+
+def check_wheels_exist_on_s3(commit_hash: str, ray_version: str) -> bool:
+    """
+    Check if all wheels exist on S3.
+
+    Args:
+        commit_hash: The commit hash of the green commit.
+        ray_version: The version of Ray.
+    """
+    s3_client = boto3.client("s3", region_name="us-west-2")
+    wheels = _get_wheel_names(ray_version=ray_version)
+    for wheel in wheels:
+        wheel_s3_key = f"releases/{ray_version}/{commit_hash}/{wheel}.whl"
+        try:
+            s3_client.head_object(Bucket=RAY_WHEELS_BUCKET, Key=wheel_s3_key)
+        except Exception as e:
+            logger.error(f"Wheel {wheel_s3_key} does not exist on S3: {e}")
+            return False
+    return True


### PR DESCRIPTION
- Call `s3_client.head_object` on all wheels to check whether they already exist on S3 before proceeding with next steps. 
- This can be called with `bazel run //ci/ray_ci/automation:check_s3_wheels_exist -- --new_version=<...> --commit_hash=<...>`