### PR TITLE
[fake autoscaler] skip empty compose ps lines

### DIFF
--- a/python/ray/autoscaler/_private/fake_multi_node/docker_monitor.py
+++ b/python/ray/autoscaler/_private/fake_multi_node/docker_monitor.py
@@ -129,7 +129,9 @@ def _update_docker_status(
         )
         data: List[Dict[str, str]] = []
         for line in data_str:
-            data.append(json.loads(line))
+            line = line.strip()
+            if line:
+                data.append(json.loads(line))
     except Exception as e:
         print(f"Ran into error when fetching status: {e}")
         return None


### PR DESCRIPTION
newer versions of docker compose can return an empty string with single end-line, and leads to a `[""]` as parsing result, which will fail the json parser and leads to test failing
