### PR TITLE
[core][experimental] Correct `num_input_consumers` for CachedChannel

### DIFF
--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -1214,7 +1214,8 @@ class CompiledDAG:
             # or use InputAttributeNode, but not both.
             num_input_consumers = 0
 
-            # Step 1: populate num_input_consumers and perform some validation.
+            # Step 1: populate `arg_to_consumers` and `num_input_consumers` and
+            # perform some validation.
             for task in tasks:
                 has_at_least_one_channel_input = False
                 is_input_consumer = False

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -1214,22 +1214,19 @@ class CompiledDAG:
             # or use InputAttributeNode, but not both.
             num_input_consumers = 0
 
-            # Step 1: populate num_channel_reads and perform some validation.
+            # Step 1: populate num_input_consumers and perform some validation.
             for task in tasks:
                 has_at_least_one_channel_input = False
+                is_input_consumer = False
                 for arg in task.args:
                     if isinstance(arg, InputNode):
                         has_at_least_one_channel_input = True
                         arg_to_consumers[arg].add(task)
-                        num_input_consumers = max(
-                            num_input_consumers, len(arg_to_consumers[arg])
-                        )
+                        is_input_consumer = True
                     elif isinstance(arg, InputAttributeNode):
                         has_at_least_one_channel_input = True
                         arg_to_consumers[arg].add(task)
-                        num_input_consumers = max(
-                            num_input_consumers, len(arg_to_consumers[arg])
-                        )
+                        is_input_consumer = True
                     elif isinstance(arg, DAGNode):  # Other DAGNodes
                         has_at_least_one_channel_input = True
                         arg_to_consumers[arg].add(task)
@@ -1238,6 +1235,8 @@ class CompiledDAG:
                         assert len(upstream_task.output_channels) == 1
                         arg_channel = upstream_task.output_channels[0]
                         assert arg_channel is not None
+                if is_input_consumer:
+                    num_input_consumers += 1
                 # TODO: Support no-input DAGs (use an empty object to signal).
                 if not has_at_least_one_channel_input:
                     raise ValueError(

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -488,6 +488,24 @@ def test_actor_method_bind_diff_input_attr_4(ray_start_regular):
     compiled_dag.teardown()
 
 
+def test_actor_method_bind_diff_kwargs_input_attr(ray_start_regular):
+    actor = Actor.remote(0)
+    with InputNode() as inp:
+        # Two class methods are bound to two different kwargs input
+        # attribute nodes.
+        output1 = actor.inc.bind(inp.x)
+        output2 = actor.inc.bind(inp.y)
+        dag = MultiOutputNode([output1, output2])
+    compiled_dag = dag.experimental_compile()
+    ref = compiled_dag.execute(x=0, y=1)
+    assert ray.get(ref) == [0, 1]
+
+    ref = compiled_dag.execute(x=1, y=2)
+    assert ray.get(ref) == [2, 4]
+
+    compiled_dag.teardown()
+
+
 def test_actor_method_bind_same_arg(ray_start_regular):
     a1 = Actor.remote(0)
     a2 = Actor.remote(0)

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -503,6 +503,26 @@ def test_actor_method_bind_diff_input_attr_4(ray_start_regular):
     compiled_dag.teardown()
 
 
+def test_actor_method_bind_diff_input_attr_5(ray_start_regular):
+    actor = Actor.remote(0)
+    c = Collector.remote()
+    with InputNode() as inp:
+        branch1 = actor.inc_two.bind(inp[0], inp[1])
+        branch2 = actor.inc_two.bind(inp[2], inp[0])
+        dag = c.collect_two.bind(branch1, branch2)
+    compiled_dag = dag.experimental_compile()
+    ref = compiled_dag.execute(0, 1, 2)
+    assert ray.get(ref) == [1, 3]
+
+    ref = compiled_dag.execute(1, 2, 3)
+    assert ray.get(ref) == [1, 3, 6, 10]
+
+    ref = compiled_dag.execute(2, 3, 4)
+    assert ray.get(ref) == [1, 3, 6, 10, 15, 21]
+
+    compiled_dag.teardown()
+
+
 def test_actor_method_bind_diff_kwargs_input_attr(ray_start_regular):
     actor = Actor.remote(0)
     c = Collector.remote()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

### Problem statement

Without this PR, the `num_input_consumers` would be 1 because both `inp[0]` and `inp[1]` are only referred to in one task on the actor, so `CachedChannel` will not be created. The read will eventually time out because the mutable object is being read by the same actor twice.

```python
def test_actor_method_bind_diff_input_attr_1(ray_start_regular):
    actor = Actor.remote(0)
    with InputNode() as inp:
        # Two class methods are bound to two different input
        # attribute nodes.
        output1 = actor.inc.bind(inp[0])
        output2 = actor.inc.bind(inp[1])
        dag = MultiOutputNode([output1, output2])
    compiled_dag = dag.experimental_compile()
    ref = compiled_dag.execute(0, 1)
    assert ray.get(ref) == [0, 1]

    ref = compiled_dag.execute(1, 2)
    assert ray.get(ref) == [2, 4]

    compiled_dag.teardown()
```
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/6316d4c9-7626-44c2-aa27-713437172cab">

### Solution

If a task is bound to either an `InputNode` or an `InputAttributeNode`, increment `num_input_consumers` by 1. Therefore, `num_input_consumers` will be 2, and a `CachedChannel` will be created.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
