### PR TITLE
[Serve] fix default serve logger behavior

### DIFF
--- a/python/ray/serve/_private/logging_utils.py
+++ b/python/ray/serve/_private/logging_utils.py
@@ -279,7 +279,7 @@ def configure_component_logger(
     component_type: Optional[ServeComponentType] = None,
     max_bytes: Optional[int] = None,
     backup_count: Optional[int] = None,
-    for_default_logger: bool = False,
+    stream_handler_only: bool = False,
 ):
     """Configure a logger to be used by a Serve component.
 
@@ -295,18 +295,18 @@ def configure_component_logger(
 
     # Only add stream handler if RAY_SERVE_LOG_TO_STDERR is True.
     # Also, setup stream handler if the default serve logger is being configured.
-    if RAY_SERVE_LOG_TO_STDERR or for_default_logger:
+    if RAY_SERVE_LOG_TO_STDERR or stream_handler_only:
         stream_handler = logging.StreamHandler()
         stream_handler.setFormatter(ServeFormatter(component_name, component_id))
         stream_handler.addFilter(log_to_stderr_filter)
         stream_handler.addFilter(ServeContextFilter())
         logger.addHandler(stream_handler)
 
-    # Skip setting up file handler and stdout/stderr redirect if the default serve
-    # logger is being configured. Default serve logger can be configured outside the
+    # Skip setting up file handler and stdout/stderr redirect if `stream_handler_only`
+    # is set to True. Default serve logger can be configured outside the
     # context of a Serve component, we don't want those logs to redirect into serve's
     # logger and log files.
-    if for_default_logger:
+    if stream_handler_only:
         return
 
     if logging_config.logs_dir:
@@ -371,7 +371,7 @@ def configure_default_serve_logger():
         logging_config=LoggingConfig(),
         max_bytes=LOGGING_ROTATE_BYTES,
         backup_count=LOGGING_ROTATE_BACKUP_COUNT,
-        for_default_logger=True,
+        stream_handler_only=True,
     )
 
 

--- a/python/ray/serve/_private/logging_utils.py
+++ b/python/ray/serve/_private/logging_utils.py
@@ -353,8 +353,8 @@ def configure_component_logger(
     # Remove unwanted attributes from the log record.
     file_handler.addFilter(ServeLogAttributeRemovalFilter())
 
-    # Redirect print, stdout, and stderr to Serve logger.
-    if not RAY_SERVE_LOG_TO_STDERR:
+    # Redirect print, stdout, and stderr to Serve logger, only when it's on the replica.
+    if not RAY_SERVE_LOG_TO_STDERR and component_type == ServeComponentType.REPLICA:
         builtins.print = redirected_print
         sys.stdout = StreamToLogger(logger, logging.INFO, sys.stdout)
         sys.stderr = StreamToLogger(logger, logging.INFO, sys.stderr)

--- a/python/ray/serve/_private/logging_utils.py
+++ b/python/ray/serve/_private/logging_utils.py
@@ -293,8 +293,8 @@ def configure_component_logger(
     logger.setLevel(logging_config.log_level)
     logger.handlers.clear()
 
-    # Only add stream handler if RAY_SERVE_LOG_TO_STDERR is True.
-    # Also, setup stream handler if the default serve logger is being configured.
+    # Only add stream handler if RAY_SERVE_LOG_TO_STDERR is True or if
+    # `stream_handler_only` is set to True.
     if RAY_SERVE_LOG_TO_STDERR or stream_handler_only:
         stream_handler = logging.StreamHandler()
         stream_handler.setFormatter(ServeFormatter(component_name, component_id))
@@ -303,7 +303,7 @@ def configure_component_logger(
         logger.addHandler(stream_handler)
 
     # Skip setting up file handler and stdout/stderr redirect if `stream_handler_only`
-    # is set to True. Default serve logger can be configured outside the
+    # is set to True. Logger such as default serve logger can be configured outside the
     # context of a Serve component, we don't want those logs to redirect into serve's
     # logger and log files.
     if stream_handler_only:

--- a/python/ray/serve/_private/logging_utils.py
+++ b/python/ray/serve/_private/logging_utils.py
@@ -279,7 +279,7 @@ def configure_component_logger(
     component_type: Optional[ServeComponentType] = None,
     max_bytes: Optional[int] = None,
     backup_count: Optional[int] = None,
-    default_serve_logger: bool = False,
+    for_default_logger: bool = False,
 ):
     """Configure a logger to be used by a Serve component.
 
