### PR TITLE
Revert PR #48186 and use `functools.cached_property` instead

### DIFF
--- a/python/ray/data/_internal/datasource/range_datasource.py
+++ b/python/ray/data/_internal/datasource/range_datasource.py
@@ -96,7 +96,7 @@ class RangeDatasource(Datasource):
             meta = BlockMetadata(
                 num_rows=count,
                 size_bytes=8 * count * element_size,
-                schema=copy(self._schema()),
+                schema=copy(self._schema),
                 input_files=None,
                 exec_stats=None,
             )
@@ -112,7 +112,7 @@ class RangeDatasource(Datasource):
 
         return read_tasks
 
-    @functools.cache
+    @functools.cached_property
     def _schema(self):
         if self._n == 0:
             return None

--- a/python/ray/data/_internal/datasource/range_datasource.py
+++ b/python/ray/data/_internal/datasource/range_datasource.py
@@ -1,4 +1,5 @@
 import builtins
+import functools
 from copy import copy
 from typing import Iterable, List, Optional, Tuple
 
@@ -24,7 +25,6 @@ class RangeDatasource(Datasource):
         self._block_format = block_format
         self._tensor_shape = tensor_shape
         self._column_name = column_name
-        self._schema_cache = None
 
     def estimate_inmemory_data_size(self) -> Optional[int]:
         if self._block_format == "tensor":
@@ -96,7 +96,7 @@ class RangeDatasource(Datasource):
             meta = BlockMetadata(
                 num_rows=count,
                 size_bytes=8 * count * element_size,
-                schema=copy(self._get_schema()),
+                schema=copy(self._schema()),
                 input_files=None,
                 exec_stats=None,
             )
@@ -112,14 +112,8 @@ class RangeDatasource(Datasource):
 
         return read_tasks
 
-    def _get_schema(self):
-        """Get the schema, using cached value if available."""
-        if self._schema_cache is None:
-            self._schema_cache = self._compute_schema()
-        return self._schema_cache
-
-    def _compute_schema(self):
-        """Compute the schema without caching."""
+    @functools.cache
+    def _schema(self):
         if self._n == 0:
             return None
 

--- a/python/ray/data/_internal/logical/operators/from_operators.py
+++ b/python/ray/data/_internal/logical/operators/from_operators.py
@@ -40,8 +40,11 @@ class AbstractFrom(LogicalOperator, metaclass=abc.ABCMeta):
     def output_data(self) -> Optional[List[RefBundle]]:
         return self._input_data
 
-    @functools.cache
     def aggregate_output_metadata(self) -> BlockMetadata:
+        return self._cached_output_metadata
+
+    @functools.cached_property
+    def _cached_output_metadata(self) -> BlockMetadata:
         return BlockMetadata(
             num_rows=self._num_rows(),
             size_bytes=self._size_bytes(),

--- a/python/ray/data/_internal/logical/operators/from_operators.py
+++ b/python/ray/data/_internal/logical/operators/from_operators.py
@@ -1,4 +1,5 @@
 import abc
+import functools
 from typing import TYPE_CHECKING, List, Optional, Union
 
 from ray.data._internal.execution.interfaces import RefBundle
@@ -31,7 +32,6 @@ class AbstractFrom(LogicalOperator, metaclass=abc.ABCMeta):
             RefBundle([(input_blocks[i], input_metadata[i])], owns_blocks=False)
             for i in range(len(input_blocks))
         ]
-        self._output_metadata_cache = None
 
     @property
     def input_data(self) -> List[RefBundle]:
@@ -40,14 +40,8 @@ class AbstractFrom(LogicalOperator, metaclass=abc.ABCMeta):
     def output_data(self) -> Optional[List[RefBundle]]:
         return self._input_data
 
+    @functools.cache
     def aggregate_output_metadata(self) -> BlockMetadata:
