### PR TITLE
[serve] raise serve exception when requests are cancelled

### DIFF
--- a/doc/source/serve/api/index.md
+++ b/doc/source/serve/api/index.md
@@ -116,6 +116,7 @@ See the [model composition guide](serve-model-composition) for how to update cod
    serve.grpc_util.RayServegRPCContext
    serve.exceptions.BackPressureError
    serve.exceptions.RayServeException
+   serve.exceptions.RequestCancelledError
 ```
 
 (serve-cli)=

--- a/python/ray/serve/_private/replica_result.py
+++ b/python/ray/serve/_private/replica_result.py
@@ -1,10 +1,13 @@
+import inspect
 import threading
 import time
 from abc import ABC, abstractmethod
-from typing import Callable, Optional, Union
+from functools import wraps
+from typing import Callable, Coroutine, Optional, Union
 
 import ray
 from ray.serve._private.utils import calculate_remaining_timeout
+from ray.serve.exceptions import RequestCancelledError
 
 
 class ReplicaResult(ABC):
@@ -38,10 +41,12 @@ class ActorReplicaResult(ReplicaResult):
         self,
         obj_ref_or_gen: Union[ray.ObjectRef, ray.ObjectRefGenerator],
         is_streaming: bool,
+        request_id: str,
     ):
         self._obj_ref: Optional[ray.ObjectRef] = None
         self._obj_ref_gen: Optional[ray.ObjectRefGenerator] = None
         self._is_streaming: bool = is_streaming
+        self._request_id: str = request_id
         self._object_ref_or_gen_sync_lock = threading.Lock()
 
         if isinstance(obj_ref_or_gen, ray.ObjectRefGenerator):
@@ -92,6 +97,27 @@ class ActorReplicaResult(ReplicaResult):
 
         return self._obj_ref
 
+    def _process_response(f: Union[Callable, Coroutine]):
+        @wraps(f)
+        def wrapper(self, *args, **kwargs):
+            try:
+                return f(self, *args, **kwargs)
+            except ray.exceptions.TaskCancelledError:
+                raise RequestCancelledError(self._request_id)
+
+        @wraps(f)
+        async def async_wrapper(self, *args, **kwargs):
+            try:
+                return await f(self, *args, **kwargs)
+            except ray.exceptions.TaskCancelledError:
+                raise RequestCancelledError(self._request_id)
+
+        if inspect.iscoroutinefunction(f):
+            return async_wrapper
+        else:
+            return wrapper
+
+    @_process_response
     def get(self, timeout_s: Optional[float]):
         assert (
             self._obj_ref is not None or not self._is_streaming
@@ -107,6 +133,7 @@ class ActorReplicaResult(ReplicaResult):
         )
         return ray.get(self._obj_ref, timeout=remaining_timeout_s)
 
+    @_process_response
     async def get_async(self):
         assert (
             self._obj_ref is not None or not self._is_streaming
@@ -115,6 +142,7 @@ class ActorReplicaResult(ReplicaResult):
         await self.resolve_gen_to_ref_if_necessary_async()
         return await self._obj_ref
 
+    @_process_response
     def __next__(self):
         assert self._obj_ref_gen is not None, (
             "next() can only be called on an ActorReplicaResult initialized with a "
@@ -124,6 +152,7 @@ class ActorReplicaResult(ReplicaResult):
         next_obj_ref = self._obj_ref_gen.__next__()
         return ray.get(next_obj_ref)
 
+    @_process_response
     async def __anext__(self):
         assert self._obj_ref_gen is not None, (
             "anext() can only be called on an ActorReplicaResult initialized with a "

--- a/python/ray/serve/_private/replica_scheduler/replica_wrapper.py
+++ b/python/ray/serve/_private/replica_scheduler/replica_wrapper.py
@@ -151,12 +151,15 @@ class ActorReplicaWrapper(ReplicaWrapper):
     def send_request(self, pr: PendingRequest) -> ReplicaResult:
         if self._replica_info.is_cross_language:
             return ActorReplicaResult(
-                self._send_request_java(pr), is_streaming=pr.metadata.is_streaming
+                self._send_request_java(pr),
+                is_streaming=pr.metadata.is_streaming,
+                request_id=pr.metadata.request_id,
             )
         else:
             return ActorReplicaResult(
                 self._send_request_python(pr, with_rejection=False),
                 is_streaming=pr.metadata.is_streaming,
+                request_id=pr.metadata.request_id,
             )
 
     async def send_request_with_rejection(
@@ -176,7 +179,9 @@ class ActorReplicaWrapper(ReplicaWrapper):
             else:
                 return (
                     ActorReplicaResult(
-                        obj_ref_gen, is_streaming=pr.metadata.is_streaming
+                        obj_ref_gen,
+                        is_streaming=pr.metadata.is_streaming,
+                        request_id=pr.metadata.request_id,
                     ),
                     queue_len_info,
                 )

--- a/python/ray/serve/exceptions.py
+++ b/python/ray/serve/exceptions.py
@@ -28,6 +28,8 @@ class BackPressureError(RayServeException):
 
 @PublicAPI(stability="alpha")
 class RequestCancelledError(RayServeException, TaskCancelledError):
+    """Raise when a Serve request is cancelled."""
+
     def __init__(self, request_id: Optional[str] = None):
         self._request_id: Optional[str] = request_id
 

--- a/python/ray/serve/exceptions.py
+++ b/python/ray/serve/exceptions.py
@@ -1,3 +1,6 @@
+from typing import Optional
+
+from ray.exceptions import TaskCancelledError
 from ray.util.annotations import PublicAPI
 
 
@@ -21,3 +24,15 @@ class BackPressureError(RayServeException):
     @property
     def message(self) -> str:
         return self._message
+
+
+@PublicAPI(stability="alpha")
+class RequestCancelledError(RayServeException, TaskCancelledError):
+    def __init__(self, request_id: Optional[str] = None):
+        self._request_id: Optional[str] = request_id
+
+    def __str__(self):
+        if self._request_id:
+            return f"Request {self._request_id} was cancelled."
+        else:
+            return "Request was cancelled."


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Add new Serve exception called `RequestCancelledError` which extends `TaskCancelledError` for now to maintain backwards compatibility. Raise `RequestCancelledError` when fetching the result of a request that was cancelled.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
