### PR TITLE
[Serve] Expose ApplicationStatus class to API docs (#34966)

### DIFF
--- a/doc/source/serve/api/index.md
+++ b/doc/source/serve/api/index.md
@@ -95,7 +95,6 @@ See the [model composition guide](serve-model-composition) for how to update cod
 
    serve.schema.ServeActorDetails
    serve.schema.ProxyDetails
-   serve.schema.ApplicationStatus
    serve.schema.ApplicationStatusOverview
    serve.schema.ServeStatus
    serve.schema.DeploymentStatusOverview
@@ -375,6 +374,7 @@ Content-Type: application/json
 
    schema.ServeInstanceDetails
    schema.APIType
+   schema.ApplicationStatus
    schema.ApplicationDetails
    schema.DeploymentDetails
    schema.ReplicaDetails

--- a/doc/source/serve/api/index.md
+++ b/doc/source/serve/api/index.md
@@ -95,6 +95,7 @@ See the [model composition guide](serve-model-composition) for how to update cod
 
    serve.schema.ServeActorDetails
    serve.schema.ProxyDetails
+   serve.schema.ApplicationStatus
    serve.schema.ApplicationStatusOverview
    serve.schema.ServeStatus
    serve.schema.DeploymentStatusOverview

--- a/python/ray/dashboard/modules/serve/tests/test_serve_dashboard.py
+++ b/python/ray/dashboard/modules/serve/tests/test_serve_dashboard.py
@@ -10,14 +10,13 @@ import requests
 
 from ray._private.test_utils import wait_for_condition
 from ray.serve._private.common import (
-    ApplicationStatus,
     DeploymentStatus,
     DeploymentStatusTrigger,
     ProxyStatus,
     ReplicaState,
 )
 from ray.serve._private.constants import SERVE_NAMESPACE
-from ray.serve.schema import ServeInstanceDetails
+from ray.serve.schema import ApplicationStatus, ServeInstanceDetails
 from ray.serve.tests.conftest import *  # noqa: F401 F403
 from ray.tests.conftest import *  # noqa: F401 F403
 from ray.util.state import list_actors

--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -1,9 +1,10 @@
+import json
 import logging
 import os
 import time
 import traceback
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, field
 from enum import Enum
 from typing import Callable, Dict, List, Optional, Tuple
 
@@ -39,11 +40,18 @@ from ray.serve._private.utils import (
 )
 from ray.serve.config import AutoscalingConfig
 from ray.serve.exceptions import RayServeException
+from ray.serve.generated.serve_pb2 import ApplicationStatus as ApplicationStatusProto
+from ray.serve.generated.serve_pb2 import (
+    ApplicationStatusInfo as ApplicationStatusInfoProto,
+)
 from ray.serve.generated.serve_pb2 import DeploymentLanguage
+from ray.serve.generated.serve_pb2 import (
+    DeploymentStatusInfoList as DeploymentStatusInfoListProto,
+)
+from ray.serve.generated.serve_pb2 import StatusOverview as StatusOverviewProto
 from ray.serve.schema import (
     APIType,
     ApplicationStatus,
-    ApplicationStatusInfo,
     DeploymentDetails,
     LoggingConfig,
     ServeApplicationSchema,
@@ -80,6 +88,97 @@ class BuildAppTaskInfo:
     target_capacity: Optional[float]
     target_capacity_direction: Optional[TargetCapacityDirection]
     finished: bool
+
+
+@dataclass(eq=True)
+class ApplicationStatusInfo:
+    status: ApplicationStatus
+    message: str = ""
+    deployment_timestamp: float = 0
+
+    def debug_string(self):
+        return json.dumps(asdict(self), indent=4)
+
+    def to_proto(self):
+        return ApplicationStatusInfoProto(
+            status=f"APPLICATION_STATUS_{self.status.name}",
+            message=self.message,
+            deployment_timestamp=self.deployment_timestamp,
+        )
+
+    @classmethod
+    def from_proto(cls, proto: ApplicationStatusInfoProto):
+        status = ApplicationStatusProto.Name(proto.status)[len("APPLICATION_STATUS_") :]
+        return cls(
+            status=ApplicationStatus(status),
+            message=proto.message,
+            deployment_timestamp=proto.deployment_timestamp,
+        )
+
+
+@dataclass(eq=True)
+class StatusOverview:
+    app_status: ApplicationStatusInfo
+    name: str = ""
+    deployment_statuses: List[DeploymentStatusInfo] = field(default_factory=list)
+
+    def debug_string(self):
+        return json.dumps(asdict(self), indent=4)
+
+    def get_deployment_status(self, name: str) -> Optional[DeploymentStatusInfo]:
+        """Get a deployment's status by name.
+
+        Args:
+            name: Deployment's name.
+
+        Return (Optional[DeploymentStatusInfo]): Status with a name matching
+            the argument, if one exists. Otherwise, returns None.
+        """
+
+        for deployment_status in self.deployment_statuses:
+            if name == deployment_status.name:
+                return deployment_status
+
+        return None
+
+    def to_proto(self):
+        # Create a protobuf for the Serve Application info
+        app_status_proto = self.app_status.to_proto()
+
+        # Create protobufs for all individual deployment statuses
+        deployment_status_protos = map(
+            lambda status: status.to_proto(), self.deployment_statuses
+        )
+
+        # Create a protobuf list containing all the deployment status protobufs
+        deployment_status_proto_list = DeploymentStatusInfoListProto()
+        deployment_status_proto_list.deployment_status_infos.extend(
+            deployment_status_protos
+        )
+
+        # Return protobuf encapsulating application and deployment protos
+        return StatusOverviewProto(
+            name=self.name,
+            app_status=app_status_proto,
+            deployment_statuses=deployment_status_proto_list,
+        )
+
+    @classmethod
+    def from_proto(cls, proto: StatusOverviewProto) -> "StatusOverview":
+        # Recreate Serve Application info
+        app_status = ApplicationStatusInfo.from_proto(proto.app_status)
+
+        # Recreate deployment statuses
+        deployment_statuses = []
+        for info_proto in proto.deployment_statuses.deployment_status_infos:
+            deployment_statuses.append(DeploymentStatusInfo.from_proto(info_proto))
+
+        # Recreate StatusInfo
+        return cls(
+            app_status=app_status,
+            deployment_statuses=deployment_statuses,
+            name=proto.name,
+        )
 
 
 @dataclass

--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -12,8 +12,6 @@ from ray import cloudpickle
 from ray._private.utils import import_attr
 from ray.exceptions import RuntimeEnvSetupError
 from ray.serve._private.common import (
-    ApplicationStatus,
-    ApplicationStatusInfo,
     DeploymentID,
     DeploymentStatus,
     DeploymentStatusInfo,
@@ -44,6 +42,8 @@ from ray.serve.exceptions import RayServeException
 from ray.serve.generated.serve_pb2 import DeploymentLanguage
 from ray.serve.schema import (
     APIType,
+    ApplicationStatus,
+    ApplicationStatusInfo,
     DeploymentDetails,
     LoggingConfig,
     ServeApplicationSchema,

--- a/python/ray/serve/_private/client.py
+++ b/python/ray/serve/_private/client.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import ray
 from ray.actor import ActorHandle
+from ray.serve._private.application_state import StatusOverview
 from ray.serve._private.common import (
     DeploymentHandleSource,
     DeploymentID,
@@ -36,7 +37,6 @@ from ray.serve.schema import (
     LoggingConfig,
     ServeApplicationSchema,
     ServeDeploySchema,
-    StatusOverview,
 )
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)

--- a/python/ray/serve/_private/client.py
+++ b/python/ray/serve/_private/client.py
@@ -7,13 +7,11 @@ from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
 import ray
 from ray.actor import ActorHandle
 from ray.serve._private.common import (
-    ApplicationStatus,
     DeploymentHandleSource,
     DeploymentID,
     DeploymentStatus,
     DeploymentStatusInfo,
     MultiplexedReplicaInfo,
-    StatusOverview,
 )
 from ray.serve._private.constants import (
     CLIENT_CHECK_CREATION_POLLING_INTERVAL_S,
@@ -33,7 +31,13 @@ from ray.serve.generated.serve_pb2 import (
 )
 from ray.serve.generated.serve_pb2 import StatusOverview as StatusOverviewProto
 from ray.serve.handle import DeploymentHandle, _HandleOptions
-from ray.serve.schema import LoggingConfig, ServeApplicationSchema, ServeDeploySchema
+from ray.serve.schema import (
+    ApplicationStatus,
+    LoggingConfig,
+    ServeApplicationSchema,
+    ServeDeploySchema,
+    StatusOverview,
+)
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -5,21 +5,13 @@ from typing import Awaitable, Callable, List, Optional
 
 from ray.actor import ActorHandle
 from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
-from ray.serve.generated.serve_pb2 import ApplicationStatus as ApplicationStatusProto
-from ray.serve.generated.serve_pb2 import (
-    ApplicationStatusInfo as ApplicationStatusInfoProto,
-)
 from ray.serve.generated.serve_pb2 import DeploymentStatus as DeploymentStatusProto
 from ray.serve.generated.serve_pb2 import (
     DeploymentStatusInfo as DeploymentStatusInfoProto,
 )
 from ray.serve.generated.serve_pb2 import (
-    DeploymentStatusInfoList as DeploymentStatusInfoListProto,
-)
-from ray.serve.generated.serve_pb2 import (
     DeploymentStatusTrigger as DeploymentStatusTriggerProto,
 )
-from ray.serve.generated.serve_pb2 import StatusOverview as StatusOverviewProto
 from ray.serve.grpc_util import RayServegRPCContext
 
 REPLICA_ID_FULL_ID_STR_PREFIX = "SERVE_REPLICA::"
@@ -113,41 +105,6 @@ class ReplicaState(str, Enum):
     RUNNING = "RUNNING"
     STOPPING = "STOPPING"
     PENDING_MIGRATION = "PENDING_MIGRATION"
-
-
-class ApplicationStatus(str, Enum):
-    NOT_STARTED = "NOT_STARTED"
-    DEPLOYING = "DEPLOYING"
-    DEPLOY_FAILED = "DEPLOY_FAILED"
-    RUNNING = "RUNNING"
-    UNHEALTHY = "UNHEALTHY"
-    DELETING = "DELETING"
-
-
-@dataclass(eq=True)
-class ApplicationStatusInfo:
-    status: ApplicationStatus
-    message: str = ""
-    deployment_timestamp: float = 0
-
-    def debug_string(self):
-        return json.dumps(asdict(self), indent=4)
-
-    def to_proto(self):
-        return ApplicationStatusInfoProto(
-            status=f"APPLICATION_STATUS_{self.status.name}",
-            message=self.message,
-            deployment_timestamp=self.deployment_timestamp,
-        )
-
-    @classmethod
-    def from_proto(cls, proto: ApplicationStatusInfoProto):
-        status = ApplicationStatusProto.Name(proto.status)[len("APPLICATION_STATUS_") :]
-        return cls(
-            status=ApplicationStatus(status),
-            message=proto.message,
-            deployment_timestamp=proto.deployment_timestamp,
-        )
 
 
 class DeploymentStatus(str, Enum):
@@ -505,71 +462,6 @@ class DeploymentStatusInfo:
             status=DeploymentStatus(status),
             status_trigger=DeploymentStatusTrigger(status_trigger),
             message=proto.message,
-        )
-
-
-@dataclass(eq=True)
-class StatusOverview:
-    app_status: ApplicationStatusInfo
-    name: str = ""
-    deployment_statuses: List[DeploymentStatusInfo] = field(default_factory=list)
-
-    def debug_string(self):
-        return json.dumps(asdict(self), indent=4)
-
-    def get_deployment_status(self, name: str) -> Optional[DeploymentStatusInfo]:
-        """Get a deployment's status by name.
-
-        Args:
-            name: Deployment's name.
-
-        Return (Optional[DeploymentStatusInfo]): Status with a name matching
-            the argument, if one exists. Otherwise, returns None.
-        """
-
-        for deployment_status in self.deployment_statuses:
-            if name == deployment_status.name:
-                return deployment_status
-
-        return None
-
-    def to_proto(self):
-        # Create a protobuf for the Serve Application info
-        app_status_proto = self.app_status.to_proto()
-
-        # Create protobufs for all individual deployment statuses
-        deployment_status_protos = map(
-            lambda status: status.to_proto(), self.deployment_statuses
-        )
-
-        # Create a protobuf list containing all the deployment status protobufs
-        deployment_status_proto_list = DeploymentStatusInfoListProto()
-        deployment_status_proto_list.deployment_status_infos.extend(
-            deployment_status_protos
-        )
-
-        # Return protobuf encapsulating application and deployment protos
-        return StatusOverviewProto(
-            name=self.name,
-            app_status=app_status_proto,
-            deployment_statuses=deployment_status_proto_list,
-        )
-
-    @classmethod
-    def from_proto(cls, proto: StatusOverviewProto) -> "StatusOverview":
-        # Recreate Serve Application info
-        app_status = ApplicationStatusInfo.from_proto(proto.app_status)
-
-        # Recreate deployment statuses
-        deployment_statuses = []
-        for info_proto in proto.deployment_statuses.deployment_status_infos:
-            deployment_statuses.append(DeploymentStatusInfo.from_proto(info_proto))
-
-        # Recreate StatusInfo
-        return cls(
-            app_status=app_status,
-            deployment_statuses=deployment_statuses,
-            name=proto.name,
         )
 
 

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -19,7 +19,6 @@ from ray.serve._private.common import (
     MultiplexedReplicaInfo,
     NodeId,
     RunningReplicaInfo,
-    StatusOverview,
     TargetCapacityDirection,
 )
 from ray.serve._private.constants import (
@@ -68,6 +67,7 @@ from ray.serve.schema import (
     ServeApplicationSchema,
     ServeDeploySchema,
     ServeInstanceDetails,
+    StatusOverview,
     gRPCOptionsSchema,
 )
 from ray.util import metrics

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -11,7 +11,7 @@ from ray._private.resource_spec import HEAD_NODE_RESOURCE_NAME
 from ray._private.utils import run_background_task
 from ray._raylet import GcsClient
 from ray.actor import ActorHandle
-from ray.serve._private.application_state import ApplicationStateManager
+from ray.serve._private.application_state import ApplicationStateManager, StatusOverview
 from ray.serve._private.autoscaling_state import AutoscalingStateManager
 from ray.serve._private.common import (
     DeploymentHandleSource,
@@ -67,7 +67,6 @@ from ray.serve.schema import (
     ServeApplicationSchema,
     ServeDeploySchema,
     ServeInstanceDetails,
-    StatusOverview,
     gRPCOptionsSchema,
 )
 from ray.util import metrics

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -15,12 +15,7 @@ import ray.util.state as state_api
 from ray import serve
 from ray.actor import ActorHandle
 from ray.serve._private.client import ServeControllerClient
-from ray.serve._private.common import (
-    ApplicationStatus,
-    DeploymentID,
-    DeploymentStatus,
-    RequestProtocol,
-)
+from ray.serve._private.common import DeploymentID, DeploymentStatus, RequestProtocol
 from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME, SERVE_NAMESPACE
 from ray.serve._private.deployment_state import ALL_REPLICA_STATES, ReplicaState
 from ray.serve._private.proxy import DRAINING_MESSAGE
@@ -28,6 +23,7 @@ from ray.serve._private.usage import ServeUsageTag
 from ray.serve._private.utils import TimerBase
 from ray.serve.context import _get_global_client
 from ray.serve.generated import serve_pb2, serve_pb2_grpc
+from ray.serve.schema import ApplicationStatus
 
 TELEMETRY_ROUTE_PREFIX = "/telemetry"
 STORAGE_ACTOR_NAME = "storage"

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -1,7 +1,6 @@
-import json
 import logging
 from collections import Counter
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Union
 from zlib import crc32
@@ -19,7 +18,6 @@ from ray._private.pydantic_compat import (
 from ray._private.runtime_env.packaging import parse_uri
 from ray.serve._private.common import (
     DeploymentStatus,
-    DeploymentStatusInfo,
     DeploymentStatusTrigger,
     ProxyStatus,
     ReplicaState,
@@ -35,14 +33,6 @@ from ray.serve._private.constants import (
 from ray.serve._private.deployment_info import DeploymentInfo
 from ray.serve._private.utils import DEFAULT
 from ray.serve.config import ProxyLocation
-from ray.serve.generated.serve_pb2 import ApplicationStatus as ApplicationStatusProto
-from ray.serve.generated.serve_pb2 import (
-    ApplicationStatusInfo as ApplicationStatusInfoProto,
-)
-from ray.serve.generated.serve_pb2 import (
-    DeploymentStatusInfoList as DeploymentStatusInfoListProto,
-)
-from ray.serve.generated.serve_pb2 import StatusOverview as StatusOverviewProto
 from ray.util.annotations import PublicAPI
 
 # Shared amongst multiple schemas.
@@ -843,99 +833,6 @@ class ApplicationStatus(str, Enum):
     RUNNING = "RUNNING"
     UNHEALTHY = "UNHEALTHY"
     DELETING = "DELETING"
-
-
-@PublicAPI(stability="stable")
-@dataclass(eq=True)
-class ApplicationStatusInfo:
-    status: ApplicationStatus
-    message: str = ""
-    deployment_timestamp: float = 0
-
-    def debug_string(self):
-        return json.dumps(asdict(self), indent=4)
-
-    def to_proto(self):
-        return ApplicationStatusInfoProto(
-            status=f"APPLICATION_STATUS_{self.status.name}",
-            message=self.message,
-            deployment_timestamp=self.deployment_timestamp,
-        )
-
-    @classmethod
-    def from_proto(cls, proto: ApplicationStatusInfoProto):
-        status = ApplicationStatusProto.Name(proto.status)[len("APPLICATION_STATUS_") :]
-        return cls(
-            status=ApplicationStatus(status),
-            message=proto.message,
-            deployment_timestamp=proto.deployment_timestamp,
-        )
-
-
-@PublicAPI(stability="stable")
-@dataclass(eq=True)
-class StatusOverview:
-    app_status: ApplicationStatusInfo
-    name: str = ""
-    deployment_statuses: List[DeploymentStatusInfo] = field(default_factory=list)
-
-    def debug_string(self):
-        return json.dumps(asdict(self), indent=4)
-
-    def get_deployment_status(self, name: str) -> Optional[DeploymentStatusInfo]:
-        """Get a deployment's status by name.
-
-        Args:
-            name: Deployment's name.
-
-        Return (Optional[DeploymentStatusInfo]): Status with a name matching
-            the argument, if one exists. Otherwise, returns None.
-        """
-
-        for deployment_status in self.deployment_statuses:
-            if name == deployment_status.name:
-                return deployment_status
-
-        return None
-
-    def to_proto(self):
-        # Create a protobuf for the Serve Application info
-        app_status_proto = self.app_status.to_proto()
-
-        # Create protobufs for all individual deployment statuses
-        deployment_status_protos = map(
-            lambda status: status.to_proto(), self.deployment_statuses
-        )
-
-        # Create a protobuf list containing all the deployment status protobufs
-        deployment_status_proto_list = DeploymentStatusInfoListProto()
-        deployment_status_proto_list.deployment_status_infos.extend(
-            deployment_status_protos
-        )
-
-        # Return protobuf encapsulating application and deployment protos
-        return StatusOverviewProto(
-            name=self.name,
-            app_status=app_status_proto,
-            deployment_statuses=deployment_status_proto_list,
-        )
-
-    @classmethod
-    def from_proto(cls, proto: StatusOverviewProto) -> "StatusOverview":
-        # Recreate Serve Application info
-        app_status = ApplicationStatusInfo.from_proto(proto.app_status)
-
-        # Recreate deployment statuses
-        deployment_statuses = []
-        for info_proto in proto.deployment_statuses.deployment_status_infos:
-            deployment_statuses.append(DeploymentStatusInfo.from_proto(info_proto))
-
-        # Recreate StatusInfo
-        return cls(
-            app_status=app_status,
-            deployment_statuses=deployment_statuses,
-            name=proto.name,
-        )
 
 
 @PublicAPI(stability="alpha")

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -1,6 +1,7 @@
+import json
 import logging
 from collections import Counter
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Union
 from zlib import crc32
@@ -17,8 +18,8 @@ from ray._private.pydantic_compat import (
 )
 from ray._private.runtime_env.packaging import parse_uri
 from ray.serve._private.common import (
-    ApplicationStatus,
     DeploymentStatus,
+    DeploymentStatusInfo,
     DeploymentStatusTrigger,
     ProxyStatus,
     ReplicaState,
@@ -34,6 +35,14 @@ from ray.serve._private.constants import (
 from ray.serve._private.deployment_info import DeploymentInfo
 from ray.serve._private.utils import DEFAULT
 from ray.serve.config import ProxyLocation
+from ray.serve.generated.serve_pb2 import ApplicationStatus as ApplicationStatusProto
+from ray.serve.generated.serve_pb2 import (
+    ApplicationStatusInfo as ApplicationStatusInfoProto,
+)
+from ray.serve.generated.serve_pb2 import (
+    DeploymentStatusInfoList as DeploymentStatusInfoListProto,
+)
+from ray.serve.generated.serve_pb2 import StatusOverview as StatusOverviewProto
 from ray.util.annotations import PublicAPI
 
 # Shared amongst multiple schemas.
@@ -822,6 +831,109 @@ class DeploymentStatusOverview:
     status_trigger: DeploymentStatusTrigger
     replica_states: Dict[ReplicaState, int]
     message: str
+
+
+@PublicAPI(stability="stable")
+class ApplicationStatus(str, Enum):
+    NOT_STARTED = "NOT_STARTED"
+    DEPLOYING = "DEPLOYING"
+    DEPLOY_FAILED = "DEPLOY_FAILED"
+    RUNNING = "RUNNING"
+    UNHEALTHY = "UNHEALTHY"
+    DELETING = "DELETING"
+
+
+@PublicAPI(stability="stable")
+@dataclass(eq=True)
+class ApplicationStatusInfo:
+    status: ApplicationStatus
+    message: str = ""
+    deployment_timestamp: float = 0
+
+    def debug_string(self):
+        return json.dumps(asdict(self), indent=4)
+
+    def to_proto(self):
+        return ApplicationStatusInfoProto(
+            status=f"APPLICATION_STATUS_{self.status.name}",
+            message=self.message,
+            deployment_timestamp=self.deployment_timestamp,
+        )
+
+    @classmethod
+    def from_proto(cls, proto: ApplicationStatusInfoProto):
+        status = ApplicationStatusProto.Name(proto.status)[len("APPLICATION_STATUS_") :]
+        return cls(
+            status=ApplicationStatus(status),
+            message=proto.message,
+            deployment_timestamp=proto.deployment_timestamp,
+        )
+
+
+@PublicAPI(stability="stable")
+@dataclass(eq=True)
+class StatusOverview:
+    app_status: ApplicationStatusInfo
+    name: str = ""
+    deployment_statuses: List[DeploymentStatusInfo] = field(default_factory=list)
+
+    def debug_string(self):
+        return json.dumps(asdict(self), indent=4)
+
+    def get_deployment_status(self, name: str) -> Optional[DeploymentStatusInfo]:
+        """Get a deployment's status by name.
+
+        Args:
+            name: Deployment's name.
+
+        Return (Optional[DeploymentStatusInfo]): Status with a name matching
+            the argument, if one exists. Otherwise, returns None.
+        """
+
+        for deployment_status in self.deployment_statuses:
+            if name == deployment_status.name:
+                return deployment_status
+
+        return None
+
+    def to_proto(self):
+        # Create a protobuf for the Serve Application info
+        app_status_proto = self.app_status.to_proto()
+
+        # Create protobufs for all individual deployment statuses
+        deployment_status_protos = map(
+            lambda status: status.to_proto(), self.deployment_statuses
+        )
+
+        # Create a protobuf list containing all the deployment status protobufs
+        deployment_status_proto_list = DeploymentStatusInfoListProto()
+        deployment_status_proto_list.deployment_status_infos.extend(
+            deployment_status_protos
+        )
+
+        # Return protobuf encapsulating application and deployment protos
+        return StatusOverviewProto(
+            name=self.name,
+            app_status=app_status_proto,
+            deployment_statuses=deployment_status_proto_list,
+        )
+
+    @classmethod
+    def from_proto(cls, proto: StatusOverviewProto) -> "StatusOverview":
+        # Recreate Serve Application info
+        app_status = ApplicationStatusInfo.from_proto(proto.app_status)
+
+        # Recreate deployment statuses
+        deployment_statuses = []
+        for info_proto in proto.deployment_statuses.deployment_status_infos:
+            deployment_statuses.append(DeploymentStatusInfo.from_proto(info_proto))
+
+        # Recreate StatusInfo
+        return cls(
+            app_status=app_status,
+            deployment_statuses=deployment_statuses,
+            name=proto.name,
+        )
 
 
 @PublicAPI(stability="alpha")

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -836,6 +836,7 @@ class DeploymentStatusOverview:
 @PublicAPI(stability="stable")
 class ApplicationStatus(str, Enum):
     """The current status of the application."""
+
     NOT_STARTED = "NOT_STARTED"
     DEPLOYING = "DEPLOYING"
     DEPLOY_FAILED = "DEPLOY_FAILED"

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -835,6 +835,7 @@ class DeploymentStatusOverview:
 
 @PublicAPI(stability="stable")
 class ApplicationStatus(str, Enum):
+    """The current status of the application."""
     NOT_STARTED = "NOT_STARTED"
     DEPLOYING = "DEPLOYING"
     DEPLOY_FAILED = "DEPLOY_FAILED"
@@ -843,7 +844,6 @@ class ApplicationStatus(str, Enum):
     DELETING = "DELETING"
 
 
-@PublicAPI(stability="stable")
 @dataclass(eq=True)
 class ApplicationStatusInfo:
     status: ApplicationStatus
@@ -870,7 +870,6 @@ class ApplicationStatusInfo:
         )
 
 
-@PublicAPI(stability="stable")
 @dataclass(eq=True)
 class StatusOverview:
     app_status: ApplicationStatusInfo

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -845,6 +845,7 @@ class ApplicationStatus(str, Enum):
     DELETING = "DELETING"
 
 
+@PublicAPI(stability="stable")
 @dataclass(eq=True)
 class ApplicationStatusInfo:
     status: ApplicationStatus
@@ -871,6 +872,7 @@ class ApplicationStatusInfo:
         )
 
 
+@PublicAPI(stability="stable")
 @dataclass(eq=True)
 class StatusOverview:
     app_status: ApplicationStatusInfo
@@ -939,7 +941,7 @@ class StatusOverview:
 @PublicAPI(stability="alpha")
 @dataclass
 class ApplicationStatusOverview:
-    """Describes the status of an application and all its deployments.
+    """Describes the satus of an application and all its deployments.
 
     Attributes:
         status: The current status of the application.

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -838,7 +838,7 @@ class ApplicationStatus(str, Enum):
 @PublicAPI(stability="alpha")
 @dataclass
 class ApplicationStatusOverview:
-    """Describes the satus of an application and all its deployments.
+    """Describes the status of an application and all its deployments.
 
     Attributes:
         status: The current status of the application.

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -16,7 +16,6 @@ import ray.util.state as state_api
 from ray import serve
 from ray._private.test_utils import SignalActor, wait_for_condition
 from ray.serve._private.common import (
-    ApplicationStatus,
     DeploymentID,
     DeploymentStatus,
     DeploymentStatusTrigger,
@@ -38,7 +37,7 @@ from ray.serve._private.test_utils import (
 )
 from ray.serve.config import AutoscalingConfig
 from ray.serve.handle import DeploymentHandle
-from ray.serve.schema import ServeDeploySchema
+from ray.serve.schema import ApplicationStatus, ServeDeploySchema
 from ray.util.state import list_actors
 
 

--- a/python/ray/serve/tests/test_controller.py
+++ b/python/ray/serve/tests/test_controller.py
@@ -6,7 +6,6 @@ import pytest
 import ray
 from ray import serve
 from ray._private.test_utils import wait_for_condition
-from ray.serve._private.common import ApplicationStatus
 from ray.serve._private.constants import (
     DEFAULT_AUTOSCALING_POLICY,
     SERVE_DEFAULT_APP_NAME,
@@ -15,7 +14,7 @@ from ray.serve._private.deployment_info import DeploymentInfo
 from ray.serve.autoscaling_policy import default_autoscaling_policy
 from ray.serve.context import _get_global_client
 from ray.serve.generated.serve_pb2 import DeploymentRoute
-from ray.serve.schema import ServeDeploySchema
+from ray.serve.schema import ApplicationStatus, ServeDeploySchema
 from ray.serve.tests.conftest import TEST_GRPC_SERVICER_FUNCTIONS
 
 

--- a/python/ray/serve/tests/test_deploy_2.py
+++ b/python/ray/serve/tests/test_deploy_2.py
@@ -13,10 +13,11 @@ import ray
 from ray import serve
 from ray._private.pydantic_compat import ValidationError
 from ray._private.test_utils import SignalActor, wait_for_condition
-from ray.serve._private.common import ApplicationStatus, DeploymentStatus
+from ray.serve._private.common import DeploymentStatus
 from ray.serve._private.logging_utils import get_serve_logs_dir
 from ray.serve._private.test_utils import check_deployment_status, check_num_replicas_eq
 from ray.serve._private.utils import get_component_file_name
+from ray.serve.schema import ApplicationStatus
 from ray.util.state import list_actors
 
 

--- a/python/ray/serve/tests/test_deploy_app.py
+++ b/python/ray/serve/tests/test_deploy_app.py
@@ -17,12 +17,7 @@ import ray.actor
 from ray import serve
 from ray._private.test_utils import SignalActor, wait_for_condition
 from ray.serve._private.client import ServeControllerClient
-from ray.serve._private.common import (
-    ApplicationStatus,
-    DeploymentID,
-    DeploymentStatus,
-    ReplicaID,
-)
+from ray.serve._private.common import DeploymentID, DeploymentStatus, ReplicaID
 from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME, SERVE_NAMESPACE
 from ray.serve._private.test_utils import (
     check_num_replicas_eq,
@@ -31,6 +26,7 @@ from ray.serve._private.test_utils import (
 )
 from ray.serve.context import _get_global_client
 from ray.serve.schema import (
+    ApplicationStatus,
     ServeApplicationSchema,
     ServeDeploySchema,
     ServeInstanceDetails,

--- a/python/ray/serve/tests/test_request_timeout.py
+++ b/python/ray/serve/tests/test_request_timeout.py
@@ -13,9 +13,8 @@ import ray
 from ray import serve
 from ray._private.test_utils import SignalActor, wait_for_condition
 from ray.dashboard.modules.serve.sdk import ServeSubmissionClient
-from ray.serve._private.common import ApplicationStatus
 from ray.serve._private.test_utils import send_signal_on_cancellation
-from ray.serve.schema import ServeInstanceDetails
+from ray.serve.schema import ApplicationStatus, ServeInstanceDetails
 from ray.util.state import list_tasks
 
 

--- a/python/ray/serve/tests/test_target_capacity.py
+++ b/python/ray/serve/tests/test_target_capacity.py
@@ -13,7 +13,6 @@ from ray.exceptions import RayActorError
 from ray.serve import Application
 from ray.serve._private.client import ServeControllerClient
 from ray.serve._private.common import (
-    ApplicationStatus,
     DeploymentStatus,
     DeploymentStatusTrigger,
     ReplicaState,
@@ -22,7 +21,11 @@ from ray.serve._private.common import (
 from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME, SERVE_NAMESPACE
 from ray.serve.config import AutoscalingConfig
 from ray.serve.context import _get_global_client
-from ray.serve.schema import ServeApplicationSchema, ServeDeploySchema
+from ray.serve.schema import (
+    ApplicationStatus,
+    ServeApplicationSchema,
+    ServeDeploySchema,
+)
 
 INGRESS_DEPLOYMENT_NAME = "ingress"
 INGRESS_DEPLOYMENT_NUM_REPLICAS = 6

--- a/python/ray/serve/tests/test_telemetry.py
+++ b/python/ray/serve/tests/test_telemetry.py
@@ -11,12 +11,11 @@ import ray
 from ray import serve
 from ray._private.test_utils import wait_for_condition
 from ray._private.usage.usage_lib import get_extra_usage_tags_to_report
-from ray.serve._private.common import ApplicationStatus
 from ray.serve._private.constants import SERVE_MULTIPLEXED_MODEL_ID
 from ray.serve._private.test_utils import check_apps_running, check_telemetry
 from ray.serve._private.usage import ServeUsageTag
 from ray.serve.context import _get_global_client
-from ray.serve.schema import ServeDeploySchema
+from ray.serve.schema import ApplicationStatus, ServeDeploySchema
 
 
 def test_fastapi_detected(manage_ray_with_telemetry):

--- a/python/ray/serve/tests/unit/test_application_state.py
+++ b/python/ray/serve/tests/unit/test_application_state.py
@@ -11,7 +11,6 @@ from ray.serve._private.application_state import (
     override_deployment_info,
 )
 from ray.serve._private.common import (
-    ApplicationStatus,
     DeploymentID,
     DeploymentStatus,
     DeploymentStatusInfo,
@@ -25,6 +24,7 @@ from ray.serve._private.utils import get_random_string
 from ray.serve.exceptions import RayServeException
 from ray.serve.schema import (
     APIType,
+    ApplicationStatus,
     DeploymentSchema,
     LoggingConfig,
     ServeApplicationSchema,

--- a/python/ray/serve/tests/unit/test_common.py
+++ b/python/ray/serve/tests/unit/test_common.py
@@ -1,27 +1,18 @@
-import time
-
 import pytest
 
 from ray.serve._private.common import (
     REPLICA_ID_FULL_ID_STR_PREFIX,
-    ApplicationStatus,
-    ApplicationStatusInfo,
     DeploymentID,
     DeploymentStatus,
     DeploymentStatusInfo,
     DeploymentStatusTrigger,
     ReplicaID,
     RunningReplicaInfo,
-    StatusOverview,
 )
 from ray.serve._private.utils import get_random_string
 from ray.serve.generated.serve_pb2 import (
-    ApplicationStatusInfo as ApplicationStatusInfoProto,
-)
-from ray.serve.generated.serve_pb2 import (
     DeploymentStatusInfo as DeploymentStatusInfoProto,
 )
-from ray.serve.generated.serve_pb2 import StatusOverview as StatusOverviewProto
 
 
 def test_replica_id_formatting():
@@ -116,138 +107,6 @@ class TestDeploymentStatusInfo:
         reconstructed_info = DeploymentStatusInfo.from_proto(deserialized_proto)
 
         assert deployment_status_info == reconstructed_info
-
-
-class TestApplicationStatusInfo:
-    def test_application_status_required(self):
-        with pytest.raises(TypeError):
-            ApplicationStatusInfo(
-                message="context about status", deployment_timestamp=time.time()
-            )
-
-    @pytest.mark.parametrize("status", list(ApplicationStatus))
-    def test_proto(self, status):
-        serve_application_status_info = ApplicationStatusInfo(
-            status=status,
-            message="context about status",
-            deployment_timestamp=time.time(),
-        )
-        serialized_proto = serve_application_status_info.to_proto().SerializeToString()
-        deserialized_proto = ApplicationStatusInfoProto.FromString(serialized_proto)
-        reconstructed_info = ApplicationStatusInfo.from_proto(deserialized_proto)
-
-        assert serve_application_status_info == reconstructed_info
-
-
-class TestStatusOverview:
-    def get_valid_serve_application_status_info(self):
-        return ApplicationStatusInfo(
-            status=ApplicationStatus.RUNNING,
-            message="",
-            deployment_timestamp=time.time(),
-        )
-
-    def test_app_status_required(self):
-        with pytest.raises(TypeError):
-            StatusOverview(deployment_statuses=[])
-
-    def test_empty_list_valid(self):
-        """Should be able to create StatusOverview with no deployment statuses."""
-
-        # Check default is empty list
-        status_info = StatusOverview(
-            app_status=self.get_valid_serve_application_status_info()
-        )
-        status_info.deployment_statuses == []
-
-        # Ensure empty list can be passed in explicitly
-        status_info = StatusOverview(
-            app_status=self.get_valid_serve_application_status_info(),
-            deployment_statuses=[],
-        )
-        status_info.deployment_statuses == []
-
-    def test_equality_mismatched_deployment_statuses(self):
-        """Check that StatusOverviews with different numbers of statuses are unequal."""
-
-        status_info_few_deployments = StatusOverview(
-            app_status=self.get_valid_serve_application_status_info(),
-            deployment_statuses=[
-                DeploymentStatusInfo(
-                    name="1",
-                    status=DeploymentStatus.HEALTHY,
-                    status_trigger=DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
-                ),
-                DeploymentStatusInfo(
-                    name="2",
-                    status=DeploymentStatus.UNHEALTHY,
-                    status_trigger=DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
-                ),
-            ],
-        )
-
-        status_info_many_deployments = StatusOverview(
-            app_status=self.get_valid_serve_application_status_info(),
-            deployment_statuses=[
-                DeploymentStatusInfo(
-                    name="1",
-                    status=DeploymentStatus.HEALTHY,
-                    status_trigger=DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
-                ),
-                DeploymentStatusInfo(
-                    name="2",
-                    status=DeploymentStatus.UNHEALTHY,
-                    status_trigger=DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
-                ),
-                DeploymentStatusInfo(
-                    name="3",
-                    status=DeploymentStatus.UNHEALTHY,
-                    status_trigger=DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
-                ),
-                DeploymentStatusInfo(
-                    name="4",
-                    status=DeploymentStatus.UPDATING,
-                    status_trigger=DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
-                ),
-            ],
-        )
-
-        assert status_info_few_deployments != status_info_many_deployments
-
-    @pytest.mark.parametrize("application_status", list(ApplicationStatus))
-    def test_proto(self, application_status):
-        status_info = StatusOverview(
-            app_status=ApplicationStatusInfo(
-                status=application_status,
-                message="context about this status",
-                deployment_timestamp=time.time(),
-            ),
-            deployment_statuses=[
-                DeploymentStatusInfo(
-                    name="name1",
-                    status=DeploymentStatus.UPDATING,
-                    message="deployment updating",
-                    status_trigger=DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
-                ),
-                DeploymentStatusInfo(
-                    name="name2",
-                    status=DeploymentStatus.HEALTHY,
-                    message="",
-                    status_trigger=DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
-                ),
-                DeploymentStatusInfo(
-                    name="name3",
-                    status=DeploymentStatus.UNHEALTHY,
-                    message="this deployment is unhealthy",
-                    status_trigger=DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
-                ),
-            ],
-        )
-        serialized_proto = status_info.to_proto().SerializeToString()
-        deserialized_proto = StatusOverviewProto.FromString(serialized_proto)
-        reconstructed_info = StatusOverview.from_proto(deserialized_proto)
-
-        assert status_info == reconstructed_info
 
 
 def test_running_replica_info():

--- a/python/ray/serve/tests/unit/test_schema.py
+++ b/python/ray/serve/tests/unit/test_schema.py
@@ -2,21 +2,34 @@ import copy
 import json
 import logging
 import sys
+import time
 from typing import Dict, List, Optional, Union
 
 import pytest
 
 from ray import serve
 from ray._private.pydantic_compat import ValidationError
+from ray.serve._private.common import (
+    DeploymentStatus,
+    DeploymentStatusInfo,
+    DeploymentStatusTrigger,
+)
 from ray.serve.config import AutoscalingConfig
 from ray.serve.deployment import deployment_to_schema, schema_to_deployment
+from ray.serve.generated.serve_pb2 import (
+    ApplicationStatusInfo as ApplicationStatusInfoProto,
+)
+from ray.serve.generated.serve_pb2 import StatusOverview as StatusOverviewProto
 from ray.serve.schema import (
+    ApplicationStatus,
+    ApplicationStatusInfo,
     DeploymentSchema,
     LoggingConfig,
     RayActorOptionsSchema,
     ServeApplicationSchema,
     ServeDeploySchema,
     ServeInstanceDetails,
+    StatusOverview,
 )
 from ray.serve.tests.common.remote_uris import (
     TEST_DEPLOY_GROUP_PINNED_URI,
@@ -99,6 +112,138 @@ def get_invalid_import_paths() -> List[str]:
         "module.submodule_1:submodule2:deployment_Graph",
         "module.submodule_1:submodule2:sm3.dg",
     ]
+
+
+class TestApplicationStatusInfo:
+    def test_application_status_required(self):
+        with pytest.raises(TypeError):
+            ApplicationStatusInfo(
+                message="context about status", deployment_timestamp=time.time()
+            )
+
+    @pytest.mark.parametrize("status", list(ApplicationStatus))
+    def test_proto(self, status):
+        serve_application_status_info = ApplicationStatusInfo(
+            status=status,
+            message="context about status",
+            deployment_timestamp=time.time(),
+        )
+        serialized_proto = serve_application_status_info.to_proto().SerializeToString()
+        deserialized_proto = ApplicationStatusInfoProto.FromString(serialized_proto)
+        reconstructed_info = ApplicationStatusInfo.from_proto(deserialized_proto)
+
+        assert serve_application_status_info == reconstructed_info
+
+
+class TestStatusOverview:
+    def get_valid_serve_application_status_info(self):
+        return ApplicationStatusInfo(
+            status=ApplicationStatus.RUNNING,
+            message="",
+            deployment_timestamp=time.time(),
+        )
+
+    def test_app_status_required(self):
+        with pytest.raises(TypeError):
+            StatusOverview(deployment_statuses=[])
+
+    def test_empty_list_valid(self):
+        """Should be able to create StatusOverview with no deployment statuses."""
+
+        # Check default is empty list
+        status_info = StatusOverview(
+            app_status=self.get_valid_serve_application_status_info()
+        )
+        status_info.deployment_statuses == []
+
+        # Ensure empty list can be passed in explicitly
+        status_info = StatusOverview(
+            app_status=self.get_valid_serve_application_status_info(),
+            deployment_statuses=[],
+        )
+        status_info.deployment_statuses == []
+
+    def test_equality_mismatched_deployment_statuses(self):
+        """Check that StatusOverviews with different numbers of statuses are unequal."""
+
+        status_info_few_deployments = StatusOverview(
+            app_status=self.get_valid_serve_application_status_info(),
+            deployment_statuses=[
+                DeploymentStatusInfo(
+                    name="1",
+                    status=DeploymentStatus.HEALTHY,
+                    status_trigger=DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
+                ),
+                DeploymentStatusInfo(
+                    name="2",
+                    status=DeploymentStatus.UNHEALTHY,
+                    status_trigger=DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
+                ),
+            ],
+        )
+
+        status_info_many_deployments = StatusOverview(
+            app_status=self.get_valid_serve_application_status_info(),
+            deployment_statuses=[
+                DeploymentStatusInfo(
+                    name="1",
+                    status=DeploymentStatus.HEALTHY,
+                    status_trigger=DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
+                ),
+                DeploymentStatusInfo(
+                    name="2",
+                    status=DeploymentStatus.UNHEALTHY,
+                    status_trigger=DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
+                ),
+                DeploymentStatusInfo(
+                    name="3",
+                    status=DeploymentStatus.UNHEALTHY,
+                    status_trigger=DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
+                ),
+                DeploymentStatusInfo(
+                    name="4",
+                    status=DeploymentStatus.UPDATING,
+                    status_trigger=DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
+                ),
+            ],
+        )
+
+        assert status_info_few_deployments != status_info_many_deployments
+
+    @pytest.mark.parametrize("application_status", list(ApplicationStatus))
+    def test_proto(self, application_status):
+        status_info = StatusOverview(
+            app_status=ApplicationStatusInfo(
+                status=application_status,
+                message="context about this status",
+                deployment_timestamp=time.time(),
+            ),
+            deployment_statuses=[
+                DeploymentStatusInfo(
+                    name="name1",
+                    status=DeploymentStatus.UPDATING,
+                    message="deployment updating",
+                    status_trigger=DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
+                ),
+                DeploymentStatusInfo(
+                    name="name2",
+                    status=DeploymentStatus.HEALTHY,
+                    message="",
+                    status_trigger=DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
+                ),
+                DeploymentStatusInfo(
+                    name="name3",
+                    status=DeploymentStatus.UNHEALTHY,
+                    message="this deployment is unhealthy",
+                    status_trigger=DeploymentStatusTrigger.CONFIG_UPDATE_STARTED,
+                ),
+            ],
+        )
+        serialized_proto = status_info.to_proto().SerializeToString()
+        deserialized_proto = StatusOverviewProto.FromString(serialized_proto)
+        reconstructed_info = StatusOverview.from_proto(deserialized_proto)
+
+        assert status_info == reconstructed_info
 
 
 class TestRayActorOptionsSchema:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR moves the ApplicationStatus class out of the _private directory, allowing it to be included in the API docs.

## Related issue number

Closes https://github.com/ray-project/ray/issues/34966

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
