### PR TITLE
[Core] Fix a Typo in dict_to_state function parameter name

### DIFF
--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -1666,8 +1666,8 @@ def remove_ansi_escape_codes(text: str) -> str:
 
     return re.sub(r"\x1b[^m]*m", "", text)
 
+def dict_to_state(d: Dict, state_resource: StateResource) -> StateSchema:
 
-def dict_to_state(d: Dict, state_source: StateResource) -> StateSchema:
     """Convert a dict to a state schema.
 
     Args:
@@ -1678,6 +1678,7 @@ def dict_to_state(d: Dict, state_source: StateResource) -> StateSchema:
         A state schema.
     """
     try:
-        return resource_to_schema(state_source)(**d)
+        return resource_to_schema(state_resource)(**d)
+
     except Exception as e:
         raise RayStateApiException(f"Failed to convert {d} to StateSchema: {e}") from e

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -1666,6 +1666,7 @@ def remove_ansi_escape_codes(text: str) -> str:
 
     return re.sub(r"\x1b[^m]*m", "", text)
 
+
 def dict_to_state(d: Dict, state_resource: StateResource) -> StateSchema:
 
     """Convert a dict to a state schema.

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -1673,7 +1673,7 @@ def dict_to_state(d: Dict, state_resource: StateResource) -> StateSchema:
 
     Args:
         d: a dict to convert.
-        state_schema: a schema to convert to.
+        state_resource: the state resource to convert to.
 
     Returns:
         A state schema.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The PR fix a typo in the dict_to_state function parameter to make it consistent with the type. 

The comment was made in https://github.com/ray-project/ray/pull/47818.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
 #44541
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
