### PR TITLE
[serve] remove warnings about ongoing requests default change

### DIFF
--- a/python/ray/dashboard/modules/serve/serve_rest_api_impl.py
+++ b/python/ray/dashboard/modules/serve/serve_rest_api_impl.py
@@ -165,8 +165,6 @@ def create_serve_rest_api(
                     text=repr(e),
                 )
 
-            self.log_config_change_default_warning(config)
-
             config_http_options = config.http_options.dict()
             location = ProxyLocation._to_deployment_mode(config.proxy_location)
             full_http_options = dict({"location": location}, **config_http_options)
@@ -212,38 +210,6 @@ def create_serve_rest_api(
                     "restarting it. Following options are attempted to be "
                     f"updated: {divergent_http_options}."
                 )
-
-        def log_config_change_default_warning(self, config):
-            from ray.serve.config import AutoscalingConfig
-
-            for deployment in [
-                d for app in config.applications for d in app.deployments
-            ]:
-                if "max_ongoing_requests" not in deployment.dict(exclude_unset=True):
-                    logger.warning(
-                        "The default value for `max_ongoing_requests` has changed "
-                        "from 100 to 5 in Ray 2.32.0."
-                    )
-                    break
-
-            for deployment in [
-                d for app in config.applications for d in app.deployments
-            ]:
-                if isinstance(deployment.autoscaling_config, dict):
-                    autoscaling_config = deployment.autoscaling_config
-                elif isinstance(deployment.autoscaling_config, AutoscalingConfig):
-                    autoscaling_config = deployment.autoscaling_config.dict(
-                        exclude_unset=True
-                    )
-                else:
-                    continue
-
-                if "target_ongoing_requests" not in autoscaling_config:
-                    logger.warning(
-                        "The default value for `target_ongoing_requests` has changed "
-                        "from 1.0 to 2.0 in Ray 2.32.0."
-                    )
-                    break
 
         async def get_serve_controller(self):
             """Gets the ServeController to the this cluster's Serve app.

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -326,27 +326,8 @@ def deployment(
         `Deployment`
     """
 
-    if autoscaling_config not in [DEFAULT.VALUE, None]:
-        if (
-            isinstance(autoscaling_config, dict)
-            and "target_ongoing_requests" not in autoscaling_config
-        ) or (
-            isinstance(autoscaling_config, AutoscalingConfig)
-            and "target_ongoing_requests"
-            not in autoscaling_config.dict(exclude_unset=True)
-        ):
-            logger.warning(
-                "The default value for `target_ongoing_requests` has changed from 1.0 "
-                "to 2.0 in Ray 2.32.0."
-            )
-
     if max_ongoing_requests is None:
         raise ValueError("`max_ongoing_requests` must be non-null, got None.")
-    elif max_ongoing_requests is DEFAULT.VALUE:
-        logger.warning(
-            "The default value for `max_ongoing_requests` has changed from "
-            "100 to 5 in Ray 2.32.0."
-        )
 
     if num_replicas == "auto":
         num_replicas = None
@@ -391,12 +372,6 @@ def deployment(
             "DeprecationWarning: `route_prefix` in `@serve.deployment` has been "
             "deprecated. To specify a route prefix for an application, pass it into "
             "`serve.run` instead."
-        )
-
-    if max_ongoing_requests is DEFAULT.VALUE:
-        logger.warning(
-            "The default value for `max_ongoing_requests` has changed from 100 to 5 in "
-            "Ray 2.32.0."
         )
 
     if isinstance(logging_config, LoggingConfig):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The defaults were changed in 2.32, and the warnings have been around since 2.32 too. The warnings have been around for 4 releases now, we can remove them.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
