### PR TITLE
[Observability] Added object refs Task is dependent on to `TaskInfoEntry`

### DIFF
--- a/python/ray/dashboard/utils.py
+++ b/python/ray/dashboard/utils.py
@@ -11,7 +11,7 @@ from abc import ABCMeta, abstractmethod
 from base64 import b64decode
 from collections import namedtuple
 from collections.abc import Mapping, MutableMapping, Sequence
-from typing import Optional
+from typing import Optional, Iterable
 
 import aiosignal  # noqa: F401
 from frozenlist import FrozenList  # noqa: F401
@@ -206,32 +206,23 @@ def to_google_style(d):
 def message_to_dict(message, decode_keys=None, **kwargs):
     """Convert protobuf message to Python dict."""
 
-    def _decode_keys(d):
-        for k, v in d.items():
-            if isinstance(v, dict):
-                d[k] = _decode_keys(v)
-            if isinstance(v, list):
-                new_list = []
-                for i in v:
-                    if isinstance(i, dict):
-                        new_list.append(_decode_keys(i))
-                    else:
-                        new_list.append(i)
-                d[k] = new_list
-            else:
-                if k in decode_keys:
-                    d[k] = binary_to_hex(b64decode(v))
-                else:
-                    d[k] = v
-        return d
-
     d = ray._private.protobuf_compat.message_to_dict(
         message, use_integers_for_enums=False, **kwargs
     )
-    if decode_keys:
-        return _decode_keys(d)
-    else:
-        return d
+
+    def _decode_rec(o, should_decode=False):
+        if isinstance(o, dict):
+            for k, v in o.items():
+                o[k] = _decode_rec(v, should_decode=k in decode_keys)
+            return o
+        elif isinstance(o, list):
+            return [_decode_rec(i, should_decode) for i in o]
+        elif should_decode:
+            return binary_to_hex(b64decode(o))
+        else:
+            return o
+
+    return _decode_rec(d) if decode_keys else d
 
 
 class SignalManager:

--- a/python/ray/dashboard/utils.py
+++ b/python/ray/dashboard/utils.py
@@ -11,7 +11,7 @@ from abc import ABCMeta, abstractmethod
 from base64 import b64decode
 from collections import namedtuple
 from collections.abc import Mapping, MutableMapping, Sequence
-from typing import Optional, Iterable
+from typing import Optional
 
 import aiosignal  # noqa: F401
 from frozenlist import FrozenList  # noqa: F401

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -23,7 +23,7 @@ import ray
 import ray.dashboard.consts as dashboard_consts
 import ray._private.state as global_state
 import ray._private.ray_constants as ray_constants
