### PR TITLE
[core] make a note GetThreadContext() can't be used in fiber context

### DIFF
--- a/src/ray/core_worker/context.cc
+++ b/src/ray/core_worker/context.cc
@@ -324,6 +324,7 @@ void WorkerContext::SetCurrentTask(const TaskSpecification &task_spec) {
 
 void WorkerContext::ResetCurrentTask() { GetThreadContext().ResetCurrentTask(); }
 
+/// NOTE: This method can't be used in fiber/async actor context.
 std::shared_ptr<const TaskSpecification> WorkerContext::GetCurrentTask() const {
   return GetThreadContext().GetCurrentTask();
 }
@@ -416,6 +417,7 @@ const ObjectID WorkerContext::GetGeneratorReturnId(
   return ObjectID::FromIndex(current_task_id, current_put_index);
 }
 
+/// NOTE: This method can't be used in fiber/async actor context.
 WorkerThreadContext &WorkerContext::GetThreadContext() const {
   if (thread_context_ == nullptr) {
     absl::ReaderMutexLock lock(&mutex_);

--- a/src/ray/core_worker/context.h
+++ b/src/ray/core_worker/context.h
@@ -91,6 +91,7 @@ class WorkerContext {
 
   void ResetCurrentTask();
 
+  /// NOTE: This method can't be used in fiber/async actor context.
   std::shared_ptr<const TaskSpecification> GetCurrentTask() const;
 
   const ActorID &GetCurrentActorID() const ABSL_LOCKS_EXCLUDED(mutex_);
@@ -165,6 +166,7 @@ class WorkerContext {
   mutable absl::Mutex mutex_;
 
  private:
+  /// NOTE: This method can't be used in fiber/async actor context.
   WorkerThreadContext &GetThreadContext() const;
 
   /// Per-thread worker context.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This is a follow up on https://github.com/ray-project/ray/pull/46973#pullrequestreview-2221933008:

> can we add a comment on worker_context_.GetCurrentTask() that we can't use it in fiber context?

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
