### PR TITLE
[core] Add more debug string types

### DIFF
--- a/src/ray/util/container_util.h
+++ b/src/ray/util/container_util.h
@@ -111,11 +111,6 @@ template <typename... Ts>
 std::ostream &operator<<(std::ostream &os, DebugStringWrapper<std::vector<Ts...>> c) {
   return c.StringifyContainer(os);
 }
-template <typename T, std::size_t N>
-std::ostream &operator<<(std::ostream &os,
-                         DebugStringWrapper<absl::InlinedVector<T, N>> c) {
-  return c.StringifyContainer(os);
-}
 template <typename... Ts>
 std::ostream &operator<<(std::ostream &os, DebugStringWrapper<std::set<Ts...>> c) {
   return c.StringifyContainer(os);

--- a/src/ray/util/container_util.h
+++ b/src/ray/util/container_util.h
@@ -148,7 +148,7 @@ std::ostream &operator<<(std::ostream &os,
 template <typename T>
 std::ostream &operator<<(std::ostream &os, DebugStringWrapper<std::optional<T>> c) {
   if (!c.obj_.has_value()) {
-    return os << "(nullopt)";
+    return os << debug_string(std::nullopt);
   }
   return os << debug_string(c.obj_.value());
 }

--- a/src/ray/util/container_util.h
+++ b/src/ray/util/container_util.h
@@ -147,6 +147,9 @@ std::ostream &operator<<(std::ostream &os,
 
 template <typename T>
 std::ostream &operator<<(std::ostream &os, DebugStringWrapper<std::optional<T>> c) {
+  if (!c.obj_.has_value()) {
+    return os << "(nullopt)";
+  }
   return os << debug_string(c.obj_.value());
 }
 

--- a/src/ray/util/container_util.h
+++ b/src/ray/util/container_util.h
@@ -14,17 +14,20 @@
 
 #pragma once
 
+#include <array>
 #include <deque>
 #include <map>
 #include <ostream>
 #include <set>
 #include <sstream>
 #include <type_traits>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
+#include "absl/container/inlined_vector.h"
 #include "ray/util/logging.h"
 
 namespace ray {
@@ -67,6 +70,13 @@ std::ostream &operator<<(std::ostream &os, DebugStringWrapper<T> wrapper) {
   return os << wrapper.obj_;
 }
 
+// TODO(hjiang): Implement debug string for `std::variant`.
+template <>
+inline std::ostream &operator<<(std::ostream &os,
+                                DebugStringWrapper<std::nullopt_t> wrapper) {
+  return os << "(nullopt)";
+}
+
 template <typename... Ts>
 std::ostream &operator<<(std::ostream &os, DebugStringWrapper<std::pair<Ts...>> pair) {
   return os << "(" << debug_string(pair.obj_.first) << ", "
@@ -93,8 +103,17 @@ std::ostream &operator<<(std::ostream &os, DebugStringWrapper<std::tuple<Ts...>>
   return os;
 }
 
+template <typename T, std::size_t N>
+std::ostream &operator<<(std::ostream &os, DebugStringWrapper<std::array<T, N>> c) {
+  return c.StringifyContainer(os);
+}
 template <typename... Ts>
 std::ostream &operator<<(std::ostream &os, DebugStringWrapper<std::vector<Ts...>> c) {
+  return c.StringifyContainer(os);
+}
+template <typename T, std::size_t N>
+std::ostream &operator<<(std::ostream &os,
+                         DebugStringWrapper<absl::InlinedVector<T, N>> c) {
   return c.StringifyContainer(os);
 }
 template <typename... Ts>
@@ -119,6 +138,16 @@ template <typename... Ts>
 std::ostream &operator<<(std::ostream &os,
                          DebugStringWrapper<absl::flat_hash_map<Ts...>> c) {
   return c.StringifyContainer(os);
+}
+template <typename... Ts>
+std::ostream &operator<<(std::ostream &os,
+                         DebugStringWrapper<std::unordered_map<Ts...>> c) {
+  return c.StringifyContainer(os);
+}
+
+template <typename T>
+std::ostream &operator<<(std::ostream &os, DebugStringWrapper<std::optional<T>> c) {
+  return os << debug_string(c.obj_.value());
 }
 
 template <typename C>

--- a/src/ray/util/tests/BUILD
+++ b/src/ray/util/tests/BUILD
@@ -7,6 +7,7 @@ cc_test(
     srcs = ["container_util_test.cc"],
     copts = COPTS,
     tags = ["team:core"],
+    linkstatic = True,
     deps = [
         "//src/ray/util",
         "@com_google_absl//absl/container:flat_hash_map",

--- a/src/ray/util/tests/container_util_test.cc
+++ b/src/ray/util/tests/container_util_test.cc
@@ -69,6 +69,7 @@ TEST(ContainerUtilTest, TestDebugString) {
 
   // Optional.
   ASSERT_EQ(debug_string_to_string(std::nullopt), "(nullopt)");
+  ASSERT_EQ(debug_string_to_string(std::optional<std::string>{}), "(nullopt)");
   ASSERT_EQ(debug_string_to_string(std::optional<std::string>{"hello"}), "hello");
 
   // Composable: tuples of pairs of maps and vectors.

--- a/src/ray/util/tests/container_util_test.cc
+++ b/src/ray/util/tests/container_util_test.cc
@@ -14,10 +14,12 @@
 
 #include "ray/util/container_util.h"
 
-#include <sstream>
-#include <tuple>
+#include <gtest/gtest.h>
 
-#include "gtest/gtest.h"
+#include <optional>
+#include <sstream>
+#include <string>
+#include <tuple>
 
 namespace ray {
 
@@ -29,8 +31,19 @@ std::string debug_string_to_string(const T &t) {
 }
 
 TEST(ContainerUtilTest, TestDebugString) {
+  // Numerical values.
   ASSERT_EQ(debug_string_to_string(static_cast<int>(2)), "2");
+
+  // String values.
+  ASSERT_EQ(debug_string_to_string(std::string_view{"hello"}), "hello");
+  ASSERT_EQ(debug_string_to_string(std::string{"hello"}), "hello");
+
+  // Non-associative containers.
   ASSERT_EQ(debug_string_to_string(std::vector<int>{1, 2}), "[1, 2]");
+  ASSERT_EQ(debug_string_to_string(std::array<int, 3>{1, 2, 3}), "[1, 2, 3]");
+  ASSERT_EQ(debug_string_to_string(absl::InlinedVector<int, 3>{1, 2}), "[1, 2]");
+
+  // Associative containers.
   ASSERT_EQ(debug_string_to_string(std::set<int>{1, 2}), "[1, 2]");
   ASSERT_EQ(debug_string_to_string(std::unordered_set<int>{2}), "[2]");
   ASSERT_EQ(debug_string_to_string(absl::flat_hash_set<int>{1}), "[1]");
@@ -53,6 +66,10 @@ TEST(ContainerUtilTest, TestDebugString) {
   ASSERT_EQ(debug_string_to_string(std::pair<std::string, int>{"key", 42}), "(key, 42)");
   ASSERT_EQ(debug_string_to_string(std::pair<int, std::string>{3, "value"}),
             "(3, value)");
+
+  // Optional.
+  ASSERT_EQ(debug_string_to_string(std::nullopt), "(nullopt)");
+  ASSERT_EQ(debug_string_to_string(std::optional<std::string>{"hello"}), "hello");
 
   // Composable: tuples of pairs of maps and vectors.
   ASSERT_EQ(debug_string_to_string(

--- a/src/ray/util/tests/container_util_test.cc
+++ b/src/ray/util/tests/container_util_test.cc
@@ -41,7 +41,6 @@ TEST(ContainerUtilTest, TestDebugString) {
   // Non-associative containers.
   ASSERT_EQ(debug_string_to_string(std::vector<int>{1, 2}), "[1, 2]");
   ASSERT_EQ(debug_string_to_string(std::array<int, 3>{1, 2, 3}), "[1, 2, 3]");
-  ASSERT_EQ(debug_string_to_string(absl::InlinedVector<int, 3>{1, 2}), "[1, 2]");
 
   // Associative containers.
   ASSERT_EQ(debug_string_to_string(std::set<int>{1, 2}), "[1, 2]");


### PR DESCRIPTION
Followup on https://github.com/ray-project/ray/pull/47893, add more "blessed container types" to debug string function.

Share some of my thoughts (some are irrelevant to this PR):
- The current implementation could be improved
  + There're a few types that we miss, if we want to general-purpose printer: `std::byte`, enum, types which supports absl stringify, fallback printer (which prints type and address, like python) if non existing printer matches; 
  + A good use case for general-purpose printer would be: https://github.com/ray-project/ray/blob/4ab6b7c1ab860c514ee44c2aa159823b2342e597/src/ray/util/logging.h#L151-L154
- We better split bazel targets
  + For example, all files under `src/ray/util` are contained in one single giant target, which greatly increase the compilation, link and test time

