### PR TITLE
[core] Add more infos to each breakpoint

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -198,6 +198,12 @@ def continue_debug_session(live_jobs: Set[str]):
                 time.sleep(1.0)
 
 
+def none_to_empty(s):
+    if s is None:
+        return ""
+    return s
+
+
 def format_table(table):
     """Format a table as a list of lines with aligned columns."""
     result = []
@@ -246,7 +252,18 @@ def debug(address):
         sessions_data = sorted(
             sessions_data, key=lambda data: data["timestamp"], reverse=True
         )
-        table = [["index", "timestamp", "Ray task", "filename:lineno"]]
+        table = [
+            [
+                "index",
+                "timestamp",
+                "Ray task",
+                "filename:lineno",
+                "Node ID",
+                "Worker ID",
+                "Actor ID",
+                "Task ID",
+            ]
+        ]
         for i, data in enumerate(sessions_data):
             date = datetime.utcfromtimestamp(data["timestamp"]).strftime(
                 "%Y-%m-%d %H:%M:%S"
@@ -257,6 +274,10 @@ def debug(address):
                     date,
                     data["proctitle"],
                     data["filename"] + ":" + str(data["lineno"]),
+                    data["node_id"],
+                    data["worker_id"],
+                    none_to_empty(data["actor_id"]),
+                    data["task_id"],
                 ]
             )
         for i, line in enumerate(format_table(table)):

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -219,7 +219,14 @@ def format_table(table):
 @click.option(
     "--address", required=False, type=str, help="Override the address to connect to."
 )
-def debug(address):
+@click.option(
+    "-v",
+    "--verbose",
+    required=False,
+    is_flag=True,
+    help="Shows additional fields in breakpoint selection page.",
+)
+def debug(address: str, verbose: bool):
     """Show all active breakpoints and exceptions in the Ray debugger."""
     address = services.canonicalize_bootstrap_address_or_die(address)
     logger.info(f"Connecting to Ray instance at {address}.")
@@ -252,34 +259,50 @@ def debug(address):
         sessions_data = sorted(
             sessions_data, key=lambda data: data["timestamp"], reverse=True
         )
-        table = [
-            [
-                "index",
-                "timestamp",
-                "Ray task",
-                "filename:lineno",
-                "Node ID",
-                "Worker ID",
-                "Actor ID",
-                "Task ID",
-            ]
-        ]
-        for i, data in enumerate(sessions_data):
-            date = datetime.utcfromtimestamp(data["timestamp"]).strftime(
-                "%Y-%m-%d %H:%M:%S"
-            )
-            table.append(
+        if verbose:
+            table = [
                 [
-                    str(i),
-                    date,
-                    data["proctitle"],
-                    data["filename"] + ":" + str(data["lineno"]),
-                    data["node_id"],
-                    data["worker_id"],
-                    none_to_empty(data["actor_id"]),
-                    data["task_id"],
+                    "index",
+                    "timestamp",
+                    "Ray task",
+                    "filename:lineno",
+                    "Task ID",
+                    "Worker ID",
+                    "Actor ID",
+                    "Node ID",
                 ]
-            )
+            ]
+            for i, data in enumerate(sessions_data):
+                date = datetime.utcfromtimestamp(data["timestamp"]).strftime(
+                    "%Y-%m-%d %H:%M:%S"
+                )
+                table.append(
+                    [
+                        str(i),
+                        date,
+                        data["proctitle"],
+                        data["filename"] + ":" + str(data["lineno"]),
+                        data["task_id"],
+                        data["worker_id"],
+                        none_to_empty(data["actor_id"]),
+                        data["node_id"],
+                    ]
+                )
+        else:
+            # Non verbose mode: no IDs.
+            table = [["index", "timestamp", "Ray task", "filename:lineno"]]
+            for i, data in enumerate(sessions_data):
+                date = datetime.utcfromtimestamp(data["timestamp"]).strftime(
+                    "%Y-%m-%d %H:%M:%S"
+                )
+                table.append(
+                    [
+                        str(i),
+                        date,
+                        data["proctitle"],
+                        data["filename"] + ":" + str(data["lineno"]),
+                    ]
+                )
         for i, line in enumerate(format_table(table)):
             print(line)
             if i >= 1 and not sessions_data[i - 1]["traceback"].startswith(

--- a/python/ray/util/rpdb.py
+++ b/python/ray/util/rpdb.py
@@ -259,6 +259,10 @@ def _connect_ray_pdb(
         "traceback": "\n".join(traceback.format_exception(*sys.exc_info())),
         "timestamp": time.time(),
         "job_id": ray.get_runtime_context().get_job_id(),
+        "node_id": ray.get_runtime_context().get_node_id(),
+        "worker_id": ray.get_runtime_context().get_worker_id(),
+        "actor_id": ray.get_runtime_context().get_actor_id(),
+        "task_id": ray.get_runtime_context().get_task_id(),
     }
     _internal_kv_put(
         "RAY_PDB_{}".format(breakpoint_uuid),


### PR DESCRIPTION
Ray debugger CLI (`ray debug`) is useful but when you have multiple tasks in the breakpoint, and they are of the same task function, one can have difficulties understanding which is which.

Add  "Node ID", "Worker ID", "Actor ID", "Task ID" to the breakpoint info so in `ray debug` these IDs show up in the breakpoint selection menu. This helps users disambiguate between active breakpoints.

Closes #48129.