### PR TITLE
[Core] Fix test_runtime_env_working_dir_4 for Windows

### DIFF
--- a/python/ray/tests/test_runtime_env_working_dir_4.py
+++ b/python/ray/tests/test_runtime_env_working_dir_4.py
@@ -213,9 +213,11 @@ def test_two_concurrent_jobs_with_same_working_dir(call_ray_start, tmp_working_d
     https://github.com/ray-project/ray/issues/47471
     """
 
+    # Windows path has backslash so we need to escape it
+    tmp_working_dir = tmp_working_dir.encode("unicode_escape").decode()
     script = f"""
 import ray
-ray.init(runtime_env={{"working_dir": "{str(tmp_working_dir)}"}})
+ray.init(runtime_env={{"working_dir": "{tmp_working_dir}"}})
 """
     job1 = run_string_as_driver_nonblocking(script)
     job2 = run_string_as_driver_nonblocking(script)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Windows path needs to be escaped.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
