### PR TITLE
Revert Revert "[Doc] Add Algolia search to docs"

### DIFF
--- a/ci/ray_ci/doc/build_cache.py
+++ b/ci/ray_ci/doc/build_cache.py
@@ -27,7 +27,7 @@ class BuildCache:
         """
         self._cache_dir = cache_dir
 
-    def upload(self) -> None:
+    def upload(self, dry_run: bool) -> None:
         """
         Upload the build artifacts to S3
         """
@@ -39,6 +39,10 @@ class BuildCache:
 
         logger.info("Creating a tarball of the cache files.")
         doc_tarball = self._zip_cache(cache_files)
+
+        if dry_run:
+            logger.info(f"Skipping upload of {doc_tarball} to S3.")
+            return
 
         logger.info("Upload the tarball to S3.")
         self._upload_cache(doc_tarball)

--- a/ci/ray_ci/doc/cmd_build.py
+++ b/ci/ray_ci/doc/cmd_build.py
@@ -28,23 +28,24 @@ def main(ray_checkout_dir: str) -> None:
     logger.info("Building ray doc.")
     _build(ray_checkout_dir)
 
+    dry_run = False
     if (
         os.environ.get("BUILDKITE_PIPELINE_ID")
         not in get_global_config()["ci_pipeline_postmerge"]
     ):
+        dry_run = True
         logger.info(
             "Not uploading build artifacts because this is not a postmerge pipeline."
         )
-        return
 
     if os.environ.get("BUILDKITE_BRANCH") != "master":
+        dry_run = True
         logger.info(
             "Not uploading build artifacts because this is not the master branch."
         )
-        return
 
     logger.info("Uploading build artifacts to S3.")
-    BuildCache(os.path.join(ray_checkout_dir, "doc")).upload()
+    BuildCache(os.path.join(ray_checkout_dir, "doc")).upload(dry_run=dry_run)
 
     return
 

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -7,7 +7,7 @@ setuptools>=70.0.0
 Pygments==2.16.1
 
 # Sphinx
-sphinx==7.1.2
+sphinx==7.3.7
 sphinx-click==5.1.0
 sphinx-copybutton==0.5.2
 sphinxemoji==0.2.0
@@ -20,6 +20,7 @@ sphinx-autobuild==2024.4.16
 pydata-sphinx-theme==0.14.1
 autodoc_pydantic==2.2.0
 appnope
+sphinx-docsearch==0.0.7
 
 pydantic!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,<3
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -70,7 +70,13 @@ extensions = [
     "sphinx_remove_toctrees",
     "sphinx_design",
     "sphinx.ext.intersphinx",
+    "sphinx_docsearch",
 ]
+
+# Configuration for algolia
+docsearch_app_id = "LBHF0PABBL"
+docsearch_api_key = "6c42f30d9669d8e42f6fc92f44028596"
+docsearch_index_name = "docs-ray"
 
 remove_from_toctrees = [
     "cluster/running-applications/job-submission/doc/*",


### PR DESCRIPTION
Redo https://github.com/ray-project/ray/pull/47483/files. The previous PR was based on a too old base so it gets merged successfully without re-compiling the dependencies

Also allow the dry-run of generating build cache to run on premerge, to block changes that can break it.

Test:
- CI