### PR TITLE
[Core] Improve NodeManager::HandleJobStarted log message

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -607,9 +607,10 @@ void NodeManager::DestroyWorker(std::shared_ptr<WorkerInterface> worker,
 }
 
 void NodeManager::HandleJobStarted(const JobID &job_id, const JobTableData &job_data) {
-  RAY_LOG(INFO) << "New job has started. Job id " << job_id << " Driver pid "
-                << job_data.driver_pid() << " is dead: " << job_data.is_dead()
-                << " driver address: " << job_data.driver_address().ip_address();
+  RAY_LOG(DEBUG).WithField(job_id)
+      << "HandleJobStarted Driver pid " << job_data.driver_pid()
+      << " is dead: " << job_data.is_dead()
+      << " driver address: " << job_data.driver_address().ip_address();
   worker_pool_.HandleJobStarted(job_id, job_data.config());
   // Tasks of this job may already arrived but failed to pop a worker because the job
   // config is not local yet. So we trigger dispatching again here to try to
@@ -618,7 +619,7 @@ void NodeManager::HandleJobStarted(const JobID &job_id, const JobTableData &job_
 }
 
 void NodeManager::HandleJobFinished(const JobID &job_id, const JobTableData &job_data) {
-  RAY_LOG(DEBUG) << "HandleJobFinished " << job_id;
+  RAY_LOG(DEBUG).WithField(job_id) << "HandleJobFinished";
   RAY_CHECK(job_data.is_dead());
   // Force kill all the worker processes belonging to the finished job
   // so that no worker processes is leaked.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When a node joins the cluster, `NodeManager::HandleJobStarted` will be called for every job (including finished ones):

```
// HandleJobStarted is idempotent so it's ok to call it again when the job
// finishes. We always need to call `HandleJobStarted` even when a job has
// finished, because we may have missed the started event (for example,
// because the node wasn't up when the job started). JobStarted +
// JobFinished events both need to be processed because we need to persist
// the job config of dead jobs in order for detached actors to function
// properly.
```

The issue is that the log message is a big confusing and makes people feel that a finished job restarts. This PR makes this a debug log (same as HandleJobFinished) and reword the message a bit.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
