### PR TITLE
[data] Fix min_rows_per_bundled_input not correctly set with default batch_size

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -633,10 +633,10 @@ class Dataset:
         batch_format = _apply_batch_format(batch_format)
 
         min_rows_per_bundled_input = None
+        batch_size = _apply_batch_size(batch_size)
         if batch_size is not None and batch_size != "default":
             # Enable blocks bundling when batch_size is specified by caller.
             min_rows_per_bundled_input = batch_size
-        batch_size = _apply_batch_size(batch_size)
 
         if batch_format not in VALID_BATCH_FORMATS:
             raise ValueError(

--- a/python/ray/data/tests/test_consumption.py
+++ b/python/ray/data/tests/test_consumption.py
@@ -531,13 +531,13 @@ def test_dataset_repr(ray_start_regular_shared):
     assert repr(ds) == (
         "MapBatches(<lambda>)\n" "+- Dataset(num_rows=9, schema={id: int64})"
     )
-    ds1, ds2 = ds.split(2)
+    ds1, ds2 = ds.split(2, equal=True)
     assert (
-        repr(ds1) == f"MaterializedDataset(num_blocks=5, num_rows={ds1.count()}, "
+        repr(ds1) == f"MaterializedDataset(num_blocks=1, num_rows={ds1.count()}, "
         "schema={id: int64})"
     )
     assert (
-        repr(ds2) == f"MaterializedDataset(num_blocks=5, num_rows={ds2.count()}, "
+        repr(ds2) == f"MaterializedDataset(num_blocks=1, num_rows={ds2.count()}, "
         "schema={id: int64})"
     )
 

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -215,7 +215,7 @@ def test_dataset(
     )
 
     # Too-large blocks will get split to respect target max block size.
-    map_ds = ds.map_batches(identity_func, compute=compute)
+    map_ds = ds.map_batches(identity_func, compute=compute, batch_size=None)
     map_ds = map_ds.materialize()
     num_blocks_expected = num_tasks * num_blocks_per_task
     assert map_ds._plan.initial_num_blocks() == num_blocks_expected

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -408,7 +408,7 @@ def test_map_batches_basic(ray_start_regular_shared, tmp_path, restore_data_cont
     ds = ray.data.range(size, override_num_blocks=size)
 
     def map_batches(batch):
-        # The range operator outputs many small batches,
+        # The range operator outputs many small batches.
         # Test that they will be accumulated to DEFAULT_BATCH_SIZE.
         assert len(batch["id"]) == DEFAULT_BATCH_SIZE
         return batch


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When batch_size is not set, each map_batches task is supposed to accumulate input blocks to the default batch size (1024). 
This PR fixes a bug that breaks this behavior. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
