### PR TITLE
[data] add backpressure reason

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/execution_options.py
+++ b/python/ray/data/_internal/execution/interfaces/execution_options.py
@@ -192,6 +192,28 @@ class ExecutionResources:
             and self.object_store_memory <= limit.object_store_memory
         )
 
+    def satisfies_limit_with_reason(self, limit: "ExecutionResources") -> List[str]:
+        """Return if this resource struct meets the specified limits.
+
+        Note that None for a field means no limit.
+        """
+        not_satisfied = []
+
+        if self.cpu is not None and limit.cpu is not None and self.cpu > limit.cpu:
+            not_satisfied.append("CPU")
+        if self.gpu is not None and limit.gpu is not None and self.gpu > limit.gpu:
+            not_satisfied.append("GPU")
+        if (
+            self.object_store_memory is not None
+            and limit.object_store_memory is not None
+            and self.object_store_memory > limit.object_store_memory
+        ):
+            not_satisfied.append("MEM")
+
+        if not not_satisfied:
+            return []
+        return not_satisfied
+
     def scale(self, f: float) -> "ExecutionResources":
         """Return copy with all set values scaled by `f`."""
         if f < 0:

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Dict, Iterator, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Union
 
 import ray
 from .ref_bundle import RefBundle
@@ -15,6 +15,10 @@ from ray.data._internal.execution.interfaces.op_runtime_metrics import OpRuntime
 from ray.data._internal.logical.interfaces import LogicalOperator, Operator
 from ray.data._internal.stats import StatsDict
 from ray.data.context import DataContext
+
+if TYPE_CHECKING:
+    from ray.data._internal.execution.operators.map_operator import MapTaskStats
+
 
 # TODO(hchen): Ray Core should have a common interface for these two types.
 Waitable = Union[ray.ObjectRef, ObjectRefGenerator]
@@ -47,7 +51,9 @@ class DataOpTask(OpTask):
         task_index: int,
         streaming_gen: ObjectRefGenerator,
         output_ready_callback: Callable[[RefBundle], None],
-        task_done_callback: Callable[[Optional[Exception]], None],
+        task_done_callback: Callable[
+            [Optional[Exception], Optional["MapTaskStats"]], None
+        ],
     ):
         """
         Args:
@@ -136,6 +142,45 @@ class MetadataOpTask(OpTask):
         self._task_done_callback()
 
 
+class TaskBackPressureState:
+    def __init__(self):
+        self._in_task_submission_backpressure = False
+        self._in_task_submission_backpressure_reason = ""
+        self._in_task_output_backpressure = False
+        self._in_task_output_backpressure_reason = ""
+
+    def set_in_task_submission_backpressure(
+        self, in_backpressure: bool, reason: str
+    ) -> bool:
+        self._in_task_submission_backpressure = in_backpressure
+        self._in_task_submission_backpressure_reason = reason
+        return (
+            self._in_task_submission_backpressure != in_backpressure
+            or self._in_task_submission_backpressure_reason != reason
+        )
+
+    def set_in_task_output_backpressure(
+        self, in_backpressure: bool, reason: str
+    ) -> bool:
+        self._in_task_output_backpressure = in_backpressure
+        self._in_task_output_backpressure_reason = reason
+        return (
+            self._in_task_output_backpressure != in_backpressure
+            or self._in_task_output_backpressure_reason != reason
+        )
+
+    def is_in_backpressure(self):
+        return (
+            self._in_task_output_backpressure or self._in_task_submission_backpressure
+        )
+
+    def is_in_task_output_backpressure(self):
+        return self._in_task_output_backpressure
+
+    def is_in_task_submission_backpressure(self):
+        return self._in_task_submission_backpressure
+
+
 class PhysicalOperator(Operator):
     """Abstract class for physical operators.
 
@@ -183,9 +228,8 @@ class PhysicalOperator(Operator):
         self._inputs_complete = not input_dependencies
         self._target_max_block_size = target_max_block_size
         self._started = False
