### PR TITLE
style: flake8 violation F401

### DIFF
--- a/python/ray/experimental/channel/nccl_group.py
+++ b/python/ray/experimental/channel/nccl_group.py
@@ -10,7 +10,7 @@ from ray.experimental.channel.gpu_communicator import (
 )
 
 if TYPE_CHECKING:
-    import cupy as cp
+    import cupy as cp  # noqa: F401
     import torch
 
 

--- a/python/ray/tests/autoscaler_test_utils.py
+++ b/python/ray/tests/autoscaler_test_utils.py
@@ -2,7 +2,7 @@ import re
 import threading
 
 from subprocess import CalledProcessError
-from typing import Any, Callable, Dict, List, Optional  # noqa: F401
+from typing import Any, Callable, Dict, List, Optional
 from ray.autoscaler.node_provider import NodeProvider
 
 
@@ -43,7 +43,7 @@ class MockNode:
 class MockProcessRunner:
     def __init__(self, fail_cmds=None, cmd_to_callback=None, print_out=False):
         self.calls = []
-        self.cmd_to_callback = cmd_to_callback or {}  # type: Dict[str, Callable]
+        self.cmd_to_callback: Dict[str, Callable] = cmd_to_callback or {}
         self.print_out = print_out
         self.fail_cmds = fail_cmds or []
         self.call_response = {}

--- a/python/ray/tests/autoscaler_test_utils.py
+++ b/python/ray/tests/autoscaler_test_utils.py
@@ -2,7 +2,7 @@ import re
 import threading
 
 from subprocess import CalledProcessError
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional  # noqa: F401
 from ray.autoscaler.node_provider import NodeProvider
 
 

--- a/rllib/evaluation/sampler.py
+++ b/rllib/evaluation/sampler.py
@@ -55,7 +55,7 @@ from ray.rllib.utils.typing import (
 from ray.util.debug import log_once
 
 if TYPE_CHECKING:
-    from gymnasium.envs.classic_control.rendering import SimpleImageViewer
+    from gymnasium.envs.classic_control.rendering import SimpleImageViewer  # noqa: F401
 
     from ray.rllib.algorithms.callbacks import DefaultCallbacks
     from ray.rllib.evaluation.observation_function import ObservationFunction


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

While running the pre-commit hook of flake8, the following error occurs if Python version is 3.12. It's because the version of flake8 is too old.

```
./python/ray/experimental/channel/nccl_group.py:13:5: F401 'cupy as cp' imported but unused
./python/ray/tests/autoscaler_test_utils.py:5:1: F401 'typing.Callable' imported but unused
./rllib/evaluation/sampler.py:58:5: F401 'gymnasium.envs.classic_control.rendering.SimpleImageViewer' imported but unused
```

However, there are another violation appeared after removing these unused import.
```
python/ray/experimental/channel/nccl_group.py:91:37: F821 undefined name 'cp'
python/ray/tests/autoscaler_test_utils.py:46:55: F821 undefined name 'Callable'
rllib/evaluation/sampler.py:343:35: F821 undefined name 'SimpleImageViewer'
```

After taking a look, 
[nccl_group.py:91](https://github.com/ray-project/ray/blob/8c28fe265a5457960bfc1b579687b6c1b632bbbc/python/ray/experimental/channel/nccl_group.py#L92) and [sampler.py:58](https://github.com/ray-project/ray/blob/8c28fe265a5457960bfc1b579687b6c1b632bbbc/rllib/evaluation/sampler.py#L345) are used in `Optional`
[autoscaler_test_utils.py:46](https://github.com/ray-project/ray/blob/8c28fe265a5457960bfc1b579687b6c1b632bbbc/python/ray/tests/autoscaler_test_utils.py#L46) `Callable` is used in type comment.

Thus, suppress F401.

## Related issue number

Closes https://github.com/ray-project/ray/issues/48062

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
