### PR TITLE
[core][compiled-graph] Throw an exception when DAGNode is inside any type of container as a DAGNode arg

### DIFF
--- a/python/ray/dag/dag_node.py
+++ b/python/ray/dag/dag_node.py
@@ -94,7 +94,11 @@ class DAGNode(DAGNodeBase):
         upstream_nodes: List["DAGNode"] = []
 
         # Ray Compiled Graphs do not allow nested DAG nodes in arguments.
-        # Specifically, a DAGNode should not be placed inside any type of container.
+        # Specifically, a DAGNode should not be placed inside any type of
+        # container. However, we only know if this is a compiled graph
+        # when calling `experimental_compile`. Therefore, we need to check
+        # in advance if the arguments contain nested DAG nodes and raise
+        # an error after compilation.
         assert hasattr(self._bound_args, "__iter__")
         for arg in self._bound_args:
             if isinstance(arg, DAGNode):

--- a/python/ray/dag/dag_node.py
+++ b/python/ray/dag/dag_node.py
@@ -410,7 +410,6 @@ class DAGNode(DAGNodeBase):
         while queue:
             node = queue.pop(0)
             if node._args_contains_nested_dag_node:
-                print(type(node))
                 for arg in node._bound_args:
                     if isinstance(arg, DAGNode):
                         continue

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -526,30 +526,34 @@ class TestDAGNodeInsideContainer:
 
     def test_dag_node_in_list(self, ray_start_regular):
         actor = Actor.remote(0)
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(ValueError) as exc_info:
             with InputNode() as inp:
-                actor.echo.bind([inp])
+                dag = actor.echo.bind([inp])
+            dag.experimental_compile()
         assert re.search(self.regex, str(exc_info.value), re.DOTALL)
 
     def test_dag_node_in_tuple(self, ray_start_regular):
         actor = Actor.remote(0)
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(ValueError) as exc_info:
             with InputNode() as inp:
-                actor.echo.bind((inp,))
+                dag = actor.echo.bind((inp,))
+            dag.experimental_compile()
         assert re.search(self.regex, str(exc_info.value), re.DOTALL)
 
     def test_dag_node_in_dict(self, ray_start_regular):
         actor = Actor.remote(0)
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(ValueError) as exc_info:
             with InputNode() as inp:
-                actor.echo.bind({"inp": inp})
+                dag = actor.echo.bind({"inp": inp})
+            dag.experimental_compile()
         assert re.search(self.regex, str(exc_info.value), re.DOTALL)
 
     def test_two_dag_nodes_in_list(self, ray_start_regular):
         actor = Actor.remote(0)
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(ValueError) as exc_info:
             with InputNode() as inp:
-                actor.echo.bind([inp, inp])
+                dag = actor.echo.bind([inp, inp])
+            dag.experimental_compile()
         assert re.search(self.regex, str(exc_info.value), re.DOTALL)
 
 

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -556,6 +556,18 @@ class TestDAGNodeInsideContainer:
             dag.experimental_compile()
         assert re.search(self.regex, str(exc_info.value), re.DOTALL)
 
+    def test_dag_node_in_class(self, ray_start_regular):
+        class OuterClass:
+            def __init__(self, ref):
+                self.ref = ref
+
+        actor = Actor.remote(0)
+        with pytest.raises(ValueError) as exc_info:
+            with InputNode() as inp:
+                dag = actor.echo.bind(OuterClass(inp))
+            dag.experimental_compile()
+        assert re.search(self.regex, str(exc_info.value), re.DOTALL)
+
 
 def test_actor_method_bind_diff_input_attr_4(ray_start_regular):
     actor = Actor.remote(0)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Based on https://github.com/ray-project/ray/pull/48045, we have decided to treat a case where a `DAGNode` is inside any type of container as a `DAGNode` argument as an error and throw an exception.

We verify whether there is a case in the constructor of the DAGNode.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
