### PR TITLE
[Data] Bump min version of PyArrow from 6.0 to 9.0

### DIFF
--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -28,7 +28,7 @@ steps:
     wanda: ci/docker/datatfxbsl.build.wanda.yaml
 
   # tests
-  - label: ":database: data: arrow 9 tests"
+  - label: ":database: data: arrow v9 tests"
     tags: 
       - python
       - data
@@ -42,7 +42,7 @@ steps:
         --except-tags data_integration,doctest
     depends_on: data9build
 
-  - label: ":database: data: arrow 17 tests"
+  - label: ":database: data: arrow v17 tests"
     tags: 
       - python
       - data
@@ -56,7 +56,7 @@ steps:
         --except-tags data_integration,doctest
     depends_on: datalbuild
 
-  - label: ":database: data: arrow 17 {{matrix.python}} tests ({{matrix.worker_id}})"
+  - label: ":database: data: arrow v17 {{matrix.python}} tests ({{matrix.worker_id}})"
     key: datal_python_tests
     if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
     tags: 

--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -4,8 +4,8 @@ depends_on:
   - oss-ci-base_ml
 steps:
   # builds
-  - name: data6build
-    wanda: ci/docker/data6.build.wanda.yaml
+  - name: data9build
+    wanda: ci/docker/data9.build.wanda.yaml
 
   - name: datalbuild
     wanda: ci/docker/datal.build.wanda.yaml
@@ -28,7 +28,7 @@ steps:
     wanda: ci/docker/datatfxbsl.build.wanda.yaml
 
   # tests
-  - label: ":database: data: arrow 6 tests"
+  - label: ":database: data: arrow 9 tests"
     tags: 
       - python
       - data
@@ -38,9 +38,9 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/data/... //python/ray/air/... data 
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" 
         --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
-        --build-name data6build
+        --build-name data9build
         --except-tags data_integration,doctest
-    depends_on: data6build
+    depends_on: data9build
 
   - label: ":database: data: arrow 17 tests"
     tags: 

--- a/ci/docker/data6.build.wanda.yaml
+++ b/ci/docker/data6.build.wanda.yaml
@@ -1,4 +1,4 @@
-name: "data6build"
+name: "data9build"
 froms: ["cr.ray.io/rayproject/oss-ci-base_ml"]
 dockerfile: ci/docker/data.build.Dockerfile
 srcs:
@@ -12,4 +12,4 @@ srcs:
 build_args:
   - ARROW_VERSION=6.*
 tags:
-  - cr.ray.io/rayproject/data6build
+  - cr.ray.io/rayproject/data9build

--- a/ci/docker/data9.build.wanda.yaml
+++ b/ci/docker/data9.build.wanda.yaml
@@ -10,6 +10,6 @@ srcs:
   - python/requirements/ml/data-requirements.txt
   - python/requirements/ml/data-test-requirements.txt
 build_args:
-  - ARROW_VERSION=6.*
+  - ARROW_VERSION=9.*
 tags:
   - cr.ray.io/rayproject/data9build

--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -119,8 +119,8 @@ if __name__ == "__main__":
                 or changed_file == "ci/docker/data.build.Dockerfile"
                 or changed_file == "ci/docker/data.build.wanda.yaml"
                 or changed_file == "ci/docker/datan.build.wanda.yaml"
-                or changed_file == "ci/docker/data6.build.wanda.yaml"
-                or changed_file == "ci/docker/data14.build.wanda.yaml"
+                or changed_file == "ci/docker/data9.build.wanda.yaml"
+                or changed_file == "ci/docker/datal.build.wanda.yaml"
             ):
                 RAY_CI_DATA_AFFECTED = 1
                 RAY_CI_ML_AFFECTED = 1

