### PR TITLE
[RLlib; Offline RL] Added `stop` method to `OfflineEnvRunner`.

### DIFF
--- a/rllib/algorithms/bc/tests/test_bc.py
+++ b/rllib/algorithms/bc/tests/test_bc.py
@@ -24,7 +24,7 @@ class TestBC(unittest.TestCase):
         data_path = "tests/data/cartpole/cartpole-v1_large"
         base_path = Path(__file__).parents[3]
         print(f"base_path={base_path}")
-        data_path = "local://" + base_path.joinpath(data_path).as_posix()
+        data_path = "local://" / base_path.joinpath(data_path)
         print(f"data_path={data_path}")
 
         # Define the BC config.
@@ -46,7 +46,7 @@ class TestBC(unittest.TestCase):
             )
             # Note, the `input_` argument is the major argument for the
             # new offline API.
-            .offline_data(input_=[data_path])
+            .offline_data(input_=[data_path.as_posix()])
             .training(
                 lr=0.0008,
                 train_batch_size_per_learner=2000,

--- a/rllib/offline/offline_env_runner.py
+++ b/rllib/offline/offline_env_runner.py
@@ -1,5 +1,4 @@
 import logging
-import numpy as np
 import ray
 
 from pathlib import Path
@@ -97,17 +96,8 @@ class OfflineSingleAgentEnvRunner(SingleAgentEnvRunner):
         # each file.
         self._sample_counter = 0
 
-        # Counts the sampled environment steps. This is used for checking,
-        # if the `ouutput_max_rows_per_file` is hit during sampling.
-        # TODO (sven): Shouldn't we just use
-        #  `self.metrics.peek(NUM_ENV_STEPS_SAMPLED_LIFETIME)` here?
-        self._num_env_steps = 0
-
-        # If we should output episodes or columns.
-        if self.output_write_episodes:
-            self._samples = []
-        else:
-            self._samples_data = []
+        # Define the buffer for experiences stored until written to disk.
+        self._samples = []
 
     @override(SingleAgentEnvRunner)
     def sample(
@@ -132,56 +122,72 @@ class OfflineSingleAgentEnvRunner(SingleAgentEnvRunner):
 
         self._sample_counter += 1
 
-        # Increase env step counter.
-        # TODO (sven): Shouldn't we just use
-        #  `self.metrics.peek(NUM_ENV_STEPS_SAMPLED_LIFETIME)` here?
-        self._num_env_steps += sum(eps.env_steps() for eps in samples)
-
         # Add data to the buffers.
         if self.output_write_episodes:
             self._samples.extend(samples)
         else:
             self._map_episodes_to_data(samples)
 
-        # Start the recording of data.
+        # If the user defined the maximum number of rows to write.
         if self.output_max_rows_per_file:
-            if self._num_env_steps >= self.output_max_rows_per_file:
+            # Check, if this number is reached.
+            if len(self._samples) >= self.output_max_rows_per_file:
+                # Start the recording of data.
                 self.write_data_this_iter = True
 
         if self.write_data_this_iter:
-            # Reset the event.
+            # If the user wants a maximum number of experiences per file,
+            # cut the samples to write to disk from the buffer.
             if self.output_max_rows_per_file:
+                # Reset the event.
                 self.write_data_this_iter = False
-            # Write episodes as objects.
-            if self.output_write_episodes:
-                # If the user wants a maximum number of experiences per file,
-                # cut the samples to write to disk from the buffer.
-                if self.output_max_rows_per_file:
-                    samples_env_steps = np.cumsum(
-                        [eps.env_steps() for eps in self._samples]
-                    )
-                    samples_cut_idx = (
-                        samples_env_steps >= self.output_max_rows_per_file
-                    ).nonzero()[0][0] or len(self._samples)
-                    samples_to_write = self._samples[:samples_cut_idx]
-                    self._samples = self._samples[samples_cut_idx:]
-                # Otherwise, we write all buffered samples to disk.
-                else:
-                    samples_to_write = self._samples
-                    self._samples = []
-                samples_ds = ray.data.from_items(samples_to_write)
-            # Otherwise store as column data.
-            else:
+
                 # Extract the number of samples to be written to disk this iteration.
-                samples_to_write = self._samples_data[: self.output_max_rows_per_file]
+                samples_to_write = self._samples[: self.output_max_rows_per_file]
                 # Reset the buffer to the remaining data. This only makes sense, if
                 # `rollout_fragment_length` is smaller `output_max_rows_per_file` or
                 # a 2 x `output_max_rows_per_file`.
                 # TODO (simon): Find a better way to write these data.
-                self._samples_data = self._samples_data[self.output_max_rows_per_file :]
-                # Reset the counter.
-                self._num_env_steps = len(self._samples_data)
+                self._samples = self._samples[self.output_max_rows_per_file :]
                 samples_ds = ray.data.from_items(samples_to_write)
+            # Otherwise, write the complete data.
+            else:
+                samples_ds = ray.data.from_items(self._samples)
+            try:
+                # Setup the path for writing data. Each run will be written to
+                # its own file. A run is a writing event. The path will look
+                # like. 'base_path/env-name/00000<WorkerID>-00000<RunID>'.
+                path = (
+                    Path(self.output_path)
+                    .joinpath(self.subdir_path)
+                    .joinpath(self.worker_path + f"-{self._sample_counter}".zfill(6))
+                )
+                getattr(samples_ds, self.output_write_method)(
+                    path.as_posix(), **self.output_write_method_kwargs
+                )
+                logger.info(f"Wrote samples to storage at {path}.")
+            except Exception as e:
+                logger.error(e)
+
+        # Finally return the samples as usual.
+        return samples
+
+    @override(EnvRunner)
+    def stop(self) -> None:
+        """Writes the reamining samples to disk
+
+        Note, if the user defined `max_rows_per_file` the
+        number of rows for the remaining samples could be
+        less than the defined maximum row number by the user.
+        """
+        # If there are samples left over we have to write htem to disk. them
+        # to a dataset.
+        if self._samples:
+            # Convert them to a `ray.data.Dataset`.
+            samples_ds = ray.data.from_items(self._samples)
+            # Increase the sample counter for the folder/file name.
+            self._sample_counter += 1.0
+            # Try to write the dataset to disk/cloud storage.
             try:
                 # Setup the path for writing data. Each run will be written to
                 # its own file. A run is a writing event. The path will look
@@ -202,37 +208,7 @@ class OfflineSingleAgentEnvRunner(SingleAgentEnvRunner):
             except Exception as e:
                 logger.error(e)
 
-        # Finally return the samples as usual.
-        return samples
-
-    @override(EnvRunner)
-    def stop(self) -> None:
-        """Writes the reamining samples to disk
-
-        Note, if the user defined `max_rows_per_file` the
-        number of rows for the remaining samples could be
-        less than the defined maximum row number by the user.
-        """
-        # If there are samples left over, convert them to a dataset.
-        if self._samples:
-            samples_ds = ray.data.from_items(self._samples)
-
-            # Try to write the dataset to disk/cloud storage.
-            try:
-                # Setup the path for writing data. Each run will be written to
-                # its own file. A run is a writing event. The path will look
-                # like. 'base_path/env-name/00000<WorkerID>-00000<RunID>'.
-                path = (
-                    Path(self.output_path)
-                    .joinpath(self.subdir_path)
-                    .joinpath(self.worker_path + f"-{self._sample_counter}".zfill(6))
-                )
-                getattr(samples_ds, self.output_write_method)(
-                    path.as_posix(), **self.output_write_method_kwargs
-                )
-                logger.info("Wrote samples to storage.")
-            except Exception as e:
-                logger.error(e)
+        logger.debug(f"Experience buffer length: {len(self._samples)}")
 
     def _map_episodes_to_data(self, samples: List[EpisodeType]) -> None:
         """Converts list of episodes to list of single dict experiences.
@@ -264,9 +240,7 @@ class OfflineSingleAgentEnvRunner(SingleAgentEnvRunner):
                         to_jsonable_if_needed(sample.get_actions(i), action_space)
                     )
                     if Columns.ACTIONS in self.output_compress_columns
-                    else action_space.to_jsonable_if_needed(
-                        sample.get_actions(i), action_space
-                    ),
+                    else to_jsonable_if_needed(sample.get_actions(i), action_space),
                     Columns.REWARDS: sample.get_rewards(i),
                     # Compress next observations, if requested.
                     Columns.NEXT_OBS: pack_if_needed(
@@ -291,4 +265,4 @@ class OfflineSingleAgentEnvRunner(SingleAgentEnvRunner):
                     },
                 }
                 # Finally append to the data buffer.
-                self._samples_data.append(sample_data)
+                self._samples.append(sample_data)


### PR DESCRIPTION
## Why are these changes needed?

The `max_rows_per_file` gives a user control over the number of writing processes during a run when recording the experiences. It does so by buffering episodes or row data until `max_rows_per_file` is reached.

If the run stops, this buffer could be still non-empty. This PR proposes to override the `EnvRunner.stop` method to write remaining episodes or step data onto disk.

## Related issue number

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
