### PR TITLE
[data] Add label to indicate if operator is backpressured

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -183,7 +183,7 @@ class PhysicalOperator(Operator):
         self._target_max_block_size = target_max_block_size
         self._started = False
         self._in_task_submission_backpressure = False
-        self._max_task_output_bytes_to_read = None
+        self._in_task_output_backpressure = False
         self._metrics = OpRuntimeMetrics(self)
         self._estimated_num_output_bundles = None
         self._estimated_output_num_rows = None

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -183,6 +183,7 @@ class PhysicalOperator(Operator):
         self._target_max_block_size = target_max_block_size
         self._started = False
         self._in_task_submission_backpressure = False
+        self._max_task_output_bytes_to_read = None
         self._metrics = OpRuntimeMetrics(self)
         self._estimated_num_output_bundles = None
         self._estimated_output_num_rows = None

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -260,8 +260,13 @@ class OpState:
         queued = self.num_queued() + self.op.internal_queue_size()
         active = self.op.num_active_tasks()
         desc = f"- {self.op.name}: {active} active, {queued} queued"
-        if self.op._in_task_submission_backpressure:
-            desc += ", BACKPRESSURED"
+        if (
+            self.op._in_task_submission_backpressure
+            and time.perf_counter()
+            - self.op.metrics._task_submission_backpressure_start_time
+            > 15
+        ):
+            desc += " 🚧"
         desc += f", [{resource_manager.get_op_usage_str(self.op)}]"
         suffix = self.op.progress_str()
         if suffix:

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -262,10 +262,7 @@ class OpState:
         desc = f"- {self.op.name}: {active} active, {queued} queued"
         if (
             self.op._in_task_submission_backpressure
-            or resource_manager.op_resource_allocator.max_task_output_bytes_to_read(
-                self.op
-            )
-            == 0
+            or self.op._max_task_output_bytes_to_read == 0
         ):
             desc += " 🚧"
         desc += f", [{resource_manager.get_op_usage_str(self.op)}]"
@@ -405,11 +402,11 @@ def process_completed_tasks(
     max_bytes_to_read_per_op: Dict[OpState, int] = {}
     if resource_manager.op_resource_allocator_enabled():
         for op, state in topology.items():
-            max_bytes_to_read = (
+            op._max_task_output_bytes_to_read = (
                 resource_manager.op_resource_allocator.max_task_output_bytes_to_read(op)
             )
-            if max_bytes_to_read is not None:
-                max_bytes_to_read_per_op[state] = max_bytes_to_read
+            if op._max_task_output_bytes_to_read is not None:
+                max_bytes_to_read_per_op[state] = op._max_task_output_bytes_to_read
 
     # Process completed Ray tasks and notify operators.
     num_errored_blocks = 0

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -262,9 +262,10 @@ class OpState:
         desc = f"- {self.op.name}: {active} active, {queued} queued"
         if (
             self.op._in_task_submission_backpressure
-            and time.perf_counter()
-            - self.op.metrics._task_submission_backpressure_start_time
-            > 15
+            or resource_manager.op_resource_allocator.max_task_output_bytes_to_read(
+                self.op
+            )
+            == 0
         ):
             desc += " 🚧"
         desc += f", [{resource_manager.get_op_usage_str(self.op)}]"

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -260,6 +260,8 @@ class OpState:
         queued = self.num_queued() + self.op.internal_queue_size()
         active = self.op.num_active_tasks()
         desc = f"- {self.op.name}: {active} active, {queued} queued"
+        if self.op._in_task_submission_backpressure:
+            desc += ", BACKPRESSURED"
         desc += f", [{resource_manager.get_op_usage_str(self.op)}]"
         suffix = self.op.progress_str()
         if suffix:


### PR DESCRIPTION
## Why are these changes needed?
During the execution of an operator, display whether or not an operator is backpressured. This will more easily surface to the viewer if there are portions of their dataset execution that are bottlenecking the other operations.

When backpressured the display will change from `Map(g): 3 active, 22 queued, [cpu: 0.3, objects: 768.0MB]: : 0.00 row [02:14, ? row/s` to `Map(g): 3 active, 22 queued, BACKPRESSURED, [cpu: 0.3, objects: 768.0MB]: : 0.00 row [02:14, ? row/s`.

### Examples:
#### Typical example

```python
import ray
import time

def f(x):
    time.sleep(0.1)
    return x

ray.data.range(1000).map(f).map(f, num_cpus=0.1).materialize()
```

https://github.com/user-attachments/assets/8283fdff-d94f-43c3-a9f0-c929924c441f

#### Backpressure example
```python
import ray
import time

def f(x):
    time.sleep(0.1)
    return x

def g(x):
    time.sleep(10000000)
    return x

ray.data.range(1000).map(f).map(g, num_cpus=0.1).materialize()
```

https://github.com/user-attachments/assets/d263b8ee-8dd2-4ec6-bd45-c55941c45253



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
