### PR TITLE
[Core] Separate the attempt_number with the task_status in memory summary and object list

### DIFF
--- a/python/ray/dashboard/memory_utils.py
+++ b/python/ray/dashboard/memory_utils.py
@@ -97,9 +97,7 @@ class MemoryTableEntry:
         self.task_status = object_ref.get("taskStatus", "?")
         if self.task_status == "NIL":
             self.task_status = "-"
-        self.attempt_number = int(object_ref.get("attemptNumber", 0))
-        if self.attempt_number > 0:
-            self.task_status = f"Attempt #{self.attempt_number + 1}: {self.task_status}"
+        self.attempt_number = int(object_ref.get("attemptNumber", 0)) + 1
         self.object_size = int(object_ref.get("objectSize", -1))
         self.call_site = object_ref.get("callSite", "<Unknown>")
         if len(self.call_site) == 0:
@@ -185,6 +183,7 @@ class MemoryTableEntry:
             "reference_type": self.reference_type,
             "call_site": self.call_site,
             "task_status": self.task_status,
+            "attempt_number": self.attempt_number,
             "local_ref_count": self.local_ref_count,
             "pinned_in_memory": self.pinned_in_memory,
             "submitted_task_ref_count": self.submitted_task_ref_count,
@@ -432,16 +431,17 @@ def memory_summary(
         "Type",
         "Call Site",
         "Status",
+        "Attampt",
         "Size",
         "Reference Type",
         "Object Ref",
     ]
     object_ref_string = "{:<13} | {:<8} | {:<7} | {:<9} \
-| {:<9} | {:<8} | {:<14} | {:<10}\n"
+| {:<9} | {:<8} | {:<8} | {:<14} | {:<10}\n"
 
     if size > line_wrap_threshold and line_wrap:
-        object_ref_string = "{:<15}  {:<5}  {:<6}  {:<22}  {:<14}  {:<6}  {:<18}  \
-{:<56}\n"
+        object_ref_string = "{:<15}  {:<5}  {:<6}  {:<22}  {:<14}  {:<8}  {:<6}  \
+{:<18}  {:<56}\n"
 
     mem += f"Grouping by {group_by}...\
         Sorting by {sort_by}...\
@@ -499,6 +499,7 @@ entries per group...\n\n\n"
                 entry["type"],
                 entry["call_site"],
                 entry["task_status"],
+                entry["attempt_number"],
                 entry["object_size"],
                 entry["reference_type"],
                 entry["object_ref"],

--- a/python/ray/tests/test_reconstruction_2.py
+++ b/python/ray/tests/test_reconstruction_2.py
@@ -354,17 +354,23 @@ def test_memory_util(config, ray_start_cluster):
         print(info)
         info = info.split("\n")
         reconstructing_waiting = [
-            line
-            for line in info
-            if "Attempt #2" in line and WAITING_FOR_DEPENDENCIES in line
+            fields
+            for fields in [[part.strip() for part in line.split("|")] for line in info]
+            if len(fields) == 9
+            and fields[4] == WAITING_FOR_DEPENDENCIES
+            and fields[5] == "2"
         ]
         reconstructing_scheduled = [
-            line
-            for line in info
-            if "Attempt #2" in line and WAITING_FOR_EXECUTION in line
+            fields
+            for fields in [[part.strip() for part in line.split("|")] for line in info]
+            if len(fields) == 9
+            and fields[4] == WAITING_FOR_EXECUTION
+            and fields[5] == "2"
         ]
         reconstructing_finished = [
-            line for line in info if "Attempt #2" in line and FINISHED in line
+            fields
+            for fields in [[part.strip() for part in line.split("|")] for line in info]
+            if len(fields) == 9 and fields[4] == FINISHED and fields[5] == "2"
         ]
         return (
             len(reconstructing_waiting),

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -108,6 +108,7 @@ from ray.util.state.common import (
     ClusterEventState,
     StateSchema,
     state_column,
+    dict_to_state,
 )
 from ray.dashboard.utils import ray_address_to_api_server_url
 from ray.util.state.exception import DataSourceUnavailable, RayStateApiException
@@ -173,6 +174,9 @@ def verify_schema(state, result_dict: dict, detail: bool = False):
 
     for k in result_dict:
         assert k in state_fields_columns
+
+    # Make the field values can be converted without error as well
+    state(**result_dict)
 
 
 def generate_actor_data(id, state=ActorTableData.ActorState.ALIVE, class_name="class"):
@@ -747,12 +751,14 @@ async def test_api_manager_list_cluster_events(state_api_manager):
                 "severity": "DEBUG",
                 "message": "a",
                 "event_id": event_id_1,
+                "source_type": "GCS",
             },
             event_id_2: {
                 "timestamp": 10,
                 "severity": "INFO",
                 "message": "b",
                 "event_id": event_id_2,
+                "source_type": "GCS",
             },
         }
     }

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -1924,8 +1924,7 @@ def test_cli_apis_sanity_check(ray_start_cluster):
     wait_for_condition(
         lambda: verify_output(
             ray_list, ["runtime-envs"], ["Stats:", "Table:", "RUNTIME_ENV"]
-        ),
-        timeout=20
+        )
     )
 
     # Test get node by id

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -108,7 +108,6 @@ from ray.util.state.common import (
     ClusterEventState,
     StateSchema,
     state_column,
-    dict_to_state,
 )
 from ray.dashboard.utils import ray_address_to_api_server_url
 from ray.util.state.exception import DataSourceUnavailable, RayStateApiException
