### PR TITLE
[doc] instruction for troubleshooting issues with _raylet.so

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -31,6 +31,10 @@ from custom_directives import (  # noqa
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
+assert not os.path.exists("../../python/ray/_raylet.so"), (
+    "_raylet.so should not be imported for the purpose for doc build, "
+    "please rename the file to _raylet.so.bak and try again."
+)
 sys.path.insert(0, os.path.abspath("../../python/"))
 
 # -- General configuration ------------------------------------------------


### PR DESCRIPTION
Add instruction for troubleshooting doc build in the presence of `_raylet.so`. The presence of `_raylet.so` will cause sphinx to fail since it will try to import this file for real, instead of parsing the docstring from the source codes.

Test:
- CI