### PR TITLE
[Data] Get AWS credentials with boto

### DIFF
--- a/release/nightly_tests/dataset/multi_node_train_benchmark.py
+++ b/release/nightly_tests/dataset/multi_node_train_benchmark.py
@@ -629,6 +629,10 @@ def benchmark_code(
                     field_names=["class"],
                     base_dir=args.data_root,
                 )
+                # Note: We explicitly define a filesystem using boto credentials
+                # due to `AWS Error ACCESS_DENIED` issues with pyarrow.fs.
+                # See for more details and potential downsides:
+                # https://github.com/ray-project/ray/issues/47230#issuecomment-2313645254 # noqa: E501
                 fs = get_s3fs_with_boto_creds()
                 ray_dataset = ray.data.read_images(
                     input_paths,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
To reduce flakiness of the `multi_node_train_benchmark.py` release tests (e.g. `read_images_train_1_gpu_5_cpu.aws`) caused by `AWS Error ACCESS_DENIED`, we get filesystem object using `boto3` and pass it to `read_parquet()` instead. We suspect the root cause of the AWS error stems from `pyarrow.fs`, but need to confirm. See below for two release test runs without such errors.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/47337

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
     - https://buildkite.com/ray-project/release/builds/21708
     - https://buildkite.com/ray-project/release/builds/21742
   - [ ] This PR is not tested :(
