### PR TITLE
[dashboard] fix syntax warnings on slashes

### DIFF
--- a/python/ray/dashboard/modules/job/utils.py
+++ b/python/ray/dashboard/modules/job/utils.py
@@ -53,7 +53,7 @@ def strip_keys_with_value_none(d: Dict[str, Any]) -> Dict[str, Any]:
 
 def redact_url_password(url: str) -> str:
     """Redact any passwords in a URL."""
-    secret = re.findall("https?:\/\/.*:(.*)@.*", url)
+    secret = re.findall(r"https?:\/\/.*:(.*)@.*", url)
     if len(secret) > 0:
         url = url.replace(f":{secret[0]}@", ":<redacted>@")
 


### PR DESCRIPTION
It was saying:

```
/home/ray/anaconda3/lib/python3.12/site-packages/ray/dashboard/modules/job/utils.py:56: SyntaxWarning: invalid escape sequence '\/'
```