--- a/python/ray/data/tests/test_huggingface.py
+++ b/python/ray/data/tests/test_huggingface.py
@@ -17,8 +17,9 @@ def hfds_assert_equals(hfds: datasets.Dataset, ds: Dataset):
     hfds_table = hfds.data.table
     ds_table = pyarrow.concat_tables([ray.get(tbl) for tbl in ds.to_arrow_refs()])
 
-    hfds_table = hfds_table.sort_by([hfds_table.schema.names[0]])
-    ds_table = ds_table.sort_by([ds_table.schema.names[0]])
+    sorting = [(name, "descending") for name in hfds_table.column_names]
+    hfds_table = hfds_table.sort_by(sorting)
+    ds_table = ds_table.sort_by(sorting)
 
     assert hfds_table.equals(ds_table)
 

--- a/python/ray/data/tests/test_iceberg.py
+++ b/python/ray/data/tests/test_iceberg.py
@@ -3,7 +3,6 @@ import random
 
 import pyarrow as pa
 import pytest
-from packaging.version import Version
 from pkg_resources import parse_version
 from pyiceberg import catalog as pyi_catalog
 from pyiceberg import expressions as pyi_expr
@@ -101,8 +100,8 @@ def pyiceberg_table():
 
 
 @pytest.mark.skipif(
-    Version(pa.__version__) < Version("9.0.0"),
-    reason="PyIceberg depends on pyarrow>=9.0.0",
+    parse_version(_get_pyarrow_version()) < parse_version("14.0.0"),
+    reason="PyIceberg 0.7.0 fails on pyarrow <= 14.0.0",
 )
 def test_get_catalog():
     # NOTE: Iceberg only works with PyArrow 9 or above.
@@ -121,8 +120,8 @@ def test_get_catalog():
 
 
 @pytest.mark.skipif(
-    Version(pa.__version__) < Version("9.0.0"),
-    reason="PyIceberg depends on pyarrow>=9.0.0",
+    parse_version(_get_pyarrow_version()) < parse_version("14.0.0"),
+    reason="PyIceberg 0.7.0 fails on pyarrow <= 14.0.0",
 )
 def test_plan_files():
     # NOTE: Iceberg only works with PyArrow 9 or above.
@@ -141,8 +140,8 @@ def test_plan_files():
 
 
 @pytest.mark.skipif(
-    Version(pa.__version__) < Version("9.0.0"),
-    reason="PyIceberg depends on pyarrow>=9.0.0",
+    parse_version(_get_pyarrow_version()) < parse_version("14.0.0"),
+    reason="PyIceberg 0.7.0 fails on pyarrow <= 14.0.0",
 )
 def test_chunk_plan_files():
     # NOTE: Iceberg only works with PyArrow 9 or above.
@@ -168,8 +167,8 @@ def test_chunk_plan_files():
 
 
 @pytest.mark.skipif(
-    Version(pa.__version__) < Version("9.0.0"),
-    reason="PyIceberg depends on pyarrow>=9.0.0",
+    parse_version(_get_pyarrow_version()) < parse_version("14.0.0"),
+    reason="PyIceberg 0.7.0 fails on pyarrow <= 14.0.0",
 )
 def test_get_read_tasks():
     # NOTE: Iceberg only works with PyArrow 9 or above.
@@ -189,8 +188,8 @@ def test_get_read_tasks():
 
 
 @pytest.mark.skipif(
-    Version(pa.__version__) < Version("9.0.0"),
-    reason="PyIceberg depends on pyarrow>=9.0.0",
+    parse_version(_get_pyarrow_version()) < parse_version("14.0.0"),
+    reason="PyIceberg 0.7.0 fails on pyarrow <= 14.0.0",
 )
 def test_filtered_read():
     # NOTE: Iceberg only works with PyArrow 9 or above.
