### PR TITLE
cherry pick version switcher to 2.30.0

### DIFF
--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -20,3 +20,6 @@ source/workflows/api/doc/
 source/data/examples.rst
 source/train/examples.rst
 source/serve/examples.rst
+
+# Ignore generated versions
+source/_static/versions.json

--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -407,3 +407,14 @@ table.autosummary tr > td:first-child > p > a > code > span {
   color: var(--pst-color-light);
   text-decoration: underline;
 }
+
+/* Prevent the the PyData theme Version Switcher from getting too large */
+.version-switcher__menu {
+  max-height: 496px;
+  overflow: scroll;
+}
+
+/* Hide the RTD version switcher since we are using PyData theme one */
+#rtd-footer-container {
+  display: none;
+}

--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -410,8 +410,8 @@ table.autosummary tr > td:first-child > p > a > code > span {
 
 /* Prevent the the PyData theme Version Switcher from getting too large */
 .version-switcher__menu {
-  max-height: 496px;
-  overflow: scroll;
+  max-height: 40rem;
+  overflow-y: scroll;
 }
 
 /* Hide the RTD version switcher since we are using PyData theme one */

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -272,6 +272,7 @@ html_theme_options = {
     },
     "navbar_start": ["navbar-ray-logo"],
     "navbar_end": [
+        "version-switcher",
         "navbar-icon-links",
         "navbar-anyscale",
     ],
@@ -292,6 +293,10 @@ html_theme_options = {
     "analytics": {"google_analytics_id": "UA-110413294-1"},
     "pygment_light_style": "stata-dark",
     "pygment_dark_style": "stata-dark",
+    "switcher": {
+        "json_url": "https://docs.ray.io/en/master/_static/versions.json",
+        "version_match": os.getenv("READTHEDOCS_VERSION", "master"),
+    },
 }
 
 html_context = {

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -20,6 +20,7 @@ from custom_directives import (  # noqa
     parse_navbar_config,
     setup_context,
     pregenerate_example_rsts,
+    generate_versions_json,
 )
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -416,6 +417,10 @@ def add_custom_assets(
 
 
 def setup(app):
+    # Only generate versions JSON during RTD build
+    if os.getenv("READTHEDOCS") == "True":
+        generate_versions_json()
+
     pregenerate_example_rsts(app)
 
     # NOTE: 'MOCK' is a custom option we introduced to illustrate mock outputs. Since

--- a/doc/source/custom_directives.py
+++ b/doc/source/custom_directives.py
@@ -1232,6 +1232,7 @@ min_version = "1.11.0"
 repo_url = "https://github.com/ray-project/ray.git"
 static_dir_name = "_static"
 version_json_filename = "versions.json"
+dereference_suffix = "^{}"
 
 
 def generate_version_url(version):
@@ -1257,11 +1258,11 @@ def generate_versions_json():
         "utf-8"
     )
     # Extract release versions from tags
-    tags = re.findall(r"refs/tags/(.+?)(?:\^|\s|$)", output)
+    tags = re.findall(r"refs/tags/(.+)", output)
     for tag in tags:
-        if ray_prefix in tag:
+        if ray_prefix in tag and dereference_suffix not in tag:
             version = tag.split(ray_prefix)[1]
-            if Version(version) >= Version(min_version):
+            if version not in git_versions and Version(version) >= Version(min_version):
                 git_versions.append(version)
     git_versions.sort(key=Version, reverse=True)
 

--- a/doc/source/custom_directives.py
+++ b/doc/source/custom_directives.py
@@ -1227,14 +1227,6 @@ def pregenerate_example_rsts(
             )
 
 
-ray_prefix = "ray-"
-min_version = "1.11.0"
-repo_url = "https://github.com/ray-project/ray.git"
-static_dir_name = "_static"
-version_json_filename = "versions.json"
-dereference_suffix = "^{}"
-
-
 def generate_version_url(version):
     return f"https://docs.ray.io/en/{version}/"
 
@@ -1243,6 +1235,13 @@ def generate_versions_json():
     """Gets the releases from the remote repo, sorts them in semver order,
     and generates the JSON needed for the version switcher
     """
+
+    ray_prefix = "ray-"
+    min_version = "1.11.0"
+    repo_url = "https://github.com/ray-project/ray.git"
+    static_dir_name = "_static"
+    version_json_filename = "versions.json"
+    dereference_suffix = "^{}"
 
     version_json_data = []
 

--- a/doc/source/custom_directives.py
+++ b/doc/source/custom_directives.py
@@ -29,6 +29,7 @@ from pygments.lexers import PythonLexer
 from pygments.formatters import HtmlFormatter
 
 
+import subprocess
 import json
 from packaging.version import Version
 

--- a/doc/source/custom_directives.py
+++ b/doc/source/custom_directives.py
@@ -9,6 +9,7 @@ import yaml
 import bs4
 import logging
 import logging.handlers
+import os
 import pathlib
 import random
 import urllib
@@ -27,6 +28,9 @@ from pygments import highlight
 from pygments.lexers import PythonLexer
 from pygments.formatters import HtmlFormatter
 
+
+import json
+from packaging.version import Version
 
 logger = logging.getLogger(__name__)
 
@@ -1221,6 +1225,63 @@ def pregenerate_example_rsts(
                 "  .. this file is pregenerated; please edit ./examples.yml to "
                 "modify examples for this library."
             )
+
+
+ray_prefix = "ray-"
+min_version = "1.11.0"
+repo_url = "https://github.com/ray-project/ray.git"
+static_dir_name = "_static"
+version_json_filename = "versions.json"
+
+
+def generate_version_url(version):
+    return f"https://docs.ray.io/en/{version}/"
+
+
+def generate_versions_json():
+    """Gets the releases from the remote repo, sorts them in semver order,
+    and generates the JSON needed for the version switcher
+    """
+
+    version_json_data = []
+
+    # Versions that should always appear at the top
+    for version in ["latest", "master"]:
+        version_json_data.append(
+            {"version": version, "url": generate_version_url(version)}
+        )
+
+    git_versions = []
+    # Fetch release tags from repo
+    output = subprocess.check_output(["git", "ls-remote", "--tags", repo_url]).decode(
+        "utf-8"
+    )
+    # Extract release versions from tags
+    tags = re.findall(r"refs/tags/(.+?)(?:\^|\s|$)", output)
+    for tag in tags:
+        if ray_prefix in tag:
+            version = tag.split(ray_prefix)[1]
+            if Version(version) >= Version(min_version):
+                git_versions.append(version)
+    git_versions.sort(key=Version, reverse=True)
+
+    for version in git_versions:
+        version_json_data.append(
+            {
+                "version": f"releases/{version}",
+                "url": generate_version_url(f"releases-{version}"),
+            }
+        )
+
+    # Ensure static path exists
+    static_dir = os.path.join(os.path.dirname(__file__), static_dir_name)
+    if not os.path.exists(static_dir):
+        os.makedirs(static_dir)
+
+    # Write JSON output
+    output_path = os.path.join(static_dir, version_json_filename)
+    with open(output_path, "w") as f:
+        json.dump(version_json_data, f, indent=4)
 
 
 REMIX_ICONS = [


### PR DESCRIPTION
## Why are these changes needed?

Cherry picks the versions picker commits from master so it shows up in this older release version. Added missing subprocess import

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
