### PR TITLE
[RLlib] Fix bugs in IMPALA/APPO + LSTM (new stack) and activate StatelessCartPole learning tests on new API stack.

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -151,10 +151,11 @@ py_test(
 # --------------------------------------------------------------------
 
 # APPO
+# CartPole
 py_test(
     name = "learning_tests_cartpole_appo",
     main = "tuned_examples/appo/cartpole_appo.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "torch_only"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_discrete", "torch_only"],
     size = "large",
     srcs = ["tuned_examples/appo/cartpole_appo.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-gpus=1"]
@@ -162,7 +163,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_appo_gpu",
     main = "tuned_examples/appo/cartpole_appo.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_cartpole", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "gpu"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "gpu"],
     size = "large",
     srcs = ["tuned_examples/appo/cartpole_appo.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-gpus=1"]
@@ -170,7 +171,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_appo_multi_cpu",
     main = "tuned_examples/appo/cartpole_appo.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_cartpole", "learning_tests_discrete", "learning_tests_pytorch_use_all_core"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core"],
     size = "large",
     srcs = ["tuned_examples/appo/cartpole_appo.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-gpus=2"]
@@ -178,7 +179,16 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_appo_multi_gpu",
     main = "tuned_examples/appo/cartpole_appo.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_cartpole", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "multi_gpu"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "multi_gpu"],
+    size = "large",
+    srcs = ["tuned_examples/appo/cartpole_appo.py"],
+    args = ["--as-test", "--enable-new-api-stack", "--num-gpus=2"]
+)
+# StatelessCartPole
+py_test(
+    name = "learning_tests_stateless_cartpole_appo_multi_gpu",
+    main = "tuned_examples/appo/stateless_cartpole_appo.py",
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "multi_gpu"],
     size = "large",
     srcs = ["tuned_examples/appo/cartpole_appo.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-gpus=2"]
@@ -186,7 +196,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_cartpole_appo",
     main = "tuned_examples/appo/multi_agent_cartpole_appo.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "torch_only"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_discrete", "torch_only"],
     size = "large",
     srcs = ["tuned_examples/appo/multi_agent_cartpole_appo.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-agents=2", "--num-gpus=1"]
@@ -194,7 +204,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_cartpole_appo_gpu",
     main = "tuned_examples/appo/multi_agent_cartpole_appo.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_cartpole", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "gpu"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "gpu"],
     size = "large",
     srcs = ["tuned_examples/appo/multi_agent_cartpole_appo.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-agents=2", "--num-gpus=1", "--num-cpus=6"]
@@ -202,7 +212,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_cartpole_appo_multi_cpu",
     main = "tuned_examples/appo/multi_agent_cartpole_appo.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_cartpole", "learning_tests_discrete", "learning_tests_pytorch_use_all_core"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core"],
     size = "large",
     srcs = ["tuned_examples/appo/multi_agent_cartpole_appo.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-agents=2", "--num-gpus=2", "--num-cpus=7"]
@@ -210,7 +220,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_cartpole_appo_multi_gpu",
     main = "tuned_examples/appo/multi_agent_cartpole_appo.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_cartpole", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "multi_gpu"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "multi_gpu"],
     size = "large",
     srcs = ["tuned_examples/appo/multi_agent_cartpole_appo.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-agents=2", "--num-gpus=2", "--num-cpus=7"]
@@ -220,7 +230,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_separate_losses_appo_old_api_stack",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "torch_only", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+    tags = ["team:rllib", "torch_only", "exclusive", "learning_tests", "learning_tests_discrete"],
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = [
@@ -233,7 +243,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_cartpole_appo_old_api_stack",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_discrete"],
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/appo/multi_agent_cartpole_appo_old_api_stack.py"],
@@ -244,21 +254,10 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_cartpole_w_100_policies_appo_old_api_stack",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "learning_tests_pytorch_use_all_core"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_discrete", "learning_tests_pytorch_use_all_core"],
     size = "enormous",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/appo/multi-agent-cartpole-w-100-policies-appo.py"],
-    args = ["--dir=tuned_examples/appo"]
-)
-
-#@OldAPIStack
-py_test(
-    name = "learning_tests_stateless_cartpole_appo_old_api_stack",
-    main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
-    size = "enormous",
-    srcs = ["tests/run_regression_tests.py"],
-    data = ["tuned_examples/appo/stateless_cartpole_appo.py"],
     args = ["--dir=tuned_examples/appo"]
 )
 
@@ -268,7 +267,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_crashing_appo_old_api_stack",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "crashing_cartpole", "torch_only"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_discrete", "crashing_cartpole", "torch_only"],
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/appo/cartpole-crashing-recreate-workers-appo.py"],
@@ -279,7 +278,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_crashing_and_stalling_appo_old_api_stack",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "crashing_cartpole", "torch_only"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_discrete", "crashing_cartpole", "torch_only"],
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/appo/cartpole-crashing-and-stalling-recreate-workers-appo.py"],
@@ -290,7 +289,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_cartpole_crashing_appo_old_api_stack",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "crashing_cartpole", "torch_only"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_discrete", "crashing_cartpole", "torch_only"],
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/appo/multi-agent-cartpole-crashing-recreate-workers-appo.py"],
@@ -301,7 +300,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_cartpole_crashing_and_stalling_appo_old_api_stack",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "crashing_cartpole", "torch_only"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_discrete", "crashing_cartpole", "torch_only"],
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/appo/multi-agent-cartpole-crashing-and-stalling-recreate-workers-appo.py"],
@@ -312,7 +311,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_bc",
     main = "tuned_examples/bc/cartpole_bc.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_cartpole", "learning_tests_discrete", "learning_tests_pytorch_use_all_core"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core"],
     size = "medium",
     srcs = ["tuned_examples/bc/cartpole_bc.py"],
     # Include the zipped json data file as well.
@@ -327,7 +326,7 @@ py_test(
 py_test(
     name = "learning_tests_pendulum_cql_old_api_stack",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous", "learning_tests_with_ray_data"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_continuous", "learning_tests_with_ray_data"],
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     # Include the zipped json data file as well.
@@ -342,7 +341,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_dqn",
     main = "tuned_examples/dqn/cartpole_dqn.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_cartpole", "learning_tests_discrete", "learning_tests_pytorch_use_all_core"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core"],
     size = "large",
     srcs = ["tuned_examples/dqn/cartpole_dqn.py"],
     args = ["--as-test", "--enable-new-api-stack"]
@@ -351,7 +350,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_cartpole_dqn",
     main = "tuned_examples/dqn/multi_agent_cartpole_dqn.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_cartpole", "learning_tests_discrete", "learning_tests_pytorch_use_all_core"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core"],
     size = "large",
     srcs = ["tuned_examples/dqn/multi_agent_cartpole_dqn.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-agents=2", "--num-cpus=4"]
@@ -361,7 +360,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_dqn_softq_old_api_stack",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_discrete"],
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/dqn/cartpole-dqn-softq.yaml"],
@@ -372,7 +371,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_impala",
     main = "tuned_examples/impala/cartpole_impala.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "torch_only"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_discrete", "torch_only"],
     size = "large",
     srcs = ["tuned_examples/impala/cartpole_impala.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-gpus=1"]
