### PR TITLE
Add perf metrics for 2.36.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 459.20256,
+    "_dashboard_memory_usage_mb": 429.867008,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.76,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3447\t1.74GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5206\t0.93GiB\tpython distributed/test_many_actors.py\n3564\t0.37GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2845\t0.32GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1249\t0.23GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3737\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n2771\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3884\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n4986\t0.07GiB\tray::JobSupervisor\n3735\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
-    "actors_per_second": 627.338335492887,
+    "_peak_memory": 3.8,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1173\t7.02GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3408\t1.75GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4371\t0.93GiB\tpython distributed/test_many_actors.py\n1954\t0.46GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3524\t0.37GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n3687\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n2361\t0.08GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3689\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4167\t0.07GiB\tray::JobSupervisor\n3712\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
+    "actors_per_second": 637.7871696983945,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 627.338335492887
+            "perf_metric_value": 637.7871696983945
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 178.601
+            "perf_metric_value": 177.731
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3542.989
+            "perf_metric_value": 3350.577
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3933.547
+            "perf_metric_value": 3361.16
         }
     ],
     "success": "1",
-    "time": 15.940361738204956
+    "time": 15.679211616516113
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 193.712128,
+    "_dashboard_memory_usage_mb": 186.601472,
     "_dashboard_test_success": true,
-    "_peak_memory": 1.65,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3461\t0.54GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1255\t0.25GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2918\t0.23GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3578\t0.18GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4426\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n4642\t0.08GiB\tray::StateAPIGeneratorActor.start\n2822\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4216\t0.07GiB\tray::JobSupervisor\n3750\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3748\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "_peak_memory": 1.69,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3498\t0.54GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1887\t0.26GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1246\t0.22GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3614\t0.18GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4558\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3780\t0.1GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n4757\t0.08GiB\tray::StateAPIGeneratorActor.start\n2312\t0.08GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3782\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4350\t0.07GiB\tray::JobSupervisor",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 342.8427005545737
+            "perf_metric_value": 353.6897053988414
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.87
+            "perf_metric_value": 4.156
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 34.039
+            "perf_metric_value": 58.592
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 119.573
+            "perf_metric_value": 125.858
         }
     ],
     "success": "1",
-    "tasks_per_second": 342.8427005545737,
-    "time": 302.91678953170776,
+    "tasks_per_second": 353.6897053988414,
+    "time": 302.82733702659607,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 120.446976,
+    "_dashboard_memory_usage_mb": 196.333568,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.12,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3438\t0.92GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5718\t0.4GiB\tpython distributed/test_many_pgs.py\n2536\t0.35GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1206\t0.24GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3560\t0.12GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2784\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3734\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n5507\t0.07GiB\tray::JobSupervisor\n3877\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-\n3732\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen",
+    "_peak_memory": 2.13,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1135\t7.03GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3382\t0.89GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4327\t0.41GiB\tpython distributed/test_many_pgs.py\n2463\t0.28GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3498\t0.11GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n3663\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n2634\t0.08GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3665\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4107\t0.07GiB\tray::JobSupervisor\n3700\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22.249430148995714
+            "perf_metric_value": 22.13026931060565
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.722
+            "perf_metric_value": 3.37
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.055
+            "perf_metric_value": 7.238
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 358.789
+            "perf_metric_value": 276.52
         }
     ],
-    "pgs_per_second": 22.249430148995714,
+    "pgs_per_second": 22.13026931060565,
     "success": "1",
-    "time": 44.944971323013306
+    "time": 45.186978340148926
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 1263.501312,
+    "_dashboard_memory_usage_mb": 1343.930368,
     "_dashboard_test_success": true,
