### PR TITLE
Add perf metrics for 2.36.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 485.167104,
+    "_dashboard_memory_usage_mb": 429.867008,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.74,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1215\t8.81GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n6550\t1.74GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n7868\t0.92GiB\tpython distributed/test_many_actors.py\n2138\t0.36GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n6668\t0.35GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n6842\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n2403\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n6844\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n7668\t0.07GiB\tray::JobSupervisor\n6868\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
-    "actors_per_second": 603.6854672610009,
+    "_peak_memory": 3.8,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1173\t7.02GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3408\t1.75GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4371\t0.93GiB\tpython distributed/test_many_actors.py\n1954\t0.46GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3524\t0.37GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n3687\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n2361\t0.08GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3689\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4167\t0.07GiB\tray::JobSupervisor\n3712\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
+    "actors_per_second": 637.7871696983945,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 603.6854672610009
+            "perf_metric_value": 637.7871696983945
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 104.211
+            "perf_metric_value": 177.731
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3768.817
+            "perf_metric_value": 3350.577
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3786.709
+            "perf_metric_value": 3361.16
         }
     ],
     "success": "1",
-    "time": 16.56491756439209
+    "time": 15.679211616516113
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 201.936896,
+    "_dashboard_memory_usage_mb": 186.601472,
     "_dashboard_test_success": true,
-    "_peak_memory": 1.71,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3523\t0.54GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1766\t0.24GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1244\t0.23GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3639\t0.19GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n5664\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3806\t0.1GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n5894\t0.08GiB\tray::StateAPIGeneratorActor.start\n2742\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3808\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n5469\t0.07GiB\tray::JobSupervisor",
+    "_peak_memory": 1.69,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3498\t0.54GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1887\t0.26GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1246\t0.22GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3614\t0.18GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4558\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3780\t0.1GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n4757\t0.08GiB\tray::StateAPIGeneratorActor.start\n2312\t0.08GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3782\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4350\t0.07GiB\tray::JobSupervisor",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 348.36498762040105
+            "perf_metric_value": 353.6897053988414
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4.917
+            "perf_metric_value": 4.156
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 70.687
+            "perf_metric_value": 58.592
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 131.198
+            "perf_metric_value": 125.858
         }
     ],
     "success": "1",
-    "tasks_per_second": 348.36498762040105,
-    "time": 302.87055253982544,
+    "tasks_per_second": 353.6897053988414,
+    "time": 302.82733702659607,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 127.606784,
+    "_dashboard_memory_usage_mb": 196.333568,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.17,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1219\t7.63GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3423\t0.89GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4478\t0.41GiB\tpython distributed/test_many_pgs.py\n2007\t0.34GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3539\t0.11GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n3704\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n3706\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n2349\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4272\t0.07GiB\tray::JobSupervisor\n3731\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
+    "_peak_memory": 2.13,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1135\t7.03GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3382\t0.89GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4327\t0.41GiB\tpython distributed/test_many_pgs.py\n2463\t0.28GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3498\t0.11GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n3663\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n2634\t0.08GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3665\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4107\t0.07GiB\tray::JobSupervisor\n3700\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22.037557767422825
+            "perf_metric_value": 22.13026931060565
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.347
+            "perf_metric_value": 3.37
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.126
+            "perf_metric_value": 7.238
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 376.468
+            "perf_metric_value": 276.52
         }
     ],
-    "pgs_per_second": 22.037557767422825,
+    "pgs_per_second": 22.13026931060565,
     "success": "1",
-    "time": 45.377079010009766
+    "time": 45.186978340148926
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 1249.652736,
+    "_dashboard_memory_usage_mb": 1343.930368,
     "_dashboard_test_success": true,
-    "_peak_memory": 5.1,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3389\t1.95GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3505\t1.58GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4343\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1881\t0.23GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1182\t0.23GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3669\t0.1GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n4547\t0.09GiB\tray::DashboardTester.run\n4621\t0.08GiB\tray::StateAPIGeneratorActor.start\n2239\t0.07GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3671\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
+    "_peak_memory": 5.16,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3344\t2.71GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3460\t0.87GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4369\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1869\t0.23GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1151\t0.22GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3623\t0.1GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n4510\t0.08GiB\tray::DashboardTester.run\n4566\t0.08GiB\tray::StateAPIGeneratorActor.start\n2192\t0.08GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3625\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 565.2052803056663
+            "perf_metric_value": 567.4860527139014
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 170.294
+            "perf_metric_value": 69.154
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2826.475
+            "perf_metric_value": 356.824
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4064.973
+            "perf_metric_value": 556.875
         }
     ],
     "success": "1",
