### PR TITLE
[core][dashboard] Expose GetAllNodeInfo filters to Python.

### DIFF
--- a/python/ray/dashboard/modules/node/node_head.py
+++ b/python/ray/dashboard/modules/node/node_head.py
@@ -4,7 +4,7 @@ import logging
 import os
 import time
 from itertools import chain
-from typing import Dict, Literal
+from typing import Dict, Literal, Optional, Union
 
 import aiohttp.web
 import grpc
@@ -110,11 +110,11 @@ class GetAllNodeInfoFromNewGcsClient:
 
     async def __call__(
         self,
-        filter_node_id: NodeID,
-        filter_state: Literal["ALIVE"] | Literal["DEAD"] | None,
-        filter_node_name: str | None,
-        limit,
-        timeout,
+        filter_node_id: Optional[NodeID],
+        filter_state: Union[Literal["ALIVE"], Literal["DEAD"], None],
+        filter_node_name: Optional[str],
+        limit: Optional[int],
+        timeout: Optional[float],
     ) -> Dict[NodeID, gcs_pb2.GcsNodeInfo]:
         return await self.gcs_aio_client.get_all_node_info(
             filter_node_id, filter_state, filter_node_name, limit, timeout
@@ -130,11 +130,11 @@ class GetAllNodeInfoFromGrpc:
 
     async def __call__(
         self,
-        filter_node_id: NodeID,
-        filter_state: Literal["ALIVE"] | Literal["DEAD"] | None,
-        filter_node_name: str | None,
-        limit,
-        timeout,
+        filter_node_id: Optional[NodeID],
+        filter_state: Union[Literal["ALIVE"], Literal["DEAD"], None],
+        filter_node_name: Optional[str],
+        limit: Optional[int],
+        timeout: Optional[float],
     ) -> Dict[NodeID, gcs_pb2.GcsNodeInfo]:
         filters = gcs_service_pb2.GetAllNodeInfoRequest.Filters()
         if filter_node_id is not None:

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -431,6 +431,10 @@ cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
             c_vector[CGcsNodeInfo] &result)
 
         CRayStatus AsyncGetAll(
+            CNodeID filter_node_id,
+            optional[CGcsNodeState] filter_state,
+            c_string filter_node_name,
+            int64_t limit,
             const MultiItemPyCallback[CGcsNodeInfo] &callback,
             int64_t timeout_ms)
 

--- a/src/mock/ray/gcs/gcs_client/accessor.h
+++ b/src/mock/ray/gcs/gcs_client/accessor.h
@@ -148,7 +148,11 @@ class MockNodeInfoAccessor : public NodeInfoAccessor {
               (override));
   MOCK_METHOD(Status,
               AsyncGetAll,
-              (const MultiItemCallback<rpc::GcsNodeInfo> &callback, int64_t timeout_ms),
+              (std::optional<rpc::GcsNodeInfo::GcsNodeState> filter_state,
+               std::optional<std::string> filter_node_name,
+               int64_t limit,
+               const MultiItemCallback<rpc::GcsNodeInfo> &callback,
+               int64_t timeout_ms),
               (override));
   MOCK_METHOD(Status,
               AsyncSubscribeToNodeChange,

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -357,10 +357,25 @@ class NodeInfoAccessor {
 
   /// Get information of all nodes from GCS asynchronously.
   ///
+  /// \param filter_node_id Only get node of this ID. If Nil, get all nodes.
+  /// \param filter_state Only get nodes of this state. If not set, get all nodes.
+  /// \param filter_node_name Only get nodes with this name. If not set, get all nodes.
+  /// \param limit Only get this many nodes. If <= 0, get all nodes.
   /// \param callback Callback that will be called after lookup finishes.
   /// \return Status
-  virtual Status AsyncGetAll(const MultiItemCallback<rpc::GcsNodeInfo> &callback,
+  virtual Status AsyncGetAll(NodeID filter_node_id,
+                             std::optional<rpc::GcsNodeInfo::GcsNodeState> filter_state,
+                             std::optional<std::string> filter_node_name,
+                             int64_t limit,
+                             const MultiItemCallback<rpc::GcsNodeInfo> &callback,
                              int64_t timeout_ms);
+
+  /// Convenience method to AsyncGetAll with no filters or limits.
+  Status AsyncGetAll(const MultiItemCallback<rpc::GcsNodeInfo> &callback,
+                     int64_t timeout_ms) {
+    return AsyncGetAll(
+        NodeID::Nil(), std::nullopt, std::nullopt, -1, callback, timeout_ms);
+  }
 
   /// Subscribe to node addition and removal events from GCS and cache those information.
   ///

--- a/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
+++ b/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
@@ -436,7 +436,11 @@ struct GcsServerMocker {
       return Status::OK();
     }
 
-    Status AsyncGetAll(const gcs::MultiItemCallback<rpc::GcsNodeInfo> &callback,
+    Status AsyncGetAll(NodeID filter_node_id,
+                       std::optional<rpc::GcsNodeInfo::GcsNodeState> filter_state,
+                       std::optional<std::string> filter_node_name,
+                       int64_t limit,
+                       const gcs::MultiItemCallback<rpc::GcsNodeInfo> &callback,
                        int64_t timeout_ms) override {
       if (callback) {
         callback(Status::OK(), {});


### PR DESCRIPTION
We already have this filter in GCS for state_manager.py. Also exposes it to node_head.py.

Smoke tested each arg manually.