### PR TITLE
[Core] Introduce env var RAY_LOG_TO_DRIVER

### DIFF
--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -55,6 +55,8 @@ def env_set_by_user(key):
 # Whether event logging to driver is enabled. Set to 0 to disable.
 AUTOSCALER_EVENTS = env_integer("RAY_SCHEDULER_EVENTS", 1)
 
+RAY_LOG_TO_DRIVER = env_bool("RAY_LOG_TO_DRIVER", True)
+
 # Filter level under which events will be filtered out, i.e. not printing to driver
 RAY_LOG_TO_DRIVER_EVENT_LEVEL = os.environ.get("RAY_LOG_TO_DRIVER_EVENT_LEVEL", "INFO")
 

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1242,7 +1242,7 @@ def init(
     logging_level: int = ray_constants.LOGGER_LEVEL,
     logging_format: Optional[str] = None,
     logging_config: Optional[LoggingConfig] = None,
-    log_to_driver: bool = True,
+    log_to_driver: Optional[bool] = None,
     namespace: Optional[str] = None,
     runtime_env: Optional[Union[Dict[str, Any], "RuntimeEnv"]] = None,  # noqa: F821
     storage: Optional[str] = None,
@@ -1401,6 +1401,9 @@ def init(
         Exception: An exception is raised if an inappropriate combination of
             arguments is passed in.
     """
+    if log_to_driver is None:
+        log_to_driver = ray_constants.RAY_LOG_TO_DRIVER
+
     # Configure the "ray" logger for the driver process.
     if configure_logging:
         setup_logger(logging_level, logging_format or ray_constants.LOGGER_FORMAT)

--- a/python/ray/tests/test_advanced_3.py
+++ b/python/ray/tests/test_advanced_3.py
@@ -5,11 +5,13 @@ import pickle
 import socket
 import sys
 import time
+import importlib
 
 import numpy as np
 import pytest
 
 import ray
+import ray._private.ray_constants
 import ray._private.utils
 import ray.cluster_utils
 import ray.util.accelerators
@@ -64,44 +66,7 @@ def test_global_state_api(shutdown_only):
     assert job_table[0]["DriverIPAddress"] == node_ip_address
 
 
-# TODO(rkn): Pytest actually has tools for capturing stdout and stderr, so we
-# should use those, but they seem to conflict with Ray's use of faulthandler.
-class CaptureOutputAndError:
-    """Capture stdout and stderr of some span.
-
-    This can be used as follows.
-
-        captured = {}
-        with CaptureOutputAndError(captured):
-            # Do stuff.
-        # Access captured["out"] and captured["err"].
-    """
-
-    def __init__(self, captured_output_and_error):
-        import io
-
-        self.output_buffer = io.StringIO()
-        self.error_buffer = io.StringIO()
-        self.captured_output_and_error = captured_output_and_error
-
-    def __enter__(self):
-        sys.stdout.flush()
-        sys.stderr.flush()
-        self.old_stdout = sys.stdout
-        self.old_stderr = sys.stderr
-        sys.stdout = self.output_buffer
-        sys.stderr = self.error_buffer
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        sys.stdout.flush()
-        sys.stderr.flush()
-        sys.stdout = self.old_stdout
-        sys.stderr = self.old_stderr
-        self.captured_output_and_error["out"] = self.output_buffer.getvalue()
-        self.captured_output_and_error["err"] = self.error_buffer.getvalue()
-
-
-def test_logging_to_driver(shutdown_only):
+def test_logging_to_driver(capsys, shutdown_only):
     ray.init(num_cpus=1, log_to_driver=True)
 
     @ray.remote
@@ -112,21 +77,40 @@ def test_logging_to_driver(shutdown_only):
             print(i, end=" ")
             print(100 + i, end=" ", file=sys.stderr)
 
-    captured = {}
-    with CaptureOutputAndError(captured):
-        ray.get(f.remote())
-        time.sleep(1)
+    ray.get(f.remote())
+    time.sleep(1)
 
-    out_lines = captured["out"]
-    err_lines = captured["err"]
+    out, err = capsys.readouterr()
     for i in range(10):
-        assert str(i) in out_lines
+        assert str(i) in out
 
     for i in range(100, 110):
-        assert str(i) in err_lines
+        assert str(i) in err
 
 
-def test_not_logging_to_driver(shutdown_only):
+def test_not_logging_to_driver_via_env_var(monkeypatch, capsys, shutdown_only):
+    monkeypatch.setenv("RAY_LOG_TO_DRIVER", "0")
+    importlib.reload(ray._private.ray_constants)
+    ray.init(num_cpus=1)
+
+    @ray.remote
+    def f():
+        for i in range(100):
+            print(i)
+            print(100 + i, file=sys.stderr)
+            sys.stdout.flush()
+            sys.stderr.flush()
+
+    capsys.readouterr()
+    ray.get(f.remote())
+    time.sleep(1)
+
+    out, err = capsys.readouterr()
+    assert len(out) == 0
+    assert len(err) == 0
+
+
+def test_not_logging_to_driver(capsys, shutdown_only):
     ray.init(num_cpus=1, log_to_driver=False)
 
     @ray.remote
@@ -137,16 +121,13 @@ def test_not_logging_to_driver(shutdown_only):
             sys.stdout.flush()
             sys.stderr.flush()
 
-    captured = {}
-    with CaptureOutputAndError(captured):
-        ray.get(f.remote())
-        time.sleep(1)
+    capsys.readouterr()
+    ray.get(f.remote())
+    time.sleep(1)
 
-    output_lines = captured["out"]
-    assert len(output_lines) == 0
-
-    err_lines = captured["err"]
-    assert len(err_lines) == 0
+    out, err = capsys.readouterr()
+    assert len(out) == 0
+    assert len(err) == 0
 
 
 def test_workers(shutdown_only):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently `log_to_driver` is an option of `ray.init()` but cannot be set through env var. This PR adds the ability to control this feature via env var as well.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
