### PR TITLE
[aDAG] Allow custom NCCL group for aDAG

### DIFF
--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -1744,10 +1744,7 @@ class CompiledDAG:
                         logger.exception("Error cancelling worker task")
                         pass
 
-                if (
-                    outer._nccl_group_id is not None
-                    and outer._custom_nccl_group is None
-                ):
+                if outer._nccl_group_id is not None:
                     _destroy_nccl_group(outer._nccl_group_id)
 
                 if wait:

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -814,7 +814,9 @@ class CompiledDAG:
                             assert self._custom_nccl_group == custom_nccl_group, (
                                 "Accelerated DAGs currently only support "
                                 "a single custom NCCL group, but multiple "
-                                "have been specified."
+                                "have been specified. Check all the "
+                                "TorchTensor(transport=nccl_group) type hints "
+                                "to make sure only one NCCL group is used."
                             )
                         self._custom_nccl_group = custom_nccl_group
             elif isinstance(dag_node, InputNode):

--- a/python/ray/dag/dag_node.py
+++ b/python/ray/dag/dag_node.py
@@ -1,3 +1,4 @@
+from ray.experimental.channel.gpu_communicator import GPUCommunicator
 import ray
 from ray.dag.base import DAGNodeBase
 from ray.dag.py_obj_scanner import _PyObjScanner
@@ -166,6 +167,7 @@ class DAGNode(DAGNodeBase):
         enable_asyncio: bool = False,
         _asyncio_max_queue_size: Optional[int] = None,
         _max_buffered_results: Optional[int] = None,
+        _nccl_group: Optional["GPUCommunicator"] = None,
     ) -> "ray.dag.CompiledDAG":
         """Compile an accelerated execution path for this DAG.
 
@@ -186,6 +188,11 @@ class DAGNode(DAGNodeBase):
                 executions is beyond the DAG capacity, the new execution would
                 be blocked in the first place; therefore, this limit is only
                 enforced when it is smaller than the DAG capacity.
+            _nccl_group: The NCCL group to use for this DAG. If None, the DAG
+                will create a NCCL group internally if NCCL communication is
+                needed. Providing a nccl group here allows reusing, which
+                avoids extra memory overhead when initializing a new NCCL group
+                from aDAG.
 
         Returns:
             A compiled DAG.
@@ -218,6 +225,7 @@ class DAGNode(DAGNodeBase):
             enable_asyncio,
             _asyncio_max_queue_size,
             _max_buffered_results,
+            _nccl_group,
         )
 
     def execute(

--- a/python/ray/dag/dag_node.py
+++ b/python/ray/dag/dag_node.py
@@ -1,4 +1,3 @@
-from ray.experimental.channel.gpu_communicator import GPUCommunicator
 import ray
 from ray.dag.base import DAGNodeBase
 from ray.dag.py_obj_scanner import _PyObjScanner
@@ -167,7 +166,6 @@ class DAGNode(DAGNodeBase):
         enable_asyncio: bool = False,
         _asyncio_max_queue_size: Optional[int] = None,
         _max_buffered_results: Optional[int] = None,
-        _nccl_group: Optional["GPUCommunicator"] = None,
     ) -> "ray.dag.CompiledDAG":
         """Compile an accelerated execution path for this DAG.
 
@@ -188,11 +186,6 @@ class DAGNode(DAGNodeBase):
                 executions is beyond the DAG capacity, the new execution would
                 be blocked in the first place; therefore, this limit is only
                 enforced when it is smaller than the DAG capacity.
-            _nccl_group: The NCCL group to use for this DAG. If None, the DAG
-                will create a NCCL group internally if NCCL communication is
-                needed. Providing a nccl group here allows reusing, which
-                avoids extra memory overhead when initializing a new NCCL group
-                from aDAG.
 
         Returns:
             A compiled DAG.
@@ -225,7 +218,6 @@ class DAGNode(DAGNodeBase):
             enable_asyncio,
             _asyncio_max_queue_size,
             _max_buffered_results,
