### PR TITLE
[Data] Add test for counting Parquet with filter

### DIFF
--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -1317,6 +1317,13 @@ def test_multiple_files_with_ragged_arrays(ray_start_regular_shared, tmp_path):
         assert item["data"].shape == (100 * (index + 1), 100 * (index + 1))
 
 
+def test_count_with_filter(ray_start_regular_shared):
+    ds = ray.data.read_parquet(
+        "example://iris.parquet", filter=(pc.field("sepal.length") < pc.scalar(0))
+    )
+    assert ds.count() == 0
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -6,6 +6,7 @@ from typing import Any
 import numpy as np
 import pandas as pd
 import pyarrow as pa
+import pyarrow.compute as pc
 import pyarrow.parquet as pq
 import pytest
 from pytest_lazyfixture import lazy_fixture

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -6,7 +6,7 @@ from typing import Any
 import numpy as np
 import pandas as pd
 import pyarrow as pa
-import pyarrow.compute as pc
+import pyarrow.dataset as pds
 import pyarrow.parquet as pq
 import pytest
 from pytest_lazyfixture import lazy_fixture
@@ -1320,7 +1320,7 @@ def test_multiple_files_with_ragged_arrays(ray_start_regular_shared, tmp_path):
 
 def test_count_with_filter(ray_start_regular_shared):
     ds = ray.data.read_parquet(
-        "example://iris.parquet", filter=(pc.field("sepal.length") < pc.scalar(0))
+        "example://iris.parquet", filter=(pds.field("sepal.length") < pds.scalar(0))
     )
     assert ds.count() == 0
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This test ensures that if the user specifies a filter, `read_parquet` produces an accurate count and doesn't just report the count from metadata.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
