### PR TITLE
[data/preprocessors] do not fail transform_batch on missing column

### DIFF
--- a/python/ray/data/preprocessors/imputer.py
+++ b/python/ray/data/preprocessors/imputer.py
@@ -13,7 +13,8 @@ from ray.util.annotations import PublicAPI
 
 @PublicAPI(stability="alpha")
 class SimpleImputer(Preprocessor):
-    """Replace missing values with imputed values.
+    """Replace missing values with imputed values. If the column is missing from a
+    batch, it will be filled with the imputed value.
 
     Examples:
         >>> import pandas as pd
@@ -131,7 +132,14 @@ class SimpleImputer(Preprocessor):
                 if is_categorical_dtype(df.dtypes[column]):
                     df[column] = df[column].cat.add_categories(value)
 
-        df = df.fillna(new_values)
+        for column_name in new_values:
+            if column_name not in df.columns:
+                # Create the column with the fill_value if it doesn't exist
+                df[column_name] = new_values[column_name]
+            else:
+                # Fill NaN (empty) values in the existing column with the fill_value
+                df[column_name].fillna(new_values[column_name], inplace=True)
+
         return df
 
     def __repr__(self):

--- a/python/ray/data/tests/preprocessors/test_imputer.py
+++ b/python/ray/data/tests/preprocessors/test_imputer.py
@@ -61,6 +61,18 @@ def test_simple_imputer():
 
     assert pred_out_df.equals(pred_expected_df)
 
+    # with missing column
+    pred_in_df = pd.DataFrame.from_dict({"A": pred_col_a, "B": pred_col_b})
+    pred_out_df = imputer.transform_batch(pred_in_df)
+    pred_expected_df = pd.DataFrame.from_dict(
+        {
+            "A": pred_processed_col_a,
+            "B": pred_processed_col_b,
+            "C": pred_processed_col_c,
+        }
+    )
+    assert pred_out_df.equals(pred_expected_df)
+
     # Test "most_frequent" strategy.
     most_frequent_col_a = [1, 2, 2, None, None, None]
     most_frequent_col_b = [None, "c", "c", "b", "b", "a"]


### PR DESCRIPTION


## Why are these changes needed?

[<!-- Please give a short summary of the change and the problem this solves. -->](https://github.com/ray-project/ray/issues/48047)

## Related issue number

Closes https://github.com/ray-project/ray/issues/48047

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
