### PR TITLE
[core] Remove serialized_allocated_resource_instances from RuntimeEnv creation.

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -745,10 +745,6 @@ RAY_CONFIG(uint64_t, resource_broadcast_batch_size, 512)
 // Maximum ray sync message batch size in bytes (1MB by default) between nodes.
 RAY_CONFIG(uint64_t, max_sync_message_batch_bytes, 1 * 1024 * 1024)
 
-// If enabled and worker stated in container, the container will add
-// resource limit.
-RAY_CONFIG(bool, worker_resource_limits_enabled, false)
-
 // When enabled, workers will not be re-used across tasks requesting different
 // resources (e.g., CPU vs GPU).
 RAY_CONFIG(bool, isolate_workers_across_resource_types, true)

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -594,15 +594,13 @@ std::string TaskSpecification::CallSiteString() const {
 }
 
 WorkerCacheKey::WorkerCacheKey(
-    const std::string serialized_runtime_env,
+    std::string serialized_runtime_env,
     const absl::flat_hash_map<std::string, double> &required_resources,
     bool is_actor,
     bool is_gpu,
     bool is_root_detached_actor)
-    : serialized_runtime_env(serialized_runtime_env),
-      required_resources(RayConfig::instance().worker_resource_limits_enabled()
-                             ? required_resources
-                             : absl::flat_hash_map<std::string, double>{}),
+    : serialized_runtime_env(std::move(serialized_runtime_env)),
+      required_resources(required_resources),
       is_actor(is_actor && RayConfig::instance().isolate_workers_across_task_types()),
       is_gpu(is_gpu && RayConfig::instance().isolate_workers_across_resource_types()),
       is_root_detached_actor(is_root_detached_actor),

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -203,7 +203,6 @@ int32_t TaskSpecification::MaxRetries() const { return message_->max_retries(); 
 
 int TaskSpecification::GetRuntimeEnvHash() const {
   WorkerCacheKey env = {SerializedRuntimeEnv(),
-                        GetRequiredResources().GetResourceMap(),
                         IsActorCreationTask(),
                         GetRequiredResources().Get(scheduling::ResourceID::GPU()) > 0,
                         !(RootDetachedActorId().IsNil())};
@@ -593,14 +592,11 @@ std::string TaskSpecification::CallSiteString() const {
   return stream.str();
 }
 
-WorkerCacheKey::WorkerCacheKey(
-    std::string serialized_runtime_env,
-    const absl::flat_hash_map<std::string, double> &required_resources,
-    bool is_actor,
-    bool is_gpu,
-    bool is_root_detached_actor)
+WorkerCacheKey::WorkerCacheKey(std::string serialized_runtime_env,
+                               bool is_actor,
+                               bool is_gpu,
+                               bool is_root_detached_actor)
     : serialized_runtime_env(std::move(serialized_runtime_env)),
-      required_resources(required_resources),
       is_actor(is_actor && RayConfig::instance().isolate_workers_across_task_types()),
       is_gpu(is_gpu && RayConfig::instance().isolate_workers_across_resource_types()),
       is_root_detached_actor(is_root_detached_actor),
@@ -621,15 +617,6 @@ std::size_t WorkerCacheKey::CalculateHash() const {
     boost::hash_combine(hash, is_actor);
     boost::hash_combine(hash, is_gpu);
     boost::hash_combine(hash, is_root_detached_actor);
-
-    std::vector<std::pair<std::string, double>> resource_vars(required_resources.begin(),
-                                                              required_resources.end());
-    // Sort the variables so different permutations yield the same hash.
-    std::sort(resource_vars.begin(), resource_vars.end());
-    for (auto &pair : resource_vars) {
-      boost::hash_combine(hash, pair.first);
-      boost::hash_combine(hash, pair.second);
-    }
   }
   return hash;
 }
@@ -640,13 +627,12 @@ bool WorkerCacheKey::operator==(const WorkerCacheKey &k) const {
 }
 
 bool WorkerCacheKey::EnvIsEmpty() const {
-  return IsRuntimeEnvEmpty(serialized_runtime_env) && required_resources.empty() &&
-         !is_gpu && !is_root_detached_actor;
+  return IsRuntimeEnvEmpty(serialized_runtime_env) && !is_gpu && !is_root_detached_actor;
 }
 
 std::size_t WorkerCacheKey::Hash() const { return hash_; }
 
-int WorkerCacheKey::IntHash() const { return (int)Hash(); }
+int WorkerCacheKey::IntHash() const { return static_cast<int>(Hash()); }
 
 std::vector<ConcurrencyGroup> TaskSpecification::ConcurrencyGroups() const {
   RAY_CHECK(IsActorCreationTask());
@@ -658,6 +644,7 @@ std::vector<ConcurrencyGroup> TaskSpecification::ConcurrencyGroups() const {
     auto &curr_group_message = actor_creation_task_spec.concurrency_groups(i);
     std::vector<ray::FunctionDescriptor> function_descriptors;
     const auto func_descriptors_size = curr_group_message.function_descriptors_size();
+    function_descriptors.reserve(func_descriptors_size);
     for (auto j = 0; j < func_descriptors_size; ++j) {
       function_descriptors.push_back(FunctionDescriptorBuilder::FromProto(
           curr_group_message.function_descriptors(j)));

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -524,7 +524,6 @@ class WorkerCacheKey {
   /// runtime_env.
   ///
   /// worker. \param serialized_runtime_env The JSON-serialized runtime env for this
-  /// worker. \param required_resources The required resouce.
   /// worker. \param is_actor Whether the worker will be an actor. This is set when
   ///         task type isolation between workers is enabled.
   /// worker. \param is_gpu Whether the worker will be using GPUs. This is set when
@@ -534,7 +533,6 @@ class WorkerCacheKey {
   ///         to prevent worker reuse between tasks whose root is the driver process
   ///         and tasks whose root is a detached actor.
   WorkerCacheKey(std::string serialized_runtime_env,
-                 const absl::flat_hash_map<std::string, double> &required_resources,
                  bool is_actor,
                  bool is_gpu,
                  bool is_root_detached_actor);
@@ -563,8 +561,6 @@ class WorkerCacheKey {
 
   /// The JSON-serialized runtime env for this worker.
   const std::string serialized_runtime_env;
-  /// The required resources for this worker.
-  const absl::flat_hash_map<std::string, double> required_resources;
   /// Whether the worker is for an actor.
   const bool is_actor;
   /// Whether the worker is to use a GPU.

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -533,7 +533,7 @@ class WorkerCacheKey {
   ///         tasks or actors whose root ancestor is a detached actor. This is set
   ///         to prevent worker reuse between tasks whose root is the driver process
   ///         and tasks whose root is a detached actor.
-  WorkerCacheKey(const std::string serialized_runtime_env,
+  WorkerCacheKey(std::string serialized_runtime_env,
                  const absl::flat_hash_map<std::string, double> &required_resources,
                  bool is_actor,
                  bool is_gpu,

--- a/src/ray/common/test/task_spec_test.cc
+++ b/src/ray/common/test/task_spec_test.cc
@@ -208,13 +208,13 @@ TEST(TaskSpecTest, TestWorkerCacheKey) {
   runtime_env_info_A.set_serialized_runtime_env(serialized_runtime_env_A);
   TaskSpecification task_spec;
   task_spec.GetMutableMessage().mutable_runtime_env_info()->CopyFrom(runtime_env_info_A);
-  const WorkerCacheKey key_A = {serialized_runtime_env_A, {}, false, false, false};
+  const WorkerCacheKey key_A = {serialized_runtime_env_A, false, false, false};
   ASSERT_EQ(task_spec.GetRuntimeEnvHash(), key_A.IntHash());
   ActorID actor_id =
       ActorID::Of(JobID::FromInt(1), TaskID::FromRandom(JobID::FromInt(1)), 0);
   task_spec.GetMutableMessage().set_root_detached_actor_id(actor_id.Binary());
   ASSERT_NE(task_spec.GetRuntimeEnvHash(), key_A.IntHash());
-  const WorkerCacheKey key_B = {serialized_runtime_env_A, {}, false, false, true};
+  const WorkerCacheKey key_B = {serialized_runtime_env_A, false, false, true};
   ASSERT_EQ(task_spec.GetRuntimeEnvHash(), key_B.IntHash());
 }
 

--- a/src/ray/protobuf/runtime_env_agent.proto
+++ b/src/ray/protobuf/runtime_env_agent.proto
@@ -25,11 +25,7 @@ message GetOrCreateRuntimeEnvRequest {
   string serialized_runtime_env = 1;
   RuntimeEnvConfig runtime_env_config = 2;
   bytes job_id = 3;
-  // Serialized allocated resource instances. Key is resource type, value is allocated
-  // instances. For example,{"CPU":20000,"memory":40000,"GPU":[10000, 10000]} means 2 cpu
-  // cores, 2 Gi memory, GPU 0 and GPU 1.
-  string serialized_allocated_resource_instances = 4;
-  string source_process = 5;
+  string source_process = 4;
 }
 
 message GetOrCreateRuntimeEnvReply {

--- a/src/ray/raylet/local_task_manager.cc
+++ b/src/ray/raylet/local_task_manager.cc
@@ -372,10 +372,6 @@ void LocalTaskManager::DispatchScheduledTasksToWorkers() {
         sched_cls_info.running_tasks.insert(spec.TaskId());
         // The local node has the available resources to run the task, so we should run
         // it.
-        std::string allocated_instances_serialized_json = "{}";
-        if (RayConfig::instance().worker_resource_limits_enabled()) {
-          allocated_instances_serialized_json = allocated_instances->SerializeAsJson();
-        }
         work->allocated_instances = allocated_instances;
         work->SetStateWaitingForWorker();
         bool is_detached_actor = spec.IsDetachedActor();
@@ -396,8 +392,7 @@ void LocalTaskManager::DispatchScheduledTasksToWorkers() {
                                          is_detached_actor,
                                          owner_address,
                                          runtime_env_setup_error_message);
-            },
-            allocated_instances_serialized_json);
+            });
         work_it++;
       }
     }

--- a/src/ray/raylet/local_task_manager_test.cc
+++ b/src/ray/raylet/local_task_manager_test.cc
@@ -37,9 +37,7 @@ class MockWorkerPool : public WorkerPoolInterface {
  public:
   MockWorkerPool() : num_pops(0) {}
 
-  void PopWorker(const TaskSpecification &task_spec,
-                 const PopWorkerCallback &callback,
-                 const std::string &allocated_instances_serialized_json) {
+  void PopWorker(const TaskSpecification &task_spec, const PopWorkerCallback &callback) {
     num_pops++;
     const int runtime_env_hash = task_spec.GetRuntimeEnvHash();
     callbacks[runtime_env_hash].push_back(callback);

--- a/src/ray/raylet/runtime_env_agent_client.cc
+++ b/src/ray/raylet/runtime_env_agent_client.cc
@@ -359,7 +359,6 @@ class HttpRuntimeEnvAgentClient : public RuntimeEnvAgentClient {
   void GetOrCreateRuntimeEnv(const JobID &job_id,
                              const std::string &serialized_runtime_env,
                              const rpc::RuntimeEnvConfig &runtime_env_config,
-                             const std::string &serialized_allocated_resource_instances,
                              GetOrCreateRuntimeEnvCallback callback) override {
     RetryInvokeOnNotFoundWithDeadline<rpc::GetOrCreateRuntimeEnvReply>(
         [=](SuccCallback<rpc::GetOrCreateRuntimeEnvReply> succ_callback,
@@ -367,7 +366,6 @@ class HttpRuntimeEnvAgentClient : public RuntimeEnvAgentClient {
           return TryGetOrCreateRuntimeEnv(job_id,
                                           serialized_runtime_env,
                                           runtime_env_config,
-                                          serialized_allocated_resource_instances,
                                           succ_callback,
                                           fail_callback);
         },
@@ -413,15 +411,12 @@ class HttpRuntimeEnvAgentClient : public RuntimeEnvAgentClient {
       const JobID &job_id,
       const std::string &serialized_runtime_env,
       const rpc::RuntimeEnvConfig &runtime_env_config,
-      const std::string &serialized_allocated_resource_instances,
       std::function<void(rpc::GetOrCreateRuntimeEnvReply)> succ_callback,
       std::function<void(ray::Status)> fail_callback) {
     rpc::GetOrCreateRuntimeEnvRequest request;
     request.set_job_id(job_id.Hex());
     request.set_serialized_runtime_env(serialized_runtime_env);
     request.mutable_runtime_env_config()->CopyFrom(runtime_env_config);
-    request.set_serialized_allocated_resource_instances(
-        serialized_allocated_resource_instances);
     std::string payload = request.SerializeAsString();
 
     auto session = Session::Create(

--- a/src/ray/raylet/runtime_env_agent_client.h
+++ b/src/ray/raylet/runtime_env_agent_client.h
@@ -65,15 +65,11 @@ class RuntimeEnvAgentClient {
   /// \param[in] job_id The job id which the runtime env belongs to.
   /// \param[in] serialized_runtime_env The runtime
   /// environment serialized in JSON as from `RuntimeEnv::Serialize` method.
-  /// \param[in] serialized_allocated_resource_instances The serialized allocated resource
-  /// instances.
   /// \param[in] callback The callback function.
-  virtual void GetOrCreateRuntimeEnv(
-      const JobID &job_id,
-      const std::string &serialized_runtime_env,
-      const rpc::RuntimeEnvConfig &runtime_env_config,
-      const std::string &serialized_allocated_resource_instances,
-      GetOrCreateRuntimeEnvCallback callback) = 0;
+  virtual void GetOrCreateRuntimeEnv(const JobID &job_id,
+                                     const std::string &serialized_runtime_env,
+                                     const rpc::RuntimeEnvConfig &runtime_env_config,
+                                     GetOrCreateRuntimeEnvCallback callback) = 0;
 
   /// Request agent to decrease the runtime env reference. This API is not idempotent. The
   /// client automatically retries on network errors.

--- a/src/ray/raylet/runtime_env_agent_client_test.cc
+++ b/src/ray/raylet/runtime_env_agent_client_test.cc
@@ -196,8 +196,6 @@ TEST(RuntimeEnvAgentClientTest, GetOrCreateRuntimeEnvOK) {
         ASSERT_TRUE(req.ParseFromString(request.body()));
         ASSERT_EQ(req.job_id(), "7b000000");  // Hex 7B == Int 123
         ASSERT_EQ(req.runtime_env_config().setup_timeout_seconds(), 12);
-        ASSERT_EQ(req.serialized_allocated_resource_instances(),
-                  "serialized_allocated_resource_instances");
         ASSERT_EQ(req.serialized_runtime_env(), "serialized_runtime_env");
 
         rpc::GetOrCreateRuntimeEnvReply reply;
@@ -225,8 +223,6 @@ TEST(RuntimeEnvAgentClientTest, GetOrCreateRuntimeEnvOK) {
   std::string serialized_runtime_env = "serialized_runtime_env";
   ray::rpc::RuntimeEnvConfig runtime_env_config;
   runtime_env_config.set_setup_timeout_seconds(12);
-  std::string serialized_allocated_resource_instances =
-      "serialized_allocated_resource_instances";
 
   size_t called_times = 0;
   auto callback = [&](bool successful,
@@ -238,11 +234,8 @@ TEST(RuntimeEnvAgentClientTest, GetOrCreateRuntimeEnvOK) {
     called_times += 1;
   };
 
-  client->GetOrCreateRuntimeEnv(job_id,
-                                serialized_runtime_env,
-                                runtime_env_config,
-                                serialized_allocated_resource_instances,
-                                callback);
+  client->GetOrCreateRuntimeEnv(
+      job_id, serialized_runtime_env, runtime_env_config, callback);
 
   ioc.run();
   ASSERT_EQ(called_times, 1);
@@ -257,8 +250,6 @@ TEST(RuntimeEnvAgentClientTest, GetOrCreateRuntimeEnvApplicationError) {
         ASSERT_TRUE(req.ParseFromString(request.body()));
         ASSERT_EQ(req.job_id(), "7b000000");  // Hex 7B == Int 123
         ASSERT_EQ(req.runtime_env_config().setup_timeout_seconds(), 12);
-        ASSERT_EQ(req.serialized_allocated_resource_instances(),
-                  "serialized_allocated_resource_instances");
         ASSERT_EQ(req.serialized_runtime_env(), "serialized_runtime_env");
 
         rpc::GetOrCreateRuntimeEnvReply reply;
@@ -286,8 +277,6 @@ TEST(RuntimeEnvAgentClientTest, GetOrCreateRuntimeEnvApplicationError) {
   std::string serialized_runtime_env = "serialized_runtime_env";
   ray::rpc::RuntimeEnvConfig runtime_env_config;
   runtime_env_config.set_setup_timeout_seconds(12);
-  std::string serialized_allocated_resource_instances =
-      "serialized_allocated_resource_instances";
 
   size_t called_times = 0;
   auto callback = [&](bool successful,
@@ -299,11 +288,8 @@ TEST(RuntimeEnvAgentClientTest, GetOrCreateRuntimeEnvApplicationError) {
     called_times += 1;
   };
 
-  client->GetOrCreateRuntimeEnv(job_id,
-                                serialized_runtime_env,
-                                runtime_env_config,
-                                serialized_allocated_resource_instances,
-                                callback);
+  client->GetOrCreateRuntimeEnv(
+      job_id, serialized_runtime_env, runtime_env_config, callback);
 
   ioc.run();
   ASSERT_EQ(called_times, 1);
@@ -321,8 +307,6 @@ TEST(RuntimeEnvAgentClientTest, GetOrCreateRuntimeEnvRetriesOnServerNotStarted) 
         ASSERT_TRUE(req.ParseFromString(request.body()));
         ASSERT_EQ(req.job_id(), "7b000000");  // Hex 7B == Int 123
         ASSERT_EQ(req.runtime_env_config().setup_timeout_seconds(), 12);
-        ASSERT_EQ(req.serialized_allocated_resource_instances(),
-                  "serialized_allocated_resource_instances");
         ASSERT_EQ(req.serialized_runtime_env(), "serialized_runtime_env");
 
         rpc::GetOrCreateRuntimeEnvReply reply;
@@ -352,8 +336,6 @@ TEST(RuntimeEnvAgentClientTest, GetOrCreateRuntimeEnvRetriesOnServerNotStarted) 
   std::string serialized_runtime_env = "serialized_runtime_env";
   ray::rpc::RuntimeEnvConfig runtime_env_config;
   runtime_env_config.set_setup_timeout_seconds(12);
-  std::string serialized_allocated_resource_instances =
-      "serialized_allocated_resource_instances";
 
   size_t called_times = 0;
   auto callback = [&](bool successful,
@@ -365,11 +347,8 @@ TEST(RuntimeEnvAgentClientTest, GetOrCreateRuntimeEnvRetriesOnServerNotStarted) 
     called_times += 1;
   };
 
-  client->GetOrCreateRuntimeEnv(job_id,
-                                serialized_runtime_env,
-                                runtime_env_config,
-                                serialized_allocated_resource_instances,
-                                callback);
+  client->GetOrCreateRuntimeEnv(
+      job_id, serialized_runtime_env, runtime_env_config, callback);
 
   ioc.run();
   ASSERT_EQ(called_times, 1);

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -1163,20 +1163,18 @@ void WorkerPool::KillIdleWorker(std::shared_ptr<WorkerInterface> idle_worker,
 }
 
 void WorkerPool::PopWorker(const TaskSpecification &task_spec,
-                           const PopWorkerCallback &callback,
-                           const std::string &allocated_instances_serialized_json) {
+                           const PopWorkerCallback &callback) {
   RAY_LOG(DEBUG) << "Pop worker for task " << task_spec.TaskId() << " task name "
                  << task_spec.FunctionDescriptor()->ToString();
   auto &state = GetStateForLanguage(task_spec.GetLanguage());
 
   std::shared_ptr<WorkerInterface> worker = nullptr;
-  auto start_worker_process_fn = [this, allocated_instances_serialized_json](
-                                     const TaskSpecification &task_spec,
-                                     State &state,
-                                     std::vector<std::string> dynamic_options,
-                                     bool dedicated,
-                                     const std::string &serialized_runtime_env_context,
-                                     const PopWorkerCallback &callback) {
+  auto start_worker_process_fn = [this](const TaskSpecification &task_spec,
+                                        State &state,
+                                        const std::vector<std::string> &dynamic_options,
+                                        bool dedicated,
+                                        const std::string &serialized_runtime_env_context,
+                                        const PopWorkerCallback &callback) {
     PopWorkerStatus status = PopWorkerStatus::OK;
     auto [proc, startup_token] = StartWorkerProcess(task_spec.GetLanguage(),
                                                     rpc::WorkerType::WORKER,
@@ -1196,7 +1194,7 @@ void WorkerPool::PopWorker(const TaskSpecification &task_spec,
       // but reuse it the next time we retry the request.
       DeleteRuntimeEnvIfPossible(task_spec.SerializedRuntimeEnv());
       state.pending_pop_worker_requests.emplace_back(
-          PopWorkerRequest{task_spec, callback, allocated_instances_serialized_json});
+          PopWorkerRequest{task_spec, callback});
     } else {
       DeleteRuntimeEnvIfPossible(task_spec.SerializedRuntimeEnv());
       PopWorkerCallbackAsync(task_spec, callback, nullptr, status);
@@ -1302,8 +1300,7 @@ void WorkerPool::PopWorker(const TaskSpecification &task_spec,
                                << task_spec.TaskId()
                                << " and couldn't create the worker.";
             }
-          },
-          allocated_instances_serialized_json);
+          });
     } else {
       start_worker_process_fn(
           task_spec, state, dynamic_options, is_actor_creation, "", callback);
@@ -1533,9 +1530,7 @@ void WorkerPool::TryPendingPopWorkerRequests(const Language &language) {
   std::deque<PopWorkerRequest> pending_pop_worker_requests;
   state.pending_pop_worker_requests.swap(pending_pop_worker_requests);
   for (const auto &pop_worker_request : pending_pop_worker_requests) {
-    PopWorker(pop_worker_request.task_spec,
-              pop_worker_request.callback,
-              pop_worker_request.allocated_instances_serialized_json);
+    PopWorker(pop_worker_request.task_spec, pop_worker_request.callback);
   }
 }
 
@@ -1612,19 +1607,16 @@ WorkerPool::IOWorkerState &WorkerPool::GetIOWorkerStateFromWorkerType(
   UNREACHABLE;
 }
 
-void WorkerPool::GetOrCreateRuntimeEnv(
-    const std::string &serialized_runtime_env,
-    const rpc::RuntimeEnvConfig &runtime_env_config,
-    const JobID &job_id,
-    const GetOrCreateRuntimeEnvCallback &callback,
-    const std::string &serialized_allocated_resource_instances) {
+void WorkerPool::GetOrCreateRuntimeEnv(const std::string &serialized_runtime_env,
+                                       const rpc::RuntimeEnvConfig &runtime_env_config,
+                                       const JobID &job_id,
+                                       const GetOrCreateRuntimeEnvCallback &callback) {
   RAY_LOG(DEBUG) << "GetOrCreateRuntimeEnv for job " << job_id << " with runtime_env "
                  << serialized_runtime_env;
   runtime_env_agent_client_->GetOrCreateRuntimeEnv(
       job_id,
       serialized_runtime_env,
       runtime_env_config,
-      serialized_allocated_resource_instances,
       [job_id,
        serialized_runtime_env = std::move(serialized_runtime_env),
        runtime_env_config = std::move(runtime_env_config),

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -1355,7 +1355,6 @@ void WorkerPool::PrestartWorkers(const TaskSpecification &task_spec,
 void WorkerPool::PrestartDefaultCpuWorkers(ray::Language language, int64_t num_needed) {
   // default workers uses 1 cpu and doesn't support actor.
   static const WorkerCacheKey kDefaultCpuWorkerCacheKey{/*serialized_runtime_env*/ "",
-                                                        {{"CPU", 1}},
                                                         /*is_actor*/ false,
                                                         /*is_gpu*/ false,
                                                         /*is_root_detached_actor*/ false};

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -99,15 +99,9 @@ class WorkerPoolInterface {
   /// Case 1: An suitable worker was found in idle worker pool.
   /// Case 2: An suitable worker registered to raylet.
   /// The corresponding PopWorkerStatus will be passed to the callback.
-  /// \param allocated_instances_serialized_json The allocated resource instances
-  /// json string, it contains resource ID which assigned to this worker.
-  /// Instance resource value will be like {"GPU":[10000,0,10000]}, non-instance
-  /// resource value will be {"CPU":20000}.
   /// \return Void.
-  virtual void PopWorker(
-      const TaskSpecification &task_spec,
-      const PopWorkerCallback &callback,
-      const std::string &allocated_instances_serialized_json = "{}") = 0;
+  virtual void PopWorker(const TaskSpecification &task_spec,
+                         const PopWorkerCallback &callback) = 0;
   /// Add an idle worker to the pool.
   ///
   /// \param The idle worker to add.
@@ -345,9 +339,7 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   void PushWorker(const std::shared_ptr<WorkerInterface> &worker);
 
   /// See interface.
-  void PopWorker(const TaskSpecification &task_spec,
-                 const PopWorkerCallback &callback,
-                 const std::string &allocated_instances_serialized_json = "{}");
+  void PopWorker(const TaskSpecification &task_spec, const PopWorkerCallback &callback);
 
   /// Try to prestart a number of workers suitable the given task spec. Prestarting
   /// is needed since core workers request one lease at a time, if starting is slow,
@@ -502,7 +494,6 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   struct PopWorkerRequest {
     TaskSpecification task_spec;
     PopWorkerCallback callback;
-    std::string allocated_instances_serialized_json;
   };
 
   /// An internal data structure that maintains the pool state per language.
@@ -670,12 +661,10 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   /// assume that the worker process has tree worker instances totally.
 
   /// Create runtime env asynchronously by runtime env agent.
-  void GetOrCreateRuntimeEnv(
-      const std::string &serialized_runtime_env,
-      const rpc::RuntimeEnvConfig &runtime_env_config,
-      const JobID &job_id,
-      const GetOrCreateRuntimeEnvCallback &callback,
-      const std::string &serialized_allocated_resource_instances = "{}");
+  void GetOrCreateRuntimeEnv(const std::string &serialized_runtime_env,
+                             const rpc::RuntimeEnvConfig &runtime_env_config,
+                             const JobID &job_id,
+                             const GetOrCreateRuntimeEnvCallback &callback);
 
   /// Delete runtime env asynchronously by runtime env agent.
   void DeleteRuntimeEnvIfPossible(const std::string &serialized_runtime_env);

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -94,7 +94,6 @@ class MockRuntimeEnvAgentClient : public RuntimeEnvAgentClient {
   void GetOrCreateRuntimeEnv(const JobID &job_id,
                              const std::string &serialized_runtime_env,
                              const rpc::RuntimeEnvConfig &runtime_env_config,
-                             const std::string &serialized_allocated_resource_instances,
                              GetOrCreateRuntimeEnvCallback callback) override {
     if (serialized_runtime_env == BAD_RUNTIME_ENV) {
       callback(false, "", BAD_RUNTIME_ENV_ERROR_MSG);


### PR DESCRIPTION
GetOrCreateRuntimeEnvRequest has field `serialized_allocated_resource_instances`. It does not serve any purpose other than a log in the Runtime Env Agent. Removes it.

Also removes required_resources in WorkerCacheKey and the flag worker_resource_limits_enabled.