### PR TITLE
Add perf metrics for 2.35.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 459.20256,
+    "_dashboard_memory_usage_mb": 485.167104,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.76,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3447\t1.74GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5206\t0.93GiB\tpython distributed/test_many_actors.py\n3564\t0.37GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2845\t0.32GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1249\t0.23GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3737\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n2771\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3884\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n4986\t0.07GiB\tray::JobSupervisor\n3735\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
-    "actors_per_second": 627.338335492887,
+    "_peak_memory": 3.74,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1215\t8.81GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n6550\t1.74GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n7868\t0.92GiB\tpython distributed/test_many_actors.py\n2138\t0.36GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n6668\t0.35GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n6842\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n2403\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n6844\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n7668\t0.07GiB\tray::JobSupervisor\n6868\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
+    "actors_per_second": 603.6854672610009,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 627.338335492887
+            "perf_metric_value": 603.6854672610009
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 178.601
+            "perf_metric_value": 104.211
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3542.989
+            "perf_metric_value": 3768.817
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3933.547
+            "perf_metric_value": 3786.709
         }
     ],
     "success": "1",
-    "time": 15.940361738204956
+    "time": 16.56491756439209
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 193.712128,
+    "_dashboard_memory_usage_mb": 201.936896,
     "_dashboard_test_success": true,
-    "_peak_memory": 1.65,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3461\t0.54GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1255\t0.25GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2918\t0.23GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3578\t0.18GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4426\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n4642\t0.08GiB\tray::StateAPIGeneratorActor.start\n2822\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4216\t0.07GiB\tray::JobSupervisor\n3750\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3748\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "_peak_memory": 1.71,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3523\t0.54GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1766\t0.24GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1244\t0.23GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3639\t0.19GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n5664\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3806\t0.1GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n5894\t0.08GiB\tray::StateAPIGeneratorActor.start\n2742\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3808\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n5469\t0.07GiB\tray::JobSupervisor",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 342.8427005545737
+            "perf_metric_value": 348.36498762040105
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.87
+            "perf_metric_value": 4.917
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 34.039
+            "perf_metric_value": 70.687
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 119.573
+            "perf_metric_value": 131.198
         }
     ],
     "success": "1",
-    "tasks_per_second": 342.8427005545737,
-    "time": 302.91678953170776,
+    "tasks_per_second": 348.36498762040105,
+    "time": 302.87055253982544,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 120.446976,
+    "_dashboard_memory_usage_mb": 127.606784,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.12,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3438\t0.92GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5718\t0.4GiB\tpython distributed/test_many_pgs.py\n2536\t0.35GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1206\t0.24GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3560\t0.12GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2784\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3734\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n5507\t0.07GiB\tray::JobSupervisor\n3877\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3732\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "_peak_memory": 2.17,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1219\t7.63GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3423\t0.89GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4478\t0.41GiB\tpython distributed/test_many_pgs.py\n2007\t0.34GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3539\t0.11GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n3704\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n3706\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n2349\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4272\t0.07GiB\tray::JobSupervisor\n3731\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22.249430148995714
+            "perf_metric_value": 22.037557767422825
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.722
+            "perf_metric_value": 3.347
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.055
+            "perf_metric_value": 12.126
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 358.789
+            "perf_metric_value": 376.468
         }
     ],
-    "pgs_per_second": 22.249430148995714,
+    "pgs_per_second": 22.037557767422825,
     "success": "1",
-    "time": 44.944971323013306
+    "time": 45.377079010009766
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 1263.501312,
+    "_dashboard_memory_usage_mb": 1249.652736,
     "_dashboard_test_success": true,
-    "_peak_memory": 5.45,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3382\t3.09GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3499\t0.83GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4186\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1117\t0.24GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2858\t0.22GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4397\t0.08GiB\tray::DashboardTester.run\n4472\t0.08GiB\tray::StateAPIGeneratorActor.start\n2725\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3674\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3984\t0.07GiB\tray::JobSupervisor",
+    "_peak_memory": 5.1,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3389\t1.95GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3505\t1.58GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4343\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1881\t0.23GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1182\t0.23GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3669\t0.1GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n4547\t0.09GiB\tray::DashboardTester.run\n4621\t0.08GiB\tray::StateAPIGeneratorActor.start\n2239\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3671\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 557.3705625276606
+            "perf_metric_value": 565.2052803056663
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 167.38
+            "perf_metric_value": 170.294
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3170.14
+            "perf_metric_value": 2826.475
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5042.844
+            "perf_metric_value": 4064.973
         }
     ],
     "success": "1",
