### PR TITLE
[Docs] Update map_reduce.ipynb chunk_size

### DIFF
--- a/doc/source/ray-core/examples/map_reduce.ipynb
+++ b/doc/source/ray-core/examples/map_reduce.ipynb
@@ -83,7 +83,8 @@
     "corpus = zen_of_python.split()\n",
     "\n",
     "num_partitions = 3\n",
-    "chunk = len(corpus) // num_partitions\n",
+    "import math\n",
+    "chunk = math.ceil(len(corpus) / num_partitions)\n",
     "partitions = [\n",
     "    corpus[i * chunk: (i + 1) * chunk] for i in range(num_partitions)\n",
     "]"


### PR DESCRIPTION
## Why are these changes needed?

I found a tiny bug in the well-known word count example, where the chunk size was wrongly `flooring` rather than `ceiling`.

The error caused the word_count unexpectedly discard last up to `num_partitions` working items. Luckily, the `zen_of_python` got a length of 144, which is well divided by 3, but it's a bug anyway.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
