### PR TITLE
[Data] Fix parallelism deriving heuristic to ensure parallelism stays w/in min/max bounds

### DIFF
--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -32,6 +32,18 @@ class Read(AbstractMap):
         self._mem_size = mem_size
         self._concurrency = concurrency
         self._detected_parallelism = None
+        # If set, determines target number of output blocks this operator
+        # is expected to produce.
+        #
+        # NOTE: This could be divergent from the total number of tasks,
+        #       therefore necessitating produced output blocks to be
+        #       further
+        #           - Recombined (in case of target output blocks < tasks) or
+        #           - Split (in case of target output blocks > tasks)
+        self._target_num_output_blocks = None
+
+    def set_target_num_blocks(self, target_num_blocks: int):
+        self._target_num_output_blocks = target_num_blocks
 
     def set_detected_parallelism(self, parallelism: int):
         """

--- a/python/ray/data/_internal/logical/optimizers.py
+++ b/python/ray/data/_internal/logical/optimizers.py
@@ -27,6 +27,7 @@ _LOGICAL_RULESET = Ruleset(
     [
         ReorderRandomizeBlocksRule,
         InheritBatchFormatRule,
+        SetReadParallelismRule,
     ]
 )
 
@@ -34,7 +35,6 @@ _LOGICAL_RULESET = Ruleset(
 _PHYSICAL_RULESET = Ruleset(
     [
         InheritTargetMaxBlockSizeRule,
-        SetReadParallelismRule,
         FuseOperators,
         EliminateBuildOutputBlocks,
         ConfigureMapTaskMemoryUsingOutputSize,

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -163,6 +163,7 @@ class FuseOperators(Rule):
         down_logical_op = self._op_map[down_op]
         up_logical_op = self._op_map[up_op]
 
+        # TODO remove
         if up_op.get_additional_split_factor() > 1:
             return False
 

--- a/python/ray/data/_internal/logical/rules/set_read_parallelism.py
+++ b/python/ray/data/_internal/logical/rules/set_read_parallelism.py
@@ -1,11 +1,8 @@
 import logging
-import math
-from typing import Optional, Tuple, Union
+from typing import Tuple, Union
 
 from ray import available_resources as ray_available_resources
-from ray.data._internal.execution.interfaces import PhysicalOperator
-from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
-from ray.data._internal.logical.interfaces import PhysicalPlan, Rule
+from ray.data._internal.logical.interfaces import Rule, LogicalPlan
 from ray.data._internal.logical.operators.read_operator import Read
 from ray.data._internal.util import _autodetect_parallelism
 from ray.data.context import WARN_PREFIX, DataContext
@@ -19,16 +16,19 @@ def compute_additional_split_factor(
     parallelism: int,
     mem_size: int,
     target_max_block_size: int,
-    cur_additional_split_factor: Optional[int] = None,
-) -> Tuple[int, str, int, Optional[int]]:
+) -> Tuple[int, str, int]:
     ctx = DataContext.get_current()
     detected_parallelism, reason, _ = _autodetect_parallelism(
-        parallelism, target_max_block_size, ctx, datasource_or_legacy_reader, mem_size
+        parallelism,
+        target_max_block_size,
+        ctx,
+        datasource_or_legacy_reader=datasource_or_legacy_reader,
+        mem_size=mem_size,
     )
     num_read_tasks = len(
         datasource_or_legacy_reader.get_read_tasks(detected_parallelism)
     )
-    expected_block_size = None
+
     if mem_size:
         expected_block_size = mem_size / num_read_tasks
         logger.debug(
@@ -37,8 +37,7 @@ def compute_additional_split_factor(
         size_based_splits = round(max(1, expected_block_size / target_max_block_size))
     else:
         size_based_splits = 1
-    if cur_additional_split_factor:
-        size_based_splits *= cur_additional_split_factor
+
     logger.debug(f"Size based split factor {size_based_splits}")
     estimated_num_blocks = num_read_tasks * size_based_splits
     logger.debug(f"Blocks after size splits {estimated_num_blocks}")
@@ -60,17 +59,7 @@ def compute_additional_split_factor(
             "You can ignore this message if the cluster is expected to autoscale."
         )
 
-    # Add more output splitting for each read task if needed.
-    # TODO(swang): For parallelism=-1 (user did not explicitly set
-    # parallelism), and if the following operator produces much larger blocks,
-    # we should scale down the target max block size here instead of using
-    # splitting, which can have higher memory usage.
-    if estimated_num_blocks < detected_parallelism and estimated_num_blocks > 0:
-        k = math.ceil(detected_parallelism / estimated_num_blocks)
-        estimated_num_blocks = estimated_num_blocks * k
-        return detected_parallelism, reason, estimated_num_blocks, k
-
-    return detected_parallelism, reason, estimated_num_blocks, None
+    return detected_parallelism, reason, estimated_num_blocks
 
 
 class SetReadParallelismRule(Rule):
@@ -84,32 +73,26 @@ class SetReadParallelismRule(Rule):
     operator will have the desired parallelism.
     """
 
