### PR TITLE
[RLlib] Activate APPO/IMPALA + LSTM + multi-GPU learning tests (new API stack; bug fix)

### DIFF
--- a/.buildkite/rllib.rayci.yml
+++ b/.buildkite/rllib.rayci.yml
@@ -189,13 +189,13 @@ steps:
     tags: 
       - rllib_gpu
       - gpu
-    parallelism: 3
+    parallelism: 2
     instance_type: gpu-large
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
         --parallelism-per-worker 2
-        --gpus 6
+        --gpus 4
         --build-name rllibgpubuild
         --only-tags multi_gpu
     depends_on: rllibgpubuild

--- a/.buildkite/rllib.rayci.yml
+++ b/.buildkite/rllib.rayci.yml
@@ -195,7 +195,7 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
         --parallelism-per-worker 2
-        --gpus 4
+        --gpus 6
         --build-name rllibgpubuild
         --only-tags multi_gpu
     depends_on: rllibgpubuild

--- a/.buildkite/rllib.rayci.yml
+++ b/.buildkite/rllib.rayci.yml
@@ -189,7 +189,7 @@ steps:
     tags: 
       - rllib_gpu
       - gpu
-    parallelism: 2
+    parallelism: 3
     instance_type: gpu-large
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -193,6 +193,14 @@ py_test(
     srcs = ["tuned_examples/appo/stateless_cartpole_appo.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-gpus=1"]
 )
