### PR TITLE
[core] fix: NewGcsClient uses default timeout when retry=0

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2697,7 +2697,7 @@ cdef class GcsClient:
             # Config py_gcs_connect_timeout_s is applied to PythonGcsClient but it's
             # not effective for gRPC connection failure. We use it as a max timeout.
             max_timeout_ms = RayConfig.instance().py_gcs_connect_timeout_s() * 1000
-            if nums_reconnect_retry > 0:            
+            if nums_reconnect_retry > 0:
                 timeout_ms = min(1000 * (nums_reconnect_retry + 1), max_timeout_ms)
             else:
                 timeout_ms = -1

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2697,7 +2697,10 @@ cdef class GcsClient:
             # Config py_gcs_connect_timeout_s is applied to PythonGcsClient but it's
             # not effective for gRPC connection failure. We use it as a max timeout.
             max_timeout_ms = RayConfig.instance().py_gcs_connect_timeout_s() * 1000
-            timeout_ms = min(1000 * (nums_reconnect_retry + 1), max_timeout_ms)
+            if nums_reconnect_retry > 0:            
+                timeout_ms = min(1000 * (nums_reconnect_retry + 1), max_timeout_ms)
+            else:
+                timeout_ms = -1
 
             self.inner = NewGcsClient.standalone(address, cluster_id, timeout_ms)
         logger.debug(f"Created GcsClient. inner {self.inner}")

--- a/src/ray/gcs/gcs_client/gcs_client.h
+++ b/src/ray/gcs/gcs_client/gcs_client.h
@@ -123,7 +123,8 @@ class RAY_EXPORT GcsClient : public std::enable_shared_from_this<GcsClient> {
   ///
   /// \param instrumented_io_context IO execution service.
   /// \param timeout_ms Timeout in milliseconds, default to
-  /// gcs_rpc_server_connect_timeout_s (5s).
+  ///   gcs_rpc_server_connect_timeout_s (5s).
+  ///   If timeout_ms < 0, it will use the default value.
   ///
   /// \return Status
   virtual Status Connect(instrumented_io_context &io_service, int64_t timeout_ms = -1);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Many of existing python code uses GcsClient(nums_reconnect_retry=0). In the OldGcsClient, this is fine because it will retry at least once with 30s timeout. But in the NewGcsClient, this will lead to 1s timeout which is too short.

## Related issue number

<!-- For example: "Closes #1234" -->

fix https://github.com/ray-project/ray/issues/47201

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