-    "tasks_per_second": 557.3705625276606,
-    "time": 317.94138526916504,
+    "tasks_per_second": 565.2052803056663,
+    "time": 317.69268679618835,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.34.0"}
+{"release_version": "2.35.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        9060.701663275304,
-        118.69740715773278
+        9012.880467992636,
+        274.39770203115614
     ],
     "1_1_actor_calls_concurrent": [
-        5167.9800954515,
-        141.99267026522367
+        5041.760637338739,
+        138.0380603219453
     ],
     "1_1_actor_calls_sync": [
-        2055.7051275912527,
-        54.594914220148404
+        1986.177233156469,
+        7.353089580388177
     ],
     "1_1_async_actor_calls_async": [
-        4456.606860484332,
-        300.0483750432424
+        4261.050694056448,
+        102.67641073560478
     ],
     "1_1_async_actor_calls_sync": [
-        1486.2327104183764,
-        35.32117622112775
+        1483.4703793760418,
+        24.55014969155573
     ],
     "1_1_async_actor_calls_with_args_async": [
-        3038.941703794114,
-        225.62938703844412
+        2836.601104413851,
+        163.9138928707045
     ],
     "1_n_actor_calls_async": [
-        8786.234839177117,
-        155.79705585932524
+        8803.178389859915,
+        248.2713616898665
     ],
     "1_n_async_actor_calls_async": [
-        7804.984752431155,
-        207.2088124010455
+        7855.576353730168,
+        104.38819846802097
     ],
     "client__1_1_actor_calls_async": [
-        963.1902909183787,
-        7.024139165271597
+        1019.3028285821217,
+        6.754799952397459
     ],
     "client__1_1_actor_calls_concurrent": [
-        947.6614978210325,
-        6.215662216629677
+        1007.6444648899972,
+        8.361807119609024
     ],
     "client__1_1_actor_calls_sync": [
-        519.725991336052,
-        5.524396654486067
+        523.3469473257671,
+        1.559621936382034
     ],
     "client__get_calls": [
-        1119.7725751916082,
-        22.31873036313672
+        966.9141307622872,
+        9.258603442950216
     ],
     "client__put_calls": [
-        801.476709529905,
-        24.90986781791733
+        806.1974515278531,
+        25.89751552055511
     ],
     "client__put_gigabytes": [
-        0.13929452807454937,
-        0.0004893965578803182
+        0.13947664668408546,
+        0.0005617088893114759
     ],
     "client__tasks_and_get_batch": [
-        0.911263457119588,
-        0.009582733256630546
+        0.9561497312686904,
+        0.009734603566212642
     ],
     "client__tasks_and_put_batch": [
-        11004.98249042869,
-        406.99702282940336
+        11214.270141950088,
+        263.0139775234698
     ],
     "multi_client_put_calls_Plasma_Store": [
-        12455.514706383783,
-        82.98752196297701
+        12536.270544865174,
+        188.62193594404053
     ],
     "multi_client_put_gigabytes": [
-        38.4735559860673,
-        1.895531621126946
+        45.440179854469804,
+        3.803265665952826
     ],
     "multi_client_tasks_async": [
-        23311.858831941317,
-        2350.5613878864333
+        21353.682091539627,
+        791.9484727327964
     ],
     "n_n_actor_calls_async": [
-        26545.931713712664,
-        526.4393166387501
+        26370.461840482538,
+        947.6739378691185
     ],
     "n_n_actor_calls_with_arg_async": [
-        2699.08314274893,
-        34.72492860665786
+        2748.863962184806,
+        67.15817575976418
     ],
     "n_n_async_actor_calls_async": [
-        22710.046003881216,
-        682.7591872434975
+        22929.738827936668,
+        1048.7531922006851
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10303.517743023112
+            "perf_metric_value": 10507.047272805994
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5241.163782117501
+            "perf_metric_value": 5273.203424794718
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12455.514706383783
+            "perf_metric_value": 12536.270544865174
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 20.184014305625574
+            "perf_metric_value": 18.32083810818594
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7.900197666889211
+            "perf_metric_value": 8.199516693089809
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 38.4735559860673
+            "perf_metric_value": 45.440179854469804
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13.679337230724197
+            "perf_metric_value": 13.204885454613315
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.485273551888224
+            "perf_metric_value": 5.39514490847805
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 986.5998779605792
+            "perf_metric_value": 973.959307673384
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8011.455682416454
+            "perf_metric_value": 7988.9069673790045
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23311.858831941317
+            "perf_metric_value": 21353.682091539627
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2055.7051275912527
+            "perf_metric_value": 1986.177233156469
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 9060.701663275304
+            "perf_metric_value": 9012.880467992636
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5167.9800954515
+            "perf_metric_value": 5041.760637338739
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8786.234839177117
+            "perf_metric_value": 8803.178389859915
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 26545.931713712664
+            "perf_metric_value": 26370.461840482538
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2699.08314274893
+            "perf_metric_value": 2748.863962184806
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1486.2327104183764
+            "perf_metric_value": 1483.4703793760418
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4456.606860484332
+            "perf_metric_value": 4261.050694056448
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3038.941703794114
+            "perf_metric_value": 2836.601104413851
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7804.984752431155
+            "perf_metric_value": 7855.576353730168
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22710.046003881216
+            "perf_metric_value": 22929.738827936668
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 824.4108502776797
+            "perf_metric_value": 805.1759941825478
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1119.7725751916082
+            "perf_metric_value": 966.9141307622872
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 801.476709529905
+            "perf_metric_value": 806.1974515278531
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.13929452807454937
+            "perf_metric_value": 0.13947664668408546
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 11004.98249042869
+            "perf_metric_value": 11214.270141950088
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 519.725991336052
+            "perf_metric_value": 523.3469473257671
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 963.1902909183787
+            "perf_metric_value": 1019.3028285821217
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 947.6614978210325
+            "perf_metric_value": 1007.6444648899972
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.911263457119588
+            "perf_metric_value": 0.9561497312686904
         }
     ],
     "placement_group_create/removal": [
-        824.4108502776797,
-        17.72810428024577
+        805.1759941825478,
+        7.473230546683027
     ],
     "single_client_get_calls_Plasma_Store": [
-        10303.517743023112,
-        277.61596662520196
+        10507.047272805994,
+        112.53291460675577
     ],
     "single_client_get_object_containing_10k_refs": [
-        13.679337230724197,
-        0.3123070691705992
+        13.204885454613315,
+        0.16663510238318005
     ],
     "single_client_put_calls_Plasma_Store": [
-        5241.163782117501,
-        47.53421003771766
+        5273.203424794718,
+        80.97664679249488
     ],
     "single_client_put_gigabytes": [
-        20.184014305625574,
-        5.646629723807168
+        18.32083810818594,
+        6.037453503779728
     ],
     "single_client_tasks_and_get_batch": [
-        7.900197666889211,
-        0.39150208385232466
+        8.199516693089809,
+        0.5202534269218758
     ],
     "single_client_tasks_async": [
-        8011.455682416454,
-        468.6887008054221
+        7988.9069673790045,
+        476.6476161596187
     ],
     "single_client_tasks_sync": [
-        986.5998779605792,
-        16.522476248712984
+        973.959307673384,
+        18.795951797682633
     ],
     "single_client_wait_1k_refs": [
-        5.485273551888224,
-        0.07839577116526375
+        5.39514490847805,
+        0.15952866665582002
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 18.28579454300001,
+    "broadcast_time": 18.961532712000007,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 18.28579454300001
+            "perf_metric_value": 18.961532712000007
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 18.382605733000005,
-    "get_time": 23.411743029999997,
+    "args_time": 17.328640389999997,
+    "get_time": 23.896780481999997,
     "large_object_size": 107374182400,
-    "large_object_time": 32.98956875599998,
+    "large_object_time": 32.70541331600003,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 18.382605733000005
+            "perf_metric_value": 17.328640389999997
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.741477676000002
+            "perf_metric_value": 5.680022101000006
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.411743029999997
+            "perf_metric_value": 23.896780481999997
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 186.319367591
+            "perf_metric_value": 189.12986922100004
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 32.98956875599998
+            "perf_metric_value": 32.70541331600003
         }
     ],
