### PR TITLE
[Doc][KubeRay] Document Fields that Will Not Trigger Downtime in RayService

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides/rayservice.md
+++ b/doc/source/cluster/kubernetes/user-guides/rayservice.md
@@ -221,7 +221,7 @@ Once the new RayCluster is ready, RayService updates the selector of the head se
 Finally, the old RayCluster is terminated.
 
 Certain exceptions don't trigger a zero downtime upgrade.
-Only the fields managed by Ray autoscaler, `replicas` and `scaleStrategy.workersToDelete`, don't trigger a zero downtime upgrade.
+Only the fields managed by Ray autoscaler—`replicas`, `minReplicas`, `maxReplicas`, and `scaleStrategy.workersToDelete`—don't trigger a zero downtime upgrade.
 When you update these fields, KubeRay doesn't propagate the update from RayService to RayCluster custom resources, so nothing happens.
 
 ```sh


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
As title. In latest KubeRay, the fields `minReplicas` and `maxReplicas` are excluded from the hash calculation for RayCluster updates. As a result, even if users modify these fields, the calculated hash remains unchanged, meaning no update or rolling restart will occur. 

See https://github.com/ray-project/kuberay/pull/2172 for more detail.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks
![image](https://github.com/user-attachments/assets/58ec7ad8-60a4-4662-be63-b62b54abdadb)


- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
