### PR TITLE
[core] Change debug_string from returning a string to streaming to an ostream.

### DIFF
--- a/src/ray/util/container_util.h
+++ b/src/ray/util/container_util.h
@@ -46,7 +46,7 @@ class DebugStringWrapper {
 
   // Only initialized for the blessed container types listed below with operator<<
   // specializations.
-  std::ostream &_container_debug_string_impl(std::ostream &os) const {
+  std::ostream &StringifyContainer(std::ostream &os) const {
     os << "[";
     for (auto it = obj_.begin(); it != obj_.end(); ++it) {
       if (it != obj_.begin()) {
@@ -92,30 +92,30 @@ std::ostream &operator<<(std::ostream &os, DebugStringWrapper<std::tuple<Ts...>>
 
 template <typename... Ts>
 std::ostream &operator<<(std::ostream &os, DebugStringWrapper<std::vector<Ts...>> c) {
-  return c._container_debug_string_impl(os);
+  return c.StringifyContainer(os);
 }
 template <typename... Ts>
 std::ostream &operator<<(std::ostream &os, DebugStringWrapper<std::set<Ts...>> c) {
-  return c._container_debug_string_impl(os);
+  return c.StringifyContainer(os);
 }
 template <typename... Ts>
 std::ostream &operator<<(std::ostream &os,
                          DebugStringWrapper<std::unordered_set<Ts...>> c) {
-  return c._container_debug_string_impl(os);
+  return c.StringifyContainer(os);
 }
 template <typename... Ts>
 std::ostream &operator<<(std::ostream &os,
                          DebugStringWrapper<absl::flat_hash_set<Ts...>> c) {
-  return c._container_debug_string_impl(os);
+  return c.StringifyContainer(os);
 }
 template <typename... Ts>
 std::ostream &operator<<(std::ostream &os, DebugStringWrapper<std::map<Ts...>> c) {
-  return c._container_debug_string_impl(os);
+  return c.StringifyContainer(os);
 }
 template <typename... Ts>
 std::ostream &operator<<(std::ostream &os,
                          DebugStringWrapper<absl::flat_hash_map<Ts...>> c) {
-  return c._container_debug_string_impl(os);
+  return c.StringifyContainer(os);
 }
 
 template <typename C>

--- a/src/ray/util/container_util.h
+++ b/src/ray/util/container_util.h
@@ -85,6 +85,9 @@ std::ostream &operator<<(std::ostream &os, DebugStringWrapper<std::tuple<Ts...>>
           ((os << debug_string(args) << (++n != sizeof...(Ts) ? ", " : "")), ...);
         },
         tuple.obj_);
+  } else {
+    // Avoid unused variable warning.
+    (void)tuple;
   }
   os << ")";
   return os;

--- a/src/ray/util/tests/container_util_test.cc
+++ b/src/ray/util/tests/container_util_test.cc
@@ -29,6 +29,7 @@ std::string debug_string_to_string(const T &t) {
 }
 
 TEST(ContainerUtilTest, TestDebugString) {
+  ASSERT_EQ(debug_string_to_string(static_cast<int>(2)), "2");
   ASSERT_EQ(debug_string_to_string(std::vector<int>{1, 2}), "[1, 2]");
   ASSERT_EQ(debug_string_to_string(std::set<int>{1, 2}), "[1, 2]");
   ASSERT_EQ(debug_string_to_string(std::unordered_set<int>{2}), "[2]");
@@ -38,6 +39,7 @@ TEST(ContainerUtilTest, TestDebugString) {
   ASSERT_EQ(debug_string_to_string(absl::flat_hash_map<int, int>{{3, 4}}), "[(3, 4)]");
   ASSERT_EQ(debug_string_to_string(absl::flat_hash_map<int, int>{{1, 2}}), "[(1, 2)]");
 
+  // Tuples
   ASSERT_EQ(debug_string_to_string(std::tuple<>()), "()");
   ASSERT_EQ(debug_string_to_string(std::tuple<int>(2)), "(2)");
   ASSERT_EQ(debug_string_to_string(std::tuple<int, std::string>({2, "hello world"})),
@@ -45,6 +47,36 @@ TEST(ContainerUtilTest, TestDebugString) {
   ASSERT_EQ(debug_string_to_string(
                 std::tuple<int, std::string, bool>({2, "hello world", true})),
             "(2, hello world, 1)");
+
+  // Pairs
+  ASSERT_EQ(debug_string_to_string(std::pair<int, int>{1, 2}), "(1, 2)");
+  ASSERT_EQ(debug_string_to_string(std::pair<std::string, int>{"key", 42}), "(key, 42)");
+  ASSERT_EQ(debug_string_to_string(std::pair<int, std::string>{3, "value"}),
+            "(3, value)");
+
+  // Composable: tuples of pairs of maps and vectors.
+  ASSERT_EQ(debug_string_to_string(
+                std::tuple<std::pair<int, std::vector<int>>, std::map<int, int>>{
+                    {1, {2, 3}}, {{4, 5}, {6, 7}}}),
+            "((1, [2, 3]), [(4, 5), (6, 7)])");
+
+  ASSERT_EQ(
+      debug_string_to_string(std::tuple<std::pair<std::string, std::vector<std::string>>,
+                                        std::map<std::string, std::string>>{
+          {"key", {"value1", "value2"}}, {{"key1", "value1"}, {"key2", "value2"}}}),
+      "((key, [value1, value2]), [(key1, value1), (key2, value2)])");
+
+  ASSERT_EQ(
+      debug_string_to_string(
+          std::tuple<std::pair<int, std::vector<int>>, std::map<int, std::vector<int>>>{
+              {1, {2, 3}}, {{4, {5, 6}}, {7, {8, 9}}}}),
+      "((1, [2, 3]), [(4, [5, 6]), (7, [8, 9])])");
+
+  ASSERT_EQ(
+      debug_string_to_string(std::tuple<std::pair<int, std::vector<int>>,
+                                        std::map<int, std::vector<std::pair<int, int>>>>{
+          {1, {2, 3}}, {{4, {{5, 6}, {7, 8}}}, {9, {{10, 11}, {12, 13}}}}}),
+      "((1, [2, 3]), [(4, [(5, 6), (7, 8)]), (9, [(10, 11), (12, 13)])])");
 }
 
 TEST(ContainerUtilTest, TestMapFindOrDie) {

--- a/src/ray/util/tests/container_util_test.cc
+++ b/src/ray/util/tests/container_util_test.cc
@@ -14,18 +14,37 @@
 
 #include "ray/util/container_util.h"
 
+#include <sstream>
+#include <tuple>
+
 #include "gtest/gtest.h"
 
 namespace ray {
 
+template <typename T>
+std::string debug_string_to_string(const T &t) {
+  std::ostringstream ss;
+  ss << debug_string(t);
+  return ss.str();
+}
+
 TEST(ContainerUtilTest, TestDebugString) {
-  ASSERT_EQ(debug_string(std::vector<int>{1, 2}), "[1, 2]");
-  ASSERT_EQ(debug_string(std::set<int>{1, 2}), "[1, 2]");
-  ASSERT_EQ(debug_string(std::unordered_set<int>{2}), "[2]");
-  ASSERT_EQ(debug_string(absl::flat_hash_set<int>{1}), "[1]");
-  ASSERT_EQ(debug_string(std::map<int, int>{{1, 2}, {3, 4}}), "[(1, 2), (3, 4)]");
-  ASSERT_EQ(debug_string(absl::flat_hash_map<int, int>{{3, 4}}), "[(3, 4)]");
-  ASSERT_EQ(debug_string(absl::flat_hash_map<int, int>{{1, 2}}), "[(1, 2)]");
+  ASSERT_EQ(debug_string_to_string(std::vector<int>{1, 2}), "[1, 2]");
+  ASSERT_EQ(debug_string_to_string(std::set<int>{1, 2}), "[1, 2]");
+  ASSERT_EQ(debug_string_to_string(std::unordered_set<int>{2}), "[2]");
+  ASSERT_EQ(debug_string_to_string(absl::flat_hash_set<int>{1}), "[1]");
+  ASSERT_EQ(debug_string_to_string(std::map<int, int>{{1, 2}, {3, 4}}),
+            "[(1, 2), (3, 4)]");
+  ASSERT_EQ(debug_string_to_string(absl::flat_hash_map<int, int>{{3, 4}}), "[(3, 4)]");
+  ASSERT_EQ(debug_string_to_string(absl::flat_hash_map<int, int>{{1, 2}}), "[(1, 2)]");
+
+  ASSERT_EQ(debug_string_to_string(std::tuple<>()), "()");
+  ASSERT_EQ(debug_string_to_string(std::tuple<int>(2)), "(2)");
+  ASSERT_EQ(debug_string_to_string(std::tuple<int, std::string>({2, "hello world"})),
+            "(2, hello world)");
+  ASSERT_EQ(debug_string_to_string(
+                std::tuple<int, std::string, bool>({2, "hello world", true})),
+            "(2, hello world, 1)");
 }
 
 TEST(ContainerUtilTest, TestMapFindOrDie) {

--- a/src/ray/util/tests/container_util_test.cc
+++ b/src/ray/util/tests/container_util_test.cc
@@ -25,7 +25,7 @@ template <typename T>
 std::string debug_string_to_string(const T &t) {
   std::ostringstream ss;
   ss << debug_string(t);
-  return ss.str();
+  return std::move(ss).str();
 }
 
 TEST(ContainerUtilTest, TestDebugString) {


### PR DESCRIPTION
We have a conveinence function `debug_string` used in Ray logs: it prints printables (operator<<), containers, pairs. However it returns a std::string which is feed into RAY_LOG(). This makes a copy.

Changes the signature to return a `DebugStringWrapper` which holds const reference to the argument, and is printable for all already supported types. Additionally supports std::tuple.

This should only have marginal perf benefits since we typically don't debug_string a very big data structure.