### PR TITLE
Fix response injection

### DIFF
--- a/python/ray/dashboard/modules/state/state_head.py
+++ b/python/ray/dashboard/modules/state/state_head.py
@@ -406,7 +406,6 @@ class StateHead(dashboard_utils.DashboardHeadModule, RateLimitedModule):
                 success=False,
                 error_message=str(e),
                 result=None,
-                reason=str(e),
             )
 
         return self._reply(success=True, error_message="", result=result)

--- a/python/ray/dashboard/optional_utils.py
+++ b/python/ray/dashboard/optional_utils.py
@@ -160,7 +160,7 @@ DashboardAgentRouteTable = method_route_table_factory()
 
 
 def rest_response(
-    success, message, convert_google_style=True, reason=None, **kwargs
+    success, message, convert_google_style=True, **kwargs
 ) -> aiohttp.web.Response:
     # In the dev context we allow a dev server running on a
     # different port to consume the API, meaning we need to allow
@@ -178,7 +178,6 @@ def rest_response(
         dumps=functools.partial(json.dumps, cls=CustomEncoder),
         headers=headers,
         status=200 if success else 500,
-        reason=reason,
     )
 
 

--- a/python/ray/tests/test_state_api_log.py
+++ b/python/ray/tests/test_state_api_log.py
@@ -4,6 +4,7 @@ import sys
 import asyncio
 from typing import List
 import urllib
+import re
 from unittest.mock import MagicMock, AsyncMock
 
 import pytest
@@ -1001,7 +1002,9 @@ def test_log_list(ray_start_cluster):
     with pytest.raises(requests.HTTPError) as e:
         list_logs(node_id=node_id)
 
-    e.match(f"Given node id {node_id} is not available")
+    assert re.match(
+        f"Given node id {node_id} is not available", e.value.response.json()["msg"]
+    )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Why are these changes needed?

Previously the error message was injected directly as the HTTP status message

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
