### PR TITLE
[style] flake8 violation E501 fix #48063

### DIFF
--- a/python/ray/data/_internal/planner/random_shuffle.py
+++ b/python/ray/data/_internal/planner/random_shuffle.py
@@ -35,7 +35,6 @@ def generate_random_shuffle_fn(
         # MapOperator->AllToAllOperator), we pass a map function which
         # is applied to each block before shuffling.
         map_transformer: Optional[MapTransformer] = ctx.upstream_map_transformer
-        upstream_map_fn = None
         nonlocal ray_remote_args
         if map_transformer:
             # NOTE(swang): We override the target block size with infinity, to

--- a/python/ray/data/_internal/planner/repartition.py
+++ b/python/ray/data/_internal/planner/repartition.py
@@ -35,7 +35,6 @@ def generate_repartition_fn(
         # MapOperator->AllToAllOperator), we pass a map function which
         # is applied to each block before shuffling.
         map_transformer: Optional["MapTransformer"] = ctx.upstream_map_transformer
-        upstream_map_fn = None
         if map_transformer:
             # NOTE(swang): We override the target block size with infinity, to
             # prevent the upstream map from slicing its output into smaller

--- a/python/ray/experimental/channel/nccl_group.py
+++ b/python/ray/experimental/channel/nccl_group.py
@@ -10,7 +10,6 @@ from ray.experimental.channel.gpu_communicator import (
 )
 
 if TYPE_CHECKING:
-    import cupy as cp
     import torch
 
 

--- a/python/ray/tune/execution/tune_controller.py
+++ b/python/ray/tune/execution/tune_controller.py
@@ -188,7 +188,8 @@ class TuneController:
                     "mode as resources (such as Ray processes, "
                     "file descriptors, and temporary files) may not be "
                     "cleaned up properly. To use "
-                    "a safer mode, use fail_fast=True."
+                    "a safer mode, use fail_fast=True.",
+                    stacklevel=2
                 )
             else:
                 raise ValueError(

--- a/python/ray/tune/execution/tune_controller.py
+++ b/python/ray/tune/execution/tune_controller.py
@@ -189,7 +189,7 @@ class TuneController:
                     "file descriptors, and temporary files) may not be "
                     "cleaned up properly. To use "
                     "a safer mode, use fail_fast=True.",
-                    stacklevel=2
+                    stacklevel=2,
                 )
             else:
                 raise ValueError(

--- a/python/ray/tune/execution/tune_controller.py
+++ b/python/ray/tune/execution/tune_controller.py
@@ -1202,9 +1202,6 @@ class TuneController:
 
         tracked_actor = self._trial_to_actor[trial]
 
-        _on_result = None
-        _on_error = None
-
         args = args or tuple()
         kwargs = kwargs or {}
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Fixes flake8 linting error [#48063](https://www.flake8rules.com/rules/F811.html), Redefinition of unused name from line n. 


## Related issue number

Closes #48063 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
