### PR TITLE
[core] add more doc for raylet startup wait failure

### DIFF
--- a/src/ray/gcs/gcs_client/global_state_accessor.cc
+++ b/src/ray/gcs/gcs_client/global_state_accessor.cc
@@ -442,7 +442,9 @@ ray::Status GlobalStateAccessor::GetNode(const std::string &node_id,
       }
 
       if (relevant_client_index < 0) {
-        status = Status::NotFound("GCS cannot find the node with node ID " + node_id);
+        status = Status::NotFound("GCS cannot find the node with node ID " + node_id +
+        ". The node registration may not be complete yet before the timeout." +
+        " Try increase the RAY_raylet_start_wait_time_s config.");
       } else {
         *node_info = nodes[relevant_client_index].SerializeAsString();
         return Status::OK();

--- a/src/ray/gcs/gcs_client/global_state_accessor.cc
+++ b/src/ray/gcs/gcs_client/global_state_accessor.cc
@@ -442,9 +442,10 @@ ray::Status GlobalStateAccessor::GetNode(const std::string &node_id,
       }
 
       if (relevant_client_index < 0) {
-        status = Status::NotFound("GCS cannot find the node with node ID " + node_id +
-        ". The node registration may not be complete yet before the timeout." +
-        " Try increase the RAY_raylet_start_wait_time_s config.");
+        status = Status::NotFound(
+            "GCS cannot find the node with node ID " + node_id +
+            ". The node registration may not be complete yet before the timeout." +
+            " Try increase the RAY_raylet_start_wait_time_s config.");
       } else {
         *node_info = nodes[relevant_client_index].SerializeAsString();
         return Status::OK();


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

During startup, the raylet will register its node info, and then the startup scripts will read the node info with a delay. The delay is determined by raylet_start_wait_time_s, 10s by default.

In the case of GCS being overloaded, 10s is not enough and will crash:

```
 File "/home/ray/virtualenv/lib/python3.10/site-packages/ray/scripts/scripts.py", line 951, in start
    node = ray._private.node.Node(
  File "/home/ray/virtualenv/lib/python3.10/site-packages/ray/_private/node.py", line 349, in __init__
    node_info = ray._private.services.get_node(
  File "/home/ray/virtualenv/lib/python3.10/site-packages/ray/_private/services.py", line 486, in get_node
    return global_state.get_node(node_id)
  File "/home/ray/virtualenv/lib/python3.10/site-packages/ray/_private/state.py", line 823, in get_node
    return self.global_state_accessor.get_node(node_id)
  File "python/ray/includes/global_state_accessor.pxi", line 279, in ray._raylet.GlobalStateAccessor.get_node
RuntimeError: b'GCS cannot find the node with node ID xxx'
```

This PR will add more info in this stack trace.

## Related issue number

<!-- For example: "Closes #1234" -->

https://github.com/ray-project/ray/issues/47087

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
