### PR TITLE
[Data] Do not free blocks in `Dataset.split()`

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1522,7 +1522,8 @@ class Dataset:
             )
 
         bundle = self._plan.execute()
-        owned_by_consumer = bundle.owns_blocks
+        # We should not free blocks since we will materialize the Datasets.
+        owned_by_consumer = False
         stats = self._plan.stats()
         block_refs, metadata = zip(*bundle.blocks)
 


### PR DESCRIPTION
## Why are these changes needed?
When using `Dataset.split()`, there is a corner case (not exactly sure for a concrete reproducible, but came up when another developer was using `Dataset.split()` along with `map_batches()` and `to_pandas()`) where the dataset blocks are destroyed after `split()`, but before other Dataset operations, causing an invalid object error. 

This PR updates `split()` so that the `owns_blocks` attribute is always `False`, ensuring that the blocks of the output `MaterializedDataset`s are never destroyed prematurely.

## Related issue number

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