-from ray._raylet import ActorID
+from ray._raylet import ActorID, ObjectRef
 from ray._private.test_utils import (
     run_string_as_driver,
     wait_for_condition,
@@ -40,7 +40,7 @@ from ray.core.generated.common_pb2 import (
     TaskInfoEntry,
     TaskStatus,
     WorkerType,
-    TaskType,
+    TaskType, ObjectReference,
 )
 from ray.core.generated.gcs_pb2 import (
     TaskEvents,
@@ -1015,6 +1015,7 @@ async def test_api_manager_list_tasks_events(state_api_manager):
     data_source_client.get_all_task_info = AsyncMock()
     id = b"1234"
     func_or_class = "f"
+    arg_ref = ObjectRef.from_random()
 
     # Generate a task event.
 
@@ -1023,8 +1024,16 @@ async def test_api_manager_list_tasks_events(state_api_manager):
         name=func_or_class,
         func_or_class_name=func_or_class,
         type=TaskType.NORMAL_TASK,
+        dependent_args_refs=[
+            ObjectReference(
+                object_id=arg_ref.binary(),
+                owner_address=Address(),
+                call_site=arg_ref.call_site(),
+            )
+        ],
     )
-    current = time.time_ns()
+    
+    current = 0
     second = int(1e9)
     state_updates = TaskStateUpdate(
         node_id=node_id.binary(),
@@ -1048,31 +1057,51 @@ async def test_api_manager_list_tasks_events(state_api_manager):
     )
     data_source_client.get_all_task_info.side_effect = [generate_task_data([events])]
     result = await state_api_manager.list_tasks(option=create_api_options(detail=True))
-    result = result.result[0]
-    assert "events" in result
-    assert result["state"] == "FINISHED"
-    expected_events = [
-        {
-            "state": "PENDING_ARGS_AVAIL",
-            "created_ms": current // 1e6,
-        },
-        {
-            "state": "SUBMITTED_TO_WORKER",
-            "created_ms": (current + second) // 1e6,
-        },
-        {
-            "state": "RUNNING",
-            "created_ms": (current + 2 * second) // 1e6,
-        },
-        {
-            "state": "FINISHED",
-            "created_ms": (current + 3 * second) // 1e6,
-        },
-    ]
-    for actual, expected in zip(result["events"], expected_events):
-        assert actual == expected
-    assert result["start_time_ms"] == (current + 2 * second) // 1e6
-    assert result["end_time_ms"] == (current + 3 * second) // 1e6
+
+    assert {
+       'state': 'FINISHED',
+       'type': 'NORMAL_TASK',
+       'name': 'f',
+       'error_message': None,
+       'events': [
+            {'state': 'PENDING_ARGS_AVAIL', 'created_ms': 0.0},
+            {'state': 'SUBMITTED_TO_WORKER', 'created_ms': 1000.0},
+            {'state': 'RUNNING', 'created_ms': 2000.0},
+            {'state': 'FINISHED', 'created_ms': 3000.0}
+       ],
+       'runtime_env_info': None,
+       'end_time_ms': 3000.0,
+       'job_id': '30303031',
+       'error_type': None,
+       'func_or_class_name': 'f',
+       'attempt_number': 0,
+       'node_id': node_id.hex(),
+       'required_resources': {},
+       'worker_pid': None,
+       'language': 'PYTHON',
+       'placement_group_id': None,
+       'creation_time_ms': 0.0,
+       'worker_id': None,
+       'task_log_info': None,
+       'profiling_data': {},
+       'actor_id': None,
+       'is_debugger_paused': None,
+       'start_time_ms': 2000.0,
+       'task_id': '31323334',
+       'parent_task_id': '',
+        'dependent_args_refs': [
+            {
+                'call_site': '',
+                'object_id': arg_ref.hex(),
+                'owner_address': {
+                    'ip_address': '',
+                    'port': 0,
+                    'raylet_id': '',
+                    'worker_id': ''
+                }
+            }
+        ]
+    } == result.result[0]
 
     """
     Test only start_time_ms is updated.
@@ -2340,8 +2369,8 @@ def test_list_cluster_events(shutdown_only):
         print(events)
         assert len(events) == 1
         assert (
-            "Error: No available node types can fulfill " "resource request"
-        ) in events[0]["message"]
+                   "Error: No available node types can fulfill " "resource request"
+               ) in events[0]["message"]
         return True
 
     wait_for_condition(verify)

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -40,7 +40,8 @@ from ray.core.generated.common_pb2 import (
     TaskInfoEntry,
     TaskStatus,
     WorkerType,
-    TaskType, ObjectReference,
+    TaskType,
+    ObjectReference,
 )
 from ray.core.generated.gcs_pb2 import (
     TaskEvents,
@@ -1032,7 +1033,7 @@ async def test_api_manager_list_tasks_events(state_api_manager):
             )
         ],
     )
-    
+
     current = 0
     second = int(1e9)
     state_updates = TaskStateUpdate(
@@ -1059,48 +1060,48 @@ async def test_api_manager_list_tasks_events(state_api_manager):
     result = await state_api_manager.list_tasks(option=create_api_options(detail=True))
 
     assert {
-       'state': 'FINISHED',
-       'type': 'NORMAL_TASK',
-       'name': 'f',
-       'error_message': None,
-       'events': [
-            {'state': 'PENDING_ARGS_AVAIL', 'created_ms': 0.0},
-            {'state': 'SUBMITTED_TO_WORKER', 'created_ms': 1000.0},
-            {'state': 'RUNNING', 'created_ms': 2000.0},
-            {'state': 'FINISHED', 'created_ms': 3000.0}
-       ],
-       'runtime_env_info': None,
-       'end_time_ms': 3000.0,
-       'job_id': '30303031',
-       'error_type': None,
-       'func_or_class_name': 'f',
-       'attempt_number': 0,
-       'node_id': node_id.hex(),
-       'required_resources': {},
-       'worker_pid': None,
-       'language': 'PYTHON',
-       'placement_group_id': None,
-       'creation_time_ms': 0.0,
-       'worker_id': None,
-       'task_log_info': None,
-       'profiling_data': {},
-       'actor_id': None,
-       'is_debugger_paused': None,
-       'start_time_ms': 2000.0,
-       'task_id': '31323334',
-       'parent_task_id': '',
-        'dependent_args_refs': [
+        "state": "FINISHED",
+        "type": "NORMAL_TASK",
+        "name": "f",
+        "error_message": None,
+        "events": [
+            {"state": "PENDING_ARGS_AVAIL", "created_ms": 0.0},
+            {"state": "SUBMITTED_TO_WORKER", "created_ms": 1000.0},
+            {"state": "RUNNING", "created_ms": 2000.0},
+            {"state": "FINISHED", "created_ms": 3000.0},
+        ],
+        "runtime_env_info": None,
+        "end_time_ms": 3000.0,
+        "job_id": "30303031",
+        "error_type": None,
+        "func_or_class_name": "f",
+        "attempt_number": 0,
+        "node_id": node_id.hex(),
+        "required_resources": {},
+        "worker_pid": None,
+        "language": "PYTHON",
+        "placement_group_id": None,
+        "creation_time_ms": 0.0,
+        "worker_id": None,
+        "task_log_info": None,
+        "profiling_data": {},
+        "actor_id": None,
+        "is_debugger_paused": None,
+        "start_time_ms": 2000.0,
+        "task_id": "31323334",
+        "parent_task_id": "",
+        "dependent_args_refs": [
             {
-                'call_site': '',
-                'object_id': arg_ref.hex(),
-                'owner_address': {
-                    'ip_address': '',
-                    'port': 0,
-                    'raylet_id': '',
-                    'worker_id': ''
-                }
+                "call_site": "",
+                "object_id": arg_ref.hex(),
+                "owner_address": {
+                    "ip_address": "",
+                    "port": 0,
+                    "raylet_id": "",
+                    "worker_id": "",
+                },
             }
-        ]
+        ],
     } == result.result[0]
 
     """
@@ -2369,8 +2370,8 @@ def test_list_cluster_events(shutdown_only):
         print(events)
         assert len(events) == 1
         assert (
-                   "Error: No available node types can fulfill " "resource request"
-               ) in events[0]["message"]
+            "Error: No available node types can fulfill " "resource request"
+        ) in events[0]["message"]
         return True
 
     wait_for_condition(verify)

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -1025,12 +1025,8 @@ async def test_api_manager_list_tasks_events(state_api_manager):
         name=func_or_class,
         func_or_class_name=func_or_class,
         type=TaskType.NORMAL_TASK,
