### PR TITLE
[RLlib] Fix assertion in `Simplex` space.

### DIFF
--- a/rllib/utils/spaces/simplex.py
+++ b/rllib/utils/spaces/simplex.py
@@ -29,8 +29,8 @@ class Simplex(gym.Space):
 
         if concentration is not None:
             assert (
-                concentration.shape == shape[:-1]
-            ), f"{concentration.shape} vs {shape[:-1]}"
+                concentration.shape[0] == shape[-1]
+            ), f"{concentration.shape[0]} vs {shape[-1]}"
             self.concentration = concentration
         else:
             self.concentration = np.array([1] * self.dim)

--- a/rllib/utils/tests/test_serialization.py
+++ b/rllib/utils/tests/test_serialization.py
@@ -141,7 +141,7 @@ class TestGymCheckEnv(unittest.TestCase):
         self.assertTrue(input_space == deserialized_space)
 
     def test_simplex_space(self):
-        space = Simplex(shape=(3, 4), concentration=np.array((1, 2, 1)))
+        space = Simplex(shape=(3, 4), concentration=np.array((1, 2, 1, 2)))
 
         d = gym_space_to_dict(space)
         sp = gym_space_from_dict(d)


### PR DESCRIPTION


## Why are these changes needed?

The assertion in the `Simplex` space is not checking the correct shape dimensions when `concentration` parameters are passed in. This PR fixes this.

## Related issue number

Closes #45804 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
