### PR TITLE
[serve] Fix broken microbenchmarks

### DIFF
--- a/python/ray/serve/_private/benchmarks/common.py
+++ b/python/ray/serve/_private/benchmarks/common.py
@@ -84,9 +84,10 @@ async def do_single_grpc_batch(
 ):
     channel = grpc.aio.insecure_channel(target)
     stub = serve_pb2_grpc.RayServeBenchmarkServiceStub(channel)
+    payload = serve_pb2.StringData(data="")
 
     async def do_query():
-        return await stub.grpc_call(serve_pb2.StringData(data=""))
+        return await stub.grpc_call(payload)
 
     await asyncio.gather(*[do_query() for _ in range(batch_size)])
 

--- a/release/serve_tests/workloads/microbenchmarks.py
+++ b/release/serve_tests/workloads/microbenchmarks.py
@@ -45,7 +45,7 @@ NUM_REQUESTS = 500
 
 # For throughput benchmarks
 BATCH_SIZE = 100
-NUM_TRIALS = 1
+NUM_TRIALS = 50
 TRIAL_RUNTIME_S = 5
 
 

--- a/release/serve_tests/workloads/microbenchmarks.py
+++ b/release/serve_tests/workloads/microbenchmarks.py
@@ -45,7 +45,7 @@ NUM_REQUESTS = 500
 
 # For throughput benchmarks
 BATCH_SIZE = 100
-NUM_TRIALS = 50
+NUM_TRIALS = 1
 TRIAL_RUNTIME_S = 5
 
 
@@ -160,15 +160,15 @@ async def _main(
 
     # GRPC
     if run_grpc:
+        serve_grpc_options = gRPCOptions(
+            port=9000,
+            grpc_servicer_functions=[
+                "ray.serve.generated.serve_pb2_grpc.add_RayServeBenchmarkServiceServicer_to_server",  # noqa
+            ],
+        )
         if run_latency:
             channel = grpc.insecure_channel("localhost:9000")
             stub = serve_pb2_grpc.RayServeBenchmarkServiceStub(channel)
-            serve_grpc_options = gRPCOptions(
-                port=9000,
-                grpc_servicer_functions=[
-                    "ray.serve.generated.serve_pb2_grpc.add_RayServeBenchmarkServiceServicer_to_server",  # noqa
-                ],
-            )
             grpc_payload_noop = serve_pb2.StringData(data="")
             grpc_payload_1mb = serve_pb2.StringData(data=payload_1mb)
             grpc_payload_10mb = serve_pb2.StringData(data=payload_10mb)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

With serve shutdown in between every microbenchmark, serve needs to be started with grpc options every time for the grpc microbenchmarks.

## Related issue number

closes #47424

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