@@ -380,7 +379,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_impala_gpu",
     main = "tuned_examples/impala/cartpole_impala.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_cartpole", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "gpu"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "gpu"],
     size = "large",
     srcs = ["tuned_examples/impala/cartpole_impala.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-gpus=1"]
@@ -388,7 +387,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_impala_multi_cpu",
     main = "tuned_examples/impala/cartpole_impala.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_cartpole", "learning_tests_discrete", "learning_tests_pytorch_use_all_core"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core"],
     size = "large",
     srcs = ["tuned_examples/impala/cartpole_impala.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-gpus=2"]
@@ -396,7 +395,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_impala_multi_gpu",
     main = "tuned_examples/impala/cartpole_impala.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_cartpole", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "multi_gpu"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "multi_gpu"],
     size = "large",
     srcs = ["tuned_examples/impala/cartpole_impala.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-gpus=2"]
@@ -404,7 +403,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_cartpole_impala",
     main = "tuned_examples/impala/multi_agent_cartpole_impala.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "torch_only"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "torch_only"],
     size = "large",
     srcs = ["tuned_examples/impala/multi_agent_cartpole_impala.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-agents=2", "--num-gpus=1", "--num-cpus=6"]
@@ -412,7 +411,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_cartpole_impala_gpu",
     main = "tuned_examples/impala/multi_agent_cartpole_impala.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_cartpole", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "gpu"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "gpu"],
     size = "large",
     srcs = ["tuned_examples/impala/multi_agent_cartpole_impala.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-agents=2", "--num-gpus=1", "--num-cpus=6"]
@@ -420,7 +419,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_cartpole_impala_multi_cpu",
     main = "tuned_examples/impala/multi_agent_cartpole_impala.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_cartpole", "learning_tests_discrete", "learning_tests_pytorch_use_all_core"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core"],
     size = "enormous",
     srcs = ["tuned_examples/impala/multi_agent_cartpole_impala.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-agents=2", "--num-gpus=2", "--num-cpus=7"]
@@ -428,7 +427,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_cartpole_impala_multi_gpu",
     main = "tuned_examples/impala/multi_agent_cartpole_impala.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_cartpole", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "multi_gpu"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "multi_gpu"],
     size = "large",
     srcs = ["tuned_examples/impala/multi_agent_cartpole_impala.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-agents=2", "--num-gpus=2", "--num-cpus=7"]
@@ -438,7 +437,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_separate_losses_impala_old_api_stack",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_discrete"],
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = [
@@ -450,7 +449,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_cartpole_impala_old_api_stack",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_discrete"],
     size = "medium",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/impala/multi_agent_cartpole_impala_old_api_stack.py"],
@@ -461,7 +460,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_marwil",
     main = "tuned_examples/marwil/cartpole_marwil.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_cartpole", "learning_tests_discrete", "learning_tests_pytorch_use_all_core"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core"],
     size = "large",
     srcs = ["tuned_examples/marwil/cartpole_marwil.py"],
     # Include the zipped json data file as well.
@@ -475,7 +474,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_ppo",
     main = "tuned_examples/ppo/cartpole_ppo.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "torch_only"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_discrete", "torch_only"],
     size = "large",
     srcs = ["tuned_examples/ppo/cartpole_ppo.py"],
     args = ["--as-test", "--enable-new-api-stack"]
@@ -483,7 +482,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_ppo_gpu",
     main = "tuned_examples/ppo/cartpole_ppo.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_cartpole", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "gpu"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "gpu"],
     size = "large",
     srcs = ["tuned_examples/ppo/cartpole_ppo.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-gpus=1"]
@@ -491,7 +490,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_ppo_multi_cpu",
     main = "tuned_examples/ppo/cartpole_ppo.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_cartpole", "learning_tests_discrete", "learning_tests_pytorch_use_all_core"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core"],
     size = "large",
     srcs = ["tuned_examples/ppo/cartpole_ppo.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-gpus=2"]
@@ -499,7 +498,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_ppo_multi_gpu",
     main = "tuned_examples/ppo/cartpole_ppo.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_cartpole", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "multi_gpu"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "multi_gpu"],
     size = "large",
     srcs = ["tuned_examples/ppo/cartpole_ppo.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-gpus=2"]
@@ -507,7 +506,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_cartpole_ppo",
     main = "tuned_examples/ppo/multi_agent_cartpole_ppo.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "torch_only"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_discrete", "torch_only"],
     size = "large",
     srcs = ["tuned_examples/ppo/multi_agent_cartpole_ppo.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-agents=2"]
@@ -515,7 +514,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_cartpole_ppo_gpu",
     main = "tuned_examples/ppo/multi_agent_cartpole_ppo.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_cartpole", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "gpu"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "gpu"],
     size = "large",
     srcs = ["tuned_examples/ppo/multi_agent_cartpole_ppo.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-agents=2", "--num-gpus=1"]
@@ -523,7 +522,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_cartpole_ppo_multi_cpu",
     main = "tuned_examples/ppo/multi_agent_cartpole_ppo.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_cartpole", "learning_tests_discrete", "learning_tests_pytorch_use_all_core"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core"],
     size = "large",
     srcs = ["tuned_examples/ppo/multi_agent_cartpole_ppo.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-agents=2", "--num-gpus=2"]
@@ -531,7 +530,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_cartpole_ppo_multi_gpu",
     main = "tuned_examples/ppo/multi_agent_cartpole_ppo.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_cartpole", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "multi_gpu"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "multi_gpu"],
     size = "large",
     srcs = ["tuned_examples/ppo/multi_agent_cartpole_ppo.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-agents=2", "--num-gpus=2"]
@@ -540,7 +539,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_truncated_ppo",
     main = "tuned_examples/ppo/cartpole_truncated_ppo.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete", "torch_only"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_discrete", "torch_only"],
     size = "large",
     srcs = ["tuned_examples/ppo/cartpole_truncated_ppo.py"],
     args = ["--as-test", "--enable-new-api-stack"]
