### PR TITLE
[RLlib] Add off-policy'ness metric to new API stack.

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -821,8 +821,8 @@ class Algorithm(Checkpointable, Trainable, AlgorithmBase):
             rl_module_state = self.learner_group.get_state(
                 components=COMPONENT_LEARNER + "/" + COMPONENT_RL_MODULE,
                 inference_only=True,
-            )[COMPONENT_LEARNER][COMPONENT_RL_MODULE]
-            self.env_runner.set_state({COMPONENT_RL_MODULE: rl_module_state})
+            )[COMPONENT_LEARNER]
+            self.env_runner.set_state(rl_module_state)
             self.env_runner_group.sync_env_runner_states(
                 config=self.config,
                 env_steps_sampled=self.metrics.peek(

--- a/rllib/algorithms/appo/appo.py
+++ b/rllib/algorithms/appo/appo.py
@@ -125,7 +125,6 @@ class APPOConfig(IMPALAConfig):
         self.epsilon = 0.1
         self.vf_loss_coeff = 0.5
         self.entropy_coeff = 0.01
-        self.entropy_coeff_schedule = None
         self.tau = 1.0
         self.exploration_config = {
             # The Exploration class to use. In the simplest case, this is the name
@@ -137,14 +136,15 @@ class APPOConfig(IMPALAConfig):
             # Add constructor kwargs here (if any).
         }
 
+        # __sphinx_doc_end__
+        # fmt: on
+
+        self.entropy_coeff_schedule = None  # @OldAPIStack
         self.num_gpus = 0  # @OldAPIStack
         self.num_multi_gpu_tower_stacks = 1  # @OldAPIStack
         self.minibatch_buffer_size = 1  # @OldAPIStack
         self.replay_proportion = 0.0  # @OldAPIStack
         self.replay_buffer_num_slots = 100  # @OldAPIStack
-
-        # __sphinx_doc_end__
-        # fmt: on
 
         self.target_update_frequency = DEPRECATED_VALUE
 

--- a/rllib/algorithms/impala/impala.py
+++ b/rllib/algorithms/impala/impala.py
@@ -375,18 +375,16 @@ class IMPALAConfig(AlgorithmConfig):
                 "`config.training(vtrace=True)`."
             )
 
-        # New stack w/ EnvRunners does NOT support aggregation workers yet or a mixin
-        # replay buffer.
+        # New API stack checks.
         if self.enable_env_runner_and_connector_v2:
+            # Does NOT support aggregation workers yet or a mixin replay buffer.
             if self.replay_ratio != 0.0:
                 raise ValueError(
                     "The new API stack in combination with the new EnvRunner API "
                     "does NOT support a mixin replay buffer yet for "
                     f"{self} (set `config.replay_proportion` to 0.0)!"
                 )
-
-        # Entropy coeff schedule checking.
-        if self.enable_rl_module_and_learner:
+            # Entropy coeff schedule checking.
             if self.entropy_coeff_schedule is not None:
                 raise ValueError(
                     "`entropy_coeff_schedule` is deprecated and must be None! Use the "
@@ -397,6 +395,28 @@ class IMPALAConfig(AlgorithmConfig):
                 setting_name="entropy_coeff",
                 description="entropy coefficient",
             )
+            # Learner API specific checks.
+            if self.minibatch_size is not None and not (
+                (self.minibatch_size % self.rollout_fragment_length == 0)
+                and self.minibatch_size <= self.total_train_batch_size
+            ):
+                raise ValueError(
+                    f"`minibatch_size` ({self._minibatch_size}) must either be None "
+                    "or a multiple of `rollout_fragment_length` "
+                    f"({self.rollout_fragment_length}) while at the same time smaller "
+                    "than or equal to `total_train_batch_size` "
+                    f"({self.total_train_batch_size})!"
+                )
+            # Make sure we have >=1 Learner and warn if `num_learners=0` (should only be
+            # used for debugging).
+            if self.num_learners == 0:
+                logger.warning(
+                    f"{self} should only be run with `num_learners` >= 1! A value of 0 "
+                    "(local learner) should only be used for debugging purposes as it "
+                    "makes the algorithm non-asynchronous. When running with "
+                    "`num_learners=0`, expect diminished learning capabilities."
+                )
+
         elif isinstance(self.entropy_coeff, float) and self.entropy_coeff < 0.0:
             raise ValueError("`entropy_coeff` must be >= 0.0")
 
@@ -424,22 +444,6 @@ class IMPALAConfig(AlgorithmConfig):
                 "`_tf_policy_handles_more_than_one_loss` must be set to True, for "
                 "TFPolicy to support more than one loss term/optimizer! Try setting "
                 "config.training(_tf_policy_handles_more_than_one_loss=True)."
-            )
-        # Learner API specific checks.
-        if (
-            self.enable_rl_module_and_learner
-            and self.minibatch_size is not None
-            and not (
-                (self.minibatch_size % self.rollout_fragment_length == 0)
-                and self.minibatch_size <= self.total_train_batch_size
-            )
-        ):
-            raise ValueError(
-                f"`minibatch_size` ({self._minibatch_size}) must either be None "
-                "or a multiple of `rollout_fragment_length` "
-                f"({self.rollout_fragment_length}) while at the same time smaller "
-                "than or equal to `total_train_batch_size` "
-                f"({self.total_train_batch_size})!"
             )
 
     @property

