### PR TITLE
[Data] Remove ordering assumption and unnecessary `override_num_blocks` from `test_parquet_roundtrip`

### DIFF
--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -1045,6 +1045,7 @@ def test_parquet_roundtrip(ray_start_regular_shared, fs, data_path):
     else:
         fs.delete_dir(_unwrap_protocol(path))
 
+
 def test_parquet_read_empty_file(ray_start_regular_shared, tmp_path):
     path = os.path.join(tmp_path, "data.parquet")
     table = pa.table({})

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -1019,27 +1019,31 @@ def test_parquet_write_create_dir(
     ],
 )
 def test_parquet_roundtrip(ray_start_regular_shared, fs, data_path):
-    df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
-    df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
-    ds = ray.data.from_pandas([df1, df2])
-    ds._set_uuid("data")
     path = os.path.join(data_path, "test_parquet_dir")
     if fs is None:
         os.mkdir(path)
     else:
         fs.create_dir(_unwrap_protocol(path))
+
+    df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
+    df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
+    ds = ray.data.from_pandas([df1, df2])
     ds.write_parquet(path, filesystem=fs)
-    ds2 = ray.data.read_parquet(path, override_num_blocks=2, filesystem=fs)
-    ds2df = ds2.to_pandas()
-    assert pd.concat([df1, df2], ignore_index=True).equals(ds2df)
+
+    ds2 = ray.data.read_parquet(path, filesystem=fs)
+
+    read_data = set(ds2.to_pandas().itertuples(index=False))
+    written_data = set(pd.concat([df1, df2]).itertuples(index=False))
+    assert read_data == written_data
+
     # Test metadata ops.
     for block, meta in ds2._plan.execute().blocks:
         BlockAccessor.for_block(ray.get(block)).size_bytes() == meta.size_bytes
+
     if fs is None:
         shutil.rmtree(path)
     else:
         fs.delete_dir(_unwrap_protocol(path))
-
 
 def test_parquet_read_empty_file(ray_start_regular_shared, tmp_path):
     path = os.path.join(tmp_path, "data.parquet")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`test_parquet_roundtrip` specifies `override_num_blocks`, even though the argument isn't required for the specific behavior under test (i.e., that you can write and then read back Parquet files). Also, the test implicitly assumes that Ray Data reads files in a particular order.

To ensure we're testing behavior and not implementation, and to make the test resilient to future code changes, this PR removes the `override_num_blocks` and updates the code to eliminate ordering.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
