### PR TITLE
[ci] correcting update high impact field of test object

### DIFF
--- a/ci/ray_ci/automation/determine_microcheck_tests.py
+++ b/ci/ray_ci/automation/determine_microcheck_tests.py
@@ -61,6 +61,7 @@ def main(
 
 def _update_high_impact_tests(tests: List[Test], high_impact_tests: Set[str]) -> None:
     for test in tests:
+        test.update_from_s3()
         test_name = test.get_name()
         test[Test.KEY_IS_HIGH_IMPACT] = (
             "true" if test_name in high_impact_tests else "false"

--- a/ci/ray_ci/automation/test_determine_microcheck_tests.py
+++ b/ci/ray_ci/automation/test_determine_microcheck_tests.py
@@ -32,6 +32,9 @@ class MockTest(dict):
     ) -> List[TestResult]:
         return self.get("test_results", [])
 
+    def update_from_s3(self) -> None:
+        pass
+
     def persist_to_s3(self) -> None:
         DB[self["name"]] = json.dumps(self)
 


### PR DESCRIPTION
Currently the logic for updating the `high impact` field of a test object uses a very old snapshot of test object. Make sure that it gets the latest information before updating. I think this has been resetting some of the test state and leads to phantom github issues.

There might still be a race between this update and the test state machine update, even though I think that would be very rare, and the worst case scenario is just that we will have phantom release blocking issues. I'll follow up to deal with this race in another PR.

Test:
- CI