-        dependent_args_refs=[
-            ObjectReference(
-                object_id=arg_ref.binary(),
-                owner_address=Address(),
-                call_site=arg_ref.call_site(),
-            )
+        args_object_ids=[
+            arg_ref.binary()
         ],
     )
 
@@ -1090,17 +1086,8 @@ async def test_api_manager_list_tasks_events(state_api_manager):
         "start_time_ms": 2000.0,
         "task_id": "31323334",
         "parent_task_id": "",
-        "dependent_args_refs": [
-            {
-                "call_site": "",
-                "object_id": arg_ref.hex(),
-                "owner_address": {
-                    "ip_address": "",
-                    "port": 0,
-                    "raylet_id": "",
-                    "worker_id": "",
-                },
-            }
+        "args_object_ids": [
+            arg_ref.hex(),
         ],
     } == result.result[0]
 

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -41,7 +41,6 @@ from ray.core.generated.common_pb2 import (
     TaskStatus,
     WorkerType,
     TaskType,
-    ObjectReference,
 )
 from ray.core.generated.gcs_pb2 import (
     TaskEvents,
@@ -1025,9 +1024,7 @@ async def test_api_manager_list_tasks_events(state_api_manager):
         name=func_or_class,
         func_or_class_name=func_or_class,
         type=TaskType.NORMAL_TASK,
-        args_object_ids=[
-            arg_ref.binary()
-        ],
+        args_object_ids=[arg_ref.binary()],
     )
 
     current = 0

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -760,6 +760,9 @@ class TaskState(StateSchema):
     error_message: Optional[str] = state_column(detail=True, filterable=False)
     # Is task paused by the debugger
     is_debugger_paused: Optional[bool] = state_column(detail=True, filterable=True)
