### PR TITLE
[Serve] allow `get_serve_logs_dir` to run outside of Ray's context

### DIFF
--- a/python/ray/serve/_private/logging_utils.py
+++ b/python/ray/serve/_private/logging_utils.py
@@ -466,7 +466,15 @@ def configure_component_cpu_profiler(
 
 
 def get_serve_logs_dir() -> str:
-    """Get the directory that stores Serve log files."""
+    """Get the directory that stores Serve log files.
+
+    If `ray._private.worker._global_node` is None (running outside the context of Ray),
+    then the current working directory with subdirectory of serve is used as the logs
+    directory. Otherwise, the logs directory is determined by the global node's logs
+    directory path.
+    """
+    if ray._private.worker._global_node is None:
+        return os.path.join(os.getcwd(), "serve")
 
     return os.path.join(ray._private.worker._global_node.get_logs_dir_path(), "serve")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Allow `get_serve_logs_dir` to run outside of Ray's context.

## Related issue number


## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
