### PR TITLE
[Data] Fix a test that checks the "eliminate_build_output_blocks" optimization

### DIFF
--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -316,6 +316,7 @@ def test_read_large_data(ray_start_regular_shared):
         RandomBytesDatasource(
             num_tasks=1,
             num_batches_per_task=num_blocks_per_task,
+            num_rows_per_batch=None,
             row_size=block_size,
         ),
         override_num_blocks=1,

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -319,7 +319,7 @@ def test_read_large_data(ray_start_regular_shared):
             num_rows_per_batch=None,
             row_size=block_size,
         ),
-        override_num_blocks=1,
+        override_num_blocks=num_blocks_per_task,
     )
 
     ds = ds.map_batches(foo)

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -304,7 +304,6 @@ def test_filter(ray_start_regular_shared, target_max_block_size):
     assert ds._plan.initial_num_blocks() == num_blocks_per_task
 
 
-@pytest.mark.skip("Needs zero-copy optimization for read->map_batches.")
 def test_read_large_data(ray_start_cluster):
     # Test 20G input with single task
     num_blocks_per_task = 20

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -310,7 +310,7 @@ def test_read_large_data(ray_start_regular_shared):
     block_size = 1024 * 1024 * 1024
 
     def foo(batch):
-        return pd.DataFrame({"one": [1]})
+        return {"one": [1]}
 
     ds = ray.data.read_datasource(
         RandomBytesDatasource(

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -304,15 +304,10 @@ def test_filter(ray_start_regular_shared, target_max_block_size):
     assert ds._plan.initial_num_blocks() == num_blocks_per_task
 
 
-def test_read_large_data(ray_start_cluster):
+def test_read_large_data(ray_start_regular_shared):
     # Test 20G input with single task
     num_blocks_per_task = 20
     block_size = 1024 * 1024 * 1024
-
-    cluster = ray_start_cluster
-    cluster.add_node(num_cpus=1)
-
-    ray.init(cluster.address)
 
     def foo(batch):
         return pd.DataFrame({"one": [1]})

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -321,7 +321,7 @@ def test_read_large_data(ray_start_regular_shared):
         override_num_blocks=1,
     )
 
-    ds = ds.map_batches(foo, num_rows_per_batch=None)
+    ds = ds.map_batches(foo)
     assert ds.count() == num_blocks_per_task
 
 

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -1604,7 +1604,6 @@ def check_transform_fns(op, expected_types):
         assert isinstance(transform_fn, expected_types[i]), transform_fn
 
 
-@pytest.mark.skip("Needs zero-copy optimization for read->map_batches.")
 def test_zero_copy_fusion_eliminate_build_output_blocks(ray_start_regular_shared):
     # Test the EliminateBuildOutputBlocks optimization rule.
     planner = Planner()

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -1607,7 +1607,7 @@ def check_transform_fns(op, expected_types):
 def test_zero_copy_fusion_eliminate_build_output_blocks(ray_start_regular_shared):
     # Test the EliminateBuildOutputBlocks optimization rule.
     planner = Planner()
-    read_op = get_parquet_read_logical_op()
+    read_op = get_parquet_read_logical_op(parallelism=1)
     op = MapBatches(read_op, lambda x: x)
     logical_plan = LogicalPlan(op)
     physical_plan = planner.plan(logical_plan)


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This removes an outdated reason on a test that shouldn't be skipped. It avoids confusion about the fact that the eliminate_build_output_blocks optimization is being applied. Hoping this keeps our tests in sync with the most current state of our library helping newcomers to Ray Data better understand expected behavior.


## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
