### PR TITLE
[core] change all callbacks to move to save copies.

### DIFF
--- a/src/mock/ray/rpc/worker/core_worker_client.h
+++ b/src/mock/ray/rpc/worker/core_worker_client.h
@@ -138,7 +138,7 @@ class MockCoreWorkerClientConfigurableRunningTasks
                        int64_t timeout_ms = -1) override {
     NumPendingTasksReply reply;
     reply.set_num_pending_tasks(num_running_tasks_);
-    callback(Status::OK(), reply);
+    callback(Status::OK(), std::move(reply));
   }
 
  private:

--- a/src/ray/common/test/ray_syncer_test.cc
+++ b/src/ray/common/test/ray_syncer_test.cc
@@ -501,17 +501,13 @@ TEST_F(SyncerTest, Test1To1) {
   std::mt19937 gen(rd());
   std::uniform_int_distribution<> rand_sleep(0, 10000);
   std::uniform_int_distribution<> choose_component(0, kTestComponents - 1);
-  size_t s1_updated = 0;
-  size_t s2_updated = 0;
 
   auto start = steady_clock::now();
   for (int i = 0; i < 10000; ++i) {
     if (choose_component(gen) == 0) {
       s1.local_versions[0]++;
-      ++s1_updated;
     } else {
       s2.local_versions[choose_component(gen)]++;
-      ++s2_updated;
     }
     if (rand_sleep(gen) < 5) {
       std::this_thread::sleep_for(1s);

--- a/src/ray/core_worker/test/actor_manager_test.cc
+++ b/src/ray/core_worker/test/actor_manager_test.cc
@@ -50,7 +50,8 @@ class MockActorInfoAccessor : public gcs::ActorInfoAccessor {
     auto it = callback_map_.find(actor_id);
     if (it == callback_map_.end()) return false;
     auto actor_state_notification_callback = it->second;
-    actor_state_notification_callback(actor_id, actor_data);
+    auto copied = actor_data;
+    actor_state_notification_callback(actor_id, std::move(copied));
     return true;
   }
 
@@ -66,7 +67,8 @@ class MockActorInfoAccessor : public gcs::ActorInfoAccessor {
       return false;
     }
 
-    if (!ActorStateNotificationPublished(actor_id, actor_data)) {
+    auto copied = actor_data;
+    if (!ActorStateNotificationPublished(actor_id, std::move(copied))) {
       return false;
     }
 

--- a/src/ray/core_worker/test/normal_task_submitter_test.cc
+++ b/src/ray/core_worker/test/normal_task_submitter_test.cc
@@ -102,7 +102,7 @@ class MockWorkerClient : public rpc::CoreWorkerClientInterface {
     if (was_cancelled_before_running) {
       reply.set_was_cancelled_before_running(true);
     }
-    callback(status, reply);
+    callback(status, std::move(reply));
     callbacks.pop_front();
     return true;
   }
@@ -200,7 +200,7 @@ class MockRayletClient : public WorkerLeaseInterface {
       const ray::rpc::ClientCallback<ray::rpc::GetTaskFailureCauseReply> &callback)
       override {
     ray::rpc::GetTaskFailureCauseReply reply;
-    callback(Status::OK(), reply);
+    callback(Status::OK(), std::move(reply));
     num_get_task_failure_causes += 1;
   }
 
@@ -275,7 +275,7 @@ class MockRayletClient : public WorkerLeaseInterface {
       return false;
     } else {
       auto callback = callbacks.front();
-      callback(Status::OK(), reply);
+      callback(Status::OK(), std::move(reply));
       callbacks.pop_front();
       return true;
     }
@@ -287,7 +287,8 @@ class MockRayletClient : public WorkerLeaseInterface {
       return false;
     } else {
       auto callback = callbacks.front();
-      callback(Status::RpcError("unavailable", grpc::StatusCode::UNAVAILABLE), reply);
+      callback(Status::RpcError("unavailable", grpc::StatusCode::UNAVAILABLE),
+               std::move(reply));
       callbacks.pop_front();
       return true;
     }
@@ -300,7 +301,7 @@ class MockRayletClient : public WorkerLeaseInterface {
       return false;
     } else {
       auto callback = cancel_callbacks.front();
-      callback(Status::OK(), reply);
+      callback(Status::OK(), std::move(reply));
       cancel_callbacks.pop_front();
       return true;
     }

--- a/src/ray/core_worker/test/object_recovery_manager_test.cc
+++ b/src/ray/core_worker/test/object_recovery_manager_test.cc
@@ -75,7 +75,7 @@ class MockRayletClient : public PinObjectsInterface {
     for (const auto &callback : callbacks_snapshot) {
       rpc::PinObjectIDsReply reply;
       reply.add_successes(success);
-      callback(Status::OK(), reply);
+      callback(Status::OK(), std::move(reply));
     }
     return flushed;
   }

--- a/src/ray/core_worker/test/reference_count_test.cc
+++ b/src/ray/core_worker/test/reference_count_test.cc
@@ -264,7 +264,8 @@ class MockDistributedPublisher : public pubsub::PublisherInterface {
       if (it != subscription_callback_map_->end()) {
         const auto callback_it = it->second.find(oid);
         RAY_CHECK(callback_it != it->second.end());
-        callback_it->second(pub_message);
+        rpc::PubMessage copied = pub_message;
+        callback_it->second(std::move(copied));
       }
     }
   }

--- a/src/ray/gcs/callback.h
+++ b/src/ray/gcs/callback.h
@@ -34,9 +34,10 @@ using StatusCallback = std::function<void(Status status)>;
 /// \param status Status indicates whether the read was successful.
 /// \param result The item returned by GCS. If the item to read doesn't exist,
 /// this optional object is empty.
+/// TODO(ryw): make an Either union type to avoid the optional.
 template <typename Data>
 using OptionalItemCallback =
-    std::function<void(Status status, const std::optional<Data> &result)>;
+    std::function<void(Status status, std::optional<Data> &&result)>;
 
 /// This callback is used to receive multiple items from GCS when a read completes.
 /// \param status Status indicates whether the read was successful.
@@ -48,12 +49,12 @@ using MultiItemCallback = std::function<void(Status status, std::vector<Data> &&
 /// \param id The id of the item.
 /// \param result The notification message.
 template <typename ID, typename Data>
-using SubscribeCallback = std::function<void(const ID &id, const Data &result)>;
+using SubscribeCallback = std::function<void(const ID &id, Data &&result)>;
 
 /// This callback is used to receive a single item from GCS.
 /// \param result The item returned by GCS.
 template <typename Data>
-using ItemCallback = std::function<void(const Data &result)>;
+using ItemCallback = std::function<void(Data &&result)>;
 
 /// This callback is used to receive multiple key-value items from GCS.
 /// \param result The key-value items returned by GCS.

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -41,7 +41,7 @@ Status JobInfoAccessor::AsyncAdd(const std::shared_ptr<JobTableData> &data_ptr,
   request.mutable_data()->CopyFrom(*data_ptr);
   client_impl_->GetGcsRpcClient().AddJob(
       request,
-      [job_id, data_ptr, callback](const Status &status, const rpc::AddJobReply &reply) {
+      [job_id, data_ptr, callback](const Status &status, rpc::AddJobReply &&reply) {
         if (callback) {
           callback(status);
         }
@@ -59,7 +59,7 @@ Status JobInfoAccessor::AsyncMarkFinished(const JobID &job_id,
   request.set_job_id(job_id.Binary());
   client_impl_->GetGcsRpcClient().MarkJobFinished(
       request,
-      [job_id, callback](const Status &status, const rpc::MarkJobFinishedReply &reply) {
+      [job_id, callback](const Status &status, rpc::MarkJobFinishedReply &&reply) {
         if (callback) {
           callback(status);
         }
@@ -73,11 +73,10 @@ Status JobInfoAccessor::AsyncSubscribeAll(
     const SubscribeCallback<JobID, JobTableData> &subscribe, const StatusCallback &done) {
   RAY_CHECK(subscribe != nullptr);
   fetch_all_data_operation_ = [this, subscribe](const StatusCallback &done) {
-    auto callback = [subscribe, done](
-                        const Status &status,
-                        const std::vector<rpc::JobTableData> &job_info_list) {
+    auto callback = [subscribe, done](const Status &status,
+                                      std::vector<rpc::JobTableData> &&job_info_list) {
       for (auto &job_info : job_info_list) {
-        subscribe(JobID::FromBinary(job_info.job_id()), job_info);
+        subscribe(JobID::FromBinary(job_info.job_id()), std::move(job_info));
       }
       if (done) {
         done(status);
@@ -113,7 +112,7 @@ Status JobInfoAccessor::AsyncGetAll(const MultiItemCallback<rpc::JobTableData> &
   rpc::GetAllJobInfoRequest request;
   client_impl_->GetGcsRpcClient().GetAllJobInfo(
       request,
-      [callback](const Status &status, const rpc::GetAllJobInfoReply &reply) {
+      [callback](const Status &status, rpc::GetAllJobInfoReply &&reply) {
         callback(status, VectorFromProtobuf(reply.job_info_list()));
         RAY_LOG(DEBUG) << "Finished getting all job info.";
       },
@@ -135,11 +134,11 @@ Status JobInfoAccessor::AsyncGetNextJobID(const ItemCallback<JobID> &callback) {
   RAY_LOG(DEBUG) << "Getting next job id";
   rpc::GetNextJobIDRequest request;
   client_impl_->GetGcsRpcClient().GetNextJobID(
-      request, [callback](const Status &status, const rpc::GetNextJobIDReply &reply) {
+      request, [callback](const Status &status, rpc::GetNextJobIDReply &&reply) {
         RAY_CHECK_OK(status);
         auto job_id = JobID::FromInt(reply.job_id());
-        callback(job_id);
         RAY_LOG(DEBUG) << "Finished getting next job id = " << job_id;
+        callback(std::move(job_id));
       });
   return Status::OK();
 }
@@ -155,7 +154,7 @@ Status ActorInfoAccessor::AsyncGet(
   request.set_actor_id(actor_id.Binary());
   client_impl_->GetGcsRpcClient().GetActorInfo(
       request,
-      [actor_id, callback](const Status &status, const rpc::GetActorInfoReply &reply) {
+      [actor_id, callback](const Status &status, rpc::GetActorInfoReply &&reply) {
         if (reply.has_actor_table_data()) {
           callback(status, reply.actor_table_data());
         } else {
@@ -190,7 +189,7 @@ Status ActorInfoAccessor::AsyncGetAllByFilter(
 
   client_impl_->GetGcsRpcClient().GetAllActorInfo(
       request,
-      [callback](const Status &status, const rpc::GetAllActorInfoReply &reply) {
+      [callback](const Status &status, rpc::GetAllActorInfoReply &&reply) {
         callback(status, VectorFromProtobuf(reply.actor_table_data()));
         RAY_LOG(DEBUG) << "Finished getting all actor info, status = " << status;
       },
@@ -209,7 +208,7 @@ Status ActorInfoAccessor::AsyncGetByName(
   request.set_ray_namespace(ray_namespace);
   client_impl_->GetGcsRpcClient().GetNamedActorInfo(
       request,
-      [name, callback](const Status &status, const rpc::GetNamedActorInfoReply &reply) {
+      [name, callback](const Status &status, rpc::GetNamedActorInfoReply &&reply) {
         if (reply.has_actor_table_data()) {
           callback(status, reply.actor_table_data());
         } else {
@@ -250,7 +249,7 @@ Status ActorInfoAccessor::AsyncListNamedActors(
   request.set_ray_namespace(ray_namespace);
   client_impl_->GetGcsRpcClient().ListNamedActors(
       request,
-      [callback](const Status &status, const rpc::ListNamedActorsReply &reply) {
+      [callback](const Status &status, rpc::ListNamedActorsReply &&reply) {
         if (!status.ok()) {
           callback(status, std::nullopt);
         } else {
@@ -290,7 +289,7 @@ Status ActorInfoAccessor::AsyncRegisterActor(const ray::TaskSpecification &task_
   request.mutable_task_spec()->CopyFrom(task_spec.GetMessage());
   client_impl_->GetGcsRpcClient().RegisterActor(
       request,
-      [callback](const Status & /*unused*/, const rpc::RegisterActorReply &reply) {
+      [callback](const Status & /*unused*/, rpc::RegisterActorReply &&reply) {
         auto status =
             reply.status().code() == (int)StatusCode::OK
                 ? Status()
@@ -322,7 +321,7 @@ Status ActorInfoAccessor::AsyncKillActor(const ActorID &actor_id,
   request.set_no_restart(no_restart);
   client_impl_->GetGcsRpcClient().KillActorViaGcs(
       request,
-      [callback](const Status & /*unused*/, const rpc::KillActorViaGcsReply &reply) {
+      [callback](const Status & /*unused*/, rpc::KillActorViaGcsReply &&reply) {
         if (callback) {
           auto status =
               reply.status().code() == (int)StatusCode::OK
@@ -342,12 +341,12 @@ Status ActorInfoAccessor::AsyncCreateActor(
   rpc::CreateActorRequest request;
   request.mutable_task_spec()->CopyFrom(task_spec.GetMessage());
   client_impl_->GetGcsRpcClient().CreateActor(
-      request, [callback](const Status & /*unused*/, const rpc::CreateActorReply &reply) {
+      request, [callback](const Status & /*unused*/, rpc::CreateActorReply &&reply) {
         auto status =
             reply.status().code() == (int)StatusCode::OK
                 ? Status()
                 : Status(StatusCode(reply.status().code()), reply.status().message());
-        callback(status, reply);
+        callback(status, std::move(reply));
       });
   return Status::OK();
 }
@@ -364,9 +363,9 @@ Status ActorInfoAccessor::AsyncSubscribe(
       [this, actor_id, subscribe](const StatusCallback &fetch_done) {
         auto callback = [actor_id, subscribe, fetch_done](
                             const Status &status,
-                            const std::optional<rpc::ActorTableData> &result) {
+                            std::optional<rpc::ActorTableData> &&result) {
           if (result) {
-            subscribe(actor_id, *result);
+            subscribe(actor_id, std::move(*result));
           }
           if (fetch_done) {
             fetch_done(status);
@@ -441,7 +440,7 @@ Status NodeInfoAccessor::RegisterSelf(const GcsNodeInfo &local_node_info,
   client_impl_->GetGcsRpcClient().RegisterNode(
       request,
       [this, node_id, local_node_info, callback](const Status &status,
-                                                 const rpc::RegisterNodeReply &reply) {
+                                                 rpc::RegisterNodeReply &&reply) {
         if (status.ok()) {
           local_node_info_.CopyFrom(local_node_info);
           local_node_id_ = NodeID::FromBinary(local_node_info.node_id());
@@ -471,7 +470,7 @@ void NodeInfoAccessor::UnregisterSelf(const rpc::NodeDeathInfo &node_death_info,
   client_impl_->GetGcsRpcClient().UnregisterNode(
       request,
       [this, node_id, unregister_done_callback](const Status &status,
-                                                const rpc::UnregisterNodeReply &reply) {
+                                                rpc::UnregisterNodeReply &&reply) {
         if (status.ok()) {
           local_node_info_.set_state(GcsNodeInfo::DEAD);
           local_node_id_ = NodeID::Nil();
@@ -493,8 +492,7 @@ Status NodeInfoAccessor::AsyncRegister(const rpc::GcsNodeInfo &node_info,
   rpc::RegisterNodeRequest request;
   request.mutable_node_info()->CopyFrom(node_info);
   client_impl_->GetGcsRpcClient().RegisterNode(
-      request,
-      [node_id, callback](const Status &status, const rpc::RegisterNodeReply &reply) {
+      request, [node_id, callback](const Status &status, rpc::RegisterNodeReply &&reply) {
         if (callback) {
           callback(status);
         }
@@ -534,7 +532,7 @@ Status NodeInfoAccessor::AsyncCheckAlive(const std::vector<std::string> &raylet_
   size_t num_raylets = raylet_addresses.size();
   client_impl_->GetGcsRpcClient().CheckAlive(
       request,
-      [num_raylets, callback](const Status &status, const rpc::CheckAliveReply &reply) {
+      [num_raylets, callback](const Status &status, rpc::CheckAliveReply &&reply) {
         if (status.ok()) {
           RAY_CHECK_EQ(static_cast<size_t>(reply.raylet_alive().size()), num_raylets);
           std::vector<bool> is_alive;
@@ -558,8 +556,7 @@ Status NodeInfoAccessor::AsyncDrainNode(const NodeID &node_id,
   auto draining_request = request.add_drain_node_data();
   draining_request->set_node_id(node_id.Binary());
   client_impl_->GetGcsRpcClient().DrainNode(
-      request,
-      [node_id, callback](const Status &status, const rpc::DrainNodeReply &reply) {
+      request, [node_id, callback](const Status &status, rpc::DrainNodeReply &&reply) {
         if (callback) {
           callback(status);
         }
@@ -594,7 +591,7 @@ Status NodeInfoAccessor::AsyncGetAll(const MultiItemCallback<GcsNodeInfo> &callb
   rpc::GetAllNodeInfoRequest request;
   client_impl_->GetGcsRpcClient().GetAllNodeInfo(
       request,
-      [callback](const Status &status, const rpc::GetAllNodeInfoReply &reply) {
+      [callback](const Status &status, rpc::GetAllNodeInfoReply &&reply) {
         std::vector<GcsNodeInfo> result;
         result.reserve((reply.node_info_list_size()));
         for (int index = 0; index < reply.node_info_list_size(); ++index) {
@@ -616,9 +613,9 @@ Status NodeInfoAccessor::AsyncSubscribeToNodeChange(
 
   fetch_node_data_operation_ = [this](const StatusCallback &done) {
     auto callback = [this, done](const Status &status,
-                                 const std::vector<GcsNodeInfo> &node_info_list) {
+                                 std::vector<GcsNodeInfo> &&node_info_list) {
       for (auto &node_info : node_info_list) {
-        HandleNotification(node_info);
+        HandleNotification(std::move(node_info));
       }
       if (done) {
         done(status);
@@ -628,7 +625,9 @@ Status NodeInfoAccessor::AsyncSubscribeToNodeChange(
   };
 
   subscribe_node_operation_ = [this](const StatusCallback &done) {
-    auto on_subscribe = [this](const GcsNodeInfo &data) { HandleNotification(data); };
+    auto on_subscribe = [this](GcsNodeInfo &&data) {
+      HandleNotification(std::move(data));
+    };
     return client_impl_->GetGcsSubscriber().SubscribeAllNodeInfo(on_subscribe, done);
   };
 
@@ -684,7 +683,7 @@ bool NodeInfoAccessor::IsRemoved(const NodeID &node_id) const {
   return removed_nodes_.count(node_id) == 1;
 }
 
-void NodeInfoAccessor::HandleNotification(const GcsNodeInfo &node_info) {
+void NodeInfoAccessor::HandleNotification(GcsNodeInfo &&node_info) {
   NodeID node_id = NodeID::FromBinary(node_info.node_id());
   bool is_alive = (node_info.state() == GcsNodeInfo::ALIVE);
   auto entry = node_cache_.find(node_id);
@@ -721,7 +720,7 @@ void NodeInfoAccessor::HandleNotification(const GcsNodeInfo &node_info) {
 
   auto &node = node_cache_[node_id];
   if (is_alive) {
-    node = node_info;
+    node = std::move(node_info);
   } else {
     node.set_node_id(node_info.node_id());
     node.set_state(rpc::GcsNodeInfo::DEAD);
@@ -735,9 +734,10 @@ void NodeInfoAccessor::HandleNotification(const GcsNodeInfo &node_info) {
     } else {
       removed_nodes_.insert(node_id);
     }
-    GcsNodeInfo &cache_data = node_cache_[node_id];
     if (node_change_callback_) {
-      node_change_callback_(node_id, cache_data);
+      // Copy happens!
+      GcsNodeInfo cache_data_copied = node_cache_[node_id];
+      node_change_callback_(node_id, std::move(cache_data_copied));
     }
   }
 }
@@ -760,8 +760,7 @@ Status NodeInfoAccessor::AsyncGetInternalConfig(
     const OptionalItemCallback<std::string> &callback) {
   rpc::GetInternalConfigRequest request;
   client_impl_->GetGcsRpcClient().GetInternalConfig(
-      request,
-      [callback](const Status &status, const rpc::GetInternalConfigReply &reply) {
+      request, [callback](const Status &status, rpc::GetInternalConfigReply &&reply) {
         if (status.ok()) {
           RAY_LOG(DEBUG) << "Fetched internal config: " << reply.config();
         } else {
@@ -780,7 +779,7 @@ Status NodeResourceInfoAccessor::AsyncGetAllAvailableResources(
   rpc::GetAllAvailableResourcesRequest request;
   client_impl_->GetGcsRpcClient().GetAllAvailableResources(
       request,
-      [callback](const Status &status, const rpc::GetAllAvailableResourcesReply &reply) {
+      [callback](const Status &status, rpc::GetAllAvailableResourcesReply &&reply) {
         callback(status, VectorFromProtobuf(reply.resources_list()));
         RAY_LOG(DEBUG) << "Finished getting available resources of all nodes, status = "
                        << status;
@@ -792,8 +791,7 @@ Status NodeResourceInfoAccessor::AsyncGetAllTotalResources(
     const MultiItemCallback<rpc::TotalResources> &callback) {
   rpc::GetAllTotalResourcesRequest request;
   client_impl_->GetGcsRpcClient().GetAllTotalResources(
-      request,
-      [callback](const Status &status, const rpc::GetAllTotalResourcesReply &reply) {
+      request, [callback](const Status &status, rpc::GetAllTotalResourcesReply &&reply) {
         callback(status, VectorFromProtobuf(reply.resources_list()));
         RAY_LOG(DEBUG) << "Finished getting total resources of all nodes, status = "
                        << status;
@@ -805,14 +803,14 @@ Status NodeResourceInfoAccessor::AsyncGetDrainingNodes(
     const ItemCallback<std::unordered_map<NodeID, int64_t>> &callback) {
   rpc::GetDrainingNodesRequest request;
   client_impl_->GetGcsRpcClient().GetDrainingNodes(
-      request, [callback](const Status &status, const rpc::GetDrainingNodesReply &reply) {
+      request, [callback](const Status &status, rpc::GetDrainingNodesReply &&reply) {
         RAY_CHECK_OK(status);
         std::unordered_map<NodeID, int64_t> draining_nodes;
         for (const auto &draining_node : VectorFromProtobuf(reply.draining_nodes())) {
           draining_nodes[NodeID::FromBinary(draining_node.node_id())] =
               draining_node.draining_deadline_timestamp_ms();
         }
-        callback(draining_nodes);
+        callback(std::move(draining_nodes));
       });
   return Status::OK();
 }
@@ -831,9 +829,8 @@ Status NodeResourceInfoAccessor::AsyncGetAllResourceUsage(
     const ItemCallback<rpc::ResourceUsageBatchData> &callback) {
   rpc::GetAllResourceUsageRequest request;
   client_impl_->GetGcsRpcClient().GetAllResourceUsage(
-      request,
-      [callback](const Status &status, const rpc::GetAllResourceUsageReply &reply) {
-        callback(reply.resource_usage_data());
+      request, [callback](const Status &status, rpc::GetAllResourceUsageReply &&reply) {
+        callback(std::move(*reply.mutable_resource_usage_data()));
         RAY_LOG(DEBUG) << "Finished getting resource usage of all nodes, status = "
                        << status;
       });
@@ -853,7 +850,7 @@ Status TaskInfoAccessor::AsyncAddTaskEventData(
   // Prevent copy here
   request.mutable_data()->Swap(data_ptr.get());
   client_impl_->GetGcsRpcClient().AddTaskEventData(
-      request, [callback](const Status &status, const rpc::AddTaskEventDataReply &reply) {
+      request, [callback](const Status &status, rpc::AddTaskEventDataReply &&reply) {
         if (callback) {
           callback(status);
         }
@@ -868,7 +865,7 @@ Status TaskInfoAccessor::AsyncGetTaskEvents(
   RAY_CHECK(callback);
   rpc::GetTaskEventsRequest request;
   client_impl_->GetGcsRpcClient().GetTaskEvents(
-      request, [callback](const Status &status, const rpc::GetTaskEventsReply &reply) {
+      request, [callback](const Status &status, rpc::GetTaskEventsReply &&reply) {
         callback(status, VectorFromProtobuf(reply.events_by_task()));
       });
 
@@ -887,7 +884,7 @@ Status ErrorInfoAccessor::AsyncReportJobError(
   request.mutable_job_error()->CopyFrom(*data_ptr);
   client_impl_->GetGcsRpcClient().ReportJobError(
       request,
-      [job_id, callback](const Status &status, const rpc::ReportJobErrorReply &reply) {
+      [job_id, callback](const Status &status, rpc::ReportJobErrorReply &&reply) {
         if (callback) {
           callback(status);
         }
@@ -928,7 +925,7 @@ Status WorkerInfoAccessor::AsyncReportWorkerFailure(
   client_impl_->GetGcsRpcClient().ReportWorkerFailure(
       request,
       [worker_address, callback](const Status &status,
-                                 const rpc::ReportWorkerFailureReply &reply) {
+                                 rpc::ReportWorkerFailureReply &&reply) {
         if (callback) {
           callback(status);
         }
@@ -946,7 +943,7 @@ Status WorkerInfoAccessor::AsyncGet(
   request.set_worker_id(worker_id.Binary());
   client_impl_->GetGcsRpcClient().GetWorkerInfo(
       request,
-      [worker_id, callback](const Status &status, const rpc::GetWorkerInfoReply &reply) {
+      [worker_id, callback](const Status &status, rpc::GetWorkerInfoReply &&reply) {
         if (reply.has_worker_table_data()) {
           callback(status, reply.worker_table_data());
         } else {
@@ -962,7 +959,7 @@ Status WorkerInfoAccessor::AsyncGetAll(
   RAY_LOG(DEBUG) << "Getting all worker info.";
   rpc::GetAllWorkerInfoRequest request;
   client_impl_->GetGcsRpcClient().GetAllWorkerInfo(
-      request, [callback](const Status &status, const rpc::GetAllWorkerInfoReply &reply) {
+      request, [callback](const Status &status, rpc::GetAllWorkerInfoReply &&reply) {
         callback(status, VectorFromProtobuf(reply.worker_table_data()));
         RAY_LOG(DEBUG) << "Finished getting all worker info, status = " << status;
       });
@@ -974,7 +971,7 @@ Status WorkerInfoAccessor::AsyncAdd(const std::shared_ptr<rpc::WorkerTableData> 
   rpc::AddWorkerInfoRequest request;
   request.mutable_worker_data()->CopyFrom(*data_ptr);
   client_impl_->GetGcsRpcClient().AddWorkerInfo(
-      request, [callback](const Status &status, const rpc::AddWorkerInfoReply &reply) {
+      request, [callback](const Status &status, rpc::AddWorkerInfoReply &&reply) {
         if (callback) {
           callback(status);
         }
@@ -992,7 +989,7 @@ Status WorkerInfoAccessor::AsyncUpdateDebuggerPort(const WorkerID &worker_id,
                  << ", port = " << debugger_port << ".";
   client_impl_->GetGcsRpcClient().UpdateWorkerDebuggerPort(
       request,
-      [callback](const Status &status, const rpc::UpdateWorkerDebuggerPortReply &reply) {
+      [callback](const Status &status, rpc::UpdateWorkerDebuggerPortReply &&reply) {
         if (callback) {
           callback(status);
         }
@@ -1011,8 +1008,7 @@ Status WorkerInfoAccessor::AsyncUpdateWorkerNumPausedThreads(
                  << " by delta = " << num_paused_threads_delta << ".";
   client_impl_->GetGcsRpcClient().UpdateWorkerNumPausedThreads(
       request,
-      [callback](const Status &status,
-                 const rpc::UpdateWorkerNumPausedThreadsReply &reply) {
+      [callback](const Status &status, rpc::UpdateWorkerNumPausedThreadsReply &&reply) {
         if (callback) {
           callback(status);
         }
@@ -1060,7 +1056,7 @@ Status PlacementGroupInfoAccessor::AsyncGet(
   client_impl_->GetGcsRpcClient().GetPlacementGroup(
       request,
       [placement_group_id, callback](const Status &status,
-                                     const rpc::GetPlacementGroupReply &reply) {
+                                     rpc::GetPlacementGroupReply &&reply) {
         if (reply.has_placement_group_table_data()) {
           callback(status, reply.placement_group_table_data());
         } else {
@@ -1083,8 +1079,7 @@ Status PlacementGroupInfoAccessor::AsyncGetByName(
   request.set_ray_namespace(ray_namespace);
   client_impl_->GetGcsRpcClient().GetNamedPlacementGroup(
       request,
-      [name, callback](const Status &status,
-                       const rpc::GetNamedPlacementGroupReply &reply) {
+      [name, callback](const Status &status, rpc::GetNamedPlacementGroupReply &&reply) {
         if (reply.has_placement_group_table_data()) {
           callback(status, reply.placement_group_table_data());
         } else {
@@ -1102,8 +1097,7 @@ Status PlacementGroupInfoAccessor::AsyncGetAll(
   RAY_LOG(DEBUG) << "Getting all placement group info.";
   rpc::GetAllPlacementGroupRequest request;
   client_impl_->GetGcsRpcClient().GetAllPlacementGroup(
-      request,
-      [callback](const Status &status, const rpc::GetAllPlacementGroupReply &reply) {
+      request, [callback](const Status &status, rpc::GetAllPlacementGroupReply &&reply) {
         callback(status, VectorFromProtobuf(reply.placement_group_table_data()));
         RAY_LOG(DEBUG) << "Finished getting all placement group info, status = "
                        << status;
@@ -1136,7 +1130,7 @@ Status InternalKVAccessor::AsyncInternalKVGet(
   req.set_namespace_(ns);
   client_impl_->GetGcsRpcClient().InternalKVGet(
       req,
-      [callback](const Status &status, const rpc::InternalKVGetReply &reply) {
+      [callback](const Status &status, rpc::InternalKVGetReply &&reply) {
         if (reply.status().code() == (int)StatusCode::NotFound) {
           callback(status, std::nullopt);
         } else {
@@ -1159,7 +1153,7 @@ Status InternalKVAccessor::AsyncInternalKVMultiGet(
   req.set_namespace_(ns);
   client_impl_->GetGcsRpcClient().InternalKVMultiGet(
       req,
-      [callback](const Status &status, const rpc::InternalKVMultiGetReply &reply) {
+      [callback](const Status &status, rpc::InternalKVMultiGetReply &&reply) {
         std::unordered_map<std::string, std::string> map;
         if (!status.ok()) {
           callback(status, map);
@@ -1190,7 +1184,7 @@ Status InternalKVAccessor::AsyncInternalKVPut(const std::string &ns,
   req.set_overwrite(overwrite);
   client_impl_->GetGcsRpcClient().InternalKVPut(
       req,
-      [callback](const Status &status, const rpc::InternalKVPutReply &reply) {
+      [callback](const Status &status, rpc::InternalKVPutReply &&reply) {
         callback(status, reply.added_num());
       },
       timeout_ms);
@@ -1207,7 +1201,7 @@ Status InternalKVAccessor::AsyncInternalKVExists(
   req.set_key(key);
   client_impl_->GetGcsRpcClient().InternalKVExists(
       req,
-      [callback](const Status &status, const rpc::InternalKVExistsReply &reply) {
+      [callback](const Status &status, rpc::InternalKVExistsReply &&reply) {
         callback(status, reply.exists());
       },
       timeout_ms);
@@ -1225,7 +1219,7 @@ Status InternalKVAccessor::AsyncInternalKVDel(const std::string &ns,
   req.set_del_by_prefix(del_by_prefix);
   client_impl_->GetGcsRpcClient().InternalKVDel(
       req,
-      [callback](const Status &status, const rpc::InternalKVDelReply &reply) {
+      [callback](const Status &status, rpc::InternalKVDelReply &&reply) {
         callback(status, reply.deleted_num());
       },
       timeout_ms);
@@ -1242,7 +1236,7 @@ Status InternalKVAccessor::AsyncInternalKVKeys(
   req.set_prefix(prefix);
   client_impl_->GetGcsRpcClient().InternalKVKeys(
       req,
-      [callback](const Status &status, const rpc::InternalKVKeysReply &reply) {
+      [callback](const Status &status, rpc::InternalKVKeysReply &&reply) {
         if (!status.ok()) {
           callback(status, std::nullopt);
         } else {
@@ -1279,8 +1273,16 @@ Status InternalKVAccessor::Keys(const std::string &ns,
                                 std::vector<std::string> &value) {
   std::promise<Status> ret_promise;
   RAY_CHECK_OK(AsyncInternalKVKeys(
-      ns, prefix, timeout_ms, [&ret_promise, &value](Status status, auto &values) {
-        value = values.value_or(std::vector<std::string>());
+      ns,
+      prefix,
+      timeout_ms,
+      [&ret_promise, &value](Status status,
+                             std::optional<std::vector<std::string>> &&values) {
+        if (values) {
+          value = std::move(*values);
+        } else {
+          value = std::vector<std::string>();
+        }
         ret_promise.set_value(status);
       }));
   return ret_promise.get_future().get();
@@ -1292,9 +1294,14 @@ Status InternalKVAccessor::Get(const std::string &ns,
                                std::string &value) {
   std::promise<Status> ret_promise;
   RAY_CHECK_OK(AsyncInternalKVGet(
-      ns, key, timeout_ms, [&ret_promise, &value](Status status, auto &v) {
+      ns,
+      key,
+      timeout_ms,
+      [&ret_promise, &value](Status status, std::optional<std::string> &&v) {
         if (v) {
-          value = *v;
+          value = std::move(v.value());
+        } else {
+          value.clear();
         }
         ret_promise.set_value(status);
       }));
@@ -1308,7 +1315,12 @@ Status InternalKVAccessor::MultiGet(
     std::unordered_map<std::string, std::string> &values) {
   std::promise<Status> ret_promise;
   RAY_CHECK_OK(AsyncInternalKVMultiGet(
-      ns, keys, timeout_ms, [&ret_promise, &values](Status status, auto &vs) {
+      ns,
+      keys,
+      timeout_ms,
+      [&ret_promise, &values](
+          Status status,
+          std::optional<std::unordered_map<std::string, std::string>> &&vs) {
         values.clear();
         if (vs) {
           values = std::move(*vs);
@@ -1329,7 +1341,7 @@ Status InternalKVAccessor::Del(const std::string &ns,
       key,
       del_by_prefix,
       timeout_ms,
-      [&ret_promise, &num_deleted](Status status, const std::optional<int> &value) {
+      [&ret_promise, &num_deleted](Status status, std::optional<int> &&value) {
         num_deleted = value.value_or(0);
         ret_promise.set_value(status);
       }));
@@ -1345,7 +1357,7 @@ Status InternalKVAccessor::Exists(const std::string &ns,
       ns,
       key,
       timeout_ms,
-      [&ret_promise, &exists](Status status, const std::optional<bool> &value) {
+      [&ret_promise, &exists](Status status, std::optional<bool> &&value) {
         exists = value.value_or(false);
         ret_promise.set_value(status);
       }));

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -445,7 +445,7 @@ class NodeInfoAccessor {
       const OptionalItemCallback<std::string> &callback);
 
   /// Add a node to accessor cache.
-  virtual void HandleNotification(const rpc::GcsNodeInfo &node_info);
+  virtual void HandleNotification(rpc::GcsNodeInfo &&node_info);
 
  private:
   /// Save the subscribe operation in this function, so we can call it again when PubSub
@@ -459,7 +459,7 @@ class NodeInfoAccessor {
   GcsClient *client_impl_;
 
   using NodeChangeCallback =
-      std::function<void(const NodeID &id, const rpc::GcsNodeInfo &node_info)>;
+      std::function<void(const NodeID &id, rpc::GcsNodeInfo &&node_info)>;
 
   rpc::GcsNodeInfo local_node_info_;
   NodeID local_node_id_;

--- a/src/ray/gcs/gcs_client/gcs_client.cc
+++ b/src/ray/gcs/gcs_client/gcs_client.cc
@@ -54,12 +54,11 @@ void GcsSubscriberClient::PubsubLongPolling(
   req.set_max_processed_sequence_id(request.max_processed_sequence_id());
   req.set_publisher_id(request.publisher_id());
   rpc_client_->GcsSubscriberPoll(
-      req,
-      [callback](const Status &status, const rpc::GcsSubscriberPollReply &poll_reply) {
+      req, [callback](const Status &status, rpc::GcsSubscriberPollReply &&poll_reply) {
         rpc::PubsubLongPollingReply reply;
-        *reply.mutable_pub_messages() = poll_reply.pub_messages();
-        *reply.mutable_publisher_id() = poll_reply.publisher_id();
-        callback(status, reply);
+        reply.mutable_pub_messages()->Swap(poll_reply.mutable_pub_messages());
+        *reply.mutable_publisher_id() = std::move(*poll_reply.mutable_publisher_id());
+        callback(status, std::move(reply));
       });
 }
 
@@ -72,9 +71,9 @@ void GcsSubscriberClient::PubsubCommandBatch(
   rpc_client_->GcsSubscriberCommandBatch(
       req,
       [callback](const Status &status,
-                 const rpc::GcsSubscriberCommandBatchReply &batch_reply) {
+                 rpc::GcsSubscriberCommandBatchReply &&batch_reply) {
         rpc::PubsubCommandBatchReply reply;
-        callback(status, reply);
+        callback(status, std::move(reply));
       });
 }
 

--- a/src/ray/gcs/gcs_client/python_callbacks.h
+++ b/src/ray/gcs/gcs_client/python_callbacks.h
@@ -102,7 +102,7 @@ template <typename T>
 using MultiItemPyCallback = PyCallback<Status, std::vector<T> &&>;
 
 template <typename Data>
-using OptionalItemPyCallback = PyCallback<Status, const std::optional<Data> &>;
+using OptionalItemPyCallback = PyCallback<Status, std::optional<Data> &&>;
 
 using StatusPyCallback = PyCallback<Status>;
 

--- a/src/ray/gcs/gcs_client/test/accessor_test.cc
+++ b/src/ray/gcs/gcs_client/test/accessor_test.cc
@@ -27,7 +27,7 @@ TEST(NodeInfoAccessorTest, TestHandleNotification) {
   node_info.set_state(rpc::GcsNodeInfo_GcsNodeState::GcsNodeInfo_GcsNodeState_DEAD);
   NodeID node_id = NodeID::FromRandom();
   node_info.set_node_id(node_id.Binary());
-  accessor.HandleNotification(node_info);
+  accessor.HandleNotification(std::move(node_info));
   ASSERT_EQ(accessor.Get(node_id, false)->node_id(), node_id.Binary());
 }
 

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -1529,7 +1529,7 @@ void GcsActorManager::NotifyCoreWorkerToKillActor(const std::shared_ptr<GcsActor
   auto actor_client = worker_client_factory_(actor->GetAddress());
   RAY_LOG(DEBUG) << "Send request to kill actor " << actor->GetActorID() << " to worker "
                  << actor->GetWorkerID() << " at node " << actor->GetNodeID();
-  actor_client->KillActor(request, [](auto &status, auto &) {
+  actor_client->KillActor(request, [](auto &status, auto &&) {
     RAY_LOG(DEBUG) << "Killing status: " << status.ToString();
   });
 }

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
@@ -547,7 +547,7 @@ bool GcsActorScheduler::KillActorOnWorker(const rpc::Address &worker_address,
   request.set_intended_actor_id(actor_id.Binary());
   request.set_force_kill(true);
   request.set_no_restart(true);
-  cli->KillActor(request, [actor_id](auto &status, auto &) {
+  cli->KillActor(request, [actor_id](auto &status, auto &&) {
     RAY_LOG(DEBUG) << "Killing actor " << actor_id
                    << " with return status: " << status.ToString();
   });

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -366,7 +366,7 @@ void GcsServer::InitGcsResourceManager(const GcsInitData &gcs_init_data) {
                            << ". Skip this round of pulling for resource load";
           } else {
             // GetResourceLoad will also get usage. Historically it didn't.
-            raylet_client->GetResourceLoad([this](auto &status, auto &load_and_usage) {
+            raylet_client->GetResourceLoad([this](auto &status, auto &&load_and_usage) {
               if (status.ok()) {
                 // TODO(vitsai): Remove duplicate reporting to GcsResourceManager
                 // after verifying that non-autoscaler paths are taken care of.

--- a/src/ray/gcs/gcs_server/gcs_table_storage.cc
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.cc
@@ -50,7 +50,7 @@ Status GcsTable<Key, Data>::Get(const Key &key,
       data.ParseFromString(*result);
       value = std::move(data);
     }
-    callback(status, value);
+    callback(status, std::move(value));
   };
   return store_client_->AsyncGet(table_name_, key.Binary(), on_done);
 }

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -96,7 +96,7 @@ class MockWorkerClient : public rpc::CoreWorkerClientInterface {
         [this, status, &promise]() {
           auto callback = callbacks_.front();
           auto reply = rpc::WaitForActorOutOfScopeReply();
-          callback(status, reply);
+          callback(status, std::move(reply));
           promise.set_value(false);
         },
         "test");

--- a/src/ray/gcs/gcs_server/test/gcs_actor_scheduler_mock_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_scheduler_mock_test.cc
@@ -111,7 +111,7 @@ TEST_F(GcsActorSchedulerMockTest, KillWorkerLeak1) {
   actor_data.set_state(rpc::ActorTableData::PENDING_CREATION);
   actor_data.set_actor_id(actor_id.Binary());
   auto actor = std::make_shared<GcsActor>(actor_data, rpc::TaskSpec(), counter);
-  std::function<void(const Status &, const rpc::RequestWorkerLeaseReply &)> cb;
+  rpc::ClientCallback<rpc::RequestWorkerLeaseReply> cb;
   EXPECT_CALL(*raylet_client, RequestWorkerLease(An<const rpc::TaskSpec &>(), _, _, _, _))
       .WillOnce(testing::SaveArg<2>(&cb));
   // Ensure actor is killed
@@ -122,7 +122,7 @@ TEST_F(GcsActorSchedulerMockTest, KillWorkerLeak1) {
   ray::rpc::RequestWorkerLeaseReply reply;
   reply.mutable_worker_address()->set_raylet_id(node_id.Binary());
   reply.mutable_worker_address()->set_worker_id(worker_id.Binary());
-  cb(Status::OK(), reply);
+  cb(Status::OK(), std::move(reply));
 }
 
 TEST_F(GcsActorSchedulerMockTest, KillWorkerLeak2) {
@@ -152,7 +152,7 @@ TEST_F(GcsActorSchedulerMockTest, KillWorkerLeak2) {
   rpc::RequestWorkerLeaseReply reply;
   reply.mutable_worker_address()->set_raylet_id(node_id.Binary());
   reply.mutable_worker_address()->set_worker_id(worker_id.Binary());
-  request_worker_lease_cb(Status::OK(), reply);
+  request_worker_lease_cb(Status::OK(), std::move(reply));
 
   rpc::ClientCallback<rpc::PushTaskReply> push_normal_task_cb;
   // Worker start to run task

--- a/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
+++ b/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
@@ -49,7 +49,7 @@ struct GcsServerMocker {
       if (exit) {
         reply.set_worker_exiting(true);
       }
-      callback(status, reply);
+      callback(status, std::move(reply));
       callbacks.pop_front();
       return true;
     }
@@ -78,7 +78,7 @@ struct GcsServerMocker {
         const ray::rpc::ClientCallback<ray::rpc::GetTaskFailureCauseReply> &callback)
         override {
       ray::rpc::GetTaskFailureCauseReply reply;
-      callback(Status::OK(), reply);
+      callback(Status::OK(), std::move(reply));
       num_get_task_failure_causes += 1;
     }
 
@@ -170,7 +170,7 @@ struct GcsServerMocker {
         return false;
       } else {
         auto callback = callbacks.front();
-        callback(status, reply);
+        callback(status, std::move(reply));
         callbacks.pop_front();
         return true;
       }
@@ -183,7 +183,7 @@ struct GcsServerMocker {
         return false;
       } else {
         auto callback = cancel_callbacks.front();
-        callback(Status::OK(), reply);
+        callback(Status::OK(), std::move(reply));
         cancel_callbacks.pop_front();
         return true;
       }
@@ -195,7 +195,7 @@ struct GcsServerMocker {
         return false;
       } else {
         auto callback = release_callbacks.front();
-        callback(Status::OK(), reply);
+        callback(Status::OK(), std::move(reply));
         release_callbacks.pop_front();
         return true;
       }
@@ -208,7 +208,7 @@ struct GcsServerMocker {
         rpc::DrainRayletReply reply;
         reply.set_is_accepted(true);
         auto callback = drain_raylet_callbacks.front();
-        callback(Status::OK(), reply);
+        callback(Status::OK(), std::move(reply));
         drain_raylet_callbacks.pop_front();
         return true;
       }
@@ -256,7 +256,7 @@ struct GcsServerMocker {
         return false;
       } else {
         auto callback = lease_callbacks.front();
-        callback(status, reply);
+        callback(status, std::move(reply));
         lease_callbacks.pop_front();
         return true;
       }
@@ -269,7 +269,7 @@ struct GcsServerMocker {
         return false;
       } else {
         auto callback = commit_callbacks.front();
-        callback(status, reply);
+        callback(status, std::move(reply));
         commit_callbacks.pop_front();
         return true;
       }
@@ -283,7 +283,7 @@ struct GcsServerMocker {
         return false;
       } else {
         auto callback = return_callbacks.front();
-        callback(status, reply);
+        callback(status, std::move(reply));
         return_callbacks.pop_front();
         return true;
       }

--- a/src/ray/gcs/pubsub/gcs_pub_sub.cc
+++ b/src/ray/gcs/pubsub/gcs_pub_sub.cc
@@ -97,10 +97,10 @@ Status GcsSubscriber::SubscribeAllJobs(
     const SubscribeCallback<JobID, rpc::JobTableData> &subscribe,
     const StatusCallback &done) {
   // GCS subscriber.
-  auto subscribe_item_callback = [subscribe](const rpc::PubMessage &msg) {
+  auto subscribe_item_callback = [subscribe](rpc::PubMessage &&msg) {
     RAY_CHECK(msg.channel_type() == rpc::ChannelType::GCS_JOB_CHANNEL);
     const JobID id = JobID::FromBinary(msg.key_id());
-    subscribe(id, msg.job_message());
+    subscribe(id, std::move(*msg.mutable_job_message()));
   };
   auto subscription_failure_callback = [](const std::string &, const Status &status) {
     RAY_LOG(WARNING) << "Subscription to Job channel failed: " << status.ToString();
@@ -125,10 +125,10 @@ Status GcsSubscriber::SubscribeActor(
     const SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,
     const StatusCallback &done) {
   // GCS subscriber.
-  auto subscription_callback = [id, subscribe](const rpc::PubMessage &msg) {
+  auto subscription_callback = [id, subscribe](rpc::PubMessage &&msg) {
     RAY_CHECK(msg.channel_type() == rpc::ChannelType::GCS_ACTOR_CHANNEL);
     RAY_CHECK(msg.key_id() == id.Binary());
-    subscribe(id, msg.actor_message());
+    subscribe(id, std::move(*msg.mutable_actor_message()));
   };
   auto subscription_failure_callback = [id](const std::string &failed_id,
                                             const Status &status) {
@@ -166,9 +166,9 @@ bool GcsSubscriber::IsActorUnsubscribed(const ActorID &id) {
 Status GcsSubscriber::SubscribeAllNodeInfo(
     const ItemCallback<rpc::GcsNodeInfo> &subscribe, const StatusCallback &done) {
   // GCS subscriber.
-  auto subscribe_item_callback = [subscribe](const rpc::PubMessage &msg) {
+  auto subscribe_item_callback = [subscribe](rpc::PubMessage &&msg) {
     RAY_CHECK(msg.channel_type() == rpc::ChannelType::GCS_NODE_INFO_CHANNEL);
-    subscribe(msg.node_info_message());
+    subscribe(std::move(*msg.mutable_node_info_message()));
   };
   auto subscription_failure_callback = [](const std::string &, const Status &status) {
     RAY_LOG(WARNING) << "Subscription to NodeInfo channel failed: " << status.ToString();
@@ -190,9 +190,9 @@ Status GcsSubscriber::SubscribeAllNodeInfo(
 
 Status GcsSubscriber::SubscribeAllWorkerFailures(
     const ItemCallback<rpc::WorkerDeltaData> &subscribe, const StatusCallback &done) {
-  auto subscribe_item_callback = [subscribe](const rpc::PubMessage &msg) {
+  auto subscribe_item_callback = [subscribe](rpc::PubMessage &&msg) {
     RAY_CHECK(msg.channel_type() == rpc::ChannelType::GCS_WORKER_DELTA_CHANNEL);
-    subscribe(msg.worker_delta_message());
+    subscribe(std::move(*msg.mutable_worker_delta_message()));
   };
   auto subscription_failure_callback = [](const std::string &, const Status &status) {
     RAY_LOG(WARNING) << "Subscription to WorkerDelta channel failed: "

--- a/src/ray/gcs/store_client/in_memory_store_client.cc
+++ b/src/ray/gcs/store_client/in_memory_store_client.cc
@@ -55,7 +55,8 @@ Status InMemoryStoreClient::AsyncGet(const std::string &table_name,
   }
 
   main_io_service_.post(
-      [callback, data = std::move(data)]() { callback(Status::OK(), data); },
+      [callback, data = std::move(data)]() mutable  // allow data to be moved
+      { callback(Status::OK(), std::move(data)); },
       "GcsInMemoryStore.Get");
 
   return Status::OK();

--- a/src/ray/object_manager/test/ownership_based_object_directory_test.cc
+++ b/src/ray/object_manager/test/ownership_based_object_directory_test.cc
@@ -55,7 +55,7 @@ class MockWorkerClient : public rpc::CoreWorkerClientInterface {
     }
     auto callback = callbacks.front();
     auto reply = rpc::UpdateObjectLocationBatchReply();
-    callback(status, reply);
+    callback(status, std::move(reply));
     callback_invoked++;
     callbacks.pop_front();
     return true;

--- a/src/ray/pubsub/subscriber.h
+++ b/src/ray/pubsub/subscriber.h
@@ -35,7 +35,7 @@ namespace pubsub {
 using SubscriberID = UniqueID;
 using PublisherID = UniqueID;
 using SubscribeDoneCallback = std::function<void(const Status &)>;
-using SubscriptionItemCallback = std::function<void(const rpc::PubMessage &)>;
+using SubscriptionItemCallback = std::function<void(rpc::PubMessage &&)>;
 using SubscriptionFailureCallback =
     std::function<void(const std::string &, const Status &)>;
 
@@ -113,7 +113,7 @@ class SubscriberChannel {
   /// \param publisher_address The address of the publisher.
   /// \param pub_message The message to handle from the publisher.
   void HandlePublishedMessage(const rpc::Address &publisher_address,
-                              const rpc::PubMessage &pub_message) const;
+                              rpc::PubMessage &&pub_message) const;
 
   /// Handle the RPC failure of the given publisher.
   /// Note that this will ensure that the callback is running on a designated IO service.
@@ -432,7 +432,7 @@ class Subscriber : public SubscriberInterface {
   /// published messages.
   void HandleLongPollingResponse(const rpc::Address &publisher_address,
                                  const Status &status,
-                                 const rpc::PubsubLongPollingReply &reply)
+                                 rpc::PubsubLongPollingReply &&reply)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   /// Make a long polling connection if it never made the one with this publisher for

--- a/src/ray/pubsub/test/integration_test.cc
+++ b/src/ray/pubsub/test/integration_test.cc
@@ -109,7 +109,7 @@ class CallbackSubscriberClient final : public pubsub::SubscriberClientInterface 
     auto *reply = new rpc::PubsubLongPollingReply;
     stub_->async()->PubsubLongPolling(
         context, &request, reply, [callback, context, reply](grpc::Status s) {
-          callback(GrpcStatusToRayStatus(s), *reply);
+          callback(GrpcStatusToRayStatus(s), std::move(*reply));
           delete reply;
           delete context;
         });
@@ -122,7 +122,7 @@ class CallbackSubscriberClient final : public pubsub::SubscriberClientInterface 
     auto *reply = new rpc::PubsubCommandBatchReply;
     stub_->async()->PubsubCommandBatch(
         context, &request, reply, [callback, context, reply](grpc::Status s) {
-          callback(GrpcStatusToRayStatus(s), *reply);
+          callback(GrpcStatusToRayStatus(s), std::move(*reply));
           delete reply;
           delete context;
         });

--- a/src/ray/pubsub/test/subscriber_test.cc
+++ b/src/ray/pubsub/test/subscriber_test.cc
@@ -47,7 +47,7 @@ class MockWorkerClient : public pubsub::SubscriberClientInterface {
     }
     auto callback = command_batch_callbacks.front();
     auto reply = rpc::PubsubCommandBatchReply();
-    callback(status, reply);
+    callback(status, std::move(reply));
     command_batch_callbacks.pop_front();
     auto r = std::make_shared<rpc::PubsubCommandBatchRequest>(requests_.front());
     requests_.pop();
@@ -82,7 +82,8 @@ class MockWorkerClient : public pubsub::SubscriberClientInterface {
       new_pub_message->set_sequence_id(sequence_id);
     }
     reply.set_publisher_id(publisher_id.empty() ? publisher_id_ : publisher_id);
-    callback(status, reply);
+    auto copied = reply;
+    callback(status, std::move(copied));
     long_polling_callbacks.pop_front();
     return true;
   }
@@ -104,7 +105,7 @@ class MockWorkerClient : public pubsub::SubscriberClientInterface {
       new_pub_message->mutable_failure_message();
       new_pub_message->set_sequence_id(GetNextSequenceId());
     }
-    callback(Status::OK(), reply);
+    callback(Status::OK(), std::move(reply));
     long_polling_callbacks.pop_front();
     return true;
   }

--- a/src/ray/raylet/test/local_object_manager_test.cc
+++ b/src/ray/raylet/test/local_object_manager_test.cc
@@ -69,7 +69,7 @@ class MockSubscriber : public pubsub::SubscriberInterface {
     msg.set_channel_type(channel_type_);
     auto *object_eviction_msg = msg.mutable_worker_object_eviction_message();
     object_eviction_msg->set_object_id(object_id.Binary());
-    callback(msg);
+    callback(std::move(msg));
     cbs->second.pop_front();
     if (cbs->second.empty()) {
       callbacks.erase(cbs);
@@ -126,7 +126,7 @@ class MockWorkerClient : public rpc::CoreWorkerClientInterface {
     }
     auto callback = update_object_location_batch_callbacks.front();
     auto reply = rpc::UpdateObjectLocationBatchReply();
-    callback(status, reply);
+    callback(status, std::move(reply));
     update_object_location_batch_callbacks.pop_front();
     return true;
   }
@@ -155,7 +155,7 @@ class MockIOWorkerClient : public rpc::CoreWorkerClientInterface {
         reply.add_spilled_objects_url(url);
       }
     }
-    callback(status, reply);
+    callback(status, std::move(reply));
     callbacks.pop_front();
     return true;
   }
@@ -173,7 +173,7 @@ class MockIOWorkerClient : public rpc::CoreWorkerClientInterface {
       return false;
     };
     auto callback = restore_callbacks.front();
-    callback(status, reply);
+    callback(status, std::move(reply));
     restore_callbacks.pop_front();
     return true;
   }
@@ -194,7 +194,7 @@ class MockIOWorkerClient : public rpc::CoreWorkerClientInterface {
 
     auto callback = delete_callbacks.front();
     auto reply = rpc::DeleteSpilledObjectsReply();
-    callback(status, reply);
+    callback(status, std::move(reply));
 
     auto &request = delete_requests.front();
     int deleted_urls_size = request.spilled_objects_url_size();
@@ -211,7 +211,7 @@ class MockIOWorkerClient : public rpc::CoreWorkerClientInterface {
 
     auto callback = delete_callbacks.front();
     auto reply = rpc::DeleteSpilledObjectsReply();
-    callback(status, reply);
+    callback(status, std::move(reply));
 
     auto &request = delete_requests.front();
     int deleted_urls_size = request.spilled_objects_url_size();

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -60,7 +60,7 @@ class MockWorkerClient : public rpc::CoreWorkerClientInterface {
     const auto &callback = callbacks_.front();
     rpc::ExitReply exit_reply;
     exit_reply.set_success(true);
-    callback(Status::OK(), exit_reply);
+    callback(Status::OK(), std::move(exit_reply));
     callbacks_.pop_front();
     return true;
   }
@@ -72,7 +72,7 @@ class MockWorkerClient : public rpc::CoreWorkerClientInterface {
     const auto &callback = callbacks_.front();
     rpc::ExitReply exit_reply;
     exit_reply.set_success(false);
-    callback(Status::OK(), exit_reply);
+    callback(Status::OK(), std::move(exit_reply));
     callbacks_.pop_front();
     return true;
   }

--- a/src/ray/raylet_client/raylet_client.cc
+++ b/src/ray/raylet_client/raylet_client.cc
@@ -364,7 +364,7 @@ void raylet::RayletClient::ReportWorkerBacklog(
   request.set_worker_id(worker_id.Binary());
   request.mutable_backlog_reports()->Add(backlog_reports.begin(), backlog_reports.end());
   grpc_client_->ReportWorkerBacklog(
-      request, [](const Status &status, const rpc::ReportWorkerBacklogReply &reply) {
+      request, [](const Status &status, rpc::ReportWorkerBacklogReply &&reply) {
         if (!status.ok()) {
           RAY_LOG(INFO) << "Error reporting task backlog information: " << status;
         }
@@ -383,12 +383,12 @@ Status raylet::RayletClient::ReturnWorker(
   request.set_disconnect_worker(disconnect_worker);
   request.set_disconnect_worker_error_detail(disconnect_worker_error_detail);
   request.set_worker_exiting(worker_exiting);
-  grpc_client_->ReturnWorker(
-      request, [](const Status &status, const rpc::ReturnWorkerReply &reply) {
-        if (!status.ok()) {
-          RAY_LOG(INFO) << "Error returning worker: " << status;
-        }
-      });
+  grpc_client_->ReturnWorker(request,
+                             [](const Status &status, rpc::ReturnWorkerReply &&reply) {
+                               if (!status.ok()) {
+                                 RAY_LOG(INFO) << "Error returning worker: " << status;
+                               }
+                             });
   return Status::OK();
 }
 
@@ -398,12 +398,11 @@ void raylet::RayletClient::GetTaskFailureCause(
   rpc::GetTaskFailureCauseRequest request;
   request.set_task_id(task_id.Binary());
   grpc_client_->GetTaskFailureCause(
-      request,
-      [callback](const Status &status, const rpc::GetTaskFailureCauseReply &reply) {
+      request, [callback](const Status &status, rpc::GetTaskFailureCauseReply &&reply) {
         if (!status.ok()) {
           RAY_LOG(INFO) << "Error getting task result: " << status;
         }
-        callback(status, reply);
+        callback(status, std::move(reply));
       });
 }
 
@@ -453,15 +452,14 @@ void raylet::RayletClient::PushMutableObject(
 
     // TODO: Add failure recovery, retries, and timeout.
     grpc_client_->PushMutableObject(
-        request,
-        [callback](const Status &status, const rpc::PushMutableObjectReply &reply) {
+        request, [callback](const Status &status, rpc::PushMutableObjectReply &&reply) {
           if (!status.ok()) {
             RAY_LOG(ERROR) << "Error pushing mutable object: " << status;
           }
           if (reply.done()) {
             // The callback is only executed once the receiver node receives all chunks
             // for the mutable object write.
-            callback(status, reply);
+            callback(status, std::move(reply));
           }
         });
   }
@@ -476,13 +474,13 @@ void raylet::RayletClient::ReleaseUnusedActorWorkers(
   }
   grpc_client_->ReleaseUnusedActorWorkers(
       request,
-      [callback](const Status &status, const rpc::ReleaseUnusedActorWorkersReply &reply) {
+      [callback](const Status &status, rpc::ReleaseUnusedActorWorkersReply &&reply) {
         if (!status.ok()) {
           RAY_LOG(WARNING)
               << "Error releasing workers from raylet, the raylet may have died:"
               << status;
         }
-        callback(status, reply);
+        callback(status, std::move(reply));
       });
 }
 
@@ -538,14 +536,13 @@ void raylet::RayletClient::ReleaseUnusedBundles(
     request.add_bundles_in_use()->CopyFrom(bundle);
   }
   grpc_client_->ReleaseUnusedBundles(
-      request,
-      [callback](const Status &status, const rpc::ReleaseUnusedBundlesReply &reply) {
+      request, [callback](const Status &status, rpc::ReleaseUnusedBundlesReply &&reply) {
         if (!status.ok()) {
           RAY_LOG(WARNING)
               << "Error releasing bundles from raylet, the raylet may have died:"
               << status;
         }
-        callback(status, reply);
+        callback(status, std::move(reply));
       });
 }
 
@@ -564,9 +561,9 @@ void raylet::RayletClient::PinObjectIDs(
   }
   pins_in_flight_++;
   auto rpc_callback = [this, callback = std::move(callback)](
-                          Status status, const rpc::PinObjectIDsReply &reply) {
+                          Status status, rpc::PinObjectIDsReply &&reply) {
     pins_in_flight_--;
-    callback(status, reply);
+    callback(status, std::move(reply));
   };
   grpc_client_->PinObjectIDs(request, rpc_callback);
 }

--- a/src/ray/rpc/client_call.h
+++ b/src/ray/rpc/client_call.h
@@ -57,7 +57,7 @@ class ClientCallManager;
 ///
 /// \tparam Reply Type of the reply message.
 template <class Reply>
-using ClientCallback = std::function<void(const Status &status, const Reply &reply)>;
+using ClientCallback = std::function<void(const Status &status, Reply &&reply)>;
 
 /// Implementation of the `ClientCall`. It represents a `ClientCall` for a particular
 /// RPC method.
@@ -102,7 +102,8 @@ class ClientCallImpl : public ClientCall {
       status = return_status_;
     }
     if (callback_ != nullptr) {
-      callback_(status, reply_);
+      // This should be only called once.
+      callback_(status, std::move(reply_));
     }
   }
 

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -229,20 +229,20 @@ class GcsRpcClient {
     auto executor = new Executor(
         [callback](const ray::Status &status) { callback(status, Reply()); });
     auto operation_callback = [this, request, callback, executor, timeout_ms](
-                                  const ray::Status &status, const Reply &reply) {
+                                  const ray::Status &status, Reply &&reply) {
       if (status.ok()) {
         if constexpr (handle_payload_status) {
           Status st =
               (reply.status().code() == (int)StatusCode::OK)
                   ? Status()
                   : Status(StatusCode(reply.status().code()), reply.status().message());
-          callback(st, reply);
+          callback(st, std::move(reply));
         } else {
-          callback(status, reply);
+          callback(status, std::move(reply));
         }
         delete executor;
       } else if (!IsGrpcRetryableStatus(status)) {
-        callback(status, reply);
+        callback(status, std::move(reply));
         delete executor;
       } else {
         /* In case of GCS failure, we queue the request and these requests will be */
@@ -260,7 +260,8 @@ class GcsRpcClient {
                     .gcs_client_check_connection_status_interval_milliseconds()));
           }
           if (shutdown_) {
-            callback(Status::Disconnected("GCS client has been disconnected."), reply);
+            callback(Status::Disconnected("GCS client has been disconnected."),
+                     std::move(reply));
             delete executor;
           } else {
             executor->Retry();

--- a/src/ray/rpc/worker/core_worker_client.h
+++ b/src/ray/rpc/worker/core_worker_client.h
@@ -420,7 +420,7 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
 
       auto rpc_callback =
           [this, this_ptr, seq_no, task_size, callback = std::move(pair.second)](
-              Status status, const rpc::PushTaskReply &reply) {
+              Status status, rpc::PushTaskReply &&reply) {
             {
               absl::MutexLock lock(&mutex_);
               if (seq_no > max_finished_seq_no_) {
@@ -430,7 +430,7 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
               RAY_CHECK(rpc_bytes_in_flight_ >= 0);
             }
             SendRequests();
-            callback(status, reply);
+            callback(status, std::move(reply));
           };
 
       RAY_UNUSED(INVOKE_RPC_CALL(CoreWorkerService,


### PR DESCRIPTION
We have many callbacks in gRPC async handling, each of them takes a shape `std::function<void(Status, const T&)>`. Notice the const ref may be later copied again into caller's data structures, some times multiple times for nested callbacks.

Changes the signature to pass by rvalue reference (T&&) to save copies. This involves GcsClient, RayletClient and GcsSubscriber callers. This should work well since almost all replies are used only once, including the SubscriberCallback, except for `NodeInfoAccessor::HandleNotification` which both saves it to `node_cache_` and passes it to the listeners, where we have to make a copy.

It's a pity we don't have a one-click performance test to verify gains of this PR.