### PR TITLE
[Core] Refine accelerator resource assessment for better node selection

### DIFF
--- a/src/ray/common/scheduling/cluster_resource_data.cc
+++ b/src/ray/common/scheduling/cluster_resource_data.cc
@@ -92,13 +92,21 @@ bool NodeResources::IsAvailable(const ResourceRequest &resource_request,
     RAY_LOG(DEBUG) << "At pull manager capacity";
     return false;
   }
-
+  auto available_resources = this->available;
   if (!this->normal_task_resources.IsEmpty()) {
-    auto available_resources = this->available;
     available_resources -= this->normal_task_resources;
-    return available_resources >= resource_request.GetResourceSet();
   }
-  return this->available >= resource_request.GetResourceSet();
+  if (!this->available_resources_instance_set.IsEmpty() &&
+      available_resources >= resource_request.GetResourceSet()) {
+    NodeResourceInstanceSet available_set = this->available_resources_instance_set;
+    auto allocation = available_set.TryAllocate(resource_request.GetResourceSet());
+    if (allocation) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+  return available_resources >= resource_request.GetResourceSet();
 }
 
 bool NodeResources::IsFeasible(const ResourceRequest &resource_request) const {

--- a/src/ray/common/scheduling/cluster_resource_data.h
+++ b/src/ray/common/scheduling/cluster_resource_data.h
@@ -293,6 +293,7 @@ class NodeResources {
       : total(resources), available(resources) {}
   NodeResourceSet total;
   NodeResourceSet available;
+  NodeResourceInstanceSet available_resources_instance_set;
   /// Only used by light resource report.
   ResourceSet load;
   /// Resources owned by normal tasks.

--- a/src/ray/common/scheduling/resource_instance_set.cc
+++ b/src/ray/common/scheduling/resource_instance_set.cc
@@ -265,4 +265,17 @@ NodeResourceSet NodeResourceInstanceSet::ToNodeResourceSet() const {
   return node_resource_set;
 }
 
+absl::flat_hash_map<std::string, std::vector<double>>
+NodeResourceInstanceSet::GetResourceMap() const {
+  absl::flat_hash_map<std::string, std::vector<double>> result;
+  for (const auto &[id, instances] : resources_) {
+    for (const auto &value : instances) {
+      result[id.Binary()].push_back(value.Double());
+    }
+  }
+  return result;
+}
+
+bool NodeResourceInstanceSet::IsEmpty() const { return resources_.empty(); }
+
 }  // namespace ray

--- a/src/ray/common/scheduling/resource_instance_set.h
+++ b/src/ray/common/scheduling/resource_instance_set.h
@@ -82,6 +82,10 @@ class NodeResourceInstanceSet {
   /// Convert to node resource set with summed per-instance values.
   NodeResourceSet ToNodeResourceSet() const;
 
+  absl::flat_hash_map<std::string, std::vector<double>> GetResourceMap() const;
+
+  bool IsEmpty() const;
+
   /// Only for testing.
   const absl::flat_hash_map<ResourceID, std::vector<FixedPoint>> &Resources() const {
     return resources_;

--- a/src/ray/protobuf/ray_syncer.proto
+++ b/src/ray/protobuf/ray_syncer.proto
@@ -28,6 +28,10 @@ message CommandsSyncMessage {
   bool cluster_full_of_actors_detected = 2;
 }
 
+message DoubleList {
+  repeated double values = 1;
+}
+
 message ResourceViewSyncMessage {
   // Resource capacity currently available on this node manager.
   map<string, double> resources_available = 1;
@@ -46,6 +50,8 @@ message ResourceViewSyncMessage {
   int64 draining_deadline_timestamp_ms = 6;
   // Why the node is not idle.
   repeated string node_activity = 7;
+  // Resource capacity currently available of each unit device on this node manager.
+  map<string, DoubleList> available_resources_instance_set = 8;
 }
 
 message RaySyncMessage {

--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -79,6 +79,8 @@ bool ClusterResourceManager::UpdateNode(
   auto resources_total = MapFromProtobuf(resource_view_sync_message.resources_total());
   auto resources_available =
       MapFromProtobuf(resource_view_sync_message.resources_available());
+  auto available_resources_instance_set =
+      MapFromProtobuf(resource_view_sync_message.available_resources_instance_set());
   NodeResources node_resources =
       ResourceMapToNodeResources(resources_total, resources_available);
   NodeResources local_view;
@@ -86,6 +88,14 @@ bool ClusterResourceManager::UpdateNode(
 
   local_view.total = node_resources.total;
   local_view.available = node_resources.available;
+  for (const auto &[resource_name, available_list] : available_resources_instance_set) {
+    std::vector<FixedPoint> instances;
+    for (const auto &value : available_list.values()) {
+      instances.push_back(FixedPoint(value));
+    }
+    local_view.available_resources_instance_set.Set(scheduling::ResourceID(resource_name),
+                                                    instances);
+  }
   local_view.object_pulls_queued = resource_view_sync_message.object_pulls_queued();
 
   // Update the idle duration for the node in terms of resources usage.

--- a/src/ray/raylet/scheduling/policy/scheduling_policy_test.cc
+++ b/src/ray/raylet/scheduling/policy/scheduling_policy_test.cc
@@ -227,6 +227,18 @@ TEST_F(SchedulingPolicyTest, AvailableDefinitionTest) {
   resources.total.Set(ResourceID::CPU(), 2.0);
   ASSERT_FALSE(resources.IsAvailable(task_req1));
   ASSERT_TRUE(resources.IsAvailable(task_req2));
+
+  auto task_req3 = ResourceMapToResourceRequest({{"GPU", 0.5}}, false);
+  auto task_req4 = ResourceMapToResourceRequest({{"GPU", 1}}, false);
+
+  std::vector<FixedPoint> available_set;
+  available_set.push_back(FixedPoint(0.5));
+  available_set.push_back(FixedPoint(0.5));
+  resources.available.Set(ResourceID::GPU(), 1.0);
+  resources.total.Set(ResourceID::GPU(), 1.0);
+  resources.available_resources_instance_set.Set(ResourceID::GPU(), available_set);
+  ASSERT_TRUE(resources.IsAvailable(task_req3));
+  ASSERT_FALSE(resources.IsAvailable(task_req4));
 }
 
 TEST_F(SchedulingPolicyTest, CriticalResourceUtilizationDefinitionTest) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR aims to optimize the determination of whether node resources meet scheduling requirements.

**Current Issue**
In cases involving fraction accelerator scheduling, for example, when the available resource state is { XPU<sub>0</sub>: 0.5, XPU<sub>1</sub>: 0.5 }, a new resource request for { XPU: 1.0 } can lead Ray to incorrectly assume that the node can meet the request. As a result, the actor is scheduled on that node but remains pending, unable to be dispatched to potentially available nodes.

**Reason**
The current scheduling logic sums the available resources of the same type (0.5 + 0.5 = 1.0) to assess capacity.

**Optimization**
Proposes an accurate assessment of remaining resources based on each individual accelerator.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
