### PR TITLE
[Core] Fix the ray_tasks{State="PENDING_ARGS_FETCH"} metric counting

### DIFF
--- a/python/ray/cluster_utils.py
+++ b/python/ray/cluster_utils.py
@@ -220,7 +220,6 @@ class Cluster:
             "object_store_memory": 150 * 1024 * 1024,  # 150 MiB
             "min_worker_port": 0,
             "max_worker_port": 0,
-            "dashboard_port": None,
         }
         ray_params = ray._private.parameter.RayParams(**node_args)
         ray_params.update_if_absent(**default_kwargs)
@@ -257,6 +256,10 @@ class Cluster:
                 ray_params.update_if_absent(include_log_monitor=False)
                 # Let grpc pick a port.
                 ray_params.update_if_absent(node_manager_port=0)
+                if "dashboard_agent_listen_port" not in node_args:
+                    # Pick a random one to not conflict
+                    # with the head node dashboard agent
+                    ray_params.dashboard_agent_listen_port = None
 
                 node = ray._private.node.Node(
                     ray_params,

--- a/python/ray/tests/test_task_metrics.py
+++ b/python/ray/tests/test_task_metrics.py
@@ -202,6 +202,41 @@ ray.get(w)
     proc.kill()
 
 
+def test_task_fetch_args(ray_start_cluster):
+    cluster = ray_start_cluster
+    cluster.add_node(
+        resources={"head": 1},
+        _system_config={
+            "metrics_report_interval_ms": 100,
+            "testing_asio_delay_us": "ObjectManagerService.grpc_server.Pull=5000000000:5000000000",  # noqa: E501
+        },
+    )
+    info = ray.init(address=cluster.address)
+    cluster.add_node(resources={"worker": 1})
+    cluster.wait_for_nodes()
+
+    @ray.remote(resources={"worker": 1})
+    def task1():
+        return [1] * 1024 * 1024
+
+    @ray.remote(resources={"head": 1})
+    def task2(obj):
+        pass
+
+    o1 = task1.remote()
+    o2 = task2.remote(o1)
+
+    wait_for_condition(
+        lambda: tasks_by_state(info).get("PENDING_ARGS_FETCH", 0.0) == 1.0
+    )
+
+    ray.cancel(o2)
+
+    wait_for_condition(
+        lambda: tasks_by_state(info).get("PENDING_ARGS_FETCH", 0.0) == 0.0
+    )
+
+
 def test_task_wait_on_deps(shutdown_only):
     info = ray.init(num_cpus=2, **METRIC_CONFIG)
 

--- a/release/benchmarks/object_store/test_object_store.py
+++ b/release/benchmarks/object_store/test_object_store.py
@@ -73,5 +73,4 @@ if "TEST_OUTPUT_JSON" in os.environ:
                 "perf_metric_type": "LATENCY",
             }
         ]
-        print(f"jjyao {results} {out_file}")
         json.dump(results, out_file)

--- a/src/ray/raylet/dependency_manager.h
+++ b/src/ray/raylet/dependency_manager.h
@@ -267,6 +267,12 @@ class DependencyManager : public TaskDependencyManagerInterface {
         waiting_task_counter_map.Decrement(task_key);
       }
     }
+
+    ~TaskDependencies() {
+      if (num_missing_dependencies > 0) {
+        waiting_task_counter_map.Decrement(task_key);
+      }
+    }
   };
 
   /// Stop tracking this object, if it is no longer needed by any worker or


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`ray_tasks{State="PENDING_ARGS_FETCH"}` means raylet is actively fetching the dependencies of a task. Currently if a task is cancelled before dependencies are fetched, `RemoveTaskDependencies()` will be called. We will cancel the pull request but we forget to decrement `ray_tasks{State="PENDING_ARGS_FETCH"}`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
