### PR TITLE
[Docs] Update Volcano Integration with The New Flag

### DIFF
--- a/doc/source/cluster/kubernetes/k8s-ecosystem/volcano.md
+++ b/doc/source/cluster/kubernetes/k8s-ecosystem/volcano.md
@@ -19,23 +19,23 @@ See [Quick Start Guide](https://github.com/volcano-sh/volcano#quick-start-guide)
 
 ### Step 3: Install the KubeRay Operator with batch scheduling
 
-Deploy the KubeRay Operator with the `--enable-batch-scheduler` flag to enable Volcano batch scheduling support.
+Deploy the KubeRay Operator with the `--batch-scheduler=volcano` flag to enable Volcano batch scheduling support.
 
 When installing KubeRay Operator using Helm, you should use one of these two options:
 
-* Set `batchScheduler.enabled` to `true` in your
+* Set `batchScheduler.name` to `volcano` in your
 [`values.yaml`](https://github.com/ray-project/kuberay/blob/753dc05dbed5f6fe61db3a43b34a1b350f26324c/helm-chart/kuberay-operator/values.yaml#L48)
 file:
 ```shell
 # values.yaml file
 batchScheduler:
-    enabled: true
+    name: volcano
 ```
 
-* Pass the `--set batchScheduler.enabled=true` flag when running on the command line:
+* Pass the `--set batchScheduler.name=volcano` flag when running on the command line:
 ```shell
-# Install the Helm chart with --enable-batch-scheduler flag set to true
-helm install kuberay-operator kuberay/kuberay-operator --version 1.2.2 --set batchScheduler.enabled=true
+# Install the Helm chart with the --batch-scheduler=volcano flag
+helm install kuberay-operator kuberay/kuberay-operator --version 1.2.2 --set batchScheduler.name=volcano
 ```
 
 ### Step 4: Install a RayCluster with the Volcano scheduler


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR addresses the deprecation of the `--enable-batch-scheduler` flag for Volcano integration in the Kubernetes ecosystem. The following changes have been made:

Replaced the deprecated `--enable-batch-scheduler` flag with `--batch-scheduler=volcano`.
Updated the Helm chart by removing the deprecated `batchScheduler.enabled` value and replacing it with `batchScheduler.name`.
## Related issue number

Closes https://github.com/ray-project/ray/issues/47852

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
