### PR TITLE
[Data] Allow specifying insertion index when registering custom plan optimization `Rule`s

### DIFF
--- a/python/ray/data/_internal/logical/optimizers.py
+++ b/python/ray/data/_internal/logical/optimizers.py
@@ -1,4 +1,4 @@
-from typing import List, Type
+from typing import List, Optional, Type
 
 from ray.data._internal.logical.interfaces import (
     LogicalPlan,
@@ -36,8 +36,11 @@ def register_logical_rule(cls: Type[Rule]):
 
 
 @DeveloperAPI
-def register_physical_rule(cls: Type[Rule]):
-    _PHYSICAL_RULES.append(cls)
+def register_physical_rule(cls: Type[Rule], insert_index: Optional[int] = None):
+    if not insert_index:
+        _PHYSICAL_RULES.append(cls)
+    else:
+        _PHYSICAL_RULES.insert(insert_index, cls)
 
 
 class LogicalOptimizer(Optimizer):

--- a/python/ray/data/_internal/logical/optimizers.py
+++ b/python/ray/data/_internal/logical/optimizers.py
@@ -31,8 +31,11 @@ _PHYSICAL_RULES = [
 
 
 @DeveloperAPI
-def register_logical_rule(cls: Type[Rule]):
-    _LOGICAL_RULES.append(cls)
+def register_logical_rule(cls: Type[Rule], insert_index: Optional[int] = None):
+    if not insert_index:
+        _LOGICAL_RULES.append(cls)
+    else:
+        _LOGICAL_RULES.insert(insert_index, cls)
 
 
 @DeveloperAPI


### PR DESCRIPTION
## Why are these changes needed?

Currently, when registering custom `LogicalPlan` or `PhysicalPlan` optimization `Rule`s, the only option is to append to the end of the registered rules. The optimization rules will then be executed in order. This is limiting because there are some cases where we want to specify the order of newly registered rules. For example, we may want to add our own custom rule prior to operator fusion taking place.

This PR adds the ability to specify an insertion index when registering a custom logical/physical rule. The existing behavior of methods are unchanged.

## Related issue number

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
