### PR TITLE
[core] GcsPublisher bindings

### DIFF
--- a/python/ray/_private/gcs_aio_client.py
+++ b/python/ray/_private/gcs_aio_client.py
@@ -74,6 +74,7 @@ class NewGcsAioClient:
         self.get_all_actor_info = self.inner.async_get_all_actor_info
         self.get_all_node_info = self.inner.async_get_all_node_info
         self.kill_actor = self.inner.async_kill_actor
+        self.publish_node_resource_usage = self.inner.async_publish_node_resource_usage
 
 
 class AsyncProxy:

--- a/python/ray/dashboard/agent.py
+++ b/python/ray/dashboard/agent.py
@@ -84,7 +84,7 @@ class DashboardAgent:
         from ray._private.gcs_pubsub import GcsAioPublisher
         from ray.dashboard.http_server_agent import HttpServerAgent
 
-        self.aio_publisher = GcsAioPublisher(address=self.gcs_address)
+        self.aio_publisher = GcsAioPublisher(self.gcs_aio_client)
 
         try:
             from grpc import aio as aiogrpc

--- a/python/ray/dashboard/agent.py
+++ b/python/ray/dashboard/agent.py
@@ -11,6 +11,7 @@ import sys
 import ray
 import ray._private.ray_constants as ray_constants
 import ray._private.services
+import ray._private.tls_utils
 import ray._private.utils
 import ray.dashboard.consts as dashboard_consts
 import ray.dashboard.utils as dashboard_utils

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -557,6 +557,22 @@ cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
             c_string &rejection_reason_message
         )
 
+    cdef cppclass CPublishToGcsAccessor "ray::gcs::PublishToGcsAccessor":
+        CRayStatus PublishError(
+            const c_string &key_id,
+            const CErrorTableData &data,
+            int64_t timeout_ms)
+
+        CRayStatus PublishLogs(
+            const c_string &key_id,
+            const CLogBatch &data,
+            int64_t timeout_ms)
+
+        CRayStatus AsyncPublishNodeResourceUsage(
+            const c_string &key_id,
+            const c_string &node_resource_usage,
+            const StatusPyCallback &callback
+        )
 
 cdef extern from "ray/gcs/gcs_client/gcs_client.h" nogil:
     cdef enum CGrpcStatusCode "grpc::StatusCode":
@@ -584,6 +600,7 @@ cdef extern from "ray/gcs/gcs_client/gcs_client.h" nogil:
         CNodeResourceInfoAccessor& NodeResources()
         CRuntimeEnvAccessor& RuntimeEnvs()
         CAutoscalerStateAccessor& Autoscaler()
+        CPublishToGcsAccessor& PublishToGcs()
 
     cdef CRayStatus ConnectOnSingletonIoContext(CGcsClient &gcs_client, int timeout_ms)
 

--- a/python/ray/includes/gcs_client.pxi
+++ b/python/ray/includes/gcs_client.pxi
@@ -423,7 +423,7 @@ cdef class NewGcsClient:
                     c_actor_id,
                     force_kill,
                     no_restart,
-                    StatusPyCallback(convert_status, assign_and_decrement_fut,  fut),
+                    StatusPyCallback(convert_status, assign_and_decrement_fut, fut),
                     timeout_ms
                 )
             )
@@ -556,6 +556,67 @@ cdef class NewGcsClient:
 
         return (is_accepted, rejection_reason_message.decode())
 
