### PR TITLE
[Core] Fix runtime env race condition when uploading the same package concurrently

### DIFF
--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -1,3 +1,4 @@
+import time
 import asyncio
 import hashlib
 import logging
@@ -578,17 +579,23 @@ def upload_package_if_needed(
         return False
 
     package_file = Path(_get_local_path(base_directory, pkg_uri))
+    # Make the temporary zip file name unique so that it doesn't conflict with
+    # concurrent upload_package_if_needed calls with the same pkg_uri.
+    # See https://github.com/ray-project/ray/issues/47471.
+    package_file = package_file.with_name(
+        f"{time.time_ns()}_{os.getpid()}_{package_file.name}"
+    )
     create_package(
         directory,
         package_file,
         include_parent_dir=include_parent_dir,
         excludes=excludes,
     )
-
-    upload_package_to_gcs(pkg_uri, package_file.read_bytes())
-
+    package_file_bytes = package_file.read_bytes()
     # Remove the local file to avoid accumulating temporary zip files.
     package_file.unlink()
+
+    upload_package_to_gcs(pkg_uri, package_file_bytes)
 
     return True
 

--- a/python/ray/tests/test_runtime_env_working_dir_4.py
+++ b/python/ray/tests/test_runtime_env_working_dir_4.py
@@ -6,7 +6,11 @@ import pytest
 from pytest_lazyfixture import lazy_fixture
 
 import ray
-from ray._private.test_utils import wait_for_condition, check_local_files_gced
+from ray._private.test_utils import (
+    wait_for_condition,
+    check_local_files_gced,
+    run_string_as_driver_nonblocking,
+)
 from ray.exceptions import GetTimeoutError
 
 # This test requires you have AWS credentials set up (any AWS credentials will
@@ -202,6 +206,21 @@ def test_task_level_gc(runtime_env_disable_URI_cache, ray_start_cluster, option)
     else:
         # Local files should not be gced because of an enough soft limit.
         assert not check_local_files_gced(cluster)
+
+
+def test_two_concurrent_jobs_with_same_working_dir(call_ray_start, tmp_working_dir):
+    """Test that uploading the same working dir concurrently works
+    https://github.com/ray-project/ray/issues/47471
+    """
+
+    script = f"""
+import ray
+ray.init(runtime_env={{"working_dir": "{str(tmp_working_dir)}"}})
+"""
+    job1 = run_string_as_driver_nonblocking(script)
+    job2 = run_string_as_driver_nonblocking(script)
+    assert job1.wait() == 0, job1.stderr.readlines()
+    assert job2.wait() == 0, job2.stderr.readlines()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently if we run two jobs with the same working dir concurrently, `upload_package_if_needed` will be called concurrently and they operate on the same zip file so they will conflict with each other. The PR makes sure they each work on a different zip file.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #47471
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
