### PR TITLE
[Core] Mark single_node_oom release test as unstable

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3322,6 +3322,8 @@
   group: core-daily-test
   working_dir: nightly_tests
 
+  stable: false
+
   frequency: nightly
   team: core
   env: aws_perf

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3322,6 +3322,7 @@
   group: core-daily-test
   working_dir: nightly_tests
 
+  # TODO: https://github.com/ray-project/ray/issues/47596
   stable: false
 
   frequency: nightly


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This has been flaky and noisy for months. Prior attempt to address flakiness did not fully resolve the problem. Marking this as unstable before it is completely fixed.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->



## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
