### PR TITLE
[Jobs] Making sure `JobManager` retries `JobSupervisor.ping` before declaring job as failed

### DIFF
--- a/python/ray/_private/async_utils.py
+++ b/python/ray/_private/async_utils.py
@@ -82,6 +82,7 @@ async def async_call_with_retry(
             else:
                 raise e
 
+    raise ValueError("This part should not be reachable")
 
 def enable_monitor_loop_lag(
     callback: Callable[[float], None],

--- a/python/ray/_private/async_utils.py
+++ b/python/ray/_private/async_utils.py
@@ -84,6 +84,7 @@ async def async_call_with_retry(
 
     raise ValueError("This part should not be reachable")
 
+
 def enable_monitor_loop_lag(
     callback: Callable[[float], None],
     interval_s: float = 0.25,

--- a/python/ray/_private/async_utils.py
+++ b/python/ray/_private/async_utils.py
@@ -1,27 +1,76 @@
 # Adapted from [aiodebug](https://gitlab.com/quantlane/libs/aiodebug)
+import asyncio
+import asyncio.events
+from asyncio import CancelledError
+from typing import Callable, Optional, Type, Any, Coroutine, Iterable
+
 
 # Copyright 2016-2022 Quantlane s.r.o.
-
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
 #    You may obtain a copy of the License at
-
 #        http://www.apache.org/licenses/LICENSE-2.0
-
 #    Unless required by applicable law or agreed to in writing, software
 #    distributed under the License is distributed on an "AS IS" BASIS,
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-
 # Modifications:
 # - Removed the dependency to `logwood`.
 # - Renamed `monitor_loop_lag.enable()` to just `enable_monitor_loop_lag()`.
 # - Miscellaneous changes to make it work with Ray.
 
-from typing import Callable, Optional
-import asyncio
-import asyncio.events
+
+async def async_call_with_retry(
+    f: Callable[[], Coroutine[Any, Any, Any]],
+    *,
+    exception_classes: Iterable[Type] = (),
+    max_attempts: int = 3,
+    initial_delay_s: float = 0.5,
+    max_backoff_s: float = 5,
+    on_exception: Optional[Callable[[Exception], None]] = None
+) -> Any:
+    """
+    Helper utility retrying a provided async function with exponential backoff policy.
+
+    NOTE: We're currently hard-coding 2 as an exponent base, meaning that `initial_delay_s`
+          will be doubled with every retry attempt up to `max_backoff_s`.
+
+    Args:
+        c: Coroutine to be awaited on.
+        exception_classes: list of exception classes that should be retried (note that, all of
+                            the exceptions have to inherit from `BaseException` and could NOT
+                            extend `CancelledError`).
+        max_attempts: The maximum number of attempts to invoke.
+        initial_delay_s: Initial delay before the first retry
+        max_backoff_s: The maximum number of seconds to backoff.
+        on_exception: Callback to be invoked with an exception being retried.
+    """
+    assert all([issubclass(c, BaseException) for c in exception_classes]), \
+        "Provided exception classes have to inherit from BaseException"
+
+    assert not any([issubclass(c, CancelledError) for c in exception_classes]), \
+        "`CancelledError` should not be retried"
+
+    assert initial_delay_s >= 0, f"`initial_delay_s`, must be non-negative value (got {initial_delay_s}"
+    assert max_backoff_s >= 0, f"`max_backoff_s`, must be non-negative value (got {max_backoff_s}"
+    assert max_attempts >= 1, f"`max_attempts` must be >= 1 (got {max_attempts})"
+
+    for i in range(max_attempts):
+        try:
+            return await f()
+        except Exception as e:
+            is_retryable = any([isinstance(e, exc_class) for exc_class in exception_classes])
+            if is_retryable and i + 1 < max_attempts:
+                # Invoke callback if provided
+                if on_exception is not None:
+                    on_exception(e)
+
+                # Retry with (capped) exponential backoff
+                backoff = min((initial_delay_s * 2 ** (i + 1)), max_backoff_s)
+                await asyncio.sleep(backoff)
+            else:
+                raise e
 
 
 def enable_monitor_loop_lag(

--- a/python/ray/_private/async_utils.py
+++ b/python/ray/_private/async_utils.py
@@ -28,39 +28,49 @@ async def async_call_with_retry(
     max_attempts: int = 3,
     initial_delay_s: float = 0.5,
     max_backoff_s: float = 5,
-    on_exception: Optional[Callable[[Exception], None]] = None
+    on_exception: Optional[Callable[[Exception], None]] = None,
 ) -> Any:
     """
-    Helper utility retrying a provided async function with exponential backoff policy.
+    Helper utility retrying a provided async function with exponential backoff
+    policy.
 
-    NOTE: We're currently hard-coding 2 as an exponent base, meaning that `initial_delay_s`
-          will be doubled with every retry attempt up to `max_backoff_s`.
+    NOTE: We're currently hard-coding 2 as an exponent base, meaning that
+          `initial_delay_s` will be doubled with every retry attempt up to
+          `max_backoff_s`.
 
     Args:
         c: Coroutine to be awaited on.
-        exception_classes: list of exception classes that should be retried (note that, all of
-                            the exceptions have to inherit from `BaseException` and could NOT
-                            extend `CancelledError`).
+        exception_classes: list of exception classes that should be retried (note that,
+                            all of the exceptions have to inherit from `BaseException`
+                            and could NOT extend `CancelledError`).
         max_attempts: The maximum number of attempts to invoke.
         initial_delay_s: Initial delay before the first retry
         max_backoff_s: The maximum number of seconds to backoff.
         on_exception: Callback to be invoked with an exception being retried.
     """
-    assert all([issubclass(c, BaseException) for c in exception_classes]), \
-        "Provided exception classes have to inherit from BaseException"
+    assert all(
+        [issubclass(c, BaseException) for c in exception_classes]
+    ), "Provided exception classes have to inherit from BaseException"
 
-    assert not any([issubclass(c, CancelledError) for c in exception_classes]), \
-        "`CancelledError` should not be retried"
+    assert not any(
+        [issubclass(c, CancelledError) for c in exception_classes]
+    ), "`CancelledError` should not be retried"
 
-    assert initial_delay_s >= 0, f"`initial_delay_s`, must be non-negative value (got {initial_delay_s}"
-    assert max_backoff_s >= 0, f"`max_backoff_s`, must be non-negative value (got {max_backoff_s}"
+    assert (
+        initial_delay_s >= 0
+    ), f"`initial_delay_s`, must be non-negative value (got {initial_delay_s}"
+    assert (
+        max_backoff_s >= 0
+    ), f"`max_backoff_s`, must be non-negative value (got {max_backoff_s}"
     assert max_attempts >= 1, f"`max_attempts` must be >= 1 (got {max_attempts})"
 
     for i in range(max_attempts):
         try:
             return await f()
         except Exception as e:
-            is_retryable = any([isinstance(e, exc_class) for exc_class in exception_classes])
+            is_retryable = any(
+                [isinstance(e, exc_class) for exc_class in exception_classes]
+            )
             if is_retryable and i + 1 < max_attempts:
                 # Invoke callback if provided
                 if on_exception is not None:

--- a/python/ray/dashboard/modules/job/job_manager.py
+++ b/python/ray/dashboard/modules/job/job_manager.py
@@ -330,7 +330,7 @@ class JobManager:
         return async_call_with_retry(
             _ping,
             exception_classes=(ray.exceptions.RpcError, asyncio.TimeoutError),
-            max_attempts=RAY_JOB_SUPERVISOR_PING_MAX_RETRIES,
+            max_attempts=RAY_JOB_SUPERVISOR_PING_MAX_RETRIES + 1,
             max_backoff_s=2,
             on_exception=lambda e: logger.warning(
                 f"Encountered failure pinging '{job_supervisor}'", exc_info=e

--- a/python/ray/dashboard/modules/job/job_manager.py
+++ b/python/ray/dashboard/modules/job/job_manager.py
@@ -323,10 +323,8 @@ class JobManager:
 
         while True:
             try:
-                with asyncio.timeout(RAY_JOB_SUPERVISOR_PING_TIMEOUT_S):
-                    await job_supervisor.ping.remote()
-
-            except ray.exceptions.RpcError as e:
+                await asyncio.wait_for(job_supervisor.ping.remote(), RAY_JOB_SUPERVISOR_PING_TIMEOUT_S)
+            except (ray.exceptions.RpcError, asyncio.TimeoutError) as e:
                 logger.warning(f"Encountered failure pinging '{job_supervisor}'", exc_info=e)
 
                 if attempt < RAY_JOB_SUPERVISOR_PING_MAX_RETRIES:

--- a/python/ray/dashboard/modules/job/job_manager.py
+++ b/python/ray/dashboard/modules/job/job_manager.py
@@ -8,12 +8,11 @@ import time
 import traceback
 from typing import Any, Dict, Iterator, Optional, Union
 
-from ray._private.ray_constants import env_integer
-
 import ray
 import ray._private.ray_constants as ray_constants
 from ray._private.event.event_logger import get_event_logger
 from ray._private.gcs_utils import GcsAioClient
+from ray._private.ray_constants import env_integer
 from ray._private.utils import run_background_task
 from ray.actor import ActorHandle
 from ray.core.generated.event_pb2 import Event
@@ -44,7 +43,9 @@ logger = logging.getLogger(__name__)
 
 # Configures max number of retries for network transport failures, before
 # `JobSupervisor` actor will be deemed unreachable
-RAY_JOB_SUPERVISOR_PING_MAX_RETRIES = env_integer("RAY_JOB_SUPERVISOR_PING_MAX_RETRIES", 5)
+RAY_JOB_SUPERVISOR_PING_MAX_RETRIES = env_integer(
+    "RAY_JOB_SUPERVISOR_PING_MAX_RETRIES", 5
+)
 # Configures timeout threshold for `JobSupervisor` actor to respond back to `JobManager`
 RAY_JOB_SUPERVISOR_PING_TIMEOUT_S = env_integer("RAY_JOB_SUPERVISOR_PING_TIMEOUT_S", 10)
 
@@ -323,16 +324,23 @@ class JobManager:
 
         while True:
             try:
-                await asyncio.wait_for(job_supervisor.ping.remote(), RAY_JOB_SUPERVISOR_PING_TIMEOUT_S)
+                await asyncio.wait_for(
+                    job_supervisor.ping.remote(), RAY_JOB_SUPERVISOR_PING_TIMEOUT_S
+                )
             except (ray.exceptions.RpcError, asyncio.TimeoutError) as e:
-                logger.warning(f"Encountered failure pinging '{job_supervisor}'", exc_info=e)
+                logger.warning(
+                    f"Encountered failure pinging '{job_supervisor}'", exc_info=e
+                )
 
                 if attempt < RAY_JOB_SUPERVISOR_PING_MAX_RETRIES:
                     attempt += 1
                     continue
                 else:
-                    logger.error(f"Failed to reach job supervisor '{job_supervisor}'"
-                                 f" after {RAY_JOB_SUPERVISOR_PING_MAX_RETRIES} attempts", exc_info=e)
+                    logger.error(
+                        f"Failed to reach job supervisor '{job_supervisor}'"
+                        f" after {RAY_JOB_SUPERVISOR_PING_MAX_RETRIES} attempts",
+                        exc_info=e,
+                    )
                     raise e
 
     def _handle_supervisor_startup(self, job_id: str, result: Optional[Exception]):

--- a/python/ray/dashboard/modules/job/job_manager.py
+++ b/python/ray/dashboard/modules/job/job_manager.py
@@ -324,8 +324,7 @@ class JobManager:
         async def _ping():
             # NOTE: We add a timeout to make our pings aren't hanging forever
             await asyncio.wait_for(
-                job_supervisor.ping.remote(),
-                RAY_JOB_SUPERVISOR_PING_TIMEOUT_S
+                job_supervisor.ping.remote(), RAY_JOB_SUPERVISOR_PING_TIMEOUT_S
             )
 
         return async_call_with_retry(
@@ -335,7 +334,7 @@ class JobManager:
             max_backoff_s=2,
             on_exception=lambda e: logger.warning(
                 f"Encountered failure pinging '{job_supervisor}'", exc_info=e
-            )
+            ),
         )
 
     @staticmethod

--- a/python/ray/dashboard/modules/job/job_manager.py
+++ b/python/ray/dashboard/modules/job/job_manager.py
@@ -8,7 +8,7 @@ import time
 import traceback
 from typing import Any, Dict, Iterator, Optional, Union
 
-from python.ray._private.ray_constants import env_integer
+from ray._private.ray_constants import env_integer
 
 import ray
 import ray._private.ray_constants as ray_constants

--- a/python/ray/dashboard/modules/job/job_manager.py
+++ b/python/ray/dashboard/modules/job/job_manager.py
@@ -284,8 +284,9 @@ class JobManager:
                     )
                 else:
                     logger.warning(
-                        f"Job supervisor for job {job_id} failed unexpectedly: {e}."
+                        f"Failed to reach Job supervisor for job {job_id}: {e}."
                     )
+
                     job_error_message = f"Unexpected error occurred: {e}"
                     job_status = JobStatus.FAILED
                     await self._job_info_client.put_status(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

These changes add retries to `JobManager` when pinging `JobSupervisor` to prevent occasions when a single RPC failure leads to a job wrongfully being declared as failed.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
