### PR TITLE
Add kuberay operator addon to cmd in gke-gcs-bucket.md

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides/gke-gcs-bucket.md
+++ b/doc/source/cluster/kubernetes/user-guides/gke-gcs-bucket.md
@@ -14,7 +14,7 @@ Run this and all following commands on your local machine or on the [Google Clou
 ```bash
 gcloud container clusters create cloud-bucket-cluster \
     --num-nodes=1 --min-nodes 0 --max-nodes 1 --enable-autoscaling \
-    --zone=us-west1-b --machine-type e2-standard-8 \
+    --zone=us-west1-b --machine-type e2-standard-8 --addons=RayOperator \
     --workload-pool=my-project-id.svc.id.goog # Replace my-project-id with your GCP project ID
 ```
 


### PR DESCRIPTION
Without this option, the `kubectl apply` cmd won't work as it doesn't know the CRD.

## Why are these changes needed?

The steps in the doc doesn't work. When trying a few times, found out that it misses the step to install kuberay operator.

## Related issue number

## Checks
NA for most as this is only adjusting a doc.

- [ X ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ NA ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ NA ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ NA ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ NA ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ NA ] Unit tests
   - [ NA ] Release tests
   - [ NA ] This PR is not tested :(

