### PR TITLE
docs: update slack join link on readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,4 +137,4 @@ Getting Involved
 .. _`StackOverflow`: https://stackoverflow.com/questions/tagged/ray
 .. _`Meetup Group`: https://www.meetup.com/Bay-Area-Ray-Meetup/
 .. _`Twitter`: https://twitter.com/raydistributed
-.. _`Slack`: https://forms.gle/9TSdDYUgxYs8SA9e8
+.. _`Slack`: https://www.ray.io/join-slack?utm_source=github&utm_medium=ray_readme&utm_campaign=getting_involved 


### PR DESCRIPTION
We moved the form to be embedded on the ray website