### PR TITLE
[serve] reorganize replica scheduler classes

### DIFF
--- a/python/ray/serve/_private/default_impl.py
+++ b/python/ray/serve/_private/default_impl.py
@@ -6,10 +6,12 @@ from ray.serve._private.cluster_node_info_cache import (
     ClusterNodeInfoCache,
     DefaultClusterNodeInfoCache,
 )
+from ray.serve._private.common import RunningReplicaInfo
 from ray.serve._private.deployment_scheduler import (
     DefaultDeploymentScheduler,
     DeploymentScheduler,
 )
+from ray.serve._private.replica_scheduler.replica_wrapper import ActorReplicaWrapper
 from ray.serve._private.utils import get_head_node_id
 
 # NOTE: Please read carefully before changing!
@@ -35,3 +37,7 @@ def create_deployment_scheduler(
         create_placement_group_fn=create_placement_group_fn_override
         or ray.util.placement_group,
     )
+
+
+def create_replica_wrapper(replica_info: RunningReplicaInfo):
+    return ActorReplicaWrapper(replica_info)

--- a/python/ray/serve/_private/replica_scheduler/__init__.py
+++ b/python/ray/serve/_private/replica_scheduler/__init__.py
@@ -1,8 +1,10 @@
-from ray.serve._private.replica_scheduler.common import (  # noqa: F401
-    PendingRequest,
-    ReplicaScheduler,
-    ReplicaWrapper,
-)
+from ray.serve._private.replica_scheduler.common import PendingRequest  # noqa: F401
 from ray.serve._private.replica_scheduler.pow_2_scheduler import (  # noqa: F401
     PowerOfTwoChoicesReplicaScheduler,
+)
+from ray.serve._private.replica_scheduler.replica_scheduler import (  # noqa: F401
+    ReplicaScheduler,
+)
+from ray.serve._private.replica_scheduler.replica_wrapper import (  # noqa: F401
+    ReplicaWrapper,
 )

--- a/python/ray/serve/_private/replica_scheduler/common.py
+++ b/python/ray/serve/_private/replica_scheduler/common.py
@@ -1,26 +1,14 @@
 import asyncio
 import logging
-import pickle
 import time
-from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Set
 
-import ray
-from ray import ObjectRef, ObjectRefGenerator
-from ray.actor import ActorHandle
-from ray.serve._private.common import (
-    ReplicaID,
-    ReplicaQueueLengthInfo,
-    RequestMetadata,
-    RunningReplicaInfo,
-)
+from ray.serve._private.common import ReplicaID, RequestMetadata
 from ray.serve._private.constants import (
     RAY_SERVE_QUEUE_LENGTH_CACHE_TIMEOUT_S,
     SERVE_LOGGER_NAME,
 )
-from ray.serve._private.utils import JavaActorHandleProxy
-from ray.serve.generated.serve_pb2 import RequestMetadata as RequestMetadataProto
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
@@ -36,179 +24,6 @@ class PendingRequest:
     def reset_future(self):
         """Reset the `asyncio.Future`, must be called if this request is re-used."""
         self.future = asyncio.Future()
