### PR TITLE
[Data] Refactor unit tests to avoid testing directly against representation

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -5337,7 +5337,11 @@ class Schema:
         return arrow_types
 
     def __eq__(self, other):
-        return isinstance(other, Schema) and other.base_schema == self.base_schema
+        return (
+            isinstance(other, Schema)
+            and other.types == self.types
+            and other.names == self.names
+        )
 
     def __repr__(self):
         column_width = max([len(name) for name in self.names] + [len("Column")])

--- a/python/ray/data/tests/test_binary.py
+++ b/python/ray/data/tests/test_binary.py
@@ -8,6 +8,7 @@ import requests
 import snappy
 
 import ray
+from ray.data import Schema
 from ray.data.datasource import (
     BaseFileMetadataProvider,
     FastFileMetadataProvider,
@@ -191,8 +192,7 @@ def test_read_binary_snappy_partitioned_with_filter(
         assert_base_partitioned_ds(
             ds,
             count=2,
-            num_rows=2,
-            schema="{bytes: binary}",
+            schema=Schema(pa.schema([("bytes", pa.binary())])),
             sorted_values=[b"1 a\n1 b\n1 c", b"3 e\n3 f\n3 g"],
             ds_take_transform_fn=lambda t: extract_values("bytes", t),
         )

--- a/python/ray/data/tests/test_consumption.py
+++ b/python/ray/data/tests/test_consumption.py
@@ -1509,11 +1509,8 @@ def test_global_tabular_std(ray_start_regular_shared, ds_format, num_parts):
 def test_column_name_type_check(ray_start_regular_shared):
     df = pd.DataFrame({"1": np.random.rand(10), "a": np.random.rand(10)})
     ds = ray.data.from_pandas(df)
-    expected_str = (
-        "MaterializedDataset(num_blocks=1, num_rows=10, "
-        "schema={1: float64, a: float64})"
-    )
-    assert str(ds) == expected_str, str(ds)
+    assert ds.count() == 10
+
     df = pd.DataFrame({1: np.random.rand(10), "a": np.random.rand(10)})
     with pytest.raises(ValueError):
         ray.data.from_pandas(df)

--- a/python/ray/data/tests/test_consumption.py
+++ b/python/ray/data/tests/test_consumption.py
@@ -12,6 +12,7 @@ import pyarrow as pa
 import pytest
 
 import ray
+from ray.data import Schema
 from ray.data._internal.block_builder import BlockBuilder
 from ray.data._internal.datasource.csv_datasink import CSVDatasink
 from ray.data._internal.datasource.csv_datasource import CSVDatasource
@@ -1509,6 +1510,7 @@ def test_global_tabular_std(ray_start_regular_shared, ds_format, num_parts):
 def test_column_name_type_check(ray_start_regular_shared):
     df = pd.DataFrame({"1": np.random.rand(10), "a": np.random.rand(10)})
     ds = ray.data.from_pandas(df)
+    assert ds.schema() == Schema(pa.schema([("1", pa.float64()), ("a", pa.float64())]))
     assert ds.count() == 10
 
     df = pd.DataFrame({1: np.random.rand(10), "a": np.random.rand(10)})

--- a/python/ray/data/tests/test_csv.py
+++ b/python/ray/data/tests/test_csv.py
@@ -11,6 +11,7 @@ from packaging.version import Version
 from pytest_lazyfixture import lazy_fixture
 
 import ray
+from ray.data import Schema
 from ray.data.block import BlockAccessor
 from ray.data.datasource import (
     BaseFileMetadataProvider,
@@ -81,7 +82,7 @@ def test_csv_read(ray_start_regular_shared, fs, data_path, endpoint_url):
     # Test metadata ops.
     assert ds.count() == 3
     assert ds.input_files() == [_unwrap_protocol(path1)]
-    assert "{one: int64, two: string}" in str(ds), ds
+    assert ds.schema() == Schema(pa.schema([("one", pa.int64()), ("two", pa.string())]))
 
     # Two files, override_num_blocks=2.
     df2 = pd.DataFrame({"one": [4, 5, 6], "two": ["e", "f", "g"]})
@@ -272,7 +273,7 @@ def test_csv_read_meta_provider(
     # Expect to lazily compute all metadata correctly.
     assert ds.count() == 3
     assert ds.input_files() == [_unwrap_protocol(path1)]
-    assert "{one: int64, two: string}" in str(ds), ds
+    assert ds.schema() == Schema(pa.schema([("one", pa.int64()), ("two", pa.string())]))
 
     with pytest.raises(NotImplementedError):
         ray.data.read_csv(
@@ -374,8 +375,7 @@ def test_csv_read_many_files_partitioned(
         ds,
         count=num_rows,
         num_input_files=num_files,
-        num_rows=num_rows,
-        schema="{one: int64, two: int64}",
+        schema=Schema(pa.schema([("one", pa.int64()), ("two", pa.int64())])),
         sorted_values=sorted(
             itertools.chain.from_iterable(
                 list(

--- a/python/ray/data/tests/test_lance.py
+++ b/python/ray/data/tests/test_lance.py
@@ -9,6 +9,7 @@ from pytest_lazyfixture import lazy_fixture
 import ray
 from ray._private.test_utils import wait_for_condition
 from ray._private.utils import _get_pyarrow_version
+from ray.data import Schema
 from ray.data.datasource.path_util import _unwrap_protocol
 
 
@@ -62,16 +63,16 @@ def test_lance_read_basic(fs, data_path, batch_size):
 
     # Test metadata-only ops.
     assert ds.count() == 6
-    assert ds.schema() is not None
-
-    assert (
-        " ".join(str(ds).split())
-        == "Dataset( num_rows=6, schema={one: int64, two: string, three: int64, four: string} )"  # noqa: E501
-    ), ds
-    assert (
-        " ".join(repr(ds).split())
-        == "Dataset( num_rows=6, schema={one: int64, two: string, three: int64, four: string} )"  # noqa: E501
-    ), ds
+    assert ds.schema() == Schema(
+        pa.schema(
+            {
+                "one": pa.int64(),
+                "two": pa.string(),
+                "three": pa.int64(),
+                "four": pa.string(),
+            }
+        )
+    )
 
     # Test read.
     values = [[s["one"], s["two"]] for s in ds.take_all()]

--- a/python/ray/data/tests/test_metadata_provider.py
+++ b/python/ray/data/tests/test_metadata_provider.py
@@ -296,7 +296,6 @@ def test_default_file_metadata_provider_many_files_partitioned(
     data_path,
     endpoint_url,
     write_partitioned_df,
-    assert_base_partitioned_ds,
 ):
     if endpoint_url is None:
         storage_options = {}

--- a/python/ray/data/tests/test_numpy.py
+++ b/python/ray/data/tests/test_numpy.py
@@ -7,6 +7,7 @@ import pytest
 from pytest_lazyfixture import lazy_fixture
 
 import ray
+from ray.data import Schema
 from ray.data.datasource import (
     BaseFileMetadataProvider,
     FastFileMetadataProvider,
@@ -14,6 +15,7 @@ from ray.data.datasource import (
     PartitionStyle,
     PathPartitionFilter,
 )
+from ray.data.extensions.tensor_extension import ArrowTensorType
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.mock_http_server import *  # noqa
 from ray.data.tests.test_partitioning import PathPartitionEncoder
@@ -114,8 +116,9 @@ def test_numpy_roundtrip(ray_start_regular_shared, fs, data_path):
     ds = ray.data.range_tensor(10, override_num_blocks=2)
     ds.write_numpy(data_path, filesystem=fs, column="data")
     ds = ray.data.read_numpy(data_path, filesystem=fs)
-    assert str(ds) == (
-        "Dataset(num_rows=?, schema={data: numpy.ndarray(shape=(1,), dtype=int64)})"
+    assert ds.count() == 10
+    assert ds.schema() == Schema(
+        pa.schema([("data", ArrowTensorType((1,), pa.int64()))])
     )
     np.testing.assert_equal(
         extract_values("data", ds.take(2)), [np.array([0]), np.array([1])]
@@ -237,7 +240,7 @@ def test_numpy_read_partitioned_with_filter(
         val_str = "".join(f"array({v}, dtype=int8), " for v in vals)[:-2]
         assert_base_partitioned_ds(
             ds,
-            schema="{data: numpy.ndarray(shape=(2,), dtype=int8)}",
+            schema=Schema(pa.schema([("data", ArrowTensorType((2,), pa.int8()))])),
             sorted_values=f"[[{val_str}]]",
             ds_take_transform_fn=lambda taken: [extract_values("data", taken)],
             sorted_values_transform_fn=lambda sorted_values: str(sorted_values),

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -12,6 +12,7 @@ from pytest_lazyfixture import lazy_fixture
 
 import ray
 from ray.air.util.tensor_extensions.arrow import ArrowTensorType, ArrowTensorTypeV2
+from ray.data import Schema
 from ray.data._internal.datasource.parquet_bulk_datasource import ParquetBulkDatasource
 from ray.data._internal.datasource.parquet_datasource import (
     NUM_CPUS_FOR_META_FETCH_TASK,
@@ -154,13 +155,11 @@ def test_parquet_read_basic(ray_start_regular_shared, fs, data_path):
     assert ds.size_bytes() > 0
     # Schema information is available from Parquet metadata, so
     # we do not need to compute the first block.
-    assert ds.schema() is not None
+    assert ds.schema() == Schema(pa.schema({"one": pa.int64(), "two": pa.string()}))
     input_files = ds.input_files()
     assert len(input_files) == 2, input_files
     assert "test1.parquet" in str(input_files)
     assert "test2.parquet" in str(input_files)
-    assert str(ds) == "Dataset(num_rows=6, schema={one: int64, two: string})", ds
-    assert repr(ds) == "Dataset(num_rows=6, schema={one: int64, two: string})", ds
 
     # Forces a data read.
     values = [[s["one"], s["two"]] for s in ds.take_all()]
@@ -229,13 +228,11 @@ def test_parquet_read_meta_provider(ray_start_regular_shared, fs, data_path):
     # Expect to lazily compute all metadata correctly.
     assert ds.count() == 6
     assert ds.size_bytes() > 0
-    assert ds.schema() is not None
+    assert ds.schema() == Schema(pa.schema({"one": pa.int64(), "two": pa.string()}))
     input_files = ds.input_files()
     assert len(input_files) == 2, input_files
     assert "test1.parquet" in str(input_files)
     assert "test2.parquet" in str(input_files)
-    assert str(ds) == "Dataset(num_rows=6, schema={one: int64, two: string})", ds
-    assert repr(ds) == "Dataset(num_rows=6, schema={one: int64, two: string})", ds
 
     # Forces a data read.
     values = [[s["one"], s["two"]] for s in ds.take()]
@@ -348,9 +345,7 @@ def test_parquet_read_bulk(ray_start_regular_shared, fs, data_path):
     assert not ds._plan.has_started_execution
 
     # Schema isn't available, so we do a partial read.
-    assert ds.schema() is not None
-    assert str(ds) == "Dataset(num_rows=?, schema={one: int64, two: string})", ds
-    assert repr(ds) == "Dataset(num_rows=?, schema={one: int64, two: string})", ds
+    assert ds.schema() == Schema(pa.schema({"one": pa.int64(), "two": pa.string()}))
     assert ds._plan.has_started_execution
     assert not ds._plan.has_computed_output()
 
@@ -430,9 +425,7 @@ def test_parquet_read_bulk_meta_provider(ray_start_regular_shared, fs, data_path
 
     assert ds.count() == 6
     assert ds.size_bytes() > 0
-    assert ds.schema() is not None
-    assert str(ds) == "Dataset(num_rows=6, schema={one: int64, two: string})", ds
-    assert repr(ds) == "Dataset(num_rows=6, schema={one: int64, two: string})", ds
+    assert ds.schema() == Schema(pa.schema({"one": pa.int64(), "two": pa.string()}))
     assert ds._plan.has_started_execution
 
     # Forces a data read.
@@ -479,11 +472,9 @@ def test_parquet_read_partitioned(ray_start_regular_shared, fs, data_path):
     assert ds.size_bytes() > 0
     # Schema information and input files are available from Parquet metadata,
     # so we do not need to compute the first block.
-    assert ds.schema() is not None
+    assert ds.schema() == Schema(pa.schema({"two": pa.string(), "one": pa.string()}))
     input_files = ds.input_files()
     assert len(input_files) == 2, input_files
-    assert str(ds) == "Dataset(num_rows=6, schema={two: string, one: string})", ds
-    assert repr(ds) == "Dataset(num_rows=6, schema={two: string, one: string})", ds
 
     # Forces a data read.
     values = [[s["one"], s["two"]] for s in ds.take()]
@@ -651,11 +642,9 @@ def test_parquet_read_partitioned_explicit(ray_start_regular_shared, tmp_path):
     assert ds.size_bytes() > 0
     # Schema information and input files are available from Parquet metadata,
     # so we do not need to compute the first block.
-    assert ds.schema() is not None
+    assert ds.schema() == Schema(pa.schema({"two": pa.string(), "one": pa.int64()}))
     input_files = ds.input_files()
     assert len(input_files) == 2, input_files
-    assert str(ds) == "Dataset(num_rows=6, schema={two: string, one: int64})", ds
-    assert repr(ds) == "Dataset(num_rows=6, schema={two: string, one: int64})", ds
 
     # Forces a data read.
     values = [[s["one"], s["two"]] for s in ds.take()]

--- a/python/ray/data/tests/test_tensor.py
+++ b/python/ray/data/tests/test_tensor.py
@@ -54,9 +54,7 @@ def test_tensors_basic(
     tensor_shape = (3, 5)
     ds = ray.data.range_tensor(6, shape=tensor_shape, override_num_blocks=6)
     assert ds.count() == 6
-    assert ds.schema() == Schema(
-        pa.schema([("data", tensor_type((3, 5), pa.int64()))])
-    )
+    assert ds.schema() == Schema(pa.schema([("data", tensor_type((3, 5), pa.int64()))]))
     # The actual size is slightly larger due to metadata.
     # We add 6 (one per tensor) offset values of 8 bytes each to account for the
     # in-memory representation of the PyArrow LargeList type

--- a/python/ray/data/tests/test_tensor.py
+++ b/python/ray/data/tests/test_tensor.py
@@ -8,7 +8,7 @@ import pytest
 
 import ray
 from ray.air.util.tensor_extensions.utils import _create_possibly_ragged_ndarray
-from ray.data import DataContext
+from ray.data import DataContext, Schema
 from ray.data.block import BlockAccessor
 from ray.data.extensions.tensor_extension import (
     ArrowTensorArray,
@@ -49,8 +49,9 @@ def test_tensors_basic(ray_start_regular_shared, restore_data_context, tensor_fo
     # Create directly.
     tensor_shape = (3, 5)
     ds = ray.data.range_tensor(6, shape=tensor_shape, override_num_blocks=6)
-    assert str(ds) == (
-        "Dataset(num_rows=6, schema={data: numpy.ndarray(shape=(3, 5), dtype=int64)})"
+    assert ds.count() == 6
+    assert ds.schema() == Schema(
+        pa.schema([("data", ArrowTensorType((3, 5), pa.int64()))])
     )
     # The actual size is slightly larger due to metadata.
     # We add 6 (one per tensor) offset values of 8 bytes each to account for the
@@ -224,23 +225,15 @@ def test_tensors_basic(ray_start_regular_shared, restore_data_context, tensor_fo
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])
 def test_batch_tensors(ray_start_regular_shared, restore_data_context, tensor_format):
-    import torch
-
     DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     ds = ray.data.from_items(
-        [torch.tensor([0, 0]) for _ in range(40)], override_num_blocks=40
+        [np.array([0, 0]) for _ in range(40)], override_num_blocks=40
     )
-    res = (
-        "MaterializedDataset(\n"
-        "   num_blocks=40,\n"
-        "   num_rows=40,\n"
-        "   schema={item: numpy.ndarray(shape=(2,), dtype=int64)}\n"
-        ")"
-    )
-    assert str(ds) == res, str(ds)
-    df = next(iter(ds.iter_batches(batch_format="pandas")))
-    assert df.to_dict().keys() == {"item"}
+
+    batch = next(iter(ds.iter_batches()))
+    assert set(batch) == {"item"}
+    assert batch["item"].shape == (40, 2)
 
 
 @pytest.mark.parametrize("tensor_format", ["v1", "v2"])

--- a/python/ray/data/tests/test_tensor.py
+++ b/python/ray/data/tests/test_tensor.py
@@ -42,8 +42,12 @@ def test_large_tensor_creation(
     assert end_time - start_time < 20
 
 
-@pytest.mark.parametrize("tensor_format", ["v1", "v2"])
-def test_tensors_basic(ray_start_regular_shared, restore_data_context, tensor_format):
+@pytest.mark.parametrize(
+    "tensor_format, tensor_type", [("v1", ArrowTensorType), ("v2", ArrowTensorTypeV2)]
+)
+def test_tensors_basic(
+    ray_start_regular_shared, restore_data_context, tensor_format, tensor_type
+):
     DataContext.get_current().use_arrow_tensor_v2 = tensor_format == "v2"
 
     # Create directly.
@@ -51,7 +55,7 @@ def test_tensors_basic(ray_start_regular_shared, restore_data_context, tensor_fo
     ds = ray.data.range_tensor(6, shape=tensor_shape, override_num_blocks=6)
     assert ds.count() == 6
     assert ds.schema() == Schema(
-        pa.schema([("data", ArrowTensorType((3, 5), pa.int64()))])
+        pa.schema([("data", tensor_type((3, 5), pa.int64()))])
     )
     # The actual size is slightly larger due to metadata.
     # We add 6 (one per tensor) offset values of 8 bytes each to account for the

--- a/python/ray/data/tests/test_text.py
+++ b/python/ray/data/tests/test_text.py
@@ -1,9 +1,11 @@
 import os
 
 import pandas as pd
+import pyarrow as pa
 import pytest
 
 import ray
+from ray.data import Schema
 from ray.data._internal.execution.interfaces.ref_bundle import (
     _ref_bundles_iterator_to_block_refs_list,
 )
@@ -158,7 +160,7 @@ def test_read_text_partitioned_with_filter(
         ds = ray.data.read_text(base_dir, partition_filter=partition_path_filter)
         assert_base_partitioned_ds(
             ds,
-            schema="{text: string}",
+            schema=Schema(pa.schema([("text", pa.string())])),
             sorted_values=["1 a", "1 b", "1 c", "3 e", "3 f", "3 g"],
             ds_take_transform_fn=_to_lines,
         )

--- a/python/ray/data/tests/test_zip.py
+++ b/python/ray/data/tests/test_zip.py
@@ -1,9 +1,11 @@
 import itertools
 
 import pandas as pd
+import pyarrow as pa
 import pytest
 
 import ray
+from ray.data import Schema
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.util import column_udf, named_values
 from ray.tests.conftest import *  # noqa
@@ -83,14 +85,12 @@ def test_zip_pandas(ray_start_regular_shared):
     ds2 = ray.data.from_pandas(pd.DataFrame({"col3": ["a", "b"], "col4": ["d", "e"]}))
     ds = ds1.zip(ds2)
     assert ds.count() == 2
-    assert "{col1: int64, col2: int64, col3: object, col4: object}" in str(ds)
     result = list(ds.take())
     assert result[0] == {"col1": 1, "col2": 4, "col3": "a", "col4": "d"}
 
     ds3 = ray.data.from_pandas(pd.DataFrame({"col2": ["a", "b"], "col4": ["d", "e"]}))
     ds = ds1.zip(ds3)
     assert ds.count() == 2
-    assert "{col1: int64, col2: int64, col2_1: object, col4: object}" in str(ds)
     result = list(ds.take())
     assert result[0] == {"col1": 1, "col2": 4, "col2_1": "a", "col4": "d"}
 
@@ -100,14 +100,18 @@ def test_zip_arrow(ray_start_regular_shared):
     ds2 = ray.data.range(5).map(lambda r: {"a": r["id"] + 1, "b": r["id"] + 2})
     ds = ds1.zip(ds2)
     assert ds.count() == 5
-    assert "{id: int64, a: int64, b: int64}" in str(ds)
+    assert ds.schema() == Schema(
+        pa.schema([("id", pa.int64()), ("a", pa.int64()), ("b", pa.int64())])
+    )
     result = list(ds.take())
     assert result[0] == {"id": 0, "a": 1, "b": 2}
 
     # Test duplicate column names.
     ds = ds1.zip(ds1).zip(ds1)
     assert ds.count() == 5
-    assert "{id: int64, id_1: int64, id_2: int64}" in str(ds)
+    assert ds.schema() == Schema(
+        pa.schema([("id", pa.int64()), ("id_1", pa.int64()), ("id_2", pa.int64())])
+    )
     result = list(ds.take())
     assert result[0] == {"id": 0, "id_1": 0, "id_2": 0}
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Testing directly against the `repr` is brittle because 1) unit tests break if the representation format changes, even if behavior under test is otherwise correct, and 2) unit tests break if implementation details change (e.g., whether the number of rows is known prior to execution).

(This PR updates most but not all assertions against representations to test against more explicit APIs)
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
