### PR TITLE
[observability] [export-api] Fix Ray Events to support writing events of multiple source types to different files

### DIFF
--- a/src/ray/core_worker/core_worker_process.cc
+++ b/src/ray/core_worker/core_worker_process.cc
@@ -136,7 +136,8 @@ CoreWorkerProcessImpl::CoreWorkerProcessImpl(const CoreWorkerOptions &options)
 
   // Initialize event framework.
   if (RayConfig::instance().event_log_reporter_enabled() && !options_.log_dir.empty()) {
-    RayEventInit(ray::rpc::Event_SourceType::Event_SourceType_CORE_WORKER,
+    const std::vector<SourceTypeVariant> source_types = { ray::rpc::Event_SourceType::Event_SourceType_CORE_WORKER };
+    RayEventInit(source_types,
                  absl::flat_hash_map<std::string, std::string>(),
                  options_.log_dir,
                  RayConfig::instance().event_level(),

--- a/src/ray/core_worker/core_worker_process.cc
+++ b/src/ray/core_worker/core_worker_process.cc
@@ -136,7 +136,8 @@ CoreWorkerProcessImpl::CoreWorkerProcessImpl(const CoreWorkerOptions &options)
 
   // Initialize event framework.
   if (RayConfig::instance().event_log_reporter_enabled() && !options_.log_dir.empty()) {
-    const std::vector<SourceTypeVariant> source_types = { ray::rpc::Event_SourceType::Event_SourceType_CORE_WORKER };
+    const std::vector<SourceTypeVariant> source_types = {
+        ray::rpc::Event_SourceType::Event_SourceType_CORE_WORKER};
     RayEventInit(source_types,
                  absl::flat_hash_map<std::string, std::string>(),
                  options_.log_dir,

--- a/src/ray/gcs/gcs_server/gcs_server_main.cc
+++ b/src/ray/gcs/gcs_server/gcs_server_main.cc
@@ -88,7 +88,8 @@ int main(int argc, char *argv[]) {
 
   // Initialize event framework.
   if (RayConfig::instance().event_log_reporter_enabled() && !log_dir.empty()) {
-    ray::RayEventInit(ray::rpc::Event_SourceType::Event_SourceType_GCS,
+    const std::vector<ray::SourceTypeVariant> source_types = {ray::rpc::Event_SourceType::Event_SourceType_GCS};
+    ray::RayEventInit(source_types,
                       absl::flat_hash_map<std::string, std::string>(),
                       log_dir,
                       RayConfig::instance().event_level(),

--- a/src/ray/gcs/gcs_server/gcs_server_main.cc
+++ b/src/ray/gcs/gcs_server/gcs_server_main.cc
@@ -88,7 +88,8 @@ int main(int argc, char *argv[]) {
 
   // Initialize event framework.
   if (RayConfig::instance().event_log_reporter_enabled() && !log_dir.empty()) {
-    const std::vector<ray::SourceTypeVariant> source_types = {ray::rpc::Event_SourceType::Event_SourceType_GCS};
+    const std::vector<ray::SourceTypeVariant> source_types = {
+        ray::rpc::Event_SourceType::Event_SourceType_GCS};
     ray::RayEventInit(source_types,
                       absl::flat_hash_map<std::string, std::string>(),
                       log_dir,

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -432,7 +432,8 @@ int main(int argc, char *argv[]) {
 
         // Initialize event framework.
         if (RayConfig::instance().event_log_reporter_enabled() && !log_dir.empty()) {
-          const std::vector<ray::SourceTypeVariant> source_types = {ray::rpc::Event_SourceType::Event_SourceType_RAYLET};
+          const std::vector<ray::SourceTypeVariant> source_types = {
+              ray::rpc::Event_SourceType::Event_SourceType_RAYLET};
           ray::RayEventInit(source_types,
                             {{"node_id", raylet->GetNodeId().Hex()}},
                             log_dir,

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -432,7 +432,8 @@ int main(int argc, char *argv[]) {
 
         // Initialize event framework.
         if (RayConfig::instance().event_log_reporter_enabled() && !log_dir.empty()) {
-          ray::RayEventInit(ray::rpc::Event_SourceType::Event_SourceType_RAYLET,
+          const std::vector<ray::SourceTypeVariant> source_types = {ray::rpc::Event_SourceType::Event_SourceType_RAYLET};
+          ray::RayEventInit(source_types,
                             {{"node_id", raylet->GetNodeId().Hex()}},
                             log_dir,
                             RayConfig::instance().event_level(),

--- a/src/ray/util/event.cc
+++ b/src/ray/util/event.cc
@@ -192,6 +192,11 @@ void EventManager::PublishExportEvent(const rpc::ExportEvent &export_event) {
   auto element = export_log_reporter_map_.find(export_event.source_type());
   if (element != export_log_reporter_map_.end()) {
     (element->second)->ReportExportEvent(export_event);
+  } else {
+    RAY_LOG(FATAL)
+        << "RayEventInit wasn't called with the necessary source type "
+        << ExportEvent_SourceType_Name(export_event.source_type())
+        << ". This indicates a bug in the code, and the event will be dropped.";
   }
 }
 

--- a/src/ray/util/event.cc
+++ b/src/ray/util/event.cc
@@ -153,6 +153,7 @@ void LogEventReporter::Report(const rpc::Event &event, const json &custom_fields
   if (Event_SourceType_Name(event.source_type()) == source_type_name_){
     std::string result = EventToString(event, custom_fields);
     log_sink_->info(result);
+  }
 
   if (force_flush_) {
     Flush();
@@ -165,6 +166,7 @@ void LogEventReporter::ReportExportEvent(const rpc::ExportEvent &export_event) {
   if (ExportEvent_SourceType_Name(export_event.source_type()) == source_type_name_){
     std::string result = ExportEventToString(export_event);
     log_sink_->info(result);
+  }
 
   if (force_flush_) {
     Flush();

--- a/src/ray/util/event.cc
+++ b/src/ray/util/event.cc
@@ -150,7 +150,7 @@ void LogEventReporter::Report(const rpc::Event &event, const json &custom_fields
   RAY_CHECK(Event_SourceType_IsValid(event.source_type()));
   RAY_CHECK(Event_Severity_IsValid(event.severity()));
   // Only write event if the event source type is for this reporter
-  if (Event_SourceType_Name(event.source_type()) == source_type_name_){
+  if (Event_SourceType_Name(event.source_type()) == source_type_name_) {
     std::string result = EventToString(event, custom_fields);
     log_sink_->info(result);
   }
@@ -163,7 +163,7 @@ void LogEventReporter::Report(const rpc::Event &event, const json &custom_fields
 void LogEventReporter::ReportExportEvent(const rpc::ExportEvent &export_event) {
   RAY_CHECK(ExportEvent_SourceType_IsValid(export_event.source_type()));
   // Only write event if the event source type is for this reporter
-  if (ExportEvent_SourceType_Name(export_event.source_type()) == source_type_name_){
+  if (ExportEvent_SourceType_Name(export_event.source_type()) == source_type_name_) {
     std::string result = ExportEventToString(export_event);
     log_sink_->info(result);
   }
@@ -176,7 +176,7 @@ void LogEventReporter::ReportExportEvent(const rpc::ExportEvent &export_event) {
 std::string LogEventReporter::GetReporterKey() {
   // Reporter key should include the source_type_name_ so the EventManager can
   // have multiple LogEventReporter corresponding to different sources/files.
-  return "log.event.reporter." + source_type_name_; 
+  return "log.event.reporter." + source_type_name_;
 }
 
 ///
@@ -438,21 +438,24 @@ void RayEventInit(const std::vector<SourceTypeVariant> source_types,
   absl::call_once(
       init_once_,
       [&source_types, &custom_fields, &log_dir, &event_level, emit_event_to_log_file]() {
-        for (const auto& source_type : source_types) {
+        for (const auto &source_type : source_types) {
           std::string source_type_name = "";
-          if (auto event_source_type_ptr = std::get_if<rpc::Event_SourceType>(&source_type)) {
+          if (auto event_source_type_ptr =
+                  std::get_if<rpc::Event_SourceType>(&source_type)) {
             // Set custom fields for non export events
-            RayEventContext::Instance().SetEventContext(std::get<rpc::Event_SourceType>(source_type), custom_fields);
+            RayEventContext::Instance().SetEventContext(
+                std::get<rpc::Event_SourceType>(source_type), custom_fields);
             source_type_name = Event_SourceType_Name(*event_source_type_ptr);
-          } else if (auto export_event_source_type_ptr = std::get_if<rpc::ExportEvent_SourceType>(&source_type)) {
+          } else if (auto export_event_source_type_ptr =
+                         std::get_if<rpc::ExportEvent_SourceType>(&source_type)) {
             // For export events
             source_type_name = ExportEvent_SourceType_Name(*export_event_source_type_ptr);
           }
-          auto event_dir = std::filesystem::path(log_dir) / std::filesystem::path("events");
+          auto event_dir =
+              std::filesystem::path(log_dir) / std::filesystem::path("events");
           ray::EventManager::Instance().AddReporter(
               std::make_shared<ray::LogEventReporter>(source_type, event_dir.string()));
-          RAY_LOG(INFO) << "Ray Event initialized for "
-                      << source_type_name;
+          RAY_LOG(INFO) << "Ray Event initialized for " << source_type_name;
         }
         SetEventLevel(event_level);
         SetEmitEventToLogFile(emit_event_to_log_file);

--- a/src/ray/util/event.h
+++ b/src/ray/util/event.h
@@ -340,7 +340,9 @@ class RayExportEvent {
 ///
 /// This function should be called when the main thread starts.
 /// Redundant calls in other thread don't take effect.
-/// \param source_types List of source types the current process can create events for.
+/// \param source_types List of source types the current process can create events for. If there
+/// are multiple rpc::Event_SourceType source_types, the last one will be used as the source type
+/// for the RAY_EVENT macro.
 /// \param custom_fields The global custom fields. These are only set for rpc::Event_SourceType events.
 /// \param log_dir The log directory to generate event subdirectory.
 /// \param event_level The input event level. It should be one of "info","warning",

--- a/src/ray/util/event.h
+++ b/src/ray/util/event.h
@@ -123,9 +123,10 @@ class LogEventReporter : public BaseEventReporter {
 
   virtual void Flush();
 
-  virtual std::string GetReporterKey() override { return "log.event.reporter"; }
+  virtual std::string GetReporterKey() override {}
 
  protected:
+  std::string source_type_name_;
   std::string log_dir_;
   bool force_flush_;
   int rotate_max_file_size_;  // MB
@@ -339,15 +340,15 @@ class RayExportEvent {
 ///
 /// This function should be called when the main thread starts.
 /// Redundant calls in other thread don't take effect.
-/// \param source_type The type of current process.
-/// \param custom_fields The global custom fields.
+/// \param source_types List of source types the current process can create events for.
+/// \param custom_fields The global custom fields. These are only set for rpc::Event_SourceType events.
 /// \param log_dir The log directory to generate event subdirectory.
 /// \param event_level The input event level. It should be one of "info","warning",
 /// "error" and "fatal". You can also use capital letters for the options above.
 /// \param emit_event_to_log_file if True, it will emit the event to the process log file
 /// (e.g., gcs_server.out). Otherwise, event will only be recorded to the event log file.
 /// \return void.
-void RayEventInit(rpc::Event_SourceType source_type,
+void RayEventInit(const std::vector<SourceTypeVariant> source_types,
                   const absl::flat_hash_map<std::string, std::string> &custom_fields,
                   const std::string &log_dir,
                   const std::string &event_level = "warning",

--- a/src/ray/util/event.h
+++ b/src/ray/util/event.h
@@ -340,10 +340,11 @@ class RayExportEvent {
 ///
 /// This function should be called when the main thread starts.
 /// Redundant calls in other thread don't take effect.
-/// \param source_types List of source types the current process can create events for. If there
-/// are multiple rpc::Event_SourceType source_types, the last one will be used as the source type
-/// for the RAY_EVENT macro.
-/// \param custom_fields The global custom fields. These are only set for rpc::Event_SourceType events.
+/// \param source_types List of source types the current process can create events for. If
+/// there are multiple rpc::Event_SourceType source_types, the last one will be used as
+/// the source type for the RAY_EVENT macro.
+/// \param custom_fields The global custom fields. These are only set for
+/// rpc::Event_SourceType events.
 /// \param log_dir The log directory to generate event subdirectory.
 /// \param event_level The input event level. It should be one of "info","warning",
 /// "error" and "fatal". You can also use capital letters for the options above.

--- a/src/ray/util/event.h
+++ b/src/ray/util/event.h
@@ -123,7 +123,7 @@ class LogEventReporter : public BaseEventReporter {
 
   virtual void Flush();
 
-  virtual std::string GetReporterKey() override {}
+  virtual std::string GetReporterKey() override;
 
  protected:
   std::string source_type_name_;

--- a/src/ray/util/tests/event_test.cc
+++ b/src/ray/util/tests/event_test.cc
@@ -477,9 +477,6 @@ TEST_F(EventTest, TestExportEvent) {
       rpc::Event_SourceType::Event_SourceType_RAYLET, log_dir));
   RayEventContext::Instance().SetEventContext(rpc::Event_SourceType::Event_SourceType_RAYLET, absl::flat_hash_map<std::string, std::string>());
 
-  // const std::vector<SourceTypeVariant> source_types = {rpc::ExportEvent_SourceType::ExportEvent_SourceType_EXPORT_TASK, rpc::Event_SourceType::Event_SourceType_RAYLET};
-  // RayEventInit(source_types, absl::flat_hash_map<std::string, std::string>(), log_dir);
-
   std::shared_ptr<rpc::ExportTaskEventData> task_event_ptr = std::make_shared<rpc::ExportTaskEventData>();
   task_event_ptr->set_task_id("task_id0");
   task_event_ptr->set_attempt_number(1);

--- a/src/ray/util/tests/event_test.cc
+++ b/src/ray/util/tests/event_test.cc
@@ -547,7 +547,8 @@ TEST_F(EventTest, TestRayEventInit) {
   custom_fields.emplace("node_id", "node 1");
   custom_fields.emplace("job_id", "job 1");
   custom_fields.emplace("task_id", "task 1");
-  RayEventInit(rpc::Event_SourceType::Event_SourceType_RAYLET, custom_fields, log_dir);
+  const std::vector<SourceTypeVariant> source_types = {rpc::Event_SourceType::Event_SourceType_RAYLET};
+  RayEventInit(source_types, custom_fields, log_dir);
 
   RAY_EVENT(FATAL, "label") << "test error event";
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Context: Export API events will be written from the same process that could be writing a non export event (eg: `core_worker_process` currently only writes `CORE_WORKER` events but will also write `EXPORT_TASK` events). Events of different source types should be written to separate files.

Changes in this PR:
- Update `RayEventInit` to take a list of source types instead of a single one. This was preferred instead of calling `RayEventInit` multiple times because this function can only be called once (in main thread) due to `absl::call_once`.
  - Initialize a `LogEventReporter` for each source type
- Update `LogEventReporter::Report` and `LogEventReporter::ReportExportEvent` to only write an event to file if the source type matches that of the `LogEventReporter`

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
