### PR TITLE
[RLlib; docs] Remove "new API stack experimental" hint from docs.

### DIFF
--- a/doc/source/_includes/rllib/new_api_stack_component.rst
+++ b/doc/source/_includes/rllib/new_api_stack_component.rst
@@ -1,3 +1,0 @@
-.. note::
-
-    This doc is related to RLlib's `new API stack </rllib/package_ref/rllib-new-api-stack.html>`__ and therefore experimental.

--- a/doc/source/rllib/package_ref/catalogs.rst
+++ b/doc/source/rllib/package_ref/catalogs.rst
@@ -3,8 +3,6 @@
 
 .. include:: /_includes/rllib/new_api_stack.rst
 
-.. include:: /_includes/rllib/new_api_stack_component.rst
-
 
 .. _catalog-reference-docs:
 

--- a/doc/source/rllib/package_ref/env/single_agent_episode.rst
+++ b/doc/source/rllib/package_ref/env/single_agent_episode.rst
@@ -3,8 +3,6 @@
 
 .. include:: /_includes/rllib/new_api_stack.rst
 
-.. include:: /_includes/rllib/new_api_stack_component.rst
-
 .. _single-agent-episode-reference-docs:
 
 SingleAgentEpisode API

--- a/doc/source/rllib/package_ref/learner.rst
+++ b/doc/source/rllib/package_ref/learner.rst
@@ -3,8 +3,6 @@
 
 .. include:: /_includes/rllib/new_api_stack.rst
 
-.. include:: /_includes/rllib/new_api_stack_component.rst
-
 .. _learner-reference-docs:
 
 

--- a/doc/source/rllib/package_ref/rl_modules.rst
+++ b/doc/source/rllib/package_ref/rl_modules.rst
@@ -3,8 +3,6 @@
 
 .. include:: /_includes/rllib/new_api_stack.rst
 
-.. include:: /_includes/rllib/new_api_stack_component.rst
-
 .. _rlmodule-reference-docs:
 
 RLModule API

--- a/doc/source/rllib/rllib-catalogs.rst
+++ b/doc/source/rllib/rllib-catalogs.rst
@@ -2,8 +2,6 @@
 
 .. include:: /_includes/rllib/new_api_stack.rst
 
-.. include:: /_includes/rllib/new_api_stack_component.rst
-
 
 Catalog (Alpha)
 ===============

--- a/doc/source/rllib/rllib-learner.rst
+++ b/doc/source/rllib/rllib-learner.rst
@@ -2,8 +2,6 @@
 
 .. include:: /_includes/rllib/new_api_stack.rst
 
-.. include:: /_includes/rllib/new_api_stack_component.rst
-
 .. |tensorflow| image:: images/tensorflow.png
     :class: inline-figure
     :width: 16

--- a/doc/source/rllib/rllib-rlmodule.rst
+++ b/doc/source/rllib/rllib-rlmodule.rst
@@ -2,8 +2,6 @@
 
 .. include:: /_includes/rllib/new_api_stack.rst
 
-.. include:: /_includes/rllib/new_api_stack_component.rst
-
 .. |tensorflow| image:: images/tensorflow.png
     :class: inline-figure
     :width: 16

--- a/doc/source/rllib/single-agent-episode.rst
+++ b/doc/source/rllib/single-agent-episode.rst
@@ -2,8 +2,6 @@
 
 .. include:: /_includes/rllib/new_api_stack.rst
 
-.. include:: /_includes/rllib/new_api_stack_component.rst
-
 
 .. _single-agent-episode-docs:
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Remove "new API stack experimental" hint from docs.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
