### PR TITLE
[core] Fix raylet CHECK failure from runtime env creation failure.

### DIFF
--- a/python/ray/tests/test_runtime_env_plugin.py
+++ b/python/ray/tests/test_runtime_env_plugin.py
@@ -470,12 +470,12 @@ priority_test_plugin_config = [
     },
 ]
 
-priority_test_plugin_fault_config = [
+priority_test_plugin_bad_config = [
     {
         "class": PRIORITY_TEST_PLUGIN1_CLASS_PATH,
         "priority": 0,
-        # Only used to distinguish the fault config in test body.
-        "tag": "fault",
+        # Only used to distinguish the bad config in test body.
+        "tag": "bad",
     },
     {
         "class": PRIORITY_TEST_PLUGIN2_CLASS_PATH,
@@ -489,7 +489,7 @@ priority_test_plugin_fault_config = [
     [
         json.dumps(priority_test_plugin_config_without_priority),
         json.dumps(priority_test_plugin_config),
-        json.dumps(priority_test_plugin_fault_config),
+        json.dumps(priority_test_plugin_bad_config),
     ],
     indirect=True,
 )
@@ -503,7 +503,7 @@ def test_plugin_priority(set_runtime_env_plugins, ray_start_regular):
 
         return os.environ.get(PRIORITY_TEST_ENV_VAR_NAME)
 
-    if "fault" in config:
+    if "bad" in config:
         with pytest.raises(RuntimeEnvSetupError, match="has been set"):
             value = ray.get(
                 f.options(

--- a/python/ray/tests/test_runtime_env_plugin.py
+++ b/python/ray/tests/test_runtime_env_plugin.py
@@ -346,7 +346,7 @@ def test_actor_fails_on_rt_env_failure(
 ):
     """
     Simulate runtime env failure on a node. The actor should be dead, but the raylet
-    should not die.
+    should not die. See https://github.com/ray-project/ray/pull/46991
     """
 
     cluster = ray_start_cluster
@@ -376,8 +376,7 @@ def test_actor_fails_on_rt_env_failure(
         ray.get(mortal.ping.remote())
     assert "Samuel Beckett" in str(e.value)
 
-    # TODO(ryw): make it consume a count in max_restarts, and restart. After that, we
-    # can test by adding a node with FAULT_PLUGIN_KEY=ok and ping immortal to get 5.
+    # Note: even immortal actor will die because a rt env failure cancels tasks.
     with pytest.raises(RuntimeEnvSetupError) as e:
         ray.get(immortal.ping.remote())
     assert "Samuel Beckett" in str(e.value)

--- a/python/ray/tests/test_runtime_env_plugin.py
+++ b/python/ray/tests/test_runtime_env_plugin.py
@@ -291,8 +291,8 @@ def test_task_fails_on_rt_env_failure(
     ray_start_cluster,
 ):
     """
-    Simulate runtime env failure on a node. The task should be rescheduled on a
-    different node.
+    Simulate runtime env failure on a node. The task should fail but the raylet should
+    not die. See https://github.com/ray-project/ray/pull/46991
     """
 
     cluster = ray_start_cluster
@@ -316,8 +316,7 @@ def test_task_fails_on_rt_env_failure(
     with pytest.raises(RuntimeEnvSetupError) as e:
         ray.get(mortal)
     assert "Samuel Beckett" in str(e.value)
-    # TODO(ryw): make it consume a count in max_retries, and retry. After that, we
-    # can test by adding a node with FAULT_PLUGIN_KEY=ok and get immortal to get 5.
+    # Note: even immortal task will fail because a rt env failure cancels tasks.
     with pytest.raises(RuntimeEnvSetupError) as e:
         ray.get(immortal)
     assert "Samuel Beckett" in str(e.value)

--- a/src/ray/core_worker/transport/normal_task_submitter.cc
+++ b/src/ray/core_worker/transport/normal_task_submitter.cc
@@ -574,6 +574,14 @@ void NormalTaskSubmitter::RequestNewWorkerIfNeeded(const SchedulingKey &scheduli
                 rpc::ErrorType::ACTOR_PLACEMENT_GROUP_REMOVED,
                 &error_status,
                 &error_info));
+          } else if (error_type == rpc::ErrorType::RUNTIME_ENV_SETUP_FAILED) {
+            // Runtime env setup failed, don't fail immediately, instead consumes 1
+            // retry attempt.
+            task_finisher_->FailOrRetryPendingTask(
+                task_spec.TaskId(),
+                rpc::ErrorType::RUNTIME_ENV_SETUP_FAILED,
+                &error_status,
+                &error_info);
           } else {
             RAY_UNUSED(task_finisher_->FailPendingTask(
                 task_spec.TaskId(), error_type, &error_status, &error_info));

--- a/src/ray/core_worker/transport/normal_task_submitter.cc
+++ b/src/ray/core_worker/transport/normal_task_submitter.cc
@@ -574,14 +574,6 @@ void NormalTaskSubmitter::RequestNewWorkerIfNeeded(const SchedulingKey &scheduli
                 rpc::ErrorType::ACTOR_PLACEMENT_GROUP_REMOVED,
                 &error_status,
                 &error_info));
-          } else if (error_type == rpc::ErrorType::RUNTIME_ENV_SETUP_FAILED) {
-            // Runtime env setup failed, don't fail immediately, instead consumes 1
-            // retry attempt.
-            task_finisher_->FailOrRetryPendingTask(
-                task_spec.TaskId(),
-                rpc::ErrorType::RUNTIME_ENV_SETUP_FAILED,
-                &error_status,
-                &error_info);
           } else {
             RAY_UNUSED(task_finisher_->FailPendingTask(
                 task_spec.TaskId(), error_type, &error_status, &error_info));


### PR DESCRIPTION
There's a raylet crash when 

1. there's a task/actor with runtime_env AND dependencies
2. the rt env fails
3. WorkerPool::PopWorker finds that rt env creation failed, so it cancels the task in [LocalTaskManager::PoppedWorkerHandler](https://github.com/ray-project/ray/blob/773157412c6341e74a3a09e12789c063934eaf7c/src/ray/raylet/local_task_manager.cc#L617)
    1. [LocalTaskManager::CancelTasks](https://github.com/ray-project/ray/blob/773157412c6341e74a3a09e12789c063934eaf7c/src/ray/raylet/local_task_manager.cc#L884) removes task dependencies with task_dependency_manager_.RemoveTaskDependencies
4. However, PoppedWorkerHandler itself [also invokes](https://github.com/ray-project/ray/blob/773157412c6341e74a3a09e12789c063934eaf7c/src/ray/raylet/local_task_manager.cc#L663) task_dependency_manager_.RemoveTaskDependencies
And we see the double free.

Adds a boolean `remove_task_dependencies` and assign it in each case in `PoppedWorkerHandler` with justification.

Now, if a runtime env failure happens on task/actor start up, the rt env agent retries 3 times (`RUNTIME_ENV_RETRY_TIMES`) and then fast fails the task/actor, *regardless of its max_retries/max_restarts*.