### PR TITLE
[train][tune] Safely check if the storage filesystem is `pyarrow.fs.S3FileSystem`

### DIFF
--- a/python/ray/train/_internal/storage.py
+++ b/python/ray/train/_internal/storage.py
@@ -19,13 +19,13 @@ except (ImportError, ModuleNotFoundError) as e:
         "pyarrow is a required dependency of Ray Train and Ray Tune. "
         "Please install with: `pip install pyarrow`"
     ) from e
-# isort: on
 
 try:
     # check if Arrow has S3 support
     from pyarrow.fs import S3FileSystem
 except ImportError:
     S3FileSystem = None
+# isort: on
 
 import fnmatch
 import logging

--- a/python/ray/train/_internal/storage.py
+++ b/python/ray/train/_internal/storage.py
@@ -98,7 +98,8 @@ class _ExcludingLocalFilesystem(LocalFileSystem):
 def _pyarrow_fs_copy_files(
     source, destination, source_filesystem=None, destination_filesystem=None, **kwargs
 ):
-    if isinstance(destination_filesystem, pyarrow.fs.S3FileSystem):
+    # Use type_name as some implementation of PyArrow do not have S3/GCP/Azure support
+    if destination_filesystem.type_name.lower() == "s3":
         # Workaround multi-threading issue with pyarrow. Note that use_threads=True
         # is safe for download, just not for uploads, see:
         # https://github.com/apache/arrow/issues/32372

--- a/python/ray/train/_internal/storage.py
+++ b/python/ray/train/_internal/storage.py
@@ -21,6 +21,12 @@ except (ImportError, ModuleNotFoundError) as e:
     ) from e
 # isort: on
 
+try:
+    # check if Arrow has S3 support
+    from pyarrow.fs import S3FileSystem
+except ImportError:
+    S3FileSystem = None
+
 import fnmatch
 import logging
 import os
@@ -98,8 +104,7 @@ class _ExcludingLocalFilesystem(LocalFileSystem):
 def _pyarrow_fs_copy_files(
     source, destination, source_filesystem=None, destination_filesystem=None, **kwargs
 ):
-    # Use type_name as some implementation of PyArrow do not have S3/GCP/Azure support
-    if destination_filesystem.type_name.lower() == "s3":
+    if S3FileSystem and isinstance(destination_filesystem, pyarrow.fs.S3FileSystem):
         # Workaround multi-threading issue with pyarrow. Note that use_threads=True
         # is safe for download, just not for uploads, see:
         # https://github.com/apache/arrow/issues/32372


### PR DESCRIPTION
## Why are these changes needed?

When PyArrow does not have support, checking if the instance is `pyarrow.fs.S3FileSystem` raises an exception.
```
>>> import pyarrow.fs
>>> pyarrow.fs.S3FileSystem
...
ImportError: The pyarrow installation is not built with support for 'S3FileSystem'
```

Fix by checking if the `S3FileSystem` is importable before doing this typecheck.

## Related issue number

Fixes #48187

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   - [x] Tested by a hotfix locally
