### PR TITLE
[Data] Fix event loop mismatch with async map

### DIFF
--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -11,6 +11,7 @@ import pandas as pd
 import pyarrow as pa
 
 import ray
+from ray._private.utils import get_or_create_event_loop
 from ray.data._internal.compute import get_compute
 from ray.data._internal.execution.interfaces import PhysicalOperator
 from ray.data._internal.execution.interfaces.task_context import TaskContext
@@ -65,7 +66,7 @@ class _MapActorContext:
 
     def _init_async(self):
         # Only used for callable class with async generator `__call__` method.
-        loop = asyncio.new_event_loop()
+        loop = get_or_create_event_loop()
 
         def run_loop():
             asyncio.set_event_loop(loop)


### PR DESCRIPTION

## Why are these changes needed?

Fix a bug with async Map operator, where in Python < 3.11, there are multiple event loops created and occurs in an event loop mismatch error. See #47734 for more details.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #47734

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
