### PR TITLE
[fake autoscaler] remove the redundant mkdir

### DIFF
--- a/python/ray/autoscaler/_private/fake_multi_node/docker_monitor.py
+++ b/python/ray/autoscaler/_private/fake_multi_node/docker_monitor.py
@@ -57,14 +57,6 @@ def _update_docker_compose(
         cmd = ["down"]
         shutdown = True
     try:
-        # Loop through parsed docker-compose and create node-specific
-        # host directories if needed
-        for node_id, node_conf in docker_compose_config["services"].items():
-            for volume_mount in node_conf["volumes"]:
-                host_dir, container_dir = volume_mount.split(":", maxsplit=1)
-                if container_dir == "/cluster/node" and not os.path.exists(host_dir):
-                    os.makedirs(host_dir, 0o755, exist_ok=True)
-
         subprocess.check_call(
             ["docker", "compose", "-f", docker_compose_path, "-p", project_name]
             + cmd


### PR DESCRIPTION
- docker compose service volume short syntax uses bind (similar to `-v` and will create the dir if not exist
- the code was not mapping the dir to host path, so it actually has no meaningful effect when it is running in a container, such as on CI
