### PR TITLE
[Data] Add `Count` logical operator

### DIFF
--- a/python/ray/data/_internal/logical/operators/count_operator.py
+++ b/python/ray/data/_internal/logical/operators/count_operator.py
@@ -1,0 +1,17 @@
+from typing import List
+
+from ray.data._internal.logical.interfaces import LogicalOperator
+
+
+class Count(LogicalOperator):
+    """An operator that counts the number of rows in input bundles.
+
+    This operator is a no-op. It exists so that we can apply counting-related logical
+    optimizations.
+    """
+
+    def __init__(
+        self,
+        input_dependencies: List["LogicalOperator"],
+    ):
+        super().__init__("Count", input_dependencies)

--- a/python/ray/data/_internal/planner/planner.py
+++ b/python/ray/data/_internal/planner/planner.py
@@ -35,6 +35,7 @@ def _register_default_plan_logical_op_fns():
     from ray.data._internal.logical.operators.all_to_all_operator import (
         AbstractAllToAll,
     )
+    from ray.data._internal.logical.operators.count_operator import Count
     from ray.data._internal.logical.operators.from_operators import AbstractFrom
     from ray.data._internal.logical.operators.input_data_operator import InputData
     from ray.data._internal.logical.operators.map_operator import AbstractUDFMap
@@ -90,6 +91,14 @@ def _register_default_plan_logical_op_fns():
         return LimitOperator(logical_op._limit, physical_children[0])
 
     register_plan_logical_op_fn(Limit, plan_limit_op)
+
+    def plan_count_op(_, physical_children):
+        # `Count` is a no-op. It exists so that we can apply counting-related logical
+        # optimizations.
+        assert len(physical_children) == 1
+        return physical_children[0]
+
+    register_plan_logical_op_fn(Count, plan_count_op)
 
 
 _register_default_plan_logical_op_fns()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

It's difficult to apply counting-related optimizations because the optimizer doesn't know whether a DAG will be counted or regularly iterated over. To make it feasible to apply counting-related logical optimizations, this PR adds the `Count` logical operator.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
