### PR TITLE
[train] update TORCH_NCCL_ASYNC_ERROR_HANDLING env var

### DIFF
--- a/python/ray/train/torch/config.py
+++ b/python/ray/train/torch/config.py
@@ -105,7 +105,7 @@ def _setup_torch_process_group(
             and TORCH_NCCL_BLOCKING_WAIT_ENV_VAR not in os.environ
         ):
             logger.debug(
-                f"Setting {TORCH_NCCL_ASYNC_ERROR_HANDLING_ENV_VAR} to fail if NCCL collective communication operations are timing out. "  # noqa: E501
+                f"Setting {TORCH_NCCL_ASYNC_ERROR_HANDLING_ENV_VAR}=1 to fail if NCCL collective communication operations are timing out. "  # noqa: E501
                 f"To override this behavior, you can set {TORCH_NCCL_ASYNC_ERROR_HANDLING_ENV_VAR}=0."  # noqa: E501
             )
             os.environ[TORCH_NCCL_ASYNC_ERROR_HANDLING_ENV_VAR] = "1"

--- a/python/ray/train/torch/config.py
+++ b/python/ray/train/torch/config.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 import torch
 import torch.distributed as dist
+from packaging.version import Version
 
 import ray
 from ray._private.accelerators.hpu import HPU_PACKAGE_AVAILABLE
@@ -90,21 +91,24 @@ def _setup_torch_process_group(
         )
     logger.debug(f"using {backend}")
 
-    # See the `timeout` arg in https://pytorch.org/docs/master/
-    # distributed.html#torch.distributed.init_process_group for description of
-    # NCCL_ASYNC_ERROR_HANDLING. We do not use NCCL_BLOCKING_WAIT due to performance
-    # overhead.
-    if (
-        backend == "nccl"
-        and "NCCL_ASYNC_ERROR_HANDLING" not in os.environ
-        and "NCCL_BLOCKING_WAIT" not in os.environ
-    ):
-        logger.debug(
-            "Setting NCCL_ASYNC_ERROR_HANDLING to fail if NCCL collective "
-            "communication operations are timing out. "
-            "To override this behavior, you can set NCCL_ASYNC_ERROR_HANDLING=0."
-        )
-        os.environ["NCCL_ASYNC_ERROR_HANDLING"] = "1"
+    if backend == "nccl":
+        # See https://github.com/pytorch/pytorch/blob/c263bd43e8e8502d4726643bc6fd046f0130ac0e/torch/distributed/distributed_c10d.py#L803-L823 # noqa: E501
+        # We do not use TORCH_NCCL_BLOCKING_WAIT due to performance overhead.
+        if Version(torch.__version__) < Version("2.2.0"):
+            TORCH_NCCL_ASYNC_ERROR_HANDLING_ENV_VAR = "NCCL_ASYNC_ERROR_HANDLING"
+            TORCH_NCCL_BLOCKING_WAIT_ENV_VAR = "NCCL_BLOCKING_WAIT"
+        else:
+            TORCH_NCCL_ASYNC_ERROR_HANDLING_ENV_VAR = "TORCH_NCCL_ASYNC_ERROR_HANDLING"
+            TORCH_NCCL_BLOCKING_WAIT_ENV_VAR = "TORCH_NCCL_BLOCKING_WAIT"
+        if (
+            TORCH_NCCL_ASYNC_ERROR_HANDLING_ENV_VAR not in os.environ
+            and TORCH_NCCL_BLOCKING_WAIT_ENV_VAR not in os.environ
+        ):
+            logger.debug(
+                f"Setting {TORCH_NCCL_ASYNC_ERROR_HANDLING_ENV_VAR} to fail if NCCL collective communication operations are timing out. "  # noqa: E501
+                f"To override this behavior, you can set {TORCH_NCCL_ASYNC_ERROR_HANDLING_ENV_VAR}=0."  # noqa: E501
+            )
+            os.environ[TORCH_NCCL_ASYNC_ERROR_HANDLING_ENV_VAR] = "1"
     elif backend == "hccl" and HPU_PACKAGE_AVAILABLE:
         import habana_frameworks.torch.core as htcore  # noqa: F401
         import habana_frameworks.torch.distributed.hccl as hpu_dist  # noqa: F401

--- a/python/ray/train/torch/xla/config.py
+++ b/python/ray/train/torch/xla/config.py
@@ -62,7 +62,6 @@ def _set_xla_env_vars():
     os.environ["FI_EFA_FORK_SAFE"] = "1"
     os.environ["XLA_TRANSFER_SEED_ASYNC"] = "1"
     os.environ["NCCL_ASYNC_ERROR_HANDLING"] = "1"
-    os.environ["NCCL_ASYNC_ERROR_HANDLING"] = "1"
 
 
 def _setup_xla_torch_process_group():

--- a/python/ray/train/torch/xla/config.py
+++ b/python/ray/train/torch/xla/config.py
@@ -62,6 +62,7 @@ def _set_xla_env_vars():
     os.environ["FI_EFA_FORK_SAFE"] = "1"
     os.environ["XLA_TRANSFER_SEED_ASYNC"] = "1"
     os.environ["NCCL_ASYNC_ERROR_HANDLING"] = "1"
+    os.environ["NCCL_ASYNC_ERROR_HANDLING"] = "1"
 
 
 def _setup_xla_torch_process_group():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Fixes this warning:

```
(RayTrainWorker pid=2273, ip=172.24.21.66) [rank7]:[W Utils.hpp:108] Warning: Environment variable NCCL_ASYNC_ERROR_HANDLING is deprecated; use TORCH_NCCL_ASYNC_ERROR_HANDLING instead (function getCvarString)
```

This environment variable was changed in `torch 2.2.0`: https://github.com/pytorch/pytorch/commit/8f8722e3f1d1121345b80428117be89209ccd772.

More details about this environment variable can be found here: https://github.com/pytorch/pytorch/blob/dc8bb2636c5412c68e72dc6e33a6589683d8fd12/docs/source/torch_nccl_environment_variables.rst.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/47286

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