@@ -295,7 +295,7 @@ def configure_component_logger(
 
     # Only add stream handler if RAY_SERVE_LOG_TO_STDERR is True.
     # Also, setup stream handler if the default serve logger is being configured.
-    if RAY_SERVE_LOG_TO_STDERR or default_serve_logger:
+    if RAY_SERVE_LOG_TO_STDERR or for_default_logger:
         stream_handler = logging.StreamHandler()
         stream_handler.setFormatter(ServeFormatter(component_name, component_id))
         stream_handler.addFilter(log_to_stderr_filter)
@@ -306,7 +306,7 @@ def configure_component_logger(
     # logger is being configured. Default serve logger can be configured outside the
     # context of a Serve component, we don't want those logs to redirect into serve's
     # logger and log files.
-    if default_serve_logger:
+    if for_default_logger:
         return
 
     if logging_config.logs_dir:
@@ -371,7 +371,7 @@ def configure_default_serve_logger():
         logging_config=LoggingConfig(),
         max_bytes=LOGGING_ROTATE_BYTES,
         backup_count=LOGGING_ROTATE_BACKUP_COUNT,
-        default_serve_logger=True,
+        for_default_logger=True,
     )
 
 

--- a/python/ray/serve/tests/test_logging.py
+++ b/python/ray/serve/tests/test_logging.py
@@ -27,7 +27,9 @@ from ray.serve._private.logging_utils import (
     ServeFormatter,
     StreamToLogger,
     configure_component_logger,
+    configure_default_serve_logger,
     get_serve_logs_dir,
+    redirected_print,
 )
 from ray.serve._private.utils import get_component_file_name
 from ray.serve.context import _get_global_client
@@ -869,6 +871,32 @@ def test_json_logging_with_unpickleable_exc_info(
         with open(logs_dir / log_file) as f:
             assert "Logging error" not in f.read()
             assert "cannot pickle" not in f.read()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")
+@pytest.mark.parametrize(
+    "ray_instance",
+    [
+        {"RAY_SERVE_LOG_TO_STDERR": "0"},
+    ],
+    indirect=True,
+)
+def test_configure_default_serve_logger_with_stderr_redirect(
+    serve_and_ray_shutdown, ray_instance, tmp_dir
+):
+    """Test configuring default serve logger with stderr redirect.
+
+    Default serve logger should only be configured with one StreamToLogger handler, and
+    print, stdout, and stderr should NOT be overridden and redirected to the logger.
+    """
+
+    configure_default_serve_logger()
+    serve_logger = logging.getLogger("ray.serve")
+    assert len(serve_logger.handlers) == 1
+    assert isinstance(serve_logger.handlers[0], logging.StreamHandler)
+    assert print != redirected_print
+    assert not isinstance(sys.stdout, StreamToLogger)
+    assert not isinstance(sys.stderr, StreamToLogger)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Re: https://github.com/ray-project/ray/pull/47229

Previous PR to setup default serve logger has some unexpected consequence. Mainly combined with Serve's stdout redirect feature (when `RAY_SERVE_LOG_TO_STDERR=0` is set in env), it will setup default serve logger and redirect all stdout/stderr into serve's log files instead going to the console. This caused on the Anyscale platform unable to identify ray start command is running successfully and unable to start the cluster. This PR fixes this behavior by only configure Serve's default logger with stream handler and skip configuring file handler altogether. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
