### PR TITLE
[core] Add from_binary and from_hex to all IDs.

### DIFF
--- a/python/ray/includes/gcs_client.pxi
+++ b/python/ray/includes/gcs_client.pxi
@@ -78,7 +78,7 @@ cdef class NewGcsClient:
     @property
     def cluster_id(self) -> ray.ClusterID:
         cdef CClusterID cluster_id = self.inner.get().GetClusterId()
-        return ray.ClusterID(cluster_id.Binary())
+        return ray.ClusterID.from_binary(cluster_id.Binary())
 
     #############################################################
     # Internal KV sync methods
@@ -612,7 +612,7 @@ cdef convert_get_all_node_info(
         for b in serialized_reply:
             proto = gcs_pb2.GcsNodeInfo()
             proto.ParseFromString(b)
-            node_table_data[NodeID(proto.node_id)] = proto
+            node_table_data[NodeID.from_binary(proto.node_id)] = proto
         return node_table_data, None
     except Exception as e:
         return None, e
@@ -634,7 +634,7 @@ cdef convert_get_all_job_info(
         for b in serialized_reply:
             proto = gcs_pb2.JobTableData()
             proto.ParseFromString(b)
-            job_table_data[JobID(proto.job_id)] = proto
+            job_table_data[JobID.from_binary(proto.job_id)] = proto
         return job_table_data, None
     except Exception as e:
         return None, e
@@ -653,7 +653,7 @@ cdef convert_get_all_actor_info(
         for b in serialized_reply:
             proto = gcs_pb2.ActorTableData()
             proto.ParseFromString(b)
-            actor_table_data[ActorID(proto.actor_id)] = proto
+            actor_table_data[ActorID.from_binary(proto.actor_id)] = proto
         return actor_table_data, None
     except Exception as e:
         return None, e

--- a/python/ray/includes/gcs_client.pxi
+++ b/python/ray/includes/gcs_client.pxi
@@ -78,7 +78,7 @@ cdef class NewGcsClient:
     @property
     def cluster_id(self) -> ray.ClusterID:
         cdef CClusterID cluster_id = self.inner.get().GetClusterId()
-        return ray.ClusterID.from_binary(cluster_id.Binary())
+        return ray.ClusterID(cluster_id.Binary())
 
     #############################################################
     # Internal KV sync methods
@@ -612,7 +612,7 @@ cdef convert_get_all_node_info(
         for b in serialized_reply:
             proto = gcs_pb2.GcsNodeInfo()
             proto.ParseFromString(b)
-            node_table_data[NodeID.from_binary(proto.node_id)] = proto
+            node_table_data[NodeID(proto.node_id)] = proto
         return node_table_data, None
     except Exception as e:
         return None, e
@@ -634,7 +634,7 @@ cdef convert_get_all_job_info(
         for b in serialized_reply:
             proto = gcs_pb2.JobTableData()
             proto.ParseFromString(b)
-            job_table_data[JobID.from_binary(proto.job_id)] = proto
+            job_table_data[JobID(proto.job_id)] = proto
         return job_table_data, None
     except Exception as e:
         return None, e
@@ -653,7 +653,7 @@ cdef convert_get_all_actor_info(
         for b in serialized_reply:
             proto = gcs_pb2.ActorTableData()
             proto.ParseFromString(b)
-            actor_table_data[ActorID.from_binary(proto.actor_id)] = proto
+            actor_table_data[ActorID(proto.actor_id)] = proto
         return actor_table_data, None
     except Exception as e:
         return None, e

--- a/python/ray/includes/unique_ids.pxd
+++ b/python/ray/includes/unique_ids.pxd
@@ -48,6 +48,9 @@ cdef extern from "ray/common/id.h" namespace "ray" nogil:
         @staticmethod
         CActorClassID FromBinary(const c_string &binary)
 
+        @staticmethod
+        CActorClassID FromHex(const c_string &binary)
+
     cdef cppclass CActorID "ray::ActorID"(CBaseID[CActorID]):
 
         @staticmethod
@@ -89,10 +92,17 @@ cdef extern from "ray/common/id.h" namespace "ray" nogil:
         @staticmethod
         CFunctionID FromBinary(const c_string &binary)
 
+        @staticmethod
+        CFunctionID FromHex(const c_string &binary)
+
+
     cdef cppclass CJobID "ray::JobID"(CBaseID[CJobID]):
 
         @staticmethod
         CJobID FromBinary(const c_string &binary)
+
+        @staticmethod
+        CJobID FromHex(const c_string &binary)
 
         @staticmethod
         const CJobID Nil()
@@ -109,6 +119,9 @@ cdef extern from "ray/common/id.h" namespace "ray" nogil:
 
         @staticmethod
         CTaskID FromBinary(const c_string &binary)
+
+        @staticmethod
+        CTaskID FromHex(const c_string &binary)
 
         @staticmethod
         const CTaskID Nil()
@@ -182,11 +195,17 @@ cdef extern from "ray/common/id.h" namespace "ray" nogil:
         @staticmethod
         CWorkerID FromBinary(const c_string &binary)
 
+        @staticmethod
+        CWorkerID FromHex(const c_string &binary)
+
     cdef cppclass CPlacementGroupID "ray::PlacementGroupID" \
                                     (CBaseID[CPlacementGroupID]):
 
         @staticmethod
         CPlacementGroupID FromBinary(const c_string &binary)
+
+        @staticmethod
+        CPlacementGroupID FromHex(const c_string &binary)
 
         @staticmethod
         const CPlacementGroupID Nil()

--- a/python/ray/includes/unique_ids.pxd
+++ b/python/ray/includes/unique_ids.pxd
@@ -95,7 +95,6 @@ cdef extern from "ray/common/id.h" namespace "ray" nogil:
         @staticmethod
         CFunctionID FromHex(const c_string &binary)
 
-
     cdef cppclass CJobID "ray::JobID"(CBaseID[CJobID]):
 
         @staticmethod

--- a/python/ray/includes/unique_ids.pxd
+++ b/python/ray/includes/unique_ids.pxd
@@ -8,7 +8,7 @@ cdef extern from "ray/common/id.h" namespace "ray" nogil:
         T FromBinary(const c_string &binary)
 
         @staticmethod
-        T FromHex(const c_string &hex)
+        T FromHex(const c_string &hex_str)
 
         @staticmethod
         const T Nil()
@@ -49,7 +49,7 @@ cdef extern from "ray/common/id.h" namespace "ray" nogil:
         CActorClassID FromBinary(const c_string &binary)
 
         @staticmethod
-        CActorClassID FromHex(const c_string &hex)
+        CActorClassID FromHex(const c_string &hex_str)
 
     cdef cppclass CActorID "ray::ActorID"(CBaseID[CActorID]):
 
@@ -93,7 +93,7 @@ cdef extern from "ray/common/id.h" namespace "ray" nogil:
         CFunctionID FromBinary(const c_string &binary)
 
         @staticmethod
-        CFunctionID FromHex(const c_string &binary)
+        CFunctionID FromHex(const c_string &hex_str)
 
     cdef cppclass CJobID "ray::JobID"(CBaseID[CJobID]):
 
@@ -101,7 +101,7 @@ cdef extern from "ray/common/id.h" namespace "ray" nogil:
         CJobID FromBinary(const c_string &binary)
 
         @staticmethod
-        CJobID FromHex(const c_string &binary)
+        CJobID FromHex(const c_string &hex_str)
 
         @staticmethod
         const CJobID Nil()
@@ -120,7 +120,7 @@ cdef extern from "ray/common/id.h" namespace "ray" nogil:
         CTaskID FromBinary(const c_string &binary)
 
         @staticmethod
-        CTaskID FromHex(const c_string &binary)
+        CTaskID FromHex(const c_string &hex_str)
 
         @staticmethod
         const CTaskID Nil()
@@ -195,7 +195,7 @@ cdef extern from "ray/common/id.h" namespace "ray" nogil:
         CWorkerID FromBinary(const c_string &binary)
 
         @staticmethod
-        CWorkerID FromHex(const c_string &binary)
+        CWorkerID FromHex(const c_string &hex_str)
 
     cdef cppclass CPlacementGroupID "ray::PlacementGroupID" \
                                     (CBaseID[CPlacementGroupID]):
@@ -204,7 +204,7 @@ cdef extern from "ray/common/id.h" namespace "ray" nogil:
         CPlacementGroupID FromBinary(const c_string &binary)
 
         @staticmethod
-        CPlacementGroupID FromHex(const c_string &binary)
+        CPlacementGroupID FromHex(const c_string &hex_str)
 
         @staticmethod
         const CPlacementGroupID Nil()

--- a/python/ray/includes/unique_ids.pxd
+++ b/python/ray/includes/unique_ids.pxd
@@ -49,7 +49,7 @@ cdef extern from "ray/common/id.h" namespace "ray" nogil:
         CActorClassID FromBinary(const c_string &binary)
 
         @staticmethod
-        CActorClassID FromHex(const c_string &binary)
+        CActorClassID FromHex(const c_string &hex)
 
     cdef cppclass CActorID "ray::ActorID"(CBaseID[CActorID]):
 

--- a/python/ray/includes/unique_ids.pxi
+++ b/python/ray/includes/unique_ids.pxi
@@ -60,11 +60,8 @@ cdef class BaseID:
     def binary(self):
         raise NotImplementedError
 
-    def size(self):
-        raise NotImplementedError
-
-    @staticmethod
-    def size():
+    @classmethod
+    def size(cls):
         raise NotImplementedError
 
     def hex(self):
@@ -122,11 +119,8 @@ cdef class UniqueID(BaseID):
     def from_random(cls):
         return cls(CUniqueID.FromRandom().Binary())
 
-    @staticmethod
-    def size():
-        return CUniqueID.Size()
-
-    def size(self):
+    @classmethod
+    def size(cls):
         return CUniqueID.Size()
 
     def binary(self):
@@ -157,7 +151,8 @@ cdef class TaskID(BaseID):
     cdef CTaskID native(self):
         return <CTaskID>self.data
 
-    def size(self):
+    @classmethod
+    def size(cls):
         return CTaskID.Size()
 
     def binary(self):
@@ -181,10 +176,6 @@ cdef class TaskID(BaseID):
     @classmethod
     def nil(cls):
         return cls(CTaskID.Nil().Binary())
-
-    @classmethod
-    def size(cls):
-        return CTaskID.Size()
 
     @classmethod
     def for_fake_task(cls, job_id):
@@ -275,9 +266,6 @@ cdef class JobID(BaseID):
     def hex(self):
         return decode(self.data.Hex())
 
-    def size(self):
-        return CJobID.Size()
-
     def is_nil(self):
         return self.data.IsNil()
 
@@ -326,9 +314,6 @@ cdef class ActorID(BaseID):
 
     @classmethod
     def size(cls):
-        return CActorID.Size()
-
-    def size(self):
         return CActorID.Size()
 
     def _set_id(self, id):
@@ -439,9 +424,6 @@ cdef class PlacementGroupID(BaseID):
 
     def hex(self):
         return decode(self.data.Hex())
-
-    def size(self):
-        return CPlacementGroupID.Size()
 
     def is_nil(self):
         return self.data.IsNil()

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -291,6 +291,7 @@ py_test_module_list(
     "test_distributed_sort.py",
     "test_environ.py",
     "test_get_or_create_actor.py",
+    "test_ids.py",
     "test_list_actors.py",
     "test_list_actors_2.py",
     "test_list_actors_3.py",
@@ -663,7 +664,7 @@ py_test(
     size = "medium",
     srcs = ["test_typing.py", "typing_files/check_typing_bad.py",
             "typing_files/check_typing_good.py"],
-    # Note(can): known issue of mypy and latest torch on windows 
+    # Note(can): known issue of mypy and latest torch on windows
     # (https://github.com/python/mypy/issues/17189)
     tags = ["exclusive", "small_size_python_tests", "no_windows", "team:core"],
     deps = ["//:ray_lib", ":conftest"],

--- a/python/ray/tests/test_ids.py
+++ b/python/ray/tests/test_ids.py
@@ -1,0 +1,92 @@
+import sys
+import os
+from ray import (
+    ActorID,
+    JobID,
+    TaskID,
+    NodeID,
+    WorkerID,
+    FunctionID,
+    ActorClassID,
+    ClusterID,
+    PlacementGroupID,
+)
+import pytest
+
+
+@pytest.mark.parametrize(
+    "id_cls, size",
+    [
+        (JobID, 4),
+        (ActorID, 16),
+        (TaskID, 24),
+        (NodeID, 28),
+        (WorkerID, 28),
+        (FunctionID, 28),
+        (ActorClassID, 28),
+        (ClusterID, 28),
+        (PlacementGroupID, 18),
+    ],
+)
+def test_id_methods(id_cls, size):
+    """
+    Tests for ID class methods:
+
+    Methods:
+    - `ctor`
+    - `from_binary(bytes: bytes) -> id_cls`
+    - `binary() -> bytes`
+    - `hex() -> str`
+    - `from_hex(hex_str: str) -> id_cls`
+    - `size() -> int`
+    - `size(self) -> int`
+    - `nil() -> id_cls`
+    - `is_nil() -> bool`
+    - `__hash__() -> int`
+
+    Invariants:
+    - `ctor` is same as `from_binary`
+    - `id_cls.from_binary(id.binary()) == id`
+    - `id_cls.from_hex(id.hex()) == id`
+    - `id_cls.size() == expected_size`
+    - `id_cls.nil().binary() == b'\xff' * expected_size`
+    - `id_cls.nil().hex() == 'ff' * expected_size`
+    - `id_cls.nil().is_nil() is True`
+
+    Note: we don't test ObjectID (that is, ObjectRef) here. It lacks from_binary and
+    from_hex methods.
+    """
+    # Generate random bytes of the given size
+    random_bytes = os.urandom(size)
+
+    id_instance = id_cls(random_bytes)
+
+    # binary and from_binary
+    id_from_binary = id_cls.from_binary(random_bytes)
+    assert id_instance == id_from_binary
+    assert id_from_binary.binary() == random_bytes
+
+    # hex and from_hex methods
+    hex_str = id_instance.hex()
+    assert isinstance(hex_str, str)
+    assert id_cls.from_hex(hex_str) == id_instance
+
+    # size() can be accessed from cls or instance
+    assert id_cls.size() == size
+    assert id_instance.size() == size
+
+    # Test the nil method
+    nil_instance = id_cls.nil()
+    assert nil_instance.binary() == b"\xff" * size
+    assert nil_instance.hex() == "ff" * size
+    assert nil_instance.is_nil()
+
+    # hash is implemented
+    id_instance.__hash__() is not None
+
+
+if __name__ == "__main__":
+    if os.environ.get("PARALLEL_CI"):
+        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
+    else:
+        sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_ids.py
+++ b/python/ray/tests/test_ids.py
@@ -38,8 +38,7 @@ def test_id_methods(id_cls, size):
     - `binary() -> bytes`
     - `hex() -> str`
     - `from_hex(hex_str: str) -> id_cls`
-    - `size() -> int`
-    - `size(self) -> int`
+    - `size(cls) -> int`
     - `nil() -> id_cls`
     - `is_nil() -> bool`
     - `__hash__() -> int`
@@ -71,7 +70,7 @@ def test_id_methods(id_cls, size):
     assert isinstance(hex_str, str)
     assert id_cls.from_hex(hex_str) == id_instance
 
-    # size() can be accessed from cls or instance
+    # size() is classmethod, can be called on both class and instance
     assert id_cls.size() == size
     assert id_instance.size() == size
 


### PR DESCRIPTION
Some Ray IDs have those fields and some don't. Unify them with a list of methods and test. Note ObjectID is not in the list.