-
-
-class ReplicaWrapper(ABC):
-    """Defines the interface for a scheduler to talk to a replica.
-
-    This is used to abstract away details of Ray actor calls for testing.
-    """
-
-    @property
-    def replica_id(self) -> ReplicaID:
-        """ID of this replica."""
-        pass
-
-    @property
-    def multiplexed_model_ids(self) -> Set[str]:
-        """Set of model IDs on this replica."""
-        pass
-
-    @property
-    def max_ongoing_requests(self) -> int:
-        """Max concurrent requests that can be sent to this replica."""
-        pass
-
-    def push_proxy_handle(self, handle: ActorHandle):
-        """When on proxy, push proxy's self handle to replica"""
-        pass
-
-    async def get_queue_len(self, *, deadline_s: float) -> int:
-        """Returns current queue len for the replica.
-
-        `deadline_s` is passed to verify backoff for testing.
-        """
-        pass
-
-    def send_request(self, pr: PendingRequest) -> Union[ObjectRef, ObjectRefGenerator]:
-        """Send request to this replica."""
-        pass
-
-    async def send_request_with_rejection(
-        self,
-        pr: PendingRequest,
-    ) -> Tuple[Optional[ObjectRefGenerator], ReplicaQueueLengthInfo]:
-        """Send request to this replica.
-
-        The replica will yield a system message (ReplicaQueueLengthInfo) before
-        executing the actual request. This can cause it to reject the request.
-
-        The result will *always* be a generator, so for non-streaming requests it's up
-        to the caller to resolve it to its first (and only) ObjectRef.
-
-        Only supported for Python replicas.
-        """
-        pass
-
-
-class ActorReplicaWrapper:
-    def __init__(self, replica_info: RunningReplicaInfo):
-        self._replica_info = replica_info
-        self._multiplexed_model_ids = set(replica_info.multiplexed_model_ids)
-
-        if replica_info.is_cross_language:
-            self._actor_handle = JavaActorHandleProxy(replica_info.actor_handle)
-        else:
-            self._actor_handle = replica_info.actor_handle
-
-    @property
-    def replica_id(self) -> ReplicaID:
-        return self._replica_info.replica_id
-
-    @property
-    def node_id(self) -> str:
-        return self._replica_info.node_id
-
-    @property
-    def availability_zone(self) -> Optional[str]:
-        return self._replica_info.availability_zone
-
-    @property
-    def multiplexed_model_ids(self) -> Set[str]:
-        return self._multiplexed_model_ids
-
-    @property
-    def max_ongoing_requests(self) -> int:
-        return self._replica_info.max_ongoing_requests
-
-    @property
-    def is_cross_language(self) -> bool:
-        return self._replica_info.is_cross_language
-
-    def push_proxy_handle(self, handle: ActorHandle):
-        self._actor_handle.push_proxy_handle.remote(handle)
-
-    async def get_queue_len(self, *, deadline_s: float) -> int:
-        # NOTE(edoakes): the `get_num_ongoing_requests` method name is shared by
-        # the Python and Java replica implementations. If you change it, you need to
-        # change both (or introduce a branch here).
-        obj_ref = self._actor_handle.get_num_ongoing_requests.remote()
-        try:
-            return await obj_ref
-        except asyncio.CancelledError:
-            ray.cancel(obj_ref)
-            raise
-
-    def _send_request_java(self, pr: PendingRequest) -> ObjectRef:
-        """Send the request to a Java replica.
-
-        Does not currently support streaming.
-        """
-        if pr.metadata.is_streaming:
-            raise RuntimeError("Streaming not supported for Java.")
-
-        if len(pr.args) != 1:
-            raise ValueError("Java handle calls only support a single argument.")
-
-        return self._actor_handle.handle_request.remote(
-            RequestMetadataProto(
-                request_id=pr.metadata.request_id,
-                endpoint=pr.metadata.endpoint,
-                # Default call method in java is "call," not "__call__" like Python.
-                call_method="call"
-                if pr.metadata.call_method == "__call__"
-                else pr.metadata.call_method,
-            ).SerializeToString(),
-            pr.args,
-        )
-
-    def _send_request_python(
-        self, pr: PendingRequest, *, with_rejection: bool
-    ) -> Union[ray.ObjectRef, ObjectRefGenerator]:
-        """Send the request to a Python replica."""
-        if with_rejection:
-            # Call a separate handler that may reject the request.
-            # This handler is *always* a streaming call and the first message will
-            # be a system message that accepts or rejects.
-            method = self._actor_handle.handle_request_with_rejection.options(
-                num_returns="streaming"
-            )
-        elif pr.metadata.is_streaming:
-            method = self._actor_handle.handle_request_streaming.options(
-                num_returns="streaming"
-            )
-        else:
-            method = self._actor_handle.handle_request
-
-        return method.remote(pickle.dumps(pr.metadata), *pr.args, **pr.kwargs)
-
-    def send_request(self, pr: PendingRequest) -> Union[ObjectRef, ObjectRefGenerator]:
-        if self._replica_info.is_cross_language:
-            return self._send_request_java(pr)
-        else:
-            return self._send_request_python(pr, with_rejection=False)
-
-    async def send_request_with_rejection(
-        self,
-        pr: PendingRequest,
-    ) -> Tuple[Optional[ObjectRefGenerator], ReplicaQueueLengthInfo]:
-        assert (
-            not self._replica_info.is_cross_language
-        ), "Request rejection not supported for Java."
-
-        obj_ref_gen = self._send_request_python(pr, with_rejection=True)
-        try:
-            first_ref = await obj_ref_gen.__anext__()
-            queue_len_info: ReplicaQueueLengthInfo = pickle.loads(await first_ref)
-
-            if not queue_len_info.accepted:
-                return None, queue_len_info
-            else:
-                return obj_ref_gen, queue_len_info
-        except asyncio.CancelledError as e:
-            # HTTP client disconnected or request was explicitly canceled.
-            ray.cancel(obj_ref_gen)
-            raise e from None
 
 
 @dataclass(frozen=True)