@@ -549,7 +548,7 @@ py_test(
 py_test(
     name = "learning_tests_pendulum_ppo",
     main = "tuned_examples/ppo/pendulum_ppo.py",
-    tags = ["torch_only", "team:rllib", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous"],
+    tags = ["torch_only", "team:rllib", "exclusive", "learning_tests", "learning_tests_continuous"],
     size = "large",
     srcs = ["tuned_examples/ppo/pendulum_ppo.py"],
     args = ["--as-test", "--enable-new-api-stack"]
@@ -557,7 +556,7 @@ py_test(
 py_test(
     name = "learning_tests_pendulum_ppo_gpu",
     main = "tuned_examples/ppo/pendulum_ppo.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_pendulum", "learning_tests_continuous", "learning_tests_pytorch_use_all_core", "gpu"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_continuous", "learning_tests_pytorch_use_all_core", "gpu"],
     size = "large",
     srcs = ["tuned_examples/ppo/pendulum_ppo.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-gpus=1"]
@@ -565,7 +564,7 @@ py_test(
 py_test(
     name = "learning_tests_pendulum_ppo_multi_cpu",
     main = "tuned_examples/ppo/pendulum_ppo.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_pendulum", "learning_tests_continuous", "learning_tests_pytorch_use_all_core"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_continuous", "learning_tests_pytorch_use_all_core"],
     size = "large",
     srcs = ["tuned_examples/ppo/pendulum_ppo.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-gpus=2"]
@@ -573,7 +572,7 @@ py_test(
 py_test(
     name = "learning_tests_pendulum_ppo_multi_gpu",
     main = "tuned_examples/ppo/pendulum_ppo.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_pendulum", "learning_tests_continuous", "learning_tests_pytorch_use_all_core", "multi_gpu"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_continuous", "learning_tests_pytorch_use_all_core", "multi_gpu"],
     size = "large",
     srcs = ["tuned_examples/ppo/pendulum_ppo.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-gpus=2"]
@@ -581,7 +580,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_pendulum_ppo",
     main = "tuned_examples/ppo/multi_agent_pendulum_ppo.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous", "torch_only"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_continuous", "torch_only"],
     size = "large",
     srcs = ["tuned_examples/ppo/multi_agent_pendulum_ppo.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-agents=2"]
@@ -589,7 +588,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_pendulum_ppo_gpu",
     main = "tuned_examples/ppo/multi_agent_pendulum_ppo.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_pendulum", "learning_tests_continuous", "learning_tests_pytorch_use_all_core", "gpu"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_continuous", "learning_tests_pytorch_use_all_core", "gpu"],
     size = "large",
     srcs = ["tuned_examples/ppo/multi_agent_pendulum_ppo.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-agents=2", "--num-gpus=1"]
@@ -597,7 +596,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_pendulum_ppo_multi_cpu",
     main = "tuned_examples/ppo/multi_agent_pendulum_ppo.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_pendulum", "learning_tests_continuous", "learning_tests_pytorch_use_all_core"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_continuous", "learning_tests_pytorch_use_all_core"],
     size = "large",
     srcs = ["tuned_examples/ppo/multi_agent_pendulum_ppo.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-agents=2", "--num-gpus=2"]
@@ -605,7 +604,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_pendulum_ppo_multi_gpu",
     main = "tuned_examples/ppo/multi_agent_pendulum_ppo.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_pendulum", "learning_tests_continuous", "learning_tests_pytorch_use_all_core", "multi_gpu"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_continuous", "learning_tests_pytorch_use_all_core", "multi_gpu"],
     size = "large",
     srcs = ["tuned_examples/ppo/multi_agent_pendulum_ppo.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-agents=2", "--num-gpus=2"]
@@ -615,7 +614,7 @@ py_test(
 py_test(
     name = "learning_tests_pendulum_ppo_old_api_stack",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous", "no_tf_static_graph"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_continuous", "no_tf_static_graph"],
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/ppo/pendulum-ppo.yaml"],
@@ -625,7 +624,7 @@ py_test(
 py_test(
     name = "learning_tests_transformed_actions_pendulum_ppo_old_api_stack",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_pendulum", "learning_tests_continuous", "no_tf_static_graph"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_continuous", "no_tf_static_graph"],
     size = "large", # bazel may complain about it being too long sometimes - large is on purpose as some frameworks take longer
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/ppo/pendulum-transformed-actions-ppo.yaml"],
@@ -646,7 +645,7 @@ py_test(
 py_test(
     name = "learning_tests_pendulum_sac",
     main = "tuned_examples/sac/pendulum_sac.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_pendulum", "learning_tests_continuous"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_continuous"],
     size = "large",
     srcs = ["tuned_examples/sac/pendulum_sac.py"],
     args = ["--as-test", "--enable-new-api-stack"]
@@ -655,7 +654,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_pendulum_sac",
     main = "tuned_examples/sac/multi_agent_pendulum_sac.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_pendulum", "learning_tests_continuous"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_continuous"],
     size = "large",
     srcs = ["tuned_examples/sac/multi_agent_pendulum_sac.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-agents=2", "--num-cpus=4"]
@@ -664,7 +663,7 @@ py_test(
 py_test(
     name = "learning_tests_multi_agent_pendulum_sac_multi_gpu",
     main = "tuned_examples/sac/multi_agent_pendulum_sac.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_pendulum", "learning_tests_continuous", "multi_gpu"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_continuous", "multi_gpu"],
     size = "large",
     srcs = ["tuned_examples/sac/multi_agent_pendulum_sac.py"],
     args = ["--enable-new-api-stack", "--num-agents=2", "--num-gpus=2"]
@@ -674,7 +673,7 @@ py_test(
 py_test(
     name = "learning_tests_cartpole_sac_old_api_stack",
     main = "tests/run_regression_tests.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_cartpole", "learning_tests_discrete"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "learning_tests_discrete"],
     size = "large",
     srcs = ["tests/run_regression_tests.py"],
     data = ["tuned_examples/sac/cartpole-sac.yaml"],

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -190,9 +190,10 @@ py_test(
     main = "tuned_examples/appo/stateless_cartpole_appo.py",
     tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "multi_gpu"],
     size = "large",
-    srcs = ["tuned_examples/appo/cartpole_appo.py"],
+    srcs = ["tuned_examples/appo/stateless_cartpole_appo.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-gpus=2"]
 )
+# MultiAgentCartPole
 py_test(
     name = "learning_tests_multi_agent_cartpole_appo",
     main = "tuned_examples/appo/multi_agent_cartpole_appo.py",
@@ -308,6 +309,7 @@ py_test(
 )
 
 # BC
+# CartPole
 py_test(
     name = "learning_tests_cartpole_bc",
     main = "tuned_examples/bc/cartpole_bc.py",
@@ -338,6 +340,7 @@ py_test(
 )
 
 # DQN
+# CartPole
 py_test(
     name = "learning_tests_cartpole_dqn",
     main = "tuned_examples/dqn/cartpole_dqn.py",
@@ -346,7 +349,7 @@ py_test(
     srcs = ["tuned_examples/dqn/cartpole_dqn.py"],
     args = ["--as-test", "--enable-new-api-stack"]
 )
-
+# MultiAgentCartPole
 py_test(
     name = "learning_tests_multi_agent_cartpole_dqn",
     main = "tuned_examples/dqn/multi_agent_cartpole_dqn.py",
@@ -368,6 +371,7 @@ py_test(
 )
 
 # IMPALA
+# CartPole
 py_test(
     name = "learning_tests_cartpole_impala",
     main = "tuned_examples/impala/cartpole_impala.py",
@@ -400,6 +404,7 @@ py_test(
     srcs = ["tuned_examples/impala/cartpole_impala.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-gpus=2"]
 )
+# MultiAgentCartPole
 py_test(
     name = "learning_tests_multi_agent_cartpole_impala",
     main = "tuned_examples/impala/multi_agent_cartpole_impala.py",
@@ -457,6 +462,7 @@ py_test(
 )
 
 # MARWIL
+# CartPole
 py_test(
     name = "learning_tests_cartpole_marwil",
     main = "tuned_examples/marwil/cartpole_marwil.py",
@@ -471,6 +477,7 @@ py_test(
 )
 
 # PPO
+# CartPole
 py_test(
     name = "learning_tests_cartpole_ppo",
     main = "tuned_examples/ppo/cartpole_ppo.py",
@@ -503,6 +510,7 @@ py_test(
     srcs = ["tuned_examples/ppo/cartpole_ppo.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-gpus=2"]
 )
+# MultiAgentCartPole
 py_test(
     name = "learning_tests_multi_agent_cartpole_ppo",
     main = "tuned_examples/ppo/multi_agent_cartpole_ppo.py",
@@ -535,7 +543,7 @@ py_test(
     srcs = ["tuned_examples/ppo/multi_agent_cartpole_ppo.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-agents=2", "--num-gpus=2"]
 )
-
+# CartPole (truncated)
 py_test(
     name = "learning_tests_cartpole_truncated_ppo",
     main = "tuned_examples/ppo/cartpole_truncated_ppo.py",
@@ -544,7 +552,7 @@ py_test(
     srcs = ["tuned_examples/ppo/cartpole_truncated_ppo.py"],
     args = ["--as-test", "--enable-new-api-stack"]
 )
-
+# Pendulum
 py_test(
     name = "learning_tests_pendulum_ppo",
     main = "tuned_examples/ppo/pendulum_ppo.py",
@@ -577,6 +585,7 @@ py_test(
     srcs = ["tuned_examples/ppo/pendulum_ppo.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-gpus=2"]
 )
+# MultiAgentPendulum
 py_test(
     name = "learning_tests_multi_agent_pendulum_ppo",
     main = "tuned_examples/ppo/multi_agent_pendulum_ppo.py",
@@ -642,6 +651,7 @@ py_test(
 )
 
 # SAC
+# Pendulum
 py_test(
     name = "learning_tests_pendulum_sac",
     main = "tuned_examples/sac/pendulum_sac.py",

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -186,12 +186,12 @@ py_test(
 )
 # StatelessCartPole
 py_test(
-    name = "learning_tests_stateless_cartpole_appo_multi_gpu",
+    name = "learning_tests_stateless_cartpole_appo",
     main = "tuned_examples/appo/stateless_cartpole_appo.py",
-    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "multi_gpu"],
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core"],
     size = "large",
     srcs = ["tuned_examples/appo/stateless_cartpole_appo.py"],
-    args = ["--as-test", "--enable-new-api-stack", "--num-gpus=2"]
+    args = ["--as-test", "--enable-new-api-stack", "--num-gpus=1"]
 )
 # MultiAgentCartPole
 py_test(
@@ -403,6 +403,15 @@ py_test(
     size = "large",
     srcs = ["tuned_examples/impala/cartpole_impala.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-gpus=2"]
+)
+# StatelessCartPole
+py_test(
+    name = "learning_tests_stateless_cartpole_impala",
+    main = "tuned_examples/impala/stateless_cartpole_impala.py",
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core"],
+    size = "large",
+    srcs = ["tuned_examples/impala/stateless_cartpole_impala.py"],
+    args = ["--as-test", "--enable-new-api-stack", "--num-gpus=1"]
 )
 # MultiAgentCartPole
 py_test(

--- a/rllib/algorithms/appo/tests/test_appo_learner.py
+++ b/rllib/algorithms/appo/tests/test_appo_learner.py
@@ -32,6 +32,7 @@ FAKE_BATCH = {
     Columns.ACTION_LOGP: np.log(
         np.random.uniform(low=0, high=1, size=(frag_length,))
     ).astype(np.float32),
+    Columns.LOSS_MASK: np.ones(shape=(frag_length,)),
 }
 
 

--- a/rllib/algorithms/appo/torch/appo_torch_learner.py
+++ b/rllib/algorithms/appo/torch/appo_torch_learner.py
@@ -35,6 +35,21 @@ class APPOTorchLearner(APPOLearner, IMPALATorchLearner):
         batch: Dict,
         fwd_out: Dict[str, TensorType],
     ) -> TensorType:
+        # TODO (sven): Now that we do the +1ts trick to be less vulnerable about
+        #  bootstrap values at the end of rollouts in the new stack, we might make
+        #  this a more flexible, configurable parameter for users, e.g.
+        #  `v_trace_seq_len` (independent of `rollout_fragment_length`). Separation
+        #  of concerns (sampling vs learning).
+        rollout_frag_or_episode_len = config.get_rollout_fragment_length()
+        recurrent_seq_len = batch.get("seq_lens")
+
+        loss_mask = batch[Columns.LOSS_MASK].float()
+        loss_mask_time_major = make_time_major(
+            loss_mask,
+            trajectory_len=rollout_frag_or_episode_len,
+            recurrent_seq_len=recurrent_seq_len,
+        )
+        size_loss_mask = torch.sum(loss_mask)
 
         module = self.module[module_id].unwrapped()
         assert isinstance(module, TargetNetworkAPI)
@@ -54,9 +69,6 @@ class APPOTorchLearner(APPOLearner, IMPALATorchLearner):
         )
         behaviour_actions_logp = batch[Columns.ACTION_LOGP]
         target_actions_logp = target_policy_dist.logp(batch[Columns.ACTIONS])
-
-        rollout_frag_or_episode_len = config.get_rollout_fragment_length()
-        recurrent_seq_len = batch.get("seq_lens")
 
         behaviour_actions_logp_time_major = make_time_major(
             behaviour_actions_logp,
@@ -119,6 +131,7 @@ class APPOTorchLearner(APPOLearner, IMPALATorchLearner):
             clip_pg_rho_threshold=config.vtrace_clip_pg_rho_threshold,
             clip_rho_threshold=config.vtrace_clip_rho_threshold,
         )
+        pg_advantages = pg_advantages * loss_mask_time_major
 
         # The policy gradients loss.
         is_ratio = torch.clip(
@@ -137,18 +150,21 @@ class APPOTorchLearner(APPOLearner, IMPALATorchLearner):
         )
 
         if config.use_kl_loss:
-            action_kl = old_target_policy_dist.kl(target_policy_dist)
-            mean_kl_loss = torch.mean(action_kl)
+            action_kl = old_target_policy_dist.kl(target_policy_dist) * loss_mask
+            mean_kl_loss = torch.sum(action_kl) / size_loss_mask
         else:
             mean_kl_loss = 0.0
-        mean_pi_loss = -torch.mean(surrogate_loss)
+        mean_pi_loss = -(torch.sum(surrogate_loss) / size_loss_mask)
 
         # The baseline loss.
         delta = values_time_major - vtrace_adjusted_target_values
-        mean_vf_loss = 0.5 * torch.mean(delta**2)
+        vf_loss = 0.5 * torch.sum(torch.pow(delta, 2.0) * loss_mask_time_major)
+        mean_vf_loss = vf_loss / size_loss_mask
 
         # The entropy loss.
-        mean_entropy_loss = -torch.mean(target_policy_dist.entropy())
+        mean_entropy_loss = (
+            -torch.sum(target_policy_dist.entropy() * loss_mask) / size_loss_mask
+        )
 
         # The summed weighted loss.
         total_loss = (

--- a/rllib/algorithms/appo/torch/appo_torch_learner.py
+++ b/rllib/algorithms/appo/torch/appo_torch_learner.py
@@ -54,8 +54,9 @@ class APPOTorchLearner(APPOLearner, IMPALATorchLearner):
         )
         behaviour_actions_logp = batch[Columns.ACTION_LOGP]
         target_actions_logp = target_policy_dist.logp(batch[Columns.ACTIONS])
+
         rollout_frag_or_episode_len = config.get_rollout_fragment_length()
-        recurrent_seq_len = None
+        recurrent_seq_len = batch.get("seq_lens")
 
         behaviour_actions_logp_time_major = make_time_major(
             behaviour_actions_logp,

--- a/rllib/algorithms/impala/torch/impala_torch_learner.py
+++ b/rllib/algorithms/impala/torch/impala_torch_learner.py
@@ -33,8 +33,8 @@ class IMPALATorchLearner(IMPALALearner, TorchLearner):
         #  this a more flexible, configurable parameter for users, e.g.
         #  `v_trace_seq_len` (independent of `rollout_fragment_length`). Separation
         #  of concerns (sampling vs learning).
-        recurrent_seq_len = None
         rollout_frag_or_episode_len = config.get_rollout_fragment_length()
+        recurrent_seq_len = batch.get("seq_lens")
 
         loss_mask = batch[Columns.LOSS_MASK].float()
         loss_mask_time_major = make_time_major(

--- a/rllib/algorithms/impala/torch/vtrace_torch_v2.py
+++ b/rllib/algorithms/impala/torch/vtrace_torch_v2.py
@@ -31,14 +31,19 @@ def make_time_major(
             for _tensor in tensor
         ]
 
-    assert (trajectory_len != recurrent_seq_len) and (
-        trajectory_len is None or recurrent_seq_len is None
-    ), "Either trajectory_len or recurrent_seq_len must be set."
+    assert trajectory_len is not None or recurrent_seq_len is not None, (
+        "Either trajectory_len or recurrent_seq_len must be set."
+    )
 
     # Figure out the sizes of the final B and T axes.
-    if recurrent_seq_len:
-        B = recurrent_seq_len.shape[0]
-        T = tensor.shape[0] // B
+    if recurrent_seq_len is not None:
+        assert len(tensor.shape) == 2
+        # Swap B and T axes.
+        tensor = torch.transpose(tensor, 1, 0)
+        return tensor
+
+        #B = recurrent_seq_len.shape[0]
+        #T = tensor.shape[0] // B
     else:
         T = trajectory_len
         # Zero-pad, if necessary.

--- a/rllib/algorithms/impala/torch/vtrace_torch_v2.py
+++ b/rllib/algorithms/impala/torch/vtrace_torch_v2.py
@@ -31,9 +31,9 @@ def make_time_major(
             for _tensor in tensor
         ]
 
-    assert trajectory_len is not None or recurrent_seq_len is not None, (
-        "Either trajectory_len or recurrent_seq_len must be set."
-    )
+    assert (
+        trajectory_len is not None or recurrent_seq_len is not None
+    ), "Either trajectory_len or recurrent_seq_len must be set."
 
     # Figure out the sizes of the final B and T axes.
     if recurrent_seq_len is not None:
@@ -42,8 +42,8 @@ def make_time_major(
         tensor = torch.transpose(tensor, 1, 0)
         return tensor
 
-        #B = recurrent_seq_len.shape[0]
-        #T = tensor.shape[0] // B
+        # B = recurrent_seq_len.shape[0]
+        # T = tensor.shape[0] // B
     else:
         T = trajectory_len
         # Zero-pad, if necessary.

--- a/rllib/algorithms/impala/torch/vtrace_torch_v2.py
+++ b/rllib/algorithms/impala/torch/vtrace_torch_v2.py
@@ -41,9 +41,6 @@ def make_time_major(
         # Swap B and T axes.
         tensor = torch.transpose(tensor, 1, 0)
         return tensor
-
-        # B = recurrent_seq_len.shape[0]
-        # T = tensor.shape[0] // B
     else:
         T = trajectory_len
         # Zero-pad, if necessary.

--- a/rllib/connectors/common/add_states_from_episodes_to_batch.py
+++ b/rllib/connectors/common/add_states_from_episodes_to_batch.py
@@ -337,13 +337,14 @@ class AddStatesFromEpisodesToBatch(ConnectorV2):
                     num_items=len(seq_lens),
                     single_agent_episode=sa_episode,
                 )
-                self.add_n_batch_items(
-                    batch=data,
-                    column=Columns.LOSS_MASK,
-                    items_to_add=mask,
-                    num_items=len(mask),
-                    single_agent_episode=sa_episode,
-                )
+                if not shared_data.get("_added_loss_mask_for_valid_episode_ts"):
+                    self.add_n_batch_items(
+                        batch=data,
+                        column=Columns.LOSS_MASK,
+                        items_to_add=mask,
+                        num_items=len(mask),
+                        single_agent_episode=sa_episode,
+                    )
             else:
                 assert not sa_episode.is_finalized
 

--- a/rllib/connectors/learner/add_one_ts_to_episodes_and_truncate.py
+++ b/rllib/connectors/learner/add_one_ts_to_episodes_and_truncate.py
@@ -146,4 +146,9 @@ class AddOneTsToEpisodesAndTruncate(ConnectorV2):
                 sa_episode,
             )
 
+        # Signal to following connector pieces that the loss-mask which masks out
+        # invalid episode ts (for the extra added ts at the end) has already been
+        # added to `data`.
+        shared_data["_added_loss_mask_for_valid_episode_ts"] = True
+
         return data

--- a/rllib/connectors/learner/add_one_ts_to_episodes_and_truncate.py
+++ b/rllib/connectors/learner/add_one_ts_to_episodes_and_truncate.py
@@ -102,9 +102,13 @@ class AddOneTsToEpisodesAndTruncate(ConnectorV2):
         # mask : t t t t t t t t f t t t t t t f t t t t t f
 
         shared_data["_sa_episodes_lengths"] = {}
-        for sa_episode in self.single_agent_episode_iterator(
+        for i, sa_episode in enumerate(self.single_agent_episode_iterator(
             episodes, agents_that_stepped_only=False
-        ):
+        )):
+            # TODO (sven): remove this hack; just for testing 
+            sa_episode.id_ += "_" + str(i)
+            # END TODO
+            
             len_ = len(sa_episode)
 
             # Extend all episodes by one ts.
@@ -120,7 +124,9 @@ class AddOneTsToEpisodesAndTruncate(ConnectorV2):
             )
 
             terminateds = (
-                [False for _ in range(len_ - 1)] + [sa_episode.is_terminated] + [True]
+                [False for _ in range(len_ - 1)]
+                + [bool(sa_episode.is_terminated)]
+                + [True]  # extra timestep
             )
             self.add_n_batch_items(
                 data,

--- a/rllib/core/learner/learner.py
+++ b/rllib/core/learner/learner.py
@@ -212,8 +212,8 @@ class Learner(Checkpointable):
 
             class MyLearner(TorchLearner):
 
-               def compute_losses(self, fwd_out, batch):
-                   # Compute the loss based on batch and output of the forward pass
+               def compute_loss(self, fwd_out, batch):
+                   # compute the loss based on batch and output of the forward pass
                    # to access the learner hyper-parameters use `self._hps`
                    return {ALL_MODULES: loss}
     """
@@ -595,22 +595,9 @@ class Learner(Checkpointable):
             The optimizer object, configured under the given `module_id` and
             `optimizer_name`.
         """
-        # `optimizer_name` could possibly be the full optimizer name (including the
-        # module_id under which it is registered).
-        if optimizer_name in self._named_optimizers:
-            return self._named_optimizers[optimizer_name]
-
-        # Normally, `optimizer_name` is just the optimizer's name, not including the
-        # `module_id`.
         full_registration_name = module_id + "_" + optimizer_name
-        if full_registration_name in self._named_optimizers:
-            return self._named_optimizers[full_registration_name]
-
-        # No optimizer found.
-        raise KeyError(
-            f"Optimizer not found! module_id={module_id} "
-            f"optimizer_name={optimizer_name}"
-        )
+        assert full_registration_name in self._named_optimizers
+        return self._named_optimizers[full_registration_name]
 
     def get_optimizers_for_module(
         self, module_id: ModuleID = ALL_MODULES
@@ -841,30 +828,33 @@ class Learner(Checkpointable):
         return should_module_be_updated_fn(module_id, multi_agent_batch)
 
     @OverrideToImplementCustomLogic
-    def compute_losses(
+    def compute_loss(
         self, *, fwd_out: Dict[str, Any], batch: Dict[str, Any]
     ) -> Dict[str, Any]:
-        """Computes the loss(es) for the module being optimized.
+        """Computes the loss for the module being optimized.
 
-        This method must be overridden by MultiRLModule-specific Learners in order to
-        define the specific loss computation logic. If the algorithm is single-agent
-        `compute_loss_for_module()` should be overridden instead. If the algorithm uses
-        independent multi-agent learning (default behavior for multi-agent setups), also
-        `compute_loss_for_module()` should be overridden, but it will be called for each
-        individual RLModule inside the MultiRLModule.
-        It is recommended to not compute any forward passes within this method, and to
-        use the `forward_train()` outputs of the RLModule(s) to compute the required
-        tensors for loss calculations.
+        This method must be overridden by multiagent-specific algorithm learners to
+        specify the specific loss computation logic. If the algorithm is single agent
+        `compute_loss_for_module()` should be overridden instead.
+        `fwd_out` is the output of the `forward_train()` method of the underlying
+        MultiRLModule. `batch` is the data that was used to compute `fwd_out`.
+        The returned dictionary must contain a key called
+        ALL_MODULES, which will be used to compute gradients. It is recommended
+        to not compute any forward passes within this method, and to use the
+        `forward_train()` outputs of the RLModule(s) to compute the required tensors for
+        loss calculations.
 
         Args:
-            fwd_out: Output from a call to the `forward_train()` method of the
-                underlying MultiRLModule (`self.module`) during training
-                (`self.update()`).
+            fwd_out: Output from a call to the `forward_train()` method of self.module
+                during training (`self.update()`).
             batch: The training batch that was used to compute `fwd_out`.
 
         Returns:
-            A dictionary mapping module IDs to individual loss terms.
+            A dictionary mapping module IDs to individual loss terms. The dictionary
+            must contain one protected key ALL_MODULES which will be used for computing
+            gradients through.
         """
+        loss_total = None
         loss_per_module = {}
         for module_id in fwd_out:
             module_batch = batch[module_id]
@@ -877,6 +867,13 @@ class Learner(Checkpointable):
                 fwd_out=module_fwd_out,
             )
             loss_per_module[module_id] = loss
+
+            if loss_total is None:
+                loss_total = loss
+            else:
+                loss_total += loss
+
+        loss_per_module[ALL_MODULES] = loss_total
 
         return loss_per_module
 
@@ -894,7 +891,7 @@ class Learner(Checkpointable):
 
         Think of this as computing loss for a single agent. For multi-agent use-cases
         that require more complicated computation for loss, consider overriding the
-        `compute_losses` method instead.
+        `compute_loss` method instead.
 
         Args:
             module_id: The id of the module.
@@ -1585,6 +1582,7 @@ class Learner(Checkpointable):
         # Logs this iteration's steps trained, based on given `episodes`.
         env_steps = sum(len(e) for e in episodes)
         log_dict = defaultdict(dict)
+        orig_lengths = shared_data.get("_sa_episodes_lengths", {})
         for sa_episode in self._learner_connector.single_agent_episode_iterator(
             episodes, agents_that_stepped_only=False
         ):
@@ -1597,7 +1595,11 @@ class Learner(Checkpointable):
             if mid != ALL_MODULES and mid not in batch.policy_batches:
                 continue
 
-            _len = len(sa_episode)
+            _len = (
+                orig_lengths[sa_episode.id_]
+                if sa_episode.id_ in orig_lengths
+                else len(sa_episode)
+            )
             # TODO (sven): Decide, whether agent_ids should be part of LEARNER_RESULTS.
             #  Currently and historically, only ModuleID keys and ALL_MODULES were used
             #  and expected. Does it make sense to include e.g. agent steps trained?
@@ -1663,13 +1665,3 @@ class Learner(Checkpointable):
     @Deprecated(new="Learner._set_optimizer_state()", error=True)
     def set_optimizer_state(self, *args, **kwargs):
         pass
-
-    @Deprecated(new="Learner.compute_losses(...)", error=False)
-    def compute_loss(self, *args, **kwargs):
-        losses_per_module = self.compute_losses(*args, **kwargs)
-        # To continue supporting the old `compute_loss` behavior (instead of
-        # the new `compute_losses`, add the ALL_MODULES key here holding the sum
-        # of all individual loss terms.
-        if ALL_MODULES not in losses_per_module:
-            losses_per_module[ALL_MODULES] = sum(losses_per_module.values())
-        return losses_per_module

--- a/rllib/core/learner/learner.py
+++ b/rllib/core/learner/learner.py
@@ -212,8 +212,8 @@ class Learner(Checkpointable):
 
             class MyLearner(TorchLearner):
 
-               def compute_loss(self, fwd_out, batch):
-                   # compute the loss based on batch and output of the forward pass
+               def compute_losses(self, fwd_out, batch):
+                   # Compute the loss based on batch and output of the forward pass
                    # to access the learner hyper-parameters use `self._hps`
                    return {ALL_MODULES: loss}
     """
@@ -595,9 +595,22 @@ class Learner(Checkpointable):
             The optimizer object, configured under the given `module_id` and
             `optimizer_name`.
         """
+        # `optimizer_name` could possibly be the full optimizer name (including the
+        # module_id under which it is registered).
+        if optimizer_name in self._named_optimizers:
+            return self._named_optimizers[optimizer_name]
+
+        # Normally, `optimizer_name` is just the optimizer's name, not including the
+        # `module_id`.
         full_registration_name = module_id + "_" + optimizer_name
-        assert full_registration_name in self._named_optimizers
-        return self._named_optimizers[full_registration_name]
+        if full_registration_name in self._named_optimizers:
+            return self._named_optimizers[full_registration_name]
+
+        # No optimizer found.
+        raise KeyError(
+            f"Optimizer not found! module_id={module_id} "
+            f"optimizer_name={optimizer_name}"
+        )
 
     def get_optimizers_for_module(
         self, module_id: ModuleID = ALL_MODULES
@@ -828,33 +841,30 @@ class Learner(Checkpointable):
         return should_module_be_updated_fn(module_id, multi_agent_batch)
 
     @OverrideToImplementCustomLogic
-    def compute_loss(
+    def compute_losses(
         self, *, fwd_out: Dict[str, Any], batch: Dict[str, Any]
     ) -> Dict[str, Any]:
-        """Computes the loss for the module being optimized.
+        """Computes the loss(es) for the module being optimized.
 
-        This method must be overridden by multiagent-specific algorithm learners to
-        specify the specific loss computation logic. If the algorithm is single agent
-        `compute_loss_for_module()` should be overridden instead.
-        `fwd_out` is the output of the `forward_train()` method of the underlying
-        MultiRLModule. `batch` is the data that was used to compute `fwd_out`.
-        The returned dictionary must contain a key called
-        ALL_MODULES, which will be used to compute gradients. It is recommended
-        to not compute any forward passes within this method, and to use the
-        `forward_train()` outputs of the RLModule(s) to compute the required tensors for
-        loss calculations.
+        This method must be overridden by MultiRLModule-specific Learners in order to
+        define the specific loss computation logic. If the algorithm is single-agent
+        `compute_loss_for_module()` should be overridden instead. If the algorithm uses
+        independent multi-agent learning (default behavior for multi-agent setups), also
+        `compute_loss_for_module()` should be overridden, but it will be called for each
+        individual RLModule inside the MultiRLModule.
+        It is recommended to not compute any forward passes within this method, and to
+        use the `forward_train()` outputs of the RLModule(s) to compute the required
+        tensors for loss calculations.
 
         Args:
-            fwd_out: Output from a call to the `forward_train()` method of self.module
-                during training (`self.update()`).
+            fwd_out: Output from a call to the `forward_train()` method of the
+                underlying MultiRLModule (`self.module`) during training
+                (`self.update()`).
             batch: The training batch that was used to compute `fwd_out`.
 
         Returns:
-            A dictionary mapping module IDs to individual loss terms. The dictionary
-            must contain one protected key ALL_MODULES which will be used for computing
-            gradients through.
+            A dictionary mapping module IDs to individual loss terms.
         """
-        loss_total = None
         loss_per_module = {}
         for module_id in fwd_out:
             module_batch = batch[module_id]
@@ -867,13 +877,6 @@ class Learner(Checkpointable):
                 fwd_out=module_fwd_out,
             )
             loss_per_module[module_id] = loss
-
-            if loss_total is None:
-                loss_total = loss
-            else:
-                loss_total += loss
-
-        loss_per_module[ALL_MODULES] = loss_total
 
         return loss_per_module
 
@@ -891,7 +894,7 @@ class Learner(Checkpointable):
 
         Think of this as computing loss for a single agent. For multi-agent use-cases
         that require more complicated computation for loss, consider overriding the
-        `compute_loss` method instead.
+        `compute_losses` method instead.
 
         Args:
             module_id: The id of the module.
@@ -1582,7 +1585,6 @@ class Learner(Checkpointable):
         # Logs this iteration's steps trained, based on given `episodes`.
         env_steps = sum(len(e) for e in episodes)
         log_dict = defaultdict(dict)
-        orig_lengths = shared_data.get("_sa_episodes_lengths", {})
         for sa_episode in self._learner_connector.single_agent_episode_iterator(
             episodes, agents_that_stepped_only=False
         ):
@@ -1595,11 +1597,7 @@ class Learner(Checkpointable):
             if mid != ALL_MODULES and mid not in batch.policy_batches:
                 continue
 
-            _len = (
-                orig_lengths[sa_episode.id_]
-                if sa_episode.id_ in orig_lengths
-                else len(sa_episode)
-            )
+            _len = len(sa_episode)
             # TODO (sven): Decide, whether agent_ids should be part of LEARNER_RESULTS.
             #  Currently and historically, only ModuleID keys and ALL_MODULES were used
             #  and expected. Does it make sense to include e.g. agent steps trained?
@@ -1665,3 +1663,13 @@ class Learner(Checkpointable):
     @Deprecated(new="Learner._set_optimizer_state()", error=True)
     def set_optimizer_state(self, *args, **kwargs):
         pass
+
+    @Deprecated(new="Learner.compute_losses(...)", error=False)
+    def compute_loss(self, *args, **kwargs):
+        losses_per_module = self.compute_losses(*args, **kwargs)
+        # To continue supporting the old `compute_loss` behavior (instead of
+        # the new `compute_losses`, add the ALL_MODULES key here holding the sum
+        # of all individual loss terms.
+        if ALL_MODULES not in losses_per_module:
+            losses_per_module[ALL_MODULES] = sum(losses_per_module.values())
+        return losses_per_module

--- a/rllib/tuned_examples/appo/stateless_cartpole_appo.py
+++ b/rllib/tuned_examples/appo/stateless_cartpole_appo.py
@@ -32,25 +32,24 @@ config = (
         env_to_module_connector=lambda env: MeanStdFilter(),
     )
     .training(
-        lr=0.0002,
+        lr=0.0003,
         num_sgd_iter=6,
-        vf_loss_coeff=0.1,
+        vf_loss_coeff=0.01,
     )
     .rl_module(
         model_config_dict={
             "fcnet_hiddens": [32],
-            "fcnet_activation": "tanh",#"linear",
-            #"fcnet_weights_initializer": nn.init.xavier_uniform_,
-            #"fcnet_bias_initializer": functools.partial(nn.init.constant_, 0.0),
+            "fcnet_activation": "linear",
             "vf_share_layers": True,
             "use_lstm": True,
+            "uses_new_env_runners": True,
             "max_seq_len": 20,
         },
     )
 )
 
 stop = {
-    f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 450.0,
+    f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 350.0,
     NUM_ENV_STEPS_SAMPLED_LIFETIME: 2000000,
 }
 

--- a/rllib/tuned_examples/appo/stateless_cartpole_appo.py
+++ b/rllib/tuned_examples/appo/stateless_cartpole_appo.py
@@ -35,6 +35,7 @@ config = (
         lr=0.0003,
         num_sgd_iter=6,
         vf_loss_coeff=0.01,
+        grad_clip=20.0,
     )
     .rl_module(
         model_config_dict={

--- a/rllib/tuned_examples/appo/stateless_cartpole_appo.py
+++ b/rllib/tuned_examples/appo/stateless_cartpole_appo.py
@@ -13,7 +13,10 @@ from ray.rllib.utils.metrics import (
 from ray.rllib.utils.test_utils import add_rllib_example_script_args
 
 parser = add_rllib_example_script_args()
-parser.set_defaults(enable_new_api_stack=True)
+parser.set_defaults(
+    enable_new_api_stack=True,
+    num_env_runners=3,
+)
 # Use `parser` to add your own custom command line options to this script
 # and (if needed) use their values toset up `config` below.
 args = parser.parse_args()
@@ -28,13 +31,12 @@ config = (
     )
     .environment(StatelessCartPole)
     .env_runners(
-        num_env_runners=3,
         env_to_module_connector=lambda env: MeanStdFilter(),
     )
     .training(
-        lr=0.0003,
+        lr=0.0005,
         num_sgd_iter=6,
-        vf_loss_coeff=0.01,
+        vf_loss_coeff=0.05,
         grad_clip=20.0,
     )
     .rl_module(
@@ -43,6 +45,7 @@ config = (
             "fcnet_activation": "linear",
             "vf_share_layers": True,
             "use_lstm": True,
+            "lstm_cell_size": 128,
             "uses_new_env_runners": True,
             "max_seq_len": 20,
         },

--- a/rllib/tuned_examples/appo/stateless_cartpole_appo.py
+++ b/rllib/tuned_examples/appo/stateless_cartpole_appo.py
@@ -1,7 +1,3 @@
-import functools
-
-from torch import nn
-
 from ray.rllib.algorithms.appo import APPOConfig
 from ray.rllib.connectors.env_to_module import MeanStdFilter
 from ray.rllib.examples.envs.classes.stateless_cartpole import StatelessCartPole

--- a/rllib/tuned_examples/appo/stateless_cartpole_appo.py
+++ b/rllib/tuned_examples/appo/stateless_cartpole_appo.py
@@ -1,34 +1,61 @@
-# @OldAPIStack
-from ray.rllib.algorithms.appo.appo import APPOConfig
+import functools
+
+from torch import nn
+
+from ray.rllib.algorithms.appo import APPOConfig
+from ray.rllib.connectors.env_to_module import MeanStdFilter
 from ray.rllib.examples.envs.classes.stateless_cartpole import StatelessCartPole
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
     NUM_ENV_STEPS_SAMPLED_LIFETIME,
 )
+from ray.rllib.utils.test_utils import add_rllib_example_script_args
+
+parser = add_rllib_example_script_args()
+parser.set_defaults(enable_new_api_stack=True)
+# Use `parser` to add your own custom command line options to this script
+# and (if needed) use their values toset up `config` below.
+args = parser.parse_args()
 
 
 config = (
     APPOConfig()
-    # TODO: Switch over to new stack once it supports LSTMs.
-    .api_stack(enable_rl_module_and_learner=False)
+    # Enable new API stack and use EnvRunner.
+    .api_stack(
+        enable_rl_module_and_learner=True,
+        enable_env_runner_and_connector_v2=True,
+    )
     .environment(StatelessCartPole)
-    .resources(num_gpus=0)
-    .env_runners(num_env_runners=1, observation_filter="MeanStdFilter")
+    .env_runners(
+        num_env_runners=3,
+        env_to_module_connector=lambda env: MeanStdFilter(),
+    )
     .training(
-        lr=0.0003,
+        lr=0.0002,
         num_sgd_iter=6,
-        vf_loss_coeff=0.01,
-        model={
+        vf_loss_coeff=0.1,
+    )
+    .rl_module(
+        model_config_dict={
             "fcnet_hiddens": [32],
-            "fcnet_activation": "linear",
+            "fcnet_activation": "tanh",#"linear",
+            #"fcnet_weights_initializer": nn.init.xavier_uniform_,
+            #"fcnet_bias_initializer": functools.partial(nn.init.constant_, 0.0),
             "vf_share_layers": True,
             "use_lstm": True,
+            "max_seq_len": 20,
         },
     )
 )
 
 stop = {
-    f"{NUM_ENV_STEPS_SAMPLED_LIFETIME}": 500000,
-    f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 150.0,
+    f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 450.0,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME: 2000000,
 }
+
+
+if __name__ == "__main__":
+    from ray.rllib.utils.test_utils import run_rllib_example_script_experiment
+
+    run_rllib_example_script_experiment(config, args, stop=stop)

--- a/rllib/tuned_examples/appo/stateless_cartpole_appo.py
+++ b/rllib/tuned_examples/appo/stateless_cartpole_appo.py
@@ -41,13 +41,10 @@ config = (
     )
     .rl_module(
         model_config_dict={
-            "fcnet_hiddens": [32],
-            "fcnet_activation": "linear",
             "vf_share_layers": True,
             "use_lstm": True,
-            "lstm_cell_size": 128,
             "uses_new_env_runners": True,
-            "max_seq_len": 20,
+            "max_seq_len": 50,
         },
     )
 )

--- a/rllib/tuned_examples/impala/stateless_cartpole_impala.py
+++ b/rllib/tuned_examples/impala/stateless_cartpole_impala.py
@@ -30,23 +30,24 @@ config = (
         env_to_module_connector=lambda env: MeanStdFilter(),
     )
     .training(
-        lr=0.0005,
+        lr=0.0005 * ((args.num_gpus or 1) ** 0.5),
         vf_loss_coeff=0.05,
         grad_clip=20.0,
+        entropy_coeff=0.0,
     )
     .rl_module(
         model_config_dict={
             "vf_share_layers": True,
             "use_lstm": True,
             "uses_new_env_runners": True,
-            "max_seq_len": 50,
+            "max_seq_len": 20,
         },
     )
 )
 
 stop = {
-    f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 250.0,
-    NUM_ENV_STEPS_SAMPLED_LIFETIME: 1000000,
+    f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 350.0,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME: 2000000,
 }
 
 

--- a/rllib/tuned_examples/impala/stateless_cartpole_impala.py
+++ b/rllib/tuned_examples/impala/stateless_cartpole_impala.py
@@ -1,0 +1,56 @@
+from ray.rllib.algorithms.impala import IMPALAConfig
+from ray.rllib.connectors.env_to_module import MeanStdFilter
+from ray.rllib.examples.envs.classes.stateless_cartpole import StatelessCartPole
+from ray.rllib.utils.metrics import (
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
+from ray.rllib.utils.test_utils import add_rllib_example_script_args
+
+parser = add_rllib_example_script_args()
+parser.set_defaults(
+    enable_new_api_stack=True,
+    num_env_runners=3,
+)
+# Use `parser` to add your own custom command line options to this script
+# and (if needed) use their values toset up `config` below.
+args = parser.parse_args()
+
+
+config = (
+    IMPALAConfig()
+    # Enable new API stack and use EnvRunner.
+    .api_stack(
+        enable_rl_module_and_learner=True,
+        enable_env_runner_and_connector_v2=True,
+    )
+    .environment(StatelessCartPole)
+    .env_runners(
+        env_to_module_connector=lambda env: MeanStdFilter(),
+    )
+    .training(
+        lr=0.0005,
+        vf_loss_coeff=0.05,
+        grad_clip=20.0,
+    )
+    .rl_module(
+        model_config_dict={
+            "vf_share_layers": True,
+            "use_lstm": True,
+            "uses_new_env_runners": True,
+            "max_seq_len": 50,
+        },
+    )
+)
+
+stop = {
+    f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 250.0,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME: 1000000,
+}
+
+
+if __name__ == "__main__":
+    from ray.rllib.utils.test_utils import run_rllib_example_script_experiment
+
+    run_rllib_example_script_experiment(config, args, stop=stop)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Fix bugs in IMPALA/APPO + LSTM (new stack) and activate StatelessCartPole learning tests on new API stack.

* `AddOneTsToEpisodesAndTruncate` connector needs to disseminate each episode chunk to NOT add an extra timestep to the middle of an episode (which happens to have two chunks in the training data).
* Fix APPO learner bugs when training with RNNs (would crash due to a malformed batch).

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
