### PR TITLE
[Core] Fix aws_cluster_launcher_full

### DIFF
--- a/docker/base-deps/README.md
+++ b/docker/base-deps/README.md
@@ -14,7 +14,7 @@ Images are `tagged` with the format `{Ray version}[-{Python version}][-{Platform
 | `x.y.z`                      | A specific Ray release, e.g. 2.9.3 |
 | `nightly`                    | The most recent Ray development build (a recent commit from GitHub `master`) |
 
-The optional `Python version` tag specifies the Python version in the image. All Python versions supported by Ray are available, e.g. `py38`, `py39` and `py310`. If unspecified, the tag points to an image using `Python 3.8`.
+The optional `Python version` tag specifies the Python version in the image. All Python versions supported by Ray are available, e.g. `py39`, `py310` and `py311`. If unspecified, the tag points to an image using `Python 3.9`.
 
 The optional `Platform` tag specifies the platform where the image is intended for:
 

--- a/docker/ray-deps/README.md
+++ b/docker/ray-deps/README.md
@@ -13,7 +13,7 @@ Images are `tagged` with the format `{Ray version}[-{Python version}][-{Platform
 | `x.y.z`                      | A specific Ray release, e.g. 2.9.3 |
 | `nightly`                    | The most recent Ray development build (a recent commit from GitHub `master`) |
 
-The optional `Python version` tag specifies the Python version in the image. All Python versions supported by Ray are available, e.g. `py38`, `py39` and `py310`. If unspecified, the tag points to an image using `Python 3.8`.
+The optional `Python version` tag specifies the Python version in the image. All Python versions supported by Ray are available, e.g. `py39`, `py310` and `py311`. If unspecified, the tag points to an image using `Python 3.9`.
 
 The optional `Platform` tag specifies the platform where the image is intended for:
 

--- a/docker/ray-ml/README.md
+++ b/docker/ray-ml/README.md
@@ -11,7 +11,7 @@ Images are `tagged` with the format `{Ray version}[-{Python version}][-{Platform
 | `x.y.z`                      | A specific Ray release, e.g. 2.9.3 |
 | `nightly`                    | The most recent Ray development build (a recent commit from GitHub `master`) |
 
-The optional `Python version` tag specifies the Python version in the image. All Python versions supported by Ray are available, e.g. `py38`, `py39` and `py310`. If unspecified, the tag points to an image using `Python 3.8`.
+The optional `Python version` tag specifies the Python version in the image. All Python versions supported by Ray are available, e.g. `py39`, `py310` and `py311`. If unspecified, the tag points to an image using `Python 3.9`.
 
 The optional `Platform` tag specifies the platform where the image is intended for:
 
@@ -24,9 +24,9 @@ The optional `Platform` tag specifies the platform where the image is intended f
 
 Examples tags:
 - none: equivalent to `latest`
-- `latest`: equivalent to `latest-py38-gpu`, i.e. image for the most recent Ray release
-- `nightly-py38-cpu`
-- `806c18-py38-cu112`
+- `latest`: equivalent to `latest-py39-gpu`, i.e. image for the most recent Ray release
+- `nightly-py39-cpu`
+- `806c18-py39-cu112`
 
 The `ray-ml` images are not built for the `arm64` (`aarch64`) architecture.
 

--- a/docker/ray/README.md
+++ b/docker/ray/README.md
@@ -12,7 +12,7 @@ Images are `tagged` with the format `{Ray version}[-{Python version}][-{Platform
 | `x.y.z`                      | A specific Ray release, e.g. 2.9.3 |
 | `nightly`                    | The most recent Ray development build (a recent commit from GitHub `master`) |
 
-The optional `Python version` tag specifies the Python version in the image. All Python versions supported by Ray are available, e.g. `py38`, `py39` and `py310`. If unspecified, the tag points to an image using `Python 3.8`.
+The optional `Python version` tag specifies the Python version in the image. All Python versions supported by Ray are available, e.g. `py39`, `py310` and `py311`. If unspecified, the tag points to an image using `Python 3.9`.
 
 The optional `Platform` tag specifies the platform where the image is intended for:
 
@@ -36,10 +36,10 @@ Please note that suffixes are only used to specify `aarch64` images. No suffix m
 
 Examples tags:
 - none: equivalent to `latest`
-- `latest`: equivalent to `latest-py38-cpu`, i.e. image for the most recent Ray release
-- `nightly-py38-cpu`
-- `806c18-py38-cu112`
-- `806c18-py38-cu116-aarch64`
+- `latest`: equivalent to `latest-py39-cpu`, i.e. image for the most recent Ray release
+- `nightly-py39-cpu`
+- `806c18-py39-cu112`
+- `806c18-py39-cu116-aarch64`
 
 ## Roadmap
 

--- a/docker/retag-lambda/lambda_function.py
+++ b/docker/retag-lambda/lambda_function.py
@@ -72,7 +72,7 @@ def lambda_handler(event, context):
         [print(i) for i in results]
         total_results.extend(results)
 
-    # Retag images without a python version specified (defaults to py38)
+    # Retag images without a python version specified (defaults to py39)
     results = []
     for repo in ["ray", "ray-ml", "ray-deps", "base-deps"]:
         # For example tag ray:1.X-cu112 to ray:latest-cu112

--- a/python/ray/autoscaler/aws/tests/aws_config.yaml
+++ b/python/ray/autoscaler/aws/tests/aws_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py39") }}
 debian_packages: []
 env_vars:
   RAY_WHEEL_URL: {{ env["RAY_WHEELS"] | default("") }}

--- a/python/ray/autoscaler/gcp/tests/gce_config.yaml
+++ b/python/ray/autoscaler/gcp/tests/gce_config.yaml
@@ -1,4 +1,4 @@
-base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py38") }}
+base_image: {{ env["RAY_IMAGE_NIGHTLY_CPU"] | default("anyscale/ray:nightly-py39") }}
 debian_packages: []
 env_vars:
   RAY_WHEEL_URL: {{ env["RAY_WHEELS"] | default("") }}

--- a/python/ray/autoscaler/launch_and_verify_cluster.py
+++ b/python/ray/autoscaler/launch_and_verify_cluster.py
@@ -96,12 +96,12 @@ def get_docker_image(docker_override):
         applicable.
     """
     if docker_override == "latest":
-        return "rayproject/ray:latest-py38"
+        return "rayproject/ray:latest-py39"
     elif docker_override == "nightly":
-        return "rayproject/ray:nightly-py38"
+        return "rayproject/ray:nightly-py39"
     elif docker_override == "commit":
         if re.match("^[0-9]+.[0-9]+.[0-9]+$", ray.__version__):
-            return f"rayproject/ray:{ray.__version__}.{ray.__commit__[:6]}-py38"
+            return f"rayproject/ray:{ray.__version__}.{ray.__commit__[:6]}-py39"
         else:
             print(
                 "Error: docker image is only available for "

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4933,7 +4933,7 @@
 
   run:
     timeout: 3000
-    script: python launch_and_verify_cluster.py aws/example-full.yaml --num-expected-nodes 2 --retries 20
+    script: python launch_and_verify_cluster.py aws/example-full.yaml --num-expected-nodes 2 --retries 20 --docker-override latest
 
 - name: gcp_cluster_launcher_minimal
   group: cluster-launcher-test


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently `aws_cluster_launcher_full` is using the `ray-ml:latest-gpu` image which is very big and slow to download and causes the test to timeout. This PR switches to the `ray:latest-cpu` image.

Also removed some already deprecated py38 stuff.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
