### PR TITLE
Add perf metrics for 2.38.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 533.397504,
+    "_dashboard_memory_usage_mb": 399.106048,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.81,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1138\t7.94GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3334\t1.82GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4274\t0.89GiB\tpython distributed/test_many_actors.py\n3452\t0.37GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1900\t0.36GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3616\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n2136\t0.08GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3618\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4065\t0.07GiB\tray::JobSupervisor\n3666\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
-    "actors_per_second": 576.4528544875533,
+    "_peak_memory": 3.74,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1260\t6.52GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3455\t1.88GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4401\t0.89GiB\tpython distributed/test_many_actors.py\n2284\t0.39GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3571\t0.23GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1040\t0.12GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n2409\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3739\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n3741\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3795\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
+    "actors_per_second": 550.7019220598719,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 576.4528544875533
+            "perf_metric_value": 550.7019220598719
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 133.9
+            "perf_metric_value": 90.11
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3471.736
+            "perf_metric_value": 3824.806
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4044.61
+            "perf_metric_value": 4641.532
         }
     ],
     "success": "1",
-    "time": 17.347472429275513
+    "time": 18.15864372253418
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 189.595648,
+    "_dashboard_memory_usage_mb": 207.106048,
     "_dashboard_test_success": true,
-    "_peak_memory": 1.7,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3362\t0.54GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1990\t0.26GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1123\t0.25GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3478\t0.18GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4546\t0.17GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3645\t0.1GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n4824\t0.08GiB\tray::StateAPIGeneratorActor.start\n2158\t0.08GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3647\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4339\t0.07GiB\tray::JobSupervisor",
+    "_peak_memory": 1.67,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3320\t0.53GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1971\t0.24GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1245\t0.22GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3438\t0.19GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4488\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1042\t0.11GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3605\t0.1GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n2148\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4712\t0.08GiB\tray::StateAPIGeneratorActor.start\n3607\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 355.14364663245095
+            "perf_metric_value": 360.10290607052235
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.983
+            "perf_metric_value": 4.308
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 39.613
+            "perf_metric_value": 8.773
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 102.131
+            "perf_metric_value": 84.553
         }
     ],
     "success": "1",
-    "tasks_per_second": 355.14364663245095,
-    "time": 302.81576204299927,
+    "tasks_per_second": 360.10290607052235,
+    "time": 302.77698397636414,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 137.936896,
+    "_dashboard_memory_usage_mb": 156.89728,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.23,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1131\t6.89GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3279\t0.98GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4259\t0.42GiB\tpython distributed/test_many_pgs.py\n2056\t0.28GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3395\t0.11GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n3558\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n1960\t0.08GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3560\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4044\t0.07GiB\tray::JobSupervisor\n3583\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
+    "_peak_memory": 2.14,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1274\t6.9GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3387\t0.92GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2115\t0.43GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4319\t0.42GiB\tpython distributed/test_many_pgs.py\n1043\t0.12GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3503\t0.11GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2363\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3668\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n3670\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3754\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22.444531603492308
+            "perf_metric_value": 22.52798235601382
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.614
+            "perf_metric_value": 4.026
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.021
+            "perf_metric_value": 8.371
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 256.665
+            "perf_metric_value": 362.19
         }
     ],
-    "pgs_per_second": 22.444531603492308,
+    "pgs_per_second": 22.52798235601382,
     "success": "1",
-    "time": 44.554282426834106
+    "time": 44.38923931121826
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 1280.004096,
+    "_dashboard_memory_usage_mb": 717.922304,
     "_dashboard_test_success": true,
-    "_peak_memory": 5.0,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3387\t2.1GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3503\t1.26GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4331\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1885\t0.24GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1139\t0.22GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3668\t0.1GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n4535\t0.09GiB\tray::DashboardTester.run\n4609\t0.08GiB\tray::StateAPIGeneratorActor.start\n1914\t0.08GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3670\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
+    "_peak_memory": 3.8,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3462\t1.32GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3578\t0.91GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4441\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n2114\t0.22GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1266\t0.21GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n1048\t0.12GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3746\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n2331\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4639\t0.08GiB\tray::StateAPIGeneratorActor.start\n3748\t0.08GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 568.6168662449907
+            "perf_metric_value": 524.9117000820374
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 69.512
+            "perf_metric_value": 126.428
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 367.275
+            "perf_metric_value": 619.317
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 553.345
+            "perf_metric_value": 877.616
         }
     ],
     "success": "1",
