### PR TITLE
:bug: do not modify user-provided runtime_env

### DIFF
--- a/python/ray/_private/runtime_env/working_dir.py
+++ b/python/ray/_private/runtime_env/working_dir.py
@@ -37,6 +37,9 @@ def upload_working_dir_if_needed(
 
     If the working_dir is already a URI, this is a no-op.
     """
+    # we copy this object because modifications are going to be made to it
+    runtime_env = runtime_env.copy()
+
     working_dir = runtime_env.get("working_dir")
     if working_dir is None:
         return runtime_env

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -423,7 +423,6 @@ RT_ENV_AGENT_SLOW_STARTUP_PLUGIN_CLASS_PATH = (
 
 
 class RtEnvAgentSlowStartupPlugin(RuntimeEnvPlugin):
-
     name = RT_ENV_AGENT_SLOW_STARTUP_PLUGIN_NAME
 
     def __init__(self):
@@ -741,7 +740,6 @@ runtime_env_retry_times = 0
 # This plugin can make runtime env creation failed before the retry times
 # increased to `success_retry_number`.
 class MyPlugin(RuntimeEnvPlugin):
-
     name = MY_PLUGIN_NAME
 
     @staticmethod
@@ -843,7 +841,6 @@ def test_serialize_deserialize(option):
 
 
 def test_runtime_env_interface():
-
     # Test the interface related to working_dir
     default_working_dir = "s3://bucket/key.zip"
     modify_working_dir = "s3://bucket/key_A.zip"
@@ -985,6 +982,18 @@ def test_runtime_env_interface():
 
     runtime_env.pop("container")
     assert runtime_env.to_dict() == {}
+
+
+def test_working_dir_is_not_mutated(start_cluster, tmp_working_dir):
+    cluster, address = start_cluster
+
+    runtime_env = {
+        "working_dir": tmp_working_dir,
+    }
+
+    ray.init(address, runtime_env=runtime_env)
+
+    assert runtime_env["working_dir"] == tmp_working_dir
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_runtime_env_2.py
+++ b/python/ray/tests/test_runtime_env_2.py
@@ -180,6 +180,9 @@ class TestNoUserInfoInLogs:
         }
         ray.init(runtime_env=runtime_env)
 
+        # we can't have `working_dir` in `runtime_env` anymore because it's only allowed as input to `ray.init`
+        runtime_env.pop("working_dir")
+
         # Run a function to ensure the runtime env is set up.
         @ray.remote
         def f():


### PR DESCRIPTION
## Why are these changes needed?

I noticed the `upload_working_dir_if_needed` function modifies the original (user-provided) `runtime_env` dict. 
Specifically, it replaces `working_dir` with the resolved package URI. 

This can lead to unexpected bugs if the user submits jobs multiple times with the same `runtime_env` dict. 

For example, because `working_dir` no longer points to a local directory, Ray won't notice if the directory has been modified and won't re-upload it.

I believe this is not the indented behavior. We shouldn't be modifying user-provided objects like this. 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Existing tests should pass