@@ -215,8 +214,8 @@ def test_filtered_read():
 
 
 @pytest.mark.skipif(
-    Version(pa.__version__) < Version("9.0.0"),
-    reason="PyIceberg depends on pyarrow>=9.0.0",
+    parse_version(_get_pyarrow_version()) < parse_version("14.0.0"),
+    reason="PyIceberg 0.7.0 fails on pyarrow <= 14.0.0",
 )
 def test_read_basic():
     # NOTE: Iceberg only works with PyArrow 9 or above.

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -618,9 +618,15 @@ def test_parquet_read_partitioned_with_partition_filter(
         ),
     )
 
-    assert ds.columns() == ["x", "y", "z"]
+    assert ds.schema() == Schema(pa.schema([
+        ('x', pa.string()),
+        ('y', pa.string()),
+        ('z', pa.float64()),
+    ]))
+
     values = [[s["x"], s["y"], s["z"]] for s in ds.take()]
-    assert sorted(values) == [[0, "a", 0.1]]
+
+    assert sorted(values) == [['0', "a", 0.1]]
 
 
 def test_parquet_read_partitioned_explicit(ray_start_regular_shared, tmp_path):

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -9,9 +9,11 @@ import pyarrow as pa
 import pyarrow.dataset as pds
 import pyarrow.parquet as pq
 import pytest
+from pkg_resources import parse_version
 from pytest_lazyfixture import lazy_fixture
 
 import ray
+from ray._private.utils import _get_pyarrow_version
 from ray.air.util.tensor_extensions.arrow import ArrowTensorType, ArrowTensorTypeV2
 from ray.data import Schema
 from ray.data._internal.datasource.parquet_bulk_datasource import ParquetBulkDatasource
@@ -573,7 +575,7 @@ def test_parquet_read_partitioned_with_columns(ray_start_regular_shared, fs, dat
 # pyarrow does not support single path with partitioning,
 # this issue cannot be resolved by Ray data itself.
 @pytest.mark.skipif(
-    tuple(pa.__version__.split(".")) < ("7",),
+    parse_version(_get_pyarrow_version()) < parse_version("7.0.0"),
     reason="Old pyarrow behavior cannot be fixed.",
 )
 @pytest.mark.parametrize(
@@ -618,15 +620,19 @@ def test_parquet_read_partitioned_with_partition_filter(
         ),
     )
 
-    assert ds.schema() == Schema(pa.schema([
-        ('x', pa.string()),
-        ('y', pa.string()),
-        ('z', pa.float64()),
-    ]))
+    assert ds.schema() == Schema(
+        pa.schema(
+            [
+                ("x", pa.string()),
+                ("y", pa.string()),
+                ("z", pa.float64()),
+            ]
+        )
+    )
 
     values = [[s["x"], s["y"], s["z"]] for s in ds.take()]
 
-    assert sorted(values) == [['0', "a", 0.1]]
+    assert sorted(values) == [["0", "a", 0.1]]
 
 
 def test_parquet_read_partitioned_explicit(ray_start_regular_shared, tmp_path):

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -27,7 +27,7 @@ numpy>=1.20
 
 # pyarrow 18 causes macos build failures.
 # See https://github.com/ray-project/ray/pull/48300
-pyarrow >= 6.0.1
+pyarrow >= 9.0.0
 pyarrow <18; sys_platform == "darwin" and platform_machine == "x86_64"
 
 # ray[all]

--- a/python/setup.py
+++ b/python/setup.py
@@ -277,7 +277,13 @@ if setup_spec.type == SetupType.RAY:
             "fastapi",
             "watchfiles",
         ],
-        "tune": ["pandas", "tensorboardX>=1.9", "requests", *pyarrow_deps, "fsspec"],
+        "tune": [
+            "pandas",
+            "tensorboardX>=1.9",
+            "requests",
+            *pyarrow_deps,
+            "fsspec",
+        ],
     }
 
     # Ray Serve depends on the Ray dashboard components.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Dropping Ray Data internal support for Arrow < 9.0.0 as of Ray 2.39.

This is necessary in avoiding over-compensating for issues resolved in old Arrow versions, like the ones surfacing in https://github.com/ray-project/ray/pull/48266.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
