### PR TITLE
[Data] Fix missing `DataContext` in `Dataset.count()`

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2657,7 +2657,7 @@ class Dataset:
 
         plan = self._plan.copy()
         count_op = Count([self._logical_plan.dag])
-        logical_plan = LogicalPlan(count_op)
+        logical_plan = LogicalPlan(count_op, self.context)
         count_ds = Dataset(plan, logical_plan)
 
         count = 0


### PR DESCRIPTION
## Why are these changes needed?

After https://github.com/ray-project/ray/pull/48038, `LogicalPlan` must have a `DataContext` as input. This PR fixes a bug in `Dataset.count()`, where we are not passing the required `DataContext` object.

## Related issue number


## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