-        """Get aggregated output metadata, using cache if available."""
-        if self._output_metadata_cache is None:
-            self._output_metadata_cache = self._compute_output_metadata()
-        return self._output_metadata_cache
-
-    def _compute_output_metadata(self) -> BlockMetadata:
-        """Compute the output metadata without caching."""
         return BlockMetadata(
             num_rows=self._num_rows(),
             size_bytes=self._size_bytes(),

--- a/python/ray/data/_internal/logical/operators/input_data_operator.py
+++ b/python/ray/data/_internal/logical/operators/input_data_operator.py
@@ -33,8 +33,11 @@ class InputData(LogicalOperator):
             return None
         return self.input_data
 
-    @functools.cache
     def aggregate_output_metadata(self) -> BlockMetadata:
+        return self._cached_output_metadata
+
+    @functools.cached_property
+    def _cached_output_metadata(self) -> BlockMetadata:
         if self.input_data is None:
             return BlockMetadata(None, None, None, None, None)
 

--- a/python/ray/data/_internal/logical/operators/input_data_operator.py
+++ b/python/ray/data/_internal/logical/operators/input_data_operator.py
@@ -1,3 +1,4 @@
+import functools
 from typing import Callable, List, Optional
 
 from ray.data._internal.execution.interfaces import RefBundle
@@ -26,24 +27,17 @@ class InputData(LogicalOperator):
         )
         self.input_data = input_data
         self.input_data_factory = input_data_factory
-        self._output_metadata_cache = None
 
     def output_data(self) -> Optional[List[RefBundle]]:
         if self.input_data is None:
             return None
         return self.input_data
 
+    @functools.cache
     def aggregate_output_metadata(self) -> BlockMetadata:
-        """Get aggregated output metadata, using cache if available."""
         if self.input_data is None:
             return BlockMetadata(None, None, None, None, None)
 
-        if self._output_metadata_cache is None:
-            self._output_metadata_cache = self._compute_output_metadata()
-        return self._output_metadata_cache
-
-    def _compute_output_metadata(self) -> BlockMetadata:
-        """Compute the output metadata without caching."""
         return BlockMetadata(
             num_rows=self._num_rows(),
             size_bytes=self._size_bytes(),

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -46,13 +46,16 @@ class Read(AbstractMap):
         """
         return self._detected_parallelism
 
-    @functools.cache
     def aggregate_output_metadata(self) -> BlockMetadata:
         """A ``BlockMetadata`` that represents the aggregate metadata of the outputs.
 
         This method gets metadata from the read tasks. It doesn't trigger any actual
         execution.
         """
+        return self._cached_output_metadata
+
+    @functools.cached_property
+    def _cached_output_metadata(self) -> BlockMetadata:
         # Legacy datasources might not implement `get_read_tasks`.
         if self._datasource.should_create_reader:
             return BlockMetadata(None, None, None, None, None)

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -1,3 +1,4 @@
+import functools
 from typing import Any, Dict, Optional, Union
 
 from ray.data._internal.logical.operators.map_operator import AbstractMap
@@ -31,7 +32,6 @@ class Read(AbstractMap):
         self._mem_size = mem_size
         self._concurrency = concurrency
         self._detected_parallelism = None
-        self._output_metadata_cache = None
 
     def set_detected_parallelism(self, parallelism: int):
         """
@@ -46,6 +46,7 @@ class Read(AbstractMap):
         """
         return self._detected_parallelism
 
+    @functools.cache
     def aggregate_output_metadata(self) -> BlockMetadata:
         """A ``BlockMetadata`` that represents the aggregate metadata of the outputs.
 
@@ -53,14 +54,6 @@ class Read(AbstractMap):
         execution.
         """
         # Legacy datasources might not implement `get_read_tasks`.
-        if self._output_metadata_cache is not None:
-            return self._output_metadata_cache
-
-        self._output_metadata_cache = self._compute_output_metadata()
-        return self._output_metadata_cache
-
-    def _compute_output_metadata(self) -> BlockMetadata:
-        """Compute the output metadata without caching."""
         if self._datasource.should_create_reader:
             return BlockMetadata(None, None, None, None, None)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
PR https://github.com/ray-project/ray/pull/48186 tries to fix flake8 rule B109: Don't use `functools.cache` on methods because it may lead to memory leak. This PR uses a simpler implementation, which uses `functools.cached_property` directly.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #48066

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
