### PR TITLE
[Data] Make sure `num_gpus` provide to Ray Data is appropriately passed to `ray.remote` call

### DIFF
--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -67,7 +67,7 @@ class TaskPoolMapOperator(MapOperator):
         #       blocks themselves are going to be passed inside `fn.options(...)`
         #       invocation
         ray_remote_static_args = {
-            **(ray_remote_args or {}),
+            **(self._ray_remote_args or {}),
             "num_returns": "streaming",
         }
 

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -63,8 +63,9 @@ class TaskPoolMapOperator(MapOperator):
         )
         self._concurrency = concurrency
 
-        # NOTE: Unlike static Ray remote args, dynamic arguments extracted from the blocks
-        #       themselves are going to be passed inside `fn.options(...)` invocation
+        # NOTE: Unlike static Ray remote args, dynamic arguments extracted from the
+        #       blocks themselves are going to be passed inside `fn.options(...)`
+        #       invocation
         ray_remote_static_args = {
             **ray_remote_args,
             "num_returns": "streaming",

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -79,19 +79,20 @@ class TaskPoolMapOperator(MapOperator):
             task_idx=self._next_data_task_idx,
             target_max_block_size=self.actual_target_max_block_size,
         )
-        data_context = DataContext.get_current()
-        ray_remote_args = self._get_runtime_ray_remote_args(input_bundle=bundle)
-        ray_remote_args["name"] = self.name
 
+        dynamic_ray_remote_args = self._get_runtime_ray_remote_args(input_bundle=bundle)
+        dynamic_ray_remote_args["name"] = self.name
+
+        data_context = DataContext.get_current()
         if data_context._max_num_blocks_in_streaming_gen_buffer is not None:
             # The `_generator_backpressure_num_objects` parameter should be
             # `2 * _max_num_blocks_in_streaming_gen_buffer` because we yield
             # 2 objects for each block: the block and the block metadata.
