### PR TITLE
[Data] Throw exception for non-streaming HF datasets with "override_num_blocks" argument

### DIFF
--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -2852,8 +2852,9 @@ def from_huggingface(
         # For non-streaming Hugging Face Dataset, we don't support override_num_blocks
         if override_num_blocks is not None:
             raise ValueError(
-                f"Invalid value for 'override_num_blocks': {override_num_blocks}. "
-                "Valid value is None for non-streaming Hugging Face Dataset"
+                "`override_num_blocks` parameter is not supported for "
+                "streaming Hugging Face Datasets. Please omit the parameter or "
+                "use non-streaming mode to read the dataset."
             )
 
         # To get the resulting Arrow table from a Hugging Face Dataset after

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -2842,8 +2842,20 @@ def from_huggingface(
 
     if isinstance(dataset, datasets.IterableDataset):
         # For an IterableDataset, we can use a streaming implementation to read data.
-        return read_datasource(HuggingFaceDatasource(dataset=dataset))
+        return read_datasource(
+            HuggingFaceDatasource(dataset=dataset),
+            parallelism=parallelism,
+            concurrency=concurrency,
+            override_num_blocks=override_num_blocks,
+        )
     if isinstance(dataset, datasets.Dataset):
+        # For non-streaming Hugging Face Dataset, we don't support override_num_blocks
+        if override_num_blocks is not None:
+            raise ValueError(
+                f"Invalid value for 'override_num_blocks': {override_num_blocks}. "
+                "Valid value is None for non-streaming Hugging Face Dataset"
+            )
+
         # To get the resulting Arrow table from a Hugging Face Dataset after
         # applying transformations (e.g., train_test_split(), shard(), select()),
         # we create a copy of the Arrow table, which applies the indices


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

As in the issue #47507, from_huggingface() does not support override_num_blocks for non-streaming HF Datasets, so we should throw exception, also we need to pass other arguments for  from_huggingface() if they are using streaming dataset

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Close #47507
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

I did manual test on exception part. Let me know if I need to do more tests.
