### PR TITLE
[CI] Fix flake8 rule E225: Missing whitespace around operator 

### DIFF
--- a/release/air_tests/air_benchmarks/mlperf-train/resnet50_ray_air.py
+++ b/release/air_tests/air_benchmarks/mlperf-train/resnet50_ray_air.py
@@ -529,7 +529,7 @@ if __name__ == "__main__":
     available_disk_space = statvfs.f_bavail * statvfs.f_frsize
     expected_disk_usage = args.num_images_per_epoch * APPROX_PREPROCESS_IMAGE_BYTES
     print(f"Available disk space: {available_disk_space / 1e9}GB")
-    print(f"Expected disk usage: {expected_disk_usage/ 1e9}GB")
+    print(f"Expected disk usage: {expected_disk_usage / 1e9}GB")
     disk_error_expected = expected_disk_usage > available_disk_space * 0.8
 
     datasets = {}

--- a/release/nightly_tests/stress_tests/test_placement_group.py
+++ b/release/nightly_tests/stress_tests/test_placement_group.py
@@ -186,7 +186,7 @@ if __name__ == "__main__":
     )
     print(
         "Avg placement group removing time: "
-        f"{total_removing_time / total_trial* 1000} ms"
+        f"{total_removing_time / total_trial * 1000} ms"
     )
     print("PASSED.")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
See #47991 
When running the following `flake8` command to check for errors:
```
flake8 --select E225 --extend-exclude python/ray/core/generated,python/ray/serve/generated/,python/ray/cloudpickle/,python/ray/_private/runtime_env/_clonevirtualenv.py,doc/external/,python/ray/dashboard/client/node_modules
```
the following error occurs : 
![image](https://github.com/user-attachments/assets/e595a58e-677d-480f-9490-f52e62e4f0cf)



## Related issue number
Closes #48059 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