@@ -259,39 +74,3 @@ class ReplicaQueueLengthCache:
         for replica_id in list(self._cache.keys()):
             if replica_id not in active_replica_ids:
                 self._cache.pop(replica_id)
-
-
-class ReplicaScheduler(ABC):
-    """Abstract interface for a replica scheduler (how the router calls it)."""
-
-    @abstractmethod
-    async def choose_replica_for_request(
-        self, pending_request: PendingRequest, *, is_retry: bool = False
-    ) -> ReplicaWrapper:
-        pass
-
-    @abstractmethod
-    def update_replicas(self, replicas: List[ReplicaWrapper]):
-        pass
-
-    def update_running_replicas(self, running_replicas: List[RunningReplicaInfo]):
-        """Compatibility shim for RunningReplicaInfo datatype."""
-        return self.update_replicas([ActorReplicaWrapper(r) for r in running_replicas])
-
-    @abstractmethod
-    def on_replica_actor_died(self, replica_id: ReplicaID):
-        pass
-
-    @abstractmethod
-    def on_replica_actor_unavailable(self, replica_id: ReplicaID):
-        pass
-
-    @property
-    @abstractmethod
-    def replica_queue_len_cache(self) -> ReplicaQueueLengthCache:
-        pass
-
-    @property
-    @abstractmethod
-    def curr_replicas(self) -> Dict[ReplicaID, ReplicaWrapper]:
-        pass

--- a/python/ray/serve/_private/replica_scheduler/pow_2_scheduler.py
+++ b/python/ray/serve/_private/replica_scheduler/pow_2_scheduler.py
@@ -35,9 +35,9 @@ from ray.serve._private.constants import (
 from ray.serve._private.replica_scheduler.common import (
     PendingRequest,
     ReplicaQueueLengthCache,
-    ReplicaScheduler,
-    ReplicaWrapper,
 )
+from ray.serve._private.replica_scheduler.replica_scheduler import ReplicaScheduler
+from ray.serve._private.replica_scheduler.replica_wrapper import ReplicaWrapper
 from ray.util import metrics
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
@@ -100,6 +100,9 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
         self_availability_zone: Optional[str] = None,
         use_replica_queue_len_cache: bool = False,
         get_curr_time_s: Optional[Callable[[], float]] = None,
+        create_replica_wrapper_func: Optional[
+            Callable[[RunningReplicaInfo], ReplicaWrapper]
+        ] = None,
     ):
         self._loop = event_loop
         self._deployment_id = deployment_id
