### PR TITLE
[ci] fix tester on empty test targets

### DIFF
--- a/ci/ray_ci/test_tester.py
+++ b/ci/ray_ci/test_tester.py
@@ -79,6 +79,37 @@ def test_get_container() -> None:
         assert isinstance(container, WindowsTesterContainer)
 
 
+def test_get_empty_test_targets() -> None:
+    with mock.patch(
+        "subprocess.check_output",
+        return_value="\n".encode("utf-8"),
+    ), mock.patch(
+        "ci.ray_ci.linux_tester_container.LinuxTesterContainer.install_ray",
+        return_value=None,
+    ), mock.patch(
+        "ray_release.test.Test.gen_from_s3",
+        return_value=set(),
+    ), mock.patch(
+        "ci.ray_ci.tester._get_new_tests",
+        return_value=set(),
+    ), mock.patch(
+        "ray_release.test.Test.gen_microcheck_tests",
+        return_value=set(),
+    ):
+        # Test that the set of test target is empty, rather than a set of empty string
+        assert (
+            set(
+                _get_test_targets(
+                    LinuxTesterContainer("core"),
+                    "targets",
+                    "core",
+                    operating_system="linux",
+                )
+            )
+            == set()
+        )
+
+
 def test_get_test_targets() -> None:
     _TEST_YAML = "flaky_tests: [//python/ray/tests:flaky_test_01]"
 

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -369,15 +369,17 @@ def _get_test_targets(
     Get test targets that are owned by a particular team
     """
     query = _get_all_test_query(targets, team, except_tags, only_tags)
-    test_targets = set(
-        container.run_script_with_output(
+    test_targets = {
+        target
+        for target in container.run_script_with_output(
             [
                 f'bazel query "{query}"',
             ]
         )
         .strip()
         .split(os.linesep)
-    )
+        if target
+    }
     flaky_tests = set(_get_flaky_test_targets(team, operating_system, yaml_dir))
 
     if get_flaky_tests:


### PR DESCRIPTION
Fix a bug in tester that return a set of empty string as the list of test targets, rather than an empty set, when the `bazel query` returns no targets to run.

This issue is observed here https://buildkite.com/ray-project/premerge/builds/28682#01917ac4-65db-4b40-8d3a-fe5d745df0fe when recent test targets become empty

Test:
- CI