### PR TITLE
[doc][ml] add one missing train public API reference + lint checker

### DIFF
--- a/.buildkite/lint.rayci.yml
+++ b/.buildkite/lint.rayci.yml
@@ -35,6 +35,7 @@ steps:
       - api_policy_check core
       - api_policy_check serve
       - api_policy_check data
+      - api_policy_check train
       - api_policy_check rllib
 
   - label: ":lint-roller: lint: linkcheck"

--- a/ci/ray_ci/doc/cmd_check_api_discrepancy.py
+++ b/ci/ray_ci/doc/cmd_check_api_discrepancy.py
@@ -42,6 +42,11 @@ TEAM_API_CONFIGS = {
             "ray.remote_function.RemoteFunction",
         },
     },
+    "train": {
+        "head_modules": {"ray.train"},
+        "head_doc_file": "doc/source/train/api/api.rst",
+        "white_list_apis": {},
+    },
     "rllib": {
         "head_modules": {"ray.rllib"},
         "head_doc_file": "doc/source/rllib/package_ref/index.rst",

--- a/doc/source/train/api/api.rst
+++ b/doc/source/train/api/api.rst
@@ -163,6 +163,17 @@ Ray Train Output
 
     ~train.Result
 
+Ray Train Errors
+----------------
+
+.. autosummary::
+    :nosignatures:
+    :template: autosummary/class_without_autosummary.rst
+    :toctree: doc/
+
+    ~train.error.SessionMisuseError
+    ~train.base_trainer.TrainingFailedError
+
 
 Ray Train Developer APIs
 ------------------------
@@ -178,7 +189,6 @@ Trainer Base Classes
 
     ~train.trainer.BaseTrainer
     ~train.data_parallel_trainer.DataParallelTrainer
-    ~train.base_trainer.TrainingFailedError
 
 
 Train Backend Base Classes


### PR DESCRIPTION
- Add one missing train public API reference. The full list of missing references is here: https://docs.google.com/spreadsheets/d/1wQALnsUuFN4dMgmGITfiVX41fCc6P6FEjYVO6jDWGtM/edit?gid=406692730#gid=406692730
- Enable api policy lint checker as well

Test:
- CI

<img width="1350" alt="Screenshot 2024-08-14 at 11 15 52 AM" src="https://github.com/user-attachments/assets/34ec0af1-5efe-4f86-9646-48ff90df742a">
