### PR TITLE
[data] add validation for shuffle arg

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -280,7 +280,6 @@ class ParquetDatasource(Datasource):
         self._schema = schema
         self._file_metadata_shuffler = None
         self._include_paths = include_paths
-
         if shuffle == "files":
             self._file_metadata_shuffler = np.random.default_rng()
 

--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -33,7 +33,6 @@ from ray.data.datasource._default_metadata_providers import (
     get_generic_metadata_provider,
 )
 from ray.data.datasource.datasource import ReadTask
-from ray.data.datasource.file_based_datasource import _validate_shuffle_arg
 from ray.data.datasource.file_meta_provider import _handle_read_os_error
 from ray.data.datasource.parquet_meta_provider import ParquetMetadataProvider
 from ray.data.datasource.partitioning import PathPartitionFilter
@@ -279,10 +278,9 @@ class ParquetDatasource(Datasource):
         self._to_batches_kwargs = to_batch_kwargs
         self._columns = columns
         self._schema = schema
+        self._file_metadata_shuffler = None
         self._include_paths = include_paths
 
-        _validate_shuffle_arg(shuffle)
-        self._file_metadata_shuffler = None
         if shuffle == "files":
             self._file_metadata_shuffler = np.random.default_rng()
 

--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -33,6 +33,7 @@ from ray.data.datasource._default_metadata_providers import (
     get_generic_metadata_provider,
 )
 from ray.data.datasource.datasource import ReadTask
+from ray.data.datasource.file_based_datasource import _validate_shuffle_arg
 from ray.data.datasource.file_meta_provider import _handle_read_os_error
 from ray.data.datasource.parquet_meta_provider import ParquetMetadataProvider
 from ray.data.datasource.partitioning import PathPartitionFilter
@@ -278,8 +279,10 @@ class ParquetDatasource(Datasource):
         self._to_batches_kwargs = to_batch_kwargs
         self._columns = columns
         self._schema = schema
-        self._file_metadata_shuffler = None
         self._include_paths = include_paths
+
+        _validate_shuffle_arg(shuffle)
+        self._file_metadata_shuffler = None
         if shuffle == "files":
             self._file_metadata_shuffler = np.random.default_rng()
 

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -150,6 +150,7 @@ class FileBasedDatasource(Datasource):
                     "'file_extensions' field is set properly."
                 )
 
+        _validate_shuffle_arg(shuffle)
         self._file_metadata_shuffler = None
         if shuffle == "files":
             self._file_metadata_shuffler = np.random.default_rng()
@@ -519,3 +520,11 @@ def _open_file_with_retry(
         max_attempts=OPEN_FILE_MAX_ATTEMPTS,
         max_backoff_s=OPEN_FILE_RETRY_MAX_BACKOFF_SECONDS,
     )
