### PR TITLE
[release auto] convert release blockers to list

### DIFF
--- a/ci/ray_ci/automation/weekly_green_metric.py
+++ b/ci/ray_ci/automation/weekly_green_metric.py
@@ -51,12 +51,17 @@ def main(production: bool, check: bool) -> None:
         )
         logger.info("Weekly green metric updated successfully")
 
-    if check and blockers.totalCount != 0:
-        print(
-            f"Found {blockers.totalCount} release blockers.",
-            file=sys.stderr,
-        )
-        sys.exit(42)  # Not retrying the check on Buildkite jobs
+    if check:
+        if len(blockers) > 0:
+            print(
+                f"Found {len(blockers)} release blockers.",
+                file=sys.stderr,
+            )
+            for issue in blockers:
+                print(f"{issue.html_url} - {issue.title}", file=sys.stderr)
+            sys.exit(42)  # Not retrying the check on Buildkite jobs
+        else:
+            print("No release blockers. Woohoo!", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/release/ray_release/test_automation/state_machine.py
+++ b/release/ray_release/test_automation/state_machine.py
@@ -79,8 +79,7 @@ class TestStateMachine(abc.ABC):
     def get_release_blockers(cls) -> List[github.Issue.Issue]:
         repo = cls.get_ray_repo()
         blocker_label = repo.get_label(WEEKLY_RELEASE_BLOCKER_TAG)
-
-        return repo.get_issues(state="open", labels=[blocker_label])
+        return list(repo.get_issues(state="open", labels=[blocker_label]))
 
     @classmethod
     def get_issue_owner(cls, issue: github.Issue.Issue) -> str:


### PR DESCRIPTION
PyGithub returns a paginator, and it needs to be converted into a list. Also prints out the issues that are being listed.