@@ -1925,7 +1924,8 @@ def test_cli_apis_sanity_check(ray_start_cluster):
     wait_for_condition(
         lambda: verify_output(
             ray_list, ["runtime-envs"], ["Stats:", "Table:", "RUNTIME_ENV"]
-        )
+        ),
+        timeout=20
     )
 
     # Test get node by id

--- a/python/ray/tests/test_state_api_summary.py
+++ b/python/ray/tests/test_state_api_summary.py
@@ -283,9 +283,10 @@ async def test_api_manager_summary_objects(state_api_manager):
     assert first_summary.total_size_mb == 4.0
     assert first_summary.total_num_workers == 3
     assert first_summary.total_num_nodes == 2
-    assert first_summary.task_state_counts["PENDING_NODE_ASSIGNMENT"] == 1
-    assert first_summary.task_state_counts["Attempt #2: PENDING_NODE_ASSIGNMENT"] == 1
+    assert first_summary.task_state_counts["PENDING_NODE_ASSIGNMENT"] == 2
     assert first_summary.task_state_counts["RUNNING"] == 2
+    assert first_summary.task_attempt_number_counts["1"] == 3
+    assert first_summary.task_attempt_number_counts["2"] == 1
     assert first_summary.ref_type_counts["PINNED_IN_MEMORY"] == 3
     assert first_summary.ref_type_counts["USED_BY_PENDING_TASK"] == 1
 
@@ -295,6 +296,7 @@ async def test_api_manager_summary_objects(state_api_manager):
     assert second_summary.total_num_workers == 1
     assert second_summary.total_num_nodes == 1
     assert second_summary.task_state_counts["RUNNING"] == 1
+    assert second_summary.task_attempt_number_counts["1"] == 1
     assert second_summary.ref_type_counts["PINNED_IN_MEMORY"] == 1
 
     """


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* Current status:
  * When we retrieve the information from GCS, the task_status as well as the attempts are in 2 fields and the task status is an enum.
  * Later during reconstruction, the 2 fields are combined into 1 and the number of attempts is added to the task_status field.
  * That's why when displaying the objects, the function isn't able to convert the string back to enum.
* Proposed solution:
  * Instead of combining the 2 fields (task_status and attempt), we will keep the 2 fields and added an additional field (attempt_number) in the Object State
  * In this way, we will keep the task_status as enum and put the attempt number information in a different field
* Changes in this PR:
  * Added the `attempt_number` in `ObjectState` and `task_attempt_number_counts` in `ObjectSummaryPerKey`
  * Added logic to populate the fields as proposed above
  * Updated the logic for the memory summary function to display the attempt number in a new column
  * Corresponding tests added as well

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #44541

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
