### PR TITLE
[Data] Fix wrong metrics group for `Object Store Memory` metrics on Ray Data Dashboard

### DIFF
--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -233,7 +233,7 @@ class _StatsActor:
         # Object store memory-related metrics
         self.execution_metrics_obj_store_memory = (
             self._create_prometheus_metrics_for_execution_metrics(
-                metrics_group="obj_store_memory",
+                metrics_group="object_store_memory",
                 tag_keys=op_tags_keys,
             )
         )


### PR DESCRIPTION
## Why are these changes needed?

Currently, there is a bug where the `Ray Data Metrics (Object Store Memory)` charts do not render any data at all:
<img width="1502" alt="before" src="https://github.com/user-attachments/assets/ddd9179e-e7e0-4208-8e6c-d0960182c1dd">

This is due to an incorrect metrics group used to initialize Prometheus metrics -- it should match `"object_store_memory"` used [here](https://github.com/ray-project/ray/blob/91e2239047bcb58d6dd47939df6dcd04f96440ad/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py#L217). 

After the fix in this PR, we see the charts populate (the workload used to generate the image is small, so there is no object spilling / significant objects piling up in the inqueue/outqueue):
<img width="1829" alt="after" src="https://github.com/user-attachments/assets/86a78f17-51b0-4fc5-99c2-4ed3c851603a">


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
