### PR TITLE
Light up Ask AI button When Seach is Open

### DIFF
--- a/doc/source/_static/css/assistant.css
+++ b/doc/source/_static/css/assistant.css
@@ -22,6 +22,22 @@
   z-index: 1000;
 }
 
+@keyframes jump {
+  0% {
+    transform: scale(1);
+    box-shadow: 0 1px 2px rgba(0,0,0,.15);
+  }
+  100% {
+    transform: scale(1.05);
+    box-shadow: 0 4px 20px rgba(0,0,0,.1);
+  }
+}
+.search-button__wrapper.show ~ .chat-widget {
+  z-index: 1050;
+  animation: .4s jump ease infinite alternate;
+  filter: brightness(1.5);
+}
+
 .chat-popup {
   display: none;
   position: fixed;

--- a/doc/source/_static/js/assistant.js
+++ b/doc/source/_static/js/assistant.js
@@ -47,6 +47,7 @@ document.body.appendChild(blurDiv);
 
 // blur background when chat popup is open
 document.getElementById('openChatBtn').addEventListener('click', function () {
+  document.querySelector('.search-button__wrapper').classList.remove('show');
   document.getElementById('chatPopup').style.display = 'block';
   blurDiv.classList.remove('blurDiv-hidden');
 });


### PR DESCRIPTION
## Why are these changes needed?

Lights up and adds a bounce animation when the search input is open
- used css sibling selector to target the ask AI button when the search input and overlay is open, to add a bounce and brighten the button by 50% as well as raise the z index so it is visible over the overlay
- JS to ensure that search is closed when ask AI is clicked
https://www.loom.com/share/c84653be0b4a42debaa71f361c11dc42?sid=58e13baf-30bc-4524-a569-9d26af2d7175

## Related issue number

Closes https://github.com/ray-project/ray/issues/46136

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
