### PR TITLE
[core][aDAG] Fix a bug where multi arg + exception doesn't work

### DIFF
--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -119,10 +119,6 @@ class Actor:
         raise RuntimeError
         return 1, 2
 
-    def raise_exception(self, x):
-        raise RuntimeError
-        return 1
-
     def get_events(self):
         return getattr(self, "__ray_adag_events", [])
 

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -114,6 +114,11 @@ class Actor:
     def return_two_from_three(self, x):
         return x, x + 1, x + 2
 
+    @ray.method(num_returns=2)
+    def return_two_but_raise_exception(self, x):
+        raise RuntimeError
+        return 1, 2
+
     def get_events(self):
         return getattr(self, "__ray_adag_events", [])
 
@@ -2447,6 +2452,23 @@ def test_torch_tensor_type(shutdown_only):
     replica = Replica.remote()
     ref = replica.call.remote(5)
     assert torch.equal(ray.get(ref), torch.tensor([5, 5, 5, 5, 5]))
+
+
+def test_multi_arg_exception(shutdown_only):
+    a = Actor.remote(0)
+    with InputNode() as i:
+        o1, o2 = a.return_two_but_raise_exception.bind(i)
+        dag = MultiOutputNode([o1, o2])
+
+    compiled_dag = dag.experimental_compile()
+    for _ in range(3):
+        x, y = compiled_dag.execute(1)
+        with pytest.raises(RuntimeError):
+            ray.get(x)
+        with pytest.raises(RuntimeError):
+            ray.get(y)
+
+    compiled_dag.teardown()
 
 
 if __name__ == "__main__":

--- a/python/ray/experimental/channel/common.py
+++ b/python/ray/experimental/channel/common.py
@@ -470,6 +470,8 @@ class SynchronousWriter(WriterInterface):
             channel.ensure_registered_as_writer()
 
     def write(self, val: Any, timeout: Optional[float] = None) -> None:
+        if isinstance(val, Exception):
+            val = tuple(val for _ in range(len(self._output_channels)))
         if not self._is_input:
             if len(self._output_channels) > 1:
                 if not isinstance(val, tuple):

--- a/python/ray/experimental/channel/common.py
+++ b/python/ray/experimental/channel/common.py
@@ -470,8 +470,11 @@ class SynchronousWriter(WriterInterface):
             channel.ensure_registered_as_writer()
 
     def write(self, val: Any, timeout: Optional[float] = None) -> None:
+        # If it is an exception, there's only 1 return value.
+        # We have to send the same data to all channels.
         if isinstance(val, Exception):
             val = tuple(val for _ in range(len(self._output_channels)))
+
         if not self._is_input:
             if len(self._output_channels) > 1:
                 if not isinstance(val, tuple):

--- a/python/ray/experimental/channel/common.py
+++ b/python/ray/experimental/channel/common.py
@@ -473,7 +473,8 @@ class SynchronousWriter(WriterInterface):
         # If it is an exception, there's only 1 return value.
         # We have to send the same data to all channels.
         if isinstance(val, Exception):
-            val = tuple(val for _ in range(len(self._output_channels)))
+            if len(self._output_channels) > 1:
+                val = tuple(val for _ in range(len(self._output_channels)))
 
         if not self._is_input:
             if len(self._output_channels) > 1:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, when there's an exception, there's only 1 return value, but multi ref assumes that the return value has to match the # of output channels. It fixes the issue by duplicating exception to match the number of output channels. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