@@ -110,6 +113,7 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
         self._self_actor_handle = self_actor_handle
         self._self_availability_zone = self_availability_zone
         self._use_replica_queue_len_cache = use_replica_queue_len_cache
+        self._create_replica_wrapper_func = create_replica_wrapper_func
 
         # Current replicas available to be scheduled.
         # Updated via `update_replicas`.
@@ -235,6 +239,11 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
     @property
     def replica_queue_len_cache(self) -> ReplicaQueueLengthCache:
         return self._replica_queue_len_cache
+
+    def create_replica_wrapper(
+        self, replica_info: RunningReplicaInfo
+    ) -> ReplicaWrapper:
+        return self._create_replica_wrapper_func(replica_info)
 
     def update_replicas(self, replicas: List[ReplicaWrapper]):
         """Update the set of available replicas to be considered for scheduling.

--- a/python/ray/serve/_private/replica_scheduler/replica_scheduler.py
+++ b/python/ray/serve/_private/replica_scheduler/replica_scheduler.py
@@ -1,0 +1,53 @@
+from abc import ABC, abstractmethod
+from typing import Dict, List
+
+from ray.serve._private.common import ReplicaID, RunningReplicaInfo
+from ray.serve._private.replica_scheduler.common import (
+    PendingRequest,
+    ReplicaQueueLengthCache,
+)
+from ray.serve._private.replica_scheduler.replica_wrapper import ReplicaWrapper
+
+
+class ReplicaScheduler(ABC):
+    """Abstract interface for a replica scheduler (how the router calls it)."""
+
+    @abstractmethod
+    async def choose_replica_for_request(
+        self, pending_request: PendingRequest, *, is_retry: bool = False
+    ) -> ReplicaWrapper:
+        pass
+
+    @abstractmethod
+    def create_replica_wrapper(
+        self, replica_info: RunningReplicaInfo
+    ) -> ReplicaWrapper:
+        pass
+
+    @abstractmethod
+    def update_replicas(self, replicas: List[ReplicaWrapper]):
+        pass
+
+    def update_running_replicas(self, running_replicas: List[RunningReplicaInfo]):
+        """Compatibility shim for RunningReplicaInfo datatype."""
+        return self.update_replicas(
+            [self.create_replica_wrapper(r) for r in running_replicas]
+        )
+
+    @abstractmethod
+    def on_replica_actor_died(self, replica_id: ReplicaID):
+        pass
+
+    @abstractmethod
+    def on_replica_actor_unavailable(self, replica_id: ReplicaID):
+        pass
+
+    @property
+    @abstractmethod
+    def replica_queue_len_cache(self) -> ReplicaQueueLengthCache:
+        pass
+
+    @property
+    @abstractmethod
+    def curr_replicas(self) -> Dict[ReplicaID, ReplicaWrapper]:
+        pass

--- a/python/ray/serve/_private/replica_scheduler/replica_wrapper.py
+++ b/python/ray/serve/_private/replica_scheduler/replica_wrapper.py
@@ -1,0 +1,189 @@
+import asyncio
+import pickle
+from abc import ABC
+from typing import Optional, Set, Tuple, Union
+
+import ray
+from ray import ObjectRef, ObjectRefGenerator
+from ray.actor import ActorHandle
+from ray.serve._private.common import (
+    ReplicaID,
+    ReplicaQueueLengthInfo,
+    RunningReplicaInfo,
+)
+from ray.serve._private.replica_scheduler.common import PendingRequest
+from ray.serve._private.utils import JavaActorHandleProxy
+from ray.serve.generated.serve_pb2 import RequestMetadata as RequestMetadataProto
+
+
+class ReplicaWrapper(ABC):
+    """Defines the interface for a scheduler to talk to a replica.
+
+    This is used to abstract away details of Ray actor calls for testing.
+    """
+
+    @property
+    def replica_id(self) -> ReplicaID:
+        """ID of this replica."""
+        pass
+
+    @property
+    def multiplexed_model_ids(self) -> Set[str]:
+        """Set of model IDs on this replica."""
+        pass
+
+    @property
+    def max_ongoing_requests(self) -> int:
+        """Max concurrent requests that can be sent to this replica."""
+        pass
+
+    def push_proxy_handle(self, handle: ActorHandle):
+        """When on proxy, push proxy's self handle to replica"""
+        pass
+
+    async def get_queue_len(self, *, deadline_s: float) -> int:
+        """Returns current queue len for the replica.
+
+        `deadline_s` is passed to verify backoff for testing.
+        """
+        pass
+
+    def send_request(self, pr: PendingRequest) -> Union[ObjectRef, ObjectRefGenerator]:
+        """Send request to this replica."""
+        pass
+
+    async def send_request_with_rejection(
+        self,
+        pr: PendingRequest,
+    ) -> Tuple[Optional[ObjectRefGenerator], ReplicaQueueLengthInfo]:
+        """Send request to this replica.
+
+        The replica will yield a system message (ReplicaQueueLengthInfo) before
+        executing the actual request. This can cause it to reject the request.
+
+        The result will *always* be a generator, so for non-streaming requests it's up
+        to the caller to resolve it to its first (and only) ObjectRef.
+
+        Only supported for Python replicas.
+        """
+        pass
+
+
+class ActorReplicaWrapper:
+    def __init__(self, replica_info: RunningReplicaInfo):
+        self._replica_info = replica_info
+        self._multiplexed_model_ids = set(replica_info.multiplexed_model_ids)
+
+        if replica_info.is_cross_language:
+            self._actor_handle = JavaActorHandleProxy(replica_info.actor_handle)
+        else:
+            self._actor_handle = replica_info.actor_handle
+
+    @property
+    def replica_id(self) -> ReplicaID:
+        return self._replica_info.replica_id
+
+    @property
+    def node_id(self) -> str:
+        return self._replica_info.node_id
+
+    @property
+    def availability_zone(self) -> Optional[str]:
+        return self._replica_info.availability_zone
+
+    @property
+    def multiplexed_model_ids(self) -> Set[str]:
+        return self._multiplexed_model_ids
+
+    @property
+    def max_ongoing_requests(self) -> int:
+        return self._replica_info.max_ongoing_requests
+
+    @property
+    def is_cross_language(self) -> bool:
+        return self._replica_info.is_cross_language
+
+    def push_proxy_handle(self, handle: ActorHandle):
+        self._actor_handle.push_proxy_handle.remote(handle)
+
+    async def get_queue_len(self, *, deadline_s: float) -> int:
+        # NOTE(edoakes): the `get_num_ongoing_requests` method name is shared by
+        # the Python and Java replica implementations. If you change it, you need to
+        # change both (or introduce a branch here).
+        obj_ref = self._actor_handle.get_num_ongoing_requests.remote()
+        try:
+            return await obj_ref
+        except asyncio.CancelledError:
+            ray.cancel(obj_ref)
+            raise
+
+    def _send_request_java(self, pr: PendingRequest) -> ObjectRef:
+        """Send the request to a Java replica.
+
+        Does not currently support streaming.
+        """
+        if pr.metadata.is_streaming:
+            raise RuntimeError("Streaming not supported for Java.")
+
+        if len(pr.args) != 1:
+            raise ValueError("Java handle calls only support a single argument.")
+
+        return self._actor_handle.handle_request.remote(
+            RequestMetadataProto(
+                request_id=pr.metadata.request_id,
+                endpoint=pr.metadata.endpoint,
+                # Default call method in java is "call," not "__call__" like Python.
+                call_method="call"
+                if pr.metadata.call_method == "__call__"
+                else pr.metadata.call_method,
+            ).SerializeToString(),
+            pr.args,
+        )
+
+    def _send_request_python(
+        self, pr: PendingRequest, *, with_rejection: bool
+    ) -> Union[ray.ObjectRef, ObjectRefGenerator]:
+        """Send the request to a Python replica."""
+        if with_rejection:
+            # Call a separate handler that may reject the request.
+            # This handler is *always* a streaming call and the first message will
+            # be a system message that accepts or rejects.
+            method = self._actor_handle.handle_request_with_rejection.options(
+                num_returns="streaming"
+            )
+        elif pr.metadata.is_streaming:
+            method = self._actor_handle.handle_request_streaming.options(
+                num_returns="streaming"
+            )
+        else:
+            method = self._actor_handle.handle_request
+
+        return method.remote(pickle.dumps(pr.metadata), *pr.args, **pr.kwargs)
+
+    def send_request(self, pr: PendingRequest) -> Union[ObjectRef, ObjectRefGenerator]:
+        if self._replica_info.is_cross_language:
+            return self._send_request_java(pr)
+        else:
+            return self._send_request_python(pr, with_rejection=False)
+
+    async def send_request_with_rejection(
+        self,
+        pr: PendingRequest,
+    ) -> Tuple[Optional[ObjectRefGenerator], ReplicaQueueLengthInfo]:
+        assert (
+            not self._replica_info.is_cross_language
+        ), "Request rejection not supported for Java."
+
+        obj_ref_gen = self._send_request_python(pr, with_rejection=True)
+        try:
+            first_ref = await obj_ref_gen.__anext__()
+            queue_len_info: ReplicaQueueLengthInfo = pickle.loads(await first_ref)
+
+            if not queue_len_info.accepted:
+                return None, queue_len_info
+            else:
+                return obj_ref_gen, queue_len_info
+        except asyncio.CancelledError as e:
+            # HTTP client disconnected or request was explicitly canceled.
+            ray.cancel(obj_ref_gen)
+            raise e from None

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -27,6 +27,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_PROXY_PREFER_LOCAL_AZ_ROUTING,
     SERVE_LOGGER_NAME,
 )
