### PR TITLE
[data] Handle errors in SplitCoordinator when generating a new epoch

### DIFF
--- a/python/ray/data/_internal/iterator/stream_split_iterator.py
+++ b/python/ray/data/_internal/iterator/stream_split_iterator.py
@@ -177,8 +177,6 @@ class SplitCoordinator:
 
         self._next_epoch = gen_epochs()
         self._output_iterator = None
-        # Used for debugging https://github.com/ray-project/ray/issues/45225
-        self._debug_info = {}
 
     def stats(self) -> DatasetStats:
         """Returns stats from the base dataset."""
@@ -245,11 +243,9 @@ class SplitCoordinator:
     def _barrier(self, split_idx: int) -> int:
         """Arrive and block until the start of the given epoch."""
 
-        self._debug_info[split_idx] = {}
         # Decrement and await all clients to arrive here.
         with self._lock:
             starting_epoch = self._cur_epoch
-            self._debug_info[split_idx]["starting_epoch"] = starting_epoch
             self._unfinished_clients_in_epoch -= 1
 
         start_time = time.time()
@@ -269,31 +265,11 @@ class SplitCoordinator:
             time.sleep(0.1)
 
         # Advance to the next epoch.
-        self._debug_info[split_idx]["entering_lock"] = (
-            self._cur_epoch,
-            self._output_iterator is None,
-            time.time(),
-        )
         with self._lock:
-            self._debug_info[split_idx]["entered_lock"] = (
-                self._cur_epoch,
-                self._output_iterator is None,
-                time.time(),
-            )
             if self._cur_epoch == starting_epoch:
                 self._cur_epoch += 1
                 self._unfinished_clients_in_epoch = self._n
                 self._output_iterator = next(self._next_epoch)
-                self._debug_info[split_idx]["set_iter"] = (
-                    self._cur_epoch,
-                    self._output_iterator is None,
-                    time.time(),
-                )
-            self._debug_info[split_idx]["leaving_lock"] = (
-                self._cur_epoch,
-                self._output_iterator is None,
-                time.time(),
-            )
 
-        assert self._output_iterator is not None, self._debug_info
+        assert self._output_iterator is not None
         return starting_epoch + 1

--- a/python/ray/data/tests/test_streaming_integration.py
+++ b/python/ray/data/tests/test_streaming_integration.py
@@ -348,7 +348,7 @@ def test_streaming_split_error_propagation(
     # Test propagating errors from Dataset execution start-up
     # (e.g. actor pool start-up timeout) to streaming_split iterators.
     ctx = DataContext.get_current()
-    ctx.wait_for_min_actors_s = 3
+    ctx.wait_for_min_actors_s = 1
 
     num_splits = 5
     ds = ray.data.range(100)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously if an error happens while launching the executor while generating a new epoch, we don't handle the error properly, thus users will get a confusing error. And the actual root cause will be hidden.

```
E                         File "/Users/chenh/code/ray/python/ray/data/_internal/iterator/stream_split_iterator.py", line 197, in start_epoch
E                           epoch_id = self._barrier(split_idx)
E                         File "/Users/chenh/code/ray/python/ray/data/_internal/iterator/stream_split_iterator.py", line 285, in _barrier
E                           assert self._output_iterator is not None
E                       AssertionError
```

This PR solves this issue by storing the error and re-raise it from all threads. 


## Related issue number

Closes https://github.com/ray-project/ray/issues/45225

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
