### PR TITLE
[Data] Fix bug with inserting custom optimization rule at index 0

### DIFF
--- a/python/ray/data/_internal/logical/optimizers.py
+++ b/python/ray/data/_internal/logical/optimizers.py
@@ -32,7 +32,7 @@ _PHYSICAL_RULES = [
 
 @DeveloperAPI
 def register_logical_rule(cls: Type[Rule], insert_index: Optional[int] = None):
-    if not insert_index:
+    if insert_index is None:
         _LOGICAL_RULES.append(cls)
     else:
         _LOGICAL_RULES.insert(insert_index, cls)
@@ -40,7 +40,7 @@ def register_logical_rule(cls: Type[Rule], insert_index: Optional[int] = None):
 
 @DeveloperAPI
 def register_physical_rule(cls: Type[Rule], insert_index: Optional[int] = None):
-    if not insert_index:
+    if insert_index is None:
         _PHYSICAL_RULES.append(cls)
     else:
         _PHYSICAL_RULES.insert(insert_index, cls)


### PR DESCRIPTION

## Why are these changes needed?
Fix the bug reported https://github.com/ray-project/ray/pull/48039#discussion_r1803592826

## Related issue number

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
