### PR TITLE
[Dashboard] Each worker should have only have coreWorkerStats

### DIFF
--- a/python/ray/dashboard/datacenter.py
+++ b/python/ray/dashboard/datacenter.py
@@ -29,8 +29,6 @@ class DataSource:
     nodes = Dict()
     # {node id hex(str): ip address(str)}
     node_id_to_ip = Dict()
-    # {node id hex(str): hostname(str)}
-    node_id_to_hostname = Dict()
     # {node id hex(str): worker list}
     node_workers = Dict()
     # {node id hex(str): {actor id hex(str): actor table data}}
@@ -53,7 +51,6 @@ class DataOrganizer:
         #   * agents
         #   * nodes
         #   * node_id_to_ip
-        #   * node_id_to_hostname
         alive_nodes = {
             node_id
             for node_id, node_info in DataSource.nodes.items()

--- a/python/ray/dashboard/datacenter.py
+++ b/python/ray/dashboard/datacenter.py
@@ -163,13 +163,6 @@ class DataOrganizer:
         ]
 
     @classmethod
-    async def get_all_node_details(cls):
-        return [
-            await DataOrganizer.get_node_info(node_id)
-            for node_id in DataSource.nodes.keys()
-        ]
-
-    @classmethod
     async def get_agent_infos(
         cls, target_node_ids: Optional[List[str]] = None
     ) -> Dict[str, Dict[str, Any]]:

--- a/python/ray/dashboard/datacenter.py
+++ b/python/ray/dashboard/datacenter.py
@@ -74,7 +74,8 @@ class DataOrganizer:
         for node_id in list(DataSource.nodes.keys()):
             workers = await cls.get_node_workers(node_id)
             for worker in workers:
-                for stats in worker.get("coreWorkerStats", []):
+                stats = worker.get("coreWorkerStats", {})
+                if stats:
                     worker_id = stats["workerId"]
                     core_worker_stats[worker_id] = stats
             node_workers[node_id] = workers
@@ -94,14 +95,14 @@ class DataOrganizer:
         for core_worker_stats in node_stats.get("coreWorkersStats", []):
             pid = core_worker_stats["pid"]
             pids_on_node.add(pid)
-            pid_to_worker_stats.setdefault(pid, []).append(core_worker_stats)
+            pid_to_worker_stats[pid] = core_worker_stats
             pid_to_language[pid] = core_worker_stats["language"]
             pid_to_job_id[pid] = core_worker_stats["jobId"]
 
         for worker in node_physical_stats.get("workers", []):
             worker = dict(worker)
             pid = worker["pid"]
-            worker["coreWorkerStats"] = pid_to_worker_stats.get(pid, [])
+            worker["coreWorkerStats"] = pid_to_worker_stats.get(pid, {})
             worker["language"] = pid_to_language.get(
                 pid, dashboard_consts.DEFAULT_LANGUAGE
             )

--- a/python/ray/dashboard/modules/node/node_head.py
+++ b/python/ray/dashboard/modules/node/node_head.py
@@ -199,11 +199,9 @@ class NodeHead(dashboard_utils.DashboardHeadModule):
                 alive_node_ids = []
                 alive_node_infos = []
                 node_id_to_ip = {}
-                node_id_to_hostname = {}
                 for node in nodes.values():
                     node_id = node["nodeId"]
                     ip = node["nodeManagerAddress"]
-                    hostname = node["nodeManagerHostname"]
                     if node["isHeadNode"] and not self._head_node_registration_time_s:
                         self._head_node_registration_time_s = (
                             time.time() - self._module_start_time
@@ -219,7 +217,6 @@ class NodeHead(dashboard_utils.DashboardHeadModule):
                             timeout=GCS_RPC_TIMEOUT_SECONDS,
                         )
                     node_id_to_ip[node_id] = ip
-                    node_id_to_hostname[node_id] = hostname
                     assert node["state"] in ["ALIVE", "DEAD"]
                     if node["state"] == "ALIVE":
                         alive_node_ids.append(node_id)
@@ -245,7 +242,6 @@ class NodeHead(dashboard_utils.DashboardHeadModule):
                     agents.pop(node_id, None)
 
                 DataSource.node_id_to_ip.reset(node_id_to_ip)
-                DataSource.node_id_to_hostname.reset(node_id_to_hostname)
                 DataSource.agents.reset(agents)
                 DataSource.nodes.reset(nodes)
             except Exception:

--- a/python/ray/dashboard/modules/node/tests/test_node.py
+++ b/python/ray/dashboard/modules/node/tests/test_node.py
@@ -45,8 +45,6 @@ def test_nodes_update(enable_test_module, ray_start_with_dashboard):
             assert len(dump_data["nodes"]) == 1
             assert len(dump_data["agents"]) == 1
             assert len(dump_data["nodeIdToIp"]) == 1
-            assert len(dump_data["nodeIdToHostname"]) == 1
-            assert dump_data["nodes"].keys() == dump_data["nodeIdToHostname"].keys()
 
             response = requests.get(webui_url + "/test/notified_agents")
             response.raise_for_status()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Value of `pid_to_worker_stats` shouldn't be a list of coreWorkerStats as each pid corresponds to only one core worker
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
