### PR TITLE
[core][aDAG] Fix cpu tensor is automatically converted to gpu tensor

### DIFF
--- a/doc/source/ray-core/api/exceptions.rst
+++ b/doc/source/ray-core/api/exceptions.rst
@@ -35,6 +35,7 @@ Exceptions
     ray.exceptions.RayChannelError
     ray.exceptions.RayChannelTimeoutError
     ray.exceptions.RayAdagCapacityExceeded
+    ray.exceptions.RayAdagDeviceMismatchError
     ray.exceptions.RuntimeEnvSetupError
     ray.exceptions.CrossLanguageError
     ray.exceptions.RaySystemError

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -861,6 +861,14 @@ class RayAdagCapacityExceeded(RaySystemError):
     pass
 
 
+@PublicAPI(stability="alpha")
+class RayAdagDeviceMismatchError(RaySystemError):
+    """Raised when an output (e.g., tensor) doesn't match a device it is
+    supposed to be created."""
+
+    pass
+
+
 RAY_EXCEPTION_TYPES = [
     PlasmaObjectNotAvailable,
     RayError,
@@ -890,4 +898,5 @@ RAY_EXCEPTION_TYPES = [
     RayChannelTimeoutError,
     OufOfBandObjectRefSerializationException,
     RayAdagCapacityExceeded,
+    RayAdagDeviceMismatchError,
 ]

--- a/python/ray/experimental/channel/serialization_context.py
+++ b/python/ray/experimental/channel/serialization_context.py
@@ -1,4 +1,6 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
+
+from ray.exceptions import RayAdagDeviceMismatchError
 
 if TYPE_CHECKING:
     import numpy as np
@@ -8,6 +10,8 @@ if TYPE_CHECKING:
 class _SerializationContext:
     def __init__(self):
         self.use_external_transport: bool = False
+        # The target device type for tensors.
+        self._target_device_type: Optional[Literal["cuda", "cpu", "auto"]] = None
         self.tensors: List["torch.Tensor"] = []
         # Buffer for transferring data between tasks in the same worker process.
         # The key is the channel ID, and the value is the data. We don't use a
@@ -19,8 +23,16 @@ class _SerializationContext:
         # reaches 0, remove the data from the buffer.
         self.channel_id_to_num_readers: Dict[str, int] = {}
 
+    # TODO(sang): Make it context manager.
     def set_use_external_transport(self, use_external_transport: bool) -> None:
         self.use_external_transport = use_external_transport
+
+    def set_target_device_type(self, target_device_type: Optional[str]):
+        self._target_device_type = target_device_type
+
+    @property
+    def target_device_type(self) -> Optional[str]:
+        return self._target_device_type
 
     def set_data(self, channel_id: str, value: Any, num_readers: int) -> None:
         assert num_readers > 0, "num_readers must be greater than 0."
@@ -74,7 +86,12 @@ class _SerializationContext:
             # Return a placeholder.
             return len(self.tensors) - 1
 
-        return self.serialize_to_numpy(tensor)
+        if self._target_device_type is None or self._target_device_type == "auto":
+            # By default, use the same device type as a tensor.
+            target_device_type = tensor.device.type
+        else:
+            target_device_type = self._target_device_type
+        return (self.serialize_to_numpy(tensor), target_device_type)
 
     def serialize_to_numpy(self, tensor: "torch.Tensor") -> "np.ndarray":
         # Transfer through Ray's shared memory store for now.
@@ -87,15 +104,16 @@ class _SerializationContext:
 
         return tensor.numpy()
 
-    def deserialize_tensor(self, val: Union["np.ndarray", int]):
+    def deserialize_tensor(self, val: Union[Tuple["np.ndarray", str], int]):
         # Found a placeholder for a tensor that was serialized via NCCL.
         # Replace it with the corresponding deserialized tensor.
         if isinstance(val, int):
             return self.tensors[val]
 
-        return self.deserialize_from_numpy(val)
+        val, target_device_type = val
+        return self.deserialize_from_numpy(val, target_device_type)
 
-    def deserialize_from_numpy(self, np_array: "np.ndarray"):
+    def deserialize_from_numpy(self, np_array: "np.ndarray", target_device_type: str):
         import torch
 
         from ray.experimental.channel import ChannelContext
@@ -104,18 +122,32 @@ class _SerializationContext:
 
         # TODO(swang): Support local P2P transfers if available.
         # If there is a GPU assigned to this worker, move it there.
-        if ctx.torch_device is not None and ctx.torch_device.type == "cuda":
-            # Use zero-copy from_numpy() because we are going to copy to GPU
-            # anyway.
-            # TODO: Pin the np_array memory to reduce data movement time.
+        if target_device_type == "cuda":
+            # OPTIMIZATION: Use zero-copy from_numpy() because we are going
+            # to copy to GPU anyway.
             # TODO: Set np_array.flags.writeable=True to avoid the PyTorch
             # warning about not owning the underlying memory. This is safe to
             # do as long as all other readers are also copying the data to a
             # GPU.
-            cpu_tensor = torch.from_numpy(np_array)
-            return cpu_tensor.to(device=ctx.torch_device)
+            if ctx.torch_device.type != target_device_type:
+                # TODO(sang): This should have a better error message. I.e.,
+                # it should say what's the upstream task.
+                raise RayAdagDeviceMismatchError(
+                    f"The tensor should be created to a device type '{target_device_type}', "
+                    f"but there's only '{ctx.torch_device.type}' available. Please specify "
+                    f".with_type_hint(TorchTensorType(_device='{ctx.torch_device.type}')) "
+                    "to transfer tensor to the correct device."
+                )
 
+            cpu_tensor = torch.from_numpy(np_array)
+            return cpu_tensor.to(device=ctx.torch_device, non_blocking=True)
         # TODO(swang): Use zero-copy from_numpy() if np_array.flags.writeable
         # is True. This is safe to set when deserializing np_array if the
         # upstream task has num_readers=1.
-        return torch.tensor(np_array, device=ctx.torch_device)
+        # TODO(sang): This doesn't work with different accelerators. Fix it.
+        elif target_device_type == "cpu":
+            device = "cpu"
+        else:
+            raise TypeError(f"The device type {target_device_type} is not supported.")
+
+        return torch.tensor(np_array, device=device)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Right now, when cpu and gpu tensors are mixed up in the arbitrary data structure, aDAG automatically converts them to a gpu tensor on the receiver side. It is not very intuitive. This PR fixes it by

- by default, tensor goes to the same type device where it was created (e.g., cpu -> cpu. gpu -> gpu that's assigned to that actor)
- This PR also allows to move tensor to different device by specifying `TorchTensorType(_device=X)`
- This PR doesn't allow implicit device conversion of tensors to avoid confusing behavior. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