+
+    #############################################################
+    # Publisher methods
+    #############################################################
+
+    def publish_error(self, key_id: bytes, error_type: str, message: str,
+                      job_id: Optional[JobID]=None, timeout=None):
+        cdef:
+            CErrorTableData error_info
+            c_string c_key_id = key_id
+            int64_t timeout_ms = round(1000 * timeout) if timeout else -1
+
+        if job_id is None:
+            job_id = ray.JobID.nil()
+        error_info.set_job_id(job_id.binary())
+        error_info.set_type(error_type)
+        error_info.set_error_message(message)
+        error_info.set_timestamp(time.time())
+
+        with nogil:
+            check_status_timeout_as_rpc_error(
+                self.inner.get().PublishToGcs().PublishError(
+                    c_key_id, error_info, timeout_ms))
+
+    def publish_logs(self, log_json: dict):
+        cdef:
+            CLogBatch log_batch
+            c_string c_job_id
+            int64_t timeout_ms = -1  # wait forever
+        job_id = log_json.get("job")
+        log_batch.set_ip(log_json.get("ip") if log_json.get("ip") else b"")
+        log_batch.set_pid(
+            str(log_json.get("pid")).encode() if log_json.get("pid") else b"")
+        log_batch.set_job_id(job_id.encode() if job_id else b"")
+        log_batch.set_is_error(bool(log_json.get("is_err")))
+        for line in log_json.get("lines", []):
+            log_batch.add_lines(line)
+        actor_name = log_json.get("actor_name")
+        log_batch.set_actor_name(actor_name.encode() if actor_name else b"")
+        task_name = log_json.get("task_name")
+        log_batch.set_task_name(task_name.encode() if task_name else b"")
+
+        c_job_id = job_id.encode() if job_id else b""
+
+        with nogil:
+            check_status_timeout_as_rpc_error(
+                self.inner.get().PublishToGcs().PublishLogs(
+                    c_job_id, log_batch, timeout_ms))
+
+    def async_publish_node_resource_usage(
+        self, key_id: str, node_resource_usage_json: str) -> Future[None]:
+        cdef:
+            c_string c_key_id = key_id
+            c_string c_node_resource_usage_json = node_resource_usage_json.encode()
+            fut = incremented_fut()
+        with nogil:
+            check_status_timeout_as_rpc_error(
+                self.inner.get().PublishToGcs().AsyncPublishNodeResourceUsage(
+                    c_key_id, c_node_resource_usage_json,
+                    StatusPyCallback(convert_status, assign_and_decrement_fut, fut)))
+        return asyncio.wrap_future(fut)
 
 # Util functions for async handling
 

--- a/python/ray/includes/gcs_client.pxi
+++ b/python/ray/includes/gcs_client.pxi
@@ -556,13 +556,12 @@ cdef class NewGcsClient:
 
         return (is_accepted, rejection_reason_message.decode())
 
-
     #############################################################
     # Publisher methods
     #############################################################
 
     def publish_error(self, key_id: bytes, error_type: str, message: str,
-                      job_id: Optional[JobID]=None, timeout=None):
+                      job_id: Optional[JobID] = None, timeout = None):
         cdef:
             CErrorTableData error_info
             c_string c_key_id = key_id
@@ -606,7 +605,7 @@ cdef class NewGcsClient:
                     c_job_id, log_batch, timeout_ms))
 
     def async_publish_node_resource_usage(
-        self, key_id: str, node_resource_usage_json: str) -> Future[None]:
+            self, key_id: str, node_resource_usage_json: str) -> Future[None]:
         cdef:
             c_string c_key_id = key_id
             c_string c_node_resource_usage_json = node_resource_usage_json.encode()

--- a/python/ray/util/state/state_manager.py
+++ b/python/ray/util/state/state_manager.py
@@ -98,7 +98,7 @@ def handle_grpc_network_errors(func):
                 raise DataSourceUnavailable(
                     "Failed to query the data source. "
                     "It is either there's a network issue, or the source is down."
-                )
+                ) from e
             else:
                 logger.exception(e)
                 raise e

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -1458,5 +1458,47 @@ Status AutoscalerStateAccessor::DrainNode(const std::string &node_id,
   return Status::OK();
 }
 
+PublishToGcsAccessor::PublishToGcsAccessor(GcsClient *client_impl)
+    : client_impl_(client_impl) {}
+
+Status PublishToGcsAccessor::PublishError(const std::string &key_id,
+                                          const rpc::ErrorTableData &data,
+                                          int64_t timeout_ms) {
+  rpc::GcsPublishRequest request;
+  auto *pub_message = request.add_pub_messages();
+  pub_message->set_channel_type(rpc::RAY_ERROR_INFO_CHANNEL);
+  pub_message->set_key_id(key_id);
+  pub_message->mutable_error_info_message()->MergeFrom(data);
+  rpc::GcsPublishReply reply;
+  return client_impl_->GetGcsRpcClient().SyncGcsPublish(request, &reply, timeout_ms);
+}
+
+Status PublishToGcsAccessor::PublishLogs(const std::string &key_id,
+                                         const rpc::LogBatch &data,
+                                         int64_t timeout_ms) {
+  rpc::GcsPublishRequest request;
+  auto *pub_message = request.add_pub_messages();
+  pub_message->set_channel_type(rpc::RAY_LOG_CHANNEL);
+  pub_message->set_key_id(key_id);
+  pub_message->mutable_log_batch_message()->MergeFrom(data);
+  rpc::GcsPublishReply reply;
+  return client_impl_->GetGcsRpcClient().SyncGcsPublish(request, &reply, timeout_ms);
+}
+
+Status PublishToGcsAccessor::AsyncPublishNodeResourceUsage(
+    const std::string &key_id,
+    const std::string &node_resource_usage_json,
+    const StatusCallback &done) {
+  rpc::GcsPublishRequest request;
+  auto *pub_message = request.add_pub_messages();
+  pub_message->set_channel_type(rpc::RAY_NODE_RESOURCE_USAGE_CHANNEL);
+  pub_message->set_key_id(key_id);
+  pub_message->mutable_node_resource_usage_message()->set_json(node_resource_usage_json);
+  client_impl_->GetGcsRpcClient().GcsPublish(
+      request,
+      [done](const Status &status, rpc::GcsPublishReply &&reply) { done(status); });
+  return Status::OK();
+}
+
 }  // namespace gcs
 }  // namespace ray

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -977,6 +977,37 @@ class AutoscalerStateAccessor {
   GcsClient *client_impl_;
 };
 
