### PR TITLE
[Data] Remove remote call for initializing `Datasource` in `read_datasource()`

### DIFF
--- a/python/ray/data/tests/test_consumption.py
+++ b/python/ray/data/tests/test_consumption.py
@@ -46,7 +46,6 @@ def test_schema(ray_start_regular):
             task_count={
                 "ReadRange": 10,
                 "reduce": 5,
-                "_get_datasource_or_legacy_reader": 1,
             }
         ),
         last_snapshot,
@@ -89,7 +88,7 @@ def test_schema_no_execution(ray_start_regular):
     last_snapshot = get_initial_core_execution_metrics_snapshot()
     ds = ray.data.range(100, override_num_blocks=10)
     last_snapshot = assert_core_execution_metrics_equals(
-        CoreExecutionMetrics(task_count={"_get_datasource_or_legacy_reader": 1}),
+        CoreExecutionMetrics(task_count={}),
         last_snapshot,
     )
     # We do not kick off the read task by default.
@@ -146,9 +145,7 @@ def test_count(ray_start_regular):
     # for ray.data.range(), as the number of rows is known beforehand.
     assert not ds._plan.has_started_execution
 
-    assert_core_execution_metrics_equals(
-        CoreExecutionMetrics(task_count={"_get_datasource_or_legacy_reader": 1})
-    )
+    assert_core_execution_metrics_equals(CoreExecutionMetrics(task_count={}))
 
 
 def test_count_edge_case(ray_start_regular):
@@ -189,11 +186,7 @@ def test_limit_execution(ray_start_regular):
 
     ds = ds.map(delay)
     last_snapshot = assert_core_execution_metrics_equals(
-        CoreExecutionMetrics(
-            task_count={
-                "_get_datasource_or_legacy_reader": 1,
-            }
-        ),
+        CoreExecutionMetrics(task_count={}),
         last_snapshot=last_snapshot,
     )
 
@@ -218,7 +211,6 @@ def test_limit_execution(ray_start_regular):
         CoreExecutionMetrics(
             task_count={
                 "ReadRange": 20,
-                "_get_datasource_or_legacy_reader": 1,
             }
         ),
         last_snapshot=last_snapshot,

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -203,7 +203,6 @@ def test_dataset(
     last_snapshot = assert_core_execution_metrics_equals(
         CoreExecutionMetrics(
             task_count={
-                "_get_datasource_or_legacy_reader": 1,
                 "ReadRandomBytes": lambda count: count < num_tasks,
             },
             object_store_stats={

--- a/python/ray/data/tests/test_splitblocks.py
+++ b/python/ray/data/tests/test_splitblocks.py
@@ -38,7 +38,6 @@ def test_small_file_split(ray_start_10_cpus_shared, restore_data_context):
         CoreExecutionMetrics(
             task_count={
                 "ReadCSV": 1,
-                "_get_datasource_or_legacy_reader": 1,
             },
         ),
         last_snapshot,
@@ -64,7 +63,6 @@ def test_small_file_split(ray_start_10_cpus_shared, restore_data_context):
     last_snapshot = assert_core_execution_metrics_equals(
         CoreExecutionMetrics(
             task_count={
-                "_get_datasource_or_legacy_reader": 1,
                 "MapBatches(<lambda>)": 10,
                 "ReadCSV->SplitBlocks(10)": 1,
             },


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Cleans up `read_datasource()` code path by removing the remote call to initialize `Datasource` / `Reader` used in the method. 

To use Ray Data with Ray Client, the suggested method is to wrap the entire Ray Data code in a remote task.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
