### PR TITLE
[Core] Fixing gRPC server handlers to properly respect max inflight RPCs settings

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -762,8 +762,11 @@ RAY_CONFIG(bool, isolate_workers_across_task_types, true)
 /// ServerCall instance number of each RPC service handler
 ///
 /// NOTE: Default value is temporarily pegged at `gcs_server_rpc_server_thread_num * 100`
-///       to keep it at the level it has been prior to https://github.com/ray-project/ray/pull/47664
-RAY_CONFIG(int64_t, gcs_max_active_rpcs_per_handler, gcs_server_rpc_server_thread_num() * 100)
+///       to keep it at the level it has been prior to
+///       https://github.com/ray-project/ray/pull/47664
+RAY_CONFIG(int64_t,
+           gcs_max_active_rpcs_per_handler,
+           gcs_server_rpc_server_thread_num() * 100)
 
 /// grpc keepalive sent interval for server.
 /// This is only configured in GCS server now.

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -760,7 +760,10 @@ RAY_CONFIG(bool, isolate_workers_across_resource_types, true)
 RAY_CONFIG(bool, isolate_workers_across_task_types, true)
 
 /// ServerCall instance number of each RPC service handler
-RAY_CONFIG(int64_t, gcs_max_active_rpcs_per_handler, 100)
+///
+/// NOTE: Default value is temporarily pegged at `gcs_server_rpc_server_thread_num * 100`
+///       to keep it at the level it has been prior to https://github.com/ray-project/ray/pull/47664
+RAY_CONFIG(int64_t, gcs_max_active_rpcs_per_handler, gcs_server_rpc_server_thread_num() * 100)
 
 /// grpc keepalive sent interval for server.
 /// This is only configured in GCS server now.

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -151,7 +151,7 @@ void GrpcServer::Run() {
       buffer_size = 32;
     }
 
-    for (int j = 0; j < buffer_size; j++) {
+    for (size_t j = 0; j < buffer_size; j++) {
       // Create pending `ServerCall` ready to accept incoming requests
       entry->CreateCall();
     }

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -133,7 +133,10 @@ void GrpcServer::Run() {
   RAY_CHECK(port_ > 0);
   RAY_LOG(INFO) << name_ << " server started, listening on port " << port_ << ".";
 
-  // Create calls for all the server call factories.
+  // Create calls for all the server call factories
+  //
+  // NOTE: That ServerCallFactory is created for every thread processing respective
+  //       CompletionQueue
   for (auto &entry : server_call_factories_) {
     // Derive target max inflight RPCs buffer based on `gcs_max_active_rpcs_per_handler`
     //
@@ -141,7 +144,7 @@ void GrpcServer::Run() {
     //       thread) buffer at 32, though it doesn't have any impact on concurrency
     //       (since we're recreating new instance of `ServerCall` as soon as one
     //       gets occupied therefore not serving as back-pressure mechanism)
-    int buffer_size;
+    size_t buffer_size;
     if (entry->GetMaxActiveRPCs() != -1) {
       buffer_size = std::max(1, int(entry->GetMaxActiveRPCs() / num_threads_));
     } else {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, b/c of the [nested loop](https://github.com/ray-project/ray/blob/master/src/ray/rpc/grpc_server.cc#L138) we're over-creating # of `ServerCalls` as `num_threads_ ^ 2` therefore rendering `gcs_max_active_rpcs_per_handler` config irrelevant.

This change addresses following issues:

 - Creates `O(gcs_max_active_rpcs_per_handler)` of `ServerCall`s

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
