### PR TITLE
[Serve] add dependencies on openssl

### DIFF
--- a/ci/docker/min.build.Dockerfile
+++ b/ci/docker/min.build.Dockerfile
@@ -36,7 +36,7 @@ elif [[ "${EXTRA_DEPENDENCY}" == "ml" ]]; then
 elif [[ "${EXTRA_DEPENDENCY}" == "default" ]]; then
   pip-compile -o min_requirements.txt python/setup.py --extra default
 elif [[ "${EXTRA_DEPENDENCY}" == "serve" ]]; then
-  pip-compile -o min_requirements.txt python/setup.py --extra serve
+  pip-compile -o min_requirements.txt python/setup.py --extra serve-grpc
 fi
 
 if [[ -f min_requirements.txt ]]; then
@@ -44,6 +44,3 @@ if [[ -f min_requirements.txt ]]; then
 fi
 
 EOF
-
-
-

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -57,3 +57,4 @@ pandas>=1.3
 pydantic!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,<3  # Serve users can use pydantic<2
 py-spy>=0.2.0
 memray; sys_platform != "win32" # memray is not supported on Windows
+pyOpenSSL

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -1683,6 +1683,7 @@ pyopengl==3.1.7
     #   mujoco
 pyopenssl==23.0.0
     # via
+    #   -r /ray/ci/../python/requirements.txt
     #   -r /ray/ci/../python/requirements/anyscale-requirements.txt
     #   -r /ray/ci/../python/requirements/test-requirements.txt
     #   azure-cli-core

--- a/python/setup.py
+++ b/python/setup.py
@@ -273,7 +273,6 @@ if setup_spec.type == SetupType.RAY:
             "starlette",
             "fastapi",
             "watchfiles",
-            "pyOpenSSL",
         ],
         "tune": ["pandas", "tensorboardX>=1.9", "requests", pyarrow_dep, "fsspec"],
     }
@@ -290,6 +289,7 @@ if setup_spec.type == SetupType.RAY:
             + [
                 "grpcio >= 1.32.0; python_version < '3.10'",  # noqa:E501
                 "grpcio >= 1.42.0; python_version >= '3.10'",  # noqa:E501
+                "pyOpenSSL",
             ]
         )
     )

--- a/python/setup.py
+++ b/python/setup.py
@@ -273,6 +273,7 @@ if setup_spec.type == SetupType.RAY:
             "starlette",
             "fastapi",
             "watchfiles",
+            "pyOpenSSL",
         ],
         "tune": ["pandas", "tensorboardX>=1.9", "requests", pyarrow_dep, "fsspec"],
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Add `pyOpenSSL` dependency for Serve. And update test docker file to use ray[serve-grpc] dependencies.

## Related issue number



## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
