### PR TITLE
[data] Adding in better json checking in test logging

### DIFF
--- a/python/ray/data/tests/test_logging.py
+++ b/python/ray/data/tests/test_logging.py
@@ -128,6 +128,7 @@ def test_json_logging_configuration(
     capsys, reset_logging, monkeypatch, shutdown_only, propagate_logs
 ):
     import json
+
     monkeypatch.setenv("RAY_DATA_LOG_ENCODING", "JSON")
     ray.init()
 
@@ -151,7 +152,7 @@ def test_json_logging_configuration(
     # Validate the log is in JSON format (a basic check for JSON)
     messages = set()
     for log_line in log_contents.splitlines():
-        log_dict = json.loads(log_line) # will error if not a json line
+        log_dict = json.loads(log_line)  # will error if not a json line
         messages.add(log_dict["message"])
 
     assert "ham" in messages

--- a/python/ray/data/tests/test_logging.py
+++ b/python/ray/data/tests/test_logging.py
@@ -127,6 +127,7 @@ def test_custom_config(reset_logging, monkeypatch, tmp_path):
 def test_json_logging_configuration(
     capsys, reset_logging, monkeypatch, shutdown_only, propagate_logs
 ):
+    import json
     monkeypatch.setenv("RAY_DATA_LOG_ENCODING", "JSON")
     ray.init()
 
@@ -148,20 +149,22 @@ def test_json_logging_configuration(
         log_contents = file.read()
 
     # Validate the log is in JSON format (a basic check for JSON)
-    assert all(
-        log_line.startswith("{") and log_line.endswith("}")
-        for log_line in log_contents.splitlines()
-    )
+    messages = set()
+    for log_line in log_contents.splitlines():
+        log_dict = json.loads(log_line) # will error if not a json line
+        messages.add(log_dict["message"])
 
-    assert '"message": "ham"' in log_contents
-    assert '"message": "turkey"' in log_contents
+    assert "ham" in messages
+    assert "turkey" in messages
 
     # Validate console logs are in text mode
     console_log_output = capsys.readouterr().err
-    assert not any(
-        log_line.startswith("{") and log_line.endswith("}")
-        for log_line in console_log_output.splitlines()
-    )
+    for log_line in console_log_output.splitlines():
+        try:
+            json.loads(log_line)
+            raise ValueError("Expected log line to be logged without JSON formatting.")
+        except json.JSONDecodeError:
+            pass
 
     assert "ham" in console_log_output
     assert "turkey" not in console_log_output

--- a/python/ray/data/tests/test_logging.py
+++ b/python/ray/data/tests/test_logging.py
@@ -150,10 +150,10 @@ def test_json_logging_configuration(
         log_contents = file.read()
 
     # Validate the log is in JSON format (a basic check for JSON)
-    messages = set()
+    messages = []
     for log_line in log_contents.splitlines():
         log_dict = json.loads(log_line)  # will error if not a json line
-        messages.add(log_dict["message"])
+        messages.append(log_dict["message"])
 
     assert "ham" in messages
     assert "turkey" in messages

--- a/python/ray/data/tests/test_logging.py
+++ b/python/ray/data/tests/test_logging.py
@@ -161,11 +161,8 @@ def test_json_logging_configuration(
     # Validate console logs are in text mode
     console_log_output = capsys.readouterr().err
     for log_line in console_log_output.splitlines():
-        try:
+        with pytest.raises(json.JSONDecodeError):
             json.loads(log_line)
-            raise ValueError("Expected log line to be logged without JSON formatting.")
-        except json.JSONDecodeError:
-            pass
 
     assert "ham" in console_log_output
     assert "turkey" not in console_log_output


### PR DESCRIPTION
## Why are these changes needed?
Previously this test simply checked if the first and last characters of a line were `{` or `}` to assert whether or not they were JSON lines. This updates the test to instead attempt to parse them as JSONs which is much more robust.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
