### PR TITLE
[RLlib] Add `torch.compile` config options to old API stack.

### DIFF
--- a/rllib/policy/torch_policy_v2.py
+++ b/rllib/policy/torch_policy_v2.py
@@ -532,13 +532,14 @@ class TorchPolicyV2(Policy):
             ):
                 raise ValueError("`torch.compile` is not supported for torch < 2.0.0!")
 
+            lw = "learner" if self.config.get("worker_index") else "worker"
             model = torch.compile(
                 model,
                 backend=self.config.get(
-                    "torch_compile_learner_dynamo_backend", "inductor"
+                    f"torch_compile_{lw}_dynamo_backend", "inductor"
                 ),
                 dynamic=False,
-                mode=self.config.get("torch_compile_learner_dynamo_mode"),
+                mode=self.config.get(f"torch_compile_{lw}_dynamo_mode"),
             )
         return model, dist_class
 

--- a/rllib/policy/torch_policy_v2.py
+++ b/rllib/policy/torch_policy_v2.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Type, U
 
 import gymnasium as gym
 import numpy as np
+from packaging import version
 import tree  # pip install dm_tree
 
 import ray
@@ -41,7 +42,10 @@ from ray.rllib.utils.metrics.learner_info import LEARNER_STATS_KEY
 from ray.rllib.utils.numpy import convert_to_numpy
 from ray.rllib.utils.spaces.space_utils import normalize_action
 from ray.rllib.utils.threading import with_lock
-from ray.rllib.utils.torch_utils import convert_to_torch_tensor
+from ray.rllib.utils.torch_utils import (
+    convert_to_torch_tensor,
+    TORCH_COMPILE_REQUIRED_VERSION,
+)
 from ray.rllib.utils.typing import (
     AlgorithmConfigDict,
     GradInfoDict,
@@ -520,6 +524,22 @@ class TorchPolicyV2(Policy):
                 framework=self.framework,
             )
 
+        # Compile the model, if requested by the user.
+        if self.config.get("torch_compile_learner"):
+            if (
+                torch is not None
+                and version.parse(torch.__version__) < TORCH_COMPILE_REQUIRED_VERSION
+            ):
+                raise ValueError("`torch.compile` is not supported for torch < 2.0.0!")
+
+            model = torch.compile(
+                model,
+                backend=self.config.get(
+                    "torch_compile_learner_dynamo_backend", "inductor"
+                ),
+                dynamic=False,
+                mode=self.config.get("torch_compile_learner_dynamo_mode"),
+            )
         return model, dist_class
 
     @override(Policy)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Add `torch.compile` config options to old API stack.

Users should use the same config properties as for the new API stack's Learner:
```
# For the learning Policy (on the local RolloutWorker):
config.framework(
    torch_compile_learner=True,
    torch_compile_learner_dynamo_backend="aot_eager|inductor|...",
    torch_compile_learner_dynamo_mode=[None|"reduce-overhead|max-autograd|always-optimize"],
)

# For the remote RolloutWorker policies (used for inference):
config.framework(
    torch_compile_worker=True,
    torch_compile_worker_dynamo_backend="aot_eager|inductor|...",
    torch_compile_worker_dynamo_mode=[None|"reduce-overhead|max-autograd|always-optimize"],
)
```



This will trigger

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
