### PR TITLE
[Data] [Release Test] Use worker node instead of head node for `read_images_comparison_microbenchmark_single_node`

### DIFF
--- a/release/nightly_tests/dataset/run_image_loader_microbenchmark.sh
+++ b/release/nightly_tests/dataset/run_image_loader_microbenchmark.sh
@@ -4,10 +4,10 @@
 # Exit if any of the test commands fail.
 set -x -e pipeline
 
-DIR="/tmp/imagenet-1gb"
-MOSAIC_DIR="/tmp/mosaicml-data"
-TFRECORDS_DIR="/tmp/tf-data"
-PARQUET_DIR="/tmp/parquet-data"
+DIR="/mnt/cluster_storage/imagenet-1gb"
+MOSAIC_DIR="/mnt/cluster_storage/mosaicml-data"
+TFRECORDS_DIR="/mnt/cluster_storage/tf-data"
+PARQUET_DIR="/mnt/cluster_storage/parquet-data"
 
 rm -rf "$DIR"
 rm -rf "$MOSAIC_DIR"

--- a/release/nightly_tests/dataset/single_node_benchmark_compute.yaml
+++ b/release/nightly_tests/dataset/single_node_benchmark_compute.yaml
@@ -5,6 +5,12 @@ max_workers: 0
 
 head_node_type:
     name: head_node
-    instance_type: m5.4xlarge
+    instance_type: m5.xlarge
+    resources:
+        cpu: 0
 
-worker_node_types: []
+worker_node_types:
+    - name: worker_node
+      instance_type: m5.4xlarge
+      min_workers: 1
+      max_workers: 1

--- a/release/nightly_tests/dataset/single_node_benchmark_compute.yaml
+++ b/release/nightly_tests/dataset/single_node_benchmark_compute.yaml
@@ -5,12 +5,6 @@ max_workers: 0
 
 head_node_type:
     name: head_node
-    instance_type: m5.xlarge
-    resources:
-        cpu: 0
+    instance_type: m5.4xlarge
 
-worker_node_types:
-    - name: worker_node
-      instance_type: m5.4xlarge
-      min_workers: 1
-      max_workers: 1
+worker_node_types: []

--- a/release/nightly_tests/dataset/single_worker_node_0_head_node_benchmark_compute.yaml
+++ b/release/nightly_tests/dataset/single_worker_node_0_head_node_benchmark_compute.yaml
@@ -1,0 +1,16 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west-2
+
+max_workers: 0
+
+head_node_type:
+    name: head_node
+    instance_type: m5.xlarge
+    resources:
+        cpu: 0
+
+worker_node_types:
+    - name: worker_node
+      instance_type: m5.4xlarge
+      min_workers: 1
+      max_workers: 1

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4061,7 +4061,7 @@
     byod:
       type: gpu
       post_build_script: byod_install_mosaicml.sh
-    cluster_compute: single_node_benchmark_compute.yaml
+    cluster_compute: single_worker_node_0_head_node_benchmark_compute.yaml
 
   run:
     timeout: 1800


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Recently, there was a change to the OOM killing threshold, being reduced from 95% to 75% for head nodes. We suspect this to be the root cause of `read_images_comparison_microbenchmark_single_node` release test failures, which uses a single head node. To mitigate the issue, this PR changes the compute config of the test, to instead use a 0-CPU head node, and a single worker node.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests - https://buildkite.com/ray-project/release/builds/21386
   - [ ] This PR is not tested :(
