### PR TITLE
[RLlib] Add option to use `torch.lr_scheduler` classes for learning rate schedules.

### DIFF
--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -544,6 +544,7 @@ class AlgorithmConfig(_Config):
 
         # `self.experimental()`
         self._torch_grad_scaler_class = None
+        self._torch_lr_scheduler_classes = None
         self._tf_policy_handles_more_than_one_loss = False
         self._disable_preprocessor_api = False
         self._disable_action_flattening = False
@@ -3213,6 +3214,9 @@ class AlgorithmConfig(_Config):
         self,
         *,
         _torch_grad_scaler_class: Optional[Type] = NotProvided,
+        _torch_lr_scheduler_classes: Optional[
+            Union[List[Type], Dict[ModuleID, Type]]
+        ] = NotProvided,
         _tf_policy_handles_more_than_one_loss: Optional[bool] = NotProvided,
         _disable_preprocessor_api: Optional[bool] = NotProvided,
         _disable_action_flattening: Optional[bool] = NotProvided,
@@ -3234,6 +3238,14 @@ class AlgorithmConfig(_Config):
                 and step the given optimizer.
                 `update()` to update the scaler after an optimizer step (for example to
                 adjust the scale factor).
+            _torch_lr_scheduler_classes: A list of `torch.lr_scheduler.LRScheduler`
+                (see here for more details
+                https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate)
+                classes or a dictionary mapping module IDs to such a list of respective
+                scheduler classes. Multiple scheduler classes can be applied in sequence
+                and will be stepped in the same sequence as defined here. Note, most
+                learning rate schedulers need arguments to be configured, i.e. you need
+                to partially initialize the schedulers in the list(s).
             _tf_policy_handles_more_than_one_loss: Experimental flag.
                 If True, TFPolicy will handle more than one loss/optimizer.
                 Set this to True, if you would like to return more than
@@ -3277,6 +3289,8 @@ class AlgorithmConfig(_Config):
             )
         if _torch_grad_scaler_class is not NotProvided:
             self._torch_grad_scaler_class = _torch_grad_scaler_class
+        if _torch_lr_scheduler_classes is not NotProvided:
+            self._torch_lr_scheduler_classes = _torch_lr_scheduler_classes
 
         return self
 

--- a/rllib/core/learner/torch/torch_learner.py
+++ b/rllib/core/learner/torch/torch_learner.py
@@ -105,6 +105,10 @@ class TorchLearner(Learner):
             self._grad_scalers = defaultdict(
                 lambda: self.config._torch_grad_scaler_class()
             )
+        self._lr_schedulers = {}
+        self._lr_scheduler_classes = None
+        if self.config._torch_lr_scheduler_classes:
+            self._lr_scheduler_classes = self.config._torch_lr_scheduler_classes
 
     @OverrideToImplementCustomLogic
     @override(Learner)
@@ -182,6 +186,25 @@ class TorchLearner(Learner):
         for module_id, optimizer_names in self._module_optimizers.items():
             for optimizer_name in optimizer_names:
                 optim = self.get_optimizer(module_id, optimizer_name)
+                # If we have learning rate schedulers for a module add them, if
+                # necessary.
+                if self._lr_scheduler_classes is not None:
+                    if module_id not in self._lr_schedulers:
+                        # Set for each module and optimizer a scheduler.
+                        self._lr_schedulers[module_id] = {optimizer_name: []}
+                        # If the classes are in a dictionary each module might have
+                        # a different set of schedulers.
+                        if isinstance(self._lr_scheduler_classes, dict):
+                            scheduler_classes = self._lr_scheduler_classes[module_id]
+                        # Else, each module has the same learning rate schedulers.
+                        else:
+                            scheduler_classes = self._lr_scheduler_classes
+                        # Initialize and add the schedulers.
+                        for scheduler_class in scheduler_classes:
+                            self._lr_schedulers[module_id][optimizer_name].append(
+                                scheduler_class(optim)
+                            )
+
                 # Step through the scaler (unscales gradients, if applicable).
                 if self._grad_scalers is not None:
                     scaler = self._grad_scalers[module_id]
@@ -200,6 +223,11 @@ class TorchLearner(Learner):
                     for param in group["params"]
                 ):
                     optim.step()
+
+                    # If the module uses learning rate schedulers, step them here.
+                    if module_id in self._lr_schedulers:
+                        for scheduler in self._lr_schedulers[module_id][optimizer_name]:
+                            scheduler.step()
 
     @override(Learner)
     def _get_optimizer_state(self) -> StateDict:


### PR DESCRIPTION
## Why are these changes needed?

In many state-of-the-art papers complex learning rate schedules are used (for example cosinus learning rate schedules). Most learning rate schedules are implemented in the `torch.lr_scheduler` module, but cannot be used in `RLlib`'s algorithms, yet. This PR proposes a way to add a list of (module-specific) learning rate schedulers for each optimizer. This empowers users to use all kind of learning rate schedules and simplifies reproducing or verifying results from state-of-the-art papers as well as supplementing industrial appications with appropriate learning rate schedules.

## Related issue number



## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