+from ray.serve._private.default_impl import create_replica_wrapper
 from ray.serve._private.long_poll import LongPollClient, LongPollNamespace
 from ray.serve._private.metrics_utils import InMemoryMetricsStore, MetricsPusher
 from ray.serve._private.replica_scheduler import (
@@ -367,6 +368,7 @@ class Router:
                 else None,
                 self_availability_zone,
                 use_replica_queue_len_cache=enable_queue_len_cache,
+                create_replica_wrapper_func=create_replica_wrapper,
             )
 
         self._replica_scheduler: ReplicaScheduler = replica_scheduler

--- a/python/ray/serve/tests/test_actor_replica_wrapper.py
+++ b/python/ray/serve/tests/test_actor_replica_wrapper.py
@@ -17,10 +17,8 @@ from ray.serve._private.common import (
     RequestMetadata,
     RunningReplicaInfo,
 )
-from ray.serve._private.replica_scheduler.common import (
-    ActorReplicaWrapper,
-    PendingRequest,
-)
+from ray.serve._private.replica_scheduler.common import PendingRequest
+from ray.serve._private.replica_scheduler.replica_wrapper import ActorReplicaWrapper
 from ray.serve._private.test_utils import send_signal_on_cancellation
 
 

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -90,6 +90,9 @@ class FakeReplicaScheduler(ReplicaScheduler):
         self._replica_queue_len_cache = ReplicaQueueLengthCache()
         self._dropped_replicas: Set[ReplicaID] = set()
 
+    def create_replica_wrapper(self, replica_info: RunningReplicaInfo):
+        return FakeReplica(replica_info)
+
     @property
     def replica_queue_len_cache(self) -> ReplicaQueueLengthCache:
         return self._replica_queue_len_cache


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Pull replica scheduler and replica wrapper out from `common.py` into their own files.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
