### PR TITLE
[Arrow] Adding `ArrowTensorTypeV2` to support tensors larger than 2Gb

### DIFF
--- a/python/ray/_private/arrow_serialization.py
+++ b/python/ray/_private/arrow_serialization.py
@@ -8,6 +8,8 @@ import os
 import sys
 from typing import List, Tuple, Optional, TYPE_CHECKING
 
+from ray.air.util.tensor_extensions.arrow import ArrowTensorTypeV2
+
 if TYPE_CHECKING:
     import pyarrow
     from ray.data.extensions import ArrowTensorArray
@@ -330,9 +332,7 @@ def _array_to_array_payload(a: "pyarrow.Array") -> "PicklableArrayPayload":
         return _dictionary_array_to_array_payload(a)
     elif pa.types.is_map(a.type):
         return _map_array_to_array_payload(a)
-    elif isinstance(a.type, ArrowTensorType) or isinstance(
-        a.type, ArrowVariableShapedTensorType
-    ):
+    elif isinstance(a.type, (ArrowTensorType, ArrowTensorTypeV2, ArrowVariableShapedTensorType)):
         return _tensor_array_to_array_payload(a)
     elif isinstance(a.type, pa.ExtensionType):
         return _extension_array_to_array_payload(a)

--- a/python/ray/_private/arrow_serialization.py
+++ b/python/ray/_private/arrow_serialization.py
@@ -254,6 +254,7 @@ def _array_payload_to_array(payload: "PicklableArrayPayload") -> "pyarrow.Array"
     import pyarrow as pa
     from ray.air.util.tensor_extensions.arrow import (
         ArrowTensorType,
+        ArrowTensorTypeV2,
         ArrowVariableShapedTensorType,
     )
 
@@ -270,9 +271,7 @@ def _array_payload_to_array(payload: "PicklableArrayPayload") -> "pyarrow.Array"
         assert len(children) == 3, len(children)
         offsets, keys, items = children
         return pa.MapArray.from_arrays(offsets, keys, items)
-    elif isinstance(payload.type, ArrowTensorType) or isinstance(
-        payload.type, ArrowVariableShapedTensorType
-    ):
+    elif isinstance(payload.type, (ArrowTensorType, ArrowTensorTypeV2, ArrowVariableShapedTensorType)):
         # Dedicated path for reconstructing an ArrowTensorArray or
         # ArrowVariableShapedTensorArray, both of which can't be reconstructed by the
         # Array.from_buffers() API.

--- a/python/ray/_private/arrow_serialization.py
+++ b/python/ray/_private/arrow_serialization.py
@@ -8,8 +8,6 @@ import os
 import sys
 from typing import List, Tuple, Optional, TYPE_CHECKING
 
-from ray.air.util.tensor_extensions.arrow import ArrowTensorTypeV2
-
 if TYPE_CHECKING:
     import pyarrow
     from ray.data.extensions import ArrowTensorArray
@@ -305,6 +303,7 @@ def _array_to_array_payload(a: "pyarrow.Array") -> "PicklableArrayPayload":
 
     from ray.air.util.tensor_extensions.arrow import (
         ArrowTensorType,
+        ArrowTensorTypeV2,
         ArrowVariableShapedTensorType,
     )
 

--- a/python/ray/_private/arrow_serialization.py
+++ b/python/ray/_private/arrow_serialization.py
@@ -273,7 +273,10 @@ def _array_payload_to_array(payload: "PicklableArrayPayload") -> "pyarrow.Array"
         assert len(children) == 3, len(children)
         offsets, keys, items = children
         return pa.MapArray.from_arrays(offsets, keys, items)
-    elif isinstance(payload.type, (ArrowTensorType, ArrowTensorTypeV2, ArrowVariableShapedTensorType)):
+    elif isinstance(
+        payload.type,
+        (ArrowTensorType, ArrowTensorTypeV2, ArrowVariableShapedTensorType),
+    ):
         # Dedicated path for reconstructing an ArrowTensorArray or
         # ArrowVariableShapedTensorArray, both of which can't be reconstructed by the
         # Array.from_buffers() API.
@@ -332,7 +335,9 @@ def _array_to_array_payload(a: "pyarrow.Array") -> "PicklableArrayPayload":
         return _dictionary_array_to_array_payload(a)
     elif pa.types.is_map(a.type):
         return _map_array_to_array_payload(a)
-    elif isinstance(a.type, (ArrowTensorType, ArrowTensorTypeV2, ArrowVariableShapedTensorType)):
+    elif isinstance(
+        a.type, (ArrowTensorType, ArrowTensorTypeV2, ArrowVariableShapedTensorType)
+    ):
         return _tensor_array_to_array_payload(a)
     elif isinstance(a.type, pa.ExtensionType):
         return _extension_array_to_array_payload(a)

--- a/python/ray/air/BUILD
+++ b/python/ray/air/BUILD
@@ -5,6 +5,11 @@ doctest(
     tags = ["team:ml"]
 )
 
+py_library(
+    name = "conftest",
+    srcs = ["tests/conftest.py"],
+)
+
 # --------------------------------------------------------------------
 # Tests from the python/ray/air/examples directory.
 # Please keep these sorted alphabetically.
