### PR TITLE
[core][dashboard] Several performance fixes.

### DIFF
--- a/python/ray/_private/metrics_agent.py
+++ b/python/ray/_private/metrics_agent.py
@@ -34,7 +34,7 @@ from opencensus.tags import tag_value as tag_value_module
 
 import ray
 from ray._raylet import GcsClient
-
+from ray.dashboard.datacenter import DataSource
 from ray.core.generated.metrics_pb2 import Metric
 from ray._private.ray_constants import env_bool
 
@@ -619,11 +619,11 @@ class PrometheusServiceDiscoveryWriter(threading.Thread):
 
     def get_file_discovery_content(self):
         """Return the content for Prometheus service discovery."""
-        nodes = ray.nodes()
+        nodes = DataSource.nodes
         metrics_export_addresses = [
-            "{}:{}".format(node["NodeManagerAddress"], node["MetricsExportPort"])
-            for node in nodes
-            if node["alive"] is True
+            "{}:{}".format(node["nodeManagerAddress"], node["metricsExportPort"])
+            for node in nodes.values()
+            if node["state"] == "ALIVE"
         ]
         autoscaler_addr = self.gcs_client.internal_kv_get(
             b"AutoscalerMetricsAddress", None

--- a/python/ray/dashboard/modules/event/event_agent.py
+++ b/python/ray/dashboard/modules/event/event_agent.py
@@ -45,7 +45,7 @@ class EventAgent(dashboard_utils.DashboardAgentModule):
                 dashboard_rpc_address = await self._gcs_aio_client.internal_kv_get(
                     dashboard_consts.DASHBOARD_RPC_ADDRESS.encode(),
                     namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
-                    timeout=1,
+                    timeout=None,
                 )
                 dashboard_rpc_address = dashboard_rpc_address.decode()
                 if dashboard_rpc_address:

--- a/python/ray/dashboard/modules/reporter/reporter_head.py
+++ b/python/ray/dashboard/modules/reporter/reporter_head.py
@@ -58,7 +58,7 @@ class ReportHead(dashboard_utils.DashboardHeadModule):
         self._gcs_address = dashboard_head.gcs_address
         temp_dir = dashboard_head.temp_dir
         self.service_discovery = PrometheusServiceDiscoveryWriter(
-            self._gcs_address, temp_dir
+            dashboard_head.gcs_client, temp_dir
         )
         self._gcs_aio_client = dashboard_head.gcs_aio_client
         self._state_api = None

--- a/python/ray/dashboard/modules/train/train_head.py
+++ b/python/ray/dashboard/modules/train/train_head.py
@@ -6,7 +6,7 @@ from aiohttp.web import Request, Response
 import ray
 import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.utils as dashboard_utils
-from ray.core.generated import gcs_service_pb2_grpc
+from ray._private.utils import get_or_create_event_loop
 from ray.dashboard.datacenter import DataOrganizer
 from ray.dashboard.modules.job.common import JobInfoStorageClient
 from ray.dashboard.modules.job.utils import find_jobs_by_job_ids
@@ -23,7 +23,6 @@ class TrainHead(dashboard_utils.DashboardHeadModule):
         super().__init__(dashboard_head)
         self._train_stats_actor = None
         self._job_info_client = None
-        self._gcs_actor_info_stub = None
 
     @routes.get("/api/train/v2/runs")
     @dashboard_optional_utils.init_ray_and_catch_exceptions()
@@ -42,7 +41,9 @@ class TrainHead(dashboard_utils.DashboardHeadModule):
                 "when setting up Ray on your cluster.",
             )
 
-        stats_actor = await self.get_train_stats_actor()
+        stats_actor = await get_or_create_event_loop().run_in_executor(
+            self._dashboard_head._thread_pool_executor, self.get_train_stats_actor
+        )
 
         if stats_actor is None:
             return Response(
@@ -187,12 +188,7 @@ class TrainHead(dashboard_utils.DashboardHeadModule):
                 self._dashboard_head.gcs_aio_client
             )
 
-        gcs_channel = self._dashboard_head.aiogrpc_gcs_channel
-        self._gcs_actor_info_stub = gcs_service_pb2_grpc.ActorInfoGcsServiceStub(
-            gcs_channel
-        )
-
-    async def get_train_stats_actor(self):
+    def get_train_stats_actor(self):
         """
         Gets the train stats actor and caches it as an instance variable.
         """

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -27,6 +27,7 @@ from ray._private.test_utils import (
 from ray.autoscaler._private.constants import AUTOSCALER_METRIC_PORT
 from ray.dashboard.consts import DASHBOARD_METRIC_PORT
 from ray.util.metrics import Counter, Gauge, Histogram
+from ray._raylet import GcsClient
 
 os.environ["RAY_event_stats"] = "1"
 
@@ -747,7 +748,7 @@ def test_prometheus_file_based_service_discovery(ray_start_cluster):
     cluster.wait_for_nodes()
     addr = ray.init(address=cluster.address)
     writer = PrometheusServiceDiscoveryWriter(
-        addr["gcs_address"],
+        GcsClient(addr["gcs_address"]),
         "/tmp/ray",
     )
 


### PR DESCRIPTION
These are some bottlenecks we observed in Dashboard during a scale test.

- `TrainHead` uses sync method ray.get_actor in async context; moved to TPE
- `EventAgent` uses a 1s timeout internal KV which times out, bringing down raylet; changed to infinite timeout
- `MetricsHead` uses a Thread that creates 1 GcsClient every 5s; changed to use a common GcsClient.
- `MetricsHead` also uses _initialize_global_state which creates a GcsClient under the hood; changed to use DataSource.