### PR TITLE
[job] don't continue on test setup 

### DIFF
--- a/python/ray/dashboard/modules/job/tests/backwards_compatibility_scripts/test_backwards_compatibility.sh
+++ b/python/ray/dashboard/modules/job/tests/backwards_compatibility_scripts/test_backwards_compatibility.sh
@@ -28,7 +28,6 @@ do
     if conda env list | grep -q "${env_name}"; then
         # Clean up if env name is already taken from previous leaking runs
         conda env remove --name="${env_name}"
-        continue
     fi
 
     printf "\n\n\n"


### PR DESCRIPTION
when the conda env exists, should just remove it and continue
the testing