+    # List of objects (passed in by ref as arguments) this task
+    # is dependent
+    dependent_args_refs: Optional[dict] = state_column(detail=True, filterable=False)
 
 
 @dataclass(init=not IS_PYDANTIC_2)
@@ -1549,6 +1552,7 @@ def protobuf_to_task_state_dict(message: TaskEvents) -> dict:
             "worker_id",
             "placement_group_id",
             "component_id",
+            "object_id",
         ],
     )
 
@@ -1579,6 +1583,7 @@ def protobuf_to_task_state_dict(message: TaskEvents) -> dict:
                 "runtime_env_info",
                 "parent_task_id",
                 "placement_group_id",
+                "dependent_args_refs",
             ],
         ),
         (task_attempt, ["task_id", "attempt_number", "job_id"]),

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -1553,6 +1553,7 @@ def protobuf_to_task_state_dict(message: TaskEvents) -> dict:
             "placement_group_id",
             "component_id",
             "object_id",
+            "args_object_ids",
         ],
     )
 

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -762,7 +762,7 @@ class TaskState(StateSchema):
     is_debugger_paused: Optional[bool] = state_column(detail=True, filterable=True)
     # List of objects (passed in by ref as arguments) this task
     # is dependent
-    dependent_args_refs: Optional[dict] = state_column(detail=True, filterable=False)
+    args_object_ids: List[str] = state_column(detail=True, filterable=False)
 
 
 @dataclass(init=not IS_PYDANTIC_2)
@@ -1583,7 +1583,7 @@ def protobuf_to_task_state_dict(message: TaskEvents) -> dict:
                 "runtime_env_info",
                 "parent_task_id",
                 "placement_group_id",
-                "dependent_args_refs",
+                "args_object_ids",
             ],
         ),
         (task_attempt, ["task_id", "attempt_number", "job_id"]),

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -761,7 +761,7 @@ class TaskState(StateSchema):
     # Is task paused by the debugger
     is_debugger_paused: Optional[bool] = state_column(detail=True, filterable=True)
     # List of objects (passed in by ref as arguments) this task
-    # is dependent
+    # is dependent on
     args_object_ids: List[str] = state_column(detail=True, filterable=False)
 
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -637,6 +637,7 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
         [this] {
           RAY_LOG(INFO) << "Event stats:\n\n"
                         << io_service_.stats().StatsString() << "\n\n"
+                        << task_execution_service_.stats().StatsString() << "\n\n"
                         << "-----------------\n"
                         << "Task Event stats:\n"
                         << task_event_buffer_->DebugString() << "\n";

--- a/src/ray/gcs/pb_util.h
+++ b/src/ray/gcs/pb_util.h
@@ -252,9 +252,13 @@ inline void FillTaskInfo(rpc::TaskInfoEntry *task_info,
                                                   resources_map.end());
   task_info->mutable_runtime_env_info()->CopyFrom(task_spec.RuntimeEnvInfo());
   const auto &pg_id = task_spec.PlacementGroupBundleId().first;
+
   if (!pg_id.IsNil()) {
     task_info->set_placement_group_id(pg_id.Binary());
   }
+
+  // Fill in task args
+  task_info->set_task_args(task_spec.GetTaskArgs());
 }
 
 // Fill task_info for the export API with task specification from task_spec
