### PR TITLE
[core][dashboard] Adds Dashboard RSS metrics

### DIFF
--- a/python/ray/dashboard/dashboard_metrics.py
+++ b/python/ray/dashboard/dashboard_metrics.py
@@ -91,9 +91,17 @@ try:
                 namespace="ray",
                 registry=self.registry,
             )
-            self.metrics_dashboard_mem = Gauge(
+            self.metrics_dashboard_mem_uss = Gauge(
                 "component_uss",
                 "USS usage of all components on the node.",
+                tuple(COMPONENT_METRICS_TAG_KEYS),
+                unit="mb",
+                namespace="ray",
+                registry=self.registry,
+            )
+            self.metrics_dashboard_mem_rss = Gauge(
+                "component_rss",
+                "RSS usage of all components on the node.",
                 tuple(COMPONENT_METRICS_TAG_KEYS),
                 unit="mb",
                 namespace="ray",


### PR DESCRIPTION
Dashboard has `ray_component_uss_mb` metrics but not `ray_component_rss_mb` but the latter is used in the Ray Grafana dash "Node Memory by Component". Adds it. Note gcs_server is still missing.