### PR TITLE
[observability][export-api] Make ErrorType and Language enum public

### DIFF
--- a/python/ray/util/state/custom_types.py
+++ b/python/ray/util/state/custom_types.py
@@ -3,6 +3,7 @@ from ray.core.generated.common_pb2 import (
     TaskType,
     WorkerExitType,
     WorkerType,
+    ErrorType,
 )
 from ray.core.generated.gcs_pb2 import (
     ActorTableData,
@@ -70,6 +71,36 @@ TypeTaskType = Literal[tuple(TASK_TYPE)]
 TypeReferenceType = Literal[
     tuple(reference_type.value for reference_type in ReferenceType)
 ]
+# The ErrorType enum is used in the export API so it is public
+# and any modifications must be backward compatible.
+ERROR_TYPE = [
+    "WORKER_DIED",
+    "ACTOR_DIED",
+    "OBJECT_UNRECONSTRUCTABLE",
+    "TASK_EXECUTION_EXCEPTION",
+    "OBJECT_IN_PLASMA",
+    "TASK_CANCELLED",
+    "ACTOR_CREATION_FAILED",
+    "RUNTIME_ENV_SETUP_FAILED",
+    "OBJECT_LOST",
+    "OWNER_DIED",
+    "OBJECT_DELETED",
+    "DEPENDENCY_RESOLUTION_FAILED",
+    "OBJECT_UNRECONSTRUCTABLE_MAX_ATTEMPTS_EXCEEDED",
+    "OBJECT_UNRECONSTRUCTABLE_LINEAGE_EVICTED",
+    "OBJECT_FETCH_TIMED_OUT",
+    "LOCAL_RAYLET_DIED",
+    "TASK_PLACEMENT_GROUP_REMOVED",
+    "ACTOR_PLACEMENT_GROUP_REMOVED",
+    "TASK_UNSCHEDULABLE_ERROR",
+    "ACTOR_UNSCHEDULABLE_ERROR",
+    "OUT_OF_DISK_ERROR",
+    "OBJECT_FREED",
+    "OUT_OF_MEMORY",
+    "NODE_DIED",
+    "END_OF_STREAMING_GENERATOR",
+    "ACTOR_UNAVAILABLE"
+]
 
 
 def validate_protobuf_enum(grpc_enum, custom_enum):
@@ -93,3 +124,4 @@ validate_protobuf_enum(GcsNodeInfo.GcsNodeState, NODE_STATUS)
 validate_protobuf_enum(WorkerType, WORKER_TYPE)
 validate_protobuf_enum(WorkerExitType, WORKER_EXIT_TYPE)
 validate_protobuf_enum(TaskType, TASK_TYPE)
+validate_protobuf_enum(ErrorType, ERROR_TYPE)

--- a/python/ray/util/state/custom_types.py
+++ b/python/ray/util/state/custom_types.py
@@ -100,15 +100,11 @@ ERROR_TYPE = [
     "OUT_OF_MEMORY",
     "NODE_DIED",
     "END_OF_STREAMING_GENERATOR",
-    "ACTOR_UNAVAILABLE"
+    "ACTOR_UNAVAILABLE",
 ]
 # The Language enum is used in the export API so it is public
 # and any modifications must be backward compatible.
-LANGUAGE = [
-    "PYTHON",
-    "JAVA,
-    "CPP"
-]
+LANGUAGE = ["PYTHON", "JAVA", "CPP"]
 
 
 def validate_protobuf_enum(grpc_enum, custom_enum):

--- a/python/ray/util/state/custom_types.py
+++ b/python/ray/util/state/custom_types.py
@@ -4,6 +4,7 @@ from ray.core.generated.common_pb2 import (
     WorkerExitType,
     WorkerType,
     ErrorType,
+    Language,
 )
 from ray.core.generated.gcs_pb2 import (
     ActorTableData,
@@ -101,6 +102,13 @@ ERROR_TYPE = [
     "END_OF_STREAMING_GENERATOR",
     "ACTOR_UNAVAILABLE"
 ]
+# The Language enum is used in the export API so it is public
+# and any modifications must be backward compatible.
+LANGUAGE = [
+    "PYTHON",
+    "JAVA,
+    "CPP"
+]
 
 
 def validate_protobuf_enum(grpc_enum, custom_enum):
@@ -125,3 +133,4 @@ validate_protobuf_enum(WorkerType, WORKER_TYPE)
 validate_protobuf_enum(WorkerExitType, WORKER_EXIT_TYPE)
 validate_protobuf_enum(TaskType, TASK_TYPE)
 validate_protobuf_enum(ErrorType, ERROR_TYPE)
+validate_protobuf_enum(Language, LANGUAGE)

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -178,6 +178,8 @@ message ConcurrencyGroup {
 // TODO(hchen): We may want to make these errors more specific. E.g., we may
 // want to distinguish between intentional and expected actor failures, and
 // between worker process failure and node failure.
+// Note: The ErrorType enum is used in the export API so it is public
+// and any modifications must be backward compatible.
 enum ErrorType {
   // Indicates that a task failed because the worker died unexpectedly while
   // executing it.

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -22,6 +22,8 @@ import "src/ray/protobuf/runtime_env_common.proto";
 option java_package = "io.ray.runtime.generated";
 
 // Language of a task or worker.
+// Note: The Language enum is used in the export API so it is public
+// and any modifications must be backward compatible.
 enum Language {
   PYTHON = 0;
   JAVA = 1;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- The `ErrorType` and `Language` enums will be used in the export API (https://github.com/ray-project/ray/pull/46758) so they need to be marked as public.
- Added comments for this, and validation of the enum values in `python/ray/util/state/custom_types.py`  

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