-            _nccl_group,
         )
 
     def execute(

--- a/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
@@ -3,7 +3,7 @@ import logging
 import os
 import re
 import sys
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 from ray.experimental.channel.gpu_communicator import (
     GPUCommunicator,
     TorchTensorAllocator,
@@ -357,6 +357,9 @@ def test_torch_tensor_custom_comm(ray_start_regular):
                 return None
             return self._inner.get_self_rank()
 
+        def get_actor_handles(self) -> List["ray.actor.ActorHandle"]:
+            return self._actor_handles
+
         def send(self, value: "torch.Tensor", peer_rank: int) -> None:
             return self._inner.send(value, peer_rank)
 
@@ -454,6 +457,9 @@ def test_torch_tensor_custom_comm_inited(ray_start_regular):
 
         def get_self_rank(self) -> Optional[int]:
             return self._rank
+
+        def get_actor_handles(self) -> List["ray.actor.ActorHandle"]:
+            return self._actor_handles
 
         def send(self, value: "torch.Tensor", peer_rank: int) -> None:
             torch.distributed.send(value, peer_rank)

--- a/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
@@ -304,7 +304,7 @@ def test_torch_tensor_nccl_dynamic(ray_start_regular):
 
 
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
-def test_torch_tensor_custom_nccl(ray_start_regular):
+def test_torch_tensor_custom_comm(ray_start_regular):
     if not USE_GPU:
         pytest.skip("NCCL tests require GPUs")
 
@@ -395,7 +395,7 @@ def test_torch_tensor_custom_nccl(ray_start_regular):
 
 
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
-def test_torch_tensor_custom_torch_nccl(ray_start_regular):
+def test_torch_tensor_custom_comm_inited(ray_start_regular):
     if not USE_GPU:
         pytest.skip("NCCL tests require GPUs")
 
@@ -423,7 +423,7 @@ def test_torch_tensor_custom_torch_nccl(ray_start_regular):
     ]
     ray.wait(refs)
 
-    class TorchNcclGroup(GPUCommunicator):
+    class InitedNcclGroup(GPUCommunicator):
         """
         A custom NCCL group based on existing torch.distributed setup.
         """
@@ -472,7 +472,7 @@ def test_torch_tensor_custom_torch_nccl(ray_start_regular):
         def destroy(self) -> None:
             pass
 
-    nccl_group = TorchNcclGroup(2, [sender, receiver])
+    nccl_group = InitedNcclGroup(2, [sender, receiver])
     with InputNode() as inp:
         dag = sender.send_with_tuple_args.bind(inp)
         dag = dag.with_type_hint(TorchTensorType(transport=nccl_group))

--- a/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
@@ -398,6 +398,122 @@ def test_torch_tensor_custom_comm(ray_start_regular):
 
 
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
+def test_torch_tensor_custom_comm_invalid(ray_start_regular):
+    if not USE_GPU:
+        pytest.skip("NCCL tests require GPUs")
+
+    assert (
+        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
+    ), "This test requires at least 2 GPUs"
+
+    actor_cls = TorchTensorWorker.options(num_cpus=0, num_gpus=1)
+
+    actor1 = actor_cls.remote()
+    actor2 = actor_cls.remote()
+
+    class MockNcclGroup(GPUCommunicator):
+        """
+        A mock NCCL group for testing. Send and recv are not implemented.
+        """
+
+        def __init__(self, world_size, actor_handles):
+            self._world_size = world_size
+            self._actor_handles = actor_handles
+            self._rank = None
+
+        def initialize(self, rank: int) -> None:
+            expected_rank = self.get_rank(ray.get_runtime_context().current_actor)
+            assert (
+                rank == expected_rank
+            ), f"NCCL actor's rank {rank} does not match expected rank {expected_rank}"
+            self._rank = rank
+            self._device = torch_utils.get_devices()[0]
+
+        def get_rank(self, actor: ray.actor.ActorHandle) -> int:
+            actor_ids = [a._ray_actor_id for a in self._actor_handles]
+            try:
+                rank = actor_ids.index(actor._ray_actor_id)
+            except ValueError:
+                raise ValueError("Actor is not in the NCCL group.")
+            return rank
+
+        def get_world_size(self) -> int:
+            return self._world_size
+
+        def get_self_rank(self) -> Optional[int]:
+            return self._rank
+
+        def get_actor_handles(self) -> List["ray.actor.ActorHandle"]:
+            return self._actor_handles
+
+        def send(self, value: "torch.Tensor", peer_rank: int) -> None:
+            return None
+
+        def recv(
+            self,
+            shape: Tuple[int],
+            dtype: "torch.dtype",
+            peer_rank: int,
+            allocator: Optional[TorchTensorAllocator] = None,
+        ) -> "torch.Tensor":
+            return None
+
+        def destroy(self) -> None:
+            pass
+
+    nccl_group = MockNcclGroup(2, [actor1, actor2])
+
+    # Mixed usage of NCCL groups should throw an error
+    # Case 1: custom NCCL group first, then default NCCL group
+    with InputNode() as inp:
+        dag = actor1.send_with_tuple_args.bind(inp)
+        dag = dag.with_type_hint(TorchTensorType(transport=nccl_group))
+        dag = actor2.recv.bind(dag)
+        dag = actor2.send_with_tuple_args.bind(dag)
+        dag = dag.with_type_hint(TorchTensorType(transport="nccl"))
+        dag = actor1.recv.bind(dag)
+    with pytest.raises(
+        ValueError,
+        match=r"Accelerated DAGs do not support mixed usage of type hints.*",
+    ):
+        dag.experimental_compile()
+
+    # Case 2: default NCCL group first, then custom NCCL group
+    with InputNode() as inp:
+        dag = actor1.send_with_tuple_args.bind(inp)
+        dag = dag.with_type_hint(TorchTensorType(transport="nccl"))
+        dag = actor2.recv.bind(dag)
+        dag = actor2.send_with_tuple_args.bind(dag)
+        dag = dag.with_type_hint(TorchTensorType(transport=nccl_group))
+        dag = actor1.recv.bind(dag)
+    with pytest.raises(
+        ValueError,
+        match=r"Accelerated DAGs do not support mixed usage of type hints.*",
+    ):
+        dag.experimental_compile()
+
+    nccl_group2 = MockNcclGroup(2, [actor1, actor2])
+
+    # Using two different custom NCCL groups are currently not supported
+    with InputNode() as inp:
+        dag = actor1.send_with_tuple_args.bind(inp)
+        dag = dag.with_type_hint(TorchTensorType(transport=nccl_group))
+        dag = actor2.recv.bind(dag)
+        dag = actor2.send_with_tuple_args.bind(dag)
+        dag = dag.with_type_hint(TorchTensorType(transport=nccl_group2))
+        dag = actor1.recv.bind(dag)
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Accelerated DAGs currently only support "
+            "a single custom NCCL group, but multiple "
+            "have been specified."
+        ),
+    ):
+        dag.experimental_compile()
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
 def test_torch_tensor_custom_comm_inited(ray_start_regular):
     if not USE_GPU:
         pytest.skip("NCCL tests require GPUs")

