### PR TITLE
[Fix][Dashboard] Fix Place Group Table table cells overflow

### DIFF
--- a/python/ray/dashboard/client/src/common/RowStyles.tsx
+++ b/python/ray/dashboard/client/src/common/RowStyles.tsx
@@ -1,9 +1,7 @@
 const rowStyles = {
   idCol: {
     display: "block",
-    width: "50px",
-    overflow: "hidden",
-    textOverflow: "ellipsis",
+    width: "100%",
     whiteSpace: "nowrap",
   },
   OverflowCol: {

--- a/python/ray/dashboard/client/src/common/RowStyles.tsx
+++ b/python/ray/dashboard/client/src/common/RowStyles.tsx
@@ -4,13 +4,6 @@ const rowStyles = {
     width: "100%",
     whiteSpace: "nowrap",
   },
-  OverflowCol: {
-    display: "block",
-    width: "100px",
-    overflow: "hidden",
-    textOverflow: "ellipsis",
-    whiteSpace: "nowrap",
-  },
 };
 
 export default rowStyles;

--- a/python/ray/dashboard/client/src/components/ActorTable.tsx
+++ b/python/ray/dashboard/client/src/components/ActorTable.tsx
@@ -35,6 +35,7 @@ import { ActorDetail, ActorEnum } from "../type/actor";
 import { Worker } from "../type/worker";
 import { memoryConverter } from "../util/converter";
 import { useFilter, useSorter } from "../util/hook";
+import OverflowCollapsibleCell from "./OverflowCollapsibleCell";
 import PercentageBar from "./PercentageBar";
 import { SearchSelect } from "./SearchComponent";
 import StateCounter from "./StatesCounter";
@@ -711,17 +712,16 @@ const ActorTable = ({
                       )}
                       arrow
                     >
-                      <Box sx={rowStyles.OverflowCol}>
-                        {Object.entries(requiredResources || {})
+                      <OverflowCollapsibleCell
+                        text={Object.entries(requiredResources || {})
                           .map(([key, val]) => `${key}: ${val}`)
                           .join(", ")}
-                      </Box>
+                        wordBreak="break-all"
+                      />
                     </Tooltip>
                   </TableCell>
                   <TableCell align="center">
-                    <Tooltip title={exitDetail} arrow>
-                      <Box sx={rowStyles.OverflowCol}>{exitDetail}</Box>
-                    </Tooltip>
+                    <OverflowCollapsibleCell text={exitDetail} />
                   </TableCell>
                 </ExpandableTableRow>
               ),

--- a/python/ray/dashboard/client/src/components/OverflowCollapsibleCell.tsx
+++ b/python/ray/dashboard/client/src/components/OverflowCollapsibleCell.tsx
@@ -1,0 +1,64 @@
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
+import React, { useEffect, useRef, useState } from "react";
+
+export type OverflowCollapsibleCellProps = {
+  text: string;
+  maxWidth?: number;
+  wordBreak?: "break-all" | "break-word";
+};
+
+const OverflowCollapsibleCell = ({
+  text,
+  maxWidth = 100,
+  wordBreak = "break-word",
+}: OverflowCollapsibleCellProps) => {
+  const [open, setOpen] = useState(false);
+  const [isOverflow, setIsOverflow] = useState(false);
+  const textRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (textRef.current) {
+      setIsOverflow(textRef.current.scrollWidth > textRef.current.clientWidth);
+    }
+  }, [text]);
+
+  return (
+    <Tooltip title={text} arrow>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <Box
+          ref={textRef}
+          sx={{
+            overflow: open ? "auto" : "hidden",
+            width: `${maxWidth}px`,
+            textOverflow: open ? "clip" : "ellipsis",
+            whiteSpace: open ? "normal" : "nowrap",
+            wordBreak,
+          }}
+        >
+          {text}
+        </Box>
+        <IconButton
+          aria-label="expand row"
+          size="small"
+          onClick={() => setOpen(!open)}
+          sx={{ display: isOverflow ? "block" : "none" }}
+        >
+          {open ? <KeyboardArrowDownIcon /> : <KeyboardArrowRightIcon />}
+        </IconButton>
+      </Box>
+    </Tooltip>
+  );
+};
+
+export default OverflowCollapsibleCell;

--- a/python/ray/dashboard/client/src/components/PlacementGroupTable.tsx
+++ b/python/ray/dashboard/client/src/components/PlacementGroupTable.tsx
@@ -12,6 +12,10 @@ import {
   Theme,
   Tooltip,
 } from "@mui/material";
+import Accordion from "@mui/material/Accordion";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import Autocomplete from "@mui/material/Autocomplete";
 import Pagination from "@mui/material/Pagination";
 import React, { useState } from "react";
@@ -24,19 +28,30 @@ import { StatusChip } from "./StatusChip";
 
 const BundleResourceRequirements = ({
   bundles,
-  sx,
 }: {
   bundles: Bundle[];
   sx?: SxProps<Theme>;
 }) => {
+  const resources = bundles.map(({ unit_resources }) => unit_resources);
+  if (resources.length === 0) {
+    return <>-</>;
+  }
+  if (resources.length === 1) {
+    return <>{JSON.stringify(resources[0])}</>;
+  }
   return (
-    <Box sx={sx}>
-      {bundles.map(({ unit_resources }, index) => {
-        return `{${Object.entries(unit_resources || {})
-          .map(([key, val]) => `${key}: ${val}`)
-          .join(", ")}}, `;
-      })}
-    </Box>
+    <Accordion>
+      <AccordionSummary expandIcon={<ArrowDropDownIcon />}>
+        Expand to see all
+      </AccordionSummary>
+      <AccordionDetails>
+        <ul>
+          {resources.map((resource, index) => {
+            return <li key={index}>{JSON.stringify(resource)}</li>;
+          })}
+        </ul>
+      </AccordionDetails>
+    </Accordion>
   );
 };
 
