### PR TITLE
Revert "[Arrow] Adding `ArrowTensorTypeV2` to support tensors larger than 2Gb"

### DIFF
--- a/python/ray/_private/arrow_serialization.py
+++ b/python/ray/_private/arrow_serialization.py
@@ -252,12 +252,12 @@ class PicklableArrayPayload:
 def _array_payload_to_array(payload: "PicklableArrayPayload") -> "pyarrow.Array":
     """Reconstruct an Arrow Array from a possibly nested PicklableArrayPayload."""
     import pyarrow as pa
-    from ray.air.util.tensor_extensions.arrow import get_arrow_extension_tensor_types
+    from ray.air.util.tensor_extensions.arrow import (
+        ArrowTensorType,
+        ArrowVariableShapedTensorType,
+    )
 
     children = [child_payload.to_array() for child_payload in payload.children]
-
-    tensor_extension_types = get_arrow_extension_tensor_types()
-
     if pa.types.is_dictionary(payload.type):
         # Dedicated path for reconstructing a DictionaryArray, since
         # Array.from_buffers() doesn't work for DictionaryArrays.
@@ -270,9 +270,8 @@ def _array_payload_to_array(payload: "PicklableArrayPayload") -> "pyarrow.Array"
         assert len(children) == 3, len(children)
         offsets, keys, items = children
         return pa.MapArray.from_arrays(offsets, keys, items)
