### PR TITLE
[core] Add thread check to job mgr callback

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -513,6 +513,7 @@ ray_cc_library(
         "@boost//:bimap",
         "@com_github_grpc_grpc//src/proto/grpc/health/v1:health_proto",
         "@com_google_absl//absl/container:btree",
+        "//src/ray/util:thread_checker",
     ],
 )
 

--- a/src/ray/gcs/gcs_server/gcs_job_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_job_manager.h
@@ -31,6 +31,7 @@
 #include "ray/rpc/worker/core_worker_client.h"
 #include "ray/rpc/worker/core_worker_client_pool.h"
 #include "ray/util/event.h"
+#include "ray/util/thread_checker.h"
 
 namespace ray {
 namespace gcs {
@@ -106,6 +107,10 @@ class GcsJobManager : public rpc::JobInfoHandler {
 
   void MarkJobAsFinished(rpc::JobTableData job_table_data,
                          std::function<void(Status)> done_callback);
+
+  // Used to validate invariants for threading; for example, all callbacks are executed on
+  // the same thread.
+  ThreadChecker thread_checker_;
 
   // Running Job IDs, used to report metrics.
   absl::flat_hash_set<JobID> running_job_ids_;


### PR DESCRIPTION
This PR followup for comment https://github.com/ray-project/ray/pull/47793#discussion_r1794767402, and adds a thread checking to GCS job manager callback to make sure no concurrent access for data members.