### PR TITLE
[core][logging] Redefine worker initialization status and add context to the driver's system logs

### DIFF
--- a/python/ray/_private/ray_logging/logging_config.py
+++ b/python/ray/_private/ray_logging/logging_config.py
@@ -56,6 +56,13 @@ class DefaultDictConfigProvider(DictConfigProvider):
                     "level": log_level,
                     "handlers": ["console"],
                 },
+                "loggers": {
+                    "ray": {
+                        "level": log_level,
+                        "handlers": ["console"],
+                        "propagate": False,
+                    }
+                },
             }
         }
 

--- a/python/ray/tests/test_logging_2.py
+++ b/python/ray/tests/test_logging_2.py
@@ -387,6 +387,29 @@ ray.get(actor_instance.print_message.remote())
         for s in should_not_exist:
             assert s not in stderr
 
+    def test_text_mode_driver_system_log(self, shutdown_only):
+        script = """
+import ray
+ray.init(
+    logging_config=ray.LoggingConfig(encoding="TEXT")
+)
+"""
+        stderr = run_string_as_driver(script)
+        should_exist = "timestamp_ns="
+        assert should_exist in stderr
+
+
+def test_structured_logging_with_working_dir(tmp_path, shutdown_only):
+    working_dir = tmp_path / "test-working-dir"
+    working_dir.mkdir()
+    runtime_env = {
+        "working_dir": str(working_dir),
+    }
+    ray.init(
+        runtime_env=runtime_env,
+        logging_config=ray.LoggingConfig(encoding="TEXT"),
+    )
+
 
 class TestSetupLogRecordFactory:
     @pytest.fixture


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

```python
import ray

runtime_env = {
    "working_dir": "./test_data"
}

ray.init(
    logging_config=ray.LoggingConfig(encoding="TEXT", log_level="INFO"),
    runtime_env=runtime_env
)
```

In this PR, we also add `CoreContextFilter` to the `ray` logger. If we specify both `LoggingConfig` and `runtime_env` at the same time. An exception will be thrown indicating that `core_worker` doesn't exist when attempting to retrieve `worker_id` from the runtime context in the `CoreContextFilter`.

# Root cause

In the function `ray.init()`, the following three things happen in order:

1. Configure loggers based on `LoggingConfig`
2. Call `connect`
  * If we call `ray.is_initialized` during the process, it will return true.
  * Set the runtime environment
  * Set `core_worker`

However, the `CoreContextFilter` is added to the driver's root logger, and some code paths in the runtime environment call `logger.info` to print logs. Since `core_worker` hasn't been set yet, the filter fails to retrieve the values of `worker_id` and `node_id` from the runtime context.

In `CoreContextFilter`, there is a check using `ray.is_initialized` to determine whether to retrieve the core context. However, `ray.is_initialized` becomes true before all the logic in the `connect` function finishes. As a result, the check doesn't work, and the logger will still attempt to retrieve core context, such as `worker_id`, before the worker process is fully initialized.

## Solution

Make `is_initialized` return true only when all the logic in `connect` finishes.

## Related issue number

Closes #47949 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