+
+
+def _validate_shuffle_arg(shuffle: Optional[str]) -> None:
+    if shuffle not in [None, "files"]:
+        raise ValueError(
+            f"Invalid value for 'shuffle': {shuffle}. "
+            "Valid values are None, 'files'."
+        )

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -755,14 +755,14 @@ def read_parquet(
         :class:`~ray.data.Dataset` producing records read from the specified parquet
         files.
     """
+    _validate_shuffle_arg(shuffle)
+
     if meta_provider is None:
         meta_provider = get_parquet_metadata_provider(override_num_blocks)
     arrow_parquet_args = _resolve_parquet_args(
         tensor_column_schema,
         **arrow_parquet_args,
     )
-
-    _validate_shuffle_arg
 
     dataset_kwargs = arrow_parquet_args.pop("dataset_kwargs", None)
     _block_udf = arrow_parquet_args.pop("_block_udf", None)

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -762,6 +762,8 @@ def read_parquet(
         **arrow_parquet_args,
     )
 
+    _validate_shuffle_arg
+
     dataset_kwargs = arrow_parquet_args.pop("dataset_kwargs", None)
     _block_udf = arrow_parquet_args.pop("_block_udf", None)
     schema = arrow_parquet_args.pop("schema", None)
@@ -3157,3 +3159,11 @@ def _get_num_output_blocks(
     elif override_num_blocks is not None:
         parallelism = override_num_blocks
     return parallelism
+
+
+def _validate_shuffle_arg(shuffle: Optional[str]) -> None:
+    if shuffle not in [None, "files"]:
+        raise ValueError(
+            f"Invalid value for 'shuffle': {shuffle}. "
+            "Valid values are None, 'files'."
+        )

--- a/python/ray/data/tests/test_file_based_datasource.py
+++ b/python/ray/data/tests/test_file_based_datasource.py
@@ -119,27 +119,35 @@ def test_windows_path():
 
 
 @pytest.mark.parametrize(
-    "shuffle, valid",
-    [
-        (None, True),
-        ("files", True),
-        (True, False),
-        (False, False),
-        ("file", False),
-    ],
+    "shuffle",
+    [True, False, "file"],
 )
-def test_shuffle_arg(ray_start_regular_shared, tmp_path, shuffle, valid):
+def test_invalid_shuffle_arg_raises_error(ray_start_regular_shared, tmp_path, shuffle):
 
     path = os.path.join(tmp_path, "test.txt")
     with open(path, "w"):
         pass
 
-    if valid:
+    with pytest.raises(ValueError):
         FileBasedDatasource(path, shuffle=shuffle)
 
-    else:
-        with pytest.raises(ValueError):
-            FileBasedDatasource(path, shuffle=shuffle)
+
+@pytest.mark.parametrize(
+    "shuffle",
+    [
+        None,
+        "files",
+    ],
+)
+def test_valid_shuffle_arg_does_not_raise_error(
+    ray_start_regular_shared, tmp_path, shuffle
+):
+
+    path = os.path.join(tmp_path, "test.txt")
+    with open(path, "w"):
+        pass
+
+    FileBasedDatasource(path, shuffle=shuffle)
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_file_based_datasource.py
+++ b/python/ray/data/tests/test_file_based_datasource.py
@@ -118,36 +118,15 @@ def test_windows_path():
         assert _is_local_windows_path("c:\\some\\where/mixed")
 
 
-@pytest.mark.parametrize(
-    "shuffle",
-    [True, False, "file"],
-)
-def test_invalid_shuffle_arg_raises_error(ray_start_regular_shared, tmp_path, shuffle):
-
-    path = os.path.join(tmp_path, "test.txt")
-    with open(path, "w"):
-        pass
-
+@pytest.mark.parametrize("shuffle", [True, False, "file"])
+def test_invalid_shuffle_arg_raises_error(ray_start_regular_shared, shuffle):
     with pytest.raises(ValueError):
-        FileBasedDatasource(path, shuffle=shuffle)
+        FileBasedDatasource("example://iris.csv", shuffle=shuffle)
 
 
-@pytest.mark.parametrize(
-    "shuffle",
-    [
-        None,
-        "files",
-    ],
-)
-def test_valid_shuffle_arg_does_not_raise_error(
-    ray_start_regular_shared, tmp_path, shuffle
-):
-
-    path = os.path.join(tmp_path, "test.txt")
-    with open(path, "w"):
-        pass
-
-    FileBasedDatasource(path, shuffle=shuffle)
+@pytest.mark.parametrize("shuffle", [None, "files"])
+def test_valid_shuffle_arg_does_not_raise_error(ray_start_regular_shared, shuffle):
+    FileBasedDatasource("example://iris.csv", shuffle=shuffle)
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_file_based_datasource.py
+++ b/python/ray/data/tests/test_file_based_datasource.py
@@ -118,6 +118,30 @@ def test_windows_path():
         assert _is_local_windows_path("c:\\some\\where/mixed")
 
 
+@pytest.mark.parametrize(
+    "shuffle, valid",
+    [
+        (None, True),
+        ("files", True),
+        (True, False),
+        (False, False),
+        ("file", False),
+    ],
+)
+def test_shuffle_arg(ray_start_regular_shared, tmp_path, shuffle, valid):
+
+    path = os.path.join(tmp_path, "test.txt")
+    with open(path, "w"):
+        pass
+
+    if valid:
+        FileBasedDatasource(path, shuffle=shuffle)
+
+    else:
+        with pytest.raises(ValueError):
+            FileBasedDatasource(path, shuffle=shuffle)
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -1179,6 +1179,18 @@ def test_write_num_rows_per_file(tmp_path, ray_start_regular_shared, num_rows_pe
         assert len(table) == num_rows_per_file
 
 
+@pytest.mark.parametrize("shuffle", [True, False, "file"])
+def test_invalid_shuffle_arg_raises_error(ray_start_regular_shared, shuffle):
+
+    with pytest.raises(ValueError):
+        ray.data.read_parquet("example://iris.parquet", shuffle=shuffle)
+
+
+@pytest.mark.parametrize("shuffle", [None, "files"])
+def test_valid_shuffle_arg_does_not_raise_error(ray_start_regular_shared, shuffle):
+    ray.data.read_parquet("example://iris.parquet", shuffle=shuffle)
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Add validation for `shuffle` argument. Previously, specifying an incorrect argument would lead to the default behavior of `None`, which does is no shuffling.

**Before:**
```
>>> ray.data.read_parquet("/tmp/files", shuffle=True)
Dataset(num_rows=?, schema={})
```

**After:**
```
>>> ray.data.read_parquet("/tmp/files", shuffle=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/matt/workspace/ray/python/ray/data/read_api.py", line 768, in read_parquet
    datasource = ParquetDatasource(
                 ^^^^^^^^^^^^^^^^^^
  File "/Users/matt/workspace/ray/python/ray/data/_internal/datasource/parquet_datasource.py", line 284, in __init__
    _validate_shuffle_arg(shuffle)
  File "/Users/matt/workspace/ray/python/ray/data/datasource/file_based_datasource.py", line 527, in _validate_shuffle_arg
    raise ValueError(
ValueError: Invalid value for 'shuffle': True. Valid values are None, 'files'.
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
