### PR TITLE
fix broken asyncio tests for aiohttp 3.10.0

### DIFF
--- a/python/ray/dashboard/modules/job/tests/test_job_agent.py
+++ b/python/ray/dashboard/modules/job/tests/test_job_agent.py
@@ -8,6 +8,7 @@ from functools import partial
 from pathlib import Path
 
 import pytest
+import pytest_asyncio
 import requests
 import yaml
 
@@ -65,8 +66,8 @@ def get_node_ip_by_id(node_id: str) -> str:
     return node.node_ip
 
 
-@pytest.fixture
-def job_sdk_client(make_sure_dashboard_http_port_unused):
+@pytest_asyncio.fixture
+async def job_sdk_client(make_sure_dashboard_http_port_unused):
     with _ray_start(include_dashboard=True, num_cpus=1) as ctx:
         ip, _ = ctx.address_info["webui_url"].split(":")
         agent_address = f"{ip}:{DEFAULT_DASHBOARD_AGENT_LISTEN_PORT}"

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -8,6 +8,7 @@ from typing import List, Tuple
 from unittest.mock import MagicMock, AsyncMock
 
 import pytest
+import pytest_asyncio
 from ray._private.state_api_test_utils import get_state_api_manager
 from ray.util.state import get_job
 from ray.dashboard.modules.job.pydantic_models import JobDetails
@@ -149,8 +150,8 @@ def state_source_client(gcs_address):
     return client
 
 
-@pytest.fixture
-def state_api_manager_e2e(ray_start_with_dashboard):
+@pytest_asyncio.fixture
+async def state_api_manager_e2e(ray_start_with_dashboard):
     address_info = ray_start_with_dashboard
     gcs_address = address_info["gcs_address"]
     manager = get_state_api_manager(gcs_address)

--- a/python/requirements/test-requirements.txt
+++ b/python/requirements/test-requirements.txt
@@ -51,7 +51,7 @@ Pygments==2.18.0
 pymongo==4.3.2
 pyspark==3.4.1
 pytest==7.4.4
-pytest-asyncio==0.23.8
+pytest-asyncio==0.17.0
 pytest-httpserver==1.0.6
 pytest-rerunfailures==11.1.2
 pytest-sugar==0.9.5

--- a/python/requirements/test-requirements.txt
+++ b/python/requirements/test-requirements.txt
@@ -51,7 +51,7 @@ Pygments==2.18.0
 pymongo==4.3.2
 pyspark==3.4.1
 pytest==7.4.4
-pytest-asyncio==0.16.0
+pytest-asyncio==0.23.8
 pytest-httpserver==1.0.6
 pytest-rerunfailures==11.1.2
 pytest-sugar==0.9.5

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -1719,7 +1719,7 @@ pytest==7.4.4
     #   pytest-sugar
     #   pytest-timeout
     #   pytest-virtualenv
-pytest-asyncio==0.16.0
+pytest-asyncio==0.23.8
     # via -r /ray/ci/../python/requirements/test-requirements.txt
 pytest-docker-tools==3.1.3
     # via -r /ray/ci/../python/requirements/test-requirements.txt

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -1719,7 +1719,7 @@ pytest==7.4.4
     #   pytest-sugar
     #   pytest-timeout
     #   pytest-virtualenv
-pytest-asyncio==0.23.8
+pytest-asyncio==0.17.0
     # via -r /ray/ci/../python/requirements/test-requirements.txt
 pytest-docker-tools==3.1.3
     # via -r /ray/ci/../python/requirements/test-requirements.txt


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Need to fix these tests for macosx. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Follow-up for #46904 
Fixes #46890 
Fixes #45356
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