-    "tasks_per_second": 568.6168662449907,
-    "time": 317.5865342617035,
+    "tasks_per_second": 524.9117000820374,
+    "time": 319.0508232116699,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.37.0"}
+{"release_version": "2.38.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        7955.532587564185,
-        175.61992810905852
+        8761.346295795662,
+        146.13285936998864
     ],
     "1_1_actor_calls_concurrent": [
-        5303.491917324765,
-        194.13480183592705
+        5144.113336604505,
+        129.05069261153022
     ],
     "1_1_actor_calls_sync": [
-        1950.1566973268486,
-        59.76900518616201
+        1934.5421437875898,
+        16.93762447499762
     ],
     "1_1_async_actor_calls_async": [
-        4784.887893686086,
-        231.37765867810697
+        5004.950764496762,
+        171.43189175368792
     ],
     "1_1_async_actor_calls_sync": [
-        1437.926664174257,
-        45.859818529626835
+        1400.8372649801115,
+        46.91695798495167
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2977.7412476335367,
-        30.87717924019962
+        2973.2069419443774,
+        237.27631176013963
     ],
     "1_n_actor_calls_async": [
-        8575.187746250078,
-        221.26506863699905
+        8623.73827147855,
+        108.35090143743467
     ],
     "1_n_async_actor_calls_async": [
-        7578.069803138395,
-        143.77100673381594
+        7649.232495352423,
+        95.6555511663449
     ],
     "client__1_1_actor_calls_async": [
-        981.829128296617,
-        14.06102035801325
+        1045.2530250056586,
+        17.729751774775785
     ],
     "client__1_1_actor_calls_concurrent": [
-        985.8616123328168,
-        7.774725729115698
+        1051.493235107139,
+        8.4794310593275
     ],
     "client__1_1_actor_calls_sync": [
-        522.5036741985014,
-        3.326284429432372
+        516.4913813381004,
+        13.142786387066948
     ],
     "client__get_calls": [
-        1143.529533443771,
-        7.843126151799877
+        988.8125976441822,
+        33.09181567140517
     ],
     "client__put_calls": [
-        806.8644229079073,
-        29.20672925266765
+        802.299977782532,
+        40.98963980585926
     ],
     "client__put_gigabytes": [
-        0.15026574145021315,
-        0.00036921229288885553
+        0.14687557695990644,
+        0.0006998145552218933
     ],
     "client__tasks_and_get_batch": [
-        0.9196822396421975,
-        0.01544850883498226
+        0.8869040099758512,
+        0.0584252596679036
     ],
     "client__tasks_and_put_batch": [
-        11329.64496989761,
-        147.88663931420538
+        12975.586508330278,
+        276.9399014147757
     ],
     "multi_client_put_calls_Plasma_Store": [
-        12279.826729270004,
-        229.27662871070967
+        14827.86504165783,
+        271.2989306333634
     ],
     "multi_client_put_gigabytes": [
-        41.02868657596857,
-        2.9523066478116053
+        46.31338079710033,
+        3.3758082719395563
     ],
     "multi_client_tasks_async": [
-        22008.554668281082,
-        1919.2339741056262
+        22222.678238606593,
+        2560.621756569957
     ],
     "n_n_actor_calls_async": [
-        27276.483183681223,
-        460.92673710271265
+        27090.36785253979,
+        639.2205723009032
     ],
     "n_n_actor_calls_with_arg_async": [
-        2632.094227669015,
-        72.47926888414577
+        2665.0370523783936,
+        17.183930355396907
     ],
     "n_n_async_actor_calls_async": [
-        23202.288075622164,
-        522.7475457723278
+        23929.36598717011,
+        574.0572010106606
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10393.949835145073
+            "perf_metric_value": 10411.918620150123
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5238.443342760728
+            "perf_metric_value": 4961.71788771872
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12279.826729270004
+            "perf_metric_value": 14827.86504165783
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 20.9008322604287
+            "perf_metric_value": 17.802093535903047
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7.988112150159331
+            "perf_metric_value": 7.649152573279892
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 41.02868657596857
+            "perf_metric_value": 46.31338079710033
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13.163538753956898
+            "perf_metric_value": 12.639316158564123
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.180954283629903
+            "perf_metric_value": 5.188428041790279
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 952.4966774001579
+            "perf_metric_value": 942.3396753458368
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7690.962784600502
+            "perf_metric_value": 7997.547070810859
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22008.554668281082
+            "perf_metric_value": 22222.678238606593
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1950.1566973268486
+            "perf_metric_value": 1934.5421437875898
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7955.532587564185
+            "perf_metric_value": 8761.346295795662
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5303.491917324765
+            "perf_metric_value": 5144.113336604505
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8575.187746250078
+            "perf_metric_value": 8623.73827147855
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 27276.483183681223
+            "perf_metric_value": 27090.36785253979
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2632.094227669015
+            "perf_metric_value": 2665.0370523783936
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1437.926664174257
+            "perf_metric_value": 1400.8372649801115
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4784.887893686086
+            "perf_metric_value": 5004.950764496762
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2977.7412476335367
+            "perf_metric_value": 2973.2069419443774
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7578.069803138395
+            "perf_metric_value": 7649.232495352423
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23202.288075622164
+            "perf_metric_value": 23929.36598717011
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 790.8896761742105
+            "perf_metric_value": 752.3917651242742
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1143.529533443771
+            "perf_metric_value": 988.8125976441822
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 806.8644229079073
+            "perf_metric_value": 802.299977782532
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.15026574145021315
+            "perf_metric_value": 0.14687557695990644
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 11329.64496989761
+            "perf_metric_value": 12975.586508330278
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 522.5036741985014
+            "perf_metric_value": 516.4913813381004
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 981.829128296617
+            "perf_metric_value": 1045.2530250056586
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 985.8616123328168
+            "perf_metric_value": 1051.493235107139
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.9196822396421975
+            "perf_metric_value": 0.8869040099758512
         }
     ],
     "placement_group_create/removal": [
-        790.8896761742105,
-        11.333834748405021
+        752.3917651242742,
+        12.692354477421576
     ],
     "single_client_get_calls_Plasma_Store": [
-        10393.949835145073,
-        189.02709759347437
+        10411.918620150123,
+        158.6907007041028
     ],
     "single_client_get_object_containing_10k_refs": [
-        13.163538753956898,
-        0.8001375683227515
+        12.639316158564123,
+        0.2958386011889404
     ],
     "single_client_put_calls_Plasma_Store": [
-        5238.443342760728,
-        78.19523136997091
+        4961.71788771872,
+        166.79751523747402
     ],
     "single_client_put_gigabytes": [
-        20.9008322604287,
-        6.2062821493233935
+        17.802093535903047,
+        8.360672252708738
     ],
     "single_client_tasks_and_get_batch": [
-        7.988112150159331,
-        0.42512877036817576
+        7.649152573279892,
+        0.3523349920439091
     ],
     "single_client_tasks_async": [
-        7690.962784600502,
-        452.9354083420549
+        7997.547070810859,
+        252.5625668857314
     ],
     "single_client_tasks_sync": [
-        952.4966774001579,
-        15.844364804953251
+        942.3396753458368,
+        9.920445637439315
     ],
     "single_client_wait_1k_refs": [
-        5.180954283629903,
-        0.06862674393775514
+        5.188428041790279,
+        0.09193312352347874
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 25.957434363999937,
+    "broadcast_time": 31.073800462999998,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 25.957434363999937
+            "perf_metric_value": 31.073800462999998
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.21842787,
-    "get_time": 23.48843703,
+    "args_time": 18.011296372000004,
+    "get_time": 24.694264806000007,
     "large_object_size": 107374182400,
-    "large_object_time": 29.675286474000018,
+    "large_object_time": 28.976551088000008,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.21842787
+            "perf_metric_value": 18.011296372000004
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.715626494000006
+            "perf_metric_value": 5.854871097
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.48843703
+            "perf_metric_value": 24.694264806000007
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 184.379147003
+            "perf_metric_value": 201.18022255099999
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 29.675286474000018
+            "perf_metric_value": 28.976551088000008
         }
     ],
