### PR TITLE
[tune][fake autoscaler] change head node to 2-cpu in tests

### DIFF
--- a/python/ray/tune/tests/test_multinode_sync.py
+++ b/python/ray/tune/tests/test_multinode_sync.py
@@ -84,7 +84,7 @@ class MultiNodeSyncTest(unittest.TestCase):
         """Test that newly added nodes from autoscaling are not stale."""
         self.cluster.update_config(
             {
-                "provider": {"head_resources": {"CPU": 4, "GPU": 0}},
+                "provider": {"head_resources": {"CPU": 2, "GPU": 0}},
                 "available_node_types": {
                     "ray.worker.cpu": {
                         "resources": {"CPU": 4},
@@ -119,7 +119,7 @@ class MultiNodeSyncTest(unittest.TestCase):
         """
         self.cluster.update_config(
             {
-                "provider": {"head_resources": {"CPU": 4, "GPU": 0}},
+                "provider": {"head_resources": {"CPU": 2, "GPU": 0}},
                 "available_node_types": {
                     "ray.worker.cpu": {
                         "resources": {"CPU": 4},


### PR DESCRIPTION
so that the test at least needs to scale up with 1-node to pass

otherwise, the test might just pass with everything running on the head node.
