### PR TITLE
[core] Change many Ray ID logs to WithField.

### DIFF
--- a/src/ray/common/ray_syncer/ray_syncer.cc
+++ b/src/ray/common/ray_syncer/ray_syncer.cc
@@ -73,7 +73,8 @@ bool NodeState::ConsumeSyncMessage(std::shared_ptr<const RaySyncMessage> message
   current = message;
   auto receiver = receivers_[message->message_type()];
   if (receiver != nullptr) {
-    RAY_LOG(DEBUG) << "Consume message from: " << NodeID::FromBinary(message->node_id());
+    RAY_LOG(DEBUG).WithField(NodeID::FromBinary(message->node_id()))
+        << "Consume message from node";
     receiver->ConsumeSyncMessage(message);
   }
   return true;

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1850,8 +1850,8 @@ Status CoreWorker::Delete(const std::vector<ObjectID> &object_ids, bool local_on
   // Send a batch delete call per owner id.
   for (const auto &entry : by_owner) {
     if (entry.first != worker_context_.GetWorkerID()) {
-      RAY_LOG(INFO) << "Deleting remote objects " << entry.second.size() << " "
-                    << entry.first;
+      RAY_LOG(INFO).WithField(entry.first)
+          << "Deleting remote objects " << entry.second.size();
       auto conn = core_worker_client_pool_->GetOrConnect(addresses[entry.first]);
       rpc::DeleteObjectsRequest request;
       for (const auto &obj_id : entry.second) {
@@ -1932,10 +1932,10 @@ Status CoreWorker::GetLocationFromOwner(
                         CreateObjectLocation(reply.object_location_infos(i))));
               }
             } else {
-              RAY_LOG(WARNING) << "Failed to query location information for objects "
-                               << debug_string(owner_object_ids) << " owned by "
-                               << owner_address.worker_id()
-                               << " with error: " << status.ToString();
+              RAY_LOG(WARNING).WithField(WorkerID::FromBinary(owner_address.worker_id()))
+                  << "Failed to query location information for objects "
+                  << debug_string(owner_object_ids)
+                  << " owned by worker with error: " << status.ToString();
             }
             (*num_remaining)--;
             if (*num_remaining == 0) {
@@ -1999,8 +1999,9 @@ Status CoreWorker::PushError(const JobID &job_id,
                              const std::string &error_message,
                              double timestamp) {
   if (options_.is_local_mode) {
-    RAY_LOG(ERROR) << "Pushed Error with JobID: " << job_id << " of type: " << type
-                   << " with message: " << error_message << " at time: " << timestamp;
+    RAY_LOG(ERROR).WithField(job_id)
+        << "Pushed Error with job of type: " << type << " with message: " << error_message
+        << " at time: " << timestamp;
     return Status::OK();
   }
   return local_raylet_client_->PushError(job_id, type, error_message, timestamp);
@@ -3697,9 +3698,10 @@ void CoreWorker::ProcessSubscribeForObjectEviction(
   const auto object_id = ObjectID::FromBinary(message.object_id());
   const auto intended_worker_id = WorkerID::FromBinary(message.intended_worker_id());
   if (intended_worker_id != worker_context_.GetWorkerID()) {
-    RAY_LOG(INFO) << "The SubscribeForObjectEviction message for object id " << object_id
-                  << " is for " << intended_worker_id << ", but the current worker id is "
-                  << worker_context_.GetWorkerID() << ". The RPC will be no-op.";
+    RAY_LOG(INFO).WithField(object_id)
+        << "The SubscribeForObjectEviction message for object is for worker "
+        << intended_worker_id << ", but the current worker is "
+        << worker_context_.GetWorkerID() << ". The RPC will be no-op.";
     unpin_object(object_id);
     return;
   }
@@ -3777,7 +3779,7 @@ void CoreWorker::HandlePubsubLongPolling(rpc::PubsubLongPollingRequest request,
                                          rpc::PubsubLongPollingReply *reply,
                                          rpc::SendReplyCallback send_reply_callback) {
   const auto subscriber_id = NodeID::FromBinary(request.subscriber_id());
-  RAY_LOG(DEBUG) << "Got a long polling request from a node " << subscriber_id;
+  RAY_LOG(DEBUG).WithField(subscriber_id) << "Got a long polling request from a node";
   object_info_publisher_->ConnectToSubscriber(
       request, reply, std::move(send_reply_callback));
 }
@@ -3842,9 +3844,9 @@ void CoreWorker::AddSpilledObjectLocationOwner(
     const std::string &spilled_url,
     const NodeID &spilled_node_id,
     const std::optional<ObjectID> &generator_id) {
-  RAY_LOG(DEBUG) << "Received object spilled location update for object " << object_id
-                 << ", which has been spilled to " << spilled_url << " on node "
-                 << spilled_node_id;
+  RAY_LOG(DEBUG).WithField(object_id).WithField(spilled_node_id)
+      << "Received object spilled location update for object, which has been spilled to "
+      << spilled_url << " on node";
   if (generator_id.has_value()) {
     // For dynamically generated return values, the raylet may spill the
     // primary copy before we know about the object. This can happen when the
@@ -3863,21 +3865,20 @@ void CoreWorker::AddSpilledObjectLocationOwner(
   auto reference_exists =
       reference_counter_->HandleObjectSpilled(object_id, spilled_url, spilled_node_id);
   if (!reference_exists) {
-    RAY_LOG(DEBUG) << "Object " << object_id << " not found";
+    RAY_LOG(DEBUG).WithField(object_id) << "Object not found";
   }
 }
 
 void CoreWorker::AddObjectLocationOwner(const ObjectID &object_id,
                                         const NodeID &node_id) {
   if (gcs_client_->Nodes().Get(node_id, /*filter_dead_nodes=*/true) == nullptr) {
-    RAY_LOG(DEBUG) << "Attempting to add object location for a dead node. "
-                   << "Ignoring this request. object_id: " << object_id
-                   << ", node_id: " << node_id;
+    RAY_LOG(DEBUG).WithField(node_id).WithField(object_id)
+        << "Attempting to add object location for a dead node. Ignoring this request.";
     return;
   }
   auto reference_exists = reference_counter_->AddObjectLocation(object_id, node_id);
   if (!reference_exists) {
-    RAY_LOG(DEBUG) << "Object " + object_id.Hex() + " not found";
+    RAY_LOG(DEBUG).WithField(object_id) << "Object not found";
   }
 
   // For generator tasks where we haven't yet received the task reply, the
@@ -3913,8 +3914,8 @@ void CoreWorker::ProcessSubscribeObjectLocations(
   const auto object_id = ObjectID::FromBinary(message.object_id());
 
   if (intended_worker_id != worker_context_.GetWorkerID()) {
-    RAY_LOG(INFO) << "The ProcessSubscribeObjectLocations message is for "
-                  << intended_worker_id << ", but the current worker id is "
+    RAY_LOG(INFO) << "The ProcessSubscribeObjectLocations message is for worker "
+                  << intended_worker_id << ", but the current worker is "
                   << worker_context_.GetWorkerID() << ". The RPC will be no-op.";
     object_info_publisher_->PublishFailure(
         rpc::ChannelType::WORKER_OBJECT_LOCATIONS_CHANNEL, object_id.Binary());
@@ -3971,8 +3972,8 @@ void CoreWorker::ProcessSubscribeForRefRemoved(
 
   const auto intended_worker_id = WorkerID::FromBinary(message.intended_worker_id());
   if (intended_worker_id != worker_context_.GetWorkerID()) {
-    RAY_LOG(INFO) << "The ProcessSubscribeForRefRemoved message is for "
-                  << intended_worker_id << ", but the current worker id is "
+    RAY_LOG(INFO) << "The ProcessSubscribeForRefRemoved message is for worker "
+                  << intended_worker_id << ", but the current worker is "
                   << worker_context_.GetWorkerID() << ". The RPC will be no-op.";
     ref_removed_callback(object_id);
     return;
@@ -4717,8 +4718,8 @@ void CoreWorker::UpdateTaskIsDebuggerPaused(const TaskID &task_id,
   auto current_task_it = current_tasks_.find(task_id);
   RAY_CHECK(current_task_it != current_tasks_.end())
       << "We should have set the current task spec before executing the task.";
-  RAY_LOG(DEBUG) << "Task " << current_task_it->second.TaskId()
-                 << " is paused by debugger set to" << is_debugger_paused;
+  RAY_LOG(DEBUG).WithField(current_task_it->second.TaskId())
+      << "Task is paused by debugger set to " << is_debugger_paused;
   RAY_UNUSED(task_manager_->RecordTaskStatusEventIfNeeded(
       task_id,
       worker_context_.GetCurrentJobID(),
@@ -4744,8 +4745,8 @@ void ClusterSizeBasedLeaseRequestRateLimiter::OnNodeChanges(
     if (num_alive_nodes_ != 0) {
       num_alive_nodes_--;
     } else {
-      RAY_LOG(WARNING) << "Node" << data.node_manager_address()
-                       << " change state to DEAD but num_alive_node is 0.";
+      RAY_LOG(WARNING).WithField(NodeID::FromBinary(data.node_manager_address()))
+          << " change state to DEAD but num_alive_node is 0.";
     }
   } else {
     num_alive_nodes_++;

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -4745,8 +4745,8 @@ void ClusterSizeBasedLeaseRequestRateLimiter::OnNodeChanges(
     if (num_alive_nodes_ != 0) {
       num_alive_nodes_--;
     } else {
-      RAY_LOG(WARNING).WithField(NodeID::FromBinary(data.node_manager_address()))
-          << " change state to DEAD but num_alive_node is 0.";
+      RAY_LOG(WARNING) << "Node" << data.node_manager_address()
+                       << " change state to DEAD but num_alive_node is 0.";
     }
   } else {
     num_alive_nodes_++;

--- a/src/ray/core_worker/object_recovery_manager.cc
+++ b/src/ray/core_worker/object_recovery_manager.cc
@@ -37,8 +37,8 @@ bool ObjectRecoveryManager::RecoverObject(const ObjectID &object_id) {
   }
 
   if (!owned_by_us) {
-    RAY_LOG(DEBUG) << "Reconstruction for borrowed objects (" << object_id
-                   << ") is not supported";
+    RAY_LOG(DEBUG).WithField(object_id)
+        << "Reconstruction for borrowed object is not supported";
     return false;
   }
 
@@ -54,12 +54,12 @@ bool ObjectRecoveryManager::RecoverObject(const ObjectID &object_id) {
   }
 
   if (!already_pending_recovery) {
-    RAY_LOG(DEBUG) << "Starting recovery for object " << object_id;
+    RAY_LOG(DEBUG).WithField(object_id) << "Starting recovery for object";
     in_memory_store_->GetAsync(
         object_id, [this, object_id](std::shared_ptr<RayObject> obj) {
           absl::MutexLock lock(&mu_);
           RAY_CHECK(objects_pending_recovery_.erase(object_id)) << object_id;
-          RAY_LOG(INFO) << "Recovery complete for object " << object_id;
+          RAY_LOG(INFO).WithField(object_id) << "Recovery complete for object";
         });
     // Lookup the object in the GCS to find another copy.
     RAY_CHECK_OK(object_lookup_(
@@ -68,10 +68,10 @@ bool ObjectRecoveryManager::RecoverObject(const ObjectID &object_id) {
           PinOrReconstructObject(object_id, locations);
         }));
   } else if (requires_recovery) {
-    RAY_LOG(DEBUG) << "Recovery already started for object " << object_id;
+    RAY_LOG(DEBUG).WithField(object_id) << "Recovery already started for object";
   } else {
-    RAY_LOG(INFO) << "Object " << object_id
-                  << " has a pinned or spilled location, skipping recovery " << pinned_at;
+    RAY_LOG(INFO).WithField(object_id).WithField(pinned_at)
+        << "Object has a pinned or spilled location, skipping recovery";
     // If the object doesn't exist in the memory store
     // (core_worker.cc removes the object from memory store before calling this method),
     // we need to add it back to indicate that it's available.
@@ -84,8 +84,8 @@ bool ObjectRecoveryManager::RecoverObject(const ObjectID &object_id) {
 
 void ObjectRecoveryManager::PinOrReconstructObject(
     const ObjectID &object_id, const std::vector<rpc::Address> &locations) {
-  RAY_LOG(DEBUG) << "Lost object " << object_id << " has " << locations.size()
-                 << " locations";
+  RAY_LOG(DEBUG).WithField(object_id)
+      << "Lost object has " << locations.size() << " locations";
   if (!locations.empty()) {
     auto locations_copy = locations;
     const auto location = locations_copy.back();
@@ -104,8 +104,8 @@ void ObjectRecoveryManager::PinExistingObjectCopy(
   // If a copy still exists, pin the object by sending a
   // PinObjectIDs RPC.
   const auto node_id = NodeID::FromBinary(raylet_address.raylet_id());
-  RAY_LOG(DEBUG) << "Trying to pin copy of lost object " << object_id << " at node "
-                 << node_id;
+  RAY_LOG(DEBUG).WithField(object_id).WithField(node_id)
+      << "Trying to pin copy of lost object at node";
 
   std::shared_ptr<PinObjectsInterface> client;
   if (node_id == NodeID::FromBinary(rpc_address_.raylet_id())) {
@@ -114,7 +114,7 @@ void ObjectRecoveryManager::PinExistingObjectCopy(
     absl::MutexLock lock(&mu_);
     auto client_it = remote_object_pinning_clients_.find(node_id);
     if (client_it == remote_object_pinning_clients_.end()) {
-      RAY_LOG(DEBUG) << "Connecting to raylet " << node_id;
+      RAY_LOG(DEBUG).WithField(node_id) << "Connecting to raylet";
       client_it = remote_object_pinning_clients_
                       .emplace(node_id,
                                client_factory_(raylet_address.ip_address(),
@@ -137,8 +137,8 @@ void ObjectRecoveryManager::PinExistingObjectCopy(
                            reference_counter_->UpdateObjectPinnedAtRaylet(object_id,
                                                                           node_id);
                          } else {
-                           RAY_LOG(INFO) << "Error pinning new copy of lost object "
-                                         << object_id << ", trying again";
+                           RAY_LOG(INFO).WithField(object_id)
+                               << "Error pinning new copy of lost object, trying again";
                            PinOrReconstructObject(object_id, other_locations);
                          }
                        });
@@ -147,7 +147,7 @@ void ObjectRecoveryManager::PinExistingObjectCopy(
 void ObjectRecoveryManager::ReconstructObject(const ObjectID &object_id) {
   bool lineage_evicted = false;
   if (!reference_counter_->IsObjectReconstructable(object_id, &lineage_evicted)) {
-    RAY_LOG(DEBUG) << "Object " << object_id << " is not reconstructable";
+    RAY_LOG(DEBUG).WithField(object_id) << "Object is not reconstructable";
     if (lineage_evicted) {
       // TODO(swang): We may not report the LINEAGE_EVICTED error (just reports
       // general OBJECT_UNRECONSTRUCTABLE error) if lineage eviction races with
@@ -163,7 +163,7 @@ void ObjectRecoveryManager::ReconstructObject(const ObjectID &object_id) {
     return;
   }
 
-  RAY_LOG(DEBUG) << "Attempting to reconstruct object " << object_id;
+  RAY_LOG(DEBUG).WithField(object_id) << "Attempting to reconstruct object";
   // Notify the task manager that we are retrying the task that created this
   // object.
   const auto task_id = object_id.TaskId();
@@ -181,7 +181,7 @@ void ObjectRecoveryManager::ReconstructObject(const ObjectID &object_id) {
     for (const auto &dep : task_deps) {
       auto recovered = RecoverObject(dep);
       if (!recovered) {
-        RAY_LOG(INFO) << "Failed to reconstruct object " << dep;
+        RAY_LOG(INFO).WithField(dep) << "Failed to reconstruct object";
         // This case can happen if the dependency was borrowed from another
         // worker, or if there was a bug in reconstruction that caused us to GC
         // the dependency ref.
@@ -192,8 +192,8 @@ void ObjectRecoveryManager::ReconstructObject(const ObjectID &object_id) {
       }
     }
   } else {
-    RAY_LOG(INFO) << "Failed to reconstruct object " << object_id
-                  << " because lineage has already been deleted";
+    RAY_LOG(INFO).WithField(object_id)
+        << "Failed to reconstruct object because lineage has already been deleted";
     reference_counter_->UpdateObjectPendingCreation(object_id, false);
     recovery_failure_callback_(
         object_id,

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -948,11 +948,11 @@ void ReferenceCounter::PopAndClearLocalBorrowers(
   ReferenceTableToProto(borrowed_refs, proto);
 
   for (const auto &borrowed_id : borrowed_ids) {
-    RAY_LOG(DEBUG).WithField(borrowed_id) << "Remove local reference to borrowed object ";
+    RAY_LOG(DEBUG).WithField(borrowed_id) << "Remove local reference to borrowed object.";
     auto it = object_id_refs_.find(borrowed_id);
     if (it == object_id_refs_.end()) {
       RAY_LOG(WARNING).WithField(borrowed_id)
-          << "Tried to decrease ref count for nonexistent object ID: ";
+          << "Tried to decrease ref count for nonexistent object.";
       continue;
     }
     if (it->second.local_ref_count == 0) {
@@ -974,8 +974,7 @@ bool ReferenceCounter::GetAndClearLocalBorrowersInternal(
     bool for_ref_removed,
     bool deduct_local_ref,
     ReferenceProtoTable *borrowed_refs) {
-  RAY_LOG(DEBUG).WithField(object_id)
-      << "Pop " << object_id << " for_ref_removed " << for_ref_removed;
+  RAY_LOG(DEBUG).WithField(object_id) << "Pop object for_ref_removed " << for_ref_removed;
   auto it = object_id_refs_.find(object_id);
   if (it == object_id_refs_.end()) {
     return false;

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -851,10 +851,10 @@ void ReferenceCounter::UpdateObjectPinnedAtRaylet(const ObjectID &object_id,
     // The object is still in scope. Track the raylet location until the object
     // has gone out of scope or the raylet fails, whichever happens first.
     if (it->second.pinned_at_raylet_id.has_value()) {
-      RAY_LOG(INFO) << "Updating primary location for object " << object_id << " to node "
-                    << raylet_id << ", but it already has a primary location "
-                    << *it->second.pinned_at_raylet_id
-                    << ". This should only happen during reconstruction";
+      RAY_LOG(INFO).WithField(object_id)
+          << "Updating primary location for object to node " << raylet_id
+          << ", but it already has a primary location " << *it->second.pinned_at_raylet_id
+          << ". This should only happen during reconstruction";
     }
     // Only the owner tracks the location.
     RAY_CHECK(it->second.owned_by_us);
@@ -948,17 +948,17 @@ void ReferenceCounter::PopAndClearLocalBorrowers(
   ReferenceTableToProto(borrowed_refs, proto);
 
   for (const auto &borrowed_id : borrowed_ids) {
-    RAY_LOG(DEBUG) << "Remove local reference to borrowed object " << borrowed_id;
+    RAY_LOG(DEBUG).WithField(borrowed_id) << "Remove local reference to borrowed object ";
     auto it = object_id_refs_.find(borrowed_id);
     if (it == object_id_refs_.end()) {
-      RAY_LOG(WARNING) << "Tried to decrease ref count for nonexistent object ID: "
-                       << borrowed_id;
+      RAY_LOG(WARNING).WithField(borrowed_id)
+          << "Tried to decrease ref count for nonexistent object ID: ";
       continue;
     }
     if (it->second.local_ref_count == 0) {
-      RAY_LOG(WARNING)
-          << "Tried to decrease ref count for object ID that has count 0 " << borrowed_id
-          << ". This should only happen if ray.internal.free was called earlier.";
+      RAY_LOG(WARNING).WithField(borrowed_id)
+          << "Tried to decrease ref count for object ID that has count 0. This should "
+             "only happen if ray.internal.free was called earlier.";
     } else {
       it->second.local_ref_count--;
     }
@@ -974,7 +974,8 @@ bool ReferenceCounter::GetAndClearLocalBorrowersInternal(
     bool for_ref_removed,
     bool deduct_local_ref,
     ReferenceProtoTable *borrowed_refs) {
-  RAY_LOG(DEBUG) << "Pop " << object_id << " for_ref_removed " << for_ref_removed;
+  RAY_LOG(DEBUG).WithField(object_id)
+      << "Pop " << object_id << " for_ref_removed " << for_ref_removed;
   auto it = object_id_refs_.find(object_id);
   if (it == object_id_refs_.end()) {
     return false;
@@ -1019,20 +1020,18 @@ bool ReferenceCounter::GetAndClearLocalBorrowersInternal(
 void ReferenceCounter::MergeRemoteBorrowers(const ObjectID &object_id,
                                             const rpc::Address &worker_addr,
                                             const ReferenceTable &borrowed_refs) {
-  RAY_LOG(DEBUG) << "Merging ref " << object_id;
+  RAY_LOG(DEBUG).WithField(object_id) << "Merging ref";
   auto borrower_it = borrowed_refs.find(object_id);
   if (borrower_it == borrowed_refs.end()) {
     return;
   }
   const auto &borrower_ref = borrower_it->second;
-  RAY_LOG(DEBUG) << "Borrower ref " << object_id << " has "
-                 << borrower_ref.borrow().borrowers.size() << " borrowers"
-                 << ", local: " << borrower_ref.local_ref_count
-                 << ", submitted: " << borrower_ref.submitted_task_ref_count
-                 << ", contained_in_owned: "
-                 << borrower_ref.nested().contained_in_owned.size()
-                 << ", stored_in_objects: "
-                 << borrower_ref.borrow().stored_in_objects.size();
+  RAY_LOG(DEBUG).WithField(object_id)
+      << "Borrower ref has " << borrower_ref.borrow().borrowers.size() << " borrowers"
+      << ", local: " << borrower_ref.local_ref_count
+      << ", submitted: " << borrower_ref.submitted_task_ref_count
+      << ", contained_in_owned: " << borrower_ref.nested().contained_in_owned.size()
+      << ", stored_in_objects: " << borrower_ref.borrow().stored_in_objects.size();
 
   auto it = object_id_refs_.find(object_id);
   if (it == object_id_refs_.end()) {
@@ -1045,8 +1044,11 @@ void ReferenceCounter::MergeRemoteBorrowers(const ObjectID &object_id,
     auto inserted = it->second.mutable_borrow()->borrowers.insert(worker_addr).second;
     // If we are the owner of id, then send WaitForRefRemoved to borrower.
     if (inserted) {
-      RAY_LOG(DEBUG) << "Adding borrower " << worker_addr.ip_address() << ":"
-                     << worker_addr.port() << " to id " << object_id;
+      RAY_LOG(DEBUG)
+              .WithField(WorkerID::FromBinary(worker_addr.worker_id()))
+              .WithField(object_id)
+          << "Adding borrower " << worker_addr.ip_address() << ":" << worker_addr.port()
+          << " to object";
       new_borrowers.push_back(worker_addr);
     }
   }
@@ -1055,8 +1057,11 @@ void ReferenceCounter::MergeRemoteBorrowers(const ObjectID &object_id,
   for (const auto &nested_borrower : borrower_ref.borrow().borrowers) {
     auto inserted = it->second.mutable_borrow()->borrowers.insert(nested_borrower).second;
     if (inserted) {
-      RAY_LOG(DEBUG) << "Adding borrower " << nested_borrower.ip_address() << ":"
-                     << nested_borrower.port() << " to id " << object_id;
+      RAY_LOG(DEBUG)
+              .WithField(WorkerID::FromBinary(nested_borrower.worker_id()))
+              .WithField(object_id)
+          << "Adding borrower " << nested_borrower.ip_address() << ":"
+          << nested_borrower.port() << " to object";
       new_borrowers.push_back(nested_borrower);
     }
   }
@@ -1118,8 +1123,8 @@ void ReferenceCounter::WaitForRefRemoved(const ReferenceTable::iterator &ref_it,
                                          const rpc::Address &addr,
                                          const ObjectID &contained_in_id) {
   const ObjectID &object_id = ref_it->first;
-  RAY_LOG(DEBUG) << "WaitForRefRemoved " << object_id
-                 << ", dest=" << WorkerID::FromBinary(addr.worker_id());
+  RAY_LOG(DEBUG).WithField(object_id).WithField(WorkerID::FromBinary(addr.worker_id()))
+      << "WaitForRefRemoved object, dest worker";
   auto sub_message = std::make_unique<rpc::SubMessage>();
   auto *request = sub_message->mutable_worker_ref_removed_message();
   // Only the owner should send requests to borrowers.
@@ -1132,19 +1137,19 @@ void ReferenceCounter::WaitForRefRemoved(const ReferenceTable::iterator &ref_it,
   request->set_subscriber_worker_id(rpc_address_.worker_id());
 
   // If the message is published, this callback will be invoked.
-  const auto message_published_callback =
-      [this, addr, object_id](const rpc::PubMessage &msg) {
-        RAY_CHECK(msg.has_worker_ref_removed_message());
-        const ReferenceTable new_borrower_refs =
-            ReferenceTableFromProto(msg.worker_ref_removed_message().borrowed_refs());
-        RAY_LOG(DEBUG) << "WaitForRefRemoved returned for " << object_id
-                       << ", dest=" << WorkerID::FromBinary(addr.worker_id());
+  const auto message_published_callback = [this, addr, object_id](
+                                              const rpc::PubMessage &msg) {
+    RAY_CHECK(msg.has_worker_ref_removed_message());
+    const ReferenceTable new_borrower_refs =
+        ReferenceTableFromProto(msg.worker_ref_removed_message().borrowed_refs());
+    RAY_LOG(DEBUG).WithField(object_id).WithField(WorkerID::FromBinary(addr.worker_id()))
+        << "WaitForRefRemoved returned for object, dest worker";
 
-        CleanupBorrowersOnRefRemoved(new_borrower_refs, object_id, addr);
-        // Unsubscribe the object once the message is published.
-        RAY_CHECK(object_info_subscriber_->Unsubscribe(
-            rpc::ChannelType::WORKER_REF_REMOVED_CHANNEL, addr, object_id.Binary()));
-      };
+    CleanupBorrowersOnRefRemoved(new_borrower_refs, object_id, addr);
+    // Unsubscribe the object once the message is published.
+    RAY_CHECK(object_info_subscriber_->Unsubscribe(
+        rpc::ChannelType::WORKER_REF_REMOVED_CHANNEL, addr, object_id.Binary()));
+  };
 
   // If the borrower is failed, this callback will be called.
   const auto publisher_failed_callback = [this, addr](const std::string &object_id_binary,
@@ -1152,8 +1157,8 @@ void ReferenceCounter::WaitForRefRemoved(const ReferenceTable::iterator &ref_it,
     // When the request is failed, there's no new borrowers ref published from this
     // borrower.
     const auto object_id = ObjectID::FromBinary(object_id_binary);
-    RAY_LOG(DEBUG) << "WaitForRefRemoved failed for " << object_id
-                   << ", dest=" << WorkerID::FromBinary(addr.worker_id());
+    RAY_LOG(DEBUG).WithField(object_id).WithField(WorkerID::FromBinary(addr.worker_id()))
+        << "WaitForRefRemoved failed for object, dest worker";
     CleanupBorrowersOnRefRemoved({}, object_id, addr);
   };
 
@@ -1189,8 +1194,8 @@ void ReferenceCounter::AddNestedObjectIdsInternal(const ObjectID &object_id,
       // until the outer object goes out of scope.
       for (const auto &inner_id : inner_ids) {
         it->second.mutable_nested()->contains.insert(inner_id);
-        RAY_LOG(DEBUG) << "Setting inner ID " << inner_id
-                       << " contained_in_owned: " << object_id;
+        RAY_LOG(DEBUG).WithField(inner_id)
+            << "Setting inner ID " << inner_id << " contained_in_owned: " << object_id;
       }
       // WARNING: Following loop could invalidate `it` iterator on insertion.
       // That's why we use two loops, and we should avoid using `it` hearafter.
@@ -1207,9 +1212,9 @@ void ReferenceCounter::AddNestedObjectIdsInternal(const ObjectID &object_id,
     // We do not own object_id. This is the case where we returned an object ID
     // from a task, and the task's caller executed in a remote process.
     for (const auto &inner_id : inner_ids) {
-      RAY_LOG(DEBUG) << "Adding borrower " << owner_address.ip_address() << ":"
-                     << owner_address.port() << " to id " << inner_id
-                     << ", borrower owns outer ID " << object_id;
+      RAY_LOG(DEBUG).WithField(inner_id)
+          << "Adding borrower " << owner_address.ip_address() << ":"
+          << owner_address.port() << " to object, borrower owns outer ID " << object_id;
       auto inner_it = object_id_refs_.find(inner_id);
       if (inner_it == object_id_refs_.end()) {
         inner_it = object_id_refs_.emplace(inner_id, Reference()).first;
@@ -1236,7 +1241,7 @@ void ReferenceCounter::AddNestedObjectIdsInternal(const ObjectID &object_id,
 }
 
 void ReferenceCounter::HandleRefRemoved(const ObjectID &object_id) {
-  RAY_LOG(DEBUG) << "HandleRefRemoved " << object_id;
+  RAY_LOG(DEBUG).WithField(object_id) << "HandleRefRemoved ";
   auto it = object_id_refs_.find(object_id);
   if (it != object_id_refs_.end()) {
     PRINT_REF_COUNT(it);
@@ -1247,8 +1252,9 @@ void ReferenceCounter::HandleRefRemoved(const ObjectID &object_id) {
                                                /*deduct_local_ref=*/false,
                                                &borrowed_refs));
   for (const auto &[id, ref] : borrowed_refs) {
-    RAY_LOG(DEBUG) << id << " has " << ref.borrowers().size() << " borrowers, stored in "
-                   << ref.stored_in_objects().size();
+    RAY_LOG(DEBUG).WithField(id)
+        << "Object has " << ref.borrowers().size() << " borrowers, stored in "
+        << ref.stored_in_objects().size();
   }
 
   // Send the owner information about any new borrowers.
@@ -1259,9 +1265,9 @@ void ReferenceCounter::HandleRefRemoved(const ObjectID &object_id) {
   ReferenceTableToProto(borrowed_refs,
                         worker_ref_removed_message->mutable_borrowed_refs());
 
-  RAY_LOG(DEBUG) << "Publishing WaitForRefRemoved message for " << object_id
-                 << ", message has " << worker_ref_removed_message->borrowed_refs().size()
-                 << " borrowed references.";
+  RAY_LOG(DEBUG).WithField(object_id)
+      << "Publishing WaitForRefRemoved message for object, message has "
+      << worker_ref_removed_message->borrowed_refs().size() << " borrowed references.";
   object_info_publisher_->Publish(std::move(pub_message));
 }
 
@@ -1271,8 +1277,8 @@ void ReferenceCounter::SetRefRemovedCallback(
     const rpc::Address &owner_address,
     const ReferenceCounter::ReferenceRemovedCallback &ref_removed_callback) {
   absl::MutexLock lock(&mutex_);
-  RAY_LOG(DEBUG) << "Received WaitForRefRemoved " << object_id << " contained in "
-                 << contained_in_id;
+  RAY_LOG(DEBUG).WithField(object_id)
+      << "Received WaitForRefRemoved object contained in " << contained_in_id;
 
   auto it = object_id_refs_.find(object_id);
   if (it == object_id_refs_.end()) {
@@ -1287,8 +1293,8 @@ void ReferenceCounter::SetRefRemovedCallback(
   }
 
   if (it->second.RefCount() == 0) {
-    RAY_LOG(DEBUG) << "Ref count for borrowed object " << object_id
-                   << " is already 0, responding to WaitForRefRemoved";
+    RAY_LOG(DEBUG).WithField(object_id)
+        << "Ref count for borrowed object is already 0, responding to WaitForRefRemoved";
     // We already stopped borrowing the object ID. Respond to the owner
     // immediately.
     ref_removed_callback(object_id);
@@ -1303,8 +1309,9 @@ void ReferenceCounter::SetRefRemovedCallback(
       // callback here, it's possible we will drop the request that was sent by
       // the more recent owner. We should fix this by setting multiple
       // callbacks or by versioning the owner requests.
-      RAY_LOG(WARNING) << "on_ref_removed already set for " << object_id
-                       << ". The owner task must have died and been re-executed.";
+      RAY_LOG(WARNING).WithField(object_id)
+          << "on_ref_removed already set for object. The owner task must have died and "
+             "been re-executed.";
     }
     it->second.on_ref_removed = ref_removed_callback;
   }
@@ -1321,9 +1328,10 @@ bool ReferenceCounter::AddObjectLocation(const ObjectID &object_id,
   absl::MutexLock lock(&mutex_);
   auto it = object_id_refs_.find(object_id);
   if (it == object_id_refs_.end()) {
-    RAY_LOG(DEBUG) << "Tried to add an object location for an object " << object_id
-                   << " that doesn't exist in the reference table. It can happen if the "
-                      "object is already evicted.";
+    RAY_LOG(DEBUG).WithField(object_id)
+        << "Tried to add an object location for an object that doesn't exist in the "
+           "reference table. It can happen if the "
+           "object is already evicted.";
     return false;
   }
   AddObjectLocationInternal(it, node_id);
@@ -1332,7 +1340,7 @@ bool ReferenceCounter::AddObjectLocation(const ObjectID &object_id,
 
 void ReferenceCounter::AddObjectLocationInternal(ReferenceTable::iterator it,
                                                  const NodeID &node_id) {
-  RAY_LOG(DEBUG) << "Adding location " << node_id << " for object " << it->first;
+  RAY_LOG(DEBUG).WithField(node_id).WithField(it->first) << "Adding location for object";
   if (it->second.locations.emplace(node_id).second) {
     // Only push to subscribers if we added a new location. We eagerly add the pinned
     // location without waiting for the object store notification to trigger a location
@@ -1344,12 +1352,14 @@ void ReferenceCounter::AddObjectLocationInternal(ReferenceTable::iterator it,
 bool ReferenceCounter::RemoveObjectLocation(const ObjectID &object_id,
                                             const NodeID &node_id) {
   absl::MutexLock lock(&mutex_);
-  RAY_LOG(DEBUG) << "Removing location " << node_id << " for object " << object_id;
+  RAY_LOG(DEBUG).WithField(node_id).WithField(object_id)
+      << "Removing location for object";
   auto it = object_id_refs_.find(object_id);
   if (it == object_id_refs_.end()) {
-    RAY_LOG(DEBUG) << "Tried to remove an object location for an object " << object_id
-                   << " that doesn't exist in the reference table. It can happen if the "
-                      "object is already evicted.";
+    RAY_LOG(DEBUG).WithField(object_id)
+        << "Tried to remove an object location for an object that doesn't exist in the "
+           "reference table. It can happen if the "
+           "object is already evicted.";
     return false;
   }
   RemoveObjectLocationInternal(it, node_id);
@@ -1380,8 +1390,9 @@ absl::optional<absl::flat_hash_set<NodeID>> ReferenceCounter::GetObjectLocations
   absl::MutexLock lock(&mutex_);
   auto it = object_id_refs_.find(object_id);
   if (it == object_id_refs_.end()) {
-    RAY_LOG(DEBUG) << "Tried to get the object locations for an object " << object_id
-                   << " that doesn't exist in the reference table";
+    RAY_LOG(DEBUG).WithField(object_id)
+        << "Tried to get the object locations for an object that doesn't exist in the "
+           "reference table";
     return absl::nullopt;
   }
   return it->second.locations;
@@ -1393,7 +1404,7 @@ bool ReferenceCounter::HandleObjectSpilled(const ObjectID &object_id,
   absl::MutexLock lock(&mutex_);
   auto it = object_id_refs_.find(object_id);
   if (it == object_id_refs_.end()) {
-    RAY_LOG(WARNING) << "Spilled object " << object_id << " already out of scope";
+    RAY_LOG(WARNING).WithField(object_id) << "Spilled object already out of scope";
     return false;
   }
   if (it->second.OutOfScope(lineage_pinning_enabled_) && !spilled_node_id.IsNil()) {
@@ -1417,8 +1428,8 @@ bool ReferenceCounter::HandleObjectSpilled(const ObjectID &object_id,
     }
     PushToLocationSubscribers(it);
   } else {
-    RAY_LOG(DEBUG) << "Object " << object_id << " spilled to dead node "
-                   << spilled_node_id;
+    RAY_LOG(DEBUG).WithField(spilled_node_id).WithField(object_id)
+        << "Object spilled to dead node ";
     DeleteObjectPrimaryCopy(it);
     objects_to_recover_.push_back(object_id);
   }
@@ -1433,8 +1444,8 @@ absl::optional<LocalityData> ReferenceCounter::GetLocalityData(
   if (it == object_id_refs_.end()) {
     // We don't have any information about this object so we can't return valid locality
     // data.
-    RAY_LOG(DEBUG) << "Object " << object_id
-                   << " not in reference table, locality data not available";
+    RAY_LOG(DEBUG).WithField(object_id)
+        << "Object not in reference table, locality data not available";
     return absl::nullopt;
   }
 
@@ -1442,9 +1453,9 @@ absl::optional<LocalityData> ReferenceCounter::GetLocalityData(
   const auto object_size = it->second.object_size;
   if (object_size < 0) {
     // We don't know the object size so we can't returned valid locality data.
-    RAY_LOG(DEBUG) << "Reference [" << it->second.call_site << "] for object "
-                   << object_id
-                   << " has an unknown object size, locality data not available";
+    RAY_LOG(DEBUG).WithField(object_id)
+        << "Reference [" << it->second.call_site
+        << "] for object has an unknown object size, locality data not available";
     return absl::nullopt;
   }
 
@@ -1472,9 +1483,9 @@ bool ReferenceCounter::ReportLocalityData(const ObjectID &object_id,
   absl::MutexLock lock(&mutex_);
   auto it = object_id_refs_.find(object_id);
   if (it == object_id_refs_.end()) {
-    RAY_LOG(DEBUG) << "Tried to report locality data for an object " << object_id
-                   << " that doesn't exist in the reference table."
-                   << " The object has probably already been freed.";
+    RAY_LOG(DEBUG).WithField(object_id) << "Tried to report locality data for an object "
+                                           "that doesn't exist in the reference table."
+                                        << " The object has probably already been freed.";
     return false;
   }
   RAY_CHECK(!it->second.owned_by_us)
@@ -1500,8 +1511,8 @@ void ReferenceCounter::AddBorrowerAddress(const ObjectID &object_id,
   RAY_CHECK(borrower_address.worker_id() != rpc_address_.worker_id())
       << "The borrower cannot be the owner itself";
 
-  RAY_LOG(DEBUG) << "Add borrower " << borrower_address.DebugString() << " for object "
-                 << object_id;
+  RAY_LOG(DEBUG).WithField(object_id)
+      << "Add borrower " << borrower_address.DebugString() << " for object";
   auto inserted = it->second.mutable_borrow()->borrowers.insert(borrower_address).second;
   if (inserted) {
     WaitForRefRemoved(it, borrower_address);
@@ -1545,12 +1556,12 @@ void ReferenceCounter::PushToLocationSubscribers(ReferenceTable::iterator it) {
   const auto &spilled_node_id = it->second.spilled_node_id;
   const auto &optional_primary_node_id = it->second.pinned_at_raylet_id;
   const auto &primary_node_id = optional_primary_node_id.value_or(NodeID::Nil());
-  RAY_LOG(DEBUG) << "Published message for " << object_id << ", " << locations.size()
-                 << " locations, spilled url: [" << spilled_url
-                 << "], spilled node ID: " << spilled_node_id
-                 << ", and object size: " << object_size
-                 << ", and primary node ID: " << primary_node_id << ", pending creation? "
-                 << it->second.pending_creation;
+  RAY_LOG(DEBUG).WithField(object_id)
+      << "Published message for object, " << locations.size()
+      << " locations, spilled url: [" << spilled_url
+      << "], spilled node ID: " << spilled_node_id << ", and object size: " << object_size
+      << ", and primary node ID: " << primary_node_id << ", pending creation? "
+      << it->second.pending_creation;
   rpc::PubMessage pub_message;
   pub_message.set_key_id(object_id.Binary());
   pub_message.set_channel_type(rpc::ChannelType::WORKER_OBJECT_LOCATIONS_CHANNEL);
@@ -1566,9 +1577,10 @@ void ReferenceCounter::FillObjectInformation(
   absl::MutexLock lock(&mutex_);
   auto it = object_id_refs_.find(object_id);
   if (it == object_id_refs_.end()) {
-    RAY_LOG(WARNING) << "Object locations requested for " << object_id
-                     << ", but ref already removed. This may be a bug in the distributed "
-                        "reference counting protocol.";
+    RAY_LOG(WARNING).WithField(object_id)
+        << "Object locations requested for object, but ref already removed. This may be "
+           "a bug in the distributed "
+           "reference counting protocol.";
     object_info->set_ref_removed(true);
   } else {
     FillObjectInformationInternal(it, object_info);
@@ -1596,9 +1608,10 @@ void ReferenceCounter::PublishObjectLocationSnapshot(const ObjectID &object_id) 
   absl::MutexLock lock(&mutex_);
   auto it = object_id_refs_.find(object_id);
   if (it == object_id_refs_.end()) {
-    RAY_LOG(WARNING) << "Object locations requested for " << object_id
-                     << ", but ref already removed. This may be a bug in the distributed "
-                        "reference counting protocol.";
+    RAY_LOG(WARNING).WithField(object_id)
+        << "Object locations requested for object, but ref already removed. This may be "
+           "a bug in the distributed "
+           "reference counting protocol.";
     // First let subscribers handle this error.
     rpc::PubMessage pub_message;
     pub_message.set_key_id(object_id.Binary());

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -35,8 +35,8 @@ JobInfoAccessor::JobInfoAccessor(GcsClient *client_impl) : client_impl_(client_i
 Status JobInfoAccessor::AsyncAdd(const std::shared_ptr<JobTableData> &data_ptr,
                                  const StatusCallback &callback) {
   JobID job_id = JobID::FromBinary(data_ptr->job_id());
-  RAY_LOG(DEBUG) << "Adding job, job id = " << job_id
-                 << ", driver pid = " << data_ptr->driver_pid();
+  RAY_LOG(DEBUG).WithField(job_id)
+      << "Adding job, driver pid = " << data_ptr->driver_pid();
   rpc::AddJobRequest request;
   request.mutable_data()->CopyFrom(*data_ptr);
   client_impl_->GetGcsRpcClient().AddJob(
@@ -45,16 +45,15 @@ Status JobInfoAccessor::AsyncAdd(const std::shared_ptr<JobTableData> &data_ptr,
         if (callback) {
           callback(status);
         }
-        RAY_LOG(DEBUG) << "Finished adding job, status = " << status
-                       << ", job id = " << job_id
-                       << ", driver pid = " << data_ptr->driver_pid();
+        RAY_LOG(DEBUG).WithField(job_id) << "Finished adding job, status = " << status
+                                         << ", driver pid = " << data_ptr->driver_pid();
       });
   return Status::OK();
 }
 
 Status JobInfoAccessor::AsyncMarkFinished(const JobID &job_id,
                                           const StatusCallback &callback) {
-  RAY_LOG(DEBUG) << "Marking job state, job id = " << job_id;
+  RAY_LOG(DEBUG).WithField(job_id) << "Marking job state";
   rpc::MarkJobFinishedRequest request;
   request.set_job_id(job_id.Binary());
   client_impl_->GetGcsRpcClient().MarkJobFinished(
@@ -63,8 +62,8 @@ Status JobInfoAccessor::AsyncMarkFinished(const JobID &job_id,
         if (callback) {
           callback(status);
         }
-        RAY_LOG(DEBUG) << "Finished marking job state, status = " << status
-                       << ", job id = " << job_id;
+        RAY_LOG(DEBUG).WithField(job_id)
+            << "Finished marking job state, status = " << status;
       });
   return Status::OK();
 }
@@ -169,8 +168,7 @@ ActorInfoAccessor::ActorInfoAccessor(GcsClient *client_impl)
 
 Status ActorInfoAccessor::AsyncGet(
     const ActorID &actor_id, const OptionalItemCallback<rpc::ActorTableData> &callback) {
-  RAY_LOG(DEBUG) << "Getting actor info, actor id = " << actor_id
-                 << ", job id = " << actor_id.JobId();
+  RAY_LOG(DEBUG).WithField(actor_id).WithField(actor_id.JobId()) << "Getting actor info";
   rpc::GetActorInfoRequest request;
   request.set_actor_id(actor_id.Binary());
   client_impl_->GetGcsRpcClient().GetActorInfo(
@@ -181,9 +179,8 @@ Status ActorInfoAccessor::AsyncGet(
         } else {
           callback(status, std::nullopt);
         }
-        RAY_LOG(DEBUG) << "Finished getting actor info, status = " << status
-                       << ", actor id = " << actor_id
-                       << ", job id = " << actor_id.JobId();
+        RAY_LOG(DEBUG).WithField(actor_id).WithField(actor_id.JobId())
+            << "Finished getting actor info, status = " << status;
       });
   return Status::OK();
 }
@@ -403,8 +400,8 @@ Status ActorInfoAccessor::AsyncSubscribe(
     const ActorID &actor_id,
     const SubscribeCallback<ActorID, rpc::ActorTableData> &subscribe,
     const StatusCallback &done) {
-  RAY_LOG(DEBUG) << "Subscribing update operations of actor, actor id = " << actor_id
-                 << ", job id = " << actor_id.JobId();
+  RAY_LOG(DEBUG).WithField(actor_id).WithField(actor_id.JobId())
+      << "Subscribing update operations of actor";
   RAY_CHECK(subscribe != nullptr) << "Failed to subscribe actor, actor id = " << actor_id;
 
   auto fetch_data_operation =
@@ -439,14 +436,14 @@ Status ActorInfoAccessor::AsyncSubscribe(
 }
 
 Status ActorInfoAccessor::AsyncUnsubscribe(const ActorID &actor_id) {
-  RAY_LOG(DEBUG) << "Cancelling subscription to an actor, actor id = " << actor_id
-                 << ", job id = " << actor_id.JobId();
+  RAY_LOG(DEBUG).WithField(actor_id).WithField(actor_id.JobId())
+      << "Cancelling subscription to an actor";
   auto status = client_impl_->GetGcsSubscriber().UnsubscribeActor(actor_id);
   absl::MutexLock lock(&mutex_);
   resubscribe_operations_.erase(actor_id);
   fetch_data_operations_.erase(actor_id);
-  RAY_LOG(DEBUG) << "Finished cancelling subscription to an actor, actor id = "
-                 << actor_id << ", job id = " << actor_id.JobId();
+  RAY_LOG(DEBUG).WithField(actor_id).WithField(actor_id.JobId())
+      << "Finished cancelling subscription to an actor";
   return status;
 }
 
@@ -479,8 +476,8 @@ NodeInfoAccessor::NodeInfoAccessor(GcsClient *client_impl) : client_impl_(client
 Status NodeInfoAccessor::RegisterSelf(const GcsNodeInfo &local_node_info,
                                       const StatusCallback &callback) {
   auto node_id = NodeID::FromBinary(local_node_info.node_id());
-  RAY_LOG(DEBUG) << "Registering node info, node id = " << node_id
-                 << ", address is = " << local_node_info.node_manager_address();
+  RAY_LOG(DEBUG).WithField(node_id)
+      << "Registering node info, address is = " << local_node_info.node_manager_address();
   RAY_CHECK(local_node_id_.IsNil()) << "This node is already connected.";
   RAY_CHECK(local_node_info.state() == GcsNodeInfo::ALIVE);
   rpc::RegisterNodeRequest request;
@@ -496,8 +493,8 @@ Status NodeInfoAccessor::RegisterSelf(const GcsNodeInfo &local_node_info,
         if (callback) {
           callback(status);
         }
-        RAY_LOG(DEBUG) << "Finished registering node info, status = " << status
-                       << ", node id = " << node_id;
+        RAY_LOG(DEBUG).WithField(node_id)
+            << "Finished registering node info, status = " << status;
       });
 
   return Status::OK();
@@ -510,7 +507,7 @@ void NodeInfoAccessor::UnregisterSelf(const rpc::NodeDeathInfo &node_death_info,
     return;
   }
   auto node_id = NodeID::FromBinary(local_node_info_.node_id());
-  RAY_LOG(INFO) << "Unregistering node, node id = " << node_id;
+  RAY_LOG(INFO).WithField(node_id) << "Unregistering node";
 
   rpc::UnregisterNodeRequest request;
   request.set_node_id(local_node_info_.node_id());
@@ -523,8 +520,8 @@ void NodeInfoAccessor::UnregisterSelf(const rpc::NodeDeathInfo &node_death_info,
           local_node_info_.set_state(GcsNodeInfo::DEAD);
           local_node_id_ = NodeID::Nil();
         }
-        RAY_LOG(INFO) << "Finished unregistering node info, status = " << status
-                      << ", node id = " << node_id;
+        RAY_LOG(INFO).WithField(node_id)
+            << "Finished unregistering node info, status = " << status;
         unregister_done_callback();
       });
 }
@@ -536,7 +533,7 @@ const GcsNodeInfo &NodeInfoAccessor::GetSelfInfo() const { return local_node_inf
 Status NodeInfoAccessor::AsyncRegister(const rpc::GcsNodeInfo &node_info,
                                        const StatusCallback &callback) {
   NodeID node_id = NodeID::FromBinary(node_info.node_id());
-  RAY_LOG(DEBUG) << "Registering node info, node id = " << node_id;
+  RAY_LOG(DEBUG).WithField(node_id) << "Registering node info";
   rpc::RegisterNodeRequest request;
   request.mutable_node_info()->CopyFrom(node_info);
   client_impl_->GetGcsRpcClient().RegisterNode(
@@ -544,8 +541,8 @@ Status NodeInfoAccessor::AsyncRegister(const rpc::GcsNodeInfo &node_info,
         if (callback) {
           callback(status);
         }
-        RAY_LOG(DEBUG) << "Finished registering node info, status = " << status
-                       << ", node id = " << node_id;
+        RAY_LOG(DEBUG).WithField(node_id)
+            << "Finished registering node info, status = " << status;
       });
   return Status::OK();
 }
@@ -599,7 +596,7 @@ Status NodeInfoAccessor::AsyncCheckAlive(const std::vector<std::string> &raylet_
 
 Status NodeInfoAccessor::AsyncDrainNode(const NodeID &node_id,
                                         const StatusCallback &callback) {
-  RAY_LOG(DEBUG) << "Draining node, node id = " << node_id;
+  RAY_LOG(DEBUG).WithField(node_id) << "Draining node";
   rpc::DrainNodeRequest request;
   auto draining_request = request.add_drain_node_data();
   draining_request->set_node_id(node_id.Binary());
@@ -608,8 +605,8 @@ Status NodeInfoAccessor::AsyncDrainNode(const NodeID &node_id,
         if (callback) {
           callback(status);
         }
-        RAY_LOG(DEBUG) << "Finished draining node, status = " << status
-                       << ", node id = " << node_id;
+        RAY_LOG(DEBUG).WithField(node_id)
+            << "Finished draining node, status = " << status;
       });
   return Status::OK();
 }
@@ -762,8 +759,8 @@ void NodeInfoAccessor::HandleNotification(GcsNodeInfo &&node_info) {
   }
 
   // Add the notification to our cache.
-  RAY_LOG(INFO) << "Received notification for node id = " << node_id
-                << ", IsAlive = " << is_alive;
+  RAY_LOG(INFO).WithField(node_id)
+      << "Received notification for node, IsAlive = " << is_alive;
 
   auto &node = node_cache_[node_id];
   if (is_alive) {
@@ -1037,8 +1034,8 @@ Status WorkerInfoAccessor::AsyncUpdateWorkerNumPausedThreads(
   rpc::UpdateWorkerNumPausedThreadsRequest request;
   request.set_worker_id(worker_id.Binary());
   request.set_num_paused_threads_delta(num_paused_threads_delta);
-  RAY_LOG(DEBUG) << "Update the num paused threads on worker id = " << worker_id
-                 << " by delta = " << num_paused_threads_delta << ".";
+  RAY_LOG(DEBUG).WithField(worker_id)
+      << "Update the num paused threads by delta = " << num_paused_threads_delta << ".";
   client_impl_->GetGcsRpcClient().UpdateWorkerNumPausedThreads(
       request,
       [callback](const Status &status, rpc::UpdateWorkerNumPausedThreadsReply &&reply) {
@@ -1060,11 +1057,11 @@ Status PlacementGroupInfoAccessor::SyncCreatePlacementGroup(
   auto status = client_impl_->GetGcsRpcClient().SyncCreatePlacementGroup(
       request, &reply, GetGcsTimeoutMs());
   if (status.ok()) {
-    RAY_LOG(DEBUG) << "Finished registering placement group. placement group id = "
-                   << placement_group_spec.PlacementGroupId();
+    RAY_LOG(DEBUG).WithField(placement_group_spec.PlacementGroupId())
+        << "Finished registering placement group.";
   } else {
-    RAY_LOG(ERROR) << "Placement group id = " << placement_group_spec.PlacementGroupId()
-                   << " failed to be registered. " << status;
+    RAY_LOG(ERROR).WithField(placement_group_spec.PlacementGroupId())
+        << "Failed to be registered. " << status;
   }
   return status;
 }
@@ -1082,8 +1079,7 @@ Status PlacementGroupInfoAccessor::SyncRemovePlacementGroup(
 Status PlacementGroupInfoAccessor::AsyncGet(
     const PlacementGroupID &placement_group_id,
     const OptionalItemCallback<rpc::PlacementGroupTableData> &callback) {
-  RAY_LOG(DEBUG) << "Getting placement group info, placement group id = "
-                 << placement_group_id;
+  RAY_LOG(DEBUG).WithField(placement_group_id) << "Getting placement group info";
   rpc::GetPlacementGroupRequest request;
   request.set_placement_group_id(placement_group_id.Binary());
   client_impl_->GetGcsRpcClient().GetPlacementGroup(
@@ -1095,8 +1091,8 @@ Status PlacementGroupInfoAccessor::AsyncGet(
         } else {
           callback(status, std::nullopt);
         }
-        RAY_LOG(DEBUG) << "Finished getting placement group info, placement group id = "
-                       << placement_group_id;
+        RAY_LOG(DEBUG).WithField(placement_group_id)
+            << "Finished getting placement group info";
       });
   return Status::OK();
 }
@@ -1147,8 +1143,8 @@ Status PlacementGroupInfoAccessor::SyncWaitUntilReady(
   request.set_placement_group_id(placement_group_id.Binary());
   auto status = client_impl_->GetGcsRpcClient().SyncWaitPlacementGroupUntilReady(
       request, &reply, absl::ToInt64Milliseconds(absl::Seconds(timeout_seconds)));
-  RAY_LOG(DEBUG) << "Finished waiting placement group until ready, placement group id = "
-                 << placement_group_id;
+  RAY_LOG(DEBUG).WithField(placement_group_id)
+      << "Finished waiting placement group until ready";
   return status;
 }
 

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -1184,13 +1184,13 @@ void GcsActorManager::OnWorkerDead(const ray::NodeID &node_id,
                                      rpc::WorkerExitType_Name(disconnect_type),
                                      ", has creation_task_exception = ",
                                      (creation_task_exception != nullptr));
-  RAY_LOG(DEBUG) << "on worker dead worker id " << worker_id << " disconnect detail "
-                 << disconnect_detail;
+  RAY_LOG(DEBUG).WithField(worker_id)
+      << "on worker dead, disconnect detail " << disconnect_detail;
   if (disconnect_type == rpc::WorkerExitType::INTENDED_USER_EXIT ||
       disconnect_type == rpc::WorkerExitType::INTENDED_SYSTEM_EXIT) {
-    RAY_LOG(DEBUG) << message;
+    RAY_LOG(DEBUG).WithField(worker_id) << message;
   } else {
-    RAY_LOG(WARNING) << message;
+    RAY_LOG(WARNING).WithField(worker_id) << message;
   }
 
   bool need_reconstruct = disconnect_type != rpc::WorkerExitType::INTENDED_USER_EXIT &&
@@ -1363,8 +1363,8 @@ void GcsActorManager::RestartActor(const ActorID &actor_id,
   // could've been destroyed and dereigstered before restart.
   auto iter = registered_actors_.find(actor_id);
   if (iter == registered_actors_.end()) {
-    RAY_LOG(DEBUG) << "Actor is destroyed before restart, actor id = " << actor_id
-                   << ", job id = " << actor_id.JobId();
+    RAY_LOG(DEBUG).WithField(actor_id.JobId()).WithField(actor_id)
+        << "Actor is destroyed before restart";
     if (done_callback) {
       done_callback();
     }
@@ -1688,8 +1688,8 @@ void GcsActorManager::RemoveUnresolvedActor(const std::shared_ptr<GcsActor> &act
 void GcsActorManager::RemoveActorFromOwner(const std::shared_ptr<GcsActor> &actor) {
   const auto &actor_id = actor->GetActorID();
   const auto &owner_id = actor->GetOwnerID();
-  RAY_LOG(DEBUG) << "Erasing actor " << actor_id << " owned by " << owner_id
-                 << ", job id = " << actor_id.JobId();
+  RAY_LOG(DEBUG).WithField(actor_id).WithField(owner_id).WithField(actor_id.JobId())
+      << "Erasing actor owned by worker";
 
   const auto &owner_node_id = actor->GetOwnerNodeID();
   auto &node = owners_[owner_node_id];
@@ -1713,16 +1713,19 @@ void GcsActorManager::NotifyCoreWorkerToKillActor(const std::shared_ptr<GcsActor
   request.mutable_death_cause()->CopyFrom(death_cause);
   request.set_force_kill(force_kill);
   auto actor_client = worker_client_factory_(actor->GetAddress());
-  RAY_LOG(DEBUG) << "Send request to kill actor " << actor->GetActorID() << " to worker "
-                 << actor->GetWorkerID() << " at node " << actor->GetNodeID();
+  RAY_LOG(DEBUG)
+          .WithField(actor->GetActorID())
+          .WithField(actor->GetWorkerID())
+          .WithField(actor->GetNodeID())
+      << "Send request to kill actor to worker at node";
   actor_client->KillActor(request, [](auto &status, auto &&) {
     RAY_LOG(DEBUG) << "Killing status: " << status.ToString();
   });
 }
 
 void GcsActorManager::KillActor(const ActorID &actor_id, bool force_kill) {
-  RAY_LOG(DEBUG) << "Killing actor, job id = " << actor_id.JobId()
-                 << ", actor id = " << actor_id << ", force_kill = " << force_kill;
+  RAY_LOG(DEBUG).WithField(actor_id.JobId()).WithField(actor_id)
+      << "Killing actor, force_kill = " << force_kill;
   auto it = registered_actors_.find(actor_id);
   if (it == registered_actors_.end()) {
     RAY_LOG(INFO) << "Tried to kill actor that does not exist " << actor_id;
@@ -1746,8 +1749,8 @@ void GcsActorManager::KillActor(const ActorID &actor_id, bool force_kill) {
         actor, GenKilledByApplicationCause(GetActor(actor_id)), force_kill);
   } else {
     const auto &task_id = actor->GetCreationTaskSpecification().TaskId();
-    RAY_LOG(DEBUG) << "The actor " << actor->GetActorID()
-                   << " hasn't been created yet, cancel scheduling " << task_id;
+    RAY_LOG(DEBUG).WithField(actor->GetActorID()).WithField(task_id)
+        << "The actor hasn't been created yet, cancel scheduling task";
     if (!worker_id.IsNil()) {
       // The actor is in phase of creating, so we need to notify the core
       // worker exit to avoid process and resource leak.
@@ -1778,8 +1781,8 @@ void GcsActorManager::AddDestroyedActorToCache(const std::shared_ptr<GcsActor> &
 
 void GcsActorManager::CancelActorInScheduling(const std::shared_ptr<GcsActor> &actor,
                                               const TaskID &task_id) {
-  RAY_LOG(DEBUG) << "Cancel actor in scheduling: actor_id " << actor->GetActorID()
-                 << ", task_id " << task_id;
+  RAY_LOG(DEBUG).WithField(actor->GetActorID()).WithField(task_id)
+      << "Cancel actor in scheduling";
   const auto &actor_id = actor->GetActorID();
   const auto &node_id = actor->GetNodeID();
   // The actor has not been created yet. It is either being scheduled or is

--- a/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.cc
@@ -199,8 +199,8 @@ void GcsAutoscalerStateManager::UpdateResourceLoadAndUsage(
   NodeID node_id = NodeID::FromBinary(data.node_id());
   auto iter = node_resource_info_.find(node_id);
   if (iter == node_resource_info_.end()) {
-    RAY_LOG(WARNING) << "Ignoring resource usage for node that is not alive: "
-                     << node_id.Hex() << ".";
+    RAY_LOG(WARNING).WithField(node_id)
+        << "Ignoring resource usage for node that is not alive.";
     return;
   }
 
@@ -355,9 +355,9 @@ void GcsAutoscalerStateManager::HandleDrainNode(
     rpc::autoscaler::DrainNodeReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
   const NodeID node_id = NodeID::FromBinary(request.node_id());
-  RAY_LOG(INFO) << "HandleDrainNode " << node_id.Hex()
-                << ", reason: " << request.reason_message()
-                << ", deadline: " << request.deadline_timestamp_ms();
+  RAY_LOG(INFO).WithField(node_id)
+      << "HandleDrainNode, reason: " << request.reason_message()
+      << ", deadline: " << request.deadline_timestamp_ms();
 
   int64_t draining_deadline_timestamp_ms = request.deadline_timestamp_ms();
   if (draining_deadline_timestamp_ms < 0) {
@@ -379,7 +379,7 @@ void GcsAutoscalerStateManager::HandleDrainNode(
       // Since gcs only stores limit number of dead nodes
       // so we don't know whether the node is dead or doesn't exist.
       // Since it's not running so still treat it as drained.
-      RAY_LOG(WARNING) << "Request to drain an unknown node " << node_id;
+      RAY_LOG(WARNING).WithField(node_id) << "Request to drain an unknown node";
       reply->set_is_accepted(true);
     }
     send_reply_callback(ray::Status::OK(), nullptr, nullptr);

--- a/src/ray/gcs/gcs_server/gcs_health_check_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_health_check_manager.cc
@@ -60,7 +60,7 @@ void GcsHealthCheckManager::RemoveNode(const NodeID &node_id) {
 }
 
 void GcsHealthCheckManager::FailNode(const NodeID &node_id) {
-  RAY_LOG(WARNING) << "Node " << node_id << " is dead because the health check failed.";
+  RAY_LOG(WARNING).WithField(node_id) << "Node is dead because the health check failed.";
   auto iter = health_check_contexts_.find(node_id);
   if (iter != health_check_contexts_.end()) {
     on_node_death_callback_(node_id);

--- a/src/ray/gcs/gcs_server/gcs_job_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_job_manager.cc
@@ -416,8 +416,8 @@ std::shared_ptr<rpc::JobConfig> GcsJobManager::GetJobConfig(const JobID &job_id)
 }
 
 void GcsJobManager::OnNodeDead(const NodeID &node_id) {
-  RAY_LOG(INFO) << "Node " << node_id
-                << " failed, mark all jobs from this node as finished";
+  RAY_LOG(INFO).WithField(node_id)
+      << "Node failed, mark all jobs from this node as finished";
 
   auto on_done = [this, node_id](const absl::flat_hash_map<JobID, JobTableData> &result) {
     // If job is not dead and from driver in current node, then mark it as finished

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -82,15 +82,16 @@ void GcsNodeManager::HandleRegisterNode(rpc::RegisterNodeRequest request,
                                         rpc::RegisterNodeReply *reply,
                                         rpc::SendReplyCallback send_reply_callback) {
   NodeID node_id = NodeID::FromBinary(request.node_info().node_id());
-  RAY_LOG(INFO) << "Registering node info, node id = " << node_id
-                << ", address = " << request.node_info().node_manager_address()
-                << ", node name = " << request.node_info().node_name();
+  RAY_LOG(INFO).WithField(node_id)
+      << "Registering node info, address = " << request.node_info().node_manager_address()
+      << ", node name = " << request.node_info().node_name();
   auto on_done = [this, node_id, request, reply, send_reply_callback](
                      const Status &status) {
     RAY_CHECK_OK(status);
-    RAY_LOG(INFO) << "Finished registering node info, node id = " << node_id
-                  << ", address = " << request.node_info().node_manager_address()
-                  << ", node name = " << request.node_info().node_name();
+    RAY_LOG(INFO).WithField(node_id)
+        << "Finished registering node info, address = "
+        << request.node_info().node_manager_address()
+        << ", node name = " << request.node_info().node_name();
     RAY_CHECK_OK(gcs_publisher_->PublishNodeInfo(node_id, request.node_info(), nullptr));
     AddNode(std::make_shared<rpc::GcsNodeInfo>(request.node_info()));
     WriteNodeExportEvent(request.node_info());
@@ -143,10 +144,10 @@ void GcsNodeManager::HandleUnregisterNode(rpc::UnregisterNodeRequest request,
                                           rpc::UnregisterNodeReply *reply,
                                           rpc::SendReplyCallback send_reply_callback) {
   NodeID node_id = NodeID::FromBinary(request.node_id());
-  RAY_LOG(DEBUG) << "HandleUnregisterNode() for node id = " << node_id;
+  RAY_LOG(DEBUG).WithField(node_id) << "HandleUnregisterNode() for node";
   auto node = RemoveNode(node_id, request.node_death_info());
   if (!node) {
-    RAY_LOG(INFO) << "Node " << node_id << " is already removed";
+    RAY_LOG(INFO).WithField(node_id) << "Node is already removed";
     return;
   }
 
@@ -186,10 +187,10 @@ void GcsNodeManager::HandleDrainNode(rpc::DrainNodeRequest request,
 }
 
 void GcsNodeManager::DrainNode(const NodeID &node_id) {
-  RAY_LOG(INFO) << "DrainNode() for node id = " << node_id;
+  RAY_LOG(INFO).WithField(node_id) << "DrainNode() for node";
   auto maybe_node = GetAliveNode(node_id);
   if (!maybe_node.has_value()) {
-    RAY_LOG(WARNING) << "Skip draining node " << node_id << " which is already removed";
+    RAY_LOG(WARNING).WithField(node_id) << "Skip draining node which is already removed";
     return;
   }
   auto node = maybe_node.value();
@@ -208,7 +209,7 @@ void GcsNodeManager::DrainNode(const NodeID &node_id) {
       node_id,
       /*graceful*/ true,
       [node_id](const Status &status, const rpc::ShutdownRayletReply &reply) {
-        RAY_LOG(INFO) << "Raylet " << node_id << " is drained. Status " << status;
+        RAY_LOG(INFO).WithField(node_id) << "Raylet is drained. Status " << status;
       });
 }
 
@@ -303,7 +304,7 @@ rpc::NodeDeathInfo GcsNodeManager::InferDeathInfo(const NodeID &node_id) {
   if (expect_force_termination) {
     death_info.set_reason(rpc::NodeDeathInfo::AUTOSCALER_DRAIN_PREEMPTED);
     death_info.set_reason_message(iter->second->reason_message());
-    RAY_LOG(INFO) << "Node " << node_id << " was forcibly preempted";
+    RAY_LOG(INFO).WithField(node_id) << "Node was forcibly preempted";
   } else {
     death_info.set_reason(rpc::NodeDeathInfo::UNEXPECTED_TERMINATION);
     death_info.set_reason_message(
@@ -332,19 +333,20 @@ void GcsNodeManager::SetNodeDraining(
     std::shared_ptr<rpc::autoscaler::DrainNodeRequest> drain_request) {
   auto maybe_node = GetAliveNode(node_id);
   if (!maybe_node.has_value()) {
-    RAY_LOG(INFO) << "Skip setting node " << node_id << " to be draining, "
-                  << "which is already removed";
+    RAY_LOG(INFO).WithField(node_id)
+        << "Skip setting node to be draining, which is already removed";
     return;
   }
   auto iter = draining_nodes_.find(node_id);
   if (iter == draining_nodes_.end()) {
     draining_nodes_.emplace(node_id, drain_request);
-    RAY_LOG(INFO) << "Set node " << node_id
-                  << " to be draining, request = " << drain_request->DebugString();
+    RAY_LOG(INFO).WithField(node_id)
+        << "Set node to be draining, request = " << drain_request->DebugString();
   } else {
-    RAY_LOG(INFO) << "Drain request for node " << node_id << " already exists. "
-                  << "Overwriting the existing request " << iter->second->DebugString()
-                  << " with the new request " << drain_request->DebugString();
+    RAY_LOG(INFO).WithField(node_id)
+        << "Drain request for node already exists. Overwriting the existing request "
+        << iter->second->DebugString() << " with the new request "
+        << drain_request->DebugString();
     iter->second = drain_request;
   }
 }
@@ -360,10 +362,10 @@ std::shared_ptr<rpc::GcsNodeInfo> GcsNodeManager::RemoveNode(
     auto death_info = removed_node->mutable_death_info();
     death_info->CopyFrom(node_death_info);
 
-    RAY_LOG(INFO) << "Removing node, node id = " << node_id
-                  << ", node name = " << removed_node->node_name() << ", death reason = "
-                  << rpc::NodeDeathInfo_Reason_Name(death_info->reason())
-                  << ", death message = " << death_info->reason_message();
+    RAY_LOG(INFO).WithField(node_id)
+        << "Removing node, node name = " << removed_node->node_name()
+        << ", death reason = " << rpc::NodeDeathInfo_Reason_Name(death_info->reason())
+        << ", death message = " << death_info->reason_message();
     // Record stats that there's a new removed node.
     stats::NodeFailureTotal.Record(1);
     // Remove from alive nodes.

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -786,8 +786,8 @@ GcsPlacementGroupManager::GetBundlesOnNode(const NodeID &node_id) const {
 }
 
 void GcsPlacementGroupManager::OnNodeDead(const NodeID &node_id) {
-  RAY_LOG(INFO) << "Node " << node_id
-                << " failed, rescheduling the placement groups on the dead node.";
+  RAY_LOG(INFO).WithField(node_id)
+      << "Node failed, rescheduling the placement groups on the dead node.";
   auto bundles = gcs_placement_group_scheduler_->GetAndRemoveBundlesOnNode(node_id);
   for (const auto &bundle : bundles) {
     auto iter = registered_placement_groups_.find(bundle.first);
@@ -799,7 +799,7 @@ void GcsPlacementGroupManager::OnNodeDead(const NodeID &node_id) {
                       << " bundle index:" << bundle_index;
       }
       // TODO(ffbin): If we have a placement group bundle that requires a unique resource
-      // (for example gpu resource when there’s only one gpu node), this can postpone
+      // (for example gpu resource when there's only one gpu node), this can postpone
       // creating until a node with the resources is added. we will solve it in next pr.
       if (iter->second->GetState() != rpc::PlacementGroupTableData::RESCHEDULING) {
         iter->second->UpdateState(rpc::PlacementGroupTableData::RESCHEDULING);

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -305,8 +305,8 @@ void GcsResourceManager::OnNodeAdd(const rpc::GcsNodeInfo &node) {
           scheduling_node_id, scheduling::ResourceID(entry.first), entry.second);
     }
   } else {
-    RAY_LOG(WARNING) << "The registered node " << node_id
-                     << " doesn't set the total resources.";
+    RAY_LOG(WARNING).WithField(node_id)
+        << "The registered node doesn't set the total resources.";
   }
 
   absl::flat_hash_map<std::string, std::string> labels(node.labels().begin(),

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -331,14 +331,15 @@ void ObjectManager::HandleSendFinished(const ObjectID &object_id,
       << " of object, chunk " << chunk_index << ", status: " << status.ToString();
   if (!status.ok()) {
     // TODO(rkn): What do we want to do if the send failed?
-    RAY_LOG(DEBUG) << "Failed to send a push request for an object " << object_id
-                   << " to " << node_id << ". Chunk index: " << chunk_index;
+    RAY_LOG(DEBUG).WithField(object_id).WithField(node_id)
+        << "Failed to send a push request for an object to node. Chunk index: "
+        << chunk_index;
   }
 }
 
 void ObjectManager::Push(const ObjectID &object_id, const NodeID &node_id) {
   RAY_LOG(DEBUG).WithField(object_id)
-      << "Push on " << self_node_id_ << " to " << node_id << " of object";
+      << "Push object on " << self_node_id_ << " to " << node_id << " of object";
   if (local_objects_.count(object_id) != 0) {
     return PushLocalObject(object_id, node_id);
   }

--- a/src/ray/object_manager/ownership_based_object_directory.cc
+++ b/src/ray/object_manager/ownership_based_object_directory.cc
@@ -78,8 +78,8 @@ bool UpdateObjectLocations(const rpc::WorkerObjectLocationsPubMessage &location_
   const std::string &new_spilled_url = location_info.spilled_url();
   if (new_spilled_url != *spilled_url) {
     const auto new_spilled_node_id = NodeID::FromBinary(location_info.spilled_node_id());
-    RAY_LOG(DEBUG) << "Received object spilled to " << new_spilled_url << " spilled on "
-                   << new_spilled_node_id;
+    RAY_LOG(DEBUG).WithField(new_spilled_node_id)
+        << "Received object spilled to " << new_spilled_url << " spilled on node";
     if (gcs_client->Nodes().IsRemoved(new_spilled_node_id)) {
       *spilled_url = "";
       *spilled_node_id = NodeID::Nil();
@@ -124,9 +124,9 @@ void OwnershipBasedObjectDirectory::ReportObjectAdded(const ObjectID &object_id,
   const auto owner_address = GetOwnerAddressFromObjectInfo(object_info);
   auto owner_client = GetClient(owner_address);
   if (owner_client == nullptr) {
-    RAY_LOG(DEBUG) << "Object " << object_id << " does not have owner. "
-                   << "ReportObjectAdded becomes a no-op."
-                   << "This should only happen for Plasma store warmup objects.";
+    RAY_LOG(DEBUG).WithField(object_id)
+        << "Object does not have owner. ReportObjectAdded becomes a no-op."
+        << "This should only happen for Plasma store warmup objects.";
     return;
   }
   metrics_num_object_locations_added_++;
@@ -147,9 +147,9 @@ void OwnershipBasedObjectDirectory::ReportObjectRemoved(const ObjectID &object_i
   const auto owner_address = GetOwnerAddressFromObjectInfo(object_info);
   auto owner_client = GetClient(owner_address);
   if (owner_client == nullptr) {
-    RAY_LOG(DEBUG) << "Object " << object_id << " does not have owner. "
-                   << "ReportObjectRemoved becomes a no-op. "
-                   << "This should only happen for Plasma store warmup objects.";
+    RAY_LOG(DEBUG).WithField(object_id)
+        << "Object does not have owner. ReportObjectRemoved becomes a no-op. "
+        << "This should only happen for Plasma store warmup objects.";
     return;
   }
   metrics_num_object_locations_removed_++;
@@ -170,15 +170,16 @@ void OwnershipBasedObjectDirectory::ReportObjectSpilled(
     const std::string &spilled_url,
     const ObjectID &generator_id,
     const bool spilled_to_local_storage) {
-  RAY_LOG(DEBUG) << "Sending spilled URL " << spilled_url << " for object " << object_id
-                 << " to owner " << WorkerID::FromBinary(owner_address.worker_id());
+  RAY_LOG(DEBUG).WithField(object_id).WithField(
+      WorkerID::FromBinary(owner_address.worker_id()))
+      << "Sending spilled URL " << spilled_url << " for object to owner worker";
 
   const WorkerID worker_id = WorkerID::FromBinary(owner_address.worker_id());
   auto owner_client = GetClient(owner_address);
   if (owner_client == nullptr) {
-    RAY_LOG(DEBUG) << "Object " << object_id << " does not have owner. "
-                   << "ReportObjectSpilled becomes a no-op. "
-                   << "This should only happen for Plasma store warmup objects.";
+    RAY_LOG(DEBUG).WithField(object_id)
+        << "Object does not have owner. ReportObjectSpilled becomes a no-op. "
+        << "This should only happen for Plasma store warmup objects.";
     return;
   }
 
@@ -253,9 +254,10 @@ void OwnershipBasedObjectDirectory::SendObjectLocationUpdateBatchIfNeeded(
           // Clean up the metadata. No need to mark objects as failed because
           // that's only needed for the object pulling path (and this RPC is not on
           // pulling path).
-          RAY_LOG(DEBUG) << "Owner " << worker_id << " failed to update locations for "
-                         << node_id << ". The owner is most likely dead. Status: "
-                         << status.ToString();
+          RAY_LOG(DEBUG).WithField(worker_id).WithField(node_id)
+              << "Owner failed to update locations for node. The owner is most likely "
+                 "dead. Status: "
+              << status.ToString();
           auto it = location_buffers_.find(worker_id);
           if (it != location_buffers_.end()) {
             location_buffers_.erase(it);
@@ -284,8 +286,8 @@ void OwnershipBasedObjectDirectory::ObjectLocationSubscriptionCallback(
   // Update entries for this object.
   for (auto const &node_id_binary : location_info.node_ids()) {
     const auto node_id = NodeID::FromBinary(node_id_binary);
-    RAY_LOG(DEBUG) << "Object " << object_id << " is on node " << node_id << " alive? "
-                   << !gcs_client_->Nodes().IsRemoved(node_id);
+    RAY_LOG(DEBUG).WithField(object_id).WithField(node_id)
+        << "Object is on node alive? " << !gcs_client_->Nodes().IsRemoved(node_id);
   }
   auto location_updated = UpdateObjectLocations(location_info,
                                                 gcs_client_,
@@ -298,12 +300,13 @@ void OwnershipBasedObjectDirectory::ObjectLocationSubscriptionCallback(
   // If the lookup has failed, that means the object is lost. Trigger the callback in this
   // case to handle failure properly.
   if (location_updated || location_lookup_failed) {
-    RAY_LOG(DEBUG) << "Pushing location updates to subscribers for object " << object_id
-                   << ": " << it->second.current_object_locations.size()
-                   << " locations, spilled_url: " << it->second.spilled_url
-                   << ", spilled node ID: " << it->second.spilled_node_id
-                   << ", object size: " << it->second.object_size
-                   << ", lookup failed: " << location_lookup_failed;
+    RAY_LOG(DEBUG).WithField(object_id)
+        << "Pushing location updates to subscribers for object: "
+        << it->second.current_object_locations.size()
+        << " locations, spilled_url: " << it->second.spilled_url
+        << ", spilled node ID: " << it->second.spilled_node_id
+        << ", object size: " << it->second.object_size
+        << ", lookup failed: " << location_lookup_failed;
     metrics_num_object_location_updates_++;
     cum_metrics_num_object_location_updates_++;
     // Copy the callbacks so that the callbacks can unsubscribe without interrupting
@@ -353,15 +356,15 @@ ray::Status OwnershipBasedObjectDirectory::SubscribeObjectLocations(
       const auto object_id = ObjectID::FromBinary(object_id_binary);
       rpc::WorkerObjectLocationsPubMessage location_info;
       if (!status.ok()) {
-        RAY_LOG(INFO) << "Failed to get the location for " << object_id
-                      << status.ToString();
+        RAY_LOG(INFO).WithField(object_id)
+            << "Failed to get the location: " << status.ToString();
         mark_as_failed_(object_id, rpc::ErrorType::OWNER_DIED);
       } else {
         // Owner is still alive but published a failure because the ref was
         // deleted.
-        RAY_LOG(INFO)
-            << "Failed to get the location for " << object_id
-            << ", object already released by distributed reference counting protocol";
+        RAY_LOG(INFO).WithField(object_id)
+            << "Failed to get the location for object, already released by distributed "
+               "reference counting protocol";
         mark_as_failed_(object_id, rpc::ErrorType::OBJECT_DELETED);
       }
       // Location lookup can fail if the owner is reachable but no longer has a
@@ -403,12 +406,11 @@ ray::Status OwnershipBasedObjectDirectory::SubscribeObjectLocations(
     auto &spilled_node_id = listener_state.spilled_node_id;
     bool pending_creation = listener_state.pending_creation;
     auto object_size = listener_state.object_size;
-    RAY_LOG(DEBUG) << "Already subscribed to object's locations, pushing location "
-                      "updates to subscribers for object "
-                   << object_id << ": " << locations.size()
-                   << " locations, spilled_url: " << spilled_url
-                   << ", spilled node ID: " << spilled_node_id
-                   << ", object size: " << object_size;
+    RAY_LOG(DEBUG).WithField(object_id)
+        << "Already subscribed to object's locations, pushing location "
+           "updates to subscribers for object: "
+        << locations.size() << " locations, spilled_url: " << spilled_url
+        << ", spilled node ID: " << spilled_node_id << ", object size: " << object_size;
     // We post the callback to the event loop in order to avoid mutating data
     // structures shared with the caller and potentially invalidating caller
     // iterators. See https://github.com/ray-project/ray/issues/2959.

--- a/src/ray/object_manager/pull_manager.cc
+++ b/src/ray/object_manager/pull_manager.cc
@@ -516,9 +516,9 @@ bool PullManager::PullFromRandomLocation(const ObjectID &object_id) {
   if (node_vector.empty()) {
     // Pull from remote node, it will be restored prior to push.
     if (!spilled_node_id.IsNil() && spilled_node_id != self_node_id_) {
-      RAY_LOG(DEBUG) << "Sending pull request from " << self_node_id_
-                     << " to spilled location at " << spilled_node_id << " of object "
-                     << object_id;
+      RAY_LOG(DEBUG).WithField(object_id)
+          << "Sending pull request from " << self_node_id_ << " to spilled location at "
+          << spilled_node_id;
       send_pull_request_(object_id, spilled_node_id);
       return true;
     }
@@ -534,8 +534,8 @@ bool PullManager::PullFromRandomLocation(const ObjectID &object_id) {
   int node_index = distribution(gen_);
   NodeID node_id = node_vector[node_index];
   RAY_CHECK(node_id != self_node_id_);
-  RAY_LOG(DEBUG) << "Sending pull request from " << self_node_id_
-                 << " to in-memory location at " << node_id << " of object " << object_id;
+  RAY_LOG(DEBUG).WithField(object_id) << "Sending pull request from " << self_node_id_
+                                      << " to in-memory location at " << node_id;
   send_pull_request_(object_id, node_id);
   return true;
 }

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -413,8 +413,8 @@ int main(int argc, char *argv[]) {
             {ray::stats::SessionNameKey, session_name}};
         ray::stats::Init(global_tags, metrics_agent_port, WorkerID::Nil());
 
-        RAY_LOG(INFO) << "Setting node ID to: " << node_id;
         ray::NodeID raylet_node_id = ray::NodeID::FromHex(node_id);
+        RAY_LOG(INFO).WithField(raylet_node_id) << "Setting node ID";
 
         node_manager_config.AddDefaultLabels(raylet_node_id.Hex());
         // Initialize the node manager.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -630,16 +630,17 @@ void NodeManager::HandleJobFinished(const JobID &job_id, const JobTableData &job
         (worker->GetAssignedJobId() == job_id)) {
       // Don't kill worker processes belonging to the detached actor
       // since those are expected to outlive the job.
-      RAY_LOG(INFO) << "The leased worker " << worker->WorkerId()
-                    << " is killed because the job " << job_id << " finished.";
+      RAY_LOG(INFO).WithField(worker->WorkerId())
+          << "The leased worker "
+          << " is killed because the job " << job_id << " finished.";
       rpc::ExitRequest request;
       request.set_force_exit(true);
       worker->rpc_client()->Exit(
           request, [this, worker](const ray::Status &status, const rpc::ExitReply &r) {
             if (!status.ok()) {
-              RAY_LOG(WARNING) << "Failed to send exit request to worker "
-                               << worker->WorkerId() << ": " << status.ToString()
-                               << ". Killing it using SIGKILL instead.";
+              RAY_LOG(WARNING).WithField(worker->WorkerId())
+                  << "Failed to send exit request to worker "
+                  << ": " << status.ToString() << ". Killing it using SIGKILL instead.";
               // Just kill-9 as a last resort.
               KillWorker(worker, /* force */ true);
             }
@@ -714,12 +715,12 @@ void NodeManager::HandleReleaseUnusedBundles(rpc::ReleaseUnusedBundlesRequest re
 
   for (const auto &worker : workers_associated_with_unused_bundles) {
     RAY_LOG(DEBUG)
-        << "Destroying worker since its bundle was unused. Placement group id: "
-        << worker->GetBundleId().first
-        << ", bundle index: " << worker->GetBundleId().second
-        << ", task id: " << worker->GetAssignedTaskId()
-        << ", actor id: " << worker->GetActorId()
-        << ", worker id: " << worker->WorkerId();
+            .WithField(worker->GetBundleId().first)
+            .WithField(worker->GetAssignedTaskId())
+            .WithField(worker->GetActorId())
+            .WithField(worker->WorkerId())
+        << "Destroying worker since its bundle was unused, bundle index: "
+        << worker->GetBundleId().second;
     DestroyWorker(worker,
                   rpc::WorkerExitType::INTENDED_SYSTEM_EXIT,
                   "Worker exits because it uses placement group bundles that are not "
@@ -990,7 +991,7 @@ void NodeManager::WarnResourceDeadlock() {
 void NodeManager::NodeAdded(const GcsNodeInfo &node_info) {
   const NodeID node_id = NodeID::FromBinary(node_info.node_id());
 
-  RAY_LOG(DEBUG) << "[NodeAdded] Received callback from node id " << node_id;
+  RAY_LOG(DEBUG).WithField(node_id) << "[NodeAdded] Received callback from node id ";
   if (node_id == self_node_id_) {
     return;
   }
@@ -1026,7 +1027,7 @@ void NodeManager::NodeAdded(const GcsNodeInfo &node_info) {
 void NodeManager::NodeRemoved(const NodeID &node_id) {
   // TODO(swang): If we receive a notification for our own death, clean up and
   // exit immediately.
-  RAY_LOG(DEBUG) << "[NodeRemoved] Received callback from node id " << node_id;
+  RAY_LOG(DEBUG).WithField(node_id) << "[NodeRemoved] Received callback from node id ";
 
   if (node_id == self_node_id_) {
     if (!is_shutdown_request_received_) {
@@ -1043,7 +1044,8 @@ void NodeManager::NodeRemoved(const NodeID &node_id) {
     } else {
       // No-op since this node already starts to be drained, and GCS already knows about
       // it.
-      RAY_LOG(INFO) << "Node is marked as dead by GCS because the node is drained.";
+      RAY_LOG(INFO).WithField(node_id)
+          << "Node is marked as dead by GCS because the node is drained.";
       return;
     }
   }
@@ -1054,8 +1056,8 @@ void NodeManager::NodeRemoved(const NodeID &node_id) {
   // Remove the node from the resource map.
   if (!cluster_resource_scheduler_->GetClusterResourceManager().RemoveNode(
           scheduling::NodeID(node_id.Binary()))) {
-    RAY_LOG(DEBUG) << "Received NodeRemoved callback for an unknown node: " << node_id
-                   << ".";
+    RAY_LOG(DEBUG).WithField(node_id)
+        << "Received NodeRemoved callback for an unknown node.";
     return;
   }
 
@@ -1080,7 +1082,7 @@ void NodeManager::HandleUnexpectedWorkerFailure(const rpc::WorkerDeltaData &data
   const WorkerID worker_id = WorkerID::FromBinary(data.worker_id());
   const NodeID node_id = NodeID::FromBinary(data.raylet_id());
   if (!worker_id.IsNil()) {
-    RAY_LOG(DEBUG) << "Worker " << worker_id << " failed";
+    RAY_LOG(DEBUG).WithField(worker_id) << "Worker failed";
     failed_workers_cache_.insert(worker_id);
   } else {
     RAY_CHECK(!node_id.IsNil());
@@ -1094,7 +1096,8 @@ void NodeManager::HandleUnexpectedWorkerFailure(const rpc::WorkerDeltaData &data
     const auto owner_worker_id =
         WorkerID::FromBinary(worker->GetOwnerAddress().worker_id());
     const auto owner_node_id = NodeID::FromBinary(worker->GetOwnerAddress().raylet_id());
-    RAY_LOG(DEBUG) << "Lease " << worker->WorkerId() << " owned by " << owner_worker_id;
+    RAY_LOG(DEBUG).WithField(worker->WorkerId())
+        << "Lease worker owned by " << owner_worker_id;
     RAY_CHECK(!owner_worker_id.IsNil() && !owner_node_id.IsNil());
     if (!worker->IsDetachedActor()) {
       if (!worker_id.IsNil()) {
@@ -1124,10 +1127,11 @@ void NodeManager::HandleUnexpectedWorkerFailure(const rpc::WorkerDeltaData &data
 
 bool NodeManager::ResourceCreateUpdated(const NodeID &node_id,
                                         const ResourceRequest &createUpdatedResources) {
-  RAY_LOG(DEBUG) << "[ResourceCreateUpdated] received callback from node id " << node_id
-                 << " with created or updated resources: "
-                 << createUpdatedResources.DebugString() << ". Updating resource map."
-                 << " skip=" << (node_id == self_node_id_);
+  RAY_LOG(DEBUG).WithField(node_id)
+      << "[ResourceCreateUpdated] received callback from node with created or updated "
+         "resources: "
+      << createUpdatedResources.DebugString()
+      << ". Updating resource map. skip=" << (node_id == self_node_id_);
 
   // Skip updating local node since local node always has the latest information.
   // Updating local node could result in a inconsistence view in cluster resource
@@ -1153,9 +1157,9 @@ bool NodeManager::ResourceDeleted(const NodeID &node_id,
     for (auto &resource_name : resource_names) {
       oss << resource_name << ", ";
     }
-    RAY_LOG(DEBUG) << "[ResourceDeleted] received callback from node id " << node_id
-                   << " with deleted resources: " << oss.str()
-                   << ". Updating resource map. skip=" << (node_id == self_node_id_);
+    RAY_LOG(DEBUG).WithField(node_id)
+        << "[ResourceDeleted] received callback from node with deleted resources: "
+        << oss.str() << ". Updating resource map. skip=" << (node_id == self_node_id_);
   }
 
   // Skip updating local node since local node always has the latest information.
@@ -1198,9 +1202,8 @@ bool NodeManager::UpdateResourceUsage(
     const syncer::ResourceViewSyncMessage &resource_view_sync_message) {
   if (!cluster_resource_scheduler_->GetClusterResourceManager().UpdateNode(
           scheduling::NodeID(node_id.Binary()), resource_view_sync_message)) {
-    RAY_LOG(INFO)
-        << "[UpdateResourceUsage]: received resource usage from unknown node id "
-        << node_id;
+    RAY_LOG(INFO).WithField(node_id)
+        << "[UpdateResourceUsage]: received resource usage from unknown node.";
     return false;
   }
 
@@ -1504,9 +1507,9 @@ void NodeManager::DisconnectClient(const std::shared_ptr<ClientConnection> &clie
   ReleaseWorker(worker->WorkerId());
 
   if (creation_task_exception != nullptr) {
-    RAY_LOG(INFO) << "Formatted creation task exception: "
-                  << creation_task_exception->formatted_exception_string()
-                  << ", worker_id: " << worker->WorkerId();
+    RAY_LOG(INFO).WithField(worker->WorkerId())
+        << "Formatted creation task exception: "
+        << creation_task_exception->formatted_exception_string();
   }
   // Publish the worker failure.
   auto worker_failure_data_ptr =
@@ -1580,9 +1583,8 @@ void NodeManager::DisconnectClient(const std::shared_ptr<ClientConnection> &clie
     RAY_CHECK_OK(gcs_client_->Jobs().AsyncMarkFinished(job_id, nullptr));
     worker_pool_.DisconnectDriver(worker);
 
-    RAY_LOG(INFO) << "Driver (pid=" << worker->GetProcess().GetId()
-                  << ") is disconnected. "
-                  << "job_id: " << worker->GetAssignedJobId();
+    RAY_LOG(INFO).WithField(worker->WorkerId()).WithField(worker->GetAssignedJobId())
+        << "Driver (pid=" << worker->GetProcess().GetId() << ") is disconnected.";
     if (disconnect_type == rpc::WorkerExitType::SYSTEM_ERROR) {
       RAY_EVENT(ERROR, EL_RAY_DRIVER_FAILURE)
               .WithField("node_id", self_node_id_.Hex())
@@ -1805,8 +1807,8 @@ void NodeManager::HandleRequestWorkerLease(rpc::RequestWorkerLeaseRequest reques
       NodeID::FromBinary(task.GetTaskSpecification().CallerAddress().raylet_id());
   if (!task.GetTaskSpecification().IsDetachedActor() &&
       IsWorkerDead(caller_worker, caller_node)) {
-    RAY_LOG(INFO) << "Caller of RequestWorkerLease is dead. worker = " << caller_worker
-                  << ", node = " << caller_node << ". Skip leasing.";
+    RAY_LOG(INFO).WithField(caller_worker).WithField(caller_node)
+        << "Caller of RequestWorkerLease is dead. Skip leasing.";
     reply->set_canceled(true);
     reply->set_failure_type(rpc::RequestWorkerLeaseReply::SCHEDULING_CANCELLED_INTENDED);
     reply->set_scheduling_failure_message(
@@ -1838,13 +1840,13 @@ void NodeManager::HandleRequestWorkerLease(rpc::RequestWorkerLeaseRequest reques
           // its resource view of this raylet.
           if (RayConfig::instance().gcs_actor_scheduling_enabled()) {
             auto normal_task_resources = local_task_manager_->CalcNormalTaskResources();
-            RAY_LOG(DEBUG) << "Reject leasing as the raylet has no enough resources."
-                           << " actor_id = " << actor_id << ", normal_task_resources = "
-                           << normal_task_resources.DebugString()
-                           << ", local_resoruce_view = "
-                           << cluster_resource_scheduler_->GetClusterResourceManager()
-                                  .GetNodeResourceViewString(
-                                      scheduling::NodeID(self_node_id_.Binary()));
+            RAY_LOG(DEBUG).WithField(actor_id)
+                << "Reject leasing as the raylet has no enough resources. "
+                   "normal_task_resources = "
+                << normal_task_resources.DebugString() << ", local_resoruce_view = "
+                << cluster_resource_scheduler_->GetClusterResourceManager()
+                       .GetNodeResourceViewString(
+                           scheduling::NodeID(self_node_id_.Binary()));
             resources_data->set_resources_normal_task_changed(true);
             auto resource_map = normal_task_resources.GetResourceMap();
             resources_data->mutable_resources_normal_task()->insert(resource_map.begin(),
@@ -2065,8 +2067,8 @@ void NodeManager::HandleReleaseUnusedActorWorkers(
   }
 
   for (auto &worker : unused_actor_workers) {
-    RAY_LOG(DEBUG) << "GCS requested to release unused actor worker: "
-                   << worker->WorkerId();
+    RAY_LOG(DEBUG).WithField(worker->WorkerId())
+        << "GCS requested to release unused actor worker.";
     DestroyWorker(worker,
                   rpc::WorkerExitType::INTENDED_SYSTEM_EXIT,
                   "Worker is no longer needed by the GCS.");
@@ -2099,8 +2101,8 @@ void NodeManager::MarkObjectsAsFailed(
   const std::string meta = std::to_string(static_cast<int>(error_type));
   for (const auto &ref : objects_to_fail) {
     ObjectID object_id = ObjectID::FromBinary(ref.object_id());
-    RAY_LOG(DEBUG) << "Mark the object id " << object_id << " as failed due to "
-                   << error_type;
+    RAY_LOG(DEBUG).WithField(object_id)
+        << "Mark the object as failed due to " << error_type;
     std::shared_ptr<Buffer> data;
     Status status;
     status = store_client_->TryCreateImmediately(
@@ -2115,7 +2117,7 @@ void NodeManager::MarkObjectsAsFailed(
       status = store_client_->Seal(object_id);
     }
     if (!status.ok() && !status.IsObjectExists()) {
-      RAY_LOG(DEBUG) << "Marking plasma object failed " << object_id;
+      RAY_LOG(DEBUG).WithField(object_id) << "Marking plasma object failed.";
       // If we failed to save the error code, log a warning and push an error message
       // to the driver.
       std::ostringstream stream;
@@ -2203,7 +2205,7 @@ bool NodeManager::FinishAssignedTask(const std::shared_ptr<WorkerInterface> &wor
   // std::shared_ptr<WorkerInterface> instead of refs.
   auto &worker = *worker_ptr;
   TaskID task_id = worker.GetAssignedTaskId();
-  RAY_LOG(DEBUG) << "Finished task " << task_id;
+  RAY_LOG(DEBUG).WithField(task_id) << "Finished task ";
 
   RayTask task;
   local_task_manager_->TaskFinished(worker_ptr, &task);
@@ -2268,9 +2270,8 @@ void NodeManager::HandleObjectLocal(const ObjectInfo &object_info) {
   const ObjectID &object_id = object_info.object_id;
   // Notify the task dependency manager that this object is local.
   const auto ready_task_ids = dependency_manager_.HandleObjectLocal(object_id);
-  RAY_LOG(DEBUG) << "Object local " << object_id << ", "
-                 << " on " << self_node_id_ << ", " << ready_task_ids.size()
-                 << " tasks ready";
+  RAY_LOG(DEBUG).WithField(object_id).WithField(self_node_id_)
+      << "Object local on node, " << ready_task_ids.size() << " tasks ready";
   local_task_manager_->TasksUnblocked(ready_task_ids);
 
   // Notify the wait manager that this object is local.
@@ -2347,7 +2348,7 @@ void NodeManager::ProcessSubscribePlasmaReady(
     rpc::PlasmaObjectReadyRequest request;
     request.set_object_id(id.Binary());
 
-    RAY_LOG(DEBUG) << "Object " << id << " is already local, firing callback directly.";
+    RAY_LOG(DEBUG).WithField(id) << "Object is already local, firing callback directly.";
     associated_worker->rpc_client()->PlasmaObjectReady(
         request, [](Status status, const rpc::PlasmaObjectReadyReply &reply) {
           if (!status.ok()) {
@@ -2473,9 +2474,10 @@ void NodeManager::HandlePinObjectIDs(rpc::PinObjectIDsRequest request,
     auto result_it = results.begin();
     while (object_id_it != object_ids.end()) {
       if (*result_it == nullptr) {
-        RAY_LOG(DEBUG) << "Failed to get object in the object store: " << *object_id_it
-                       << ". This should only happen when the owner tries to pin a "
-                       << "secondary copy and it's evicted in the meantime";
+        RAY_LOG(DEBUG).WithField(*object_id_it)
+            << "Failed to get object in the object store. This should only happen when "
+               "the owner tries to pin a "
+            << "secondary copy and it's evicted in the meantime";
         object_id_it = object_ids.erase(object_id_it);
         result_it = results.erase(result_it);
         reply->add_successes(false);
@@ -2860,20 +2862,22 @@ MemoryUsageRefreshCallback NodeManager::CreateMemoryUsageRefreshCallback() {
                 float usage_threshold) {
     if (high_memory_eviction_target_ != nullptr) {
       if (!high_memory_eviction_target_->GetProcess().IsAlive()) {
-        RAY_LOG(INFO) << "Worker evicted and process killed to reclaim memory. "
-                      << "worker pid: "
-                      << high_memory_eviction_target_->GetProcess().GetId()
-                      << " task: " << high_memory_eviction_target_->GetAssignedTaskId();
+        RAY_LOG(INFO)
+                .WithField(high_memory_eviction_target_->WorkerId())
+                .WithField(high_memory_eviction_target_->GetAssignedTaskId())
+            << "Worker evicted and process killed to reclaim memory. "
+            << "worker pid: " << high_memory_eviction_target_->GetProcess().GetId();
         high_memory_eviction_target_ = nullptr;
       }
     }
     if (is_usage_above_threshold) {
       if (high_memory_eviction_target_ != nullptr) {
         RAY_LOG_EVERY_MS(INFO, 1000)
+                .WithField(high_memory_eviction_target_->GetAssignedTaskId())
+                .WithField(high_memory_eviction_target_->WorkerId())
             << "Memory usage above threshold. "
             << "Still waiting for worker eviction to free up memory. "
-            << "worker pid: " << high_memory_eviction_target_->GetProcess().GetId()
-            << "task: " << high_memory_eviction_target_->GetAssignedTaskId();
+            << "worker pid: " << high_memory_eviction_target_->GetProcess().GetId();
       } else {
         system_memory.process_used_bytes = MemoryMonitor::GetProcessMemoryUsage();
         auto workers = worker_pool_.GetAllRegisteredWorkers();
@@ -3036,13 +3040,13 @@ const std::string NodeManager::CreateOomKillMessageSuggestions(
 void NodeManager::SetTaskFailureReason(const TaskID &task_id,
                                        const rpc::RayErrorInfo &failure_reason,
                                        bool should_retry) {
-  RAY_LOG(DEBUG) << "set failure reason for task " << task_id;
+  RAY_LOG(DEBUG).WithField(task_id) << "set failure reason for task ";
   ray::TaskFailureEntry entry(failure_reason, should_retry);
   auto result = task_failure_reasons_.emplace(task_id, std::move(entry));
   if (!result.second) {
-    RAY_LOG(WARNING) << "Trying to insert failure reason more than once for the same "
-                        "task, the previous failure will be removed. Task id: "
-                     << task_id;
+    RAY_LOG(WARNING).WithField(task_id)
+        << "Trying to insert failure reason more than once for the same "
+           "task, the previous failure will be removed.";
   }
 }
 
@@ -3053,8 +3057,8 @@ void NodeManager::GCTaskFailureReason() {
             std::chrono::steady_clock::now() - entry.second.creation_time)
             .count());
     if (duration > RayConfig::instance().task_failure_entry_ttl_ms()) {
-      RAY_LOG(INFO) << "Removing task failure reason since it expired, task: "
-                    << entry.first;
+      RAY_LOG(INFO).WithField(entry.first)
+          << "Removing task failure reason since it expired";
       task_failure_reasons_.erase(entry.first);
     }
   }


### PR DESCRIPTION
Use structured logging by changing more `<< node_id` to use `.WithField(node_id)`. This is not intended to be a complete work, but it should cover most of the cases. We did the work for NodeID, WorkerID, ActorID, JobID, TaskID, PlacementGroupID.

Some logs have multiple node_ids, for example:

```
  RAY_LOG(DEBUG).WithField(object_id)
      << "ReceiveObjectChunk on " << self_node_id_ << " from " << node_id
      << " of object, chunk index: " << chunk_index
      << ", chunk data size: " << data.size() << ", object size: " << data_size;
```

To avoid confusion, for these we only use WithField(object_id) don't use WithField on either of the Node IDs.

This PR should have no change on Ray other than logs.