### PR TITLE
[core] Make preloading Jemalloc configurable for worker

### DIFF
--- a/doc/source/ray-contribute/profiling.rst
+++ b/doc/source/ray-contribute/profiling.rst
@@ -88,11 +88,12 @@ Ray supports environment variables that override `LD_PRELOAD` on core components
 You can find the component name from `ray_constants.py`. For example, if you'd like to profile gcs_server, 
 search `PROCESS_TYPE_GCS_SERVER` in `ray_constants.py`. You can see the value is `gcs_server`.
 
-Users are supposed to provide 3 env vars for memory profiling.
+Users are supposed to provide 4 env vars for memory profiling.
 
 * `RAY_JEMALLOC_LIB_PATH`: The path to the jemalloc shared library `libjemalloc.so`
 * `RAY_JEMALLOC_CONF`: The MALLOC_CONF configuration for jemalloc, using comma-separated values. Read `jemalloc docs <http://jemalloc.net/jemalloc.3.html>`_ for more details.
 * `RAY_JEMALLOC_PROFILE`: Comma separated Ray components to run Jemalloc `.so`. e.g., ("raylet,gcs_server"). Note that the components should match the process type in `ray_constants.py`. (It means "RAYLET,GCS_SERVER" won't work).
+* `RAY_LD_PRELOAD_ON_WORKERS`: Default value is `0`, which means Ray doesn't preload Jemalloc for workers if a library is incompatible with Jemalloc. Set to `1` to instruct Ray to preload Jemalloc for a worker using values configured by `RAY_JEMALLOC_LIB_PATH` and `RAY_JEMALLOC_PROFILE`.
 
 .. code-block:: bash
 

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -227,7 +227,10 @@ def propagate_jemalloc_env_var(
     if not jemalloc_path:
         return {}
 
-    env_vars = {"LD_PRELOAD": jemalloc_path, "RAY_LD_PRELOAD": "1"}
+    env_vars = {
+        "LD_PRELOAD": jemalloc_path,
+        "RAY_LD_PRELOAD_ON_WORKERS": os.environ.get("RAY_LD_PRELOAD_ON_WORKERS", "0"),
+    }
     if process_type in jemalloc_comps and jemalloc_conf:
         env_vars.update({"MALLOC_CONF": jemalloc_conf})
     return env_vars

--- a/python/ray/tests/test_advanced_4.py
+++ b/python/ray/tests/test_advanced_4.py
@@ -1,5 +1,7 @@
+import os
 import subprocess
 import sys
+from unittest.mock import patch
 
 import pytest
 
@@ -67,7 +69,7 @@ def test_jemalloc_env_var_propagate():
     When the shared library is specified
     """
     library_path = "/abc"
-    expected = {"LD_PRELOAD": library_path, "RAY_LD_PRELOAD": "1"}
+    expected = {"LD_PRELOAD": library_path, "RAY_LD_PRELOAD_ON_WORKERS": "0"}
     actual = ray._private.services.propagate_jemalloc_env_var(
         jemalloc_path=library_path,
         jemalloc_conf="",
@@ -85,14 +87,15 @@ def test_jemalloc_env_var_propagate():
             process_type=gcs_ptype,
         )
 
-    # When comps don't match the process_type, it should return an empty dict.
-    expected = {}
+    # When comps don't match the process_type, it should not contain MALLOC_CONF.
     actual = ray._private.services.propagate_jemalloc_env_var(
         jemalloc_path=library_path,
         jemalloc_conf="",
         jemalloc_comps=[ray._private.ray_constants.PROCESS_TYPE_RAYLET],
         process_type=gcs_ptype,
     )
+    assert "MALLOC_CONF" not in actual
+
     """
     When the malloc config is specified
     """
@@ -101,13 +104,31 @@ def test_jemalloc_env_var_propagate():
     expected = {
         "LD_PRELOAD": library_path,
         "MALLOC_CONF": malloc_conf,
-        "RAY_LD_PRELOAD": "1",
+        "RAY_LD_PRELOAD_ON_WORKERS": "0",
     }
     actual = ray._private.services.propagate_jemalloc_env_var(
         jemalloc_path=library_path,
         jemalloc_conf=malloc_conf,
         jemalloc_comps=[ray._private.ray_constants.PROCESS_TYPE_GCS_SERVER],
         process_type=gcs_ptype,
+    )
+    assert actual == expected
+
+
+@patch.dict(os.environ, {"RAY_LD_PRELOAD_ON_WORKERS": "1"})
+def test_enable_jemallc_for_workers():
+    library_path = "/abc"
+    malloc_conf = "a,b,c"
+    expected = {
+        "LD_PRELOAD": library_path,
+        "MALLOC_CONF": malloc_conf,
+        "RAY_LD_PRELOAD_ON_WORKERS": "1",
+    }
+    actual = ray._private.services.propagate_jemalloc_env_var(
+        jemalloc_path=library_path,
+        jemalloc_conf=malloc_conf,
+        jemalloc_comps=[ray._private.ray_constants.PROCESS_TYPE_WORKER],
+        process_type=ray._private.ray_constants.PROCESS_TYPE_WORKER,
     )
     assert actual == expected
 

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -178,8 +178,8 @@ int main(int argc, char *argv[]) {
 
 #ifdef __linux__
   // Reset LD_PRELOAD if it's loaded with ray jemalloc
-  auto ray_ld_preload = std::getenv("RAY_LD_PRELOAD");
-  if (ray_ld_preload != nullptr && std::string(ray_ld_preload) == "1") {
+  auto ray_ld_preload = std::getenv("RAY_LD_PRELOAD_ON_WORKERS");
+  if (ray_ld_preload != nullptr && std::string(ray_ld_preload) == "0") {
     unsetenv("LD_PRELOAD");
   }
 #endif


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The PR https://github.com/ray-project/ray/pull/39446 disables preloading Jemalloc for workers totally. However, Jemalloc is still useful in some cases, and we could make it configurable if user setting env RAY_LD_PRELOAD as 0.

The batch inference example code, using a TF model to infer the batch input of numpy's ndarray.
~~~python
ds = ray.data.read_tfrecords(xxx)
ds.map_batches(BatchPredictor)
.map_batches(BatchPostProcessor)
.write_parquet(path=output_path
~~~

I did a inference test with limited memory, and we can see the OOM counts decrease from 900+ to 700.
![image](https://github.com/user-attachments/assets/12e3f428-6b97-467d-801d-7ab4b9e3b659)




## Related issue number
Closes #47242

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
