### PR TITLE
[doc][rllib] add missing public api references

### DIFF
--- a/doc/source/rllib/package_ref/utils.rst
+++ b/doc/source/rllib/package_ref/utils.rst
@@ -215,3 +215,43 @@ Numpy utilities
    ~relu
    ~sigmoid
    ~softmax
+
+Checkpoint utilities
+~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: ray.rllib.utils.checkpoints
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   Checkpointable
+   convert_to_msgpack_checkpoint
+   convert_to_msgpack_policy_checkpoint
+   get_checkpoint_info
+   try_import_msgpack
+
+Policy utilities
+~~~~~~~~~~~~~~~~
+
+.. currentmodule:: ray.rllib.utils.policy
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   compute_log_likelihoods_from_input_dict
+   create_policy_for_framework
+   local_policy_inference
+   parse_policy_specs_from_checkpoint
+
+Other utilities
+~~~~~~~~~~~~~~~
+
+.. currentmodule:: ray.rllib.utils
+
+.. autosummary::
+   :nosignatures:
+   :toctree: doc/
+
+   tensor_dtype.get_np_dtype


### PR DESCRIPTION
Add missing public API references for rllib. The full list of missing references is here: https://docs.google.com/spreadsheets/d/1wQALnsUuFN4dMgmGITfiVX41fCc6P6FEjYVO6jDWGtM/edit?gid=623756217#gid=623756217. This PR covers the utility APIs.

Test:
- CI

<img width="1346" alt="Screenshot 2024-08-13 at 11 23 06 AM" src="https://github.com/user-attachments/assets/5ffb5ef1-cee1-4de1-8c54-b1c58f6c9f40">
