### PR TITLE
[WIP] add support for TPU v6e in kuberay autoscaler

### DIFF
--- a/python/ray/autoscaler/_private/kuberay/utils.py
+++ b/python/ray/autoscaler/_private/kuberay/utils.py
@@ -11,6 +11,7 @@ gke_tpu_accelerator_to_generation = {
     "tpu-v5-lite-device": "v5e",
     "tpu-v5-lite-podslice": "v5e",
     "tpu-v5p-slice": "v5p",
+    "tpu-v6e-slice": "v6e",
 }
 
 
@@ -103,7 +104,7 @@ def tpu_node_selectors_to_type(topology: str, accelerator: str) -> Optional[str]
         chip_dimensions = [int(chip_count) for chip_count in topology.split("x")]
         num_chips = reduce(lambda x, y: x * y, chip_dimensions)
         default_num_cores_per_chip = 2
-        if generation == "v5e":
+        if generation == "v5e" or generation == "v6e":
             default_num_cores_per_chip = 1
         num_cores = num_chips * default_num_cores_per_chip
         return f"{generation}-{num_cores}"


### PR DESCRIPTION
## Why are these changes needed?

This PR adds support in the kuberay autoscaler for TPU v6e. Marking WIP for now since it still needs to be tested

## Related issue number

N/A

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