-            ray_remote_args["_generator_backpressure_num_objects"] = (
+            dynamic_ray_remote_args["_generator_backpressure_num_objects"] = (
                 2 * data_context._max_num_blocks_in_streaming_gen_buffer
             )
 
-        gen = self._map_task.options(**ray_remote_args).remote(
+        gen = self._map_task.options(**dynamic_ray_remote_args).remote(
             self._map_transformer_ref,
             data_context,
             ctx,

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -67,7 +67,7 @@ class TaskPoolMapOperator(MapOperator):
         #       blocks themselves are going to be passed inside `fn.options(...)`
         #       invocation
         ray_remote_static_args = {
-            **ray_remote_args,
+            **(ray_remote_args or {}),
             "num_returns": "streaming",
         }
 

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -437,8 +437,11 @@ def _are_remote_args_compatible(prev_args, next_args):
     next_args = _canonicalize(next_args)
     remote_args = next_args.copy()
     for key in INHERITABLE_REMOTE_ARGS:
-        if key in prev_args:
+        # NOTE: We only carry over inheritable value in case
+        #       of it not being provided in the remote args
+        if key in prev_args and key not in remote_args:
             remote_args[key] = prev_args[key]
+
     if prev_args != remote_args:
         return False
     return True

--- a/python/ray/data/_internal/remote_fn.py
+++ b/python/ray/data/_internal/remote_fn.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, Hashable, List
 
 import ray
 
@@ -50,7 +50,7 @@ def _make_hashable(obj):
     elif isinstance(obj, Dict):
         converted = [(_make_hashable(k), _make_hashable(v)) for k, v in obj.items()]
         return tuple(sorted(converted, key=lambda t: t[0]))
-    elif isinstance(obj, (bool, int, float, str, bytes, type(None))):
+    elif isinstance(obj, Hashable):
         return obj
     else:
         raise ValueError(f"Type {type(obj)} is not hashable")

--- a/python/ray/data/_internal/remote_fn.py
+++ b/python/ray/data/_internal/remote_fn.py
@@ -24,7 +24,7 @@ def cached_remote_fn(fn: Any, **ray_remote_args) -> Any:
     #   - Sort all KV-pairs by the keys
     #   - Convert sorted list into tuple
     #   - Compute hash of the resulting tuple
-    arg_pairs = tuple(sorted(list(ray_remote_args.items()), key=lambda t: t[0]))
+    arg_pairs = tuple(sorted(ray_remote_args.items(), key=lambda t: t[0]))
     args_hash = hash(arg_pairs)
 
     if (fn, args_hash) not in CACHED_FUNCTIONS:
@@ -38,7 +38,6 @@ def cached_remote_fn(fn: Any, **ray_remote_args) -> Any:
         }
         ray_remote_args = {**default_ray_remote_args, **ray_remote_args}
         _add_system_error_to_retry_exceptions(ray_remote_args)
-
 
         CACHED_FUNCTIONS[(fn, args_hash)] = ray.remote(**ray_remote_args)(fn)
 

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -661,7 +661,7 @@ def test_read_map_batches_operator_fusion_incompatible_remote_args(
     ray_start_regular_shared,
 ):
     # Test that map operators won't get fused if the remote args are incompatible.
-    incompatiple_remote_args_pairs = [
+    incompatible_remote_args_pairs = [
         # Use different resources.
         ({"num_cpus": 2}, {"num_gpus": 2}),
         # Same resource, but different values.
@@ -670,9 +670,9 @@ def test_read_map_batches_operator_fusion_incompatible_remote_args(
         ({"resources": {"custom": 2}}, {"resources": {"custom": 1}}),
         ({"resources": {"custom1": 1}}, {"resources": {"custom2": 1}}),
         # Different scheduling strategies.
-        ({"scheduling_strategy": "SPREAD"}, {"scheduing_strategy": "PACK"}),
+        ({"scheduling_strategy": "SPREAD"}, {"scheduling_strategy": "PACK"}),
     ]
-    for up_remote_args, down_remote_args in incompatiple_remote_args_pairs:
+    for up_remote_args, down_remote_args in incompatible_remote_args_pairs:
         planner = Planner()
         read_op = get_parquet_read_logical_op(
             ray_remote_args={"resources": {"non-existent": 1}}

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -268,8 +268,7 @@ def test_gpu_workers_not_reused(shutdown_only):
     ds = ray.data.range(5, override_num_blocks=total_blocks)
 
     def _get_worker_id(_):
-        worker = ray._private.worker.global_worker
-        return {"worker_id": worker.core_worker.get_worker_id().hex()}
+        return {"worker_id": ray.get_runtime_context().get_worker_id()}
 
     unique_worker_ids = ds.map(_get_worker_id, num_gpus=1).unique("worker_id")
 

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -256,6 +256,26 @@ def test_actor_task_failure(shutdown_only, restore_data_context):
     ds.map_batches(Mapper, concurrency=1).materialize()
 
 
+def test_gpu_workers_not_reused(shutdown_only):
+    """By default, in Ray Core if `num_gpus` is specified workers will not be reused
+    for tasks invocation.
+
+    For more context check out https://github.com/ray-project/ray/issues/29624"""
+
+    ray.init(num_gpus=1)
+
+    total_blocks = 5
+    ds = ray.data.range(5, override_num_blocks=total_blocks)
+
+    def _get_worker_id(_):
+        worker = ray._private.worker.global_worker
+        return {"worker_id": worker.core_worker.get_worker_id().hex()}
+
+    unique_worker_ids = ds.map(_get_worker_id, num_gpus=1).unique("worker_id")
+
+    assert len(unique_worker_ids) == total_blocks
+
+
 def test_concurrency(shutdown_only):
     ray.init(num_cpus=6)
     ds = ray.data.range(10, override_num_blocks=10)

--- a/python/ray/data/tests/test_util.py
+++ b/python/ray/data/tests/test_util.py
@@ -11,7 +11,7 @@ from ray.data._internal.memory_tracing import (
     trace_allocation,
     trace_deallocation,
 )
-from ray.data._internal.remote_fn import cached_remote_fn, _make_hashable
+from ray.data._internal.remote_fn import _make_hashable, cached_remote_fn
 from ray.data._internal.util import (
     _check_pyarrow_version,
     _split_list,
@@ -49,25 +49,26 @@ def test_make_hashable():
 
     hashable_args = _make_hashable(valid_args)
 
-    assert hash(hashable_args) == hash((
-        ('dict', ((0, 0), (1.2, 1.2))),
-        ('float', 1.2),
-        ('int', 0),
-        ('list', (0, 1, 2, 3, 4, 5, 6, 7, 8, 9)),
-        ('str', 'foo'),
-        ('tuple', (0, 1, 2)),
-    ))
+    assert hash(hashable_args) == hash(
+        (
+            ("dict", ((0, 0), (1.2, 1.2))),
+            ("float", 1.2),
+            ("int", 0),
+            ("list", (0, 1, 2, 3, 4, 5, 6, 7, 8, 9)),
+            ("str", "foo"),
+            ("tuple", (0, 1, 2)),
+        )
+    )
 
     # Invalid case # 1: can't mix up key types
-    invalid_args = {
-        0: 1,
-        "bar": "baz"
-    }
+    invalid_args = {0: 1, "bar": "baz"}
 
     with pytest.raises(TypeError) as exc_info:
         _make_hashable(invalid_args)
 
-    assert str(exc_info.value) == "'<' not supported between instances of 'str' and 'int'"
+    assert (
+        str(exc_info.value) == "'<' not supported between instances of 'str' and 'int'"
+    )
 
     # Invalid case # 2: can't use anything but dict, list, tuple or primitive types
     class Foo:
@@ -80,7 +81,10 @@ def test_make_hashable():
     with pytest.raises(ValueError) as exc_info:
         _make_hashable(invalid_args)
 
-    assert str(exc_info.value) == "Type <class 'test_util.test_make_hashable.<locals>.Foo'> is not hashable"
+    assert (
+        str(exc_info.value)
+        == "Type <class 'test_util.test_make_hashable.<locals>.Foo'> is not hashable"
+    )
 
 
 def test_check_pyarrow_version_bounds(unsupported_pyarrow_version):

--- a/python/ray/data/tests/test_util.py
+++ b/python/ray/data/tests/test_util.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, Optional
 
 import numpy as np
 import pytest
+from typing_extensions import Hashable
 
 import ray
 from ray.data._internal.datasource.parquet_datasource import ParquetDatasource
@@ -45,6 +46,7 @@ def test_make_hashable():
         },
         "list": list(range(10)),
         "tuple": tuple(range(3)),
+        "type": Hashable,
     }
 
     hashable_args = _make_hashable(valid_args)
@@ -57,6 +59,7 @@ def test_make_hashable():
             ("list", (0, 1, 2, 3, 4, 5, 6, 7, 8, 9)),
             ("str", "foo"),
             ("tuple", (0, 1, 2)),
+            ("type", Hashable),
         )
     )
 
@@ -68,22 +71,6 @@ def test_make_hashable():
 
     assert (
         str(exc_info.value) == "'<' not supported between instances of 'str' and 'int'"
-    )
-
-    # Invalid case # 2: can't use anything but dict, list, tuple or primitive types
-    class Foo:
-        bar: 0
-
-    invalid_args = {
-        0: Foo(),
-    }
-
-    with pytest.raises(ValueError) as exc_info:
-        _make_hashable(invalid_args)
-
-    assert (
-        str(exc_info.value)
-        == "Type <class 'test_util.test_make_hashable.<locals>.Foo'> is not hashable"
     )
 
 

--- a/python/ray/data/tests/test_util.py
+++ b/python/ray/data/tests/test_util.py
@@ -11,7 +11,7 @@ from ray.data._internal.memory_tracing import (
     trace_allocation,
     trace_deallocation,
 )
-from ray.data._internal.remote_fn import cached_remote_fn
+from ray.data._internal.remote_fn import cached_remote_fn, _make_hashable
 from ray.data._internal.util import (
     _check_pyarrow_version,
     _split_list,
@@ -32,6 +32,55 @@ def test_cached_remote_fn():
     gpu_only_foo = cached_remote_fn(foo, num_gpus=1)
 
     assert cpu_only_foo != gpu_only_foo
+
+
+def test_make_hashable():
+    valid_args = {
+        "int": 0,
+        "float": 1.2,
+        "str": "foo",
+        "dict": {
+            0: 0,
+            1.2: 1.2,
+        },
+        "list": list(range(10)),
+        "tuple": tuple(range(3)),
+    }
+
+    hashable_args = _make_hashable(valid_args)
+
+    assert hash(hashable_args) == hash((
+        ('dict', ((0, 0), (1.2, 1.2))),
+        ('float', 1.2),
+        ('int', 0),
+        ('list', (0, 1, 2, 3, 4, 5, 6, 7, 8, 9)),
+        ('str', 'foo'),
+        ('tuple', (0, 1, 2)),
+    ))
+
+    # Invalid case # 1: can't mix up key types
+    invalid_args = {
+        0: 1,
+        "bar": "baz"
+    }
+
+    with pytest.raises(TypeError) as exc_info:
+        _make_hashable(invalid_args)
+
+    assert str(exc_info.value) == "'<' not supported between instances of 'str' and 'int'"
+
+    # Invalid case # 2: can't use anything but dict, list, tuple or primitive types
+    class Foo:
+        bar: 0
+
+    invalid_args = {
+        0: Foo(),
+    }
+
+    with pytest.raises(ValueError) as exc_info:
+        _make_hashable(invalid_args)
+
+    assert str(exc_info.value) == "Type <class 'test_util.test_make_hashable.<locals>.Foo'> is not hashable"
 
 
 def test_check_pyarrow_version_bounds(unsupported_pyarrow_version):

--- a/python/ray/data/tests/test_util.py
+++ b/python/ray/data/tests/test_util.py
@@ -11,12 +11,27 @@ from ray.data._internal.memory_tracing import (
     trace_allocation,
     trace_deallocation,
 )
+from ray.data._internal.remote_fn import cached_remote_fn
 from ray.data._internal.util import (
     _check_pyarrow_version,
     _split_list,
     iterate_with_retry,
 )
 from ray.data.tests.conftest import *  # noqa: F401, F403
+
+
+def test_cached_remote_fn():
+    def foo():
+        pass
+
+    cpu_only_foo = cached_remote_fn(foo, num_cpus=1)
+    cached_cpu_only_foo = cached_remote_fn(foo, num_cpus=1)
+
+    assert cpu_only_foo == cached_cpu_only_foo
+
+    gpu_only_foo = cached_remote_fn(foo, num_gpus=1)
+
+    assert cpu_only_foo != gpu_only_foo
 
 
 def test_check_pyarrow_version_bounds(unsupported_pyarrow_version):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Addressing https://github.com/ray-project/ray/issues/47767

Addresses:

 - Fixes `cached_remote_fn` to properly handle different arg-lists
 - Makes sure we pass static args to `ray.remote` ctor in `TaskPoolMapOperator`

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
