### PR TITLE
[data] Add a parameter to allow overriding LanceDB scanner options

### DIFF
--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -3007,6 +3007,7 @@ def read_lance(
     columns: Optional[List[str]] = None,
     filter: Optional[str] = None,
     storage_options: Optional[Dict[str, str]] = None,
+    scanner_options: Optional[Dict[str, Any]] = None,
     ray_remote_args: Optional[Dict[str, Any]] = None,
     concurrency: Optional[int] = None,
     override_num_blocks: Optional[int] = None,
@@ -3033,6 +3034,10 @@ def read_lance(
             connection. This is used to store connection parameters like credentials,
             endpoint, etc. For more information, see `Object Store Configuration <https\
                 ://lancedb.github.io/lance/read_and_write.html#object-store-configuration>`_.
+        scanner_options: Additional options to configure the `LanceDataset.scanner()`
+            method, such as `batch_size`. For more information,
+            see `LanceDB API doc <https://lancedb.github.io\
+            /lance/api/python/lance.html#lance.dataset.LanceDataset.scanner>`_
         ray_remote_args: kwargs passed to :meth:`~ray.remote` in the read tasks.
         concurrency: The maximum number of Ray tasks to run concurrently. Set this
             to control number of tasks to run concurrently. This doesn't change the
@@ -3051,6 +3056,7 @@ def read_lance(
         columns=columns,
         filter=filter,
         storage_options=storage_options,
+        scanner_options=scanner_options,
     )
 
     return read_datasource(

--- a/python/ray/data/tests/test_lance.py
+++ b/python/ray/data/tests/test_lance.py
@@ -28,7 +28,11 @@ from ray.data.datasource.path_util import _unwrap_protocol
         ),
     ],
 )
-def test_lance_read_basic(fs, data_path):
+@pytest.mark.parametrize(
+    "batch_size",
+    [None, 100],
+)
+def test_lance_read_basic(fs, data_path, batch_size):
     # NOTE: Lance only works with PyArrow 12 or above.
     pyarrow_version = _get_pyarrow_version()
     if pyarrow_version is not None:
@@ -51,7 +55,10 @@ def test_lance_read_basic(fs, data_path):
     )
     ds_lance.merge(df2, "one")
 
-    ds = ray.data.read_lance(path)
+    if batch_size is None:
+        ds = ray.data.read_lance(path)
+    else:
+        ds = ray.data.read_lance(path, scanner_options={"batch_size": batch_size})
 
     # Test metadata-only ops.
     assert ds.count() == 6


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The default `batch_size` for the LanceDatasource is too big for some use cases. This PR adds a new `scanner_options` argument to allow overriding the LanceDB scanner options.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
