### PR TITLE
[data] remove _split_list dead code

### DIFF
--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -529,23 +529,6 @@ def AllToAllAPI(*args, **kwargs):
     return _all_to_all_api()(args[0])
 
 
-def _split_list(arr: List[Any], num_splits: int) -> List[List[Any]]:
-    """Split the list into `num_splits` lists.
-
-    The splits will be even if the `num_splits` divides the length of list, otherwise
-    the remainder (suppose it's R) will be allocated to the first R splits (one for
-    each).
-    This is the same as numpy.array_split(). The reason we make this a separate
-    implementation is to allow the heterogeneity in the elements in the list.
-    """
-    assert num_splits > 0
-    q, r = divmod(len(arr), num_splits)
-    splits = [
-        arr[i * q + min(i, r) : (i + 1) * q + min(i + 1, r)] for i in range(num_splits)
-    ]
-    return splits
-
-
 def get_compute_strategy(
     fn: "UserDefinedFunction",
     fn_constructor_args: Optional[Iterable[Any]] = None,

--- a/python/ray/data/tests/test_util.py
+++ b/python/ray/data/tests/test_util.py
@@ -16,7 +16,6 @@ from ray.data._internal.remote_fn import _make_hashable, cached_remote_fn
 from ray.data._internal.util import (
     NULL_SENTINEL,
     _check_pyarrow_version,
-    _split_list,
     iterate_with_retry,
 )
 from ray.data.tests.conftest import *  # noqa: F401, F403
@@ -149,21 +148,6 @@ def test_memory_tracing(enabled):
         assert "test3" not in report, report
         assert "test4" not in report, report
         assert "test5" not in report, report
-
-
-def test_list_splits():
-    with pytest.raises(AssertionError):
-        _split_list(list(range(5)), 0)
-
-    with pytest.raises(AssertionError):
-        _split_list(list(range(5)), -1)
-
-    assert _split_list(list(range(5)), 7) == [[0], [1], [2], [3], [4], [], []]
-    assert _split_list(list(range(5)), 2) == [[0, 1, 2], [3, 4]]
-    assert _split_list(list(range(6)), 2) == [[0, 1, 2], [3, 4, 5]]
-    assert _split_list(list(range(5)), 1) == [[0, 1, 2, 3, 4]]
-    assert _split_list(["foo", 1, [0], None], 2) == [["foo", 1], [[0], None]]
-    assert _split_list(["foo", 1, [0], None], 3) == [["foo", 1], [[0]], [None]]
 
 
 def get_parquet_read_logical_op(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Using np.split to split a list in NumPy is not as performant as not using split_list, and the performance difference can be significant.
```python
int_array = range(1000003)
start = time.perf_counter()

for split in np.array_split(int_array, 100):
    len(split)

end1 = time.perf_counter()
print(f"np array_split 100w elements to 100 , cost {(end1 - start)*1000} ms")

for split in _split_list(int_array, 100):
    len(split)
end2 = time.perf_counter()
print(f"_split_list 100w elements to 100, {(end2 - end1)*1000} ms")
```

result is：
<img width="466" alt="image" src="https://github.com/user-attachments/assets/22dedc15-dbd8-4961-ae35-881aa36c7a5a">



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