-    def apply(self, plan: PhysicalPlan) -> PhysicalPlan:
-        ops = [plan.dag]
+    def apply(self, plan: LogicalPlan) -> LogicalPlan:
+        for op in plan.dag.post_order_iter():
+            if isinstance(op, Read):
+                # TODO avoid modifying the plan in place, instead return new plan
+                self._apply(op)
 
-        while len(ops) > 0:
-            op = ops.pop(0)
-            if isinstance(op, InputDataBuffer):
-                continue
-            logical_op = plan.op_map[op]
-            if isinstance(logical_op, Read):
-                self._apply(op, logical_op)
-            ops += op.input_dependencies
+            # TODO replace original Read-op plan with Repartition
 
         return plan
 
-    def _apply(self, op: PhysicalOperator, logical_op: Read):
+    def _apply(self, logical_op: Read):
         (
             detected_parallelism,
             reason,
             estimated_num_blocks,
-            k,
         ) = compute_additional_split_factor(
             logical_op._datasource_or_legacy_reader,
             logical_op._parallelism,
             logical_op._mem_size,
-            op.actual_target_max_block_size,
-            op._additional_split_factor,
+            DataContext.target_max_block_size,
         )
 
         if logical_op._parallelism == -1:
@@ -118,15 +101,14 @@ class SetReadParallelismRule(Rule):
                 f"Using autodetected parallelism={detected_parallelism} "
                 f"for operator {logical_op.name} to satisfy {reason}."
             )
+
+        # TODO avoid propagating parallelism t/h logical op
         logical_op.set_detected_parallelism(detected_parallelism)
 
-        if k is not None:
+        if estimated_num_blocks > 0 and estimated_num_blocks != detected_parallelism:
+            logical_op.set_target_num_blocks(estimated_num_blocks)
+
             logger.debug(
-                f"To satisfy the requested parallelism of {detected_parallelism}, "
-                f"each read task output is split into {k} smaller blocks."
+                f"Deduced parallelism of {detected_parallelism} for {logical_op.name}, "
+                f"producing {estimated_num_blocks}."
             )