-    "tasks_per_second": 565.2052803056663,
-    "time": 317.69268679618835,
+    "tasks_per_second": 567.4860527139014,
+    "time": 317.6215784549713,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.35.0"}
+{"release_version": "2.36.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        9012.880467992636,
-        274.39770203115614
+        9011.034048587637,
+        194.0628029853825
     ],
     "1_1_actor_calls_concurrent": [
-        5041.760637338739,
-        138.0380603219453
+        5263.2434276145505,
+        145.80604482427896
     ],
     "1_1_actor_calls_sync": [
-        1986.177233156469,
-        7.353089580388177
+        2080.236653557758,
+        23.13824039798905
     ],
     "1_1_async_actor_calls_async": [
-        4261.050694056448,
-        102.67641073560478
+        4501.850720954102,
+        147.87207834752016
     ],
     "1_1_async_actor_calls_sync": [
-        1483.4703793760418,
-        24.55014969155573
+        1516.7172089797605,
+        36.37949468906624
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2836.601104413851,
-        163.9138928707045
+        3062.7131794844063,
+        139.85737128748647
     ],
     "1_n_actor_calls_async": [
-        8803.178389859915,
-        248.2713616898665
+        8370.014425096557,
+        432.75202747065646
     ],
     "1_n_async_actor_calls_async": [
-        7855.576353730168,
-        104.38819846802097
+        8002.339829198115,
+        128.47546109549722
     ],
     "client__1_1_actor_calls_async": [
-        1019.3028285821217,
-        6.754799952397459
+        984.156036006501,
+        13.717632534060987
     ],
     "client__1_1_actor_calls_concurrent": [
-        1007.6444648899972,
-        8.361807119609024
+        976.8103650114274,
+        10.754697369485774
     ],
     "client__1_1_actor_calls_sync": [
-        523.3469473257671,
-        1.559621936382034
+        473.62862729568997,
+        16.15435893429041
     ],
     "client__get_calls": [
-        966.9141307622872,
-        9.258603442950216
+        1142.0198619070275,
+        24.778997750410955
     ],
     "client__put_calls": [
-        806.1974515278531,
-        25.89751552055511
+        806.172478450918,
+        26.541778900550913
     ],
     "client__put_gigabytes": [
-        0.13947664668408546,
-        0.0005617088893114759
+        0.13945791828216536,
+        0.0009825552590766468
     ],
     "client__tasks_and_get_batch": [
-        0.9561497312686904,
-        0.009734603566212642
+        0.9601675934161155,
+        0.015386698591663932
     ],
     "client__tasks_and_put_batch": [
-        11214.270141950088,
-        263.0139775234698
+        12017.023866540812,
+        97.56477930019382
     ],
     "multi_client_put_calls_Plasma_Store": [
-        12536.270544865174,
-        188.62193594404053
+        12906.774263883479,
+        209.17121340433738
     ],
     "multi_client_put_gigabytes": [
-        45.440179854469804,
-        3.803265665952826
+        42.368678421213005,
+        2.479245917314356
     ],
     "multi_client_tasks_async": [
-        21353.682091539627,
-        791.9484727327964
+        22489.617400047606,
+        2527.3493250916217
     ],
     "n_n_actor_calls_async": [
-        26370.461840482538,
-        947.6739378691185
+        27662.820243691007,
+        694.5263617445811
     ],
     "n_n_actor_calls_with_arg_async": [
-        2748.863962184806,
-        67.15817575976418
+        2641.837605625889,
+        48.21948083604403
     ],
     "n_n_async_actor_calls_async": [
-        22929.738827936668,
-        1048.7531922006851
+        23190.04299787998,
+        705.5689531826766
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10507.047272805994
+            "perf_metric_value": 10553.076587142574
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5273.203424794718
+            "perf_metric_value": 5255.898134426729
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12536.270544865174
+            "perf_metric_value": 12906.774263883479
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 18.32083810818594
+            "perf_metric_value": 19.720556713345232
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8.199516693089809
+            "perf_metric_value": 8.290762106646564
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 45.440179854469804
+            "perf_metric_value": 42.368678421213005
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13.204885454613315
+            "perf_metric_value": 11.533423619760748
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.39514490847805
+            "perf_metric_value": 5.483366864446084
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 973.959307673384
+            "perf_metric_value": 982.0408892888784
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7988.9069673790045
+            "perf_metric_value": 7999.110134185503
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 21353.682091539627
+            "perf_metric_value": 22489.617400047606
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1986.177233156469
+            "perf_metric_value": 2080.236653557758
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 9012.880467992636
+            "perf_metric_value": 9011.034048587637
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5041.760637338739
+            "perf_metric_value": 5263.2434276145505
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8803.178389859915
+            "perf_metric_value": 8370.014425096557
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 26370.461840482538
+            "perf_metric_value": 27662.820243691007
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2748.863962184806
+            "perf_metric_value": 2641.837605625889
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1483.4703793760418
+            "perf_metric_value": 1516.7172089797605
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4261.050694056448
+            "perf_metric_value": 4501.850720954102
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2836.601104413851
+            "perf_metric_value": 3062.7131794844063
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7855.576353730168
+            "perf_metric_value": 8002.339829198115
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22929.738827936668
+            "perf_metric_value": 23190.04299787998
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 805.1759941825478
+            "perf_metric_value": 799.9345402492929
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 966.9141307622872
+            "perf_metric_value": 1142.0198619070275
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 806.1974515278531
+            "perf_metric_value": 806.172478450918
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.13947664668408546
+            "perf_metric_value": 0.13945791828216536
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 11214.270141950088
+            "perf_metric_value": 12017.023866540812
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 523.3469473257671
+            "perf_metric_value": 473.62862729568997
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1019.3028285821217
+            "perf_metric_value": 984.156036006501
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1007.6444648899972
+            "perf_metric_value": 976.8103650114274
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.9561497312686904
+            "perf_metric_value": 0.9601675934161155
         }
     ],
     "placement_group_create/removal": [
-        805.1759941825478,
-        7.473230546683027
+        799.9345402492929,
+        8.768796669691211
     ],
     "single_client_get_calls_Plasma_Store": [
-        10507.047272805994,
-        112.53291460675577
+        10553.076587142574,
+        142.90627657771753
     ],
     "single_client_get_object_containing_10k_refs": [
-        13.204885454613315,
-        0.16663510238318005
+        11.533423619760748,
+        0.45616357536687985
     ],
     "single_client_put_calls_Plasma_Store": [
-        5273.203424794718,
-        80.97664679249488
+        5255.898134426729,
+        75.1273959701687
     ],
     "single_client_put_gigabytes": [
-        18.32083810818594,
-        6.037453503779728
+        19.720556713345232,
+        5.448758230305697
     ],
     "single_client_tasks_and_get_batch": [
-        8.199516693089809,
-        0.5202534269218758
+        8.290762106646564,
+        0.24002041960421341
     ],
     "single_client_tasks_async": [
-        7988.9069673790045,
-        476.6476161596187
+        7999.110134185503,
+        186.45035251864658
     ],
     "single_client_tasks_sync": [
-        973.959307673384,
-        18.795951797682633
+        982.0408892888784,
+        20.30778037321339
     ],
     "single_client_wait_1k_refs": [
-        5.39514490847805,
-        0.15952866665582002
+        5.483366864446084,
+        0.10904900052460728
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 18.961532712000007,
+    "broadcast_time": 21.451945214000006,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 18.961532712000007
+            "perf_metric_value": 21.451945214000006
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.328640389999997,
-    "get_time": 23.896780481999997,
+    "args_time": 17.61703060299999,
+    "get_time": 23.942006032999984,
     "large_object_size": 107374182400,
-    "large_object_time": 32.70541331600003,
+    "large_object_time": 32.519903322000005,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.328640389999997
+            "perf_metric_value": 17.61703060299999
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.680022101000006
+            "perf_metric_value": 5.935367576000004
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.896780481999997
+            "perf_metric_value": 23.942006032999984
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 189.12986922100004
+            "perf_metric_value": 188.57777046200002
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 32.70541331600003
+            "perf_metric_value": 32.519903322000005
         }
     ],