-        self._in_task_submission_backpressure = False
-        self._in_task_output_backpressure = False
         self._metrics = OpRuntimeMetrics(self)
+        self._backpressure_state = TaskBackPressureState()
         self._estimated_num_output_bundles = None
         self._estimated_output_num_rows = None
         self._execution_completed = False
@@ -481,17 +525,30 @@ class PhysicalOperator(Operator):
         """
         return ExecutionResources()
 
-    def notify_in_task_submission_backpressure(self, in_backpressure: bool) -> None:
+    def notify_in_task_submission_backpressure(
+        self, in_backpressure: bool, reason: str
+    ) -> None:
         """Called periodically from the executor to update internal in backpressure
         status for stats collection purposes.
 
         Args:
             in_backpressure: Value this operator's in_backpressure should be set to.
+            reason: reason for in_backpressure
         """
         # only update on change to in_backpressure
-        if self._in_task_submission_backpressure != in_backpressure:
+        changed = self._backpressure_state.set_in_task_submission_backpressure(
+            in_backpressure, reason
+        )
+        if changed:
             self._metrics.on_toggle_task_submission_backpressure(in_backpressure)
-            self._in_task_submission_backpressure = in_backpressure
+
+    def notify_in_task_output_backpressure(
+        self, in_backpressure: bool, reason: str
+    ) -> None:
+        # only update on change to in_backpressure
+        self._backpressure_state.set_in_task_output_backpressure(
+            in_backpressure, reason
+        )
 
     def get_autoscaling_actor_pools(self) -> List[AutoscalingActorPool]:
         """Return a list of `AutoscalingActorPool`s managed by this operator."""

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -315,6 +315,8 @@ class DataContext:
     enable_progress_bar_name_truncation: bool = (
         DEFAULT_ENABLE_PROGRESS_BAR_NAME_TRUNCATION
     )
+    enable_show_backpressure_reason: bool = False
+    # By default, disable the backpressure reason for operator-level progress.
     enable_get_object_locations_for_metrics: bool = (
         DEFAULT_ENABLE_GET_OBJECT_LOCATIONS_FOR_METRICS
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->
# Background
The concurrency of raydata's operators is mostly set manually, and the automatic perception mostly cannot meet the situation of resource utilization. However, manually setting the operator concurrency is very easy to trigger rate limiting, but it is currently difficult to obtain the reason for rate limiting.
# Backpressure trigger conditions
There are a total of four trigger conditions:
- **Reserved resources**: DataContext.get_current()data_context.op_resource_reservation_enabled = true (default). Each time a new task is submitted, it will check whether the resources required by the task can still be met. The overall resources will be divided into reserved and shared.
- **Unreserved resources**: DataContext.get_current()data_context.op_resource_reservation_enabled = false. Resources are managed uniformly.
- **Backpressure policy**: In the open-source policy, only ConcurrencyCapBackpressurePolicy is supported, whether the number of running tasks exceeds the set concurrency number.
- **Whether the Op can increase input**: For the actor pool, whether there is remaining free slots space, mainly depending on the difference between the number of running tasks on the actor and the default number.
# Backpressure enhancement
## Backpressure observability enhancement
- Before enhancement:
![image](https://github.com/user-attachments/assets/08afe5c8-d102-477d-a31b-a8f78396e672)

- After enhancement
  - Concurrent backpressure policy
  ![image](https://github.com/user-attachments/assets/825f1b79-7f0f-4dae-b76d-b582708efebd)

  - Backpressure in non-reserved mode
![image](https://github.com/user-attachments/assets/6fc2918a-1a47-4d57-aad2-a44f047db33d)
  - Backpressure in reserved mode
![image](https://github.com/user-attachments/assets/3ea6df89-754b-45c3-afb1-2b0f368516f2)
  - Insufficient free slots of actor
![image](https://github.com/user-attachments/assets/a8815f40-5002-45bd-9686-336953e480bb)

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
