### PR TITLE
[core] remove unused node_id_to_ip.

### DIFF
--- a/python/ray/dashboard/datacenter.py
+++ b/python/ray/dashboard/datacenter.py
@@ -27,8 +27,6 @@ class DataSource:
     agents = Dict()
     # {node id hex(str): gcs node info(dict of GcsNodeInfo in gcs.proto)}
     nodes = Dict()
-    # {node id hex(str): ip address(str)}
-    node_id_to_ip = Dict()
     # {node id hex(str): hostname(str)}
     node_id_to_hostname = Dict()
     # {node id hex(str): worker list}
@@ -52,7 +50,6 @@ class DataOrganizer:
         # we do not needs to purge them:
         #   * agents
         #   * nodes
-        #   * node_id_to_ip
         #   * node_id_to_hostname
         alive_nodes = {
             node_id
@@ -193,7 +190,7 @@ class DataOrganizer:
 
         def _create_agent_info(node_id: str):
             (http_port, grpc_port) = DataSource.agents[node_id]
-            node_ip = DataSource.node_id_to_ip[node_id]
+            node_ip = DataSource.nodes[node_id]["nodeManagerAddress"]
 
             return dict(
                 ipAddress=node_ip,

--- a/python/ray/dashboard/modules/job/tests/test_http_job_server.py
+++ b/python/ray/dashboard/modules/job/tests/test_http_job_server.py
@@ -743,7 +743,7 @@ async def test_job_head_pick_random_job_agent(monkeypatch):
                 self._agents = dict()
 
         DataSource.agents = {}
-        DataSource.node_id_to_ip = {}
+        DataSource.nodes = {}
         job_head = MockJobHead()
 
         def add_agent(agent):
@@ -751,12 +751,12 @@ async def test_job_head_pick_random_job_agent(monkeypatch):
             node_ip = agent[1]["ipAddress"]
             http_port = agent[1]["httpPort"]
             grpc_port = agent[1]["grpcPort"]
-            DataSource.node_id_to_ip[node_id] = node_ip
+            DataSource.nodes[node_id] = {"NodeManagerAddress": node_ip}
             DataSource.agents[node_id] = (http_port, grpc_port)
 
         def del_agent(agent):
             node_id = agent[0]
-            DataSource.node_id_to_ip.pop(node_id)
+            DataSource.nodes.pop(node_id)
             DataSource.agents.pop(node_id)
 
         head_node_id = "node1"

--- a/python/ray/dashboard/modules/job/tests/test_http_job_server.py
+++ b/python/ray/dashboard/modules/job/tests/test_http_job_server.py
@@ -751,7 +751,7 @@ async def test_job_head_pick_random_job_agent(monkeypatch):
             node_ip = agent[1]["ipAddress"]
             http_port = agent[1]["httpPort"]
             grpc_port = agent[1]["grpcPort"]
-            DataSource.nodes[node_id] = {"NodeManagerAddress": node_ip}
+            DataSource.nodes[node_id] = {"nodeManagerAddress": node_ip}
             DataSource.agents[node_id] = (http_port, grpc_port)
 
         def del_agent(agent):

--- a/python/ray/dashboard/modules/node/node_head.py
+++ b/python/ray/dashboard/modules/node/node_head.py
@@ -198,11 +198,9 @@ class NodeHead(dashboard_utils.DashboardHeadModule):
 
                 alive_node_ids = []
                 alive_node_infos = []
-                node_id_to_ip = {}
                 node_id_to_hostname = {}
                 for node in nodes.values():
                     node_id = node["nodeId"]
-                    ip = node["nodeManagerAddress"]
                     hostname = node["nodeManagerHostname"]
                     if node["isHeadNode"] and not self._head_node_registration_time_s:
                         self._head_node_registration_time_s = (
@@ -218,7 +216,6 @@ class NodeHead(dashboard_utils.DashboardHeadModule):
                             namespace=ray_constants.KV_NAMESPACE_JOB,
                             timeout=GCS_RPC_TIMEOUT_SECONDS,
                         )
-                    node_id_to_ip[node_id] = ip
                     node_id_to_hostname[node_id] = hostname
                     assert node["state"] in ["ALIVE", "DEAD"]
                     if node["state"] == "ALIVE":
@@ -244,7 +241,6 @@ class NodeHead(dashboard_utils.DashboardHeadModule):
                 for node_id in agents.keys() - set(alive_node_ids):
                     agents.pop(node_id, None)
 
-                DataSource.node_id_to_ip.reset(node_id_to_ip)
                 DataSource.node_id_to_hostname.reset(node_id_to_hostname)
                 DataSource.agents.reset(agents)
                 DataSource.nodes.reset(nodes)

--- a/python/ray/dashboard/modules/node/tests/test_node.py
+++ b/python/ray/dashboard/modules/node/tests/test_node.py
@@ -44,7 +44,6 @@ def test_nodes_update(enable_test_module, ray_start_with_dashboard):
             dump_data = dump_info["data"]
             assert len(dump_data["nodes"]) == 1
             assert len(dump_data["agents"]) == 1
-            assert len(dump_data["nodeIdToIp"]) == 1
             assert len(dump_data["nodeIdToHostname"]) == 1
             assert dump_data["nodes"].keys() == dump_data["nodeIdToHostname"].keys()
 

--- a/python/ray/dashboard/modules/reporter/reporter_head.py
+++ b/python/ray/dashboard/modules/reporter/reporter_head.py
@@ -66,11 +66,11 @@ class ReportHead(dashboard_utils.DashboardHeadModule):
     async def _update_stubs(self, change):
         if change.old:
             node_id, port = change.old
-            ip = DataSource.node_id_to_ip[node_id]
+            ip = DataSource.nodes[node_id]["nodeManagerAddress"]
             self._stubs.pop(ip)
         if change.new:
             node_id, ports = change.new
-            ip = DataSource.node_id_to_ip[node_id]
+            ip = DataSource.nodes[node_id]["nodeManagerAddress"]
             options = GLOBAL_GRPC_OPTIONS
             channel = init_grpc_channel(
                 f"{ip}:{ports[1]}", options=options, asynchronous=True
@@ -248,7 +248,7 @@ class ReportHead(dashboard_utils.DashboardHeadModule):
         attempt_number = req.query.get("attempt_number")
         node_id = req.query.get("node_id")
 
-        ip = DataSource.node_id_to_ip[node_id]
+        ip = DataSource.nodes[node_id]["nodeManagerAddress"]
 
         reporter_stub = self._stubs[ip]
 
@@ -340,7 +340,7 @@ class ReportHead(dashboard_utils.DashboardHeadModule):
         attempt_number = req.query.get("attempt_number")
         node_id = req.query.get("node_id")
 
-        ip = DataSource.node_id_to_ip[node_id]
+        ip = DataSource.nodes[node_id]["nodeManagerAddress"]
 
         duration_s = int(req.query.get("duration", 5))
         if duration_s > 60:
@@ -514,7 +514,7 @@ class ReportHead(dashboard_utils.DashboardHeadModule):
             task_id = req.query.get("task_id")
             attempt_number = req.query.get("attempt_number")
             node_id = req.query.get("node_id")
-            ip = DataSource.node_id_to_ip[node_id]
+            ip = DataSource.nodes[node_id]["nodeManagerAddress"]
             try:
                 (pid, _) = await self.get_worker_details_for_running_task(
                     task_id, attempt_number

--- a/python/ray/dashboard/modules/state/state_head.py
+++ b/python/ray/dashboard/modules/state/state_head.py
@@ -263,7 +263,7 @@ class StateHead(dashboard_utils.DashboardHeadModule, RateLimitedModule):
         if change.new:
             # When a new node information is written to DataSource.
             node_id, ports = change.new
-            ip = DataSource.node_id_to_ip[node_id]
+            ip = DataSource.nodes[node_id]["nodeManagerAddress"]
             self._state_api_data_source_client.register_agent_client(
                 node_id,
                 ip,

--- a/python/ray/util/state/state_manager.py
+++ b/python/ray/util/state/state_manager.py
@@ -159,7 +159,7 @@ class StateDataSourceClient:
         self._runtime_env_agent_addresses = {}  # {node_id -> url}
         self._log_agent_stub = {}
         self._job_client = JobInfoStorageClient(gcs_aio_client)
-        self._id_id_map = IdToIpMap()
+        self._id_ip_map = IdToIpMap()
         self._gcs_aio_client = gcs_aio_client
         self._client_session = aiohttp.ClientSession()
 
@@ -200,12 +200,12 @@ class StateDataSourceClient:
         self._runtime_env_agent_addresses[
             node_id
         ] = f"http://{address}:{runtime_env_agent_port}"
-        self._id_id_map.put(node_id, address)
+        self._id_ip_map.put(node_id, address)
 
     def unregister_raylet_client(self, node_id: str):
         self._raylet_stubs.pop(node_id)
         self._runtime_env_agent_addresses.pop(node_id)
-        self._id_id_map.pop(node_id)
+        self._id_ip_map.pop(node_id)
 
     def register_agent_client(self, node_id, address: str, port: int):
         options = _STATE_MANAGER_GRPC_OPTIONS
@@ -213,11 +213,11 @@ class StateDataSourceClient:
             f"{address}:{port}", options=options, asynchronous=True
         )
         self._log_agent_stub[node_id] = LogServiceStub(channel)
-        self._id_id_map.put(node_id, address)
+        self._id_ip_map.put(node_id, address)
 
     def unregister_agent_client(self, node_id: str):
         self._log_agent_stub.pop(node_id)
-        self._id_id_map.pop(node_id)
+        self._id_ip_map.pop(node_id)
 
     def get_all_registered_raylet_ids(self) -> List[str]:
         return self._raylet_stubs.keys()
@@ -243,7 +243,7 @@ class StateDataSourceClient:
         """
         if not ip:
             return None
-        return self._id_id_map.get_node_id(ip)
+        return self._id_ip_map.get_node_id(ip)
 
     @handle_grpc_network_errors
     async def get_all_actor_info(


### PR DESCRIPTION
This info is always present in `DataSource.nodes` so we don't need a separate map.