### PR TITLE
[Core] Fix ray_unintentional_worker_failures_total to only count unintentional worker failures

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -161,6 +161,7 @@ py_test_module_list(
     "test_task_events.py",
     "test_task_events_2.py",
     "test_task_events_3.py",
+    "test_system_metrics.py",
     "test_task_metrics.py",
     "test_task_metrics_reconstruction.py",
     "test_actor_state_metrics.py",
@@ -663,7 +664,7 @@ py_test(
     size = "medium",
     srcs = ["test_typing.py", "typing_files/check_typing_bad.py",
             "typing_files/check_typing_good.py"],
-    # Note(can): known issue of mypy and latest torch on windows 
+    # Note(can): known issue of mypy and latest torch on windows
     # (https://github.com/python/mypy/issues/17189)
     tags = ["exclusive", "small_size_python_tests", "no_windows", "team:core"],
     deps = ["//:ray_lib", ":conftest"],

--- a/python/ray/tests/test_system_metrics.py
+++ b/python/ray/tests/test_system_metrics.py
@@ -1,5 +1,8 @@
 import os
 import time
+
+import pytest
+
 import ray
 from ray._private.test_utils import (
     raw_metrics,
@@ -37,3 +40,12 @@ def test_unintentional_worker_failures_metric(shutdown_only):
     # Wait for metrics to be reported
     time.sleep(1)
     wait_for_condition(lambda: verify())
+
+
+if __name__ == "__main__":
+    import sys
+
+    if os.environ.get("PARALLEL_CI"):
+        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
+    else:
+        sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_system_metrics.py
+++ b/python/ray/tests/test_system_metrics.py
@@ -1,0 +1,39 @@
+import os
+import time
+import ray
+from ray._private.test_utils import (
+    raw_metrics,
+    wait_for_condition,
+)
+
+METRIC_CONFIG = {
+    "_system_config": {
+        "metrics_report_interval_ms": 100,
+    }
+}
+
+
+def test_unintentional_worker_failures_metric(shutdown_only):
+    context = ray.init(num_cpus=2, **METRIC_CONFIG)
+
+    @ray.remote
+    class Actor:
+        def exit(self):
+            os._exit(1)
+
+    actor1 = Actor.remote()
+    actor2 = Actor.remote()
+    # intentional
+    ray.kill(actor1)
+    # unintentional
+    actor2.exit.remote()
+
+    def verify():
+        metrics = raw_metrics(context)
+        for sample in metrics["ray_unintentional_worker_failures_total"]:
+            assert sample.value == 1
+        return True
+
+    # Wait for metrics to be reported
+    time.sleep(1)
+    wait_for_condition(lambda: verify())

--- a/src/ray/gcs/gcs_server/gcs_worker_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_worker_manager.cc
@@ -52,6 +52,7 @@ void GcsWorkerManager::HandleReportWorkerFailure(
                 rpc::WorkerExitType::INTENDED_SYSTEM_EXIT) {
           RAY_LOG(DEBUG) << message;
         } else {
+          stats::UnintentionalWorkerFailures.Record(1);
           RAY_LOG(WARNING)
               << message
               << ". Unintentional worker failures have been reported. If there "
@@ -81,7 +82,6 @@ void GcsWorkerManager::HandleReportWorkerFailure(
                            << ", node id = " << node_id
                            << ", address = " << worker_address.ip_address();
           } else {
-            stats::UnintentionalWorkerFailures.Record(1);
             // Only publish worker_id and raylet_id in address as they are the only fields
             // used by sub clients.
             rpc::WorkerDeltaData worker_failure;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently `ray_unintentional_worker_failures_total` counts both intentional and unintentional worker failures

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
