### PR TITLE
[serve] deflake test_failure::test_replica_actor_died

### DIFF
--- a/python/ray/serve/tests/test_failure.py
+++ b/python/ray/serve/tests/test_failure.py
@@ -13,7 +13,12 @@ from ray._private.test_utils import SignalActor, wait_for_condition
 from ray.exceptions import RayActorError
 from ray.serve._private.common import DeploymentID
 from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
-from ray.serve._private.test_utils import Counter, get_deployment_details, tlog
+from ray.serve._private.test_utils import (
+    Counter,
+    check_num_replicas_eq,
+    get_deployment_details,
+    tlog,
+)
 
 
 def request_with_retries(endpoint, timeout=30):
@@ -304,6 +309,8 @@ def test_replica_actor_died(serve_instance, die_during_request):
         replica_to_kill = random.choice(replicas)
         tlog(f"Killing replica {replica_to_kill}")
         ray.kill(ray.get_actor(replica_to_kill, namespace="serve"))
+
+    wait_for_condition(check_num_replicas_eq, name="Dummy", target=1)
 
     # The controller just health checked both of them, so it should not
     # be able to health check and notify the handle router in time. Then


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Make `test_failure.py::test_replica_actor_died` more stable by waiting until one of the two actors is confirmed to be dead, before sending the next batch of requests.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
