### PR TITLE
[ci] change data build for all python versions to arrow 17

### DIFF
--- a/ci/docker/data.build.wanda.yaml
+++ b/ci/docker/data.build.wanda.yaml
@@ -11,6 +11,6 @@ srcs:
   - python/requirements/ml/data-test-requirements.txt
 build_args:
   - DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_ml-py$PYTHON
-  - ARROW_VERSION=16.*
+  - ARROW_VERSION=17.*
 tags:
   - cr.ray.io/rayproject/databuild-py$PYTHON


### PR DESCRIPTION
Following up from https://github.com/ray-project/ray/pull/47082, we actually have 6 different data builds, with this matrix

```
                                  python 3.9           python 3.12
arrow 6                            X                            X   
arrow 17                           X                            X    
arrow nightly                      X                            X
```

They all share the same build environment (https://github.com/ray-project/ray/blob/master/ci/docker/data.build.Dockerfile), but we have 6 configurations of these build environments given the above matrix

This PR updates other flavors to use arrow 17 as well

Test:
- CI