### PR TITLE
[CI] Fix: flake8 rule E231: Missing whitespace after ',', ';', or ':'

### DIFF
--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -354,7 +354,7 @@ def test_large_args_scheduling_strategy(
         f"Dataset throughput:\n"
         f"    * Ray Data throughput: N rows/s\n"
         f"    * Estimated single node throughput: N rows/s\n"
-        f"{gen_runtime_metrics_str(['ReadRange','MapBatches(dummy_map_batches)'], verbose_stats_logs)}"  # noqa: E501
+        f"{gen_runtime_metrics_str(['ReadRange', 'MapBatches(dummy_map_batches)'], verbose_stats_logs)}"  # noqa: E501
     )
     assert canonicalize(stats) == expected_stats
 
@@ -421,7 +421,7 @@ def test_dataset_stats_basic(
                 f"Dataset throughput:\n"
                 f"    * Ray Data throughput: N rows/s\n"
                 f"    * Estimated single node throughput: N rows/s\n"
-                f"{gen_runtime_metrics_str(['ReadRange->MapBatches(dummy_map_batches)','Map(dummy_map_batches)'], verbose_stats_logs)}"  # noqa: E501
+                f"{gen_runtime_metrics_str(['ReadRange->MapBatches(dummy_map_batches)', 'Map(dummy_map_batches)'], verbose_stats_logs)}"  # noqa: E501
             )
 
     for batch in ds.iter_batches():
@@ -473,7 +473,7 @@ def test_dataset_stats_basic(
         f"Dataset throughput:\n"
         f"    * Ray Data throughput: N rows/s\n"
         f"    * Estimated single node throughput: N rows/s\n"
-        f"{gen_runtime_metrics_str(['ReadRange->MapBatches(dummy_map_batches)','Map(dummy_map_batches)'], verbose_stats_logs)}"  # noqa: E501
+        f"{gen_runtime_metrics_str(['ReadRange->MapBatches(dummy_map_batches)', 'Map(dummy_map_batches)'], verbose_stats_logs)}"  # noqa: E501
     )
 
 

--- a/python/ray/serve/tests/unit/test_deployment_scheduler.py
+++ b/python/ray/serve/tests/unit/test_deployment_scheduler.py
@@ -304,7 +304,7 @@ def test_get_node_to_running_replicas():
     # Test random case
     node_to_running_replicas = defaultdict(set)
     for i in range(40):
-        node_id = f"node{random.randint(0,5)}"
+        node_id = f"node{random.randint(0, 5)}"
         r_id = ReplicaID(f"r{i}", d_id)
         node_to_running_replicas[node_id].add(r_id)
         scheduler.on_replica_running(r_id, node_id)

--- a/python/ray/train/torch/xla/config.py
+++ b/python/ray/train/torch/xla/config.py
@@ -98,7 +98,7 @@ def _neuron_compile_extracted_graphs():
         logger.info("Compiling extracted graphs on local rank0 worker")
 
         parallel_compile_workdir = (
-            f"/tmp/{os.environ.get('USER','no-user')}/parallel_compile_workdir/"
+            f"/tmp/{os.environ.get('USER', 'no-user')}/parallel_compile_workdir/"
         )
         if os.path.exists(parallel_compile_workdir):
             shutil.rmtree(parallel_compile_workdir)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

While running the pre-commit hook of flake8, the following error occurs if Python version is 3.12. It's because the version of flake8 is too old.

![image](https://github.com/user-attachments/assets/985b1d64-714b-49dd-82fc-3d6a2db47034)

version:
- python: 3.12.7
- flake8: 7.1.1 
- flake8-bugbear: 24.8.19


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #48060

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
