### PR TITLE
[Serve] fix grpc performance issue

### DIFF
--- a/release/serve_tests/workloads/microbenchmarks.py
+++ b/release/serve_tests/workloads/microbenchmarks.py
@@ -180,15 +180,18 @@ async def _main(
             serve.run(GrpcDeployment.bind())
             channel = grpc.insecure_channel("localhost:9000")
             stub = serve_pb2_grpc.RayServeBenchmarkServiceStub(channel)
+            grpc_payload_noop = serve_pb2.StringData(data="")
+            grpc_payload_1mb = serve_pb2.StringData(data=payload_1mb)
+            grpc_payload_10mb = serve_pb2.StringData(data=payload_10mb)
             # Microbenchmark: GRPC noop latencies
             latencies: pd.Series = await run_latency_benchmark(
-                lambda: stub.call_with_string(serve_pb2.StringData(data="")),
+                lambda: stub.call_with_string(grpc_payload_noop),
                 num_requests=NUM_REQUESTS,
             )
             perf_metrics.extend(convert_latencies_to_perf_metrics("grpc", latencies))
             # Microbenchmark: GRPC 1MB latencies
             latencies: pd.Series = await run_latency_benchmark(
-                lambda: stub.call_with_string(serve_pb2.StringData(data=payload_1mb)),
+                lambda: stub.call_with_string(grpc_payload_1mb),
                 num_requests=NUM_REQUESTS,
             )
             perf_metrics.extend(
@@ -196,7 +199,7 @@ async def _main(
             )
             # Microbenchmark: GRPC 10MB latencies
             latencies: pd.Series = await run_latency_benchmark(
-                lambda: stub.call_with_string(serve_pb2.StringData(data=payload_10mb)),
+                lambda: stub.call_with_string(grpc_payload_10mb),
                 num_requests=NUM_REQUESTS,
             )
             perf_metrics.extend(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR fixes part of the problem by creating the payload message once and reusing it throughout the benchmark.

Ran the release test on this change [build](https://buildkite.com/ray-project/release/builds/21663#01918fe1-853b-46f2-9699-c4045b182b8c) now seeing the `grpc_10mb_p50_latency` now dropped to ~58ms from ~80ms previously.  

The rest of the issue came from the existing gRPC server implementation requires to wait on the entirety of the unary request before it's able to continue it's work on replica. We will need to create a new HTTP2 proxy and pass the request transparently between the replica and the proxy to speed thing up. Will follow up in the future on https://github.com/ray-project/ray/issues/47370

## Related issue number

Closes https://github.com/ray-project/ray/issues/47371

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
