### PR TITLE
[core][compiled graphs] Evolve microbenchmark suite names

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2981,6 +2981,56 @@
     timeout: 1800
     script: python experimental/accelerated_dag_gpu_microbenchmark.py --distributed
 
+- name: compiled_graphs
+  group: core-daily-test
+  team: core
+  frequency: nightly
+  working_dir: microbenchmark
+
+  stable: false
+
+  cluster:
+    byod: {}
+    cluster_compute: tpl_64.yaml
+
+  run:
+    timeout: 1800
+    script: OMP_NUM_THREADS=64 RAY_ADDRESS=local python run_microbenchmark.py --experimental
+
+- name: compiled_graphs_GPU
+  group: core-daily-test
+  team: core
+  frequency: nightly
+  working_dir: microbenchmark
+
+  stable: false
+
+  cluster:
+    byod:
+      type: gpu
+    cluster_compute: experimental/compute_gpu_2_aws.yaml
+
+  run:
+    timeout: 1800
+    script: python experimental/accelerated_dag_gpu_microbenchmark.py
+
+- name: compiled_graphs_GPU_multinode
+  group: core-daily-test
+  team: core
+  frequency: nightly
+  working_dir: microbenchmark
+
+  stable: false
+
+  cluster:
+    byod:
+      type: gpu
+    cluster_compute: experimental/compute_gpu_2x1_aws.yaml
+
+  run:
+    timeout: 1800
+    script: python experimental/accelerated_dag_gpu_microbenchmark.py --distributed
+
 - name: benchmark_worker_startup
   group: core-daily-test
   team: core

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2987,7 +2987,7 @@
   frequency: nightly
   working_dir: microbenchmark
 
-  stable: false
+  stable: true
 
   cluster:
     byod: {}
@@ -3003,7 +3003,7 @@
   frequency: nightly
   working_dir: microbenchmark
 
-  stable: false
+  stable: true
 
   cluster:
     byod:
@@ -3020,7 +3020,7 @@
   frequency: nightly
   working_dir: microbenchmark
 
-  stable: false
+  stable: true
 
   cluster:
     byod:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

We'd like to change the compiled graphs microbenchmark suite names, especially to remove the "unstable" from the naming. To keep historical data, we will do this by replicating current microbenchmarks with new names, waiting for a month for data population, and then delete the old ones. This is the first step to add the replicated microbenchmarks with new names.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