--- a/rllib/core/learner/learner_group.py
+++ b/rllib/core/learner/learner_group.py
@@ -392,7 +392,7 @@ class LearnerGroup(Checkpointable):
             if _return_state:
                 result["_rl_module_state_after_update"] = _learner.get_state(
                     components=COMPONENT_RL_MODULE, inference_only=True
-                )[COMPONENT_RL_MODULE]
+                )
 
             return result
 

--- a/rllib/core/learner/torch/torch_learner.py
+++ b/rllib/core/learner/torch/torch_learner.py
@@ -407,9 +407,9 @@ class TorchLearner(Learner):
         #  API in ray.train but allow for session to be None without any errors raised.
         if self._use_gpu:
             # get_devices() returns a list that contains the 0th device if
-            # it is called from outside of a Ray Train session. Its necessary to give
+            # it is called from outside a Ray Train session. It's necessary to give
             # the user the option to run on the gpu of their choice, so we enable that
-            # option here via the local gpu id scaling config parameter.
+            # option here through the local gpu id scaling config parameter.
             if self._distributed:
                 devices = get_devices()
                 assert len(devices) == 1, (
@@ -459,8 +459,6 @@ class TorchLearner(Learner):
 
             self._possibly_compiled_update = self._uncompiled_update
 
-        self._make_modules_ddp_if_necessary()
-
         # Log number of non-trainable and trainable parameters of our RLModule.
         num_trainable_params = {
             (mid, NUM_TRAINABLE_PARAMETERS): sum(
@@ -476,6 +474,7 @@ class TorchLearner(Learner):
             for mid, rlm in self.module._rl_modules.items()
             if isinstance(rlm, TorchRLModule)
         }
+
         self.metrics.log_dict(
             {
                 **{
@@ -490,6 +489,8 @@ class TorchLearner(Learner):
                 **num_non_trainable_params,
             }
         )
+
+        self._make_modules_ddp_if_necessary()
 
     @override(Learner)
     def _update(self, batch: Dict[str, Any]) -> Tuple[Any, Any, Any]:

--- a/rllib/env/env_runner_group.py
+++ b/rllib/env/env_runner_group.py
@@ -184,7 +184,7 @@ class EnvRunnerGroup:
         # Starting remote workers from ID=1 to avoid conflicts.
         self._worker_manager = FaultTolerantActorManager(
             max_remote_requests_in_flight_per_actor=(
-                config["max_requests_in_flight_per_env_runner"]
+                config.max_requests_in_flight_per_env_runner
             ),
             init_id=1,
         )
@@ -404,11 +404,7 @@ class EnvRunnerGroup:
                         if env_steps_sampled is not None
                         else {}
                     ),
-                    **(
-                        {COMPONENT_RL_MODULE: rl_module_state}
-                        if rl_module_state is not None
-                        else {}
-                    ),
+                    **(rl_module_state if rl_module_state is not None else {}),
                 }
             )
             return