+/// \class PublishToGcsAccessor
+/// `PublishToGcsAccessor` is a sub-interface of `GcsClient`.
+/// Most pubsub messages are GCS -> Clients, e.g. actor updates, node updates.
+/// But we have cases Clients -> GCS:
+/// 1. (sync)  RAY_ERROR_INFO_CHANNEL, used by workers and dashboard.
+/// 2. (sync)  RAY_LOG_CHANNEL, used by workers and dashboard.
+/// 3. (async) RAY_NODE_RESOURCE_USAGE_CHANNEL, used by reporter agent.
+class PublishToGcsAccessor {
+ public:
+  PublishToGcsAccessor();
+  explicit PublishToGcsAccessor(GcsClient *client_impl);
+  virtual ~PublishToGcsAccessor() = default;
+
+  virtual Status PublishError(const std::string &key_id,
+                              const rpc::ErrorTableData &data,
+                              int64_t timeout_ms);
+
+  virtual Status PublishLogs(const std::string &key_id,
+                             const rpc::LogBatch &data,
+                             int64_t timeout_ms);
+
+  virtual Status AsyncPublishNodeResourceUsage(
+      const std::string &key_id,
+      const std::string &node_resource_usage_json,
+      const StatusCallback &done);
+
+ private:
+  GcsClient *client_impl_;
+};
+;
+
 }  // namespace gcs
 
 }  // namespace ray

--- a/src/ray/gcs/gcs_client/gcs_client.cc
+++ b/src/ray/gcs/gcs_client/gcs_client.cc
@@ -154,6 +154,7 @@ Status GcsClient::Connect(instrumented_io_context &io_service, int64_t timeout_m
   task_accessor_ = std::make_unique<TaskInfoAccessor>(this);
   runtime_env_accessor_ = std::make_unique<RuntimeEnvAccessor>(this);
   autoscaler_state_accessor_ = std::make_unique<AutoscalerStateAccessor>(this);
+  publish_accessor_ = std::make_unique<PublishToGcsAccessor>(this);
 
   RAY_LOG(DEBUG) << "GcsClient connected " << options_.gcs_address_ << ":"
                  << options_.gcs_port_;

--- a/src/ray/gcs/gcs_client/gcs_client.h
+++ b/src/ray/gcs/gcs_client/gcs_client.h
@@ -209,6 +209,11 @@ class RAY_EXPORT GcsClient : public std::enable_shared_from_this<GcsClient> {
     return *autoscaler_state_accessor_;
   }
 
+  PublishToGcsAccessor &PublishToGcs() {
+    RAY_CHECK(publish_accessor_ != nullptr);
+    return *publish_accessor_;
+  }
+
   // Gets ClusterID. If it's not set in Connect(), blocks on a sync RPC to GCS to get it.
   virtual ClusterID GetClusterId() const;
 
@@ -234,6 +239,7 @@ class RAY_EXPORT GcsClient : public std::enable_shared_from_this<GcsClient> {
   std::unique_ptr<TaskInfoAccessor> task_accessor_;
   std::unique_ptr<RuntimeEnvAccessor> runtime_env_accessor_;
   std::unique_ptr<AutoscalerStateAccessor> autoscaler_state_accessor_;
+  std::unique_ptr<PublishToGcsAccessor> publish_accessor_;
 
  private:
   /// If client_call_manager_ does not have a cluster ID, fetches it from GCS. The


### PR DESCRIPTION
GcsPublisher is, deep down, just a rpc call to GCS. So we can bind it just like other Accessor methods.