### PR TITLE
[deps] pin doc test dependencies

### DIFF
--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -244,9 +244,9 @@ install_pip_packages() {
 
     # For DAG visualization
     requirements_packages+=("pydot")
-    requirements_packages+=("pytesseract")
-    requirements_packages+=("spacy>=3")
-    requirements_packages+=("spacy_langdetect")
+    requirements_packages+=("pytesseract==0.3.13")
+    requirements_packages+=("spacy==3.7.5")
+    requirements_packages+=("spacy_langdetect==0.1.2")
   fi
 
   # Additional RLlib test dependencies.


### PR DESCRIPTION
these are not captured in the compiled file, and it is
making ml build taking more than 5 hours to build