-    "queued_time": 184.379147003,
-    "returns_time": 5.715626494000006,
+    "queued_time": 201.18022255099999,
+    "returns_time": 5.854871097,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 0.982008113861084,
-    "max_iteration_time": 2.3912973403930664,
-    "min_iteration_time": 0.48903322219848633,
+    "avg_iteration_time": 1.186143352985382,
+    "max_iteration_time": 2.8529767990112305,
+    "min_iteration_time": 0.41348743438720703,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.982008113861084
+            "perf_metric_value": 1.186143352985382
         }
     ],
     "success": 1,
-    "total_time": 98.20105314254761
+    "total_time": 118.6146011352539
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 9.495225667953491
+            "perf_metric_value": 8.909741163253784
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 27.7483500957489
+            "perf_metric_value": 26.390845274925233
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 68.16796236038208
+            "perf_metric_value": 66.36001825332642
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.5987753868103027
+            "perf_metric_value": 2.8864474296569824
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3431.3032166957855
+            "perf_metric_value": 3249.9383351802826
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.45902135965347457
+            "perf_metric_value": 0.3168361946930436
         }
     ],
-    "stage_0_time": 9.495225667953491,
-    "stage_1_avg_iteration_time": 27.7483500957489,
-    "stage_1_max_iteration_time": 29.508095264434814,
-    "stage_1_min_iteration_time": 26.858633518218994,
-    "stage_1_time": 277.48361372947693,
-    "stage_2_avg_iteration_time": 68.16796236038208,
-    "stage_2_max_iteration_time": 69.19305539131165,
-    "stage_2_min_iteration_time": 66.24201941490173,
-    "stage_2_time": 340.8411283493042,
-    "stage_3_creation_time": 1.5987753868103027,
-    "stage_3_time": 3431.3032166957855,
-    "stage_4_spread": 0.45902135965347457,
+    "stage_0_time": 8.909741163253784,
+    "stage_1_avg_iteration_time": 26.390845274925233,
+    "stage_1_max_iteration_time": 28.665843725204468,
+    "stage_1_min_iteration_time": 24.76340889930725,
+    "stage_1_time": 263.90854692459106,
+    "stage_2_avg_iteration_time": 66.36001825332642,
+    "stage_2_max_iteration_time": 69.15732741355896,
+    "stage_2_min_iteration_time": 64.64686346054077,
+    "stage_2_time": 331.8009421825409,
+    "stage_3_creation_time": 2.8864474296569824,
+    "stage_3_time": 3249.9383351802826,
+    "stage_4_spread": 0.3168361946930436,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 0.961928168167732,
-    "avg_pg_remove_time_ms": 0.9391719909912679,
+    "avg_pg_create_time_ms": 1.0143646081080508,
+    "avg_pg_remove_time_ms": 1.0055548888891201,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.961928168167732
+            "perf_metric_value": 1.0143646081080508
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9391719909912679
+            "perf_metric_value": 1.0055548888891201
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 14.83%: single_client_put_gigabytes (THROUGHPUT) regresses from 20.9008322604287 to 17.802093535903047 in microbenchmark.json
REGRESSION 13.53%: client__get_calls (THROUGHPUT) regresses from 1143.529533443771 to 988.8125976441822 in microbenchmark.json
REGRESSION 7.69%: tasks_per_second (THROUGHPUT) regresses from 568.6168662449907 to 524.9117000820374 in benchmarks/many_tasks.json
REGRESSION 5.28%: single_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 5238.443342760728 to 4961.71788771872 in microbenchmark.json
REGRESSION 4.87%: placement_group_create/removal (THROUGHPUT) regresses from 790.8896761742105 to 752.3917651242742 in microbenchmark.json
REGRESSION 4.47%: actors_per_second (THROUGHPUT) regresses from 576.4528544875533 to 550.7019220598719 in benchmarks/many_actors.json
REGRESSION 4.24%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 7.988112150159331 to 7.649152573279892 in microbenchmark.json
REGRESSION 3.98%: single_client_get_object_containing_10k_refs (THROUGHPUT) regresses from 13.163538753956898 to 12.639316158564123 in microbenchmark.json
REGRESSION 3.56%: client__tasks_and_get_batch (THROUGHPUT) regresses from 0.9196822396421975 to 0.8869040099758512 in microbenchmark.json
REGRESSION 3.01%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 5303.491917324765 to 5144.113336604505 in microbenchmark.json
REGRESSION 2.58%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1437.926664174257 to 1400.8372649801115 in microbenchmark.json
REGRESSION 2.26%: client__put_gigabytes (THROUGHPUT) regresses from 0.15026574145021315 to 0.14687557695990644 in microbenchmark.json
REGRESSION 1.15%: client__1_1_actor_calls_sync (THROUGHPUT) regresses from 522.5036741985014 to 516.4913813381004 in microbenchmark.json
REGRESSION 1.07%: single_client_tasks_sync (THROUGHPUT) regresses from 952.4966774001579 to 942.3396753458368 in microbenchmark.json
REGRESSION 0.80%: 1_1_actor_calls_sync (THROUGHPUT) regresses from 1950.1566973268486 to 1934.5421437875898 in microbenchmark.json
REGRESSION 0.68%: n_n_actor_calls_async (THROUGHPUT) regresses from 27276.483183681223 to 27090.36785253979 in microbenchmark.json
REGRESSION 0.57%: client__put_calls (THROUGHPUT) regresses from 806.8644229079073 to 802.299977782532 in microbenchmark.json
REGRESSION 0.15%: 1_1_async_actor_calls_with_args_async (THROUGHPUT) regresses from 2977.7412476335367 to 2973.2069419443774 in microbenchmark.json
REGRESSION 81.88%: dashboard_p50_latency_ms (LATENCY) regresses from 69.512 to 126.428 in benchmarks/many_tasks.json
REGRESSION 80.54%: stage_3_creation_time (LATENCY) regresses from 1.5987753868103027 to 2.8864474296569824 in stress_tests/stress_test_many_tasks.json
REGRESSION 68.62%: dashboard_p95_latency_ms (LATENCY) regresses from 367.275 to 619.317 in benchmarks/many_tasks.json
REGRESSION 58.60%: dashboard_p99_latency_ms (LATENCY) regresses from 553.345 to 877.616 in benchmarks/many_tasks.json
REGRESSION 41.11%: dashboard_p99_latency_ms (LATENCY) regresses from 256.665 to 362.19 in benchmarks/many_pgs.json
REGRESSION 20.79%: avg_iteration_time (LATENCY) regresses from 0.982008113861084 to 1.186143352985382 in stress_tests/stress_test_dead_actors.json
REGRESSION 19.71%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 25.957434363999937 to 31.073800462999998 in scalability/object_store.json
REGRESSION 14.76%: dashboard_p99_latency_ms (LATENCY) regresses from 4044.61 to 4641.532 in benchmarks/many_actors.json
REGRESSION 11.40%: dashboard_p50_latency_ms (LATENCY) regresses from 3.614 to 4.026 in benchmarks/many_pgs.json
REGRESSION 10.17%: dashboard_p95_latency_ms (LATENCY) regresses from 3471.736 to 3824.806 in benchmarks/many_actors.json
REGRESSION 9.11%: 1000000_queued_time (LATENCY) regresses from 184.379147003 to 201.18022255099999 in scalability/single_node.json
REGRESSION 8.16%: dashboard_p50_latency_ms (LATENCY) regresses from 3.983 to 4.308 in benchmarks/many_nodes.json
REGRESSION 7.07%: avg_pg_remove_time_ms (LATENCY) regresses from 0.9391719909912679 to 1.0055548888891201 in stress_tests/stress_test_placement_group.json
REGRESSION 5.45%: avg_pg_create_time_ms (LATENCY) regresses from 0.961928168167732 to 1.0143646081080508 in stress_tests/stress_test_placement_group.json
REGRESSION 5.13%: 10000_get_time (LATENCY) regresses from 23.48843703 to 24.694264806000007 in scalability/single_node.json
REGRESSION 4.60%: 10000_args_time (LATENCY) regresses from 17.21842787 to 18.011296372000004 in scalability/single_node.json
REGRESSION 2.44%: 3000_returns_time (LATENCY) regresses from 5.715626494000006 to 5.854871097 in scalability/single_node.json
```