### PR TITLE
[Data] Remove ineffective retry code in `plan_read_op` 

### DIFF
--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -24,11 +24,6 @@ from ray.util.debug import log_once
 
 TASK_SIZE_WARN_THRESHOLD_BYTES = 1024 * 1024  # 1 MiB
 
-# Transient errors that can occur during longer reads. Trigger retry when these occur.
-READ_FILE_RETRY_ON_ERRORS = ["AWS Error NETWORK_CONNECTION", "AWS Error ACCESS_DENIED"]
-READ_FILE_MAX_ATTEMPTS = 10
-READ_FILE_RETRY_MAX_BACKOFF_SECONDS = 32
-
 logger = logging.getLogger(__name__)
 
 
@@ -96,17 +91,8 @@ def plan_read_op(
     )
 
     def do_read(blocks: Iterable[ReadTask], _: TaskContext) -> Iterable[Block]:
-        """Yield from read tasks, with retry logic upon transient read errors."""
         for read_task in blocks:
-            read_fn_name = read_task._read_fn.__name__
-
-            yield from call_with_retry(
-                f=read_task,
-                description=f"read file {read_fn_name}",
-                match=READ_FILE_RETRY_ON_ERRORS,
-                max_attempts=READ_FILE_MAX_ATTEMPTS,
-                max_backoff_s=READ_FILE_RETRY_MAX_BACKOFF_SECONDS,
-            )
+            yield from read_task()
 
     # Create a MapTransformer for a read operator
     transform_fns: List[MapTransformFn] = [

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -17,7 +17,7 @@ from ray.data._internal.execution.operators.map_transformer import (
 )
 from ray.data._internal.execution.util import memory_string
 from ray.data._internal.logical.operators.read_operator import Read
-from ray.data._internal.util import _warn_on_high_parallelism, call_with_retry
+from ray.data._internal.util import _warn_on_high_parallelism
 from ray.data.block import Block, BlockMetadata
 from ray.data.datasource.datasource import ReadTask
 from ray.util.debug import log_once


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Currently, Ray Data calls read tasks with retries. The intended purpose is to retry transient errors while reading data. 

https://github.com/ray-project/ray/blob/eda6d092973831523693be15535872ed8ea14fdd/python/ray/data/_internal/planner/plan_read_op.py#L103-L109

However, the code doesn't achieve the intended result because read tasks return generator objects, and Python will never raise runtime errors while returning a generator (Python might raise runtime errors when the programs iterates over the returned generator).

https://github.com/ray-project/ray/blob/eda6d092973831523693be15535872ed8ea14fdd/python/ray/data/datasource/datasource.py#L160-L168
 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