@@ -145,7 +150,7 @@ py_test(
     size = "small",
     srcs = ["tests/test_tensor_extension.py"],
     tags = ["team:ml", "team:data", "exclusive", "ray_data"],
-    deps = [":ml_lib"]
+    deps = [":ml_lib", ":conftest"]
 )
 
 py_test(

--- a/python/ray/air/_internal/tensorflow_utils.py
+++ b/python/ray/air/_internal/tensorflow_utils.py
@@ -5,7 +5,10 @@ import pyarrow
 import tensorflow as tf
 
 from ray.air.util.data_batch_conversion import _unwrap_ndarray_object_type_if_needed
-from ray.air.util.tensor_extensions.arrow import ArrowTensorTypeV2, ArrowVariableShapedTensorType
+from ray.air.util.tensor_extensions.arrow import (
+    ArrowTensorTypeV2,
+    ArrowVariableShapedTensorType,
+)
 
 if TYPE_CHECKING:
     from ray.data._internal.pandas_block import PandasBlockSchema
@@ -99,7 +102,9 @@ def get_type_spec(
 
     def get_shape(dtype: Union[np.dtype, pa.DataType]) -> Tuple[int, ...]:
         shape = (None,)
-        if isinstance(dtype, (ArrowTensorType, ArrowTensorTypeV2, ArrowVariableShapedTensorType)):
+        if isinstance(
+            dtype, (ArrowTensorType, ArrowTensorTypeV2, ArrowVariableShapedTensorType)
+        ):
             dtype = dtype.to_pandas_dtype()
         if isinstance(dtype, TensorDtype):
             shape += dtype.element_shape

--- a/python/ray/air/_internal/tensorflow_utils.py
+++ b/python/ray/air/_internal/tensorflow_utils.py
@@ -5,6 +5,7 @@ import pyarrow
 import tensorflow as tf
 
 from ray.air.util.data_batch_conversion import _unwrap_ndarray_object_type_if_needed
+from ray.air.util.tensor_extensions.arrow import ArrowTensorTypeV2, ArrowVariableShapedTensorType
 
 if TYPE_CHECKING:
     from ray.data._internal.pandas_block import PandasBlockSchema
@@ -98,7 +99,7 @@ def get_type_spec(
 
     def get_shape(dtype: Union[np.dtype, pa.DataType]) -> Tuple[int, ...]:
         shape = (None,)
-        if isinstance(dtype, ArrowTensorType):
+        if isinstance(dtype, (ArrowTensorType, ArrowTensorTypeV2, ArrowVariableShapedTensorType)):
             dtype = dtype.to_pandas_dtype()
         if isinstance(dtype, TensorDtype):
             shape += dtype.element_shape

--- a/python/ray/air/_internal/tensorflow_utils.py
+++ b/python/ray/air/_internal/tensorflow_utils.py
@@ -5,10 +5,7 @@ import pyarrow
 import tensorflow as tf
 
 from ray.air.util.data_batch_conversion import _unwrap_ndarray_object_type_if_needed
-from ray.air.util.tensor_extensions.arrow import (
-    ArrowTensorTypeV2,
-    ArrowVariableShapedTensorType,
-)
+from ray.air.util.tensor_extensions.arrow import get_arrow_extension_tensor_types
 
 if TYPE_CHECKING:
     from ray.data._internal.pandas_block import PandasBlockSchema
@@ -85,7 +82,9 @@ def get_type_spec(
 ) -> Union[tf.TypeSpec, Dict[str, tf.TypeSpec]]:
     import pyarrow as pa
 
-    from ray.data.extensions import ArrowTensorType, TensorDtype
+    from ray.data.extensions import TensorDtype
+
+    tensor_extension_types = get_arrow_extension_tensor_types()
 
     assert not isinstance(schema, type)
 
@@ -102,9 +101,7 @@ def get_type_spec(
 
     def get_shape(dtype: Union[np.dtype, pa.DataType]) -> Tuple[int, ...]:
         shape = (None,)
-        if isinstance(
-            dtype, (ArrowTensorType, ArrowTensorTypeV2, ArrowVariableShapedTensorType)
-        ):
+        if isinstance(dtype, tensor_extension_types):
             dtype = dtype.to_pandas_dtype()
         if isinstance(dtype, TensorDtype):
             shape += dtype.element_shape

--- a/python/ray/air/tests/conftest.py
+++ b/python/ray/air/tests/conftest.py
@@ -1,2 +1,15 @@
 # Trigger pytest hook to automatically zip test cluster logs to archive dir on failure
+import copy
+
+import pytest
+
+import ray
+
 from ray.tests.conftest import pytest_runtest_makereport  # noqa
+
+@pytest.fixture
+def restore_data_context(request):
+    """Restore any DataContext changes after the test runs"""
+    original = copy.deepcopy(ray.data.context.DataContext.get_current())
+    yield
+    ray.data.context.DataContext._set_current(original)

--- a/python/ray/air/tests/conftest.py
+++ b/python/ray/air/tests/conftest.py
@@ -4,8 +4,8 @@ import copy
 import pytest
 
 import ray
-
 from ray.tests.conftest import pytest_runtest_makereport  # noqa
+
 
 @pytest.fixture
 def restore_data_context(request):

--- a/python/ray/air/tests/test_tensor_extension.py
+++ b/python/ray/air/tests/test_tensor_extension.py
@@ -11,7 +11,7 @@ from ray.air.util.tensor_extensions.arrow import (
     ArrowTensorArray,
     ArrowTensorType,
     ArrowVariableShapedTensorArray,
-    ArrowVariableShapedTensorType, ArrowConversionError,
+    ArrowVariableShapedTensorType, ArrowConversionError, ArrowTensorTypeV2,
 )
 from ray.air.util.tensor_extensions.pandas import TensorArray, TensorDtype
 from ray.air.util.tensor_extensions.utils import create_ragged_ndarray
@@ -700,7 +700,14 @@ def test_arrow_tensor_array_concat(a1, a2, restore_data_context, tensor_format):
     ta = ArrowTensorArray._concat_same_type([ta1, ta2])
     assert len(ta) == a1.shape[0] + a2.shape[0]
     if a1.shape[1:] == a2.shape[1:]:
-        assert isinstance(ta.type, ArrowTensorType)
+        if tensor_format == "v1":
+            tensor_type_class = ArrowTensorType
+        elif tensor_format == "v2":
+            tensor_type_class = ArrowTensorTypeV2
+        else:
+            raise ValueError(f"unexpected format: {tensor_format}")
+
+        assert isinstance(ta.type, tensor_type_class)
         assert ta.type.storage_type == ta1.type.storage_type
         assert ta.type.storage_type == ta2.type.storage_type
         assert ta.type.shape == a1.shape[1:]

--- a/python/ray/air/tests/test_tensor_extension.py
+++ b/python/ray/air/tests/test_tensor_extension.py
@@ -29,7 +29,7 @@ from ray.data import DataContext
     ],
 )
 def test_create_ragged_ndarray(values, restore_data_context, tensor_format):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     ragged_array = create_ragged_ndarray(values)
     assert len(ragged_array) == len(values)
@@ -52,7 +52,7 @@ def test_tensor_array_validation():
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 def test_arrow_scalar_tensor_array_roundtrip(restore_data_context, tensor_format):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     arr = np.arange(10)
     ata = ArrowTensorArray.from_numpy(arr)
@@ -66,7 +66,7 @@ def test_arrow_scalar_tensor_array_roundtrip(restore_data_context, tensor_format
 def test_arrow_scalar_tensor_array_roundtrip_boolean(
     restore_data_context, tensor_format
 ):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     arr = np.array([True, False, False, True])
     ata = ArrowTensorArray.from_numpy(arr)
@@ -80,7 +80,7 @@ def test_arrow_scalar_tensor_array_roundtrip_boolean(
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 def test_scalar_tensor_array_roundtrip(restore_data_context, tensor_format):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     arr = np.arange(10)
     ta = TensorArray(arr)
@@ -101,7 +101,7 @@ def test_scalar_tensor_array_roundtrip(restore_data_context, tensor_format):
 def test_arrow_variable_shaped_tensor_array_validation(
     restore_data_context, tensor_format
 ):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     # Test tensor elements with differing dimensions raises ValueError.
     with pytest.raises(ValueError):
@@ -151,7 +151,7 @@ def test_arrow_variable_shaped_tensor_array_validation(
 def test_arrow_variable_shaped_tensor_array_roundtrip(
     restore_data_context, tensor_format
 ):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     shapes = [(2, 2), (3, 3), (4, 4)]
     cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
@@ -172,7 +172,7 @@ def test_arrow_variable_shaped_tensor_array_roundtrip(
 def test_arrow_variable_shaped_tensor_array_roundtrip_boolean(
     restore_data_context, tensor_format
 ):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     arr = np.array(
         [[True, False], [False, False, True], [False], [True, True, False, True]],
@@ -190,7 +190,7 @@ def test_arrow_variable_shaped_tensor_array_roundtrip_boolean(
 def test_arrow_variable_shaped_tensor_array_roundtrip_contiguous_optimization(
     restore_data_context, tensor_format
 ):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     # Test that a roundtrip on slices of an already-contiguous 1D base array does not
     # create any unnecessary copies.
@@ -209,7 +209,7 @@ def test_arrow_variable_shaped_tensor_array_roundtrip_contiguous_optimization(
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 def test_arrow_variable_shaped_tensor_array_slice(restore_data_context, tensor_format):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     shapes = [(2, 2), (3, 3), (4, 4)]
     cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
@@ -248,7 +248,7 @@ def test_arrow_variable_shaped_tensor_array_slice(restore_data_context, tensor_f
 def test_arrow_variable_shaped_bool_tensor_array_slice(
     restore_data_context, tensor_format
 ):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     arr = np.array(
         [
@@ -289,7 +289,7 @@ def test_arrow_variable_shaped_bool_tensor_array_slice(
 def test_arrow_variable_shaped_string_tensor_array_slice(
     restore_data_context, tensor_format
 ):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     arr = np.array(
         [
@@ -332,7 +332,7 @@ def test_arrow_variable_shaped_string_tensor_array_slice(
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 def test_variable_shaped_tensor_array_roundtrip(restore_data_context, tensor_format):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     shapes = [(2, 2), (3, 3), (4, 4)]
     cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
@@ -359,7 +359,7 @@ def test_variable_shaped_tensor_array_roundtrip(restore_data_context, tensor_for
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 def test_variable_shaped_tensor_array_slice(restore_data_context, tensor_format):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     shapes = [(2, 2), (3, 3), (4, 4)]
     cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
@@ -389,7 +389,7 @@ def test_variable_shaped_tensor_array_slice(restore_data_context, tensor_format)
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 def test_tensor_array_ops(restore_data_context, tensor_format):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     outer_dim = 3
     inner_shape = (2, 2, 2)
@@ -418,7 +418,7 @@ def test_tensor_array_ops(restore_data_context, tensor_format):
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 def test_tensor_array_array_protocol(restore_data_context, tensor_format):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     outer_dim = 3
     inner_shape = (2, 2, 2)
@@ -441,7 +441,7 @@ def test_tensor_array_array_protocol(restore_data_context, tensor_format):
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 def test_tensor_array_dataframe_repr(restore_data_context, tensor_format):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     outer_dim = 3
     inner_shape = (2, 2)
@@ -461,7 +461,7 @@ def test_tensor_array_dataframe_repr(restore_data_context, tensor_format):
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 def test_tensor_array_scalar_cast(restore_data_context, tensor_format):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     outer_dim = 3
     inner_shape = (1,)
@@ -481,7 +481,7 @@ def test_tensor_array_scalar_cast(restore_data_context, tensor_format):
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 def test_tensor_array_reductions(restore_data_context, tensor_format):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     outer_dim = 3
     inner_shape = (2, 2, 2)
@@ -505,7 +505,7 @@ def test_tensor_array_reductions(restore_data_context, tensor_format):
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 @pytest.mark.parametrize("chunked", [False, True])
 def test_arrow_tensor_array_getitem(chunked, restore_data_context, tensor_format):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     outer_dim = 3
     inner_shape = (2, 2, 2)
@@ -574,7 +574,7 @@ def test_arrow_tensor_array_getitem(chunked, restore_data_context, tensor_format
 def test_arrow_variable_shaped_tensor_array_getitem(
     chunked, restore_data_context, tensor_format
 ):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     shapes = [(2, 2), (3, 3), (4, 4)]
     outer_dim = len(shapes)
@@ -658,7 +658,7 @@ def test_arrow_variable_shaped_tensor_array_getitem(
     ],
 )
 def test_arrow_tensor_array_slice(test_arr, dtype, restore_data_context, tensor_format):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     # Test that ArrowTensorArray slicing works as expected.
     arr = np.array(test_arr, dtype=dtype)
@@ -690,7 +690,7 @@ pytest_tensor_array_concat_arr_combinations = list(
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 @pytest.mark.parametrize("a1,a2", pytest_tensor_array_concat_arr_combinations)
 def test_tensor_array_concat(a1, a2, restore_data_context, tensor_format):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     ta1 = TensorArray(a1)
     ta2 = TensorArray(a2)
@@ -711,7 +711,7 @@ def test_tensor_array_concat(a1, a2, restore_data_context, tensor_format):
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 @pytest.mark.parametrize("a1,a2", pytest_tensor_array_concat_arr_combinations)
 def test_arrow_tensor_array_concat(a1, a2, restore_data_context, tensor_format):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     ta1 = ArrowTensorArray.from_numpy(a1)
     ta2 = ArrowTensorArray.from_numpy(a2)
@@ -743,7 +743,7 @@ def test_arrow_tensor_array_concat(a1, a2, restore_data_context, tensor_format):
 def test_variable_shaped_tensor_array_chunked_concat(
     restore_data_context, tensor_format
 ):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     # Test that chunking a tensor column and concatenating its chunks preserves typing
     # and underlying data.
@@ -766,7 +766,7 @@ def test_variable_shaped_tensor_array_chunked_concat(
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 def test_variable_shaped_tensor_array_uniform_dim(restore_data_context, tensor_format):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     shape1 = (3, 2, 2)
     shape2 = (3, 4, 4)
@@ -781,7 +781,7 @@ def test_variable_shaped_tensor_array_uniform_dim(restore_data_context, tensor_f
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 def test_large_arrow_tensor_array(restore_data_context, tensor_format):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     test_arr = np.ones((1000, 550), dtype=np.uint8)
 

--- a/python/ray/air/tests/test_tensor_extension.py
+++ b/python/ray/air/tests/test_tensor_extension.py
@@ -8,10 +8,12 @@ from packaging.version import parse as parse_version
 
 from ray._private.utils import _get_pyarrow_version
 from ray.air.util.tensor_extensions.arrow import (
+    ArrowConversionError,
     ArrowTensorArray,
     ArrowTensorType,
+    ArrowTensorTypeV2,
     ArrowVariableShapedTensorArray,
-    ArrowVariableShapedTensorType, ArrowConversionError, ArrowTensorTypeV2,
+    ArrowVariableShapedTensorType,
 )
 from ray.air.util.tensor_extensions.pandas import TensorArray, TensorDtype
 from ray.air.util.tensor_extensions.utils import create_ragged_ndarray
@@ -61,7 +63,9 @@ def test_arrow_scalar_tensor_array_roundtrip(restore_data_context, tensor_format
 
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_arrow_scalar_tensor_array_roundtrip_boolean(restore_data_context, tensor_format):
+def test_arrow_scalar_tensor_array_roundtrip_boolean(
+    restore_data_context, tensor_format
+):
     DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
 
     arr = np.array([True, False, False, True])
@@ -94,7 +98,9 @@ def test_scalar_tensor_array_roundtrip(restore_data_context, tensor_format):
 
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_arrow_variable_shaped_tensor_array_validation(restore_data_context, tensor_format):
+def test_arrow_variable_shaped_tensor_array_validation(
+    restore_data_context, tensor_format
+):
     DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
 
     # Test tensor elements with differing dimensions raises ValueError.
@@ -142,7 +148,9 @@ def test_arrow_variable_shaped_tensor_array_validation(restore_data_context, ten
 
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_arrow_variable_shaped_tensor_array_roundtrip(restore_data_context, tensor_format):
+def test_arrow_variable_shaped_tensor_array_roundtrip(
+    restore_data_context, tensor_format
+):
     DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
 
     shapes = [(2, 2), (3, 3), (4, 4)]
@@ -161,7 +169,9 @@ def test_arrow_variable_shaped_tensor_array_roundtrip(restore_data_context, tens
 
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_arrow_variable_shaped_tensor_array_roundtrip_boolean(restore_data_context, tensor_format):
+def test_arrow_variable_shaped_tensor_array_roundtrip_boolean(
+    restore_data_context, tensor_format
+):
     DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
 
     arr = np.array(
@@ -177,7 +187,9 @@ def test_arrow_variable_shaped_tensor_array_roundtrip_boolean(restore_data_conte
 
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_arrow_variable_shaped_tensor_array_roundtrip_contiguous_optimization(restore_data_context, tensor_format):
+def test_arrow_variable_shaped_tensor_array_roundtrip_contiguous_optimization(
+    restore_data_context, tensor_format
+):
     DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
 
     # Test that a roundtrip on slices of an already-contiguous 1D base array does not
@@ -233,7 +245,9 @@ def test_arrow_variable_shaped_tensor_array_slice(restore_data_context, tensor_f
 
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_arrow_variable_shaped_bool_tensor_array_slice(restore_data_context, tensor_format):
+def test_arrow_variable_shaped_bool_tensor_array_slice(
+    restore_data_context, tensor_format
+):
     DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
 
     arr = np.array(
@@ -272,7 +286,9 @@ def test_arrow_variable_shaped_bool_tensor_array_slice(restore_data_context, ten
 
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_arrow_variable_shaped_string_tensor_array_slice(restore_data_context, tensor_format):
+def test_arrow_variable_shaped_string_tensor_array_slice(
+    restore_data_context, tensor_format
+):
     DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
 
     arr = np.array(
@@ -555,7 +571,9 @@ def test_arrow_tensor_array_getitem(chunked, restore_data_context, tensor_format
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 @pytest.mark.parametrize("chunked", [False, True])
-def test_arrow_variable_shaped_tensor_array_getitem(chunked, restore_data_context, tensor_format):
+def test_arrow_variable_shaped_tensor_array_getitem(
+    chunked, restore_data_context, tensor_format
+):
     DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
 
     shapes = [(2, 2), (3, 3), (4, 4)]
@@ -722,7 +740,9 @@ def test_arrow_tensor_array_concat(a1, a2, restore_data_context, tensor_format):
 
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_variable_shaped_tensor_array_chunked_concat(restore_data_context, tensor_format):
+def test_variable_shaped_tensor_array_chunked_concat(
+    restore_data_context, tensor_format
+):
     DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
 
     # Test that chunking a tensor column and concatenating its chunks preserves typing
@@ -769,7 +789,10 @@ def test_large_arrow_tensor_array(restore_data_context, tensor_format):
         with pytest.raises(ArrowConversionError) as exc_info:
             ta = ArrowTensorArray.from_numpy([test_arr] * 4000)
 
-        assert repr(exc_info.value.__cause__) == "ArrowInvalid('Negative offsets in list array')"
+        assert (
+            repr(exc_info.value.__cause__)
+            == "ArrowInvalid('Negative offsets in list array')"
+        )
     else:
         ta = ArrowTensorArray.from_numpy([test_arr] * 4000)
         assert len(ta) == 4000

--- a/python/ray/air/tests/test_tensor_extension.py
+++ b/python/ray/air/tests/test_tensor_extension.py
@@ -676,6 +676,14 @@ def test_variable_shaped_tensor_array_uniform_dim():
         np.testing.assert_array_equal(a, expected)
 
 
+def test_large_arrow_tensor_array():
+    test_arr = np.ones((1000, 550), dtype=np.uint8)
+    ta = ArrowTensorArray.from_numpy([test_arr] * 4000)
+    assert len(ta) == 4000
+    for arr in ta:
+        assert np.asarray(arr).shape == (1000, 550)
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -189,7 +189,7 @@ class _BaseArrowTensorType(pa.ExtensionType, abc.ABC):
     def _need_variable_shaped_tensor_array(
         cls,
         array_types: Sequence[
-            Union["ArrowTensorType", "ArrowVariableShapedTensorType"]
+            Union["ArrowTensorType", "ArrowTensorTypeV2", "ArrowVariableShapedTensorType"]
         ],
     ) -> bool:
         """
@@ -214,7 +214,7 @@ class _BaseArrowTensorType(pa.ExtensionType, abc.ABC):
             # short-circuit since we require a variable-shaped representation.
             if isinstance(arr_type, ArrowVariableShapedTensorType):
                 return True
-            if not isinstance(arr_type, ArrowTensorType):
+            if not isinstance(arr_type, (ArrowTensorType, ArrowTensorTypeV2)):
                 raise ValueError(
                     "All provided array types must be an instance of either "
                     "ArrowTensorType or ArrowVariableShapedTensorType, but "

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -115,7 +115,7 @@ class ArrowTensorType(pa.ExtensionType):
             dtype: pyarrow dtype of tensor elements.
         """
         self._shape = shape
-        super().__init__(pa.list_(dtype), "ray.data.arrow_tensor")
+        super().__init__(pa.large_list(dtype), "ray.data.arrow_tensor")
 
     @property
     def shape(self):
@@ -326,7 +326,7 @@ class ArrowTensorArray(_ArrowTensorScalarIndexingMixin, pa.ExtensionArray):
     https://arrow.apache.org/docs/python/extending_types.html#custom-extension-array-class
     """
 
-    OFFSET_DTYPE = np.int32
+    OFFSET_DTYPE = np.int64
 
     @classmethod
     def from_numpy(
@@ -424,7 +424,7 @@ class ArrowTensorArray(_ArrowTensorScalarIndexingMixin, pa.ExtensionArray):
         )
 
         storage = pa.Array.from_buffers(
-            pa.list_(pa_dtype),
+            pa.large_list(pa_dtype),
             outer_len,
             [None, offset_buffer],
             children=[data_array],
@@ -622,7 +622,9 @@ class ArrowVariableShapedTensorType(pa.ExtensionType):
         """
         self._ndim = ndim
         super().__init__(
-            pa.struct([("data", pa.list_(dtype)), ("shape", pa.list_(pa.int64()))]),
+            pa.struct(
+                [("data", pa.large_list(dtype)), ("shape", pa.list_(pa.int64()))]
+            ),
             "ray.data.arrow_variable_shaped_tensor",
         )
 
@@ -729,7 +731,7 @@ class ArrowVariableShapedTensorArray(
     https://arrow.apache.org/docs/python/extending_types.html#custom-extension-array-class
     """
 
-    OFFSET_DTYPE = np.int32
+    OFFSET_DTYPE = np.int64
 
     @classmethod
     def from_numpy(
@@ -819,7 +821,7 @@ class ArrowVariableShapedTensorArray(
         # corresponds to a tensor element.
         size_offsets = np.insert(size_offsets, 0, 0)
         offset_array = pa.array(size_offsets)
-        data_array = pa.ListArray.from_arrays(offset_array, value_array)
+        data_array = pa.LargeListArray.from_arrays(offset_array, value_array)
         # We store the tensor element shapes so we can reconstruct each tensor when
         # converting back to NumPy ndarrays.
         shape_array = pa.array(shapes)

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -1020,6 +1020,7 @@ try:
     # Registration needs an extension type instance, but then works for any instance of
     # the same subclass regardless of parametrization of the type.
     pa.register_extension_type(ArrowTensorType((0,), pa.int64()))
+    pa.register_extension_type(ArrowTensorTypeV2((0,), pa.int64()))
     pa.register_extension_type(ArrowVariableShapedTensorType(pa.int64(), 0))
 except pa.ArrowKeyError:
     # Extension types are already registered.

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -14,7 +14,6 @@ from ray.air.util.tensor_extensions.utils import (
     _is_ndarray_variable_shaped_tensor,
     create_ragged_ndarray,
 )
-from ray.data import DataContext
 from ray.util.annotations import DeveloperAPI, PublicAPI
 
 PYARROW_VERSION = _get_pyarrow_version()
@@ -453,6 +452,7 @@ class ArrowTensorArray(_ArrowTensorScalarIndexingMixin, pa.ExtensionArray):
             scalar_dtype, total_num_items, [None, data_buffer]
         )
 
+        from ray.data import DataContext
         should_use_tensor_v2 = DataContext.get_current().should_use_tensor_v2
 
         if should_use_tensor_v2:

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -233,8 +233,12 @@ class _BaseArrowTensorType(pa.ExtensionType, abc.ABC):
 
 @PublicAPI(stability="beta")
 class ArrowTensorType(_BaseArrowTensorType):
+    """Arrow ExtensionType (v1) for tensors.
 
-    # TODO elaborate
+    NOTE: This type does *NOT* support tensors larger than 4Gb (due to
+          overflow of int32 offsets utilized inside Pyarrow `ListType`)
+    """
+
     OFFSET_DTYPE = np.int32
 
     def __init__(self, shape: Tuple[int, ...], dtype: pa.DataType):
@@ -256,8 +260,8 @@ class ArrowTensorType(_BaseArrowTensorType):
 
 @PublicAPI(stability="alpha")
 class ArrowTensorTypeV2(_BaseArrowTensorType):
+    """Arrow ExtensionType (v2) for tensors (supporting tensors > 4Gb)."""
 
-    # TODO elaborate
     OFFSET_DTYPE = np.int64
 
     def __init__(self, shape: Tuple[int, ...], dtype: pa.DataType):

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -106,7 +106,9 @@ class _BaseArrowTensorType(pa.ExtensionType, abc.ABC):
     https://arrow.apache.org/docs/python/extending_types.html#defining-extension-types-user-defined-types
     """
 
-    def __init__(self, shape: Tuple[int, ...], tensor_dtype: pa.DataType, ext_type_id: str):
+    def __init__(
+        self, shape: Tuple[int, ...], tensor_dtype: pa.DataType, ext_type_id: str
+    ):
         self._shape = shape
 
         super().__init__(tensor_dtype, ext_type_id)
@@ -188,7 +190,9 @@ class _BaseArrowTensorType(pa.ExtensionType, abc.ABC):
     def _need_variable_shaped_tensor_array(
         cls,
         array_types: Sequence[
-            Union["ArrowTensorType", "ArrowTensorTypeV2", "ArrowVariableShapedTensorType"]
+            Union[
+                "ArrowTensorType", "ArrowTensorTypeV2", "ArrowVariableShapedTensorType"
+            ]
         ],
     ) -> bool:
         """
@@ -452,6 +456,7 @@ class ArrowTensorArray(_ArrowTensorScalarIndexingMixin, pa.ExtensionArray):
         )
 
         from ray.data import DataContext
+
         should_use_tensor_v2 = DataContext.get_current().should_use_tensor_v2
 
         if should_use_tensor_v2:
@@ -461,7 +466,9 @@ class ArrowTensorArray(_ArrowTensorScalarIndexingMixin, pa.ExtensionArray):
 
         # Create Offset buffer
         offset_buffer = pa.py_buffer(
-            pa_type_.OFFSET_DTYPE([i * num_items_per_element for i in range(outer_len + 1)])
+            pa_type_.OFFSET_DTYPE(
+                [i * num_items_per_element for i in range(outer_len + 1)]
+            )
         )
 
         storage = pa.Array.from_buffers(

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -616,7 +616,7 @@ class ArrowTensorArray(_ArrowTensorScalarIndexingMixin, pa.ExtensionArray):
         if ArrowTensorType._need_variable_shaped_tensor_array(arrs_types):
             new_arrs = []
             for a in arrs:
-                if isinstance(a.type, ArrowTensorType):
+                if isinstance(a.type, (ArrowTensorType, ArrowTensorTypeV2)):
                     a = a.to_variable_shaped_tensor_array()
                 assert isinstance(a.type, ArrowVariableShapedTensorType)
                 new_arrs.append(a)

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -521,7 +521,7 @@ class ArrowTensorArray(_ArrowTensorScalarIndexingMixin, pa.ExtensionArray):
             # Getting a single tensor element of the array.
             offset_buffer = buffers[1]
             offset_array = np.ndarray(
-                (len(self),), buffer=offset_buffer, dtype=ArrowTensorType.OFFSET_DTYPE
+                (len(self),), buffer=offset_buffer, dtype=self.type.OFFSET_DTYPE
             )
             # Offset into array to reach logical index.
             index_offset = offset_array[index]

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -108,7 +108,6 @@ class _BaseArrowTensorType(pa.ExtensionType, abc.ABC):
 
     def __init__(self, shape: Tuple[int, ...], tensor_dtype: pa.DataType, ext_type_id: str):
         self._shape = shape
-        self.tensor_dtype = tensor_dtype
 
         super().__init__(tensor_dtype, ext_type_id)
 
@@ -466,7 +465,7 @@ class ArrowTensorArray(_ArrowTensorScalarIndexingMixin, pa.ExtensionArray):
         )
 
         storage = pa.Array.from_buffers(
-            pa_type_.tensor_dtype,
+            pa_type_.storage_type,
             outer_len,
             [None, offset_buffer],
             children=[data_array],

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -106,6 +106,8 @@ class ArrowTensorType(pa.ExtensionType):
     https://arrow.apache.org/docs/python/extending_types.html#defining-extension-types-user-defined-types
     """
 
+    OFFSET_DTYPE = np.int64
+
     def __init__(self, shape: Tuple[int, ...], dtype: pa.DataType):
         """
         Construct the Arrow extension type for array of fixed-shaped tensors.
@@ -326,8 +328,6 @@ class ArrowTensorArray(_ArrowTensorScalarIndexingMixin, pa.ExtensionArray):
     https://arrow.apache.org/docs/python/extending_types.html#custom-extension-array-class
     """
 
-    OFFSET_DTYPE = np.int64
-
     @classmethod
     def from_numpy(
         cls,
@@ -420,7 +420,7 @@ class ArrowTensorArray(_ArrowTensorScalarIndexingMixin, pa.ExtensionArray):
 
         # Offset buffer.
         offset_buffer = pa.py_buffer(
-            cls.OFFSET_DTYPE([i * num_items_per_element for i in range(outer_len + 1)])
+            ArrowTensorType.OFFSET_DTYPE([i * num_items_per_element for i in range(outer_len + 1)])
         )
 
         storage = pa.Array.from_buffers(
@@ -479,7 +479,7 @@ class ArrowTensorArray(_ArrowTensorScalarIndexingMixin, pa.ExtensionArray):
             # Getting a single tensor element of the array.
             offset_buffer = buffers[1]
             offset_array = np.ndarray(
-                (len(self),), buffer=offset_buffer, dtype=self.OFFSET_DTYPE
+                (len(self),), buffer=offset_buffer, dtype=ArrowTensorType.OFFSET_DTYPE
             )
             # Offset into array to reach logical index.
             index_offset = offset_array[index]
@@ -730,8 +730,6 @@ class ArrowVariableShapedTensorArray(
     See Arrow docs for customizing extension arrays:
     https://arrow.apache.org/docs/python/extending_types.html#custom-extension-array-class
     """
-
-    OFFSET_DTYPE = np.int64
 
     @classmethod
     def from_numpy(

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -452,9 +452,14 @@ class ArrowTensorArray(_ArrowTensorScalarIndexingMixin, pa.ExtensionArray):
             pa_dtype, total_num_items, [None, data_buffer]
         )
 
-        # Offset buffer.
+        if DataContext.get_current().should_use_tensor_v2:
+            offset_dtype = ArrowTensorTypeV2.OFFSET_DTYPE
+        else:
+            offset_dtype = ArrowTensorType.OFFSET_DTYPE
+
+        # Create Offset buffer
         offset_buffer = pa.py_buffer(
-            ArrowTensorType.OFFSET_DTYPE([i * num_items_per_element for i in range(outer_len + 1)])
+            offset_dtype([i * num_items_per_element for i in range(outer_len + 1)])
         )
 
         storage = pa.Array.from_buffers(

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -95,7 +95,15 @@ def convert_list_to_pyarrow_array(
         raise ArrowConversionError(str(enclosing_dict)) from e
 
 
-class _BaseArrowTensorType(pa.ExtensionType, abc.ABC):
+@DeveloperAPI
+def get_arrow_extension_tensor_types():
+    """Returns list of extension types of Arrow Array holding
+    multidimensional tensors
+    """
+    return ArrowTensorType, ArrowTensorTypeV2, ArrowVariableShapedTensorType
+
+
+class _BaseFixedShapeArrowTensorType(pa.ExtensionType, abc.ABC):
     """
     Arrow ExtensionType for an array of fixed-shaped, homogeneous-typed
     tensors.
@@ -232,7 +240,7 @@ class _BaseArrowTensorType(pa.ExtensionType, abc.ABC):
 
 
 @PublicAPI(stability="beta")
-class ArrowTensorType(_BaseArrowTensorType):
+class ArrowTensorType(_BaseFixedShapeArrowTensorType):
     """Arrow ExtensionType (v1) for tensors.
 
     NOTE: This type does *NOT* support tensors larger than 4Gb (due to
@@ -259,7 +267,7 @@ class ArrowTensorType(_BaseArrowTensorType):
 
 
 @PublicAPI(stability="alpha")
-class ArrowTensorTypeV2(_BaseArrowTensorType):
+class ArrowTensorTypeV2(_BaseFixedShapeArrowTensorType):
     """Arrow ExtensionType (v2) for tensors (supporting tensors > 4Gb)."""
 
     OFFSET_DTYPE = np.int64

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -461,7 +461,7 @@ class ArrowTensorArray(_ArrowTensorScalarIndexingMixin, pa.ExtensionArray):
 
         from ray.data import DataContext
 
-        should_use_tensor_v2 = DataContext.get_current().should_use_tensor_v2
+        should_use_tensor_v2 = DataContext.get_current().use_arrow_tensor_v2
 
         if should_use_tensor_v2:
             pa_type_ = ArrowTensorTypeV2(element_shape, scalar_dtype)

--- a/python/ray/air/util/transform_pyarrow.py
+++ b/python/ray/air/util/transform_pyarrow.py
@@ -20,20 +20,18 @@ def _concatenate_extension_column(ca: "pyarrow.ChunkedArray") -> "pyarrow.Array"
     """
     from ray.air.util.tensor_extensions.arrow import (
         ArrowTensorArray,
-        ArrowTensorType,
-        ArrowTensorTypeV2,
-        ArrowVariableShapedTensorType,
+        get_arrow_extension_tensor_types
     )
 
     if not _is_column_extension_type(ca):
         raise ValueError("Chunked array isn't an extension array: {ca}")
 
+    tensor_extension_types = get_arrow_extension_tensor_types()
+
     if ca.num_chunks == 0:
         # Create empty storage array.
         storage = pyarrow.array([], type=ca.type.storage_type)
-    elif isinstance(
-        ca.type, (ArrowTensorType, ArrowTensorTypeV2, ArrowVariableShapedTensorType)
-    ):
+    elif isinstance(ca.type, tensor_extension_types):
         return ArrowTensorArray._concat_same_type(ca.chunks)
     else:
         storage = pyarrow.concat_arrays([c.storage for c in ca.chunks])

--- a/python/ray/air/util/transform_pyarrow.py
+++ b/python/ray/air/util/transform_pyarrow.py
@@ -31,7 +31,9 @@ def _concatenate_extension_column(ca: "pyarrow.ChunkedArray") -> "pyarrow.Array"
     if ca.num_chunks == 0:
         # Create empty storage array.
         storage = pyarrow.array([], type=ca.type.storage_type)
-    elif isinstance(ca.type, (ArrowTensorType, ArrowTensorTypeV2, ArrowVariableShapedTensorType)):
+    elif isinstance(
+        ca.type, (ArrowTensorType, ArrowTensorTypeV2, ArrowVariableShapedTensorType)
+    ):
         return ArrowTensorArray._concat_same_type(ca.chunks)
     else:
         storage = pyarrow.concat_arrays([c.storage for c in ca.chunks])

--- a/python/ray/air/util/transform_pyarrow.py
+++ b/python/ray/air/util/transform_pyarrow.py
@@ -21,6 +21,7 @@ def _concatenate_extension_column(ca: "pyarrow.ChunkedArray") -> "pyarrow.Array"
     from ray.air.util.tensor_extensions.arrow import (
         ArrowTensorArray,
         ArrowTensorType,
+        ArrowTensorTypeV2,
         ArrowVariableShapedTensorType,
     )
 
@@ -30,7 +31,7 @@ def _concatenate_extension_column(ca: "pyarrow.ChunkedArray") -> "pyarrow.Array"
     if ca.num_chunks == 0:
         # Create empty storage array.
         storage = pyarrow.array([], type=ca.type.storage_type)
-    elif isinstance(ca.type, (ArrowTensorType, ArrowVariableShapedTensorType)):
+    elif isinstance(ca.type, (ArrowTensorType, ArrowTensorTypeV2, ArrowVariableShapedTensorType)):
         return ArrowTensorArray._concat_same_type(ca.chunks)
     else:
         storage = pyarrow.concat_arrays([c.storage for c in ca.chunks])

--- a/python/ray/air/util/transform_pyarrow.py
+++ b/python/ray/air/util/transform_pyarrow.py
@@ -20,7 +20,7 @@ def _concatenate_extension_column(ca: "pyarrow.ChunkedArray") -> "pyarrow.Array"
     """
     from ray.air.util.tensor_extensions.arrow import (
         ArrowTensorArray,
-        get_arrow_extension_tensor_types
+        get_arrow_extension_tensor_types,
     )
 
     if not _is_column_extension_type(ca):

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -95,8 +95,8 @@ class ArrowRow(TableRow):
     def __getitem__(self, key: Union[str, List[str]]) -> Any:
         from ray.data.extensions import (
             ArrowTensorType,
-            ArrowVariableShapedTensorType,
             ArrowTensorTypeV2,
+            ArrowVariableShapedTensorType,
         )
 
         def get_item(keys: List[str]) -> Any:

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -93,16 +93,17 @@ class ArrowRow(TableRow):
     """
 
     def __getitem__(self, key: Union[str, List[str]]) -> Any:
-        from ray.data.extensions.tensor_extension import (
+        from ray.data.extensions import (
             ArrowTensorType,
             ArrowVariableShapedTensorType,
+            ArrowTensorTypeV2,
         )
 
         def get_item(keys: List[str]) -> Any:
             schema = self._row.schema
             if isinstance(
                 schema.field(keys[0]).type,
-                (ArrowTensorType, ArrowVariableShapedTensorType),
+                (ArrowTensorType, ArrowTensorTypeV2, ArrowVariableShapedTensorType),
             ):
                 # Build a tensor row.
                 return tuple(

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -93,18 +93,13 @@ class ArrowRow(TableRow):
     """
 
     def __getitem__(self, key: Union[str, List[str]]) -> Any:
-        from ray.data.extensions import (
-            ArrowTensorType,
-            ArrowTensorTypeV2,
-            ArrowVariableShapedTensorType,
-        )
+        from ray.data.extensions import get_arrow_extension_tensor_types
+
+        tensor_arrow_extension_types = get_arrow_extension_tensor_types()
 
         def get_item(keys: List[str]) -> Any:
             schema = self._row.schema
-            if isinstance(
-                schema.field(keys[0]).type,
-                (ArrowTensorType, ArrowTensorTypeV2, ArrowVariableShapedTensorType),
-            ):
+            if isinstance(schema.field(keys[0]).type, tensor_arrow_extension_types):
                 # Build a tensor row.
                 return tuple(
                     [

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, List, Union
 from packaging.version import parse as parse_version
 
 from ray._private.utils import _get_pyarrow_version
+from ray.air.util.tensor_extensions.arrow import ArrowTensorTypeV2
 
 try:
     import pyarrow
@@ -89,7 +90,7 @@ def unify_schemas(
                 cols_with_null_list.add(col_name)
             all_columns.add(col_name)
 
-    arrow_tensor_types = (ArrowVariableShapedTensorType, ArrowTensorType)
+    arrow_tensor_types = (ArrowVariableShapedTensorType, ArrowTensorType, ArrowTensorTypeV2)
     columns_with_objects = set()
     columns_with_tensor_array = set()
     for col_name in all_columns:

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, List, Union
 from packaging.version import parse as parse_version
 
 from ray._private.utils import _get_pyarrow_version
-from ray.air.util.tensor_extensions.arrow import ArrowTensorTypeV2, get_arrow_extension_tensor_types
+from ray.air.util.tensor_extensions.arrow import ArrowTensorTypeV2
 
 try:
     import pyarrow

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -123,7 +123,7 @@ def unify_schemas(
         if ArrowTensorType._need_variable_shaped_tensor_array(tensor_array_types):
             if isinstance(tensor_array_types[0], ArrowVariableShapedTensorType):
                 new_type = tensor_array_types[0]
-            elif isinstance(tensor_array_types[0], ArrowTensorType):
+            elif isinstance(tensor_array_types[0], (ArrowTensorType, ArrowTensorTypeV2)):
                 new_type = ArrowVariableShapedTensorType(
                     dtype=tensor_array_types[0].scalar_type,
                     ndim=len(tensor_array_types[0].shape),
@@ -169,7 +169,7 @@ def _concatenate_chunked_arrays(arrs: "pyarrow.ChunkedArray") -> "pyarrow.Chunke
     """
     Concatenate provided chunked arrays into a single chunked array.
     """
-    from ray.data.extensions import ArrowTensorType, ArrowVariableShapedTensorType
+    from ray.data.extensions import ArrowTensorType, ArrowTensorTypeV2, ArrowVariableShapedTensorType
 
     # Single flat list of chunks across all chunked arrays.
     chunks = []
@@ -178,7 +178,7 @@ def _concatenate_chunked_arrays(arrs: "pyarrow.ChunkedArray") -> "pyarrow.Chunke
         if type_ is None:
             type_ = arr.type
         else:
-            if isinstance(type_, (ArrowTensorType, ArrowVariableShapedTensorType)):
+            if isinstance(type_, (ArrowTensorType, ArrowTensorTypeV2, ArrowVariableShapedTensorType)):
                 raise ValueError(
                     "_concatenate_chunked_arrays should only be used on non-tensor "
                     f"extension types, but got a chunked array of type {type_}."
@@ -238,7 +238,7 @@ def concat(blocks: List["pyarrow.Table"]) -> "pyarrow.Table":
                 col_chunked_arrays.append(block.column(col_name))
             if isinstance(
                 schema.field(col_name).type,
-                (ArrowTensorType, ArrowVariableShapedTensorType),
+                (ArrowTensorType, ArrowTensorTypeV2, ArrowVariableShapedTensorType),
             ):
                 # For our tensor extension types, manually construct a chunked array
                 # containing chunks from all blocks. This is to handle

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -90,7 +90,11 @@ def unify_schemas(
                 cols_with_null_list.add(col_name)
             all_columns.add(col_name)
 
-    arrow_tensor_types = (ArrowVariableShapedTensorType, ArrowTensorType, ArrowTensorTypeV2)
+    arrow_tensor_types = (
+        ArrowVariableShapedTensorType,
+        ArrowTensorType,
+        ArrowTensorTypeV2,
+    )
     columns_with_objects = set()
     columns_with_tensor_array = set()
     for col_name in all_columns:
@@ -123,7 +127,9 @@ def unify_schemas(
         if ArrowTensorType._need_variable_shaped_tensor_array(tensor_array_types):
             if isinstance(tensor_array_types[0], ArrowVariableShapedTensorType):
                 new_type = tensor_array_types[0]
-            elif isinstance(tensor_array_types[0], (ArrowTensorType, ArrowTensorTypeV2)):
+            elif isinstance(
+                tensor_array_types[0], (ArrowTensorType, ArrowTensorTypeV2)
+            ):
                 new_type = ArrowVariableShapedTensorType(
                     dtype=tensor_array_types[0].scalar_type,
                     ndim=len(tensor_array_types[0].shape),
@@ -169,7 +175,11 @@ def _concatenate_chunked_arrays(arrs: "pyarrow.ChunkedArray") -> "pyarrow.Chunke
     """
     Concatenate provided chunked arrays into a single chunked array.
     """
-    from ray.data.extensions import ArrowTensorType, ArrowTensorTypeV2, ArrowVariableShapedTensorType
+    from ray.data.extensions import (
+        ArrowTensorType,
+        ArrowTensorTypeV2,
+        ArrowVariableShapedTensorType,
+    )
 
     # Single flat list of chunks across all chunked arrays.
     chunks = []
@@ -178,7 +188,10 @@ def _concatenate_chunked_arrays(arrs: "pyarrow.ChunkedArray") -> "pyarrow.Chunke
         if type_ is None:
             type_ = arr.type
         else:
-            if isinstance(type_, (ArrowTensorType, ArrowTensorTypeV2, ArrowVariableShapedTensorType)):
+            if isinstance(
+                type_,
+                (ArrowTensorType, ArrowTensorTypeV2, ArrowVariableShapedTensorType),
+            ):
                 raise ValueError(
                     "_concatenate_chunked_arrays should only be used on non-tensor "
                     f"extension types, but got a chunked array of type {type_}."

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -74,6 +74,8 @@ DEFAULT_MIN_PARALLELISM = 200
 
 DEFAULT_ENABLE_TENSOR_EXTENSION_CASTING = True
 
+DEFAULT_SHOULD_USE_TENSOR_V2 = env_bool("RAY_DATA_SHOULD_USE_TENSOR_V2", False)
+
 DEFAULT_AUTO_LOG_STATS = False
 
 DEFAULT_VERBOSE_STATS_LOG = False
@@ -286,6 +288,7 @@ class DataContext:
     min_parallelism: int = DEFAULT_MIN_PARALLELISM
     read_op_min_num_blocks: int = DEFAULT_READ_OP_MIN_NUM_BLOCKS
     enable_tensor_extension_casting: bool = DEFAULT_ENABLE_TENSOR_EXTENSION_CASTING
+    should_use_tensor_v2: bool = DEFAULT_SHOULD_USE_TENSOR_V2
     enable_auto_log_stats: bool = DEFAULT_AUTO_LOG_STATS
     verbose_stats_logs: bool = DEFAULT_VERBOSE_STATS_LOG
     trace_allocations: bool = DEFAULT_TRACE_ALLOCATIONS

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -74,7 +74,7 @@ DEFAULT_MIN_PARALLELISM = 200
 
 DEFAULT_ENABLE_TENSOR_EXTENSION_CASTING = True
 
-DEFAULT_SHOULD_USE_TENSOR_V2 = env_bool("RAY_DATA_SHOULD_USE_TENSOR_V2", False)
+DEFAULT_USE_ARROW_TENSOR_V2 = env_bool("RAY_DATA_USE_ARROW_TENSOR_V2", False)
 
 DEFAULT_AUTO_LOG_STATS = False
 
@@ -288,7 +288,7 @@ class DataContext:
     min_parallelism: int = DEFAULT_MIN_PARALLELISM
     read_op_min_num_blocks: int = DEFAULT_READ_OP_MIN_NUM_BLOCKS
     enable_tensor_extension_casting: bool = DEFAULT_ENABLE_TENSOR_EXTENSION_CASTING
-    should_use_tensor_v2: bool = DEFAULT_SHOULD_USE_TENSOR_V2
+    use_arrow_tensor_v2: bool = DEFAULT_USE_ARROW_TENSOR_V2
     enable_auto_log_stats: bool = DEFAULT_AUTO_LOG_STATS
     verbose_stats_logs: bool = DEFAULT_VERBOSE_STATS_LOG
     trace_allocations: bool = DEFAULT_TRACE_ALLOCATIONS

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -74,6 +74,10 @@ DEFAULT_MIN_PARALLELISM = 200
 
 DEFAULT_ENABLE_TENSOR_EXTENSION_CASTING = True
 
+# NOTE: V1 tensor type format only supports tensors of no more than 2Gb in
+#       total cumulative size (due to it internally utilizing int32 offsets)
+#
+#       V2 in turn relies on int64 offsets, therefore having a limit of ~9Eb (exabytes)
 DEFAULT_USE_ARROW_TENSOR_V2 = env_bool("RAY_DATA_USE_ARROW_TENSOR_V2", False)
 
 DEFAULT_AUTO_LOG_STATS = False

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -5197,7 +5197,7 @@ class Schema:
         for dtype in self.base_schema.types:
             if isinstance(dtype, TensorDtype):
 
-                if DataContext.use_arrow_tensor_v2:
+                if self.context.use_arrow_tensor_v2:
                     pa_tensor_type_class = ArrowTensorTypeV2
                 else:
                     pa_tensor_type_class = ArrowTensorType

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -5197,7 +5197,7 @@ class Schema:
         for dtype in self.base_schema.types:
             if isinstance(dtype, TensorDtype):
 
-                if DataContext.should_use_tensor_v2:
+                if DataContext.use_arrow_tensor_v2:
                     pa_tensor_type_class = ArrowTensorTypeV2
                 else:
                     pa_tensor_type_class = ArrowTensorType

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -5197,7 +5197,7 @@ class Schema:
         for dtype in self.base_schema.types:
             if isinstance(dtype, TensorDtype):
 
-                if self.context.use_arrow_tensor_v2:
+                if DataContext.get_current().use_arrow_tensor_v2:
                     pa_tensor_type_class = ArrowTensorTypeV2
                 else:
                     pa_tensor_type_class = ArrowTensorType

--- a/python/ray/data/extensions/__init__.py
+++ b/python/ray/data/extensions/__init__.py
@@ -1,3 +1,4 @@
+from ray.air.util.tensor_extensions.arrow import ArrowTensorTypeV2
 from ray.data.extensions.object_extension import (
     ArrowPythonObjectArray,
     ArrowPythonObjectScalar,
@@ -24,6 +25,7 @@ __all__ = [
     "TensorArray",
     "TensorArrayElement",
     "ArrowTensorType",
+    "ArrowTensorTypeV2",
     "ArrowTensorArray",
     "ArrowVariableShapedTensorType",
     "ArrowVariableShapedTensorArray",

--- a/python/ray/data/extensions/__init__.py
+++ b/python/ray/data/extensions/__init__.py
@@ -1,4 +1,7 @@
-from ray.air.util.tensor_extensions.arrow import ArrowTensorTypeV2
+from ray.air.util.tensor_extensions.arrow import (
+    ArrowTensorTypeV2,
+    get_arrow_extension_tensor_types,
+)
 from ray.data.extensions.object_extension import (
     ArrowPythonObjectArray,
     ArrowPythonObjectScalar,
@@ -38,4 +41,5 @@ __all__ = [
     "PythonObjectArray",
     "PythonObjectDtype",
     "object_extension_type_allowed",
+    "get_arrow_extension_tensor_types"
 ]

--- a/python/ray/data/extensions/__init__.py
+++ b/python/ray/data/extensions/__init__.py
@@ -41,5 +41,5 @@ __all__ = [
     "PythonObjectArray",
     "PythonObjectDtype",
     "object_extension_type_allowed",
-    "get_arrow_extension_tensor_types"
+    "get_arrow_extension_tensor_types",
 ]

--- a/python/ray/data/extensions/tensor_extension.py
+++ b/python/ray/data/extensions/tensor_extension.py
@@ -2,6 +2,7 @@ from ray.air.util.tensor_extensions.arrow import (  # noqa: F401
     ArrowConversionError,
     ArrowTensorArray,
     ArrowTensorType,
+    ArrowTensorTypeV2,
     ArrowVariableShapedTensorArray,
     ArrowVariableShapedTensorType,
 )

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -11,6 +11,7 @@ import pytest
 from pytest_lazyfixture import lazy_fixture
 
 import ray
+from ray.air.util.tensor_extensions.arrow import (ArrowTensorType, ArrowTensorTypeV2)
 from ray.data._internal.datasource.parquet_bulk_datasource import ParquetBulkDatasource
 from ray.data._internal.datasource.parquet_datasource import (
     NUM_CPUS_FOR_META_FETCH_TASK,
@@ -1202,6 +1203,91 @@ def test_partitioning_in_dataset_kwargs_raises_error(ray_start_regular_shared):
         ray.data.read_parquet(
             "example://iris.parquet", dataset_kwargs=dict(partitioning="hive")
         )
+
+
+def test_tensors_in_tables_parquet(
+    ray_start_regular_shared, tmp_path, restore_data_context
+):
+    """This test verifies both V1 and V2 Tensor Type extensions of
+    Arrow Array types
+    """
+
+    num_rows = 100
+    num_groups = 10
+
+    inner_shape = (2, 2, 2)
+    shape = (num_rows,) + inner_shape
+    num_tensor_elem = np.prod(np.array(shape))
+
+    arr = np.arange(num_tensor_elem).reshape(shape)
+
+    id_col_name = "_id"
+    group_col_name = "group"
+    tensor_col_name = "tensor"
+
+    id_vals = list(range(num_rows))
+    group_vals = [i % num_groups for i in id_vals]
+
+    df = pd.DataFrame({
+        id_col_name: id_vals,
+        group_col_name: group_vals,
+        tensor_col_name: [a.tobytes() for a in arr]
+    })
+
+    #
+    # Test #1: Verify writing tensors as ArrowTensorType (v1)
+    #
+
+    tensor_v1_path = f"{tmp_path}/tensor_v1"
+
+    ds = ray.data.from_pandas([df])
+    ds.write_parquet(tensor_v1_path)
+
+    ds = ray.data.read_parquet(
+        tensor_v1_path,
+        tensor_column_schema={tensor_col_name: (arr.dtype, inner_shape)},
+        override_num_blocks=10
+    )
+
+    assert isinstance(
+        ds.schema().base_schema.field_by_name(tensor_col_name).type, ArrowTensorType
+    )
+
+    expected_tuples = list(zip(id_vals, group_vals, arr))
+
+    def _assert_equal(rows, expected):
+        values = [[s[id_col_name], s[group_col_name], s[tensor_col_name]] for s in rows]
+
+        assert len(values) == len(expected)
+
+        for v, e in zip(sorted(values, key=lambda v: v[0]), expected):
+            np.testing.assert_equal(v, e)
+
+    _assert_equal(ds.take_all(), expected_tuples)
+
+
+    #
+    # Test #2: Verify writing tensors as ArrowTensorTypeV2
+    #
+
+    DataContext.get_current().should_use_tensor_v2 = True
+
+    tensor_v2_path = f"{tmp_path}/tensor_v2"
+
+    ds = ray.data.from_pandas([df])
+    ds.write_parquet(tensor_v2_path)
+
+    ds = ray.data.read_parquet(
+        tensor_v2_path,
+        tensor_column_schema={tensor_col_name: (arr.dtype, inner_shape)},
+        override_num_blocks=10
+    )
+
+    assert isinstance(
+        ds.schema().base_schema.field_by_name(tensor_col_name).type, ArrowTensorTypeV2
+    )
+
+    _assert_equal(ds.take_all(), expected_tuples)
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -1212,7 +1212,7 @@ def test_tensors_in_tables_parquet(
     Arrow Array types
     """
 
-    num_rows = 100
+    num_rows = 10_000
     num_groups = 10
 
     inner_shape = (2, 2, 2)

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -11,7 +11,7 @@ import pytest
 from pytest_lazyfixture import lazy_fixture
 
 import ray
-from ray.air.util.tensor_extensions.arrow import (ArrowTensorType, ArrowTensorTypeV2)
+from ray.air.util.tensor_extensions.arrow import ArrowTensorType, ArrowTensorTypeV2
 from ray.data._internal.datasource.parquet_bulk_datasource import ParquetBulkDatasource
 from ray.data._internal.datasource.parquet_datasource import (
     NUM_CPUS_FOR_META_FETCH_TASK,
@@ -1228,11 +1228,13 @@ def test_tensors_in_tables_parquet(
     id_vals = list(range(num_rows))
     group_vals = [i % num_groups for i in id_vals]
 
-    df = pd.DataFrame({
-        id_col_name: id_vals,
-        group_col_name: group_vals,
-        tensor_col_name: [a.tobytes() for a in arr]
-    })
+    df = pd.DataFrame(
+        {
+            id_col_name: id_vals,
+            group_col_name: group_vals,
+            tensor_col_name: [a.tobytes() for a in arr],
+        }
+    )
 
     #
     # Test #1: Verify writing tensors as ArrowTensorType (v1)
@@ -1246,7 +1248,7 @@ def test_tensors_in_tables_parquet(
     ds = ray.data.read_parquet(
         tensor_v1_path,
         tensor_column_schema={tensor_col_name: (arr.dtype, inner_shape)},
-        override_num_blocks=10
+        override_num_blocks=10,
     )
 
     assert isinstance(
@@ -1265,7 +1267,6 @@ def test_tensors_in_tables_parquet(
 
     _assert_equal(ds.take_all(), expected_tuples)
 
-
     #
     # Test #2: Verify writing tensors as ArrowTensorTypeV2
     #
@@ -1280,7 +1281,7 @@ def test_tensors_in_tables_parquet(
     ds = ray.data.read_parquet(
         tensor_v2_path,
         tensor_column_schema={tensor_col_name: (arr.dtype, inner_shape)},
-        override_num_blocks=10
+        override_num_blocks=10,
     )
 
     assert isinstance(

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -1271,7 +1271,7 @@ def test_tensors_in_tables_parquet(
     # Test #2: Verify writing tensors as ArrowTensorTypeV2
     #
 
-    DataContext.get_current().should_use_tensor_v2 = True
+    DataContext.get_current().use_arrow_tensor_v2 = True
 
     tensor_v2_path = f"{tmp_path}/tensor_v2"
 

--- a/python/ray/data/tests/test_tensor.py
+++ b/python/ray/data/tests/test_tensor.py
@@ -26,7 +26,9 @@ from ray.tests.conftest import *  # noqa
 
 # https://github.com/ray-project/ray/issues/33695
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_large_tensor_creation(ray_start_regular_shared, restore_data_context, tensor_format):
+def test_large_tensor_creation(
+    ray_start_regular_shared, restore_data_context, tensor_format
+):
     """Tests that large tensor read task creation can complete successfully without
     hanging."""
 
@@ -321,7 +323,9 @@ def test_tensors_sort(ray_start_regular_shared, restore_data_context, tensor_for
 
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_tensors_inferred_from_map(ray_start_regular_shared, restore_data_context, tensor_format):
+def test_tensors_inferred_from_map(
+    ray_start_regular_shared, restore_data_context, tensor_format
+):
     DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
 
     # Test map.
@@ -542,7 +546,9 @@ def test_tensor_array_boolean_slice_pandas_roundtrip(init_with_pandas, test_data
 
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_tensors_in_tables_from_pandas(ray_start_regular_shared, restore_data_context, tensor_format):
+def test_tensors_in_tables_from_pandas(
+    ray_start_regular_shared, restore_data_context, tensor_format
+):
     DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
 
     outer_dim = 3
@@ -561,7 +567,9 @@ def test_tensors_in_tables_from_pandas(ray_start_regular_shared, restore_data_co
 
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_tensors_in_tables_from_pandas_variable_shaped(ray_start_regular_shared, restore_data_context, tensor_format):
+def test_tensors_in_tables_from_pandas_variable_shaped(
+    ray_start_regular_shared, restore_data_context, tensor_format
+):
     DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
 
     shapes = [(2, 2), (3, 3), (4, 4)]
@@ -634,7 +642,9 @@ def test_tensors_in_tables_pandas_roundtrip_variable_shaped(
 
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_tensors_in_tables_parquet_roundtrip(ray_start_regular_shared, tmp_path, restore_data_context, tensor_format):
+def test_tensors_in_tables_parquet_roundtrip(
+    ray_start_regular_shared, tmp_path, restore_data_context, tensor_format
+):
     DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
 
     outer_dim = 3
@@ -678,8 +688,13 @@ def test_tensors_in_tables_parquet_roundtrip_variable_shaped(
 
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_tensors_in_tables_parquet_with_schema(ray_start_regular_shared, tmp_path, restore_data_context, tensor_format,
-                                               tensor_type=ArrowTensorType):
+def test_tensors_in_tables_parquet_with_schema(
+    ray_start_regular_shared,
+    tmp_path,
+    restore_data_context,
+    tensor_format,
+    tensor_type=ArrowTensorType,
+):
     DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
 
     outer_dim = 3
@@ -849,7 +864,8 @@ def test_tensors_in_tables_parquet_bytes_manual_serde_udf(
         raise ValueError(f"Unexpected tensor format: {tensor_format}")
 
     assert isinstance(
-        ds.schema().base_schema.field_by_name(tensor_col_name).type, expected_tensor_type
+        ds.schema().base_schema.field_by_name(tensor_col_name).type,
+        expected_tensor_type,
     )
 
     values = [[s["one"], s["two"]] for s in ds.take()]
@@ -895,7 +911,8 @@ def test_tensors_in_tables_parquet_bytes_manual_serde_col_schema(
         raise ValueError(f"Unexpected tensor format: {tensor_format}")
 
     assert isinstance(
-        ds.schema().base_schema.field_by_name(tensor_col_name).type, expected_tensor_type
+        ds.schema().base_schema.field_by_name(tensor_col_name).type,
+        expected_tensor_type,
     )
 
     values = [[s["one"], s["two"]] for s in ds.take()]
@@ -942,7 +959,7 @@ def test_tensors_in_tables_iter_batches(
     ray_start_regular_shared,
     enable_automatic_tensor_extension_cast,
     restore_data_context,
-    tensor_format
+    tensor_format,
 ):
     DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
 

--- a/python/ray/data/tests/test_tensor.py
+++ b/python/ray/data/tests/test_tensor.py
@@ -42,7 +42,9 @@ def test_tensors_basic(ray_start_regular_shared):
         "Dataset(num_rows=6, schema={data: numpy.ndarray(shape=(3, 5), dtype=int64)})"
     )
     # The actual size is slightly larger due to metadata.
-    assert math.isclose(ds.size_bytes(), 5 * 3 * 6 * 8, rel_tol=0.1)
+    # We add 6 (one per tensor) offset values of 8 bytes each to account for the
+    # in-memory representation of the PyArrow LargeList type
+    assert math.isclose(ds.size_bytes(), 5 * 3 * 6 * 8 + 6 * 8, rel_tol=0.1)
 
     # Test row iterator yields tensors.
     for tensor in ds.iter_rows():

--- a/python/ray/data/tests/test_tensor.py
+++ b/python/ray/data/tests/test_tensor.py
@@ -32,7 +32,7 @@ def test_large_tensor_creation(
     """Tests that large tensor read task creation can complete successfully without
     hanging."""
 
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     start_time = time.time()
     ray.data.range_tensor(1000, override_num_blocks=1000, shape=(80, 80, 100, 100))
@@ -44,7 +44,7 @@ def test_large_tensor_creation(
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 def test_tensors_basic(ray_start_regular_shared, restore_data_context, tensor_format):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     # Create directly.
     tensor_shape = (3, 5)
@@ -226,7 +226,7 @@ def test_tensors_basic(ray_start_regular_shared, restore_data_context, tensor_fo
 def test_batch_tensors(ray_start_regular_shared, restore_data_context, tensor_format):
     import torch
 
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     ds = ray.data.from_items(
         [torch.tensor([0, 0]) for _ in range(40)], override_num_blocks=40
@@ -245,7 +245,7 @@ def test_batch_tensors(ray_start_regular_shared, restore_data_context, tensor_fo
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 def test_tensors_shuffle(ray_start_regular_shared, restore_data_context, tensor_format):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     # Test Arrow table representation.
     tensor_shape = (3, 5)
@@ -285,7 +285,7 @@ def test_tensors_shuffle(ray_start_regular_shared, restore_data_context, tensor_
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 def test_tensors_sort(ray_start_regular_shared, restore_data_context, tensor_format):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     # Test Arrow table representation.
     t = pa.table({"a": TensorArray(np.arange(32).reshape((2, 4, 4))), "b": [1, 2]})
@@ -326,7 +326,7 @@ def test_tensors_sort(ray_start_regular_shared, restore_data_context, tensor_for
 def test_tensors_inferred_from_map(
     ray_start_regular_shared, restore_data_context, tensor_format
 ):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     # Test map.
     ds = ray.data.range(10, override_num_blocks=10).map(
@@ -396,7 +396,7 @@ def test_tensors_inferred_from_map(
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 def test_tensor_array_block_slice(restore_data_context, tensor_format):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     # Test that ArrowBlock slicing works with tensor column extension type.
     def check_for_copy(table1, table2, a, b, is_copy):
@@ -549,7 +549,7 @@ def test_tensor_array_boolean_slice_pandas_roundtrip(init_with_pandas, test_data
 def test_tensors_in_tables_from_pandas(
     ray_start_regular_shared, restore_data_context, tensor_format
 ):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     outer_dim = 3
     inner_shape = (2, 2, 2)
@@ -570,7 +570,7 @@ def test_tensors_in_tables_from_pandas(
 def test_tensors_in_tables_from_pandas_variable_shaped(
     ray_start_regular_shared, restore_data_context, tensor_format
 ):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     shapes = [(2, 2), (3, 3), (4, 4)]
     cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
@@ -596,7 +596,7 @@ def test_tensors_in_tables_pandas_roundtrip(
     restore_data_context,
     tensor_format,
 ):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     outer_dim = 3
     inner_shape = (2, 2, 2)
@@ -620,7 +620,7 @@ def test_tensors_in_tables_pandas_roundtrip_variable_shaped(
     restore_data_context,
     tensor_format,
 ):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     shapes = [(2, 2), (3, 3), (4, 4)]
     cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
@@ -645,7 +645,7 @@ def test_tensors_in_tables_pandas_roundtrip_variable_shaped(
 def test_tensors_in_tables_parquet_roundtrip(
     ray_start_regular_shared, tmp_path, restore_data_context, tensor_format
 ):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     outer_dim = 3
     inner_shape = (2, 2, 2)
@@ -667,7 +667,7 @@ def test_tensors_in_tables_parquet_roundtrip(
 def test_tensors_in_tables_parquet_roundtrip_variable_shaped(
     ray_start_regular_shared, tmp_path, restore_data_context, tensor_format
 ):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     shapes = [(2, 2), (3, 3), (4, 4)]
     cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
@@ -695,7 +695,7 @@ def test_tensors_in_tables_parquet_with_schema(
     tensor_format,
     tensor_type=ArrowTensorType,
 ):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     outer_dim = 3
     inner_shape = (2, 2, 2)
@@ -732,7 +732,7 @@ def test_tensors_in_tables_parquet_pickle_manual_serde(
 ):
     import pickle
 
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     outer_dim = 3
     inner_shape = (2, 2, 2)
@@ -778,7 +778,7 @@ def test_tensors_in_tables_parquet_pickle_manual_serde(
 def test_tensors_in_tables_parquet_bytes_manual_serde(
     ray_start_regular_shared, tmp_path, restore_data_context, tensor_format
 ):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     outer_dim = 3
     inner_shape = (2, 2, 2)
@@ -823,7 +823,7 @@ def test_tensors_in_tables_parquet_bytes_manual_serde(
 def test_tensors_in_tables_parquet_bytes_manual_serde_udf(
     ray_start_regular_shared, tmp_path, restore_data_context, tensor_format
 ):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     outer_dim = 3
     inner_shape = (2, 2, 2)
@@ -878,7 +878,7 @@ def test_tensors_in_tables_parquet_bytes_manual_serde_udf(
 def test_tensors_in_tables_parquet_bytes_manual_serde_col_schema(
     ray_start_regular_shared, tmp_path, restore_data_context, tensor_format
 ):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     outer_dim = 3
     inner_shape = (2, 2, 2)
@@ -961,7 +961,7 @@ def test_tensors_in_tables_iter_batches(
     restore_data_context,
     tensor_format,
 ):
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     outer_dim = 3
     inner_shape = (2, 2, 2)
@@ -999,7 +999,7 @@ def test_ragged_tensors(ray_start_regular_shared, restore_data_context, tensor_f
     ArrowVariableShapedTensorType when a column contains ragged tensors."""
     import numpy as np
 
-    DataContext.get_current().should_use_tensor_v2 = tensor_format == "v2"
+    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     ds = ray.data.from_items(
         [


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, when using tensor type in Ray Data if single tensor in a block grows above 2Gb (due to use of signed `int32` as offsets) this would result in the following issue:

```
pyarrow.lib.ArrowInvalid: offset overflow while concatenating arrays
```

Consequently, this change adds support for tensors of > 2Gb in size, while maintaining compatibility with existing datasets already using tensors.

This is done by forking off `ArrowTensorType` in 2:

 - `ArrowTensorType` (v1) remaining intact
 - `ArrowTensorTypeV2` is rebased on Arrow's `LargeListType` as well as now using `int64` offsets

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