+py_test(
+    name = "learning_tests_stateless_cartpole_appo_multi_gpu",
+    main = "tuned_examples/appo/stateless_cartpole_appo.py",
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "multi_gpu"],
+    size = "large",
+    srcs = ["tuned_examples/appo/stateless_cartpole_appo.py"],
+    args = ["--as-test", "--enable-new-api-stack", "--num-gpus=2"]
+)
 # MultiAgentCartPole
 py_test(
     name = "learning_tests_multi_agent_cartpole_appo",
@@ -412,6 +420,14 @@ py_test(
     size = "large",
     srcs = ["tuned_examples/impala/stateless_cartpole_impala.py"],
     args = ["--as-test", "--enable-new-api-stack", "--num-gpus=1"]
+)
+py_test(
+    name = "learning_tests_stateless_cartpole_impala_multi_gpu",
+    main = "tuned_examples/impala/stateless_cartpole_impala.py",
+    tags = ["team:rllib", "exclusive", "learning_tests", "torch_only", "learning_tests_discrete", "learning_tests_pytorch_use_all_core", "multi_gpu"],
+    size = "large",
+    srcs = ["tuned_examples/impala/stateless_cartpole_impala.py"],
+    args = ["--as-test", "--enable-new-api-stack", "--num-gpus=2"]
 )
 # MultiAgentCartPole
 py_test(

--- a/rllib/core/rl_module/torch/torch_rl_module.py
+++ b/rllib/core/rl_module/torch/torch_rl_module.py
@@ -120,16 +120,27 @@ class TorchDDPRLModule(RLModule, nn.parallel.DistributedDataParallel):
         # the interface of that base-class not the actual implementation.
         self.config = self.unwrapped().config
 
+    @override(RLModule)
     def get_train_action_dist_cls(self, *args, **kwargs) -> Type[TorchDistribution]:
         return self.unwrapped().get_train_action_dist_cls(*args, **kwargs)
 
+    @override(RLModule)
     def get_exploration_action_dist_cls(
         self, *args, **kwargs
     ) -> Type[TorchDistribution]:
         return self.unwrapped().get_exploration_action_dist_cls(*args, **kwargs)
 
+    @override(RLModule)
     def get_inference_action_dist_cls(self, *args, **kwargs) -> Type[TorchDistribution]:
         return self.unwrapped().get_inference_action_dist_cls(*args, **kwargs)
+
+    @override(RLModule)
+    def get_initial_state(self) -> Any:
+        return self.unwrapped().get_initial_state()
+
+    @override(RLModule)
+    def is_stateful(self) -> bool:
+        return self.unwrapped().is_stateful()
 
     @override(RLModule)
     def _forward_train(self, *args, **kwargs):

--- a/rllib/tuned_examples/appo/stateless_cartpole_appo.py
+++ b/rllib/tuned_examples/appo/stateless_cartpole_appo.py
@@ -1,14 +1,12 @@
 from ray.rllib.algorithms.appo import APPOConfig
 from ray.rllib.connectors.env_to_module import MeanStdFilter
 from ray.rllib.examples.envs.classes.stateless_cartpole import StatelessCartPole
-from ray.rllib.utils.metrics import (
-    ENV_RUNNER_RESULTS,
-    EPISODE_RETURN_MEAN,
-    NUM_ENV_STEPS_SAMPLED_LIFETIME,
-)
 from ray.rllib.utils.test_utils import add_rllib_example_script_args
 
-parser = add_rllib_example_script_args()
+parser = add_rllib_example_script_args(
+    default_timesteps=2000000,
+    default_reward=350.0,
+)
 parser.set_defaults(
     enable_new_api_stack=True,
     num_env_runners=3,
@@ -45,13 +43,8 @@ config = (
     )
 )
 
-stop = {
-    f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 350.0,
-    NUM_ENV_STEPS_SAMPLED_LIFETIME: 2000000,
-}
-
 
 if __name__ == "__main__":
     from ray.rllib.utils.test_utils import run_rllib_example_script_experiment
 
-    run_rllib_example_script_experiment(config, args, stop=stop)
+    run_rllib_example_script_experiment(config, args)

--- a/rllib/tuned_examples/appo/stateless_cartpole_appo.py
+++ b/rllib/tuned_examples/appo/stateless_cartpole_appo.py
@@ -30,7 +30,7 @@ config = (
         env_to_module_connector=lambda env: MeanStdFilter(),
     )
     .training(
-        lr=0.0005,
+        lr=0.0005 * ((args.num_gpus or 1) ** 0.5),
         num_sgd_iter=6,
         vf_loss_coeff=0.05,
         grad_clip=20.0,

--- a/rllib/tuned_examples/impala/stateless_cartpole_impala.py
+++ b/rllib/tuned_examples/impala/stateless_cartpole_impala.py
@@ -1,14 +1,12 @@
 from ray.rllib.algorithms.impala import IMPALAConfig
 from ray.rllib.connectors.env_to_module import MeanStdFilter
 from ray.rllib.examples.envs.classes.stateless_cartpole import StatelessCartPole
-from ray.rllib.utils.metrics import (
-    ENV_RUNNER_RESULTS,
-    EPISODE_RETURN_MEAN,
-    NUM_ENV_STEPS_SAMPLED_LIFETIME,
-)
 from ray.rllib.utils.test_utils import add_rllib_example_script_args
 
-parser = add_rllib_example_script_args()
+parser = add_rllib_example_script_args(
+    default_reward=350.0,
+    default_timesteps=2000000,
+)
 parser.set_defaults(
     enable_new_api_stack=True,
     num_env_runners=3,
@@ -30,7 +28,7 @@ config = (
         env_to_module_connector=lambda env: MeanStdFilter(),
     )
     .training(
-        lr=0.0005 * ((args.num_gpus or 1) ** 0.5),
+        lr=0.0004 * ((args.num_gpus or 1) ** 0.5),
         vf_loss_coeff=0.05,
         grad_clip=20.0,
         entropy_coeff=0.0,
@@ -45,13 +43,8 @@ config = (
     )
 )
 
-stop = {
-    f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 350.0,
-    NUM_ENV_STEPS_SAMPLED_LIFETIME: 2000000,
-}
-
 
 if __name__ == "__main__":
     from ray.rllib.utils.test_utils import run_rllib_example_script_experiment
 
-    run_rllib_example_script_experiment(config, args, stop=stop)
+    run_rllib_example_script_experiment(config, args)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Activate APPO/IMPALA + LSTM + multi-GPU learning tests (new API stack; bug fix)
* A missing `get_initial_state()` and `is_stateful()` in the torch DDP wrapper RLModule was causing the connector to think that the RLModule was NOT stateful so it "forgot" to add the time-rank to the train batch.
* Added StatelessCartPole learning tests (until +350.0 return) for both IMPALA and APPO on 2 GPUs.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