-
-        if k is not None:
-            op.set_additional_split_factor(k)
-
-        logger.debug(f"Estimated num output blocks {estimated_num_blocks}")

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -109,12 +109,11 @@ def plan_read_op(
     transform_fns: List[MapTransformFn] = [
         # First, execute the read tasks.
         BlockMapTransformFn(do_read),
+        BuildOutputBlocksMapTransformFn.for_blocks()
     ]
-    transform_fns.append(BuildOutputBlocksMapTransformFn.for_blocks())
-    map_transformer = MapTransformer(transform_fns)
 
     return MapOperator.create(
-        map_transformer,
+        MapTransformer(transform_fns),
         inputs,
         data_context,
         name=op.name,

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -109,7 +109,7 @@ def plan_read_op(
     transform_fns: List[MapTransformFn] = [
         # First, execute the read tasks.
         BlockMapTransformFn(do_read),
-        BuildOutputBlocksMapTransformFn.for_blocks()
+        BuildOutputBlocksMapTransformFn.for_blocks(),
     ]
 
     return MapOperator.create(

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -39,14 +39,18 @@ class ShuffleStrategy(str, enum.Enum):
 # tasks, the memory footprint will be about 2 * num_cpus * target_max_block_size ~= RAM
 # * DEFAULT_OBJECT_STORE_MEMORY_LIMIT_FRACTION * 0.3 (default object store memory
 # fraction set by Ray core), assuming typical memory:core ratio of 4:1.
-DEFAULT_TARGET_MAX_BLOCK_SIZE = 128 * 1024 * 1024
+DEFAULT_TARGET_MAX_BLOCK_SIZE = env_integer(
+    "RAY_DATA_DEFAULT_TARGET_MAX_BLOCK_SIZE", 128 * 1024 * 1024
+)
 
 # We set a higher target block size because we have to materialize
 # all input blocks anyway, so there is no performance advantage to having
 # smaller blocks. Setting a larger block size allows avoiding overhead from an
 # excessive number of partitions.
 # We choose 1GiB as 4x less than the typical memory:core ratio (4:1).
-DEFAULT_SHUFFLE_TARGET_MAX_BLOCK_SIZE = 1024 * 1024 * 1024
+DEFAULT_SHUFFLE_TARGET_MAX_BLOCK_SIZE = env_integer(
+    "RAY_DATA_DEFAULT_SHUFFLE_TARGET_MAX_BLOCK_SIZE", 1024 * 1024 * 1024
+)
 
 # We will attempt to slice blocks whose size exceeds this factor *
 # target_max_block_size. We will warn the user if slicing fails and we produce
@@ -59,11 +63,15 @@ MAX_SAFE_BLOCK_SIZE_FACTOR = 1.5
 MAX_SAFE_ROWS_PER_BLOCK_FACTOR = 1.5
 
 
-DEFAULT_TARGET_MIN_BLOCK_SIZE = 1 * 1024 * 1024
+DEFAULT_TARGET_MIN_BLOCK_SIZE = env_integer(
+    "RAY_DATA_DEFAULT_TARGET_MIN_BLOCK_SIZE", 16 * 1024 * 1024
+)
 
 # This default appears to work well with most file sizes on remote storage systems,
 # which is very sensitive to the buffer size.
-DEFAULT_STREAMING_READ_BUFFER_SIZE = 32 * 1024 * 1024
+DEFAULT_STREAMING_READ_BUFFER_SIZE = env_integer(
+    "RAY_DATA_DEFAULT_STREAMING_READ_BUFFER_SIZE", 32 * 1024 * 1024
+)
 
 DEFAULT_ENABLE_PANDAS_BLOCK = True
 

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -181,10 +181,12 @@ def from_items(
     if parallelism == 0:
         raise ValueError(f"parallelism must be -1 or > 0, got: {parallelism}")
 
+    ctx = DataContext.get_current()
     detected_parallelism, _, _ = _autodetect_parallelism(
         parallelism,
-        ray.util.get_current_placement_group(),
-        DataContext.get_current(),
+        ctx.target_max_block_size,
+        ctx,
+        placement_group=ray.util.get_current_placement_group(),
     )
     # Truncate parallelism to number of items to avoid empty blocks.
     detected_parallelism = min(len(items), detected_parallelism)
@@ -394,8 +396,8 @@ def read_datasource(
     requested_parallelism, _, inmemory_size = _autodetect_parallelism(
         parallelism,
         ctx.target_max_block_size,
-        DataContext.get_current(),
-        datasource_or_legacy_reader,
+        ctx,
+        datasource_or_legacy_reader=datasource_or_legacy_reader,
         placement_group=cur_pg,
     )
 

--- a/python/ray/data/tests/test_auto_parallelism.py
+++ b/python/ray/data/tests/test_auto_parallelism.py
@@ -20,84 +20,55 @@ class TestCase:
 MiB = 1024 * 1024
 GiB = 1024 * MiB
 
+
 TEST_CASES = [
     TestCase(
         avail_cpus=4,
         target_max_block_size=DataContext.get_current().target_max_block_size,
         data_size=1024,
-        expected_parallelism=8,  # avail_cpus has precedence
+        expected_parallelism=1,  # Capped by DataContext.target_min_block_size (16Mb)
     ),
     TestCase(
         avail_cpus=4,
         target_max_block_size=DataContext.get_current().target_max_block_size,
         data_size=10 * MiB,
-        expected_parallelism=10,  # MIN_BLOCK_SIZE has precedence
-    ),
-    TestCase(
-        avail_cpus=4,
-        target_max_block_size=DataContext.get_current().target_max_block_size,
-        data_size=20 * MiB,
-        expected_parallelism=20,  # MIN_BLOCK_SIZE has precedence
-    ),
-    TestCase(
-        avail_cpus=4,
-        target_max_block_size=DataContext.get_current().target_max_block_size,
-        data_size=100 * MiB,
-        expected_parallelism=100,  # MIN_BLOCK_SIZE has precedence
+        expected_parallelism=1,  # Capped by DataContext.target_min_block_size (16Mb)
     ),
     TestCase(
         avail_cpus=4,
         target_max_block_size=DataContext.get_current().target_max_block_size,
         data_size=1 * GiB,
-        expected_parallelism=200,  # MIN_PARALLELISM has precedence
+        expected_parallelism=64,  # Capped by DataContext.target_min_block_size (16Mb)
     ),
     TestCase(
         avail_cpus=4,
         target_max_block_size=DataContext.get_current().target_max_block_size,
         data_size=10 * GiB,
-        expected_parallelism=200,  # MIN_PARALLELISM has precedence
+        expected_parallelism=200,  # Determined by DataContext.read_op_min_num_blocks
     ),
     TestCase(
         avail_cpus=150,
         target_max_block_size=DataContext.get_current().target_max_block_size,
         data_size=10 * GiB,
-        expected_parallelism=300,  # avail_cpus has precedence
+        expected_parallelism=300,  # Determined by available CPUs (x2)
     ),
     TestCase(
         avail_cpus=400,
         target_max_block_size=DataContext.get_current().target_max_block_size,
         data_size=10 * GiB,
-        expected_parallelism=800,  # avail_cpus has precedence
-    ),
-    TestCase(
-        avail_cpus=400,
-        target_max_block_size=DataContext.get_current().target_max_block_size,
-        data_size=1 * MiB,
-        expected_parallelism=800,  # avail_cpus has precedence
+        expected_parallelism=640,  # Capped by DataContext.target_min_block_size (16Mb)
     ),
     TestCase(
         avail_cpus=4,
         target_max_block_size=DataContext.get_current().target_max_block_size,
         data_size=1000 * GiB,
-        expected_parallelism=8000,  # MAX_BLOCK_SIZE has precedence
-    ),
-    TestCase(
-        avail_cpus=4,
-        target_max_block_size=DataContext.get_current().target_max_block_size,
-        data_size=10000 * GiB,
-        expected_parallelism=80000,  # MAX_BLOCK_SIZE has precedence
+        expected_parallelism=8000,  # Floored by DataContext.target_max_block_size
     ),
     TestCase(
         avail_cpus=4,
         target_max_block_size=512 * MiB,
         data_size=1000 * GiB,
-        expected_parallelism=2000,  # passed max_block_size has precedence
-    ),
-    TestCase(
-        avail_cpus=4,
-        target_max_block_size=512 * MiB,
-        data_size=10000 * GiB,
-        expected_parallelism=20000,  # passed max_block_size has precedence
+        expected_parallelism=2000,  # Floored by passed in target_max_block_size (128Mb)
     ),
 ]
 
@@ -113,27 +84,37 @@ def test_autodetect_parallelism(
         def estimate_inmemory_data_size(self):
             return data_size
 
-    result, _, _ = _autodetect_parallelism(
+    result, reason, _ = _autodetect_parallelism(
         parallelism=-1,
         target_max_block_size=target_max_block_size,
         ctx=DataContext.get_current(),
         datasource_or_legacy_reader=MockReader(),
         avail_cpus=avail_cpus,
     )
-    assert result == expected, (result, expected)
+
+    print(f">>> Parallelism chosen based on: {reason}")
+
+    assert result == expected, reason
 
 
-def test_auto_parallelism_basic(shutdown_only):
+def test_auto_parallelism_basic(shutdown_only, restore_data_context):
     ray.init(num_cpus=8)
+
     context = DataContext.get_current()
     context.read_op_min_num_blocks = 1
+    context.target_min_block_size = 1 * MiB
+
     # Datasource bound.
     ds = ray.data.range_tensor(5, shape=(100,), override_num_blocks=-1)
-    assert ds._plan.initial_num_blocks() == 5, ds
-    # CPU bound. TODO(ekl) we should fix range datasource to respect parallelism more
-    # properly, currently it can go a little over.
+    # Expected data size is < 4Kb, therefore all of the data could fit into
+    # 1 block (of at least 1MiB)
+    assert ds._plan.initial_num_blocks() == 1, ds
+
     ds = ray.data.range_tensor(10000, shape=(100,), override_num_blocks=-1)
-    assert ds._plan.initial_num_blocks() == 16, ds
+    # Expected data size is < 8Mb, therefore all of the data could fit into
+    # 8 blocks (of at least 1MiB each)
+    assert ds._plan.initial_num_blocks() == 8, ds
+
     # Block size bound.
     ds = ray.data.range_tensor(100000000, shape=(100,), override_num_blocks=-1)
     assert ds._plan.initial_num_blocks() >= 590, ds
@@ -147,7 +128,8 @@ def test_auto_parallelism_placement_group(shutdown_only):
     def run():
         context = DataContext.get_current()
         context.min_parallelism = 1
-        ds = ray.data.range_tensor(2000, shape=(100,), override_num_blocks=-1)
+        context.target_min_block_size = 1 * MiB
+        ds = ray.data.range_tensor(10000, shape=(100,), override_num_blocks=-1)
         return ds._plan.initial_num_blocks()
 
     # 1/16 * 4 * 16 = 4

--- a/python/ray/data/tests/test_consumption.py
+++ b/python/ray/data/tests/test_consumption.py
@@ -164,7 +164,7 @@ def test_count_after_caching_after_execution(ray_start_regular):
     FILE_ROW_COUNT = 150
     DS_ROW_COUNT = FILE_ROW_COUNT * SCALE_FACTOR
     paths = ["example://iris.csv"] * SCALE_FACTOR
-    ds = ray.data.read_csv(paths)
+    ds = ray.data.read_csv(paths, override_num_blocks=2)
     # Row count should be unknown before execution.
     assert "num_rows=?" in str(ds)
     # After iterating over bundles and completing execution, row count should be known.
@@ -367,7 +367,7 @@ def test_empty_dataset(ray_start_regular_shared):
     ds = ds.materialize()
     assert (
         str(ds)
-        == "MaterializedDataset(num_blocks=2, num_rows=0, schema=Unknown schema)"
+        == "MaterializedDataset(num_blocks=1, num_rows=0, schema=Unknown schema)"
     )
 
     # Test map on empty dataset.

--- a/python/ray/data/tests/test_split.py
+++ b/python/ray/data/tests/test_split.py
@@ -753,8 +753,8 @@ def test_train_test_split(ray_start_regular_shared):
 
     # shuffle
     train, test = ds.train_test_split(test_size=0.25, shuffle=True, seed=1)
-    assert extract_values("id", train.take()) == [4, 5, 3, 2, 7, 6]
-    assert extract_values("id", test.take()) == [0, 1]
+    assert extract_values("id", train.take()) == [5, 1, 2, 3, 7, 0]
+    assert extract_values("id", test.take()) == [6, 4]
 
     # error handling
     with pytest.raises(TypeError):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, min/max parallelism isn't actually being enforced correctly -- for large enough clusters we will be scaling out too aggressively purely based on the # of available CPUs disregarding the target block-sizes.

This change

 - Fixes parallelism detection heuristic to appropriately respect min/target block-sizes
 - Makes block-sizes configs' defaults env-var-configurable
 - Adjusts default min-block-size from 1Mb to 16Mb

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
