### PR TITLE
[Data] Change pickling log level from warning to debug

### DIFF
--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -242,7 +242,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
                 except ArrowConversionError as e:
                     if object_extension_type_allowed() and is_object_fixable_error(e):
                         if log_once(f"arrow_object_pickle_{col_name}"):
-                            logger.warning(
+                            logger.debug(
                                 f"Failed to interpret {col_name} as "
                                 "multi-dimensional arrays. It will be pickled."
                             )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

When Ray Data can't represent objects as multi-dimensional arrays, it emits a warning and uses the `ArrowPythonObjectArray` extension type. This behavior is expected and doesn't always indicate an actual issue. To prevent confusion, I'm changing the log level from warning to debug.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