@@ -180,21 +195,7 @@ const PlacementGroupTable = ({
                     <StatusChip type="placementGroup" status={state} />
                   </TableCell>
                   <TableCell align="center">
-                    <Tooltip
-                      title={<BundleResourceRequirements bundles={bundles} />}
-                      arrow
-                    >
-                      <BundleResourceRequirements
-                        sx={{
-                          display: "block",
-                          width: "100px",
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                          whiteSpace: "nowrap",
-                        }}
-                        bundles={bundles}
-                      />
-                    </Tooltip>
+                    <BundleResourceRequirements bundles={bundles} />
                   </TableCell>
                   <TableCell align="center">
                     {stats ? stats.scheduling_state : "-"}

--- a/python/ray/dashboard/client/src/components/PlacementGroupTable.tsx
+++ b/python/ray/dashboard/client/src/components/PlacementGroupTable.tsx
@@ -1,4 +1,3 @@
-import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import {
   Box,
   InputAdornment,
@@ -13,9 +12,6 @@ import {
   Theme,
   Tooltip,
 } from "@mui/material";
-import Accordion from "@mui/material/Accordion";
-import AccordionDetails from "@mui/material/AccordionDetails";
-import AccordionSummary from "@mui/material/AccordionSummary";
 import Autocomplete from "@mui/material/Autocomplete";
 import Pagination from "@mui/material/Pagination";
 import React, { useState } from "react";
@@ -23,6 +19,7 @@ import rowStyles from "../common/RowStyles";
 import { sliceToPage } from "../common/util";
 import { Bundle, PlacementGroup } from "../type/placementGroup";
 import { useFilter } from "../util/hook";
+import OverflowCollapsibleCell from "./OverflowCollapsibleCell";
 import StateCounter from "./StatesCounter";
 import { StatusChip } from "./StatusChip";
 
@@ -33,26 +30,12 @@ const BundleResourceRequirements = ({
   sx?: SxProps<Theme>;
 }) => {
   const resources = bundles.map(({ unit_resources }) => unit_resources);
-  if (resources.length === 0) {
-    return <React.Fragment>-</React.Fragment>;
-  }
-  if (resources.length === 1) {
-    return <React.Fragment>{JSON.stringify(resources[0])}</React.Fragment>;
-  }
-  return (
-    <Accordion>
-      <AccordionSummary expandIcon={<ArrowDropDownIcon />}>
-        Expand to see all
-      </AccordionSummary>
-      <AccordionDetails>
-        <ul>
-          {resources.map((resource, index) => {
-            return <li key={index}>{JSON.stringify(resource)}</li>;
-          })}
-        </ul>
-      </AccordionDetails>
-    </Accordion>
-  );
+  const resourceString =
+    resources.length === 0
+      ? "-"
+      : resources.map((resource) => JSON.stringify(resource)).join(", ");
+
+  return <OverflowCollapsibleCell text={resourceString} maxWidth={300} />;
 };
 
 const PlacementGroupTable = ({

--- a/python/ray/dashboard/client/src/components/PlacementGroupTable.tsx
+++ b/python/ray/dashboard/client/src/components/PlacementGroupTable.tsx
@@ -1,3 +1,4 @@
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import {
   Box,
   InputAdornment,
@@ -15,7 +16,6 @@ import {
 import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import AccordionSummary from "@mui/material/AccordionSummary";
-import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import Autocomplete from "@mui/material/Autocomplete";
 import Pagination from "@mui/material/Pagination";
 import React, { useState } from "react";
@@ -34,10 +34,10 @@ const BundleResourceRequirements = ({
 }) => {
   const resources = bundles.map(({ unit_resources }) => unit_resources);
   if (resources.length === 0) {
-    return <>-</>;
+    return <React.Fragment>-</React.Fragment>;
   }
   if (resources.length === 1) {
-    return <>{JSON.stringify(resources[0])}</>;
+    return <React.Fragment>{JSON.stringify(resources[0])}</React.Fragment>;
   }
   return (
     <Accordion>


### PR DESCRIPTION
## Why are these changes needed?

See the description in the corresponding issue for details.

In this PR, the ID will never be cut, and the bundles will display differently according to the array length.

Before:

![image](https://github.com/user-attachments/assets/0dcb3f4c-01f3-4e0c-ab1c-01f0e43d1101)

After:

- length is 0 (show `-`)

![image](https://github.com/user-attachments/assets/4fc3b8f0-8b9d-4a38-b49f-ef2215ae6ad0)

- length is 1 (show directly)

![image](https://github.com/user-attachments/assets/860b1ed6-ae7c-4bca-9a36-c05fe8092ef6)

- length >= 2 (click to expand)

![image](https://github.com/user-attachments/assets/d5ebb1af-e658-4688-90f6-beef38c9e1a1)
![image](https://github.com/user-attachments/assets/8d210572-76c8-448a-9df4-a761b3d66adf)

## Related issue number

Closes: ray-project/ray#47315

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
