### PR TITLE
Version Switcher Part 3

### DIFF
--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -393,8 +393,8 @@ table.autosummary tr > td:first-child > p > a > code > span {
 
 /* Prevent the the PyData theme Version Switcher from getting too large */
 .version-switcher__menu {
-  max-height: 496px;
-  overflow: scroll;
+  max-height: 40rem;
+  overflow-y: scroll;
 }
 
 /* Hide the RTD version switcher since we are using PyData theme one */

--- a/doc/source/custom_directives.py
+++ b/doc/source/custom_directives.py
@@ -1256,14 +1256,6 @@ def pregenerate_example_rsts(
             )
 
 
-ray_prefix = "ray-"
-min_version = "1.11.0"
-repo_url = "https://github.com/ray-project/ray.git"
-static_dir_name = "_static"
-version_json_filename = "versions.json"
-dereference_suffix = "^{}"
-
-
 def generate_version_url(version):
     return f"https://docs.ray.io/en/{version}/"
 
@@ -1272,6 +1264,13 @@ def generate_versions_json():
     """Gets the releases from the remote repo, sorts them in semver order,
     and generates the JSON needed for the version switcher
     """
+
+    ray_prefix = "ray-"
+    min_version = "1.11.0"
+    repo_url = "https://github.com/ray-project/ray.git"
+    static_dir_name = "_static"
+    version_json_filename = "versions.json"
+    dereference_suffix = "^{}"
 
     version_json_data = []
 


### PR DESCRIPTION
## Why are these changes needed?

A few small follow ups for the version switcher:
- move constants to inside the versions JSON generation function
- updated height of version switcher to be relative so it scales up with zoom level
- changed `overflow` to `overflow-y` to stop the extra horizontal scroll from showing up
Before:
 ![Screenshot 2024-08-08 at 9 56 01 AM](https://github.com/user-attachments/assets/ac94b727-ca20-4c3b-8488-347549d19eca)
After:
![Screenshot 2024-08-08 at 10 02 21 AM](https://github.com/user-attachments/assets/05813997-bee1-480a-bbcb-e4f02ac88a99)

## Related issue number

Relevant issues already closed

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
