### PR TITLE
[CI] Fix: flake8 rule B108: Found useless Tuple expression. Consider either assigning it to a variable or removing it.

### DIFF
--- a/doc/source/serve/doc_code/tutorial_sklearn.py
+++ b/doc/source/serve/doc_code/tutorial_sklearn.py
@@ -28,7 +28,8 @@ data, target, target_names = (
     iris_dataset["target_names"],
 )
 
-np.random.shuffle(data), np.random.shuffle(target)
+np.random.shuffle(data)
+np.random.shuffle(target)
 train_x, train_y = data[:100], target[:100]
 val_x, val_y = data[100:], target[100:]
 # __doc_data_end__

--- a/python/ray/dashboard/head.py
+++ b/python/ray/dashboard/head.py
@@ -318,7 +318,7 @@ class DashboardHead:
             f"{dashboard_http_host}:{http_port}".encode(),
             True,
             namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
-        ),
+        )
         self.gcs_client.internal_kv_put(
             dashboard_consts.DASHBOARD_RPC_ADDRESS.encode(),
             f"{self.ip}:{self.grpc_port}".encode(),

--- a/python/ray/data/_internal/datasource/sql_datasource.py
+++ b/python/ray/data/_internal/datasource/sql_datasource.py
@@ -81,7 +81,7 @@ class SQLDatasource(Datasource):
         self.connection_factory = connection_factory
 
     def estimate_inmemory_data_size(self) -> Optional[int]:
-        None
+        pass
 
     def get_read_tasks(self, parallelism: int) -> List[ReadTask]:
         def fallback_read_fn() -> Iterable[Block]:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->



## Why are these changes needed?

While running the pre-commit hook of flake8, the following error occurs if Python version is 3.12. It's because the version of flake8 is too old.
![image](https://github.com/user-attachments/assets/7c103728-2e48-42f3-8b2f-b47ab93e560b)

version:
- python: 3.12.7
- flake8: 7.1.1 
- flake8-bugbear: 24.8.19


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #48065

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
