### PR TITLE
[doc] Updated Comments in `Helm Chart RBAC` for Consistency

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides/helm-chart-rbac.md
+++ b/doc/source/cluster/kubernetes/user-guides/helm-chart-rbac.md
@@ -121,7 +121,7 @@ helm install raycluster kuberay/ray-cluster --version 1.0.0
 helm install raycluster kuberay/ray-cluster --version 1.0.0 -n n1
 helm install raycluster kuberay/ray-cluster --version 1.0.0 -n n2
 
-# KubeRay only creates a RayCluster in `default`.
+# KubeRay only creates a RayCluster in the `default` namespace.
 kubectl get raycluster -A
 # NAMESPACE   NAME                 DESIRED WORKERS   AVAILABLE WORKERS   STATUS   AGE
 # default     raycluster-kuberay   1                 1                   ready    54s
@@ -177,7 +177,7 @@ helm install raycluster kuberay/ray-cluster --version 1.0.0
 helm install raycluster kuberay/ray-cluster --version 1.0.0 -n n1
 helm install raycluster kuberay/ray-cluster --version 1.0.0 -n n2
 
-# KubeRay creates a RayCluster only in n1 and n2.
+# KubeRay creates a RayCluster only in the `n1` and `n2` namespaces.
 kubectl get raycluster -A
 # NAMESPACE   NAME                 DESIRED WORKERS   AVAILABLE WORKERS   STATUS   AGE
 # default     raycluster-kuberay                                                  74s


### PR DESCRIPTION
## Why are these changes needed?
In the `Helm Chart RBAC` document, each case includes the comment
``` 
# Install RayCluster in the 'default', 'n1', and 'n2' namespaces.
```
However, in Case 3, the comment reads 
```
# KubeRay creates a RayCluster only in n1 and n2.
```
The overall format could be more consistent.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
