### PR TITLE
[RLlib; Offline RL] Offline RL; slow Ray Data `map_batches` issue.

### DIFF
--- a/rllib/offline/offline_data.py
+++ b/rllib/offline/offline_data.py
@@ -62,11 +62,8 @@ class OfflineData:
         num_shards: int = 1,
     ):
         if (
-            not return_iterator
-            or return_iterator
-            and num_shards <= 1
-            and not self.batch_iterator
-        ):
+            not return_iterator or (return_iterator and num_shards <= 1)
+        ) and not self.batch_iterator:
             # If no iterator should be returned, or if we want to return a single
             # batch iterator, we instantiate the batch iterator once, here.
             # TODO (simon, sven): The iterator depends on the `num_samples`, i.e.abs

--- a/rllib/tuned_examples/bc/cartpole_bc.py
+++ b/rllib/tuned_examples/bc/cartpole_bc.py
@@ -48,7 +48,7 @@ config = (
     # configured. The read method needs at least as many blocks
     # as remote learners.
     .offline_data(
-        input_=[data_path.as_posix()],
+        input_=[f.as_posix() for f in data_path.iterdir()] * 2,
         # Define the number of reading blocks, these should be larger than 1
         # and aligned with the data size.
         input_read_method_kwargs={"override_num_blocks": max(args.num_gpus, 2)},

--- a/test_benchmark_atari_pong_bc_components.py
+++ b/test_benchmark_atari_pong_bc_components.py
@@ -1,0 +1,299 @@
+"""
+This example shows that `map_batches` is extremly slow on real-world
+massive data, as it is used in typical Offline RL cases.
+
+The example lists the single steps that are used in RLlib's data pipeline
+and times them.
+"""
+
+import io
+import time
+from pathlib import Path
+from typing import Optional
+
+import gymnasium as gym
+import numpy as np
+import tree
+from google.cloud import storage
+from PIL import Image
+
+from ray import tune
+from ray.data.datasource.tfrecords_datasource import TFXReadOptions
+from ray.rllib.algorithms.bc import BCConfig
+from ray.rllib.connectors.connector_v2 import ConnectorV2
+from ray.rllib.core.columns import Columns
+from ray.rllib.env.wrappers.atari_wrappers import wrap_atari_for_new_api_stack
+from ray.rllib.utils.annotations import override
+from ray.rllib.utils.test_utils import add_rllib_example_script_args
+
+
+class DecodeObservations(ConnectorV2):
+    def __init__(
+        self,
+        input_observation_space: Optional[gym.Space] = None,
+        input_action_space: Optional[gym.Space] = None,
+        *,
+        multi_agent: bool = False,
+        as_learner_connector: bool = True,
+        **kwargs,
+    ):
+        """Decodes observation from PNG to numpy array.
+
+        Note, `rl_unplugged`'s stored observations are framestacked with
+        four frames per observation. This connector returns therefore
+        decoded observations of shape `(84, 84, 4)`.
+
+        Args:
+            multi_agent: Whether this is a connector operating on a multi-agent
+                observation space mapping AgentIDs to individual agents' observations.
+            as_learner_connector: Whether this connector is part of a Learner connector
+                pipeline, as opposed to an env-to-module pipeline.
+        """
+        super().__init__(
+            input_observation_space=input_observation_space,
+            input_action_space=input_action_space,
+            **kwargs,
+        )
+
+        self._multi_agent = multi_agent
+        self._as_learner_connector = as_learner_connector
+
+    @override(ConnectorV2)
+    def __call__(
+        self,
+        *,
+        rl_module,
+        data,
+        episodes,
+        explore=None,
+        shared_data=None,
+        **kwargs,
+    ):
+
+        for sa_episode in self.single_agent_episode_iterator(
+            episodes, agents_that_stepped_only=False
+        ):
+            # Map encoded PNGs into arrays of shape (84, 84, 4).
+            def _map_fn(s):
+                return np.concatenate(
+                    [
+                        np.array(Image.open(io.BytesIO(s[i]))).reshape(84, 84, 1)
+                        for i in range(4)
+                    ],
+                    axis=2,
+                )
+
+            # Add the observations for t.
+            self.add_n_batch_items(
+                batch=data,
+                column=Columns.OBS,
+                items_to_add=tree.map_structure(
+                    _map_fn,
+                    sa_episode.get_observations(slice(0, len(sa_episode))),
+                ),
+                num_items=len(sa_episode),
+                single_agent_episode=sa_episode,
+            )
+            # Add the observations for t+1.
+            self.add_n_batch_items(
+                batch=data,
+                column=Columns.NEXT_OBS,
+                items_to_add=tree.map_structure(
+                    _map_fn,
+                    sa_episode.get_observations(slice(1, len(sa_episode) + 1)),
+                ),
+                num_items=len(sa_episode),
+                single_agent_episode=sa_episode,
+            )
+
+        return data
+
+
+# Make the learner connector.
+def _make_learner_connector(observation_space, action_space):
+    return DecodeObservations()
+
+
+# Wrap the environment used in evalaution into `RLlib`'s Atari Wrapper
+# that automatically stacks frames and converts to the dimension used
+# in the collection of the `rl_unplugged` data.
+def _env_creator(cfg):
+    return wrap_atari_for_new_api_stack(
+        gym.make("ALE/Pong-v5", **cfg),
+        # Perform frame-stacking through ConnectorV2 API.
+        framestack=4,
+        dim=84,
+    )
+
+
+# Register the wrapped environment to `tune`.
+tune.register_env("WrappedALE/Pong-v5", _env_creator)
+
+parser = add_rllib_example_script_args()
+# Use `parser` to add your own custom command line options to this script
+# and (if needed) use their values toset up `config` below.
+args = parser.parse_args()
+
+# We only use the Atari game `Pong` here. Users can choose other Atari
+# games and set here the name. This will download `TfRecords` dataset from GCS.
+game = "Pong"
+# There are many run numbers, we choose the first one for demonstration. This
+# can be chosen by users. To use all data use a list of file paths (see
+# `num_shards`) and its usage further below.
+run_number = 1
+# num_shards = 1
+
+# Make the temporary directory for the downloaded data.
+tmp_path = "/tmp/atari"
+Path(tmp_path).joinpath(game).mkdir(exist_ok=True, parents=True)
+destination_file_name = f"{tmp_path}/{game}/run_{run_number}-00000-of-00001"
+
+# If the file is not downloaded, yet, download it here.
+if not Path(destination_file_name).exists():
+    # Define the bucket and source file.
+    bucket_name = "rl_unplugged"
+    source_blob_name = f"atari/{game}/run_{run_number}-00000-of-00100"
+
+    # Download the data from the bucket.
+    storage_client = storage.Client.create_anonymous_client()
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(source_blob_name)
+    blob.download_to_filename(destination_file_name)
+
+# Define the config for Behavior Cloning.
+config = (
+    BCConfig()
+    .environment(
+        env="WrappedALE/Pong-v5",
+        clip_rewards=True,
+    )
+    # Use the new API stack that makes directly use of `ray.data`.
+    .api_stack(
+        enable_rl_module_and_learner=True,
+        enable_env_runner_and_connector_v2=True,
+    )
+    # Evaluate in the actual environment online.
+    .evaluation(
+        evaluation_interval=3,
+        evaluation_num_env_runners=1,
+        evaluation_duration=5,
+        evaluation_parallel_to_training=True,
+    )
+    .learners(
+        num_learners=0,
+    )
+    # Note, the `input_` argument is the major argument for the
+    # new offline API. Via the `input_read_method_kwargs` the
+    # arguments for the `ray.data.Dataset` read method can be
+    # configured. The read method needs at least as many blocks
+    # as remote learners.
+    .offline_data(
+        input_=destination_file_name,
+        input_read_method="read_tfrecords",
+        input_read_method_kwargs={
+            # Note, `TFRecords` datasets in `rl_unplugged` are GZIP
+            # compressed and Arrow needs to decompress them.
+            "arrow_open_stream_args": {"compression": "gzip"},
+            # Use enough reading blocks to scale well.
+            "override_num_blocks": 10,
+            "concurrency": 10,
+            # TFX improves performance extensively. `tfx-bsl` needs to be
+            # installed for this.
+            "tfx_read_options": TFXReadOptions(
+                batch_size=2000,
+            ),
+        },
+        # `rl_unplugged`'s data schema is different from the one used
+        # internally in `RLlib`. Define the schema here so it can be used
+        # when transforming column data to episodes.
+        input_read_schema={
+            Columns.EPS_ID: "episode_id",
+            Columns.OBS: "o_t",
+            Columns.ACTIONS: "a_t",
+            Columns.REWARDS: "r_t",
+            Columns.NEXT_OBS: "o_tp1",
+            Columns.TERMINATEDS: "d_t",
+        },
+        dataset_num_iters_per_learner=1,
+        # Increase the parallelism in transforming batches, such that while
+        # training, new batches are transformed while others are used in updating.
+        map_batches_kwargs={"concurrency": 10, "num_cpus": 10}
+        # # When iterating over batches in the dataset, prefetch at least 20
+        # # batches per learner. Increase this for scaling out more.
+        # iter_batches_kwargs={
+        #     "prefetch_batches": max(args.num_gpus * 10, 10),
+        #     "local_shuffle_buffer_size": None,
+        # },
+    )
+    .training(
+        # To increase learning speed with multiple learners,
+        # increase the learning rate correspondingly.
+        lr=0.0008,
+        train_batch_size_per_learner=2000,
+        # Use the defined learner connector above, to decode observations.
+        learner_connector=_make_learner_connector,
+    )
+    .rl_module(
+        model_config_dict={
+            "vf_share_layers": True,
+            "conv_filters": [[16, 4, 2], [32, 4, 2], [64, 4, 2], [128, 4, 2]],
+            "conv_activation": "relu",
+            "post_fcnet_hiddens": [256],
+            "uses_new_env_runners": True,
+        }
+    )
+)
+
+# Build RLlib's `Algorithm`` object.
+algo = config.build()
+
+# Build an `OfflinePreLearner` as used inside of `map_batches` and use it
+# outside of `map_batches` to time it.
+oplr = algo.offline_data.prelearner_class(
+    config=algo.offline_data.config,
+    learner=algo.offline_data.learner_handles[0],
+)
+
+# ------------------------------------------------------------
+# 1. Test `take_batch` directly on the data set wihtout preprocessing.
+# Expected time: ~1.6s.
+start = time.perf_counter()
+batch = algo.offline_data.data.take_batch(2000)
+stop = time.perf_counter()
+print(f"Time for `take_batch`: {stop-start} secs")
+
+# ------------------------------------------------------------
+# 2. Test RLlib's preprocessing pipeline (outside of `map_batches`) to get
+#   a direct comparison. This should be fast enough to feed the learner
+#   constantly while it updates the model.
+# Expected value: ~3.5s.
+start = time.perf_counter()
+ma_batch = oplr(batch)
+stop = time.perf_counter()
+print(f"Time for `OfflinePreLearner.__call__`: {stop-start} secs")
+
+# ------------------------------------------------------------
+# 3. Test RLlib's preprocessing pipeline INSIDE of `map_batches`.
+# Expected time: ~107s!
+start = time.perf_counter()
+ma_batch = algo.offline_data.data.map_batches(
+    algo.offline_data.prelearner_class,
+    fn_constructor_kwargs={
+        "config": algo.offline_data.config,
+        "learner": algo.offline_data.learner_handles[0],
+    },
+    batch_size=2000,
+    **algo.offline_data.map_batches_kwargs,
+).take_batch(2000)
+stop = time.perf_counter()
+print(f"Time for `take_batch` (with `map_batch`; no iterator): {stop-start} secs")
+
+# ------------------------------------------------------------
+# 4. Test RLlib's preprocessing pipeline INSIDE of `map_batches`
+#   together with `next(iter_batches)` all wrapped in RLlib's
+#   `OfflineData.sample` method.
+# Expexted value: ~145s!
+start = time.perf_counter()
+ma_batch = algo.offline_data.sample(2000)
+stop = time.perf_counter()
+print(f"Time to sample a single batch: {stop - start} secs")

--- a/test_map_batches_simple.py
+++ b/test_map_batches_simple.py
@@ -1,0 +1,81 @@
+"""Minimal example for `map_batches` to test performance.
+
+The `map_batches` as used in `RLlib`'s OFfline RL API is very slow.
+This example is one of three to test `map_batches` in different
+scenarios.
+
+This aprticular example should show how `map_batches` can be tuned
+by `override_num_blocks` and should show that more blocks should
+in general increase performance by an almost constant rate. This
+relationship gets, however, lost when turning to more real-world
+use cases.
+
+Note, `RLlib` uses `map_batches` for preprocessing data while its
+(remote/local) learner(s) is/are learning on already processed
+batches. The `MapBatches`  class should emulate this preprocessing
+by using the `time.sleep` method.
+Note further, the 3 seconds are large, normally preprocessing steps
+on batches of 2000 take RLlib around 0.02 seconds (see for this also
+the `test_offline_data.py` that tests performance on each step.)
+"""
+
+import time
+
+import numpy as np
+import pandas as pd
+
+import ray
+import ray.data
+
+
+# This class should emulate `RLlib`s `OfflinePreLearner`'s `__call__`
+# method. Note, 3 seconds is a lot, we usually need around 0.02s (for
+# a batch of 2,000).
+class MapBatches:
+    def __call__(self, batch):
+        time.sleep(3)
+
+        return batch
+
+
+# Initialize Ray
+ray.init(ignore_reinit_error=True)
+
+# Create a larger sample dataset
+np.random.seed(42)  # For reproducibility
+data = {
+    "col1": np.random.randint(1, 100, size=10000),
+    "col2": np.random.choice(["a", "b", "c", "d", "e"], size=10000),
+    "col3": np.random.random(size=10000),
+}
+
+# Convert the data dictionary to a Ray dataset.
+df = pd.DataFrame(data)
+# Define also the number of blocks.
+ds = ray.data.from_pandas(df, override_num_blocks=60)
+
+# ---------------------------------------------------
+# 1. Test `take_batch`. This should be quite fast
+# Expected value: 0.03s.
+start = time.perf_counter()
+batch = ds.take_batch(200)
+stop = time.perf_counter()
+print(f"Time for simple take_batch: {stop - start}")
+
+# ---------------------------------------------------
+# 2. Test ´map_batches` with the emulated PreLearner.
+#   This is slow.
+# Expected value: 75s!
+start = time.perf_counter()
+batch = ds.map_batches(
+    MapBatches,
+    batch_size=200,
+    concurrency=4,
+    num_gpus=0,
+    num_cpus=4,
+).take_batch(200)
+print(batch)
+stop = time.perf_counter()
+print(f"Time for map_batches: {stop - start}")
+
+ray.shutdown()

--- a/test_offline_data.py
+++ b/test_offline_data.py
@@ -1,0 +1,169 @@
+"""Script tests the performance of `map_batches` and all componets.
+
+Using `map_batches` is very slow at this moment. We use `map_batches`
+as preprocessing channel for our (remote/local) learner(s) to digest
+data before computing loss. The main idea is to make prefetching
+possible and preprocess data batches while others are used already
+in learner(s).
+
+This script tests the single steps performed before, in, and after
+`map_batches` to test where the bottleneck lies.
+
+Use `NUM_TEST_ITERATIONS`  to modify the number of iterations for
+performance timing.
+"""
+import time
+from pathlib import Path
+
+import ray
+from ray.rllib.algorithms.bc.bc import BCConfig
+from ray.rllib.offline.offline_data import OfflineData, OfflinePreLearner
+from ray.rllib.policy.sample_batch import MultiAgentBatch, SampleBatch
+
+# The number of iterations over which performance time will be averaged.
+NUM_TEST_ITERATIONS = 10
+
+# For data we use our test data for `CartPole-v1` (~16k rows).
+data_path = "tests/data/cartpole/cartpole-v1_large"
+base_path = Path(__file__).parents[0].joinpath("rllib")
+data_path = "local://" + base_path.joinpath(data_path).as_posix()
+
+# Setup the algorithm config. We need this config as c'tor arguments
+# for the `OfflinePreLearner` (the preprocessor for batches in `map_batches`).
+config = (
+    BCConfig()
+    .environment(env="CartPole-v1")
+    .api_stack(
+        enable_rl_module_and_learner=True,
+        enable_env_runner_and_connector_v2=True,
+    )
+    .learners(
+        num_learners=0,
+    )
+    .evaluation(
+        evaluation_interval=3,
+        evaluation_num_env_runners=1,
+        evaluation_duration=5,
+        evaluation_parallel_to_training=True,
+    )
+    # Note, the `input_` argument is the major argument for the
+    # new offline API.
+    .offline_data(
+        input_=[data_path],
+        dataset_num_iters_per_learner=1,
+        map_batches_kwargs={},
+        iter_batches_kwargs={},
+    )
+    .training(
+        lr=0.0008,
+        train_batch_size_per_learner=2000,
+    )
+)
+
+# --------------------------------------------------
+# 1. Test `iter_batches` without any of `RLlib`s code.
+# Expected value: ~0.04s.
+
+# Load the dataset. Note, the RLlib wrapped data logic uses
+# `override_num_blocks=2` by default, so we use it here, too.
+# To modify arguments to `read_parquet` in `RLlib` use
+# `BCConfig.offline_data.read_input_method_kwargs`.
+data = ray.data.read_parquet(data_path, override_num_blocks=2)
+
+i = 0
+start = time.perf_counter()
+# Note, we use here again `RLlib`s, default for `iter_batches`. To
+# change the arguments use `BCConfig.offline_data.iter_batches_kwargs`.
+for batch in data.iter_batches(batch_size=2000, prefetch_batches=2):
+    i += 1
+    batch = batch
+stop = time.perf_counter()
+del data
+print(f" Time for sampling directly: {(stop - start) / (i + 1)}")
+
+
+# --------------------------------------------------
+# 2. Test `iter_batches` with `RLlib`s wrapping.
+# Expected value: ~0.04s.
+
+# Setup `OfflineData` with our config. Note, this loads the dataset
+# as above into the attribute class `data`.
+offline_data = OfflineData(config)
+
+# Iterate over the dataset stored in the `OfflineData` instance.
+start = time.perf_counter()
+i = 0
+for batch in offline_data.data.iter_batches(batch_size=2000, prefetch_batches=2):
+    batch = batch
+    i += 1
+stop = time.perf_counter()
+print(f"Time to iterate a batch: {(stop - start)/i} secs")
+print(f"Batch size: {batch['obs'].shape}")
+
+# --------------------------------------------------
+# 3. Test the first part of the `OfflinePreLearner`, namely mapping to
+#   RLlib's `SingleAgentEpisode`s. The `OfflinePreLearner` is used in
+#   `map_batches`.
+# Expected value: ~0.007s.
+start = time.perf_counter()
+for i in range(NUM_TEST_ITERATIONS):
+    episodes = OfflinePreLearner._map_to_episodes(False, batch)["episodes"]
+stop = time.perf_counter()
+print(f"Time converting to episodes: {(stop - start) / NUM_TEST_ITERATIONS} secs")
+
+
+# --------------------------------------------------
+# 4. Test the second and third part of the `OfflinePreLearner`, namely,
+#   running the learner connectors and converting to `RLlib`'s
+#   `MultiAgentBatch`.
+# Expected value: ~0.005s.
+algo = config.build()
+learner = algo.learner_group._learner
+
+start = time.perf_counter()
+for i in range(NUM_TEST_ITERATIONS):
+    batch = learner._learner_connector(
+        rl_module=learner._module,
+        data={},
+        episodes=episodes,
+        shared_data={},
+    )
+
+    batch = MultiAgentBatch(
+        {
+            module_id: SampleBatch(module_data)
+            for module_id, module_data in batch.items()
+        },
+        # TODO (simon): This can be run once for the batch and the
+        # metrics, but we run it twice: here and later in the learner.
+        env_steps=sum(e.env_steps() for e in episodes),
+    )
+stop = time.perf_counter()
+print(
+    "Time for running the learner connectors and converting to "
+    f"MA-batch: {(stop - start) / NUM_TEST_ITERATIONS} secs"
+)
+
+# --------------------------------------------------
+# 5. Run the complete `map_batches` as used in `RLlib`s preprocessing.
+#   Note, we use here the default arguments used in `RLlib`'s
+#   `OfflineData.sample` method (here with a single local learner, i.e.
+#   `num_shards < 1`). To change the default arguments to `map_batches`
+#   in `RLlib` use `BCConfig.offline_data.map_batches_kwargs`.
+# Expected value: 4.5s
+start = time.perf_counter()
+for i, batch in enumerate(
+    algo.offline_data.data.map_batches(
+        OfflinePreLearner,
+        fn_constructor_kwargs={
+            "config": config,
+            "learner": learner,
+        },
+        concurrency=2,
+        batch_size=2000,
+    ).iter_batches(batch_size=2000, prefetch_batches=2)
+):
+    batch = batch["batch"]
+stop = time.perf_counter()
+print(f"Batch: {batch}")
+print(f"Time to pull batches and map them: {(stop - start)/ (i + 1)} secs")

--- a/test_offline_data.py
+++ b/test_offline_data.py
@@ -22,11 +22,16 @@ from ray.rllib.policy.sample_batch import MultiAgentBatch, SampleBatch
 
 # The number of iterations over which performance time will be averaged.
 NUM_TEST_ITERATIONS = 10
+SCALE_FACTOR = 1
 
 # For data we use our test data for `CartPole-v1` (~16k rows).
 data_path = "tests/data/cartpole/cartpole-v1_large"
 base_path = Path(__file__).parents[0].joinpath("rllib")
 data_path = "local://" + base_path.joinpath(data_path).as_posix()
+# Multiply this list by a scale factor to scale the data amount.
+data_paths = [
+    p.as_posix() for p in Path(data_path.split(":")[1]).iterdir()
+] * SCALE_FACTOR
 
 # Setup the algorithm config. We need this config as c'tor arguments
 # for the `OfflinePreLearner` (the preprocessor for batches in `map_batches`).
@@ -49,7 +54,7 @@ config = (
     # Note, the `input_` argument is the major argument for the
     # new offline API.
     .offline_data(
-        input_=[data_path],
+        input_=data_paths,
         dataset_num_iters_per_learner=1,
         map_batches_kwargs={},
         iter_batches_kwargs={},
@@ -68,7 +73,7 @@ config = (
 # `override_num_blocks=2` by default, so we use it here, too.
 # To modify arguments to `read_parquet` in `RLlib` use
 # `BCConfig.offline_data.read_input_method_kwargs`.
-data = ray.data.read_parquet(data_path, override_num_blocks=2)
+data = ray.data.read_parquet(data_paths, override_num_blocks=2)
 
 i = 0
 start = time.perf_counter()


### PR DESCRIPTION
## Why are these changes needed?

This PR is for test purposes and shows that `map_batches` in `ray.data.Dataset` is very slow. It contains three examples:

1. `test_map_batches_simple.py`: Contains simple code (without RLlib's code) that emulates the RLlib use case and shows that (a) `map_batches` is very slow and (b) can be tuned to a certain degree with `override_num_blocks`, `concurrency` and `num_cpus`, but does not become very fast.
2. `test_offline_data.py`: Contains code that compares the single steps in RLlib's preprocessing pipeline in performance and shows that the pipeline outside of `map_batches` is quite fast, but within `map_batches` slows down. This example uses typical RL data, but in a small amount (~16k rows).
3. `rllib/tuned_examples/benchmark_atari_pong_bc.py`: Contains code for a real-world offline RL use case (namely RLUnplugged for Atari Pong). It downloads one file of the huge dataset available (one file is around750MB) and loads the data via `ray.data.read_tfrecords`. It uses the code from RLlib to preprocess the data and shows that a "single" iteration takes around 170 seconds! of time. For customers this use case should work fast.
4. `test_benchmark_atari_pong_bc_components.py`: Contains code for the real world offline RL example in `rllib/tuned_examples/benchmark_atari_pong_bc.py`, but divides the pipeline into its components and tests these components separately. This example shows that the summed up time for each step is by multiples less than its time consumed inside of `map_batches`. 

Requirements for running the last file(s):
`tfx-bsl`
`"gymnasium[atari,accept-rom-license]"`

Several arguments to `ray.data.Dataset.map_batches`, `ray.data. read_parquet/tfrecords` and `iter_bacthes` do improve performance, but at least in real-world cases not to a degree to which a customer would be satisfied. It needs some deeper investigation that can only be done by the `ray.data` team.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