--- a/python/ray/experimental/channel/__init__.py
+++ b/python/ray/experimental/channel/__init__.py
@@ -10,6 +10,7 @@ from ray.experimental.channel.common import (  # noqa: F401
     SynchronousWriter,
     WriterInterface,
 )
+from ray.experimental.channel.gpu_communicator import GPUCommunicator
 from ray.experimental.channel.intra_process_channel import IntraProcessChannel
 from ray.experimental.channel.shared_memory_channel import Channel, CompositeChannel
 from ray.experimental.channel.torch_tensor_nccl_channel import TorchTensorNcclChannel
@@ -19,6 +20,7 @@ __all__ = [
     "AwaitableBackgroundWriter",
     "CachedChannel",
     "Channel",
+    "GPUCommunicator",
     "ReaderInterface",
     "SynchronousReader",
     "SynchronousWriter",

--- a/python/ray/experimental/channel/common.py
+++ b/python/ray/experimental/channel/common.py
@@ -100,6 +100,14 @@ class ChannelOutputType:
         # By default, channels do not require NCCL.
         return False
 
+    def get_custom_nccl_group(self) -> Optional[GPUCommunicator]:
+        """
+        Return the custom NCCL group if one is specified.
+        """
+        if self._contains_type is not None:
+            return self._contains_type.get_custom_nccl_group()
+        return None
+
     def set_nccl_group_id(self, group_id: str) -> None:
         raise NotImplementedError
 

--- a/python/ray/experimental/channel/common.py
+++ b/python/ray/experimental/channel/common.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import ray
-from ray.experimental.channel.nccl_group import _NcclGroup
+from ray.experimental.channel.gpu_communicator import GPUCommunicator
 from ray.experimental.channel.serialization_context import _SerializationContext
 from ray.util.annotations import DeveloperAPI, PublicAPI
 
@@ -112,7 +112,7 @@ class ChannelContext:
 
     def __init__(self):
         # Used for the torch.Tensor NCCL transport.
-        self.nccl_groups: Dict[str, "_NcclGroup"] = {}
+        self.nccl_groups: Dict[str, "GPUCommunicator"] = {}
 
     @staticmethod
     def get_current() -> "ChannelContext":

--- a/python/ray/experimental/channel/conftest.py
+++ b/python/ray/experimental/channel/conftest.py
@@ -87,6 +87,9 @@ class MockNcclGroup(ray_channel.nccl_group._NcclGroup):
         barrier_key = f"barrier-{peer_rank}-{self.get_self_rank()}"
         barrier = ray.get_actor(name=barrier_key)
         received_tensor = ray.get(barrier.wait.remote(self.num_ops[barrier_key]))
+        assert (
+            allocator is not None
+        ), "torch tensor allocator is required for MockNcclGroup"
         buf = allocator(shape, dtype)
         buf[:] = received_tensor[:]
         self.num_ops[barrier_key] += 1

--- a/python/ray/experimental/channel/gpu_communicator.py
+++ b/python/ray/experimental/channel/gpu_communicator.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Callable, Optional, Tuple
+from typing import TYPE_CHECKING, Callable, List, Optional, Tuple
 
 import ray
 from ray.util.annotations import DeveloperAPI
@@ -32,6 +32,13 @@ class GPUCommunicator(ABC):
 
         Args:
             rank: The rank of this actor in the group.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_actor_handles(self) -> List["ray.actor.ActorHandle"]:
+        """
+        Get handles of all actors for this communicator group.
         """
         raise NotImplementedError
 
@@ -94,5 +101,15 @@ class GPUCommunicator(ABC):
             dtype: The dtype of the tensor to receive.
             peer_rank: The rank of the actor to receive from.
             allocator: A function to allocate the tensor to receive into.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def destroy() -> None:
+        """
+        Destroy the GPU communicator.
+
+        Any destruction and cleanup for the GPU communicator should be
+        done here. Implement as a noop is nothing is needed.
         """
         raise NotImplementedError

--- a/python/ray/experimental/channel/gpu_communicator.py
+++ b/python/ray/experimental/channel/gpu_communicator.py
@@ -66,9 +66,6 @@ class GPUCommunicator(ABC):
         This returns when the send kernel has been queued, but the kernel may
         not have completed. Therefore, the caller should ensure that there are
         no concurrent writes to the sent `value` until the send has finished.
-        That is, either all writes should be submitted on the current stream
-        (self._cuda_stream) or, if on a different stream, that stream should
-        synchronize with the current stream.
 
         Args:
             value: The torch.Tensor to send. It should already be on this

--- a/python/ray/experimental/channel/gpu_communicator.py
+++ b/python/ray/experimental/channel/gpu_communicator.py
@@ -22,18 +22,18 @@ class GPUCommunicator(ABC):
     between actors in the group.
     """
 
-    def register(self, group_id: str):
+    @abstractmethod
+    def initialize(self, rank: int) -> None:
         """
-        Register the group in the Ray channel context.
+        Initialize the communicator from the actor.
 
-        This should be called once remotely on each actor
-        in the group before any other methods can be called,
-        with the same `group_id`.
+        This is called once by aDAG on each actor to initialize the communicator,
+        before any other methods.
+
+        Args:
+            rank: The rank of this actor in the group.
         """
-        from ray.experimental.channel.common import ChannelContext
-
-        ctx = ChannelContext.get_current()
-        ctx.nccl_groups[group_id] = self
+        raise NotImplementedError
 
     @abstractmethod
     def get_rank(self, actor: ray.actor.ActorHandle) -> int:
@@ -49,6 +49,12 @@ class GPUCommunicator(ABC):
     def get_self_rank(self) -> Optional[int]:
         """
         Return this actor's rank.
+        """
+        raise NotImplementedError
+
+    def get_world_size(self) -> int:
+        """
+        Return the number of ranks in the group.
         """
         raise NotImplementedError
 

--- a/python/ray/experimental/channel/gpu_communicator.py
+++ b/python/ray/experimental/channel/gpu_communicator.py
@@ -1,0 +1,95 @@
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Callable, Optional, Tuple
+
+import ray
+from ray.util.annotations import DeveloperAPI
+
+if TYPE_CHECKING:
+    import torch
+
+
+# Signature for a torch.Tensor allocator is:
+# (shape: Tuple[int], dtype: torch.dtype) -> torch.Tensor.
+TorchTensorAllocator = Callable[[Tuple[int], "torch.dtype"], "torch.Tensor"]
+
+
+@DeveloperAPI
+class GPUCommunicator(ABC):
+    """
+    Communicator for a group of aDAG actors on Nvidia GPU.
+
+    The aDAG execution leverages this internally to support communication
+    between actors in the group.
+    """
+
+    def register(self, group_id: str):
+        """
+        Register the group in the Ray channel context.
+
+        This should be called once remotely on each actor
+        in the group before any other methods can be called,
+        with the same `group_id`.
+        """
+        from ray.experimental.channel.common import ChannelContext
+
+        ctx = ChannelContext.get_current()
+        ctx.nccl_groups[group_id] = self
+
+    @abstractmethod
+    def get_rank(self, actor: ray.actor.ActorHandle) -> int:
+        """
+        Return the given actor's rank in the group.
+
+        Args:
+            actor: The actor handle to look up.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_self_rank(self) -> Optional[int]:
+        """
+        Return this actor's rank.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def send(self, value: "torch.Tensor", peer_rank: int) -> None:
+        """
+        Send a torch.Tensor to a peer.
+
+        This returns when the send kernel has been queued, but the kernel may
+        not have completed. Therefore, the caller should ensure that there are
+        no concurrent writes to the sent `value` until the send has finished.
+        That is, either all writes should be submitted on the current stream
+        (self._cuda_stream) or, if on a different stream, that stream should
+        synchronize with the current stream.
+
+        Args:
+            value: The torch.Tensor to send. It should already be on this
+                actor's default device.
+            peer_rank: The rank of the actor to send to.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def recv(
+        self,
+        shape: Tuple[int],
+        dtype: "torch.dtype",
+        peer_rank: int,
+        allocator: Optional[TorchTensorAllocator] = None,
+    ) -> "torch.Tensor":
+        """
+        Receive a torch.Tensor from a peer and synchronize.
+
+        After this call returns, the receive buffer is safe to read from from
+        any stream. An RayChannelError will be raised if an error occurred (e.g.,
+        remote actor died), and the buffer is not safe to read.
+
+        Args:
+            shape: The shape of the tensor to receive.
+            dtype: The dtype of the tensor to receive.
+            peer_rank: The rank of the actor to receive from.
+            allocator: A function to allocate the tensor to receive into.
+        """
+        raise NotImplementedError

--- a/python/ray/experimental/channel/nccl_group.py
+++ b/python/ray/experimental/channel/nccl_group.py
@@ -67,6 +67,7 @@ class _NcclGroup(GPUCommunicator):
             cuda_stream: A raw CUDA stream to dispatch NCCL ops to. If rank is
                 specified, then this must be specified too.
         """
+        self._world_size = world_size
         self._rank: Optional[int] = rank
         self.nccl_util: Optional[ModuleType] = None
         self._actor_handles = actor_handles
@@ -105,6 +106,10 @@ class _NcclGroup(GPUCommunicator):
 
         self._closed = False
 
+    def initialize(self, rank: int) -> None:
+        # No additional initialization is needed.
+        pass
+
     def _get_actor_handles(self) -> List["ray.actor.ActorHandle"]:
         return self._actor_handles
 
@@ -127,6 +132,12 @@ class _NcclGroup(GPUCommunicator):
         Return this actor's rank.
         """
         return self._rank
+
+    def get_world_size(self) -> int:
+        """
+        Return the number of ranks in the NCCL communicator.
+        """
+        return self._world_size
 
     def send(self, value: "torch.Tensor", peer_rank: int) -> None:
         """

--- a/python/ray/experimental/channel/nccl_group.py
+++ b/python/ray/experimental/channel/nccl_group.py
@@ -110,7 +110,7 @@ class _NcclGroup(GPUCommunicator):
         # No additional initialization is needed.
         pass
 
-    def _get_actor_handles(self) -> List["ray.actor.ActorHandle"]:
+    def get_actor_handles(self) -> List["ray.actor.ActorHandle"]:
         return self._actor_handles
 
     def get_rank(self, actor: ray.actor.ActorHandle) -> int:

--- a/python/ray/experimental/channel/torch_tensor_type.py
+++ b/python/ray/experimental/channel/torch_tensor_type.py
@@ -3,12 +3,11 @@ from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 import ray
 from ray.experimental.channel import ChannelContext, ChannelOutputType
+from ray.experimental.channel.gpu_communicator import TorchTensorAllocator
 from ray.util.annotations import PublicAPI
 
 if TYPE_CHECKING:
     import torch
-
-    from ray.experimental.channel.torch_tensor_nccl_channel import TorchTensorAllocator
 
 logger = logging.getLogger(__name__)
 

--- a/python/ray/experimental/channel/torch_tensor_type.py
+++ b/python/ray/experimental/channel/torch_tensor_type.py
@@ -3,7 +3,10 @@ from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 import ray
 from ray.experimental.channel import ChannelContext, ChannelOutputType
-from ray.experimental.channel.gpu_communicator import TorchTensorAllocator
+from ray.experimental.channel.gpu_communicator import (
+    GPUCommunicator,
+    TorchTensorAllocator,
+)
 from ray.util.annotations import PublicAPI
 
 if TYPE_CHECKING:
@@ -27,7 +30,7 @@ class TorchTensorType(ChannelOutputType):
         self,
         _shape: Union[int, Tuple[int], str] = AUTO,
         _dtype: "torch.dtype" = AUTO,
-        transport: Optional[str] = AUTO,
+        transport: Optional[Union[str, GPUCommunicator]] = AUTO,
         _direct_return: Optional[bool] = False,
     ):
         """
@@ -71,6 +74,11 @@ class TorchTensorType(ChannelOutputType):
         self._shape = _shape
         self._dtype = _dtype
         self._direct_return = _direct_return
+
+        self._custom_nccl_group: Optional[GPUCommunicator] = None
+        if isinstance(transport, GPUCommunicator):
+            self._custom_nccl_group = transport
+            transport = self.NCCL
 
         if transport not in [self.AUTO, self.NCCL]:
             raise ValueError(
@@ -168,6 +176,12 @@ class TorchTensorType(ChannelOutputType):
 
     def requires_nccl(self) -> bool:
         return self.transport == self.NCCL
+
+    def get_custom_nccl_group(self) -> Optional[GPUCommunicator]:
+        """
+        Return the custom NCCL group if one is specified.
+        """
+        return self._custom_nccl_group
 
     def set_nccl_group_id(self, group_id: str) -> None:
         self._nccl_group_id = group_id


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Allow custom NCCL group for aDAG so that we can reuse what the user already created.

Marking `NcclGroupInterface` as DeveloperAPI for now. After validation by using it in vLLM we can change to alpha stability.

vLLM prototype: https://github.com/vllm-project/vllm/pull/7568

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #45593
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
