### PR TITLE
[core][experimental] Raise an exception if a DAG is compiled twice

### DIFF
--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -729,7 +729,10 @@ class CompiledDAG:
                 task.dag_node, InputAttributeNode
             ):
                 continue
-            if len(task.downstream_task_idxs) == 0 and task.dag_node.is_output_node:
+            if (
+                len(task.downstream_task_idxs) == 0
+                and task.dag_node.is_adag_output_node
+            ):
                 assert self.output_task_idx is None, "More than one output node found"
                 self.output_task_idx = idx
 

--- a/python/ray/dag/dag_node.py
+++ b/python/ray/dag/dag_node.py
@@ -72,7 +72,8 @@ class DAGNode(DAGNodeBase):
         self.cache_from_last_execute = {}
 
         self._type_hint: Optional[ChannelOutputType] = ChannelOutputType()
-        self.is_output_node = False
+        # Whether this node calls `experimental_compile`.
+        self.is_adag_output_node = False
 
     def _collect_upstream_nodes(self) -> List["DAGNode"]:
         """
@@ -200,15 +201,16 @@ class DAGNode(DAGNodeBase):
             _max_buffered_results = ctx.max_buffered_results
 
         # Validate whether this DAG node has already been compiled.
-        if self.is_output_node:
+        if self.is_adag_output_node:
             raise ValueError(
-                "The DAG has already been compiled! "
-                "Please reuse the existing compiled DAG."
+                "It is not allowed to call `experimental_compile` on the same DAG "
+                "object multiple times no matter whether `teardown` is called or not. "
+                "Please reuse the existing compiled DAG or create a new one."
             )
         # Whether this node is an output node in the DAG. We cannot determine
         # this in the constructor because the output node is determined when
         # `experimental_compile` is called.
-        self.is_output_node = True
+        self.is_adag_output_node = True
         return build_compiled_dag_from_ray_dag(
             self,
             _execution_timeout,
@@ -386,20 +388,21 @@ class DAGNode(DAGNodeBase):
         """
         visited = set()
         queue = [self]
-        num_output_nodes = 0
+        adag_output_node: Optional[DAGNode] = None
 
         while queue:
             node = queue.pop(0)
             if node not in visited:
-                if node.is_output_node:
-                    num_output_nodes += 1
+                if node.is_adag_output_node:
                     # Validate whether there are multiple nodes that call
                     # `experimental_compile`.
-                    if num_output_nodes > 1:
+                    if adag_output_node is not None:
                         raise ValueError(
-                            "The DAG was compiled more than once, so some output "
-                            "nodes became leaf nodes."
+                            "The DAG was compiled more than once. The following two "
+                            "nodes call `experimental_compile`: "
+                            f"(1) {adag_output_node}, (2) {node}"
                         )
