### PR TITLE
[data] Fixed pyarrow error when the writer receives empty table

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -59,9 +59,9 @@ class ParquetDatasink(_FileDatasink):
     ) -> Any:
         import pyarrow.parquet as pq
 
-        blocks = list(blocks)
+        blocks = list(block for block in blocks if BlockAccessor.for_block(block).num_rows() > 0)
 
-        if all(BlockAccessor.for_block(block).num_rows() == 0 for block in blocks):
+        if len(blocks) == 0:
             return "skip"
 
         filename = self.filename_provider.get_filename_for_block(

--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -59,7 +59,7 @@ class ParquetDatasink(_FileDatasink):
     ) -> Any:
         import pyarrow.parquet as pq
 
-        blocks = list(block for block in blocks if BlockAccessor.for_block(block).num_rows() > 0)
+        blocks = [b for b in blocks if BlockAccessor.for_block(b).num_rows() > 0]
 
         if len(blocks) == 0:
             return "skip"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When processing datasets with `Dataset.filter()`, `Dataset.map()` and then `Dataset.write_parquet()`, the parquet writer frequently receives empty tables in which a schema cannot be analyzed. The process crashes with the following error:

```log
Traceback (most recent call last):
  File [...]
    dataset.write_parquet("[...]", num_rows_per_file=100)
  File "/[...]/site-packages/ray/data/dataset.py", line 2774, in write_parquet
    self.write_datasink(
  File "/[...]/site-packages/ray/data/dataset.py", line 3608, in write_datasink
    self._write_ds = Dataset(plan, logical_plan).materialize()
  File "/[...]/site-packages/ray/data/dataset.py", line 4596, in materialize
    copy._plan.execute()
  File "/[...]/site-packages/ray/data/exceptions.py", line 89, in handle_trace
    raise e.with_traceback(None) from SystemException()
ray.exceptions.RayTaskError(ValueError): ray::Write() (pid=299740, ip=[...])
    for b_out in map_transformer.apply_transform(iter(blocks), ctx):
  File "/[...]/site-packages/ray/data/_internal/execution/operators/map_transformer.py", line 253, in __call__
    yield from self._block_fn(input, ctx)
  File "/[...]/site-packages/ray/data/_internal/planner/plan_write_op.py", line 26, in fn
    write_result = datasink_or_legacy_datasource.write(blocks, ctx)
  File "/[...]/site-packages/ray/data/_internal/datasource/parquet_datasink.py", line 86, in write
    call_with_retry(
  File "/[...]/site-packages/ray/data/_internal/util.py", line 986, in call_with_retry
    raise e from None
  File "/[...]/site-packages/ray/data/_internal/util.py", line 973, in call_with_retry
    return f()
  File "/[...]/site-packages/ray/data/_internal/datasource/parquet_datasink.py", line 83, in write_blocks_to_path
    writer.write_table(table)
  File "/[...]/site-packages/pyarrow/parquet/core.py", line 1114, in write_table
    raise ValueError(msg)
ValueError: Table schema does not match schema used to create file: 
table:
 vs. 
file:
[...]: extension<ray.data.arrow_tensor<ArrowTensorType>>
[...]: extension<ray.data.arrow_tensor<ArrowTensorType>>
label_0: double
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [x] This PR is not tested :(