-    elif isinstance(
-        payload.type,
-        tensor_extension_types,
+    elif isinstance(payload.type, ArrowTensorType) or isinstance(
+        payload.type, ArrowVariableShapedTensorType
     ):
         # Dedicated path for reconstructing an ArrowTensorArray or
         # ArrowVariableShapedTensorArray, both of which can't be reconstructed by the
@@ -300,9 +299,10 @@ def _array_to_array_payload(a: "pyarrow.Array") -> "PicklableArrayPayload":
     """
     import pyarrow as pa
 
-    from ray.air.util.tensor_extensions.arrow import get_arrow_extension_tensor_types
-
-    tensor_extension_types = get_arrow_extension_tensor_types()
+    from ray.air.util.tensor_extensions.arrow import (
+        ArrowTensorType,
+        ArrowVariableShapedTensorType,
+    )
 
     if _is_dense_union(a.type):
         # Dense unions are not supported.
@@ -331,7 +331,9 @@ def _array_to_array_payload(a: "pyarrow.Array") -> "PicklableArrayPayload":
         return _dictionary_array_to_array_payload(a)
     elif pa.types.is_map(a.type):
         return _map_array_to_array_payload(a)
-    elif isinstance(a.type, tensor_extension_types):
+    elif isinstance(a.type, ArrowTensorType) or isinstance(
+        a.type, ArrowVariableShapedTensorType
+    ):
         return _tensor_array_to_array_payload(a)
     elif isinstance(a.type, pa.ExtensionType):
         return _extension_array_to_array_payload(a)

--- a/python/ray/air/BUILD
+++ b/python/ray/air/BUILD
@@ -5,11 +5,6 @@ doctest(
     tags = ["team:ml"]
 )
 
-py_library(
-    name = "conftest",
-    srcs = ["tests/conftest.py"],
-)
-
 # --------------------------------------------------------------------
 # Tests from the python/ray/air/examples directory.
 # Please keep these sorted alphabetically.
@@ -150,7 +145,7 @@ py_test(
     size = "small",
     srcs = ["tests/test_tensor_extension.py"],
     tags = ["team:ml", "team:data", "exclusive", "ray_data"],
-    deps = [":ml_lib", ":conftest"]
+    deps = [":ml_lib"]
 )
 
 py_test(

--- a/python/ray/air/_internal/tensorflow_utils.py
+++ b/python/ray/air/_internal/tensorflow_utils.py
@@ -5,7 +5,6 @@ import pyarrow
 import tensorflow as tf
 
 from ray.air.util.data_batch_conversion import _unwrap_ndarray_object_type_if_needed
-from ray.air.util.tensor_extensions.arrow import get_arrow_extension_tensor_types
 
 if TYPE_CHECKING:
     from ray.data._internal.pandas_block import PandasBlockSchema
@@ -82,9 +81,7 @@ def get_type_spec(
 ) -> Union[tf.TypeSpec, Dict[str, tf.TypeSpec]]:
     import pyarrow as pa
 
-    from ray.data.extensions import TensorDtype
-
-    tensor_extension_types = get_arrow_extension_tensor_types()
+    from ray.data.extensions import ArrowTensorType, TensorDtype
 
     assert not isinstance(schema, type)
 
@@ -101,7 +98,7 @@ def get_type_spec(
 
     def get_shape(dtype: Union[np.dtype, pa.DataType]) -> Tuple[int, ...]:
         shape = (None,)
-        if isinstance(dtype, tensor_extension_types):
+        if isinstance(dtype, ArrowTensorType):
             dtype = dtype.to_pandas_dtype()
         if isinstance(dtype, TensorDtype):
             shape += dtype.element_shape

--- a/python/ray/air/tests/conftest.py
+++ b/python/ray/air/tests/conftest.py
@@ -1,15 +1,2 @@
 # Trigger pytest hook to automatically zip test cluster logs to archive dir on failure
-import copy
-
-import pytest
-
-import ray
 from ray.tests.conftest import pytest_runtest_makereport  # noqa
-
-
-@pytest.fixture
-def restore_data_context(request):
-    """Restore any DataContext changes after the test runs"""
-    original = copy.deepcopy(ray.data.context.DataContext.get_current())
-    yield
-    ray.data.context.DataContext._set_current(original)

--- a/python/ray/air/tests/test_tensor_extension.py
+++ b/python/ray/air/tests/test_tensor_extension.py
@@ -8,19 +8,15 @@ from packaging.version import parse as parse_version
 
 from ray._private.utils import _get_pyarrow_version
 from ray.air.util.tensor_extensions.arrow import (
-    ArrowConversionError,
     ArrowTensorArray,
     ArrowTensorType,
-    ArrowTensorTypeV2,
     ArrowVariableShapedTensorArray,
     ArrowVariableShapedTensorType,
 )
 from ray.air.util.tensor_extensions.pandas import TensorArray, TensorDtype
 from ray.air.util.tensor_extensions.utils import create_ragged_ndarray
-from ray.data import DataContext
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 @pytest.mark.parametrize(
     "values",
     [
@@ -28,9 +24,7 @@ from ray.data import DataContext
         [np.zeros((3,))],
     ],
 )
-def test_create_ragged_ndarray(values, restore_data_context, tensor_format):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_create_ragged_ndarray(values):
     ragged_array = create_ragged_ndarray(values)
     assert len(ragged_array) == len(values)
     for actual_array, expected_array in zip(ragged_array, values):
@@ -50,10 +44,7 @@ def test_tensor_array_validation():
         TensorArray([object(), object()])
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_arrow_scalar_tensor_array_roundtrip(restore_data_context, tensor_format):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_arrow_scalar_tensor_array_roundtrip():
     arr = np.arange(10)
     ata = ArrowTensorArray.from_numpy(arr)
     assert isinstance(ata.type, pa.DataType)
@@ -62,12 +53,7 @@ def test_arrow_scalar_tensor_array_roundtrip(restore_data_context, tensor_format
     np.testing.assert_array_equal(out, arr)
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_arrow_scalar_tensor_array_roundtrip_boolean(
-    restore_data_context, tensor_format
-):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_arrow_scalar_tensor_array_roundtrip_boolean():
     arr = np.array([True, False, False, True])
     ata = ArrowTensorArray.from_numpy(arr)
     assert isinstance(ata.type, pa.DataType)
@@ -78,10 +64,7 @@ def test_arrow_scalar_tensor_array_roundtrip_boolean(
     np.testing.assert_array_equal(out, arr)
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_scalar_tensor_array_roundtrip(restore_data_context, tensor_format):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_scalar_tensor_array_roundtrip():
     arr = np.arange(10)
     ta = TensorArray(arr)
     assert isinstance(ta.dtype, TensorDtype)
@@ -97,12 +80,7 @@ def test_scalar_tensor_array_roundtrip(restore_data_context, tensor_format):
     np.testing.assert_array_equal(out, arr)
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_arrow_variable_shaped_tensor_array_validation(
-    restore_data_context, tensor_format
-):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_arrow_variable_shaped_tensor_array_validation():
     # Test tensor elements with differing dimensions raises ValueError.
     with pytest.raises(ValueError):
         ArrowVariableShapedTensorArray.from_numpy([np.ones((2, 2)), np.ones((3, 3, 3))])
@@ -147,12 +125,7 @@ def test_arrow_variable_shaped_tensor_array_validation(
         )
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_arrow_variable_shaped_tensor_array_roundtrip(
-    restore_data_context, tensor_format
-):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_arrow_variable_shaped_tensor_array_roundtrip():
     shapes = [(2, 2), (3, 3), (4, 4)]
     cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
     arrs = [
@@ -168,12 +141,7 @@ def test_arrow_variable_shaped_tensor_array_roundtrip(
         np.testing.assert_array_equal(o, a)
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_arrow_variable_shaped_tensor_array_roundtrip_boolean(
-    restore_data_context, tensor_format
-):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_arrow_variable_shaped_tensor_array_roundtrip_boolean():
     arr = np.array(
         [[True, False], [False, False, True], [False], [True, True, False, True]],
         dtype=object,
@@ -186,12 +154,7 @@ def test_arrow_variable_shaped_tensor_array_roundtrip_boolean(
         np.testing.assert_array_equal(o, a)
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_arrow_variable_shaped_tensor_array_roundtrip_contiguous_optimization(
-    restore_data_context, tensor_format
-):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_arrow_variable_shaped_tensor_array_roundtrip_contiguous_optimization():
     # Test that a roundtrip on slices of an already-contiguous 1D base array does not
     # create any unnecessary copies.
     base = np.arange(6)
@@ -207,10 +170,7 @@ def test_arrow_variable_shaped_tensor_array_roundtrip_contiguous_optimization(
         np.testing.assert_array_equal(o, a)
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_arrow_variable_shaped_tensor_array_slice(restore_data_context, tensor_format):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_arrow_variable_shaped_tensor_array_slice():
     shapes = [(2, 2), (3, 3), (4, 4)]
     cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
     arrs = [
@@ -244,12 +204,7 @@ def test_arrow_variable_shaped_tensor_array_slice(restore_data_context, tensor_f
             np.testing.assert_array_equal(o, e)
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_arrow_variable_shaped_bool_tensor_array_slice(
-    restore_data_context, tensor_format
-):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_arrow_variable_shaped_bool_tensor_array_slice():
     arr = np.array(
         [
             [True],
@@ -285,12 +240,7 @@ def test_arrow_variable_shaped_bool_tensor_array_slice(
             np.testing.assert_array_equal(o, e)
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_arrow_variable_shaped_string_tensor_array_slice(
-    restore_data_context, tensor_format
-):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_arrow_variable_shaped_string_tensor_array_slice():
     arr = np.array(
         [
             ["Philip", "J", "Fry"],
@@ -330,10 +280,7 @@ def test_arrow_variable_shaped_string_tensor_array_slice(
             np.testing.assert_array_equal(o, e)
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_variable_shaped_tensor_array_roundtrip(restore_data_context, tensor_format):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_variable_shaped_tensor_array_roundtrip():
     shapes = [(2, 2), (3, 3), (4, 4)]
     cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
     arrs = [
@@ -357,10 +304,7 @@ def test_variable_shaped_tensor_array_roundtrip(restore_data_context, tensor_for
         np.testing.assert_array_equal(o, a)
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_variable_shaped_tensor_array_slice(restore_data_context, tensor_format):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_variable_shaped_tensor_array_slice():
     shapes = [(2, 2), (3, 3), (4, 4)]
     cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
     arrs = [
@@ -387,10 +331,7 @@ def test_variable_shaped_tensor_array_slice(restore_data_context, tensor_format)
             np.testing.assert_array_equal(o, e)
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_tensor_array_ops(restore_data_context, tensor_format):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_tensor_array_ops():
     outer_dim = 3
     inner_shape = (2, 2, 2)
     shape = (outer_dim,) + inner_shape
@@ -416,10 +357,7 @@ def test_tensor_array_ops(restore_data_context, tensor_format):
     np.testing.assert_equal(apply_logical_ops(arr), apply_logical_ops(df["two"]))
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_tensor_array_array_protocol(restore_data_context, tensor_format):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_tensor_array_array_protocol():
     outer_dim = 3
     inner_shape = (2, 2, 2)
     shape = (outer_dim,) + inner_shape
@@ -439,10 +377,7 @@ def test_tensor_array_array_protocol(restore_data_context, tensor_format):
     )
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_tensor_array_dataframe_repr(restore_data_context, tensor_format):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_tensor_array_dataframe_repr():
     outer_dim = 3
     inner_shape = (2, 2)
     shape = (outer_dim,) + inner_shape
@@ -459,10 +394,7 @@ def test_tensor_array_dataframe_repr(restore_data_context, tensor_format):
     assert repr(df) == expected_repr
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_tensor_array_scalar_cast(restore_data_context, tensor_format):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_tensor_array_scalar_cast():
     outer_dim = 3
     inner_shape = (1,)
     shape = (outer_dim,) + inner_shape
@@ -479,10 +411,7 @@ def test_tensor_array_scalar_cast(restore_data_context, tensor_format):
     assert float(t_arr) == float(arr)
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_tensor_array_reductions(restore_data_context, tensor_format):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_tensor_array_reductions():
     outer_dim = 3
     inner_shape = (2, 2, 2)
     shape = (outer_dim,) + inner_shape
@@ -502,11 +431,8 @@ def test_tensor_array_reductions(restore_data_context, tensor_format):
         np.testing.assert_equal(df["two"].agg(name), reducer(arr, axis=0, **np_kwargs))
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 @pytest.mark.parametrize("chunked", [False, True])
-def test_arrow_tensor_array_getitem(chunked, restore_data_context, tensor_format):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_arrow_tensor_array_getitem(chunked):
     outer_dim = 3
     inner_shape = (2, 2, 2)
     shape = (outer_dim,) + inner_shape
@@ -569,13 +495,8 @@ def test_arrow_tensor_array_getitem(chunked, restore_data_context, tensor_format
             np.testing.assert_array_equal(t_arr2[idx - 1], arr[idx])
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 @pytest.mark.parametrize("chunked", [False, True])
-def test_arrow_variable_shaped_tensor_array_getitem(
-    chunked, restore_data_context, tensor_format
-):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_arrow_variable_shaped_tensor_array_getitem(chunked):
     shapes = [(2, 2), (3, 3), (4, 4)]
     outer_dim = len(shapes)
     cumsum_sizes = np.cumsum([0] + [np.prod(shape) for shape in shapes[:-1]])
@@ -643,7 +564,6 @@ def test_arrow_variable_shaped_tensor_array_getitem(
             np.testing.assert_array_equal(t_arr2[idx - 1], arr[idx])
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 @pytest.mark.parametrize(
     "test_arr,dtype",
     [
@@ -657,9 +577,7 @@ def test_arrow_variable_shaped_tensor_array_getitem(
         ([[False, True], [True, False], [True, True], [False, False]], None),
     ],
 )
-def test_arrow_tensor_array_slice(test_arr, dtype, restore_data_context, tensor_format):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_arrow_tensor_array_slice(test_arr, dtype):
     # Test that ArrowTensorArray slicing works as expected.
     arr = np.array(test_arr, dtype=dtype)
     ata = ArrowTensorArray.from_numpy(arr)
@@ -687,11 +605,8 @@ pytest_tensor_array_concat_arr_combinations = list(
 )
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 @pytest.mark.parametrize("a1,a2", pytest_tensor_array_concat_arr_combinations)
-def test_tensor_array_concat(a1, a2, restore_data_context, tensor_format):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_tensor_array_concat(a1, a2):
     ta1 = TensorArray(a1)
     ta2 = TensorArray(a2)
     ta = TensorArray._concat_same_type([ta1, ta2])
@@ -708,24 +623,14 @@ def test_tensor_array_concat(a1, a2, restore_data_context, tensor_format):
             np.testing.assert_array_equal(arr, expected)
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 @pytest.mark.parametrize("a1,a2", pytest_tensor_array_concat_arr_combinations)
-def test_arrow_tensor_array_concat(a1, a2, restore_data_context, tensor_format):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_arrow_tensor_array_concat(a1, a2):
     ta1 = ArrowTensorArray.from_numpy(a1)
     ta2 = ArrowTensorArray.from_numpy(a2)
     ta = ArrowTensorArray._concat_same_type([ta1, ta2])
     assert len(ta) == a1.shape[0] + a2.shape[0]
     if a1.shape[1:] == a2.shape[1:]:
-        if tensor_format == "v1":
-            tensor_type_class = ArrowTensorType
-        elif tensor_format == "v2":
-            tensor_type_class = ArrowTensorTypeV2
-        else:
-            raise ValueError(f"unexpected format: {tensor_format}")
-
-        assert isinstance(ta.type, tensor_type_class)
+        assert isinstance(ta.type, ArrowTensorType)
         assert ta.type.storage_type == ta1.type.storage_type
         assert ta.type.storage_type == ta2.type.storage_type
         assert ta.type.shape == a1.shape[1:]
@@ -739,12 +644,7 @@ def test_arrow_tensor_array_concat(a1, a2, restore_data_context, tensor_format):
             np.testing.assert_array_equal(arr, expected)
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_variable_shaped_tensor_array_chunked_concat(
-    restore_data_context, tensor_format
-):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_variable_shaped_tensor_array_chunked_concat():
     # Test that chunking a tensor column and concatenating its chunks preserves typing
     # and underlying data.
     shape1 = (2, 2, 2)
@@ -764,10 +664,7 @@ def test_variable_shaped_tensor_array_chunked_concat(
         np.testing.assert_array_equal(arr, expected)
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_variable_shaped_tensor_array_uniform_dim(restore_data_context, tensor_format):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
+def test_variable_shaped_tensor_array_uniform_dim():
     shape1 = (3, 2, 2)
     shape2 = (3, 4, 4)
     a1 = np.arange(np.prod(shape1)).reshape(shape1)
@@ -777,27 +674,6 @@ def test_variable_shaped_tensor_array_uniform_dim(restore_data_context, tensor_f
     assert ta.is_variable_shaped
     for a, expected in zip(ta.to_numpy(), [a1, a2]):
         np.testing.assert_array_equal(a, expected)
-
-
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_large_arrow_tensor_array(restore_data_context, tensor_format):
-    DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
-
-    test_arr = np.ones((1000, 550), dtype=np.uint8)
-
-    if tensor_format == "v1":
-        with pytest.raises(ArrowConversionError) as exc_info:
-            ta = ArrowTensorArray.from_numpy([test_arr] * 4000)
-
-        assert (
-            repr(exc_info.value.__cause__)
-            == "ArrowInvalid('Negative offsets in list array')"
-        )
-    else:
-        ta = ArrowTensorArray.from_numpy([test_arr] * 4000)
-        assert len(ta) == 4000
-        for arr in ta:
-            assert np.asarray(arr).shape == (1000, 550)
 
 
 if __name__ == "__main__":

--- a/python/ray/air/util/transform_pyarrow.py
+++ b/python/ray/air/util/transform_pyarrow.py
@@ -20,18 +20,17 @@ def _concatenate_extension_column(ca: "pyarrow.ChunkedArray") -> "pyarrow.Array"
     """
     from ray.air.util.tensor_extensions.arrow import (
         ArrowTensorArray,
-        get_arrow_extension_tensor_types,
+        ArrowTensorType,
+        ArrowVariableShapedTensorType,
     )
 
     if not _is_column_extension_type(ca):
         raise ValueError("Chunked array isn't an extension array: {ca}")
 
-    tensor_extension_types = get_arrow_extension_tensor_types()
-
     if ca.num_chunks == 0:
         # Create empty storage array.
         storage = pyarrow.array([], type=ca.type.storage_type)
-    elif isinstance(ca.type, tensor_extension_types):
+    elif isinstance(ca.type, (ArrowTensorType, ArrowVariableShapedTensorType)):
         return ArrowTensorArray._concat_same_type(ca.chunks)
     else:
         storage = pyarrow.concat_arrays([c.storage for c in ca.chunks])

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -93,13 +93,17 @@ class ArrowRow(TableRow):
     """
 
     def __getitem__(self, key: Union[str, List[str]]) -> Any:
-        from ray.data.extensions import get_arrow_extension_tensor_types
-
-        tensor_arrow_extension_types = get_arrow_extension_tensor_types()
+        from ray.data.extensions.tensor_extension import (
+            ArrowTensorType,
+            ArrowVariableShapedTensorType,
+        )
 
         def get_item(keys: List[str]) -> Any:
             schema = self._row.schema
-            if isinstance(schema.field(keys[0]).type, tensor_arrow_extension_types):
+            if isinstance(
+                schema.field(keys[0]).type,
+                (ArrowTensorType, ArrowVariableShapedTensorType),
+            ):
                 # Build a tensor row.
                 return tuple(
                     [

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -74,12 +74,6 @@ DEFAULT_MIN_PARALLELISM = 200
 
 DEFAULT_ENABLE_TENSOR_EXTENSION_CASTING = True
 
-# NOTE: V1 tensor type format only supports tensors of no more than 2Gb in
-#       total cumulative size (due to it internally utilizing int32 offsets)
-#
-#       V2 in turn relies on int64 offsets, therefore having a limit of ~9Eb (exabytes)
-DEFAULT_USE_ARROW_TENSOR_V2 = env_bool("RAY_DATA_USE_ARROW_TENSOR_V2", False)
-
 DEFAULT_AUTO_LOG_STATS = False
 
 DEFAULT_VERBOSE_STATS_LOG = False
@@ -292,7 +286,6 @@ class DataContext:
     min_parallelism: int = DEFAULT_MIN_PARALLELISM
     read_op_min_num_blocks: int = DEFAULT_READ_OP_MIN_NUM_BLOCKS
     enable_tensor_extension_casting: bool = DEFAULT_ENABLE_TENSOR_EXTENSION_CASTING
-    use_arrow_tensor_v2: bool = DEFAULT_USE_ARROW_TENSOR_V2
     enable_auto_log_stats: bool = DEFAULT_AUTO_LOG_STATS
     verbose_stats_logs: bool = DEFAULT_VERBOSE_STATS_LOG
     trace_allocations: bool = DEFAULT_TRACE_ALLOCATIONS

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -28,7 +28,6 @@ import ray
 import ray.cloudpickle as pickle
 from ray._private.thirdparty.tabulate.tabulate import tabulate
 from ray._private.usage import usage_lib
-from ray.air.util.tensor_extensions.arrow import ArrowTensorTypeV2
 from ray.air.util.tensor_extensions.utils import _create_possibly_ragged_ndarray
 from ray.data._internal.aggregate import Max, Mean, Min, Std, Sum
 from ray.data._internal.compute import ComputeStrategy
@@ -2587,12 +2586,10 @@ class Dataset:
             schema is not known and fetch_if_missing is False.
         """
 
-        context = self._plan._context
-
         # First check if the schema is already known from materialized blocks.
         base_schema = self._plan.schema(fetch_if_missing=False)
         if base_schema is not None:
-            return Schema(base_schema, data_context=context)
+            return Schema(base_schema)
 
         # Lazily execute only the first block to minimize computation. We achieve this
         # by appending a Limit[1] operation to a copy of this Dataset, which we then
@@ -2600,7 +2597,7 @@ class Dataset:
         base_schema = self.limit(1)._plan.schema(fetch_if_missing=fetch_if_missing)
         if base_schema is not None:
             self._plan.cache_schema(base_schema)
-            return Schema(base_schema, data_context=context)
+            return Schema(base_schema)
         else:
             return None
 
@@ -5188,17 +5185,8 @@ class Schema:
         base_schema: The underlying Arrow or Pandas schema.
     """
 
-    def __init__(
-        self,
-        base_schema: Union["pyarrow.lib.Schema", "PandasBlockSchema"],
-        *,
-        data_context: Optional[DataContext] = None,
-    ):
+    def __init__(self, base_schema: Union["pyarrow.lib.Schema", "PandasBlockSchema"]):
         self.base_schema = base_schema
-
-        # Snapshot the current context, so that the config of Datasets is always
-        # determined by the config at the time it was created.
-        self._context = data_context or copy.deepcopy(DataContext.get_current())
 
     @property
     def names(self) -> List[str]:
@@ -5221,19 +5209,12 @@ class Schema:
         arrow_types = []
         for dtype in self.base_schema.types:
             if isinstance(dtype, TensorDtype):
-
-                if self._context.use_arrow_tensor_v2:
-                    pa_tensor_type_class = ArrowTensorTypeV2
-                else:
-                    pa_tensor_type_class = ArrowTensorType
-
                 # Manually convert our Pandas tensor extension type to Arrow.
                 arrow_types.append(
-                    pa_tensor_type_class(
+                    ArrowTensorType(
                         shape=dtype._shape, dtype=pa.from_numpy_dtype(dtype._dtype)
                     )
                 )
-
             else:
                 try:
                     arrow_types.append(pa.from_numpy_dtype(dtype))

--- a/python/ray/data/extensions/__init__.py
+++ b/python/ray/data/extensions/__init__.py
@@ -1,7 +1,3 @@
-from ray.air.util.tensor_extensions.arrow import (
-    ArrowTensorTypeV2,
-    get_arrow_extension_tensor_types,
-)
 from ray.data.extensions.object_extension import (
     ArrowPythonObjectArray,
     ArrowPythonObjectScalar,
@@ -28,7 +24,6 @@ __all__ = [
     "TensorArray",
     "TensorArrayElement",
     "ArrowTensorType",
-    "ArrowTensorTypeV2",
     "ArrowTensorArray",
     "ArrowVariableShapedTensorType",
     "ArrowVariableShapedTensorArray",
@@ -41,5 +36,4 @@ __all__ = [
     "PythonObjectArray",
     "PythonObjectDtype",
     "object_extension_type_allowed",
-    "get_arrow_extension_tensor_types",
 ]

--- a/python/ray/data/extensions/tensor_extension.py
+++ b/python/ray/data/extensions/tensor_extension.py
@@ -2,7 +2,6 @@ from ray.air.util.tensor_extensions.arrow import (  # noqa: F401
     ArrowConversionError,
     ArrowTensorArray,
     ArrowTensorType,
-    ArrowTensorTypeV2,
     ArrowVariableShapedTensorArray,
     ArrowVariableShapedTensorType,
 )

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -11,7 +11,6 @@ import pytest
 from pytest_lazyfixture import lazy_fixture
 
 import ray
-from ray.air.util.tensor_extensions.arrow import ArrowTensorType, ArrowTensorTypeV2
 from ray.data._internal.datasource.parquet_bulk_datasource import ParquetBulkDatasource
 from ray.data._internal.datasource.parquet_datasource import (
     NUM_CPUS_FOR_META_FETCH_TASK,
@@ -1203,92 +1202,6 @@ def test_partitioning_in_dataset_kwargs_raises_error(ray_start_regular_shared):
         ray.data.read_parquet(
             "example://iris.parquet", dataset_kwargs=dict(partitioning="hive")
         )
-
-
-def test_tensors_in_tables_parquet(
-    ray_start_regular_shared, tmp_path, restore_data_context
-):
-    """This test verifies both V1 and V2 Tensor Type extensions of
-    Arrow Array types
-    """
-
-    num_rows = 10_000
-    num_groups = 10
-
-    inner_shape = (2, 2, 2)
-    shape = (num_rows,) + inner_shape
-    num_tensor_elem = np.prod(np.array(shape))
-
-    arr = np.arange(num_tensor_elem).reshape(shape)
-
-    id_col_name = "_id"
-    group_col_name = "group"
-    tensor_col_name = "tensor"
-
-    id_vals = list(range(num_rows))
-    group_vals = [i % num_groups for i in id_vals]
-
-    df = pd.DataFrame(
-        {
-            id_col_name: id_vals,
-            group_col_name: group_vals,
-            tensor_col_name: [a.tobytes() for a in arr],
-        }
-    )
-
-    #
-    # Test #1: Verify writing tensors as ArrowTensorType (v1)
-    #
-
-    tensor_v1_path = f"{tmp_path}/tensor_v1"
-
-    ds = ray.data.from_pandas([df])
-    ds.write_parquet(tensor_v1_path)
-
-    ds = ray.data.read_parquet(
-        tensor_v1_path,
-        tensor_column_schema={tensor_col_name: (arr.dtype, inner_shape)},
-        override_num_blocks=10,
-    )
-
-    assert isinstance(
-        ds.schema().base_schema.field_by_name(tensor_col_name).type, ArrowTensorType
-    )
-
-    expected_tuples = list(zip(id_vals, group_vals, arr))
-
-    def _assert_equal(rows, expected):
-        values = [[s[id_col_name], s[group_col_name], s[tensor_col_name]] for s in rows]
-
-        assert len(values) == len(expected)
-
-        for v, e in zip(sorted(values, key=lambda v: v[0]), expected):
-            np.testing.assert_equal(v, e)
-
-    _assert_equal(ds.take_all(), expected_tuples)
-
-    #
-    # Test #2: Verify writing tensors as ArrowTensorTypeV2
-    #
-
-    DataContext.get_current().use_arrow_tensor_v2 = True
-
-    tensor_v2_path = f"{tmp_path}/tensor_v2"
-
-    ds = ray.data.from_pandas([df])
-    ds.write_parquet(tensor_v2_path)
-
-    ds = ray.data.read_parquet(
-        tensor_v2_path,
-        tensor_column_schema={tensor_col_name: (arr.dtype, inner_shape)},
-        override_num_blocks=10,
-    )
-
-    assert isinstance(
-        ds.schema().base_schema.field_by_name(tensor_col_name).type, ArrowTensorTypeV2
-    )
-
-    _assert_equal(ds.take_all(), expected_tuples)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reverts ray-project/ray#47832

Seeing some unit test failures / flakiness after this PR was merged. The PR contents look unrelated to the failing tests, so not sure why it's happening, but going to try the revert...

Impacted tests:
- ` TestBackwardsCompatibility.test_cli`
- `test_failed_driver_exit_code`


 [BK link](https://buildkite.com/ray-project/postmerge/builds/6448#01924eeb-104f-4c6b-a5c0-39789ed9b0ee)