+                    adag_output_node = node
                 fn(node)
                 visited.add(node)
                 """

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -756,8 +756,9 @@ class TestDAGExceptionCompileMultipleTimes:
         compiled_dag.teardown()
         with pytest.raises(
             ValueError,
-            match="The DAG has already been compiled! "
-            "Please reuse the existing compiled DAG.",
+            match="It is not allowed to call `experimental_compile` on the same DAG "
+            "object multiple times no matter whether `teardown` is called or not. "
+            "Please reuse the existing compiled DAG or create a new one.",
         ):
             compiled_dag = dag.experimental_compile()
 
@@ -768,8 +769,9 @@ class TestDAGExceptionCompileMultipleTimes:
         compiled_dag = dag.experimental_compile()
         with pytest.raises(
             ValueError,
-            match="The DAG has already been compiled! "
-            "Please reuse the existing compiled DAG.",
+            match="It is not allowed to call `experimental_compile` on the same DAG "
+            "object multiple times no matter whether `teardown` is called or not. "
+            "Please reuse the existing compiled DAG or create a new one.",
         ):
             compiled_dag = dag.experimental_compile()
         compiled_dag.teardown()
@@ -782,8 +784,9 @@ class TestDAGExceptionCompileMultipleTimes:
         compiled_dag.teardown()
         with pytest.raises(
             ValueError,
-            match="The DAG has already been compiled! "
-            "Please reuse the existing compiled DAG.",
+            match="It is not allowed to call `experimental_compile` on the same DAG "
+            "object multiple times no matter whether `teardown` is called or not. "
+            "Please reuse the existing compiled DAG or create a new one.",
         ):
             compiled_dag = dag.experimental_compile()
 
@@ -796,8 +799,9 @@ class TestDAGExceptionCompileMultipleTimes:
         compiled_dag = dag.experimental_compile()
         with pytest.raises(
             ValueError,
-            match="The DAG has already been compiled! "
-            "Please reuse the existing compiled DAG.",
+            match="It is not allowed to call `experimental_compile` on the same DAG "
+            "object multiple times no matter whether `teardown` is called or not. "
+            "Please reuse the existing compiled DAG or create a new one.",
         ):
             compiled_dag = dag.experimental_compile()
         compiled_dag.teardown()
@@ -813,8 +817,8 @@ class TestDAGExceptionCompileMultipleTimes:
         compiled_dag.teardown()
         with pytest.raises(
             ValueError,
-            match="The DAG was compiled more than once, "
-            "so some output nodes became leaf nodes.",
+            match="The DAG was compiled more than once. The following two "
+            "nodes call `experimental_compile`: ",
         ):
             compiled_dag = branch2.experimental_compile()
 

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -747,6 +747,78 @@ def test_dag_errors(ray_start_regular):
     compiled_dag.teardown()
 
 
+class TestDAGExceptionCompileMultipleTimes:
+    def test_compile_twice_with_teardown(self, ray_start_regular):
+        a = Actor.remote(0)
+        with InputNode() as i:
+            dag = a.echo.bind(i)
+        compiled_dag = dag.experimental_compile()
+        compiled_dag.teardown()
+        with pytest.raises(
+            ValueError,
+            match="The DAG has already been compiled! "
+            "Please reuse the existing compiled DAG.",
+        ):
+            compiled_dag = dag.experimental_compile()
+
+    def test_compile_twice_without_teardown(self, ray_start_regular):
+        a = Actor.remote(0)
+        with InputNode() as i:
+            dag = a.echo.bind(i)
+        compiled_dag = dag.experimental_compile()
+        with pytest.raises(
+            ValueError,
+            match="The DAG has already been compiled! "
+            "Please reuse the existing compiled DAG.",
+        ):
+            compiled_dag = dag.experimental_compile()
+        compiled_dag.teardown()
+
+    def test_compile_twice_with_multioutputnode(self, ray_start_regular):
+        a = Actor.remote(0)
+        with InputNode() as i:
+            dag = MultiOutputNode([a.echo.bind(i)])
+        compiled_dag = dag.experimental_compile()
+        compiled_dag.teardown()
+        with pytest.raises(
+            ValueError,
+            match="The DAG has already been compiled! "
+            "Please reuse the existing compiled DAG.",
+        ):
+            compiled_dag = dag.experimental_compile()
+
+    def test_compile_twice_with_multioutputnode_without_teardown(
+        self, ray_start_regular
+    ):
+        a = Actor.remote(0)
+        with InputNode() as i:
+            dag = MultiOutputNode([a.echo.bind(i)])
+        compiled_dag = dag.experimental_compile()
+        with pytest.raises(
+            ValueError,
+            match="The DAG has already been compiled! "
+            "Please reuse the existing compiled DAG.",
+        ):
+            compiled_dag = dag.experimental_compile()
+        compiled_dag.teardown()
+
+    def test_compile_twice_with_different_nodes(self, ray_start_regular):
+        a = Actor.remote(0)
+        b = Actor.remote(0)
+        with InputNode() as i:
+            branch1 = a.echo.bind(i)
+            branch2 = b.echo.bind(i)
+            dag = MultiOutputNode([branch1])
+        compiled_dag = dag.experimental_compile()
+        compiled_dag.teardown()
+        with pytest.raises(
+            ValueError,
+            match="The DAG was compiled more than once, "
+            "so some output nodes became leaf nodes.",
+        ):
+            compiled_dag = branch2.experimental_compile()
+
+
 def test_exceed_max_buffered_results(ray_start_regular):
     a = Actor.remote(0)
     with InputNode() as i:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If a DAG calls `experimental_compile` twice, the first compiled node may become a leaf node. For example, 

```python
a = DAGActor.remote()
with InputNode() as inp:
    dag = a.echo.bind(inp)
...
compiled_dag_1 = dag.experimental_compile()
# driver -> a.echo -> compiled_dag_1 (output)
...
compiled_dag.teardown()
...
compiled_dag_2 = dag.experimental_compile(enable_asyncio=True)
# driver -> a.echo -> compiled_dag_1
#                  |
#                  |-> compiled_dag_2 (output)
```

This PR raises an exception if a DAG is compiled twice.

## Related issue number

Closes #47408

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
