### PR TITLE
[Serve / Jobs] Check if conda env exists before removing

### DIFF
--- a/python/ray/dashboard/modules/job/tests/backwards_compatibility_scripts/test_backwards_compatibility.sh
+++ b/python/ray/dashboard/modules/job/tests/backwards_compatibility_scripts/test_backwards_compatibility.sh
@@ -24,8 +24,12 @@ for RAY_VERSION in "${RAY_VERSIONS[@]}"
 do
     env_name=${JOB_COMPATIBILITY_TEST_TEMP_ENV}
 
-    # Clean up if env name is already taken from previous leaking runs
-    conda env remove --name="${env_name}"
+    # Check if the conda env exists
+    if conda env list | grep -q "${env_name}"; then
+        # Clean up if env name is already taken from previous leaking runs
+        conda env remove --name="${env_name}"
+        continue
+    fi
 
     printf "\n\n\n"
     echo "========================================================================================="


### PR DESCRIPTION
## Why are these changes needed?
Fixes some failing/flaky unit tests tests, which fail with errors like:
```
EnvironmentLocationNotFound: Not a conda environment: /opt/miniconda/envs/jobs-backwards-compatibility-cc452d926b8748a1ab6b4fbf6a6dba2b
```
- TestBackwardsCompatibility.test_cli
- test_failed_driver_exit_code

Previously failing test now passes with this PR applied:
https://buildkite.com/ray-project/postmerge/builds/6479#0192693b-1b8f-4dbc-a497-26d163b52c70/181-934

## Related issue number

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git
commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for
https://docs.ray.io/en/master/.
- [ ] I've added any new APIs to the API Reference. For example, if I
added a
method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a
few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

Signed-off-by: Scott Lee <sjl@anyscale.com>