@@ -472,7 +468,7 @@ class EnvRunnerGroup:
 
         # Update the rl_module component of the EnvRunner states, if necessary:
         if rl_module_state:
-            env_runner_states[COMPONENT_RL_MODULE] = rl_module_state
+            env_runner_states.update(rl_module_state)
 
         # If we do NOT want remote EnvRunners to get their Connector states updated,
         # only update the local worker here (with all state components) and then remove

--- a/rllib/env/multi_agent_env_runner.py
+++ b/rllib/env/multi_agent_env_runner.py
@@ -328,6 +328,7 @@ class MultiAgentEnvRunner(EnvRunner, Checkpointable):
                 ma_dict = ma_dict_list[0]
                 for agent_id, val in ma_dict.items():
                     extra_model_outputs[agent_id][col] = val
+                    extra_model_outputs[agent_id][WEIGHTS_SEQ_NO] = self._weights_seq_no
             extra_model_outputs = dict(extra_model_outputs)
 
             # Record the timestep in the episode instance.
@@ -528,6 +529,7 @@ class MultiAgentEnvRunner(EnvRunner, Checkpointable):
                 ma_dict = ma_dict_list[0]
                 for agent_id, val in ma_dict.items():
                     extra_model_outputs[agent_id][col] = val
+                    extra_model_outputs[agent_id][WEIGHTS_SEQ_NO] = self._weights_seq_no
             extra_model_outputs = dict(extra_model_outputs)
 
             # Record the timestep in the episode instance.

--- a/rllib/env/single_agent_env_runner.py
+++ b/rllib/env/single_agent_env_runner.py
@@ -336,6 +336,7 @@ class SingleAgentEnvRunner(EnvRunner, Checkpointable):
                 #  certain env parameter during different episodes (for example for
                 #  benchmarking).
                 extra_model_output = {k: v[env_index] for k, v in to_env.items()}
+                extra_model_output[WEIGHTS_SEQ_NO] = self._weights_seq_no
 
                 # In inference, we have only the action logits.
                 if terminateds[env_index] or truncateds[env_index]:
@@ -534,6 +535,7 @@ class SingleAgentEnvRunner(EnvRunner, Checkpointable):
 
             for env_index in range(self.num_envs):
                 extra_model_output = {k: v[env_index] for k, v in to_env.items()}
+                extra_model_output[WEIGHTS_SEQ_NO] = self._weights_seq_no
 
                 if terminateds[env_index] or truncateds[env_index]:
                     eps += 1

--- a/rllib/utils/metrics/__init__.py
+++ b/rllib/utils/metrics/__init__.py
@@ -65,7 +65,7 @@ WEIGHTS_SEQ_NO = "weights_seq_no"
 NUM_GRAD_UPDATES_LIFETIME = "num_grad_updates_lifetime"
 # Average difference between the number of grad-updates that the policy/ies had
 # that collected the training batch vs the policy that was just updated (trained).
-# Good measuere for the off-policy'ness of training. Should be 0.0 for PPO and PG,
+# Good measure for the off-policy'ness of training. Should be 0.0 for PPO and PG,
 # small for IMPALA and APPO, and any (larger) value for DQN and other off-policy algos.
 DIFF_NUM_GRAD_UPDATES_VS_SAMPLER_POLICY = "diff_num_grad_updates_vs_sampler_policy"
 

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -1416,7 +1416,6 @@ def run_rllib_example_script_experiment(
                 num_learners=args.num_gpus,
                 num_gpus_per_learner=1 if num_gpus >= args.num_gpus > 0 else 0,
             )
-            config.resources(num_gpus=0)
         # Old stack.
         else:
             config.resources(num_gpus=args.num_gpus)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Add off-policy'ness metric to new API stack.

The old stack has a convenient metric measuring how many policy updates the sampling/behavior policy is behind the actually trained one. For algorithms like APPO and IMPALA, this metrics is crucial for understanding learning deficiencies and its values should be as close to 1 as possible (1 update behind).

The metric can be found in the result dict under (analogous to the old API stack's metric):
learners/[module_id]/diff_num_grad_updates_vs_sampler_policy


<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
