### PR TITLE
[release] simplify the process of getting job logs

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -37,5 +37,5 @@ urllib3 < 1.27
 # External dependencies such as ML libraries should be mocked out, not added here.
 # See doc/source/conf.py for examples of how to mock out external dependencies.
 click==8.1.7
-boto3==1.35.2
+boto3==1.34.69
 requests==2.32.3

--- a/release/ray_release/anyscale_util.py
+++ b/release/ray_release/anyscale_util.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from anyscale.sdk.anyscale_client.sdk import AnyscaleSDK
 
 
-LAST_LOGS_LENGTH = 30
+LAST_LOGS_LENGTH = 100
 
 
 def find_cloud_by_name(

--- a/release/ray_release/job_manager/anyscale_job_manager.py
+++ b/release/ray_release/job_manager/anyscale_job_manager.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 from typing import Any, Dict, Optional, Tuple, List
 
 
+import anyscale
 from anyscale.sdk.anyscale_client.models import (
     CreateProductionJob,
     HaJobStates,
@@ -273,64 +274,14 @@ class AnyscaleJobManager:
         )
         return self._wait_job(timeout)
 
-    def _get_ray_logs(self) -> Tuple[Optional[str], Optional[str]]:
+    def _get_ray_logs(self) -> str:
         """
-        Obtain any ray logs that contain keywords that indicate a crash, such as
-        ERROR or Traceback
+        Obtain the last few logs
         """
-        with tempfile.TemporaryDirectory() as tmpdir:
-            try:
-                subprocess.check_output(
-                    [
-                        "anyscale",
-                        "logs",
-                        "cluster",
-                        "--id",
-                        self.cluster_manager.cluster_id,
-                        "--head-only",
-                        "--download",
-                        "--download-dir",
-                        tmpdir,
-                    ]
-                )
-            except Exception as e:
-                logger.exception(f"Failed to download logs from anyscale {e}")
-                return None, None
-            return AnyscaleJobManager._find_job_driver_and_ray_error_logs(tmpdir)
-
-    @staticmethod
-    def _find_job_driver_and_ray_error_logs(
-        tmpdir: str,
-    ) -> Tuple[Optional[str], Optional[str]]:
-        # Ignored some ray files that do not crash ray despite having exceptions
-        ignored_ray_files = [
-            "monitor.log",
-            "event_AUTOSCALER.log",
-            "event_JOBS.log",
-        ]
-        error_output = None
-        job_driver_output = None
-        matched_pattern_count = 0
-        for root, _, files in os.walk(tmpdir):
-            files.sort()  # Make the iteration order deterministic.
-            for file in files:
-                if file in ignored_ray_files:
-                    continue
-                with open(os.path.join(root, file)) as lines:
-                    output = "".join(deque(lines, maxlen=3 * LAST_LOGS_LENGTH))
-                    # job-driver logs
-                    if file.startswith("job-driver-"):
-                        job_driver_output = output
-                        continue
-                    # ray error logs, favor those that match with the most number of
-                    # error patterns
-                    this_match = len(
-                        [error for error in ERROR_LOG_PATTERNS if error in output]
-                    )
-                    if this_match > matched_pattern_count:
-                        error_output = output
-                        matched_pattern_count = this_match
-        return job_driver_output, error_output
+        return anyscale.job.get_logs(
+            id=self.cluster_manager.cluster_id,
+            max_lines=LAST_LOGS_LENGTH,
+        )
 
     def get_last_logs(self):
         if not self.job_id:
@@ -345,16 +296,8 @@ class AnyscaleJobManager:
         if self._duration is not None and self._duration > 4 * 3_600:
             return None
 
-        def _get_logs():
-            job_driver_log, ray_error_log = self._get_ray_logs()
-            assert job_driver_log or ray_error_log, "No logs fetched"
-            if job_driver_log:
-                return job_driver_log
-            else:
-                return ray_error_log
-
         ret = exponential_backoff_retry(
-            _get_logs,
+            self._get_ray_logs(),
             retry_exceptions=Exception,
             initial_retry_delay_s=30,
             max_retries=3,

--- a/release/ray_release/job_manager/anyscale_job_manager.py
+++ b/release/ray_release/job_manager/anyscale_job_manager.py
@@ -1,8 +1,4 @@
-import os
 import time
-import subprocess
-import tempfile
-from collections import deque
 from contextlib import contextmanager
 from typing import Any, Dict, Optional, Tuple, List
 
@@ -22,7 +18,6 @@ from ray_release.exception import (
 from ray_release.logger import logger
 from ray_release.signal_handling import register_handler, unregister_handler
 from ray_release.util import (
-    ERROR_LOG_PATTERNS,
     exponential_backoff_retry,
     anyscale_job_url,
     format_link,
@@ -278,10 +273,7 @@ class AnyscaleJobManager:
         """
         Obtain the last few logs
         """
-        return anyscale.job.get_logs(
-            id=self.cluster_manager.cluster_id,
-            max_lines=LAST_LOGS_LENGTH,
-        )
+        return anyscale.job.get_logs(id=self.job_id, max_lines=LAST_LOGS_LENGTH)
 
     def get_last_logs(self):
         if not self.job_id:
@@ -297,7 +289,7 @@ class AnyscaleJobManager:
             return None
 
         ret = exponential_backoff_retry(
-            self._get_ray_logs(),
+            self._get_ray_logs,
             retry_exceptions=Exception,
             initial_retry_delay_s=30,
             max_retries=3,

--- a/release/ray_release/tests/test_anyscale_job_manager.py
+++ b/release/ray_release/tests/test_anyscale_job_manager.py
@@ -1,31 +1,12 @@
 import pytest
 import sys
-import tempfile
-import os
 
-from ray_release.util import ERROR_LOG_PATTERNS
 from ray_release.job_manager.anyscale_job_manager import AnyscaleJobManager
 
 
 class FakeJobResult:
     def __init__(self, _id: str):
         self.id = _id
-
-
-def test_get_ray_error_logs():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, "log01"), "w") as f:
-            f.writelines(ERROR_LOG_PATTERNS[:1])
-        with open(os.path.join(tmpdir, "log02"), "w") as f:
-            f.writelines(ERROR_LOG_PATTERNS + ["haha"])
-        with open(os.path.join(tmpdir, "job-driver-w00t"), "w") as f:
-            f.writelines("w00t")
-        (
-            job_driver_log,
-            ray_error_log,
-        ) = AnyscaleJobManager._find_job_driver_and_ray_error_logs(tmpdir)
-        assert ray_error_log == "".join(ERROR_LOG_PATTERNS + ["haha"])
-        assert job_driver_log == "w00t"
 
 
 def test_get_last_logs_long_running_job():

--- a/release/requirements_buildkite.in
+++ b/release/requirements_buildkite.in
@@ -1,6 +1,6 @@
 # Requirements to run release tests from buildkite (client dependencies will be installed separately)
 # Copy anyscale pin to requirements.txt and util.py
-anyscale
+anyscale >= 0.24.62
 bazel-runfiles
 aioboto3
 boto3

--- a/release/requirements_buildkite.txt
+++ b/release/requirements_buildkite.txt
@@ -112,8 +112,14 @@ annotated-types==0.7.0 \
     --hash=sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53 \
     --hash=sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89
     # via pydantic
-anyscale==0.24.23 \
-    --hash=sha256:31f208ed659cc8f3f1b18f417b2dea8cbcfb32bf4726900ca78fade6f003e408
+anyio==4.4.0 \
+    --hash=sha256:5aadc6a1bbb7cdb0bede386cac5e2940f5e2ff3aa20277e991cf028e0585ce94 \
+    --hash=sha256:c1b2d8f46a8a812513012e1107cb0e68c17159a7a594208005a57dc776e1bdc7
+    # via
+    #   starlette
+    #   watchfiles
+anyscale==0.24.62 \
+    --hash=sha256:a07115a2a65ffc79852d9d65a8b313987d8850d93f2c383c394ac9af7f08485f
     # via -r release/requirements_buildkite.in
 appnope==0.1.4 \
     --hash=sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee \
@@ -163,6 +169,7 @@ boto3==1.34.69 \
     --hash=sha256:2e25ef6bd325217c2da329829478be063155897d8d3b29f31f7f23ab548519b1 \
     --hash=sha256:898a5fed26b1351352703421d1a8b886ef2a74be6c97d5ecc92432ae01fda203
     # via
+    #   -r release/requirements-doc.txt
     #   -r release/requirements_buildkite.in
     #   aiobotocore
     #   anyscale
@@ -336,10 +343,12 @@ click==8.1.7 \
     --hash=sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28 \
     --hash=sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de
     # via
+    #   -r release/requirements-doc.txt
     #   -r release/requirements_buildkite.in
     #   anyscale
     #   jupyter-cache
     #   sphinx-click
+    #   uvicorn
 colorama==0.4.6 \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
@@ -347,6 +356,7 @@ colorama==0.4.6 \
     #   anyscale
     #   halo
     #   log-symbols
+    #   sphinx-autobuild
 comm==0.2.2 \
     --hash=sha256:3fd7a84065306e07bea1773df6eb8282de51ba82f77c72f9c85716ab11fe980e \
     --hash=sha256:e6fb86cb70ff661ee8c9c14e7d36d6de3b4066f1441be4063df9c5009f0a64d3
@@ -439,6 +449,7 @@ exceptiongroup==1.2.1 \
     --hash=sha256:5258b9ed329c5bbdd31a309f53cbfb0b155341807f6ff7606a1e801a891b29ad \
     --hash=sha256:a4785e48b045528f5bfe627b6ad554ff32def154f42372786903b7abcfe1aa16
     # via
+    #   anyio
     #   ipython
     #   pytest
 executing==2.0.1 \
@@ -704,6 +715,10 @@ greenlet==3.0.3 \
     --hash=sha256:fd096eb7ffef17c456cfa587523c5f92321ae02427ff955bebe9e3c63bc9f0da \
     --hash=sha256:fe754d231288e1e64323cfad462fcee8f0288654c10bdf4f603a39ed923bef33
     # via sqlalchemy
+h11==0.14.0 \
+    --hash=sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d \
+    --hash=sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761
+    # via uvicorn
 halo==0.0.31 \
     --hash=sha256:5350488fb7d2aa7c31a1344120cee67a872901ce8858f60da7946cef96c208ab \
     --hash=sha256:7b67a3521ee91d53b7152d4ee3452811e1d2a6321975137762eb3d70063cc9d6
@@ -720,6 +735,7 @@ idna==3.7 \
     --hash=sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc \
     --hash=sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0
     # via
+    #   anyio
     #   requests
     #   yarl
 imagesize==1.4.1 \
@@ -1503,10 +1519,11 @@ referencing==0.35.1 \
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.31.0 \
-    --hash=sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f \
-    --hash=sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1
+requests==2.32.3 \
+    --hash=sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760 \
+    --hash=sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
     # via
+    #   -r release/requirements-doc.txt
     #   -r release/requirements_buildkite.in
     #   anyscale
     #   aws-requests-auth
@@ -1671,6 +1688,10 @@ smmap==5.0.1 \
     --hash=sha256:dceeb6c0028fdb6734471eb07c0cd2aae706ccaecab45965ee83f11c8d3b1f62 \
     --hash=sha256:e6d8668fa5f93e706934a62d7b4db19c8d9eb8cf2adbb75ef1b675aa332b69da
     # via gitdb
+sniffio==1.3.1 \
+    --hash=sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2 \
+    --hash=sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc
+    # via anyio
 snowballstemmer==2.2.0 \
     --hash=sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1 \
     --hash=sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a
@@ -1679,22 +1700,28 @@ soupsieve==2.5 \
     --hash=sha256:5663d5a7b3bfaeee0bc4372e7fc48f9cff4940b3eec54a6451cc5299f1097690 \
     --hash=sha256:eaa337ff55a1579b6549dc679565eac1e3d000563bcb1c8ab0d0fefbc0c2cdc7
     # via beautifulsoup4
-sphinx==7.1.2 \
-    --hash=sha256:780f4d32f1d7d1126576e0e5ecc19dc32ab76cd24e950228dcf7b1f6d3d9e22f \
-    --hash=sha256:d170a81825b2fcacb6dfd5a0d7f578a053e45d3f2b153fecc948c37344eb4cbe
+sphinx==7.3.7 \
+    --hash=sha256:413f75440be4cacf328f580b4274ada4565fb2187d696a84970c23f77b64d8c3 \
+    --hash=sha256:a4a7db75ed37531c05002d56ed6948d4c42f473a36f46e1382b0bd76ca9627bc
     # via
     #   -r release/requirements-doc.txt
     #   autodoc-pydantic
     #   myst-nb
     #   myst-parser
     #   pydata-sphinx-theme
+    #   sphinx-autobuild
     #   sphinx-click
     #   sphinx-copybutton
     #   sphinx-design
+    #   sphinx-docsearch
     #   sphinx-remove-toctrees
     #   sphinx-sitemap
     #   sphinxcontrib-redoc
     #   sphinxemoji
+sphinx-autobuild==2024.4.16 \
+    --hash=sha256:1c0ed37a1970eed197f9c5a66d65759e7c4e4cba7b5a5d77940752bf1a59f2c7 \
+    --hash=sha256:f2522779d30fcbf0253e09714f274ce8c608cb6ebcd67922b1c54de59faba702
+    # via -r release/requirements-doc.txt
 sphinx-click==5.1.0 \
     --hash=sha256:6812c2db62d3fae71a4addbe5a8a0a16c97eb491f3cd63fe34b4ed7e07236f33 \
     --hash=sha256:ae97557a4e9ec646045089326c3b90e026c58a45e083b8f35f17d5d6558d08a0
@@ -1706,6 +1733,10 @@ sphinx-copybutton==0.5.2 \
 sphinx-design==0.5.0 \
     --hash=sha256:1af1267b4cea2eedd6724614f19dcc88fe2e15aff65d06b2f6252cee9c4f4c1e \
     --hash=sha256:e8e513acea6f92d15c6de3b34e954458f245b8e761b45b63950f65373352ab00
+    # via -r release/requirements-doc.txt
+sphinx-docsearch==0.0.7 \
+    --hash=sha256:53ee7c669e82a72156e694128b7737d6c5fc481e09ae642a6e63604a9018a8fb \
+    --hash=sha256:cd096cf8445768fcb3e47bd9504077b1daefdcaec1374ae99272a3bdae158d83
     # via -r release/requirements-doc.txt
 sphinx-jsonschema==1.19.1 \
     --hash=sha256:b2385fe1c7acf2e759152aefed0cb17c920645b2a75c9934000c9c528e7d53c1
@@ -1807,6 +1838,10 @@ stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
     # via ipython
+starlette==0.38.4 \
+    --hash=sha256:526f53a77f0e43b85f583438aee1a940fd84f8fd610353e8b0c1a77ad8a87e76 \
+    --hash=sha256:53a7439060304a208fea17ed407e998f46da5e5d9b1addfea3040094512a6379
+    # via sphinx-autobuild
 tabulate==0.9.0 \
     --hash=sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c \
     --hash=sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f
@@ -1824,7 +1859,9 @@ toml==0.10.2 \
 tomli==2.0.1 \
     --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc \
     --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f
-    # via pytest
+    # via
+    #   pytest
+    #   sphinx
 tornado==6.4.1 \
     --hash=sha256:163b0aafc8e23d8cdc3c9dfb24c5368af84a81e3364745ccb4427669bf84aec8 \
     --hash=sha256:25486eb223babe3eed4b8aecbac33b37e3dd6d776bc730ca14e1bf93888b979f \
@@ -1865,6 +1902,7 @@ typing-extensions==4.11.0 \
     --hash=sha256:c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a
     # via
     #   aioitertools
+    #   anyio
     #   anyscale
     #   ipython
     #   myst-nb
@@ -1873,6 +1911,8 @@ typing-extensions==4.11.0 \
     #   pydata-sphinx-theme
     #   pygithub
     #   sqlalchemy
+    #   starlette
+    #   uvicorn
 tzdata==2024.1 \
     --hash=sha256:2674120f8d891909751c38abcdfd386ac0a5a1127954fbc332af6b5ceae07efd \
     --hash=sha256:9068bc196136463f5245e51efda838afa15aaeca9903f49050dfa2679db4d252
@@ -1892,10 +1932,187 @@ urllib3==1.26.18 \
     #   pygithub
     #   requests
     #   twine
+uvicorn==0.30.6 \
+    --hash=sha256:4b15decdda1e72be08209e860a1e10e92439ad5b97cf44cc945fcbee66fc5788 \
+    --hash=sha256:65fd46fe3fda5bdc1b03b94eb634923ff18cd35b2f084813ea79d1f103f711b5
+    # via sphinx-autobuild
+watchfiles==0.24.0 \
+    --hash=sha256:01550ccf1d0aed6ea375ef259706af76ad009ef5b0203a3a4cce0f6024f9b68a \
+    --hash=sha256:01def80eb62bd5db99a798d5e1f5f940ca0a05986dcfae21d833af7a46f7ee22 \
+    --hash=sha256:07cdef0c84c03375f4e24642ef8d8178e533596b229d32d2bbd69e5128ede02a \
+    --hash=sha256:083dc77dbdeef09fa44bb0f4d1df571d2e12d8a8f985dccde71ac3ac9ac067a0 \
+    --hash=sha256:1cf1f6dd7825053f3d98f6d33f6464ebdd9ee95acd74ba2c34e183086900a827 \
+    --hash=sha256:21ab23fdc1208086d99ad3f69c231ba265628014d4aed31d4e8746bd59e88cd1 \
+    --hash=sha256:2dadf8a8014fde6addfd3c379e6ed1a981c8f0a48292d662e27cabfe4239c83c \
+    --hash=sha256:2e28d91ef48eab0afb939fa446d8ebe77e2f7593f5f463fd2bb2b14132f95b6e \
+    --hash=sha256:2efec17819b0046dde35d13fb8ac7a3ad877af41ae4640f4109d9154ed30a188 \
+    --hash=sha256:30bbd525c3262fd9f4b1865cb8d88e21161366561cd7c9e1194819e0a33ea86b \
+    --hash=sha256:316449aefacf40147a9efaf3bd7c9bdd35aaba9ac5d708bd1eb5763c9a02bef5 \
+    --hash=sha256:327763da824817b38ad125dcd97595f942d720d32d879f6c4ddf843e3da3fe90 \
+    --hash=sha256:32aa53a9a63b7f01ed32e316e354e81e9da0e6267435c7243bf8ae0f10b428ef \
+    --hash=sha256:34e19e56d68b0dad5cff62273107cf5d9fbaf9d75c46277aa5d803b3ef8a9e9b \
+    --hash=sha256:3770e260b18e7f4e576edca4c0a639f704088602e0bc921c5c2e721e3acb8d15 \
+    --hash=sha256:3d2e3ab79a1771c530233cadfd277fcc762656d50836c77abb2e5e72b88e3a48 \
+    --hash=sha256:41face41f036fee09eba33a5b53a73e9a43d5cb2c53dad8e61fa6c9f91b5a51e \
+    --hash=sha256:43e3e37c15a8b6fe00c1bce2473cfa8eb3484bbeecf3aefbf259227e487a03df \
+    --hash=sha256:449f43f49c8ddca87c6b3980c9284cab6bd1f5c9d9a2b00012adaaccd5e7decd \
+    --hash=sha256:4933a508d2f78099162da473841c652ad0de892719043d3f07cc83b33dfd9d91 \
+    --hash=sha256:49d617df841a63b4445790a254013aea2120357ccacbed00253f9c2b5dc24e2d \
+    --hash=sha256:49fb58bcaa343fedc6a9e91f90195b20ccb3135447dc9e4e2570c3a39565853e \
+    --hash=sha256:4a7fa2bc0efef3e209a8199fd111b8969fe9db9c711acc46636686331eda7dd4 \
+    --hash=sha256:4abf4ad269856618f82dee296ac66b0cd1d71450fc3c98532d93798e73399b7a \
+    --hash=sha256:4b8693502d1967b00f2fb82fc1e744df128ba22f530e15b763c8d82baee15370 \
+    --hash=sha256:4d28cea3c976499475f5b7a2fec6b3a36208656963c1a856d328aeae056fc5c1 \
+    --hash=sha256:5148c2f1ea043db13ce9b0c28456e18ecc8f14f41325aa624314095b6aa2e9ea \
+    --hash=sha256:54ca90a9ae6597ae6dc00e7ed0a040ef723f84ec517d3e7ce13e63e4bc82fa04 \
+    --hash=sha256:551ec3ee2a3ac9cbcf48a4ec76e42c2ef938a7e905a35b42a1267fa4b1645896 \
+    --hash=sha256:5c51749f3e4e269231510da426ce4a44beb98db2dce9097225c338f815b05d4f \
+    --hash=sha256:632676574429bee8c26be8af52af20e0c718cc7f5f67f3fb658c71928ccd4f7f \
+    --hash=sha256:6509ed3f467b79d95fc62a98229f79b1a60d1b93f101e1c61d10c95a46a84f43 \
+    --hash=sha256:6bdcfa3cd6fdbdd1a068a52820f46a815401cbc2cb187dd006cb076675e7b735 \
+    --hash=sha256:7138eff8baa883aeaa074359daabb8b6c1e73ffe69d5accdc907d62e50b1c0da \
+    --hash=sha256:7211b463695d1e995ca3feb38b69227e46dbd03947172585ecb0588f19b0d87a \
+    --hash=sha256:73bde715f940bea845a95247ea3e5eb17769ba1010efdc938ffcb967c634fa61 \
+    --hash=sha256:78470906a6be5199524641f538bd2c56bb809cd4bf29a566a75051610bc982c3 \
+    --hash=sha256:7ae3e208b31be8ce7f4c2c0034f33406dd24fbce3467f77223d10cd86778471c \
+    --hash=sha256:7e4bd963a935aaf40b625c2499f3f4f6bbd0c3776f6d3bc7c853d04824ff1c9f \
+    --hash=sha256:82ae557a8c037c42a6ef26c494d0631cacca040934b101d001100ed93d43f361 \
+    --hash=sha256:82b2509f08761f29a0fdad35f7e1638b8ab1adfa2666d41b794090361fb8b855 \
+    --hash=sha256:8360f7314a070c30e4c976b183d1d8d1585a4a50c5cb603f431cebcbb4f66327 \
+    --hash=sha256:85d5f0c7771dcc7a26c7a27145059b6bb0ce06e4e751ed76cdf123d7039b60b5 \
+    --hash=sha256:88bcd4d0fe1d8ff43675360a72def210ebad3f3f72cabfeac08d825d2639b4ab \
+    --hash=sha256:9301c689051a4857d5b10777da23fafb8e8e921bcf3abe6448a058d27fb67633 \
+    --hash=sha256:951088d12d339690a92cef2ec5d3cfd957692834c72ffd570ea76a6790222777 \
+    --hash=sha256:95cf3b95ea665ab03f5a54765fa41abf0529dbaf372c3b83d91ad2cfa695779b \
+    --hash=sha256:96619302d4374de5e2345b2b622dc481257a99431277662c30f606f3e22f42be \
+    --hash=sha256:999928c6434372fde16c8f27143d3e97201160b48a614071261701615a2a156f \
+    --hash=sha256:9a60e2bf9dc6afe7f743e7c9b149d1fdd6dbf35153c78fe3a14ae1a9aee3d98b \
+    --hash=sha256:9f895d785eb6164678ff4bb5cc60c5996b3ee6df3edb28dcdeba86a13ea0465e \
+    --hash=sha256:a2a9891723a735d3e2540651184be6fd5b96880c08ffe1a98bae5017e65b544b \
+    --hash=sha256:a974231b4fdd1bb7f62064a0565a6b107d27d21d9acb50c484d2cdba515b9366 \
+    --hash=sha256:aa0fd7248cf533c259e59dc593a60973a73e881162b1a2f73360547132742823 \
+    --hash=sha256:acbfa31e315a8f14fe33e3542cbcafc55703b8f5dcbb7c1eecd30f141df50db3 \
+    --hash=sha256:afb72325b74fa7a428c009c1b8be4b4d7c2afedafb2982827ef2156646df2fe1 \
+    --hash=sha256:b3ef2c69c655db63deb96b3c3e587084612f9b1fa983df5e0c3379d41307467f \
+    --hash=sha256:b52a65e4ea43c6d149c5f8ddb0bef8d4a1e779b77591a458a893eb416624a418 \
+    --hash=sha256:b665caeeda58625c3946ad7308fbd88a086ee51ccb706307e5b1fa91556ac886 \
+    --hash=sha256:b74fdffce9dfcf2dc296dec8743e5b0332d15df19ae464f0e249aa871fc1c571 \
+    --hash=sha256:b995bfa6bf01a9e09b884077a6d37070464b529d8682d7691c2d3b540d357a0c \
+    --hash=sha256:bd82010f8ab451dabe36054a1622870166a67cf3fce894f68895db6f74bbdc94 \
+    --hash=sha256:bdcd5538e27f188dd3c804b4a8d5f52a7fc7f87e7fd6b374b8e36a4ca03db428 \
+    --hash=sha256:c79d7719d027b7a42817c5d96461a99b6a49979c143839fc37aa5748c322f234 \
+    --hash=sha256:cdab9555053399318b953a1fe1f586e945bc8d635ce9d05e617fd9fe3a4687d6 \
+    --hash=sha256:ce72dba6a20e39a0c628258b5c308779b8697f7676c254a845715e2a1039b968 \
+    --hash=sha256:d337193bbf3e45171c8025e291530fb7548a93c45253897cd764a6a71c937ed9 \
+    --hash=sha256:d3dcb774e3568477275cc76554b5a565024b8ba3a0322f77c246bc7111c5bb9c \
+    --hash=sha256:d64ba08db72e5dfd5c33be1e1e687d5e4fcce09219e8aee893a4862034081d4e \
+    --hash=sha256:d7a2e3b7f5703ffbd500dabdefcbc9eafeff4b9444bbdd5d83d79eedf8428fab \
+    --hash=sha256:d831ee0a50946d24a53821819b2327d5751b0c938b12c0653ea5be7dea9c82ec \
+    --hash=sha256:d9018153cf57fc302a2a34cb7564870b859ed9a732d16b41a9b5cb2ebed2d444 \
+    --hash=sha256:e5171ef898299c657685306d8e1478a45e9303ddcd8ac5fed5bd52ad4ae0b69b \
+    --hash=sha256:e94e98c7cb94cfa6e071d401ea3342767f28eb5a06a58fafdc0d2a4974f4f35c \
+    --hash=sha256:ec39698c45b11d9694a1b635a70946a5bad066b593af863460a8e600f0dff1ca \
+    --hash=sha256:ed9aba6e01ff6f2e8285e5aa4154e2970068fe0fc0998c4380d0e6278222269b \
+    --hash=sha256:edf71b01dec9f766fb285b73930f95f730bb0943500ba0566ae234b5c1618c18 \
+    --hash=sha256:ee82c98bed9d97cd2f53bdb035e619309a098ea53ce525833e26b93f673bc318 \
+    --hash=sha256:f4c96283fca3ee09fb044f02156d9570d156698bc3734252175a38f0e8975f07 \
+    --hash=sha256:f7d9b87c4c55e3ea8881dfcbf6d61ea6775fffed1fedffaa60bd047d3c08c430 \
+    --hash=sha256:f83df90191d67af5a831da3a33dd7628b02a95450e168785586ed51e6d28943c \
+    --hash=sha256:fca9433a45f18b7c779d2bae7beeec4f740d28b788b117a48368d95a3233ed83 \
+    --hash=sha256:fd92bbaa2ecdb7864b7600dcdb6f2f1db6e0346ed425fbd01085be04c63f0b05
+    # via sphinx-autobuild
 wcwidth==0.2.13 \
     --hash=sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859 \
     --hash=sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5
     # via prompt-toolkit
+websockets==13.0.1 \
+    --hash=sha256:00fd961943b6c10ee6f0b1130753e50ac5dcd906130dcd77b0003c3ab797d026 \
+    --hash=sha256:03d3f9ba172e0a53e37fa4e636b86cc60c3ab2cfee4935e66ed1d7acaa4625ad \
+    --hash=sha256:0513c727fb8adffa6d9bf4a4463b2bade0186cbd8c3604ae5540fae18a90cb99 \
+    --hash=sha256:05e70fec7c54aad4d71eae8e8cab50525e899791fc389ec6f77b95312e4e9920 \
+    --hash=sha256:0617fd0b1d14309c7eab6ba5deae8a7179959861846cbc5cb528a7531c249448 \
+    --hash=sha256:06c0a667e466fcb56a0886d924b5f29a7f0886199102f0a0e1c60a02a3751cb4 \
+    --hash=sha256:0f52504023b1480d458adf496dc1c9e9811df4ba4752f0bc1f89ae92f4f07d0c \
+    --hash=sha256:10a0dc7242215d794fb1918f69c6bb235f1f627aaf19e77f05336d147fce7c37 \
+    --hash=sha256:11f9976ecbc530248cf162e359a92f37b7b282de88d1d194f2167b5e7ad80ce3 \
+    --hash=sha256:132511bfd42e77d152c919147078460c88a795af16b50e42a0bd14f0ad71ddd2 \
+    --hash=sha256:139add0f98206cb74109faf3611b7783ceafc928529c62b389917a037d4cfdf4 \
+    --hash=sha256:14b9c006cac63772b31abbcd3e3abb6228233eec966bf062e89e7fa7ae0b7333 \
+    --hash=sha256:15c7d62ee071fa94a2fc52c2b472fed4af258d43f9030479d9c4a2de885fd543 \
+    --hash=sha256:165bedf13556f985a2aa064309baa01462aa79bf6112fbd068ae38993a0e1f1b \
+    --hash=sha256:17118647c0ea14796364299e942c330d72acc4b248e07e639d34b75067b3cdd8 \
+    --hash=sha256:1841c9082a3ba4a05ea824cf6d99570a6a2d8849ef0db16e9c826acb28089e8f \
+    --hash=sha256:1a678532018e435396e37422a95e3ab87f75028ac79570ad11f5bf23cd2a7d8c \
+    --hash=sha256:1ee4cc030a4bdab482a37462dbf3ffb7e09334d01dd37d1063be1136a0d825fa \
+    --hash=sha256:1f3cf6d6ec1142412d4535adabc6bd72a63f5f148c43fe559f06298bc21953c9 \
+    --hash=sha256:1f613289f4a94142f914aafad6c6c87903de78eae1e140fa769a7385fb232fdf \
+    --hash=sha256:1fa082ea38d5de51dd409434edc27c0dcbd5fed2b09b9be982deb6f0508d25bc \
+    --hash=sha256:249aab278810bee585cd0d4de2f08cfd67eed4fc75bde623be163798ed4db2eb \
+    --hash=sha256:254ecf35572fca01a9f789a1d0f543898e222f7b69ecd7d5381d8d8047627bdb \
+    --hash=sha256:2a02b0161c43cc9e0232711eff846569fad6ec836a7acab16b3cf97b2344c060 \
+    --hash=sha256:30d3a1f041360f029765d8704eae606781e673e8918e6b2c792e0775de51352f \
+    --hash=sha256:3624fd8664f2577cf8de996db3250662e259bfbc870dd8ebdcf5d7c6ac0b5185 \
+    --hash=sha256:3f55b36d17ac50aa8a171b771e15fbe1561217510c8768af3d546f56c7576cdc \
+    --hash=sha256:46af561eba6f9b0848b2c9d2427086cabadf14e0abdd9fde9d72d447df268418 \
+    --hash=sha256:47236c13be337ef36546004ce8c5580f4b1150d9538b27bf8a5ad8edf23ccfab \
+    --hash=sha256:4a365bcb7be554e6e1f9f3ed64016e67e2fa03d7b027a33e436aecf194febb63 \
+    --hash=sha256:4d6ece65099411cfd9a48d13701d7438d9c34f479046b34c50ff60bb8834e43e \
+    --hash=sha256:4e85f46ce287f5c52438bb3703d86162263afccf034a5ef13dbe4318e98d86e7 \
+    --hash=sha256:4f0426d51c8f0926a4879390f53c7f5a855e42d68df95fff6032c82c888b5f36 \
+    --hash=sha256:518f90e6dd089d34eaade01101fd8a990921c3ba18ebbe9b0165b46ebff947f0 \
+    --hash=sha256:52aed6ef21a0f1a2a5e310fb5c42d7555e9c5855476bbd7173c3aa3d8a0302f2 \
+    --hash=sha256:556e70e4f69be1082e6ef26dcb70efcd08d1850f5d6c5f4f2bcb4e397e68f01f \
+    --hash=sha256:56a952fa2ae57a42ba7951e6b2605e08a24801a4931b5644dfc68939e041bc7f \
+    --hash=sha256:59197afd478545b1f73367620407b0083303569c5f2d043afe5363676f2697c9 \
+    --hash=sha256:5df891c86fe68b2c38da55b7aea7095beca105933c697d719f3f45f4220a5e0e \
+    --hash=sha256:63848cdb6fcc0bf09d4a155464c46c64ffdb5807ede4fb251da2c2692559ce75 \
+    --hash=sha256:64a11aae1de4c178fa653b07d90f2fb1a2ed31919a5ea2361a38760192e1858b \
+    --hash=sha256:6724b554b70d6195ba19650fef5759ef11346f946c07dbbe390e039bcaa7cc3d \
+    --hash=sha256:67494e95d6565bf395476e9d040037ff69c8b3fa356a886b21d8422ad86ae075 \
+    --hash=sha256:67648f5e50231b5a7f6d83b32f9c525e319f0ddc841be0de64f24928cd75a603 \
+    --hash=sha256:68264802399aed6fe9652e89761031acc734fc4c653137a5911c2bfa995d6d6d \
+    --hash=sha256:699ba9dd6a926f82a277063603fc8d586b89f4cb128efc353b749b641fcddda7 \
+    --hash=sha256:6aa74a45d4cdc028561a7d6ab3272c8b3018e23723100b12e58be9dfa5a24491 \
+    --hash=sha256:6b41a1b3b561f1cba8321fb32987552a024a8f67f0d05f06fcf29f0090a1b956 \
+    --hash=sha256:71e6e5a3a3728886caee9ab8752e8113670936a193284be9d6ad2176a137f376 \
+    --hash=sha256:7d20516990d8ad557b5abeb48127b8b779b0b7e6771a265fa3e91767596d7d97 \
+    --hash=sha256:80e4ba642fc87fa532bac07e5ed7e19d56940b6af6a8c61d4429be48718a380f \
+    --hash=sha256:872afa52a9f4c414d6955c365b6588bc4401272c629ff8321a55f44e3f62b553 \
+    --hash=sha256:8eb2b9a318542153674c6e377eb8cb9ca0fc011c04475110d3477862f15d29f0 \
+    --hash=sha256:9bbc525f4be3e51b89b2a700f5746c2a6907d2e2ef4513a8daafc98198b92237 \
+    --hash=sha256:a1a2e272d067030048e1fe41aa1ec8cfbbaabce733b3d634304fa2b19e5c897f \
+    --hash=sha256:a5dc0c42ded1557cc7c3f0240b24129aefbad88af4f09346164349391dea8e58 \
+    --hash=sha256:acab3539a027a85d568c2573291e864333ec9d912675107d6efceb7e2be5d980 \
+    --hash=sha256:acbebec8cb3d4df6e2488fbf34702cbc37fc39ac7abf9449392cefb3305562e9 \
+    --hash=sha256:ad327ac80ba7ee61da85383ca8822ff808ab5ada0e4a030d66703cc025b021c4 \
+    --hash=sha256:b448a0690ef43db5ef31b3a0d9aea79043882b4632cfc3eaab20105edecf6097 \
+    --hash=sha256:b5a06d7f60bc2fc378a333978470dfc4e1415ee52f5f0fce4f7853eb10c1e9df \
+    --hash=sha256:b74593e9acf18ea5469c3edaa6b27fa7ecf97b30e9dabd5a94c4c940637ab96e \
+    --hash=sha256:b79915a1179a91f6c5f04ece1e592e2e8a6bd245a0e45d12fd56b2b59e559a32 \
+    --hash=sha256:b80f0c51681c517604152eb6a572f5a9378f877763231fddb883ba2f968e8817 \
+    --hash=sha256:b8ac5b46fd798bbbf2ac6620e0437c36a202b08e1f827832c4bf050da081b501 \
+    --hash=sha256:c3c493d0e5141ec055a7d6809a28ac2b88d5b878bb22df8c621ebe79a61123d0 \
+    --hash=sha256:c44ca9ade59b2e376612df34e837013e2b273e6c92d7ed6636d0556b6f4db93d \
+    --hash=sha256:c4a6343e3b0714e80da0b0893543bf9a5b5fa71b846ae640e56e9abc6fbc4c83 \
+    --hash=sha256:c5870b4a11b77e4caa3937142b650fbbc0914a3e07a0cf3131f35c0587489c1c \
+    --hash=sha256:ca48914cdd9f2ccd94deab5bcb5ac98025a5ddce98881e5cce762854a5de330b \
+    --hash=sha256:cf2fae6d85e5dc384bf846f8243ddaa9197f3a1a70044f59399af001fd1f51d4 \
+    --hash=sha256:d450f5a7a35662a9b91a64aefa852f0c0308ee256122f5218a42f1d13577d71e \
+    --hash=sha256:d6716c087e4aa0b9260c4e579bb82e068f84faddb9bfba9906cb87726fa2e870 \
+    --hash=sha256:d93572720d781331fb10d3da9ca1067817d84ad1e7c31466e9f5e59965618096 \
+    --hash=sha256:dbb0b697cc0655719522406c059eae233abaa3243821cfdfab1215d02ac10231 \
+    --hash=sha256:e33505534f3f673270dd67f81e73550b11de5b538c56fe04435d63c02c3f26b5 \
+    --hash=sha256:e801ca2f448850685417d723ec70298feff3ce4ff687c6f20922c7474b4746ae \
+    --hash=sha256:e82db3756ccb66266504f5a3de05ac6b32f287faacff72462612120074103329 \
+    --hash=sha256:ef48e4137e8799998a343706531e656fdec6797b80efd029117edacb74b0a10a \
+    --hash=sha256:f1d3d1f2eb79fe7b0fb02e599b2bf76a7619c79300fc55f0b5e2d382881d4f7f \
+    --hash=sha256:f3fea72e4e6edb983908f0db373ae0732b275628901d909c382aae3b592589f2 \
+    --hash=sha256:f40de079779acbcdbb6ed4c65af9f018f8b77c5ec4e17a4b737c05c2db554491 \
+    --hash=sha256:f73e676a46b0fe9426612ce8caeca54c9073191a77c3e9d5c94697aef99296af \
+    --hash=sha256:f9c9e258e3d5efe199ec23903f5da0eeaad58cf6fccb3547b74fd4750e5ac47a \
+    --hash=sha256:fac2d146ff30d9dd2fcf917e5d147db037a5c573f0446c564f16f1f94cf87462 \
+    --hash=sha256:faef9ec6354fe4f9a2c0bbb52fb1ff852effc897e2a4501e25eb3a47cb0a4f89
+    # via sphinx-autobuild
 wrapt==1.16.0 \
     --hash=sha256:0d2691979e93d06a95a26257adb7bfd0c93818e89b1406f5a28f36e0d8c1e1fc \
     --hash=sha256:14d7dc606219cdd7405133c713f2c218d4252f2a469003f8c46bb92d5d095d81 \


### PR DESCRIPTION
The current logic to parse logs from anyscale job is very complicated. It first downloads all the logs from the cluster, and try to guess the main job logs and error job logs.  The logic of getting error job log is no longer neccessary.

The new API offers a much simpler way to get the log, update to that API.

Test:
- CI
- so much cleaner: https://buildkite.com/ray-project/release/builds/22057#0191ba75-2f0b-4a0b-9bad-8603003eba4c/741-742