### PR TITLE
[core] Deflake test_threaded_actor by increasing timeout

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -455,7 +455,6 @@ py_test_module_list(
     "test_actor_resources.py",
     "test_failure.py",
     "test_multi_node.py",
-    "test_threaded_actor.py",
     "test_generators.py",
     "test_stress_failure.py",
     "test_state_api.py",
@@ -532,6 +531,7 @@ py_test_module_list(
   files = [
     "test_plasma_unlimited.py",
     "test_implicit_resource.py",
+    "test_threaded_actor.py",
   ],
   size = "enormous",
   tags = ["exclusive", "large_size_python_tests_shard_1", "team:core"],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The test is flaky on Mac because it exceeds 180s timeout. I ran it locally and the time taken is 100+ seconds. Increasing timeout to deflake.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #44663

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