-    "queued_time": 189.12986922100004,
-    "returns_time": 5.680022101000006,
+    "queued_time": 188.57777046200002,
+    "returns_time": 5.935367576000004,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 0.9740754842758179,
-    "max_iteration_time": 2.2291815280914307,
-    "min_iteration_time": 0.36443448066711426,
+    "avg_iteration_time": 1.012664566040039,
+    "max_iteration_time": 2.325312614440918,
+    "min_iteration_time": 0.1943213939666748,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9740754842758179
+            "perf_metric_value": 1.012664566040039
         }
     ],
     "success": 1,
-    "total_time": 97.40779948234558
+    "total_time": 101.26667356491089
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 11.421970844268799
+            "perf_metric_value": 9.101566553115845
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 26.23279986381531
+            "perf_metric_value": 23.997523522377016
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 63.694758081436156
+            "perf_metric_value": 65.44879236221314
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2.0420665740966797
+            "perf_metric_value": 1.563896894454956
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3321.615835428238
+            "perf_metric_value": 3026.7471375465393
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.45063567085147194
+            "perf_metric_value": 0.4569625792772166
         }
     ],
-    "stage_0_time": 11.421970844268799,
-    "stage_1_avg_iteration_time": 26.23279986381531,
-    "stage_1_max_iteration_time": 27.9172306060791,
-    "stage_1_min_iteration_time": 24.92852473258972,
-    "stage_1_time": 262.3281092643738,
-    "stage_2_avg_iteration_time": 63.694758081436156,
-    "stage_2_max_iteration_time": 64.70488262176514,
-    "stage_2_min_iteration_time": 62.95923352241516,
-    "stage_2_time": 318.4745900630951,
-    "stage_3_creation_time": 2.0420665740966797,
-    "stage_3_time": 3321.615835428238,
-    "stage_4_spread": 0.45063567085147194,
+    "stage_0_time": 9.101566553115845,
+    "stage_1_avg_iteration_time": 23.997523522377016,
+    "stage_1_max_iteration_time": 25.68898844718933,
+    "stage_1_min_iteration_time": 23.086692810058594,
+    "stage_1_time": 239.97532105445862,
+    "stage_2_avg_iteration_time": 65.44879236221314,
+    "stage_2_max_iteration_time": 66.88093996047974,
+    "stage_2_min_iteration_time": 62.800971031188965,
+    "stage_2_time": 327.2448856830597,
+    "stage_3_creation_time": 1.563896894454956,
+    "stage_3_time": 3026.7471375465393,
+    "stage_4_spread": 0.4569625792772166,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 0.9705077387385862,
-    "avg_pg_remove_time_ms": 0.9207600330309926,
+    "avg_pg_create_time_ms": 0.967716537537761,
+    "avg_pg_remove_time_ms": 0.9198866005999815,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9705077387385862
+            "perf_metric_value": 0.967716537537761
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9207600330309926
+            "perf_metric_value": 0.9198866005999815
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 12.66%: single_client_get_object_containing_10k_refs (THROUGHPUT) regresses from 13.204885454613315 to 11.533423619760748 in microbenchmark.json
REGRESSION 9.50%: client__1_1_actor_calls_sync (THROUGHPUT) regresses from 523.3469473257671 to 473.62862729568997 in microbenchmark.json
REGRESSION 6.76%: multi_client_put_gigabytes (THROUGHPUT) regresses from 45.440179854469804 to 42.368678421213005 in microbenchmark.json
REGRESSION 4.92%: 1_n_actor_calls_async (THROUGHPUT) regresses from 8803.178389859915 to 8370.014425096557 in microbenchmark.json
REGRESSION 3.89%: n_n_actor_calls_with_arg_async (THROUGHPUT) regresses from 2748.863962184806 to 2641.837605625889 in microbenchmark.json
REGRESSION 3.45%: client__1_1_actor_calls_async (THROUGHPUT) regresses from 1019.3028285821217 to 984.156036006501 in microbenchmark.json
REGRESSION 3.06%: client__1_1_actor_calls_concurrent (THROUGHPUT) regresses from 1007.6444648899972 to 976.8103650114274 in microbenchmark.json
REGRESSION 0.65%: placement_group_create/removal (THROUGHPUT) regresses from 805.1759941825478 to 799.9345402492929 in microbenchmark.json
REGRESSION 0.33%: single_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 5273.203424794718 to 5255.898134426729 in microbenchmark.json
REGRESSION 0.02%: 1_1_actor_calls_async (THROUGHPUT) regresses from 9012.880467992636 to 9011.034048587637 in microbenchmark.json
REGRESSION 0.01%: client__put_gigabytes (THROUGHPUT) regresses from 0.13947664668408546 to 0.13945791828216536 in microbenchmark.json
REGRESSION 0.00%: client__put_calls (THROUGHPUT) regresses from 806.1974515278531 to 806.172478450918 in microbenchmark.json
REGRESSION 70.55%: dashboard_p50_latency_ms (LATENCY) regresses from 104.211 to 177.731 in benchmarks/many_actors.json
REGRESSION 13.13%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 18.961532712000007 to 21.451945214000006 in scalability/object_store.json
REGRESSION 4.50%: 3000_returns_time (LATENCY) regresses from 5.680022101000006 to 5.935367576000004 in scalability/single_node.json
REGRESSION 3.96%: avg_iteration_time (LATENCY) regresses from 0.9740754842758179 to 1.012664566040039 in stress_tests/stress_test_dead_actors.json
REGRESSION 2.75%: stage_2_avg_iteration_time (LATENCY) regresses from 63.694758081436156 to 65.44879236221314 in stress_tests/stress_test_many_tasks.json
REGRESSION 1.66%: 10000_args_time (LATENCY) regresses from 17.328640389999997 to 17.61703060299999 in scalability/single_node.json
REGRESSION 1.40%: stage_4_spread (LATENCY) regresses from 0.45063567085147194 to 0.4569625792772166 in stress_tests/stress_test_many_tasks.json
REGRESSION 0.69%: dashboard_p50_latency_ms (LATENCY) regresses from 3.347 to 3.37 in benchmarks/many_pgs.json
REGRESSION 0.19%: 10000_get_time (LATENCY) regresses from 23.896780481999997 to 23.942006032999984 in scalability/single_node.json
```