-    "_peak_memory": 5.45,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3382\t3.09GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3499\t0.83GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4186\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1117\t0.24GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2858\t0.22GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4397\t0.08GiB\tray::DashboardTester.run\n4472\t0.08GiB\tray::StateAPIGeneratorActor.start\n2725\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3674\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3984\t0.07GiB\tray::JobSupervisor",
+    "_peak_memory": 5.16,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3344\t2.71GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3460\t0.87GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4369\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1869\t0.23GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1151\t0.22GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3623\t0.1GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n4510\t0.08GiB\tray::DashboardTester.run\n4566\t0.08GiB\tray::StateAPIGeneratorActor.start\n2192\t0.08GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3625\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 557.3705625276606
+            "perf_metric_value": 567.4860527139014
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 167.38
+            "perf_metric_value": 69.154
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3170.14
+            "perf_metric_value": 356.824
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5042.844
+            "perf_metric_value": 556.875
         }
     ],
     "success": "1",
-    "tasks_per_second": 557.3705625276606,
-    "time": 317.94138526916504,
+    "tasks_per_second": 567.4860527139014,
+    "time": 317.6215784549713,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.34.0"}
+{"release_version": "2.36.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        9060.701663275304,
-        118.69740715773278
+        9011.034048587637,
+        194.0628029853825
     ],
     "1_1_actor_calls_concurrent": [
-        5167.9800954515,
-        141.99267026522367
+        5263.2434276145505,
+        145.80604482427896
     ],
     "1_1_actor_calls_sync": [
-        2055.7051275912527,
-        54.594914220148404
+        2080.236653557758,
+        23.13824039798905
     ],
     "1_1_async_actor_calls_async": [
-        4456.606860484332,
-        300.0483750432424
+        4501.850720954102,
+        147.87207834752016
     ],
     "1_1_async_actor_calls_sync": [
-        1486.2327104183764,
-        35.32117622112775
+        1516.7172089797605,
+        36.37949468906624
     ],
     "1_1_async_actor_calls_with_args_async": [
-        3038.941703794114,
-        225.62938703844412
+        3062.7131794844063,
+        139.85737128748647
     ],
     "1_n_actor_calls_async": [
-        8786.234839177117,
-        155.79705585932524
+        8370.014425096557,
+        432.75202747065646
     ],
     "1_n_async_actor_calls_async": [
-        7804.984752431155,
-        207.2088124010455
+        8002.339829198115,
+        128.47546109549722
     ],
     "client__1_1_actor_calls_async": [
-        963.1902909183787,
-        7.024139165271597
+        984.156036006501,
+        13.717632534060987
     ],
     "client__1_1_actor_calls_concurrent": [
-        947.6614978210325,
-        6.215662216629677
+        976.8103650114274,
+        10.754697369485774
     ],
     "client__1_1_actor_calls_sync": [
-        519.725991336052,
-        5.524396654486067
+        473.62862729568997,
+        16.15435893429041
     ],
     "client__get_calls": [
-        1119.7725751916082,
-        22.31873036313672
+        1142.0198619070275,
+        24.778997750410955
     ],
     "client__put_calls": [
-        801.476709529905,
-        24.90986781791733
+        806.172478450918,
+        26.541778900550913
     ],
     "client__put_gigabytes": [
-        0.13929452807454937,
-        0.0004893965578803182
+        0.13945791828216536,
+        0.0009825552590766468
     ],
     "client__tasks_and_get_batch": [
-        0.911263457119588,
-        0.009582733256630546
+        0.9601675934161155,
+        0.015386698591663932
     ],
     "client__tasks_and_put_batch": [
-        11004.98249042869,
-        406.99702282940336
+        12017.023866540812,
+        97.56477930019382
     ],
     "multi_client_put_calls_Plasma_Store": [
-        12455.514706383783,
-        82.98752196297701
+        12906.774263883479,
+        209.17121340433738
     ],
     "multi_client_put_gigabytes": [
-        38.4735559860673,
-        1.895531621126946
+        42.368678421213005,
+        2.479245917314356
     ],
     "multi_client_tasks_async": [
-        23311.858831941317,
-        2350.5613878864333
+        22489.617400047606,
+        2527.3493250916217
     ],
     "n_n_actor_calls_async": [
-        26545.931713712664,
-        526.4393166387501
+        27662.820243691007,
+        694.5263617445811
     ],
     "n_n_actor_calls_with_arg_async": [
-        2699.08314274893,
-        34.72492860665786
+        2641.837605625889,
+        48.21948083604403
     ],
     "n_n_async_actor_calls_async": [
-        22710.046003881216,
-        682.7591872434975
+        23190.04299787998,
+        705.5689531826766
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10303.517743023112
+            "perf_metric_value": 10553.076587142574
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5241.163782117501
+            "perf_metric_value": 5255.898134426729
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12455.514706383783
+            "perf_metric_value": 12906.774263883479
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 20.184014305625574
+            "perf_metric_value": 19.720556713345232
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7.900197666889211
+            "perf_metric_value": 8.290762106646564
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 38.4735559860673
+            "perf_metric_value": 42.368678421213005
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13.679337230724197
+            "perf_metric_value": 11.533423619760748
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.485273551888224
+            "perf_metric_value": 5.483366864446084
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 986.5998779605792
+            "perf_metric_value": 982.0408892888784
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8011.455682416454
+            "perf_metric_value": 7999.110134185503
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23311.858831941317
+            "perf_metric_value": 22489.617400047606
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2055.7051275912527
+            "perf_metric_value": 2080.236653557758
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 9060.701663275304
+            "perf_metric_value": 9011.034048587637
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5167.9800954515
+            "perf_metric_value": 5263.2434276145505
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8786.234839177117
+            "perf_metric_value": 8370.014425096557
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 26545.931713712664
+            "perf_metric_value": 27662.820243691007
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2699.08314274893
+            "perf_metric_value": 2641.837605625889
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1486.2327104183764
+            "perf_metric_value": 1516.7172089797605
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4456.606860484332
+            "perf_metric_value": 4501.850720954102
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3038.941703794114
+            "perf_metric_value": 3062.7131794844063
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7804.984752431155
+            "perf_metric_value": 8002.339829198115
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22710.046003881216
+            "perf_metric_value": 23190.04299787998
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 824.4108502776797
+            "perf_metric_value": 799.9345402492929
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1119.7725751916082
+            "perf_metric_value": 1142.0198619070275
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 801.476709529905
+            "perf_metric_value": 806.172478450918
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.13929452807454937
+            "perf_metric_value": 0.13945791828216536
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 11004.98249042869
+            "perf_metric_value": 12017.023866540812
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 519.725991336052
+            "perf_metric_value": 473.62862729568997
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 963.1902909183787
+            "perf_metric_value": 984.156036006501
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 947.6614978210325
+            "perf_metric_value": 976.8103650114274
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.911263457119588
+            "perf_metric_value": 0.9601675934161155
         }
     ],
     "placement_group_create/removal": [
-        824.4108502776797,
-        17.72810428024577
+        799.9345402492929,
+        8.768796669691211
     ],
     "single_client_get_calls_Plasma_Store": [
-        10303.517743023112,
-        277.61596662520196
+        10553.076587142574,
+        142.90627657771753
     ],
     "single_client_get_object_containing_10k_refs": [
-        13.679337230724197,
-        0.3123070691705992
+        11.533423619760748,
+        0.45616357536687985
     ],
     "single_client_put_calls_Plasma_Store": [
-        5241.163782117501,
-        47.53421003771766
+        5255.898134426729,
+        75.1273959701687
     ],
     "single_client_put_gigabytes": [
-        20.184014305625574,
-        5.646629723807168
+        19.720556713345232,
+        5.448758230305697
     ],
     "single_client_tasks_and_get_batch": [
-        7.900197666889211,
-        0.39150208385232466
+        8.290762106646564,
+        0.24002041960421341
     ],
     "single_client_tasks_async": [
-        8011.455682416454,
-        468.6887008054221
+        7999.110134185503,
+        186.45035251864658
     ],
     "single_client_tasks_sync": [
-        986.5998779605792,
-        16.522476248712984
+        982.0408892888784,
+        20.30778037321339
     ],
     "single_client_wait_1k_refs": [
-        5.485273551888224,
-        0.07839577116526375
+        5.483366864446084,
+        0.10904900052460728
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 18.28579454300001,
+    "broadcast_time": 21.451945214000006,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 18.28579454300001
+            "perf_metric_value": 21.451945214000006
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 18.382605733000005,
-    "get_time": 23.411743029999997,
+    "args_time": 17.61703060299999,
+    "get_time": 23.942006032999984,
     "large_object_size": 107374182400,
-    "large_object_time": 32.98956875599998,
+    "large_object_time": 32.519903322000005,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 18.382605733000005
+            "perf_metric_value": 17.61703060299999
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.741477676000002
+            "perf_metric_value": 5.935367576000004
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.411743029999997
+            "perf_metric_value": 23.942006032999984
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 186.319367591
+            "perf_metric_value": 188.57777046200002
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 32.98956875599998
+            "perf_metric_value": 32.519903322000005
         }
     ],
