### PR TITLE
[Data] Make `test_insert_xxx_optimization_rules` less brittle

### DIFF
--- a/python/ray/data/_internal/logical/optimizers.py
+++ b/python/ray/data/_internal/logical/optimizers.py
@@ -32,6 +32,9 @@ _PHYSICAL_RULES = [
 
 @DeveloperAPI
 def register_logical_rule(cls: Type[Rule], insert_index: Optional[int] = None):
+    if cls in _LOGICAL_RULES:
+        return
+
     if insert_index is None:
         _LOGICAL_RULES.append(cls)
     else:
@@ -39,11 +42,24 @@ def register_logical_rule(cls: Type[Rule], insert_index: Optional[int] = None):
 
 
 @DeveloperAPI
+def get_logical_rules() -> List[Type[Rule]]:
+    return list(_LOGICAL_RULES)
+
+
+@DeveloperAPI
 def register_physical_rule(cls: Type[Rule], insert_index: Optional[int] = None):
+    if cls in _PHYSICAL_RULES:
+        return
+
     if insert_index is None:
         _PHYSICAL_RULES.append(cls)
     else:
         _PHYSICAL_RULES.insert(insert_index, cls)
+
+
+@DeveloperAPI
+def get_physical_rules() -> List[Type[Rule]]:
+    return list(_PHYSICAL_RULES)
 
 
 class LogicalOptimizer(Optimizer):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`test_insert_logical_optimization_rules` and `test_insert_physical_optimization_rules` break if you add a rule to the respective default list. This PR refactors the test so that it doesn't break in this scenario.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
