### PR TITLE
[Serve] use serve logger name for logs in serve

### DIFF
--- a/python/ray/serve/_private/api.py
+++ b/python/ray/serve/_private/api.py
@@ -14,6 +14,7 @@ from ray.serve._private.constants import (
     HTTP_PROXY_TIMEOUT,
     RAY_SERVE_ENABLE_TASK_EVENTS,
     SERVE_CONTROLLER_NAME,
+    SERVE_LOGGER_NAME,
     SERVE_NAMESPACE,
 )
 from ray.serve._private.controller import ServeController
@@ -23,7 +24,7 @@ from ray.serve.deployment import Application, Deployment
 from ray.serve.exceptions import RayServeException
 from ray.serve.schema import LoggingConfig
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(SERVE_LOGGER_NAME)
 
 
 def get_deployment(name: str, app_name: str = ""):

--- a/python/ray/serve/_private/client.py
+++ b/python/ray/serve/_private/client.py
@@ -20,6 +20,7 @@ from ray.serve._private.constants import (
     CLIENT_POLLING_INTERVAL_S,
     MAX_CACHED_HANDLES,
     SERVE_DEFAULT_APP_NAME,
+    SERVE_LOGGER_NAME,
 )
 from ray.serve._private.controller import ServeController
 from ray.serve._private.deploy_utils import get_deploy_args
@@ -34,7 +35,7 @@ from ray.serve.generated.serve_pb2 import StatusOverview as StatusOverviewProto
 from ray.serve.handle import DeploymentHandle, _HandleOptions
 from ray.serve.schema import LoggingConfig, ServeApplicationSchema, ServeDeploySchema
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(SERVE_LOGGER_NAME)
 
 
 def _ensure_connected(f: Callable) -> Callable:

--- a/python/ray/serve/context.py
+++ b/python/ray/serve/context.py
@@ -13,12 +13,16 @@ from ray.exceptions import RayActorError
 from ray.serve._private.client import ServeControllerClient
 from ray.serve._private.common import ReplicaID
 from ray.serve._private.config import DeploymentConfig
-from ray.serve._private.constants import SERVE_CONTROLLER_NAME, SERVE_NAMESPACE
+from ray.serve._private.constants import (
+    SERVE_CONTROLLER_NAME,
+    SERVE_LOGGER_NAME,
+    SERVE_NAMESPACE,
+)
 from ray.serve.exceptions import RayServeException
 from ray.serve.grpc_util import RayServegRPCContext
 from ray.util.annotations import DeveloperAPI
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(SERVE_LOGGER_NAME)
 
 _INTERNAL_REPLICA_CONTEXT: "ReplicaContext" = None
 _global_client: ServeControllerClient = None

--- a/python/ray/serve/gradio_integrations.py
+++ b/python/ray/serve/gradio_integrations.py
@@ -2,6 +2,7 @@ import logging
 from typing import Callable
 
 from ray import serve
+from ray.serve._private.constants import SERVE_LOGGER_NAME
 from ray.serve._private.http_util import ASGIAppReplicaWrapper
 from ray.util.annotations import PublicAPI
 
@@ -11,7 +12,7 @@ except ModuleNotFoundError:
     print("Gradio isn't installed. Run `pip install gradio` to install Gradio.")
     raise
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(SERVE_LOGGER_NAME)
 
 
 @PublicAPI(stability="alpha")

--- a/python/ray/serve/tests/test_standalone_3.py
+++ b/python/ray/serve/tests/test_standalone_3.py
@@ -16,7 +16,7 @@ from ray._private.test_utils import SignalActor, wait_for_condition
 from ray.cluster_utils import AutoscalingCluster, Cluster
 from ray.exceptions import RayActorError
 from ray.serve._private.common import ProxyStatus
-from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
+from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME, SERVE_LOGGER_NAME
 from ray.serve._private.logging_utils import get_serve_logs_dir
 from ray.serve._private.utils import get_head_node_id
 from ray.serve.context import _get_global_client
@@ -596,8 +596,8 @@ def test_client_shutdown_gracefully_when_timeout(
     log timeout message and exit the process. The controller will continue to shutdown
     everything gracefully.
     """
-    logger = logging.getLogger("ray.serve")
-    caplog.set_level(logging.WARNING, logger="ray.serve")
+    logger = logging.getLogger(SERVE_LOGGER_NAME)
+    caplog.set_level(logging.WARNING, logger=SERVE_LOGGER_NAME)
 
     warning_msg = []
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Some Serve logs are not using the configured `ray.serve` logger, so the logs are redirected to the root logger and can cause unwanted logs to be logged to the terminal when running Serve. This PR ensure all the logger in Serve are using `ray.serve` logger to log messages. 

Tested in premerge using runtime wheel and not seeing the unwanted logs anymore:
<img width="1665" alt="image" src="https://github.com/user-attachments/assets/4decc420-cdd5-4752-bd5f-462b4cc83124">

Also note this is how it looks without the change:
<img width="1704" alt="image" src="https://github.com/user-attachments/assets/8556ef80-3d95-4d8f-bc9c-350bb8b3eb0d">


## Related issue number

Closes: https://github.com/anyscale/ray-llm/issues/1962

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
