### PR TITLE
[RLlib] Add framework-check to `MultiRLModule.add_module()`.

### DIFF
--- a/rllib/core/rl_module/multi_rl_module.py
+++ b/rllib/core/rl_module/multi_rl_module.py
@@ -288,6 +288,19 @@ class MultiRLModule(RLModule):
         # has `inference_only=False`.
         if not module.inference_only:
             self.inference_only = False
+
+        # Check framework of incoming RLModule against `self.framework`.
+        if module.framework is not None:
+            if self.framework is None:
+                self.framework = module.framework
+            elif module.framework != self.framework:
+                raise ValueError(
+                    f"Framework ({module.framework}) of incoming RLModule does NOT "
+                    f"match framework ({self.framework}) of MultiRLModule! If the "
+                    f"added module should not be trained, try setting its framework "
+                    f"to None."
+                )
+
         self._rl_modules[module_id] = module
         # Update our RLModuleSpecs dict, such that - if written to disk -
         # it'll allow for proper restoring this instance through `.from_checkpoint()`.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Add framework-check to `MultiRLModule.add_module()`.


Feedback from a `MultiRLModule` user:
```
When adding a new module to an existing MultiRLModule (https://github.com/ray-project/ray/blob/312730e6d3bc5d9bf8e4dcd66f00b411366323e3/rllib/core/rl_module/multi_rl_module.py#L152),
it would be nice to have a check of the framework of the new model, making sure it doesn't conflict with the
frameworks of other modules, and also setting the framework of the MultiRLModule
if the framework is None at that point. The setting of framework is done in
https://github.com/ray-project/ray/blob/312730e6d3bc5d9bf8e4dcd66f00b411366323e3/rllib/core/rl_module/multi_rl_module.py#L74,
but it doesn't cover the case of modules added after setup.
```

This PR solves the above problem.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
