### PR TITLE
[Core] Remove unnecessary gcs rpc reply status conversion

### DIFF
--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -289,11 +289,7 @@ Status ActorInfoAccessor::AsyncRegisterActor(const ray::TaskSpecification &task_
   request.mutable_task_spec()->CopyFrom(task_spec.GetMessage());
   client_impl_->GetGcsRpcClient().RegisterActor(
       request,
-      [callback](const Status & /*unused*/, rpc::RegisterActorReply &&reply) {
-        auto status =
-            reply.status().code() == (int)StatusCode::OK
-                ? Status()
-                : Status(StatusCode(reply.status().code()), reply.status().message());
+      [callback](const Status &status, rpc::RegisterActorReply &&reply) {
         callback(status);
       },
       timeout_ms);
@@ -321,12 +317,8 @@ Status ActorInfoAccessor::AsyncKillActor(const ActorID &actor_id,
   request.set_no_restart(no_restart);
   client_impl_->GetGcsRpcClient().KillActorViaGcs(
       request,
-      [callback](const Status & /*unused*/, rpc::KillActorViaGcsReply &&reply) {
+      [callback](const Status &status, rpc::KillActorViaGcsReply &&reply) {
         if (callback) {
-          auto status =
-              reply.status().code() == (int)StatusCode::OK
-                  ? Status()
-                  : Status(StatusCode(reply.status().code()), reply.status().message());
           callback(status);
         }
       },
@@ -341,11 +333,7 @@ Status ActorInfoAccessor::AsyncCreateActor(
   rpc::CreateActorRequest request;
   request.mutable_task_spec()->CopyFrom(task_spec.GetMessage());
   client_impl_->GetGcsRpcClient().CreateActor(
-      request, [callback](const Status & /*unused*/, rpc::CreateActorReply &&reply) {
-        auto status =
-            reply.status().code() == (int)StatusCode::OK
-                ? Status()
-                : Status(StatusCode(reply.status().code()), reply.status().message());
+      request, [callback](const Status &status, rpc::CreateActorReply &&reply) {
         callback(status, std::move(reply));
       });
   return Status::OK();


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The status conversion is already done inside gcs_rpc_client:

```
void invoke_async_method(
      PrepareAsyncFunction<Service, Request, Reply> prepare_async_function,
      GrpcClient<Service> &grpc_client,
      const std::string &call_name,
      const Request &request,
      const ClientCallback<Reply> &callback,
      const int64_t timeout_ms) {
    auto executor = new Executor(
        [callback](const ray::Status &status) { callback(status, Reply()); });
    auto operation_callback = [this, request, callback, executor, timeout_ms](
                                  const ray::Status &status, Reply &&reply) {
      if (status.ok()) {
        if constexpr (handle_payload_status) {
          Status st =
              (reply.status().code() == (int)StatusCode::OK)
                  ? Status()
                  : Status(StatusCode(reply.status().code()), reply.status().message());
          callback(st, std::move(reply));
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
