### PR TITLE
[observability][export-api] Write node events

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -39,6 +39,27 @@ GcsNodeManager::GcsNodeManager(
       raylet_client_pool_(std::move(raylet_client_pool)),
       cluster_id_(cluster_id) {}
 
+void GcsNodeManager::WriteNodeExportEvent(rpc::GcsNodeInfo node_info) const {
+  std::cout << "WriteNodeExportEvent\n";
+  std::shared_ptr<rpc::ExportNodeData> export_node_data_ptr = std::make_shared<rpc::ExportNodeData>();
+
+  export_node_data_ptr->set_node_id(node_info.node_id());
+  export_node_data_ptr->set_node_manager_address(node_info.node_manager_address());
+  export_node_data_ptr->mutable_resources_total()->insert(node_info.resources_total().begin(),
+                                                   node_info.resources_total().end());
+  export_node_data_ptr->set_node_name(node_info.node_name());
+  export_node_data_ptr->set_start_time_ms(node_info.start_time_ms());
+  export_node_data_ptr->set_end_time_ms(node_info.end_time_ms());
+  export_node_data_ptr->set_is_head_node(node_info.is_head_node());
+  export_node_data_ptr->mutable_labels()->insert(node_info.labels().begin(),
+                                                   node_info.labels().end());
+  export_node_data_ptr->set_state(ConvertGCSNodeStateToExport(node_info.state()));
+  export_node_data_ptr->mutable_death_info()->set_reason_message(node_info.death_info().reason_message());
+  export_node_data_ptr->mutable_death_info()->set_reason(ConvertNodeDeathReasonToExport(node_info.death_info().reason()));
+
+  RayExportEvent(export_node_data_ptr).SendEvent();
+}
+
 // Note: ServerCall will populate the cluster_id.
 void GcsNodeManager::HandleGetClusterId(rpc::GetClusterIdRequest request,
                                         rpc::GetClusterIdReply *reply,
@@ -64,6 +85,7 @@ void GcsNodeManager::HandleRegisterNode(rpc::RegisterNodeRequest request,
     RAY_CHECK_OK(gcs_publisher_->PublishNodeInfo(node_id, request.node_info(), nullptr));
     AddNode(std::make_shared<rpc::GcsNodeInfo>(request.node_info()));
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
+    WriteNodeExportEvent(request.node_info());
   };
   if (request.node_info().is_head_node()) {
     // mark all old head nodes as dead if exists:
@@ -132,6 +154,7 @@ void GcsNodeManager::HandleUnregisterNode(rpc::UnregisterNodeRequest request,
 
   auto on_put_done = [=](const Status &status) {
     RAY_CHECK_OK(gcs_publisher_->PublishNodeInfo(node_id, *node_info_delta, nullptr));
+    WriteNodeExportEvent(*node);
   };
   RAY_CHECK_OK(gcs_table_storage_->NodeTable().Put(node_id, *node, on_put_done));
   GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
@@ -358,12 +381,13 @@ void GcsNodeManager::OnNodeFailure(const NodeID &node_id,
     node_info_delta->set_end_time_ms(node->end_time_ms());
     node_info_delta->mutable_death_info()->CopyFrom(node->death_info());
 
-    auto on_done = [this, node_id, node_table_updated_callback, node_info_delta](
+    auto on_done = [this, node_id, node_table_updated_callback, node_info_delta, node](
                        const Status &status) {
       if (node_table_updated_callback != nullptr) {
         node_table_updated_callback(Status::OK());
       }
       RAY_CHECK_OK(gcs_publisher_->PublishNodeInfo(node_id, *node_info_delta, nullptr));
+      WriteNodeExportEvent(*node);
     };
     RAY_CHECK_OK(gcs_table_storage_->NodeTable().Put(node_id, *node, on_done));
   } else if (node_table_updated_callback != nullptr) {

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -43,21 +43,26 @@ void GcsNodeManager::WriteNodeExportEvent(rpc::GcsNodeInfo node_info) const {
   /// Write node_info as a export node event if
   /// enable_export_api_write() is enabled.
   if (RayConfig::instance().enable_export_api_write()) {
-    std::shared_ptr<rpc::ExportNodeData> export_node_data_ptr = std::make_shared<rpc::ExportNodeData>();
+    std::shared_ptr<rpc::ExportNodeData> export_node_data_ptr =
+        std::make_shared<rpc::ExportNodeData>();
     export_node_data_ptr->set_node_id(node_info.node_id());
     export_node_data_ptr->set_node_manager_address(node_info.node_manager_address());
-    export_node_data_ptr->mutable_resources_total()->insert(node_info.resources_total().begin(),
-                                                    node_info.resources_total().end());
+    export_node_data_ptr->mutable_resources_total()->insert(
+        node_info.resources_total().begin(), node_info.resources_total().end());
     export_node_data_ptr->set_node_name(node_info.node_name());
     export_node_data_ptr->set_start_time_ms(node_info.start_time_ms());
     export_node_data_ptr->set_end_time_ms(node_info.end_time_ms());
     export_node_data_ptr->set_is_head_node(node_info.is_head_node());
     export_node_data_ptr->mutable_labels()->insert(node_info.labels().begin(),
-                                                    node_info.labels().end());
+                                                   node_info.labels().end());
     export_node_data_ptr->set_state(ConvertGCSNodeStateToExport(node_info.state()));
-    if (!node_info.death_info().reason_message().empty() || node_info.death_info().reason() != rpc::NodeDeathInfo_Reason::NodeDeathInfo_Reason_UNSPECIFIED){
-      export_node_data_ptr->mutable_death_info()->set_reason_message(node_info.death_info().reason_message());
-      export_node_data_ptr->mutable_death_info()->set_reason(ConvertNodeDeathReasonToExport(node_info.death_info().reason()));
+    if (!node_info.death_info().reason_message().empty() ||
+        node_info.death_info().reason() !=
+            rpc::NodeDeathInfo_Reason::NodeDeathInfo_Reason_UNSPECIFIED) {
+      export_node_data_ptr->mutable_death_info()->set_reason_message(
+          node_info.death_info().reason_message());
+      export_node_data_ptr->mutable_death_info()->set_reason(
+          ConvertNodeDeathReasonToExport(node_info.death_info().reason()));
     }
     RayExportEvent(export_node_data_ptr).SendEvent();
   }
@@ -283,11 +288,7 @@ void GcsNodeManager::AddNode(std::shared_ptr<rpc::GcsNodeInfo> node) {
   if (iter == alive_nodes_.end()) {
     auto node_addr =
         node->node_manager_address() + ":" + std::to_string(node->node_manager_port());
-    try {
-      node_map_.insert(NodeIDAddrBiMap::value_type(node_id, node_addr));
-    } catch (const std::length_error& e) {
-      std::cerr << "Memory allocation error: " << e.what() << std::endl;
-    }
+    node_map_.insert(NodeIDAddrBiMap::value_type(node_id, node_addr));
     alive_nodes_.emplace(node_id, node);
     // Notify all listeners.
     for (auto &listener : node_added_listeners_) {

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -42,30 +42,31 @@ GcsNodeManager::GcsNodeManager(
 void GcsNodeManager::WriteNodeExportEvent(rpc::GcsNodeInfo node_info) const {
   /// Write node_info as a export node event if
   /// enable_export_api_write() is enabled.
-  if (RayConfig::instance().enable_export_api_write()) {
-    std::shared_ptr<rpc::ExportNodeData> export_node_data_ptr =
-        std::make_shared<rpc::ExportNodeData>();
-    export_node_data_ptr->set_node_id(node_info.node_id());
-    export_node_data_ptr->set_node_manager_address(node_info.node_manager_address());
-    export_node_data_ptr->mutable_resources_total()->insert(
-        node_info.resources_total().begin(), node_info.resources_total().end());
-    export_node_data_ptr->set_node_name(node_info.node_name());
-    export_node_data_ptr->set_start_time_ms(node_info.start_time_ms());
-    export_node_data_ptr->set_end_time_ms(node_info.end_time_ms());
-    export_node_data_ptr->set_is_head_node(node_info.is_head_node());
-    export_node_data_ptr->mutable_labels()->insert(node_info.labels().begin(),
-                                                   node_info.labels().end());
-    export_node_data_ptr->set_state(ConvertGCSNodeStateToExport(node_info.state()));
-    if (!node_info.death_info().reason_message().empty() ||
-        node_info.death_info().reason() !=
-            rpc::NodeDeathInfo_Reason::NodeDeathInfo_Reason_UNSPECIFIED) {
-      export_node_data_ptr->mutable_death_info()->set_reason_message(
-          node_info.death_info().reason_message());
-      export_node_data_ptr->mutable_death_info()->set_reason(
-          ConvertNodeDeathReasonToExport(node_info.death_info().reason()));
-    }
-    RayExportEvent(export_node_data_ptr).SendEvent();
+  if (!RayConfig::instance().enable_export_api_write()) {
+    return;
   }
+  std::shared_ptr<rpc::ExportNodeData> export_node_data_ptr =
+      std::make_shared<rpc::ExportNodeData>();
+  export_node_data_ptr->set_node_id(node_info.node_id());
+  export_node_data_ptr->set_node_manager_address(node_info.node_manager_address());
+  export_node_data_ptr->mutable_resources_total()->insert(
+      node_info.resources_total().begin(), node_info.resources_total().end());
+  export_node_data_ptr->set_node_name(node_info.node_name());
+  export_node_data_ptr->set_start_time_ms(node_info.start_time_ms());
+  export_node_data_ptr->set_end_time_ms(node_info.end_time_ms());
+  export_node_data_ptr->set_is_head_node(node_info.is_head_node());
+  export_node_data_ptr->mutable_labels()->insert(node_info.labels().begin(),
+                                                 node_info.labels().end());
+  export_node_data_ptr->set_state(ConvertGCSNodeStateToExport(node_info.state()));
+  if (!node_info.death_info().reason_message().empty() ||
+      node_info.death_info().reason() !=
+          rpc::NodeDeathInfo_Reason::NodeDeathInfo_Reason_UNSPECIFIED) {
+    export_node_data_ptr->mutable_death_info()->set_reason_message(
+        node_info.death_info().reason_message());
+    export_node_data_ptr->mutable_death_info()->set_reason(
+        ConvertNodeDeathReasonToExport(node_info.death_info().reason()));
+  }
+  RayExportEvent(export_node_data_ptr).SendEvent();
 }
 
 // Note: ServerCall will populate the cluster_id.

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -40,24 +40,27 @@ GcsNodeManager::GcsNodeManager(
       cluster_id_(cluster_id) {}
 
 void GcsNodeManager::WriteNodeExportEvent(rpc::GcsNodeInfo node_info) const {
-  std::shared_ptr<rpc::ExportNodeData> export_node_data_ptr = std::make_shared<rpc::ExportNodeData>();
-
-  export_node_data_ptr->set_node_id(node_info.node_id());
-  export_node_data_ptr->set_node_manager_address(node_info.node_manager_address());
-  export_node_data_ptr->mutable_resources_total()->insert(node_info.resources_total().begin(),
-                                                   node_info.resources_total().end());
-  export_node_data_ptr->set_node_name(node_info.node_name());
-  export_node_data_ptr->set_start_time_ms(node_info.start_time_ms());
-  export_node_data_ptr->set_end_time_ms(node_info.end_time_ms());
-  export_node_data_ptr->set_is_head_node(node_info.is_head_node());
-  export_node_data_ptr->mutable_labels()->insert(node_info.labels().begin(),
-                                                   node_info.labels().end());
-  export_node_data_ptr->set_state(ConvertGCSNodeStateToExport(node_info.state()));
-  if (!node_info.death_info().reason_message().empty() || node_info.death_info().reason() != rpc::NodeDeathInfo_Reason::NodeDeathInfo_Reason_UNSPECIFIED){
-    export_node_data_ptr->mutable_death_info()->set_reason_message(node_info.death_info().reason_message());
-    export_node_data_ptr->mutable_death_info()->set_reason(ConvertNodeDeathReasonToExport(node_info.death_info().reason()));
+  /// Write node_info as a export node event if
+  /// enable_export_api_write() is enabled.
+  if (RayConfig::instance().enable_export_api_write()) {
+    std::shared_ptr<rpc::ExportNodeData> export_node_data_ptr = std::make_shared<rpc::ExportNodeData>();
+    export_node_data_ptr->set_node_id(node_info.node_id());
+    export_node_data_ptr->set_node_manager_address(node_info.node_manager_address());
+    export_node_data_ptr->mutable_resources_total()->insert(node_info.resources_total().begin(),
+                                                    node_info.resources_total().end());
+    export_node_data_ptr->set_node_name(node_info.node_name());
+    export_node_data_ptr->set_start_time_ms(node_info.start_time_ms());
+    export_node_data_ptr->set_end_time_ms(node_info.end_time_ms());
+    export_node_data_ptr->set_is_head_node(node_info.is_head_node());
+    export_node_data_ptr->mutable_labels()->insert(node_info.labels().begin(),
+                                                    node_info.labels().end());
+    export_node_data_ptr->set_state(ConvertGCSNodeStateToExport(node_info.state()));
+    if (!node_info.death_info().reason_message().empty() || node_info.death_info().reason() != rpc::NodeDeathInfo_Reason::NodeDeathInfo_Reason_UNSPECIFIED){
+      export_node_data_ptr->mutable_death_info()->set_reason_message(node_info.death_info().reason_message());
+      export_node_data_ptr->mutable_death_info()->set_reason(ConvertNodeDeathReasonToExport(node_info.death_info().reason()));
+    }
+    RayExportEvent(export_node_data_ptr).SendEvent();
   }
-  RayExportEvent(export_node_data_ptr).SendEvent();
 }
 
 // Note: ServerCall will populate the cluster_id.

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -40,7 +40,6 @@ GcsNodeManager::GcsNodeManager(
       cluster_id_(cluster_id) {}
 
 void GcsNodeManager::WriteNodeExportEvent(rpc::GcsNodeInfo node_info) const {
-  std::cout << "WriteNodeExportEvent\n";
   std::shared_ptr<rpc::ExportNodeData> export_node_data_ptr = std::make_shared<rpc::ExportNodeData>();
 
   export_node_data_ptr->set_node_id(node_info.node_id());
@@ -275,17 +274,38 @@ rpc::NodeDeathInfo GcsNodeManager::InferDeathInfo(const NodeID &node_id) {
 }
 
 void GcsNodeManager::AddNode(std::shared_ptr<rpc::GcsNodeInfo> node) {
+  std::cout << "DEBUG AddNode\n";
   auto node_id = NodeID::FromBinary(node->node_id());
+  std::cout << "DEBUG node_id " << node_id << "\n";
   auto iter = alive_nodes_.find(node_id);
   if (iter == alive_nodes_.end()) {
+    std::cout << "DEBUG adding node because not found\n";
     auto node_addr =
         node->node_manager_address() + ":" + std::to_string(node->node_manager_port());
-    node_map_.insert(NodeIDAddrBiMap::value_type(node_id, node_addr));
+    std::cout << "DEBUG node addr " << node_addr << "\n";
+    try {
+      node_map_.insert(NodeIDAddrBiMap::value_type(node_id, node_addr));
+    } catch (const std::length_error& e) {
+      std::cerr << "Memory allocation error: " << e.what() << std::endl;
+    }
+    std::cout << "DEBUG insert\n";
     alive_nodes_.emplace(node_id, node);
+    std::cout << "DEBUG emplace\n";
     // Notify all listeners.
     for (auto &listener : node_added_listeners_) {
+      std::cout << "DEBUG notify listener\n";
       listener(node);
     }
+    std::cout << "DEBUG finish notifying listeners\n";
+  } else {
+    std::cout << "DEBUG not adding node because already found\n";
+  }
+  std::cout << "DEBUG finish adding\n";
+  auto iter_found = alive_nodes_.find(node_id);
+  if (iter_found == alive_nodes_.end()) {
+    std::cout << "DEBUG node not found\n";
+  } else {
+    std::cout << "DEBUG node found\n";
   }
 }
 

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -31,8 +31,8 @@
 #include "ray/rpc/gcs_server/gcs_rpc_server.h"
 #include "ray/rpc/node_manager/node_manager_client.h"
 #include "ray/rpc/node_manager/node_manager_client_pool.h"
-#include "src/ray/protobuf/gcs.pb.h"
 #include "ray/util/event.h"
+#include "src/ray/protobuf/gcs.pb.h"
 
 namespace ray {
 namespace gcs {
@@ -52,7 +52,7 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
                           std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage,
                           std::shared_ptr<rpc::NodeManagerClientPool> raylet_client_pool,
                           const ClusterID &cluster_id);
-  
+
   /// Handle register rpc request come from raylet.
   void HandleGetClusterId(rpc::GetClusterIdRequest request,
                           rpc::GetClusterIdReply *reply,
@@ -187,35 +187,45 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
 
   void WriteNodeExportEvent(rpc::GcsNodeInfo node_info) const;
 
-  rpc::ExportNodeData::GcsNodeState ConvertGCSNodeStateToExport(rpc::GcsNodeInfo::GcsNodeState node_state) const {
+  rpc::ExportNodeData::GcsNodeState ConvertGCSNodeStateToExport(
+      rpc::GcsNodeInfo::GcsNodeState node_state) const {
     switch (node_state) {
-        case rpc::GcsNodeInfo_GcsNodeState::GcsNodeInfo_GcsNodeState_ALIVE:
-            return rpc::ExportNodeData_GcsNodeState::ExportNodeData_GcsNodeState_ALIVE;
-        case rpc::GcsNodeInfo_GcsNodeState::GcsNodeInfo_GcsNodeState_DEAD:
-            return rpc::ExportNodeData_GcsNodeState::ExportNodeData_GcsNodeState_DEAD;
-        default:
-            // Unknown rpc::GcsNodeInfo::GcsNodeState value
-            RAY_LOG(FATAL) << "Invalid value for rpc::GcsNodeInfo::GcsNodeState " << rpc::GcsNodeInfo::GcsNodeState_Name(node_state);
-            return rpc::ExportNodeData_GcsNodeState::ExportNodeData_GcsNodeState_DEAD;
+    case rpc::GcsNodeInfo_GcsNodeState::GcsNodeInfo_GcsNodeState_ALIVE:
+      return rpc::ExportNodeData_GcsNodeState::ExportNodeData_GcsNodeState_ALIVE;
+    case rpc::GcsNodeInfo_GcsNodeState::GcsNodeInfo_GcsNodeState_DEAD:
+      return rpc::ExportNodeData_GcsNodeState::ExportNodeData_GcsNodeState_DEAD;
+    default:
+      // Unknown rpc::GcsNodeInfo::GcsNodeState value
+      RAY_LOG(FATAL) << "Invalid value for rpc::GcsNodeInfo::GcsNodeState "
+                     << rpc::GcsNodeInfo::GcsNodeState_Name(node_state);
+      return rpc::ExportNodeData_GcsNodeState::ExportNodeData_GcsNodeState_DEAD;
     }
   }
 
-  rpc::ExportNodeData::NodeDeathInfo::Reason ConvertNodeDeathReasonToExport(rpc::NodeDeathInfo::Reason reason) const {
+  rpc::ExportNodeData::NodeDeathInfo::Reason ConvertNodeDeathReasonToExport(
+      rpc::NodeDeathInfo::Reason reason) const {
     switch (reason) {
-        case rpc::NodeDeathInfo_Reason::NodeDeathInfo_Reason_UNSPECIFIED:
-            return rpc::ExportNodeData_NodeDeathInfo_Reason::ExportNodeData_NodeDeathInfo_Reason_UNSPECIFIED;
-        case rpc::NodeDeathInfo_Reason::NodeDeathInfo_Reason_EXPECTED_TERMINATION:
-            return rpc::ExportNodeData_NodeDeathInfo_Reason::ExportNodeData_NodeDeathInfo_Reason_EXPECTED_TERMINATION;
-        case rpc::NodeDeathInfo_Reason::NodeDeathInfo_Reason_UNEXPECTED_TERMINATION:
-            return rpc::ExportNodeData_NodeDeathInfo_Reason::ExportNodeData_NodeDeathInfo_Reason_UNEXPECTED_TERMINATION;
-        case rpc::NodeDeathInfo_Reason::NodeDeathInfo_Reason_AUTOSCALER_DRAIN_PREEMPTED:
-            return rpc::ExportNodeData_NodeDeathInfo_Reason::ExportNodeData_NodeDeathInfo_Reason_AUTOSCALER_DRAIN_PREEMPTED;
-        case rpc::NodeDeathInfo_Reason::NodeDeathInfo_Reason_AUTOSCALER_DRAIN_IDLE:
-            return rpc::ExportNodeData_NodeDeathInfo_Reason::ExportNodeData_NodeDeathInfo_Reason_AUTOSCALER_DRAIN_IDLE;
-        default:
-            // Unknown rpc::GcsNodeInfo::GcsNodeState value
-            RAY_LOG(FATAL) << "Invalid value for rpc::NodeDeathInfo::Reason " << rpc::NodeDeathInfo::Reason_Name(reason);
-            return rpc::ExportNodeData_NodeDeathInfo_Reason::ExportNodeData_NodeDeathInfo_Reason_UNSPECIFIED;
+    case rpc::NodeDeathInfo_Reason::NodeDeathInfo_Reason_UNSPECIFIED:
+      return rpc::ExportNodeData_NodeDeathInfo_Reason::
+          ExportNodeData_NodeDeathInfo_Reason_UNSPECIFIED;
+    case rpc::NodeDeathInfo_Reason::NodeDeathInfo_Reason_EXPECTED_TERMINATION:
+      return rpc::ExportNodeData_NodeDeathInfo_Reason::
+          ExportNodeData_NodeDeathInfo_Reason_EXPECTED_TERMINATION;
+    case rpc::NodeDeathInfo_Reason::NodeDeathInfo_Reason_UNEXPECTED_TERMINATION:
+      return rpc::ExportNodeData_NodeDeathInfo_Reason::
+          ExportNodeData_NodeDeathInfo_Reason_UNEXPECTED_TERMINATION;
+    case rpc::NodeDeathInfo_Reason::NodeDeathInfo_Reason_AUTOSCALER_DRAIN_PREEMPTED:
+      return rpc::ExportNodeData_NodeDeathInfo_Reason::
+          ExportNodeData_NodeDeathInfo_Reason_AUTOSCALER_DRAIN_PREEMPTED;
+    case rpc::NodeDeathInfo_Reason::NodeDeathInfo_Reason_AUTOSCALER_DRAIN_IDLE:
+      return rpc::ExportNodeData_NodeDeathInfo_Reason::
+          ExportNodeData_NodeDeathInfo_Reason_AUTOSCALER_DRAIN_IDLE;
+    default:
+      // Unknown rpc::GcsNodeInfo::GcsNodeState value
+      RAY_LOG(FATAL) << "Invalid value for rpc::NodeDeathInfo::Reason "
+                     << rpc::NodeDeathInfo::Reason_Name(reason);
+      return rpc::ExportNodeData_NodeDeathInfo_Reason::
+          ExportNodeData_NodeDeathInfo_Reason_UNSPECIFIED;
     }
   }
 

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -32,6 +32,7 @@
 #include "ray/rpc/node_manager/node_manager_client.h"
 #include "ray/rpc/node_manager/node_manager_client_pool.h"
 #include "src/ray/protobuf/gcs.pb.h"
+#include "ray/util/event.h"
 
 namespace ray {
 namespace gcs {
@@ -51,7 +52,7 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
                           std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage,
                           std::shared_ptr<rpc::NodeManagerClientPool> raylet_client_pool,
                           const ClusterID &cluster_id);
-
+  
   /// Handle register rpc request come from raylet.
   void HandleGetClusterId(rpc::GetClusterIdRequest request,
                           rpc::GetClusterIdReply *reply,
@@ -183,6 +184,40 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   /// from alive nodes yet.
   /// \return The inferred death info of the node.
   rpc::NodeDeathInfo InferDeathInfo(const NodeID &node_id);
+
+  void WriteNodeExportEvent(rpc::GcsNodeInfo node_info) const;
+
+  rpc::ExportNodeData::GcsNodeState ConvertGCSNodeStateToExport(rpc::GcsNodeInfo::GcsNodeState node_state) const {
+    switch (node_state) {
+        case rpc::GcsNodeInfo_GcsNodeState::GcsNodeInfo_GcsNodeState_ALIVE:
+            return rpc::ExportNodeData_GcsNodeState::ExportNodeData_GcsNodeState_ALIVE;
+        case rpc::GcsNodeInfo_GcsNodeState::GcsNodeInfo_GcsNodeState_DEAD:
+            return rpc::ExportNodeData_GcsNodeState::ExportNodeData_GcsNodeState_DEAD;
+        default:
+            // Unknown rpc::GcsNodeInfo::GcsNodeState value
+            RAY_LOG(FATAL) << "Invalid value for rpc::GcsNodeInfo::GcsNodeState " << rpc::GcsNodeInfo::GcsNodeState_Name(node_state);
+            return rpc::ExportNodeData_GcsNodeState::ExportNodeData_GcsNodeState_DEAD;
+    }
+  }
+
+  rpc::ExportNodeData::NodeDeathInfo::Reason ConvertNodeDeathReasonToExport(rpc::NodeDeathInfo::Reason reason) const {
+    switch (reason) {
+        case rpc::NodeDeathInfo_Reason::NodeDeathInfo_Reason_UNSPECIFIED:
+            return rpc::ExportNodeData_NodeDeathInfo_Reason::ExportNodeData_NodeDeathInfo_Reason_UNSPECIFIED;
+        case rpc::NodeDeathInfo_Reason::NodeDeathInfo_Reason_EXPECTED_TERMINATION:
+            return rpc::ExportNodeData_NodeDeathInfo_Reason::ExportNodeData_NodeDeathInfo_Reason_EXPECTED_TERMINATION;
+        case rpc::NodeDeathInfo_Reason::NodeDeathInfo_Reason_UNEXPECTED_TERMINATION:
+            return rpc::ExportNodeData_NodeDeathInfo_Reason::ExportNodeData_NodeDeathInfo_Reason_UNEXPECTED_TERMINATION;
+        case rpc::NodeDeathInfo_Reason::NodeDeathInfo_Reason_AUTOSCALER_DRAIN_PREEMPTED:
+            return rpc::ExportNodeData_NodeDeathInfo_Reason::ExportNodeData_NodeDeathInfo_Reason_AUTOSCALER_DRAIN_PREEMPTED;
+        case rpc::NodeDeathInfo_Reason::NodeDeathInfo_Reason_AUTOSCALER_DRAIN_IDLE:
+            return rpc::ExportNodeData_NodeDeathInfo_Reason::ExportNodeData_NodeDeathInfo_Reason_AUTOSCALER_DRAIN_IDLE;
+        default:
+            // Unknown rpc::GcsNodeInfo::GcsNodeState value
+            RAY_LOG(FATAL) << "Invalid value for rpc::NodeDeathInfo::Reason " << rpc::NodeDeathInfo::Reason_Name(reason);
+            return rpc::ExportNodeData_NodeDeathInfo_Reason::ExportNodeData_NodeDeathInfo_Reason_UNSPECIFIED;
+    }
+  }
 
   /// Alive nodes.
   absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>> alive_nodes_;

--- a/src/ray/gcs/gcs_server/gcs_server_main.cc
+++ b/src/ray/gcs/gcs_server/gcs_server_main.cc
@@ -89,7 +89,8 @@ int main(int argc, char *argv[]) {
   // Initialize event framework.
   if (RayConfig::instance().event_log_reporter_enabled() && !log_dir.empty()) {
     const std::vector<ray::SourceTypeVariant> source_types = {
-        ray::rpc::Event_SourceType::Event_SourceType_GCS};
+        ray::rpc::Event_SourceType::Event_SourceType_GCS,
+        ray::rpc::ExportEvent_SourceType::ExportEvent_SourceType_EXPORT_NODE};
     ray::RayEventInit(source_types,
                       absl::flat_hash_map<std::string, std::string>(),
                       log_dir,

--- a/src/ray/gcs/gcs_server/gcs_server_main.cc
+++ b/src/ray/gcs/gcs_server/gcs_server_main.cc
@@ -88,6 +88,9 @@ int main(int argc, char *argv[]) {
 
   // Initialize event framework.
   if (RayConfig::instance().event_log_reporter_enabled() && !log_dir.empty()) {
+    // This GCS server process emits GCS standard events, and Node export events
+    // so the various source types are passed to RayEventInit. The type of an
+    // event is determined by the schema of its event data.
     const std::vector<ray::SourceTypeVariant> source_types = {
         ray::rpc::Event_SourceType::Event_SourceType_GCS,
         ray::rpc::ExportEvent_SourceType::ExportEvent_SourceType_EXPORT_NODE};

--- a/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
@@ -157,7 +157,7 @@ TEST_F(GcsNodeManagerExportAPITest, TestExportEvents) {
       [](ray::Status status, std::function<void()> f1, std::function<void()> f2) {};
 
   node_manager.HandleRegisterNode(register_request, &register_reply, send_reply_callback);
-  ASSERT_EQ(io_service_.poll_one(), 1);
+  ASSERT_TRUE(io_service_.poll_one() <= 1);
 
   Mocker::ReadContentFromFile(vc, log_dir_ + "/events/event_EXPORT_NODE.log");
   ASSERT_EQ((int)vc.size(), 1);
@@ -172,7 +172,7 @@ TEST_F(GcsNodeManagerExportAPITest, TestExportEvents) {
   rpc::UnregisterNodeReply unregister_reply;
   node_manager.HandleUnregisterNode(
       unregister_request, &unregister_reply, send_reply_callback);
-  ASSERT_EQ(io_service_.poll_one(), 1);
+  ASSERT_TRUE(io_service_.poll_one() <= 1);
 
   vc.clear();
   Mocker::ReadContentFromFile(vc, log_dir_ + "/events/event_EXPORT_NODE.log");

--- a/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 #include <chrono>
-#include <filesystem>
-#include <fstream>
 #include <memory>
 #include <thread>
 
@@ -29,7 +27,6 @@
 // clang-format on
 
 namespace ray {
-
 class GcsNodeManagerTest : public ::testing::Test {
  public:
   GcsNodeManagerTest() {

--- a/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
@@ -162,6 +162,7 @@ TEST_F(GcsNodeManagerExportAPITest, TestExportEvents) {
 
   bool finished_register_node = false;
   node_manager.HandleRegisterNode(register_request, &register_reply, send_reply_callback);
+  io_service_.poll();
 
   for (int i = 0; i < num_retry; i++) {
     Mocker::ReadContentFromFile(vc, log_dir_ + "/events/event_EXPORT_NODE.log");
@@ -187,6 +188,7 @@ TEST_F(GcsNodeManagerExportAPITest, TestExportEvents) {
   rpc::UnregisterNodeReply unregister_reply;
   node_manager.HandleUnregisterNode(
       unregister_request, &unregister_reply, send_reply_callback);
+  io_service_.poll();
 
   vc.clear();
   for (int i = 0; i < num_retry; i++) {

--- a/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
@@ -79,6 +79,7 @@ class GcsNodeManagerExportAPITest : public ::testing::Test {
   instrumented_io_context io_service_;
   std::unique_ptr<std::thread> thread_io_service_;
   std::string log_dir_;
+  absl::Mutex mutex_;
 };
 
 TEST_F(GcsNodeManagerTest, TestManagement) {
@@ -158,29 +159,41 @@ TEST_F(GcsNodeManagerExportAPITest, TestExportEvents) {
   auto send_reply_callback =
       [](ray::Status status, std::function<void()> f1, std::function<void()> f2) {};
 
-  node_manager.HandleRegisterNode(register_request, &register_reply, send_reply_callback);
-  int num_retry = 5;
-  for (int i = 0; i < num_retry; i++) {
-    if (node_manager.GetAliveNode(node_id).has_value()) {
-      ASSERT_EQ(node_manager.GetAliveNode(node_id).value()->state(),
-                rpc::GcsNodeInfo::ALIVE);
-    } else {
-      // Sleep and retry
-      std::this_thread::sleep_for(std::chrono::seconds(1));
-    }
+  {
+    absl::MutexLock lock(&mutex_);
+    node_manager.HandleRegisterNode(
+        register_request, &register_reply, send_reply_callback);
   }
-  ASSERT_TRUE(node_manager.GetAliveNode(node_id).has_value())
-      << "No alive node found after HandleRegisterNode";
-
+  int num_retry = 5;
+  {
+    absl::MutexLock lock(&mutex_);
+    for (int i = 0; i < num_retry; i++) {
+      if (node_manager.GetAliveNode(node_id).has_value()) {
+        ASSERT_EQ(node_manager.GetAliveNode(node_id).value()->state(),
+                  rpc::GcsNodeInfo::ALIVE);
+      } else {
+        // Sleep and retry
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+      }
+    }
+    ASSERT_TRUE(node_manager.GetAliveNode(node_id).has_value())
+        << "No alive node found after HandleRegisterNode";
+  }
   rpc::UnregisterNodeRequest unregister_request;
   unregister_request.set_node_id(node_id.Binary());
   unregister_request.mutable_node_death_info()->set_reason(
       rpc::NodeDeathInfo::UNEXPECTED_TERMINATION);
   unregister_request.mutable_node_death_info()->set_reason_message("mock reason message");
   rpc::UnregisterNodeReply unregister_reply;
-  node_manager.HandleUnregisterNode(
-      unregister_request, &unregister_reply, send_reply_callback);
-  ASSERT_TRUE(!node_manager.GetAliveNode(node_id).has_value());
+  {
+    absl::MutexLock lock(&mutex_);
+    node_manager.HandleUnregisterNode(
+        unregister_request, &unregister_reply, send_reply_callback);
+  }
+  {
+    absl::MutexLock lock(&mutex_);
+    ASSERT_TRUE(!node_manager.GetAliveNode(node_id).has_value());
+  }
 
   int num_export_events = 2;
   std::vector<std::string> expected_states = {"ALIVE", "DEAD"};

--- a/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
@@ -123,6 +123,13 @@ TEST_F(GcsNodeManagerTest, TestListener) {
 
 TEST_F(GcsNodeManagerTest, TestExportEvents) {
   // Test adding and removing node, and that export events are written
+  RayConfig::instance().initialize(
+        R"(
+{
+  "enable_export_api_write": true
+}
+  )");
+
   const std::vector<ray::SourceTypeVariant> source_types = {rpc::ExportEvent_SourceType::ExportEvent_SourceType_EXPORT_NODE};
   RayEventInit(source_types, absl::flat_hash_map<std::string, std::string>(), log_dir_);
   gcs::GcsNodeManager node_manager(

--- a/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
@@ -163,24 +163,11 @@ TEST_F(GcsNodeManagerExportAPITest, TestExportEventRegisterNode) {
   node_manager.HandleRegisterNode(register_request, &register_reply, send_reply_callback);
   io_service_.poll();
 
-  int num_retry = 5;
-  bool finished_register_node = false;
   std::vector<std::string> vc;
-  for (int i = 0; i < num_retry; i++) {
-    Mocker::ReadContentFromFile(vc, log_dir_ + "/events/event_EXPORT_NODE.log");
-    if ((int)vc.size() == 1) {
-      json event_data = json::parse(vc[0])["event_data"].get<json>();
-      ASSERT_EQ(event_data["state"], "ALIVE");
-      finished_register_node = true;
-      break;
-    } else {
-      // Sleep and retry
-      std::this_thread::sleep_for(std::chrono::seconds(1));
-      vc.clear();
-    }
-  }
-  ASSERT_TRUE(finished_register_node)
-      << "No export event with state ALIVE found after HandleRegisterNode.";
+  Mocker::ReadContentFromFile(vc, log_dir_ + "/events/event_EXPORT_NODE.log");
+  ASSERT_EQ((int)vc.size(), 1);
+  json event_data = json::parse(vc[0])["event_data"].get<json>();
+  ASSERT_EQ(event_data["state"], "ALIVE");
 }
 
 TEST_F(GcsNodeManagerExportAPITest, TestExportEventUnregisterNode) {
@@ -204,28 +191,14 @@ TEST_F(GcsNodeManagerExportAPITest, TestExportEventUnregisterNode) {
       unregister_request, &unregister_reply, send_reply_callback);
   io_service_.poll();
 
-  int num_retry = 5;
-  bool finished_unregister_node = false;
   std::vector<std::string> vc;
-  vc.clear();
-  for (int i = 0; i < num_retry; i++) {
-    Mocker::ReadContentFromFile(vc, log_dir_ + "/events/event_EXPORT_NODE.log");
-    if ((int)vc.size() == 1) {
-      json event_data = json::parse(vc[0])["event_data"].get<json>();
-      ASSERT_EQ(event_data["state"], "DEAD");
-      // Verify death cause for last node DEAD event
-      ASSERT_EQ(event_data["death_info"]["reason"], "UNEXPECTED_TERMINATION");
-      ASSERT_EQ(event_data["death_info"]["reason_message"], "mock reason message");
-      finished_unregister_node = true;
-      break;
-    } else {
-      // Sleep and retry
-      std::this_thread::sleep_for(std::chrono::seconds(1));
-      vc.clear();
-    }
-  }
-  ASSERT_TRUE(finished_unregister_node)
-      << "Expected DEAD export event not found after HandleUnregisterNode.";
+  Mocker::ReadContentFromFile(vc, log_dir_ + "/events/event_EXPORT_NODE.log");
+  ASSERT_EQ((int)vc.size(), 1);
+  json event_data = json::parse(vc[0])["event_data"].get<json>();
+  ASSERT_EQ(event_data["state"], "DEAD");
+  // Verify death cause for last node DEAD event
+  ASSERT_EQ(event_data["death_info"]["reason"], "UNEXPECTED_TERMINATION");
+  ASSERT_EQ(event_data["death_info"]["reason_message"], "mock reason message");
 }
 
 }  // namespace ray

--- a/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_node_manager_test.cc
@@ -157,7 +157,7 @@ TEST_F(GcsNodeManagerExportAPITest, TestExportEvents) {
       [](ray::Status status, std::function<void()> f1, std::function<void()> f2) {};
 
   node_manager.HandleRegisterNode(register_request, &register_reply, send_reply_callback);
-  ASSERT_TRUE(io_service_.poll_one() <= 1);
+  ASSERT_TRUE(io_service_.run_one() <= 1);
 
   Mocker::ReadContentFromFile(vc, log_dir_ + "/events/event_EXPORT_NODE.log");
   ASSERT_EQ((int)vc.size(), 1);
@@ -172,7 +172,7 @@ TEST_F(GcsNodeManagerExportAPITest, TestExportEvents) {
   rpc::UnregisterNodeReply unregister_reply;
   node_manager.HandleUnregisterNode(
       unregister_request, &unregister_reply, send_reply_callback);
-  ASSERT_TRUE(io_service_.poll_one() <= 1);
+  ASSERT_TRUE(io_service_.run_one() <= 1);
 
   vc.clear();
   Mocker::ReadContentFromFile(vc, log_dir_ + "/events/event_EXPORT_NODE.log");

--- a/src/ray/gcs/test/gcs_test_util.h
+++ b/src/ray/gcs/test/gcs_test_util.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <filesystem>
+#include <fstream>
 #include <memory>
 #include <utility>
 
@@ -425,6 +427,16 @@ struct Mocker {
                                                                     resource.end());
     }
     return constraint;
+  }
+  // Read all lines of a file into vector vc
+  static void ReadContentFromFile(std::vector<std::string> &vc, std::string log_file) {
+    std::string line;
+    std::ifstream read_file;
+    read_file.open(log_file, std::ios::binary);
+    while (std::getline(read_file, line)) {
+      vc.push_back(line);
+    }
+    read_file.close();
   }
 };
 

--- a/src/ray/util/event.cc
+++ b/src/ray/util/event.cc
@@ -134,6 +134,10 @@ std::string LogEventReporter::ExportEventToString(const rpc::ExportEvent &export
     RAY_CHECK(google::protobuf::util::MessageToJsonString(
                   export_event.task_event_data(), &event_data_as_string, options)
                   .ok());
+  } else if (export_event.has_node_event_data()) {
+    RAY_CHECK(google::protobuf::util::MessageToJsonString(
+                  export_event.node_event_data(), &event_data_as_string, options)
+                  .ok());
   } else {
     RAY_LOG(FATAL)
         << "event_data missing from export event with id " << export_event.event_id()

--- a/src/ray/util/event.cc
+++ b/src/ray/util/event.cc
@@ -130,6 +130,8 @@ std::string LogEventReporter::ExportEventToString(const rpc::ExportEvent &export
   std::string event_data_as_string;
   google::protobuf::util::JsonPrintOptions options;
   options.preserve_proto_field_names = true;
+  // Required so enum with value 0 is not omitted
+  options.always_print_primitive_fields = true;
   if (export_event.has_task_event_data()) {
     RAY_CHECK(google::protobuf::util::MessageToJsonString(
                   export_event.task_event_data(), &event_data_as_string, options)
@@ -163,7 +165,6 @@ void LogEventReporter::Report(const rpc::Event &event, const json &custom_fields
 void LogEventReporter::ReportExportEvent(const rpc::ExportEvent &export_event) {
   RAY_CHECK(ExportEvent_SourceType_IsValid(export_event.source_type()));
   std::string result = ExportEventToString(export_event);
-  std::cout << "ReportExportEvent ExportEventToString " << result << "\n";
   log_sink_->info(result);
   if (force_flush_) {
     Flush();

--- a/src/ray/util/event.cc
+++ b/src/ray/util/event.cc
@@ -165,8 +165,8 @@ void LogEventReporter::Report(const rpc::Event &event, const json &custom_fields
 void LogEventReporter::ReportExportEvent(const rpc::ExportEvent &export_event) {
   RAY_CHECK(ExportEvent_SourceType_IsValid(export_event.source_type()));
   std::string result = ExportEventToString(export_event);
-  log_sink_->info(result);
 
+  log_sink_->info(result);
   if (force_flush_) {
     Flush();
   }

--- a/src/ray/util/event.cc
+++ b/src/ray/util/event.cc
@@ -166,6 +166,7 @@ void LogEventReporter::ReportExportEvent(const rpc::ExportEvent &export_event) {
   RAY_CHECK(ExportEvent_SourceType_IsValid(export_event.source_type()));
   std::string result = ExportEventToString(export_event);
   log_sink_->info(result);
+
   if (force_flush_) {
     Flush();
   }

--- a/src/ray/util/event.cc
+++ b/src/ray/util/event.cc
@@ -163,7 +163,7 @@ void LogEventReporter::Report(const rpc::Event &event, const json &custom_fields
 void LogEventReporter::ReportExportEvent(const rpc::ExportEvent &export_event) {
   RAY_CHECK(ExportEvent_SourceType_IsValid(export_event.source_type()));
   std::string result = ExportEventToString(export_event);
-
+  std::cout << "ReportExportEvent ExportEventToString " << result << "\n";
   log_sink_->info(result);
   if (force_flush_) {
     Flush();
@@ -184,7 +184,9 @@ EventManager &EventManager::Instance() {
   return instance_;
 }
 
-bool EventManager::IsEmpty() { return reporter_map_.empty(); }
+bool EventManager::IsEmpty() {
+  return reporter_map_.empty() && export_log_reporter_map_.empty();
+}
 
 void EventManager::Publish(const rpc::Event &event, const json &custom_fields) {
   for (const auto &element : reporter_map_) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- Write node events to file as part of the export API. This logic is only run if `RayConfig::instance().enable_export_api_write()` is `true`. Default value is `false`.
- Event write is called whenever a value in the node event data schema is modified. Typically this occurs in the callback after writing NodeTable to the GCS table

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
