### PR TITLE
[data] Remove ray.kill in ActorPoolMapOperator

### DIFF
--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -640,13 +640,15 @@ class _ActorPool(AutoscalingActorPool):
 
     def _kill_running_actor(self, actor: ray.actor.ActorHandle):
         """Kill the provided actor and remove it from the pool."""
-        ray.kill(actor)
         del self._num_tasks_in_flight[actor]
+        del self._actor_locations[actor]
+        assert actor not in self._pending_actors
 
     def _kill_pending_actor(self, ready_ref: ray.ObjectRef):
         """Kill the provided pending actor and remove it from the pool."""
         actor = self._pending_actors.pop(ready_ref)
-        ray.kill(actor)
+        assert actor not in self._num_tasks_in_flight
+        assert actor not in self._actor_locations
 
     def _get_location(self, bundle: RefBundle) -> Optional[NodeIdStr]:
         """Ask Ray for the node id of the given bundle.

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -1,14 +1,16 @@
 import collections
-import time
 import unittest
+from typing import Any, Optional
 
 import pytest
 
 import ray
+from ray.actor import ActorHandle
 from ray.data._internal.compute import ActorPoolStrategy
 from ray.data._internal.execution.operators.actor_pool_map_operator import _ActorPool
 from ray.data._internal.execution.util import make_ref_bundles
 from ray.tests.conftest import *  # noqa
+from ray.types import ObjectRef
 
 
 @ray.remote
@@ -22,17 +24,19 @@ class PoolWorker:
 
 class TestActorPool(unittest.TestCase):
     def setup_class(self):
-        self._last_created_actor_and_ready_ref = (None, None)
+        self._last_created_actor_and_ready_ref: Optional[
+            Tuple[ActorHandle, ObjectRef[Any]]
+        ] = None
         self._actor_node_id = "node1"
         ray.init(num_cpus=4)
 
     def teardown_class(self):
         ray.shutdown()
 
-    def _create_actor_fn(self):
+    def _create_actor_fn(self) -> Tuple[ActorHandle, ObjectRef[Any]]:
         actor = PoolWorker.remote(self._actor_node_id)
         ready_ref = actor.get_location.remote()
-        self._last_created_actor_and_ready_ref = (actor, ready_ref)
+        self._last_created_actor_and_ready_ref = actor, ready_ref
         return actor, ready_ref
 
     def _create_actor_pool(
@@ -51,18 +55,21 @@ class TestActorPool(unittest.TestCase):
         )
         return pool
 
-    def _add_pending_actor(self, pool: _ActorPool, node_id="node1"):
+    def _add_pending_actor(
+        self, pool: _ActorPool, node_id="node1"
+    ) -> Tuple[ActorHandle, ObjectRef[Any]]:
         self._actor_node_id = node_id
         assert pool.scale_up(1) == 1
+        assert self._last_created_actor_and_ready_ref is not None
         actor, ready_ref = self._last_created_actor_and_ready_ref
-        self._last_created_actor_and_ready_ref = (None, None)
+        self._last_created_actor_and_ready_ref = None
         return actor, ready_ref
 
     def _wait_for_actor_ready(self, pool: _ActorPool, ready_ref):
         ray.get(ready_ref)
         pool.pending_to_running(ready_ref)
 
-    def _add_ready_actor(self, pool: _ActorPool, node_id="node1"):
+    def _add_ready_actor(self, pool: _ActorPool, node_id="node1") -> ActorHandle:
         actor, ready_ref = self._add_pending_actor(pool, node_id)
         self._wait_for_actor_ready(pool, ready_ref)
         return actor
@@ -226,11 +233,10 @@ class TestActorPool(unittest.TestCase):
         assert killed
         # Check that actor is not in pool.
         assert pool.get_pending_actor_refs() == []
-        # Check that actor was killed.
-        # Wait a second to let actor killing happen.
-        time.sleep(1)
-        with pytest.raises(ray.exceptions.RayActorError):
-            ray.get(actor.get_location.remote())
+        # Check that actor is dead.
+        actor_id = actor._actor_id.hex()
+        del actor
+        self._wait_for_actor_dead(actor_id)
         # Check that the per-state pool sizes are as expected.
         assert pool.current_size() == 0
         assert pool.num_pending_actors() == 0
@@ -249,11 +255,10 @@ class TestActorPool(unittest.TestCase):
         assert killed
         # Check that actor is not in pool.
         assert pool.pick_actor() is None
-        # Check that actor was killed.
-        # Wait a second to let actor killing happen.
-        time.sleep(1)
-        with pytest.raises(ray.exceptions.RayActorError):
-            ray.get(actor.get_location.remote())
+        # Check that actor is dead.
+        actor_id = actor._actor_id.hex()
+        del actor
+        self._wait_for_actor_dead(actor_id)
         # Check that the per-state pool sizes are as expected.
         assert pool.current_size() == 0
         assert pool.num_pending_actors() == 0
@@ -292,11 +297,10 @@ class TestActorPool(unittest.TestCase):
         pool.return_actor(idle_actor)
         # Check that the pending actor is not in pool.
         assert pool.get_pending_actor_refs() == []
-        # Check that actor was killed.
-        # Wait a second to let actor killing happen.
-        time.sleep(1)
-        with pytest.raises(ray.exceptions.RayActorError):
-            ray.get(pending_actor.get_location.remote())
+        # Check that actor is dead.
+        actor_id = pending_actor._actor_id.hex()
+        del pending_actor
+        self._wait_for_actor_dead(actor_id)
         # Check that the per-state pool sizes are as expected.
         assert pool.current_size() == 1
         assert pool.num_pending_actors() == 0
@@ -316,11 +320,10 @@ class TestActorPool(unittest.TestCase):
         # Check that actor is no longer in the pool as pending, to protect against
         # ready/killed races.
         assert not pool.pending_to_running(ready_ref)
-        # Check that actor was killed.
-        # Wait a few seconds to let actor killing happen.
-        time.sleep(1)
-        with pytest.raises(ray.exceptions.RayActorError):
-            ray.get(actor.get_location.remote())
+        # Check that actor is dead.
+        actor_id = actor._actor_id.hex()
+        del actor
+        self._wait_for_actor_dead(actor_id)
         # Check that the per-state pool sizes are as expected.
         assert pool.current_size() == 0
         assert pool.num_pending_actors() == 0
@@ -337,11 +340,10 @@ class TestActorPool(unittest.TestCase):
         pool.kill_all_inactive_actors()
         # Check that actor is not in pool.
         assert pool.pick_actor() is None
-        # Check that actor was killed.
-        # Wait a few seconds to let actor killing happen.
-        time.sleep(1)
-        with pytest.raises(ray.exceptions.RayActorError):
-            ray.get(actor.get_location.remote())
+        # Check that actor is dead.
+        actor_id = actor._actor_id.hex()
+        del actor
+        self._wait_for_actor_dead(actor_id)
         # Check that the per-state pool sizes are as expected.
         assert pool.current_size() == 0
         assert pool.num_pending_actors() == 0
@@ -378,11 +380,10 @@ class TestActorPool(unittest.TestCase):
             pool.return_actor(actor)
         # Check that actor is not in pool.
         assert pool.pick_actor() is None
-        # Check that actor was killed.
-        # Wait a few seconds to let actor killing happen.
-        time.sleep(1)
-        with pytest.raises(ray.exceptions.RayActorError):
-            ray.get(actor.get_location.remote())
+        # Check that actor is dead.
+        actor_id = actor._actor_id.hex()
+        del actor
+        self._wait_for_actor_dead(actor_id)
         # Check that the per-state pool sizes are as expected.
         assert pool.current_size() == 0
         assert pool.num_pending_actors() == 0
@@ -427,11 +428,10 @@ class TestActorPool(unittest.TestCase):
             pool.return_actor(actor1)
         # Check that actor is not in pool.
         assert pool.pick_actor() is None
-        # Check that actor was killed.
-        # Wait a few seconds to let actor killing happen.
-        time.sleep(1)
-        with pytest.raises(ray.exceptions.RayActorError):
-            ray.get(actor1.get_location.remote())
+        # Check that actor is dead.
+        actor_id = actor1._actor_id.hex()
+        del actor1
+        self._wait_for_actor_dead(actor_id)
         # Check that the per-state pool sizes are as expected.
         assert pool.current_size() == 0
         assert pool.num_pending_actors() == 0

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -1,10 +1,11 @@
 import collections
 import unittest
-from typing import Any, Optional
+from typing import Any, Optional, Tuple
 
 import pytest
 
 import ray
+from ray._private.test_utils import wait_for_condition
 from ray.actor import ActorHandle
 from ray.data._internal.compute import ActorPoolStrategy
 from ray.data._internal.execution.operators.actor_pool_map_operator import _ActorPool

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -16,6 +16,7 @@ import ray
 from ray.data._internal.execution.interfaces.ref_bundle import (
     _ref_bundles_iterator_to_block_refs_list,
 )
+from ray.data._internal.execution.operators.actor_pool_map_operator import _MapWorker
 from ray.data.context import DataContext
 from ray.data.exceptions import UserCodeException
 from ray.data.tests.conftest import *  # noqa
@@ -75,6 +76,19 @@ def test_basic_actors(shutdown_only):
             column_udf_class("id", lambda x: x),
             concurrency=(8, 4),
         )
+
+    # Make sure all actors are dead after dataset execution finishes.
+    def _all_actors_dead():
+        actor_table = ray.state.actors()
+        actors = {
+            id: actor_info
+            for actor_info in actor_table.values()
+            if actor_info["ActorClassName"] == _MapWorker.__name__
+        }
+        assert len(actors) > 0
+        return all(actor_info["State"] == "DEAD" for actor_info in actors.values())
+
+    wait_for_condition(_all_actors_dead)
 
 
 def test_callable_classes(shutdown_only):

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -13,6 +13,7 @@ import pyarrow.parquet as pq
 import pytest
 
 import ray
+from ray._private.test_utils import wait_for_condition
 from ray.data._internal.execution.interfaces.ref_bundle import (
     _ref_bundles_iterator_to_block_refs_list,
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

With https://github.com/ray-project/ray/pull/47396, now Ray Core can automatically restarts an actor when needing to resubmit tasks. 
This doesn't work with `ray.kill`-ed actors. 
This PR removes ray.kill and let ref counting garbage-collect the actors. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
