### PR TITLE
[Data] Only show message regarding hiding op-level progress bar once

### DIFF
--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -5,7 +5,9 @@ import warnings
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
+import ray
 from ray._private.ray_constants import env_bool, env_integer
+from ray._private.worker import WORKER_MODE
 from ray.util.annotations import DeveloperAPI
 from ray.util.debug import log_once
 from ray.util.scheduling_strategies import SchedulingStrategyT
@@ -328,7 +330,10 @@ class DataContext:
 
         is_ray_job = os.environ.get("RAY_JOB_ID") is not None
         if is_ray_job:
-            if log_once("ray_data_disable_operator_progress_bars_in_ray_jobs"):
+            is_driver = ray.get_runtime_context().worker.mode != WORKER_MODE
+            if is_driver and log_once(
+                "ray_data_disable_operator_progress_bars_in_ray_jobs"
+            ):
                 logger.info(
                     "Disabling operator-level progress bars by default in Ray Jobs. "
                     "To enable progress bars for all operators, set "

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -93,23 +93,6 @@ DEFAULT_ENABLE_PROGRESS_BAR_NAME_TRUNCATION = env_bool(
     "RAY_DATA_ENABLE_PROGRESS_BAR_NAME_TRUNCATION", True
 )
 
-is_ray_job = os.environ.get("RAY_JOB_ID") is not None
-if is_ray_job:
-    if log_once("ray_data_disable_operator_progress_bars_in_ray_jobs"):
-        logger.info(
-            "Disabling operator-level progress bars by default in Ray Jobs. "
-            "To enable progress bars for all operators, set "
-            "`ray.data.DataContext.get_current().enable_operator_progress_bars = True`."
-        )
-    # Disable operator-level progress bars by default in Ray jobs.
-    # The global progress bar for the overall Dataset execution will
-    # still be enabled, unless the user also sets
-    # `ray.data.DataContext.get_current().enable_progress_bars = False`.
-    DEFAULT_ENABLE_OPERATOR_PROGRESS_BARS = False
-else:
-    # When not running in Ray job, operator-level progress bars are enabled by default.
-    DEFAULT_ENABLE_OPERATOR_PROGRESS_BARS = True
-
 DEFAULT_ENABLE_GET_OBJECT_LOCATIONS_FOR_METRICS = False
 
 
@@ -300,7 +283,10 @@ class DataContext:
     )
     use_ray_tqdm: bool = DEFAULT_USE_RAY_TQDM
     enable_progress_bars: bool = DEFAULT_ENABLE_PROGRESS_BARS
-    enable_operator_progress_bars: bool = DEFAULT_ENABLE_OPERATOR_PROGRESS_BARS
+    # By default, enable the progress bar for operator-level progress.
+    # In __post_init__(), we disable operator-level progress
+    # bars when running in a Ray job.
+    enable_operator_progress_bars: bool = True
     enable_progress_bar_name_truncation: bool = (
         DEFAULT_ENABLE_PROGRESS_BAR_NAME_TRUNCATION
     )
@@ -339,6 +325,25 @@ class DataContext:
         self._max_num_blocks_in_streaming_gen_buffer = (
             DEFAULT_MAX_NUM_BLOCKS_IN_STREAMING_GEN_BUFFER
         )
+
+        is_ray_job = os.environ.get("RAY_JOB_ID") is not None
+        if is_ray_job:
+            if log_once("ray_data_disable_operator_progress_bars_in_ray_jobs"):
+                logger.info(
+                    "Disabling operator-level progress bars by default in Ray Jobs. "
+                    "To enable progress bars for all operators, set "
+                    "`ray.data.DataContext.get_current()"
+                    ".enable_operator_progress_bars = True`."
+                )
+            # Disable operator-level progress bars by default in Ray jobs.
+            # The global progress bar for the overall Dataset execution will
+            # still be enabled, unless the user also sets
+            # `ray.data.DataContext.get_current().enable_progress_bars = False`.
+            self.enable_operator_progress_bars = False
+        else:
+            # When not running in Ray job, operator-level progress
+            # bars are enabled by default.
+            self.enable_operator_progress_bars = True
 
     def __setattr__(self, name: str, value: Any) -> None:
         if (


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
https://github.com/ray-project/ray/pull/46826 introduced a bug, where the info log regarding hiding operator-level progress bars is always shown, regardless of whether the code was run via a Ray Job or not. 

This PR fixes the bug by moving the check for whether the code is run via a Ray Job or not into the `DataContext.__post_init__()` method, so that the check is done only after the DataContext singleton is initialized.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