-    "queued_time": 186.319367591,
-    "returns_time": 5.741477676000002,
+    "queued_time": 188.57777046200002,
+    "returns_time": 5.935367576000004,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.0309033346176149,
-    "max_iteration_time": 3.268310546875,
-    "min_iteration_time": 0.07307100296020508,
+    "avg_iteration_time": 1.012664566040039,
+    "max_iteration_time": 2.325312614440918,
+    "min_iteration_time": 0.1943213939666748,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.0309033346176149
+            "perf_metric_value": 1.012664566040039
         }
     ],
     "success": 1,
-    "total_time": 103.0905613899231
+    "total_time": 101.26667356491089
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 8.773437261581421
+            "perf_metric_value": 9.101566553115845
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.938837790489195
+            "perf_metric_value": 23.997523522377016
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 61.69442081451416
+            "perf_metric_value": 65.44879236221314
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2.573246955871582
+            "perf_metric_value": 1.563896894454956
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3035.906775712967
+            "perf_metric_value": 3026.7471375465393
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.5129273527822178
+            "perf_metric_value": 0.4569625792772166
         }
     ],
-    "stage_0_time": 8.773437261581421,
-    "stage_1_avg_iteration_time": 23.938837790489195,
-    "stage_1_max_iteration_time": 24.63253116607666,
-    "stage_1_min_iteration_time": 23.625248670578003,
-    "stage_1_time": 239.38846349716187,
-    "stage_2_avg_iteration_time": 61.69442081451416,
-    "stage_2_max_iteration_time": 62.908058643341064,
-    "stage_2_min_iteration_time": 59.646355867385864,
-    "stage_2_time": 308.4730384349823,
-    "stage_3_creation_time": 2.573246955871582,
-    "stage_3_time": 3035.906775712967,
-    "stage_4_spread": 0.5129273527822178,
+    "stage_0_time": 9.101566553115845,
+    "stage_1_avg_iteration_time": 23.997523522377016,
+    "stage_1_max_iteration_time": 25.68898844718933,
+    "stage_1_min_iteration_time": 23.086692810058594,
+    "stage_1_time": 239.97532105445862,
+    "stage_2_avg_iteration_time": 65.44879236221314,
+    "stage_2_max_iteration_time": 66.88093996047974,
+    "stage_2_min_iteration_time": 62.800971031188965,
+    "stage_2_time": 327.2448856830597,
+    "stage_3_creation_time": 1.563896894454956,
+    "stage_3_time": 3026.7471375465393,
+    "stage_4_spread": 0.4569625792772166,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 0.9371462897900398,
-    "avg_pg_remove_time_ms": 0.9081441951950084,
+    "avg_pg_create_time_ms": 0.967716537537761,
+    "avg_pg_remove_time_ms": 0.9198866005999815,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9371462897900398
+            "perf_metric_value": 0.967716537537761
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9081441951950084
+            "perf_metric_value": 0.9198866005999815
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 15.69%: single_client_get_object_containing_10k_refs (THROUGHPUT) regresses from 13.679337230724197 to 11.533423619760748 in microbenchmark.json
REGRESSION 8.87%: client__1_1_actor_calls_sync (THROUGHPUT) regresses from 519.725991336052 to 473.62862729568997 in microbenchmark.json
REGRESSION 4.74%: 1_n_actor_calls_async (THROUGHPUT) regresses from 8786.234839177117 to 8370.014425096557 in microbenchmark.json
REGRESSION 3.53%: multi_client_tasks_async (THROUGHPUT) regresses from 23311.858831941317 to 22489.617400047606 in microbenchmark.json
REGRESSION 2.97%: placement_group_create/removal (THROUGHPUT) regresses from 824.4108502776797 to 799.9345402492929 in microbenchmark.json
REGRESSION 2.30%: single_client_put_gigabytes (THROUGHPUT) regresses from 20.184014305625574 to 19.720556713345232 in microbenchmark.json
REGRESSION 2.12%: n_n_actor_calls_with_arg_async (THROUGHPUT) regresses from 2699.08314274893 to 2641.837605625889 in microbenchmark.json
REGRESSION 0.55%: 1_1_actor_calls_async (THROUGHPUT) regresses from 9060.701663275304 to 9011.034048587637 in microbenchmark.json
REGRESSION 0.54%: pgs_per_second (THROUGHPUT) regresses from 22.249430148995714 to 22.13026931060565 in benchmarks/many_pgs.json
REGRESSION 0.46%: single_client_tasks_sync (THROUGHPUT) regresses from 986.5998779605792 to 982.0408892888784 in microbenchmark.json
REGRESSION 0.15%: single_client_tasks_async (THROUGHPUT) regresses from 8011.455682416454 to 7999.110134185503 in microbenchmark.json
REGRESSION 0.03%: single_client_wait_1k_refs (THROUGHPUT) regresses from 5.485273551888224 to 5.483366864446084 in microbenchmark.json
REGRESSION 72.13%: dashboard_p95_latency_ms (LATENCY) regresses from 34.039 to 58.592 in benchmarks/many_nodes.json
REGRESSION 17.31%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 18.28579454300001 to 21.451945214000006 in scalability/object_store.json
REGRESSION 7.39%: dashboard_p50_latency_ms (LATENCY) regresses from 3.87 to 4.156 in benchmarks/many_nodes.json
REGRESSION 6.09%: stage_2_avg_iteration_time (LATENCY) regresses from 61.69442081451416 to 65.44879236221314 in stress_tests/stress_test_many_tasks.json
REGRESSION 5.26%: dashboard_p99_latency_ms (LATENCY) regresses from 119.573 to 125.858 in benchmarks/many_nodes.json
REGRESSION 3.74%: stage_0_time (LATENCY) regresses from 8.773437261581421 to 9.101566553115845 in stress_tests/stress_test_many_tasks.json
REGRESSION 3.38%: 3000_returns_time (LATENCY) regresses from 5.741477676000002 to 5.935367576000004 in scalability/single_node.json
REGRESSION 3.26%: avg_pg_create_time_ms (LATENCY) regresses from 0.9371462897900398 to 0.967716537537761 in stress_tests/stress_test_placement_group.json
REGRESSION 2.26%: 10000_get_time (LATENCY) regresses from 23.411743029999997 to 23.942006032999984 in scalability/single_node.json
REGRESSION 1.29%: avg_pg_remove_time_ms (LATENCY) regresses from 0.9081441951950084 to 0.9198866005999815 in stress_tests/stress_test_placement_group.json
REGRESSION 1.21%: 1000000_queued_time (LATENCY) regresses from 186.319367591 to 188.57777046200002 in scalability/single_node.json
REGRESSION 0.25%: stage_1_avg_iteration_time (LATENCY) regresses from 23.938837790489195 to 23.997523522377016 in stress_tests/stress_test_many_tasks.json
```