### PR TITLE
[Serve] no added latency for locality routing

### DIFF
--- a/python/ray/serve/tests/unit/test_pow_2_replica_scheduler.py
+++ b/python/ray/serve/tests/unit/test_pow_2_replica_scheduler.py
@@ -1819,7 +1819,7 @@ async def test_replicas_actor_unavailable_error(
     ],
     indirect=True,
 )
-async def test_not_to_backoff_sleep_for_locally_failed_schedule(pow_2_scheduler):
+async def test_locality_aware_backoff_skips_sleeps(pow_2_scheduler):
     """
     When the scheduler fails to schedule a request to a replica on the same node, and
     the same zone, it should not sleep before retrying and add additional latency.

--- a/python/ray/serve/tests/unit/test_pow_2_replica_scheduler.py
+++ b/python/ray/serve/tests/unit/test_pow_2_replica_scheduler.py
@@ -151,7 +151,10 @@ def pow_2_scheduler(request) -> PowerOfTwoChoicesReplicaScheduler:
             ),
             get_curr_time_s=TIMER.time,
         )
-        scheduler.backoff_sequence_s = [0, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001]
+        scheduler.backoff_sequence_s = request.param.get(
+            "backoff_sequence_s",
+            [0, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001],
+        )
         return scheduler
 
     s = asyncio.new_event_loop().run_until_complete(
@@ -1801,6 +1804,58 @@ async def test_replicas_actor_unavailable_error(
     # The scheduler should keep picking r1 since it has a smaller queue length.
     for _ in range(10):
         assert (await s.choose_replica_for_request(fake_pending_request())) == r1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "pow_2_scheduler",
+    [
+        {
+            "prefer_local_node": True,
+            "prefer_local_az": True,
+            "az": SCHEDULER_AZ,
+            "backoff_sequence_s": [999, 999, 999, 999],
+        },
+    ],
+    indirect=True,
+)
+async def test_not_to_backoff_sleep_for_locally_failed_schedule(pow_2_scheduler):
+    """
+    When the scheduler fails to schedule a request to a replica on the same node, and
+    the same zone, it should not sleep before retrying and add additional latency.
+    """
+    s = pow_2_scheduler
+    loop = get_or_create_event_loop()
+    task = loop.create_task(s.choose_replica_for_request(fake_pending_request()))
+
+    # Setting up 3 replicas:
+    #   - r1 being same node and same zone
+    #   - r2 being different node but same zone
+    #   - r3 being different node and different zone
+    #
+    # only r3 is available to serve requests
+    r1 = FakeReplicaWrapper(
+        "r1", node_id=SCHEDULER_NODE_ID, availability_zone=SCHEDULER_AZ
+    )
+    r2 = FakeReplicaWrapper(
+        "r2",
+        node_id="some_other_node_in_the_stratosphere",
+        availability_zone=SCHEDULER_AZ,
+    )
+    r3 = FakeReplicaWrapper(
+        "r3",
+        node_id="some_other_node_in_the_stratosphere",
+        availability_zone="some_other_az_in_the_solar_system",
+    )
+    r1.set_queue_len_response(DEFAULT_MAX_ONGOING_REQUESTS + 1)
+    r2.set_queue_len_response(DEFAULT_MAX_ONGOING_REQUESTS + 1)
+    r3.set_queue_len_response(0)
+    s.update_replicas([r1, r2, r3])
+
+    # The request should be served by r3 without added latency.
+    done, _ = await asyncio.wait([task], timeout=0.01)
+    assert len(done) == 1
+    assert done.pop().result() == r3
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There are some added latency for locality routing when failed to schedule both same node and same zone. This PR added a test case to ensure there are not added latency between scheduling and added a flag to skip the backoff. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
