### PR TITLE
[core] Add a thread checker

### DIFF
--- a/src/ray/util/BUILD
+++ b/src/ray/util/BUILD
@@ -41,3 +41,10 @@ cc_library(
         "@nlohmann_json",
     ],
 )
+
+cc_library(
+    name = "thread_checker",
+    hdrs = ["thread_checker.h"],
+    srcs = ["thread_checker.cc"],
+    visibility = ["//visibility:public"],
+)

--- a/src/ray/util/tests/BUILD
+++ b/src/ray/util/tests/BUILD
@@ -2,6 +2,18 @@ load("@rules_cc//cc:defs.bzl", "cc_test")
 load("//bazel:ray.bzl", "COPTS")
 
 cc_test(
+    name = "thread_checker_test",
+    srcs = ["thread_checker_test.cc"],
+    copts = COPTS,
+    size = "small",
+    tags = ["team:core"],
+    deps = [
+        "//src/ray/util:thread_checker",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "container_util_test",
     size = "small",
     srcs = ["container_util_test.cc"],

--- a/src/ray/util/tests/thread_checker_test.cc
+++ b/src/ray/util/tests/thread_checker_test.cc
@@ -23,11 +23,11 @@ namespace ray {
 TEST(ThreadCheckerTest, BasicTest) {
   ThreadChecker thread_checker;
   // Pass at initialization.
-  ASSERT_TRUE(thread_checker.ok());
+  ASSERT_TRUE(thread_checker.IsOnSameThread());
   // Pass when invoked at the same thread.
-  ASSERT_TRUE(thread_checker.ok());
+  ASSERT_TRUE(thread_checker.IsOnSameThread());
 
-  auto thd = std::thread([&]() { ASSERT_FALSE(thread_checker.ok()); });
+  auto thd = std::thread([&]() { ASSERT_FALSE(thread_checker.IsOnSameThread()); });
   thd.join();
 }
 

--- a/src/ray/util/tests/thread_checker_test.cc
+++ b/src/ray/util/tests/thread_checker_test.cc
@@ -1,0 +1,34 @@
+// Copyright 2024 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/ray/util/thread_checker.h"
+
+#include <gtest/gtest.h>
+
+#include <thread>
+
+namespace ray {
+
+TEST(ThreadCheckerTest, BasicTest) {
+  ThreadChecker thread_checker;
+  // Pass at initialization.
+  ASSERT_TRUE(thread_checker.ok());
+  // Pass when invoked at the same thread.
+  ASSERT_TRUE(thread_checker.ok());
+
+  auto thd = std::thread([&]() { ASSERT_FALSE(thread_checker.ok()); });
+  thd.join();
+}
+
+}  // namespace ray

--- a/src/ray/util/thread_checker.cc
+++ b/src/ray/util/thread_checker.cc
@@ -1,0 +1,26 @@
+// Copyright 2024 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/ray/util/thread_checker.h"
+
+namespace ray {
+
+bool ThreadChecker::ok() const {
+  const auto cur_id = std::this_thread::get_id();
+  std::thread::id uninitialized_id;
+  return thread_id_.compare_exchange_strong(uninitialized_id, cur_id) ||
+         (uninitialized_id == cur_id);
+}
+
+}  // namespace ray

--- a/src/ray/util/thread_checker.cc
+++ b/src/ray/util/thread_checker.cc
@@ -16,7 +16,7 @@
 
 namespace ray {
 
-bool ThreadChecker::ok() const {
+bool ThreadChecker::IsOnSameThread() {
   const auto cur_id = std::this_thread::get_id();
   std::thread::id uninitialized_id;
   return thread_id_.compare_exchange_strong(uninitialized_id, cur_id) ||

--- a/src/ray/util/thread_checker.h
+++ b/src/ray/util/thread_checker.h
@@ -1,0 +1,43 @@
+// Copyright 2024 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Used to sanity check threading issues by checking current thread id.
+//
+// Example usage:
+// ThreadChecker thread_checker{};
+//
+// // Initialize on the thread at first usage.
+// RAY_CHECK(thread_checker.ok());
+//
+// // Check it's on the same thread.
+// RAY_CHECK(thread_checker.ok());
+
+#pragma once
+
+#include <atomic>
+#include <thread>
+
+namespace ray {
+
+class ThreadChecker {
+ public:
+  // Return true at initialization, or current invocation happens on the same thread as
+  // initialization.
+  bool ok() const;
+
+ private:
+  mutable std::atomic<std::thread::id> thread_id_{};
+};
+
+}  // namespace ray

--- a/src/ray/util/thread_checker.h
+++ b/src/ray/util/thread_checker.h
@@ -34,10 +34,10 @@ class ThreadChecker {
  public:
   // Return true at initialization, or current invocation happens on the same thread as
   // initialization.
-  bool ok() const;
+  bool IsOnSameThread();
 
  private:
-  mutable std::atomic<std::thread::id> thread_id_{};
+  std::atomic<std::thread::id> thread_id_{};
 };
 
 }  // namespace ray


### PR DESCRIPTION
As @rynewang mentioned at comment https://github.com/ray-project/ray/pull/47793#discussion_r1794767402, ray core uses ASIO io context for event scheduling and callback execution.

Merely reading through the code, it's not always easy to justify correct threading usage, whether data race.

TSAN is a great tool to verify against data race and invalid memory access at runtime, but is generally not enough, since 
- It completely relies on the coverage for unit tests, which is hard to enforce along the codebase;
- Certain tests cannot run with TSAN, for example, if we have non-default memory allocator (i.e. tcmalloc); or large tests which exceeds binary size (for static link), or too long runtime (usually for dynamic link)

`ThreadChecker` is a cheap runtime checker, which only takes two atomic operations, which 
- guards against threading invariants;
- serves for better code readability, so code readers and developers are easy to understand thread execution status

Intended usage for `GcsJobManager`:
```
void CreateJob() {
  auto callback = [this]() {
    RAY_CHECK(this->thread_checker.ok());
  };
}
```