-    "queued_time": 186.319367591,
-    "returns_time": 5.741477676000002,
+    "queued_time": 189.12986922100004,
+    "returns_time": 5.680022101000006,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.0309033346176149,
-    "max_iteration_time": 3.268310546875,
-    "min_iteration_time": 0.07307100296020508,
+    "avg_iteration_time": 0.9740754842758179,
+    "max_iteration_time": 2.2291815280914307,
+    "min_iteration_time": 0.36443448066711426,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.0309033346176149
+            "perf_metric_value": 0.9740754842758179
         }
     ],
     "success": 1,
-    "total_time": 103.0905613899231
+    "total_time": 97.40779948234558
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 8.773437261581421
+            "perf_metric_value": 11.421970844268799
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.938837790489195
+            "perf_metric_value": 26.23279986381531
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 61.69442081451416
+            "perf_metric_value": 63.694758081436156
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2.573246955871582
+            "perf_metric_value": 2.0420665740966797
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3035.906775712967
+            "perf_metric_value": 3321.615835428238
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.5129273527822178
+            "perf_metric_value": 0.45063567085147194
         }
     ],
-    "stage_0_time": 8.773437261581421,
-    "stage_1_avg_iteration_time": 23.938837790489195,
-    "stage_1_max_iteration_time": 24.63253116607666,
-    "stage_1_min_iteration_time": 23.625248670578003,
-    "stage_1_time": 239.38846349716187,
-    "stage_2_avg_iteration_time": 61.69442081451416,
-    "stage_2_max_iteration_time": 62.908058643341064,
-    "stage_2_min_iteration_time": 59.646355867385864,
-    "stage_2_time": 308.4730384349823,
-    "stage_3_creation_time": 2.573246955871582,
-    "stage_3_time": 3035.906775712967,
-    "stage_4_spread": 0.5129273527822178,
+    "stage_0_time": 11.421970844268799,
+    "stage_1_avg_iteration_time": 26.23279986381531,
+    "stage_1_max_iteration_time": 27.9172306060791,
+    "stage_1_min_iteration_time": 24.92852473258972,
+    "stage_1_time": 262.3281092643738,
+    "stage_2_avg_iteration_time": 63.694758081436156,
+    "stage_2_max_iteration_time": 64.70488262176514,
+    "stage_2_min_iteration_time": 62.95923352241516,
+    "stage_2_time": 318.4745900630951,
+    "stage_3_creation_time": 2.0420665740966797,
+    "stage_3_time": 3321.615835428238,
+    "stage_4_spread": 0.45063567085147194,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 0.9371462897900398,
-    "avg_pg_remove_time_ms": 0.9081441951950084,
+    "avg_pg_create_time_ms": 0.9705077387385862,
+    "avg_pg_remove_time_ms": 0.9207600330309926,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9371462897900398
+            "perf_metric_value": 0.9705077387385862
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9081441951950084
+            "perf_metric_value": 0.9207600330309926
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 13.65%: client__get_calls (THROUGHPUT) regresses from 1119.7725751916082 to 966.9141307622872 in microbenchmark.json
REGRESSION 9.23%: single_client_put_gigabytes (THROUGHPUT) regresses from 20.184014305625574 to 18.32083810818594 in microbenchmark.json
REGRESSION 8.40%: multi_client_tasks_async (THROUGHPUT) regresses from 23311.858831941317 to 21353.682091539627 in microbenchmark.json
REGRESSION 6.66%: 1_1_async_actor_calls_with_args_async (THROUGHPUT) regresses from 3038.941703794114 to 2836.601104413851 in microbenchmark.json
REGRESSION 4.39%: 1_1_async_actor_calls_async (THROUGHPUT) regresses from 4456.606860484332 to 4261.050694056448 in microbenchmark.json
REGRESSION 3.77%: actors_per_second (THROUGHPUT) regresses from 627.338335492887 to 603.6854672610009 in benchmarks/many_actors.json
REGRESSION 3.47%: single_client_get_object_containing_10k_refs (THROUGHPUT) regresses from 13.679337230724197 to 13.204885454613315 in microbenchmark.json
REGRESSION 3.38%: 1_1_actor_calls_sync (THROUGHPUT) regresses from 2055.7051275912527 to 1986.177233156469 in microbenchmark.json
REGRESSION 2.44%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 5167.9800954515 to 5041.760637338739 in microbenchmark.json
REGRESSION 2.33%: placement_group_create/removal (THROUGHPUT) regresses from 824.4108502776797 to 805.1759941825478 in microbenchmark.json
REGRESSION 1.64%: single_client_wait_1k_refs (THROUGHPUT) regresses from 5.485273551888224 to 5.39514490847805 in microbenchmark.json
REGRESSION 1.28%: single_client_tasks_sync (THROUGHPUT) regresses from 986.5998779605792 to 973.959307673384 in microbenchmark.json
REGRESSION 0.95%: pgs_per_second (THROUGHPUT) regresses from 22.249430148995714 to 22.037557767422825 in benchmarks/many_pgs.json
REGRESSION 0.66%: n_n_actor_calls_async (THROUGHPUT) regresses from 26545.931713712664 to 26370.461840482538 in microbenchmark.json
REGRESSION 0.53%: 1_1_actor_calls_async (THROUGHPUT) regresses from 9060.701663275304 to 9012.880467992636 in microbenchmark.json
REGRESSION 0.28%: single_client_tasks_async (THROUGHPUT) regresses from 8011.455682416454 to 7988.9069673790045 in microbenchmark.json
REGRESSION 0.19%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1486.2327104183764 to 1483.4703793760418 in microbenchmark.json
REGRESSION 107.66%: dashboard_p95_latency_ms (LATENCY) regresses from 34.039 to 70.687 in benchmarks/many_nodes.json
REGRESSION 30.19%: stage_0_time (LATENCY) regresses from 8.773437261581421 to 11.421970844268799 in stress_tests/stress_test_many_tasks.json
REGRESSION 27.05%: dashboard_p50_latency_ms (LATENCY) regresses from 3.87 to 4.917 in benchmarks/many_nodes.json
REGRESSION 9.72%: dashboard_p99_latency_ms (LATENCY) regresses from 119.573 to 131.198 in benchmarks/many_nodes.json
REGRESSION 9.58%: stage_1_avg_iteration_time (LATENCY) regresses from 23.938837790489195 to 26.23279986381531 in stress_tests/stress_test_many_tasks.json
REGRESSION 9.41%: stage_3_time (LATENCY) regresses from 3035.906775712967 to 3321.615835428238 in stress_tests/stress_test_many_tasks.json
REGRESSION 6.37%: dashboard_p95_latency_ms (LATENCY) regresses from 3542.989 to 3768.817 in benchmarks/many_actors.json
REGRESSION 4.93%: dashboard_p99_latency_ms (LATENCY) regresses from 358.789 to 376.468 in benchmarks/many_pgs.json
REGRESSION 3.70%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 18.28579454300001 to 18.961532712000007 in scalability/object_store.json
REGRESSION 3.56%: avg_pg_create_time_ms (LATENCY) regresses from 0.9371462897900398 to 0.9705077387385862 in stress_tests/stress_test_placement_group.json
REGRESSION 3.24%: stage_2_avg_iteration_time (LATENCY) regresses from 61.69442081451416 to 63.694758081436156 in stress_tests/stress_test_many_tasks.json
REGRESSION 2.07%: 10000_get_time (LATENCY) regresses from 23.411743029999997 to 23.896780481999997 in scalability/single_node.json
REGRESSION 1.74%: dashboard_p50_latency_ms (LATENCY) regresses from 167.38 to 170.294 in benchmarks/many_tasks.json
REGRESSION 1.51%: 1000000_queued_time (LATENCY) regresses from 186.319367591 to 189.12986922100004 in scalability/single_node.json
REGRESSION 1.39%: avg_pg_remove_time_ms (LATENCY) regresses from 0.9081441951950084 to 0.9207600330309926 in stress_tests/stress_test_placement_group.json
REGRESSION 0.59%: dashboard_p95_latency_ms (LATENCY) regresses from 12.055 to 12.126 in benchmarks/many_pgs.json
```