### PR TITLE
[Docs][KubeRay] Fix broken Istio Jaeger dashboard link

### DIFF
--- a/doc/source/cluster/kubernetes/k8s-ecosystem/istio.md
+++ b/doc/source/cluster/kubernetes/k8s-ecosystem/istio.md
@@ -310,7 +310,8 @@ Run the following command to start the Jaeger dashboard:
 istioctl dashboard jaeger
 ```
 
-Go to the Jaeger dashboard with the `service=raycluster-istio.default` query: [http://localhost:16686/jaeger/search?limit=1000&lookback=1h&maxDuration&minDuration&service=raycluster-istio.default](http://localhost:16686/jaeger/search?limit=1000&lookback=1h&maxDuration&minDuration&service=raycluster-istio.default)
+<!-- TODO: Change the following link to markdown syntax after this issue  https://github.com/executablebooks/MyST-Parser/issues/760 is resolved -->
+Go to the Jaeger dashboard with the `service=raycluster-istio.default` query: <a class="reference external" href="http://localhost:16686/jaeger/search?limit=1000&lookback=1h&maxDuration&minDuration&service=raycluster-istio.default">http://localhost:16686/jaeger/search?limit=1000&lookback=1h&maxDuration&minDuration&service=raycluster-istio.default</a>
 
 ![Istio Jaeger Overview](../images/istio-jaeger-1.png)
 


### PR DESCRIPTION
## Why are these changes needed?

See the description in the corresponding issue for details.

## Related issue number

Closes: ray-project/ray#47239

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
