### PR TITLE
[core][compiled graphs] Mark release tests with new names as unstable

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2987,7 +2987,7 @@
   frequency: nightly
   working_dir: microbenchmark
 
-  stable: true
+  stable: false
 
   cluster:
     byod: {}
@@ -3003,7 +3003,7 @@
   frequency: nightly
   working_dir: microbenchmark
 
-  stable: true
+  stable: false
 
   cluster:
     byod:
@@ -3020,7 +3020,7 @@
   frequency: nightly
   working_dir: microbenchmark
 
-  stable: true
+  stable: false
 
   cluster:
     byod:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Some tests are failing when we duplicate the original release tests. Marking them as unstable to be non-blocking.
Will mark as stable once they are truly stable.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