@@ -308,6 +312,9 @@ inline void FillExportTaskInfo(rpc::ExportTaskEventData::TaskInfoEntry *task_inf
   if (!pg_id.IsNil()) {
     task_info->set_placement_group_id(pg_id.Binary());
   }
+
+  // Fill in task args
+  task_info->set_task_args(task_spec.GetTaskArgs());
 }
 
 /// Generate a RayErrorInfo from ErrorType

--- a/src/ray/gcs/pb_util.h
+++ b/src/ray/gcs/pb_util.h
@@ -258,7 +258,11 @@ inline void FillTaskInfo(rpc::TaskInfoEntry *task_info,
   }
 
   // Fill in task args
-  task_info->set_task_args(task_spec.GetTaskArgs());
+  for (int i = 0; i < task_spec.NumArgs(); i++) {
+    if (task_spec.ArgByRef(i)) {
+      task_info->add_dependent_args_refs()->CopyFrom(task_spec.ArgRef(i));
+    }
+  }
 }
 
 // Fill task_info for the export API with task specification from task_spec
@@ -312,9 +316,6 @@ inline void FillExportTaskInfo(rpc::ExportTaskEventData::TaskInfoEntry *task_inf
   if (!pg_id.IsNil()) {
     task_info->set_placement_group_id(pg_id.Binary());
   }
-
-  // Fill in task args
-  task_info->set_task_args(task_spec.GetTaskArgs());
 }
 
 /// Generate a RayErrorInfo from ErrorType

--- a/src/ray/gcs/pb_util.h
+++ b/src/ray/gcs/pb_util.h
@@ -260,7 +260,7 @@ inline void FillTaskInfo(rpc::TaskInfoEntry *task_info,
   // Fill in task args
   for (int i = 0; i < task_spec.NumArgs(); i++) {
     if (task_spec.ArgByRef(i)) {
-      task_info->add_dependent_args_refs()->CopyFrom(task_spec.ArgRef(i));
+      task_info->add_args_object_ids(task_spec.ArgRef(i).object_id());
     }
   }
 }

--- a/src/ray/gcs/pb_util.h
+++ b/src/ray/gcs/pb_util.h
@@ -258,7 +258,7 @@ inline void FillTaskInfo(rpc::TaskInfoEntry *task_info,
   }
 
   // Fill in task args
-  for (int i = 0; i < task_spec.NumArgs(); i++) {
+  for (size_t i = 0; i < task_spec.NumArgs(); i++) {
     if (task_spec.ArgByRef(i)) {
       task_info->add_args_object_ids(task_spec.ArgRef(i).object_id());
     }

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -589,6 +589,8 @@ message TaskInfoEntry {
   // If the task/actor is created within a placement group,
   // this value is configured.
   optional bytes placement_group_id = 26;
+  // Tasks arguments
+  repeated TaskArg task_args = 27;
 }
 
 message Bundle {

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -589,8 +589,13 @@ message TaskInfoEntry {
   // If the task/actor is created within a placement group,
   // this value is configured.
   optional bytes placement_group_id = 26;
-  // Tasks arguments
-  repeated TaskArg task_args = 27;
+  // Tasks arguments passed in as (object) references.
+  //
+  // NOTE: This list only contains `ObjectReference`s passed in as arguments
+  //       this task is dependent on and does NOT contain
+  //        - Args passed by value (inlined)
+  //        - ObjectRefs of the args passed by value
+  repeated ObjectReference dependent_args_refs = 27;
 }
 
 message Bundle {

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -595,7 +595,7 @@ message TaskInfoEntry {
   //       this task is dependent on and does NOT contain
   //        - Args passed by value (inlined)
   //        - ObjectRefs of the args passed by value
-  repeated ObjectReference dependent_args_refs = 27;
+  repeated bytes args_object_ids = 27;
 }
 
 message Bundle {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently when listing current tasks using `ray get task <task-id>` we're not reflecting the args the task might be dependent on and therefore waiting to become available.

That substantially complicates troubleshooting when the task is blocked on an argument passed in as an object-ref.

This change adds arguments passed in by reference to the `TaskInfoEntry` to subsequently make it available to our StateHead APIs.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
