### PR TITLE
[Docs][Minor] RuntimeEnv py_modules example wrong function name

### DIFF
--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -327,7 +327,7 @@ To ensure your local changes show up across all Ray workers and can be imported 
       # No need to import my_module inside this function.
       my_module.test()
 
-  ray.get(f.remote())
+  ray.get(test_my_module.remote())
 
 .. _runtime-environments-api-ref:
 


### PR DESCRIPTION
## Why are these changes needed?

In https://docs.ray.io/en/latest/ray-core/handling-dependencies.html#library-development

![Screenshot from 2024-09-22 22-07-05](https://github.com/user-attachments/assets/b8c056de-9007-4590-a139-759661c13d9a)

See the red rectangle above, the function name is wrong. It should be `test_my_module`.

## Related issue number

N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
