### PR TITLE
[Data] Cast `Dataset.count()` explicitly to `int`

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2667,7 +2667,9 @@ class Dataset:
                 f"named '{Count.COLUMN_NAME}'"
             )
             count += batch[Count.COLUMN_NAME].sum()
-        return count
+        # Explicitly cast to int to avoid returning `np.int64`, which is the result
+        # from calculating `sum()` from numpy batches.
+        return int(count)
 
     @ConsumptionAPI(
         if_more_than_read=True,

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -1312,6 +1312,7 @@ def test_count_with_filter(ray_start_regular_shared):
         "example://iris.parquet", filter=(pds.field("sepal.length") < pds.scalar(0))
     )
     assert ds.count() == 0
+    assert isinstance(ds.count(), int)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?

https://github.com/ray-project/ray/pull/48126 introduced a `LogicalOperator` for calculating `Dataset.count()`. As an unintended side effect, calculating `sum()` over numpy batches can result in returning `np.int64` instead of a regular `int`. This PR explicitly cases the result to an `int` before returning.

## Related issue number

Closes https://github.com/ray-project/ray/issues/48177, https://github.com/ray-project/ray/issues/48176

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
