### PR TITLE
[Core] Fix broken dashboard cluster page when there are dead nodes

### DIFF
--- a/python/ray/dashboard/datacenter.py
+++ b/python/ray/dashboard/datacenter.py
@@ -147,8 +147,6 @@ class DataOrganizer:
         node_info["raylet"] = node_stats
         node_info["raylet"].update(ray_stats)
 
-        node_info["status"] = node["stateSnapshot"]["state"]
-
         # Merge GcsNodeInfo to node physical stats
         node_info["raylet"].update(node)
         death_info = node.get("deathInfo", {})


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
After #47367, nodes are updated through pub-sub and for dead node there is no `state_snapshot` set anymore. The `datacenter.py` tries to access it even for dead node which leads to KeyError:

```
File "/local_disk0/.ephemeral_nfs/envs/pythonEnv-8ac7e00d-2d10-430a-b39d-ad4447d3a5ed/lib/python3.11/site-packages/ray/dashboard/datacenter.py", line 150, in get_node_info
    node_info["status"] = node["stateSnapshot"]["state"]
                          ~~~~^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/envs/pythonEnv-8ac7e00d-2d10-430a-b39d-ad4447d3a5ed/lib/python3.11/site-packages/ray/dashboard/utils.py", line 435, in __getitem__
    proxy = self._proxy[item] = make_immutable(self._dict[item])
                                               ~~~~~~~~~~^^^^^^
KeyError: 'stateSnapshot'
```

It turns out the problematic line of code is dead code so this PR just removes it.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #47668
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
