### PR TITLE
[serve] Refactor `UserCallableWrapper` to return `concurrent.futures.Future`

### DIFF
--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1,4 +1,5 @@
 import asyncio
+import concurrent.futures
 import inspect
 import logging
 import os
@@ -521,8 +522,10 @@ class ReplicaActor:
         """Entrypoint for `stream=False` calls."""
         request_metadata = pickle.loads(pickled_request_metadata)
         with self._wrap_user_method_call(request_metadata, request_args):
-            return await self._user_callable_wrapper.call_user_method(
-                request_metadata, request_args, request_kwargs
+            return await asyncio.wrap_future(
+                self._user_callable_wrapper.call_user_method(
+                    request_metadata, request_args, request_kwargs
+                )
             )
 
     async def handle_request_streaming(
@@ -593,8 +596,10 @@ class ReplicaActor:
                 ):
                     yield result
             else:
-                yield await self._user_callable_wrapper.call_user_method(
-                    request_metadata, request_args, request_kwargs
+                yield await asyncio.wrap_future(
+                    self._user_callable_wrapper.call_user_method(
+                        request_metadata, request_args, request_kwargs
+                    )
                 )
 
     async def handle_request_from_java(
@@ -617,8 +622,10 @@ class ReplicaActor:
             route=proto.route,
         )
         with self._wrap_user_method_call(request_metadata, request_args):
-            return await self._user_callable_wrapper.call_user_method(
-                request_metadata, request_args, request_kwargs
+            return await asyncio.wrap_future(
+                self._user_callable_wrapper.call_user_method(
+                    request_metadata, request_args, request_kwargs
+                )
             )
 
     async def is_allocated(self) -> str:
@@ -663,16 +670,18 @@ class ReplicaActor:
             async with self._user_callable_initialized_lock:
                 initialization_start_time = time.time()
                 if not self._user_callable_initialized:
-                    self._user_callable_asgi_app = (
-                        await self._user_callable_wrapper.initialize_callable()
+                    self._user_callable_asgi_app = await asyncio.wrap_future(
+                        self._user_callable_wrapper.initialize_callable()
                     )
                     self._user_callable_initialized = True
                     self._set_internal_replica_context(
                         servable_object=self._user_callable_wrapper.user_callable
                     )
                 if deployment_config:
-                    await self._user_callable_wrapper.call_reconfigure(
-                        deployment_config.user_config
+                    await asyncio.wrap_future(
+                        self._user_callable_wrapper.call_reconfigure(
+                            deployment_config.user_config
+                        )
                     )
 
             # A new replica should not be considered healthy until it passes
@@ -713,8 +722,10 @@ class ReplicaActor:
                 self._configure_logger_and_profilers(deployment_config.logging_config)
 
             if user_config_changed:
-                await self._user_callable_wrapper.call_reconfigure(
-                    deployment_config.user_config
+                await asyncio.wrap_future(
+                    self._user_callable_wrapper.call_reconfigure(
+                        deployment_config.user_config
+                    )
                 )
 
             # We need to update internal replica context to reflect the new
@@ -789,7 +800,7 @@ class ReplicaActor:
             await self._drain_ongoing_requests()
 
         try:
-            await self._user_callable_wrapper.call_destructor()
+            await asyncio.wrap_future(self._user_callable_wrapper.call_destructor())
         except:  # noqa: E722
             # We catch a blanket exception since the constructor may still be
             # running, so instance variables used by the destructor may not exist.
@@ -804,7 +815,11 @@ class ReplicaActor:
         await self._metrics_manager.shutdown()
 
     async def check_health(self):
-        await self._user_callable_wrapper.call_user_health_check()
+        # If there's no user-defined health check, nothing runs on the user code event
+        # loop and no future is returned.
+        f: Optional[concurrent.futures.Future] = self._user_callable_wrapper.call_user_health_check()
+        if f is not None:
+            await asyncio.wrap_future(f)
 
 
 class UserCallableWrapper:
@@ -860,20 +875,18 @@ class UserCallableWrapper:
     def _run_on_user_code_event_loop(f: Callable):
         """Decorator to run a coroutine method on the user code event loop.
 
-        The method will be modified to be a sync function that returns an
-        `asyncio.Future`.
+        The method will be modified to be a sync function that returns a
+        `concurrent.futures.Future`.
         """
         assert inspect.iscoroutinefunction(
             f
         ), "_run_on_user_code_event_loop can only be used on coroutine functions."
 
         @wraps(f)
-        def wrapper(*args, **kwargs) -> asyncio.Future:
-            return asyncio.wrap_future(
-                asyncio.run_coroutine_threadsafe(
-                    f(*args, **kwargs),
-                    UserCallableWrapper._user_code_event_loop,
-                )
+        def wrapper(*args, **kwargs) -> concurrent.futures.Future:
+            return asyncio.run_coroutine_threadsafe(
+                f(*args, **kwargs),
+                UserCallableWrapper._user_code_event_loop,
             )
 
         return wrapper
@@ -985,17 +998,13 @@ class UserCallableWrapper:
             else None
         )
 
-    @_run_on_user_code_event_loop
-    async def _call_user_health_check(self):
-        await self._call_func_or_gen(self._user_health_check)
-
     def _raise_if_not_initialized(self, method_name: str):
         if self._callable is None:
             raise RuntimeError(
                 "`initialize_callable` must be called before `{method_name}`."
             )
 
-    async def call_user_health_check(self):
+    def call_user_health_check(self) -> Optional[concurrent.futures.Future]:
         self._raise_if_not_initialized("call_user_health_check")
 
         # If the user provided a health check, call it on the user code thread. If user
@@ -1004,7 +1013,13 @@ class UserCallableWrapper:
         # To avoid this issue for basic cases without a user-defined health check, skip
         # interacting with the user callable entirely.
         if self._user_health_check is not None:
-            return await self._call_user_health_check()
+            return self._call_user_health_check()
+
+        return None
+
+    @_run_on_user_code_event_loop
+    async def _call_user_health_check(self):
+        await self._call_func_or_gen(self._user_health_check)
 
     @_run_on_user_code_event_loop
     async def call_reconfigure(self, user_config: Any):

--- a/python/ray/serve/tests/unit/test_user_callable_wrapper.py
+++ b/python/ray/serve/tests/unit/test_user_callable_wrapper.py
@@ -1,8 +1,8 @@
 import asyncio
+import concurrent.futures
 import pickle
 import sys
 import threading
-import concurrent.futures
 from dataclasses import dataclass
 from typing import Any, AsyncGenerator, Callable, Generator, Optional
 
@@ -298,11 +298,15 @@ def test_basic_function_callable(fn: Callable):
     # Call non-generator function with is_streaming.
     request_metadata = _make_request_metadata(is_streaming=True)
     with pytest.raises(RayTaskError, match="did not return a generator."):
-        user_callable_wrapper.call_user_method(request_metadata, tuple(), dict()).result()
+        user_callable_wrapper.call_user_method(
+            request_metadata, tuple(), dict()
+        ).result()
 
     request_metadata = _make_request_metadata()
     assert (
-        user_callable_wrapper.call_user_method(request_metadata, tuple(), dict()).result()
+        user_callable_wrapper.call_user_method(
+            request_metadata, tuple(), dict()
+        ).result()
     ) == "hi"
     assert (
         user_callable_wrapper.call_user_method(
@@ -412,7 +416,9 @@ def test_callable_with_async_init():
     user_callable_wrapper.initialize_callable().result()
     request_metadata = _make_request_metadata()
     assert (
-        user_callable_wrapper.call_user_method(request_metadata, tuple(), dict()).result()
+        user_callable_wrapper.call_user_method(
+            request_metadata, tuple(), dict()
+        ).result()
     ) == msg
 
 
@@ -441,7 +447,9 @@ def test_destructor_only_called_once(async_del: bool):
 
     # Call `call_destructor` many times in parallel; only the first one should actually
     # run the `__del__` method.
-    concurrent.futures.wait([user_callable_wrapper.call_destructor() for _ in range(100)])
+    concurrent.futures.wait(
+        [user_callable_wrapper.call_destructor() for _ in range(100)]
+    )
     assert num_destructor_calls == 1
 
 

--- a/python/ray/serve/tests/unit/test_user_callable_wrapper.py
+++ b/python/ray/serve/tests/unit/test_user_callable_wrapper.py
@@ -2,6 +2,7 @@ import asyncio
 import pickle
 import sys
 import threading
+import concurrent.futures
 from dataclasses import dataclass
 from typing import Any, AsyncGenerator, Callable, Generator, Optional
 
@@ -123,93 +124,102 @@ def _make_request_metadata(
     )
 
 
-@pytest.mark.asyncio
-async def test_calling_initialize_twice():
+def test_calling_initialize_twice():
     user_callable_wrapper = _make_user_callable_wrapper()
 
-    await user_callable_wrapper.initialize_callable()
+    user_callable_wrapper.initialize_callable().result()
     assert isinstance(user_callable_wrapper.user_callable, BasicClass)
     with pytest.raises(RuntimeError):
-        await user_callable_wrapper.initialize_callable()
+        user_callable_wrapper.initialize_callable().result()
 
 
-@pytest.mark.asyncio
-async def test_calling_methods_before_initialize():
+def test_calling_methods_before_initialize():
     user_callable_wrapper = _make_user_callable_wrapper()
 
     with pytest.raises(RuntimeError):
-        await user_callable_wrapper.call_user_method(None, tuple(), dict())
+        user_callable_wrapper.call_user_method(None, tuple(), dict()).result()
 
     with pytest.raises(RuntimeError):
-        await user_callable_wrapper.call_user_health_check()
+        user_callable_wrapper.call_user_health_check().result()
 
     with pytest.raises(RuntimeError):
-        await user_callable_wrapper.call_reconfigure(None)
+        user_callable_wrapper.call_reconfigure(None).result()
 
 
-@pytest.mark.asyncio
-async def test_basic_class_callable():
+def test_basic_class_callable():
     user_callable_wrapper = _make_user_callable_wrapper()
 
-    await user_callable_wrapper.initialize_callable()
+    user_callable_wrapper.initialize_callable().result()
 
     # Call non-generator method with is_streaming.
     request_metadata = _make_request_metadata(is_streaming=True)
     with pytest.raises(RayTaskError, match="did not return a generator."):
-        await user_callable_wrapper.call_user_method(request_metadata, tuple(), dict())
+        user_callable_wrapper.call_user_method(
+            request_metadata, tuple(), dict()
+        ).result()
 
     # Test calling default sync `__call__` method.
     request_metadata = _make_request_metadata()
     assert (
-        await user_callable_wrapper.call_user_method(request_metadata, tuple(), dict())
+        user_callable_wrapper.call_user_method(
+            request_metadata, tuple(), dict()
+        ).result()
     ) == "hi"
     assert (
-        await user_callable_wrapper.call_user_method(
+        user_callable_wrapper.call_user_method(
             request_metadata, ("-arg",), dict()
-        )
-    ) == "hi-arg"
+        ).result()
+        == "hi-arg"
+    )
     assert (
-        await user_callable_wrapper.call_user_method(
+        user_callable_wrapper.call_user_method(
             request_metadata, tuple(), {"suffix": "-kwarg"}
-        )
-    ) == "hi-kwarg"
+        ).result()
+        == "hi-kwarg"
+    )
     with pytest.raises(RayTaskError, match="uh-oh"):
-        await user_callable_wrapper.call_user_method(
+        user_callable_wrapper.call_user_method(
             request_metadata, tuple(), {"raise_exception": True}
-        )
+        ).result()
 
     # Call non-generator async method with is_streaming.
     request_metadata = _make_request_metadata(
         call_method="call_async", is_streaming=True
     )
     with pytest.raises(RayTaskError, match="did not return a generator."):
-        await user_callable_wrapper.call_user_method(request_metadata, tuple(), dict())
+        user_callable_wrapper.call_user_method(
+            request_metadata, tuple(), dict()
+        ).result()
 
     # Test calling `call_async` method.
     request_metadata = _make_request_metadata(call_method="call_async")
     assert (
-        await user_callable_wrapper.call_user_method(request_metadata, tuple(), dict())
-    ) == "hi"
+        user_callable_wrapper.call_user_method(
+            request_metadata, tuple(), dict()
+        ).result()
+        == "hi"
+    )
     assert (
-        await user_callable_wrapper.call_user_method(
+        user_callable_wrapper.call_user_method(
             request_metadata, ("-arg",), dict()
-        )
-    ) == "hi-arg"
+        ).result()
+        == "hi-arg"
+    )
     assert (
-        await user_callable_wrapper.call_user_method(
+        user_callable_wrapper.call_user_method(
             request_metadata, tuple(), {"suffix": "-kwarg"}
-        )
-    ) == "hi-kwarg"
+        ).result()
+        == "hi-kwarg"
+    )
     with pytest.raises(RayTaskError, match="uh-oh"):
-        await user_callable_wrapper.call_user_method(
+        user_callable_wrapper.call_user_method(
             request_metadata, tuple(), {"raise_exception": True}
-        )
+        ).result()
 
 
-@pytest.mark.asyncio
-async def test_basic_class_callable_generators():
+def test_basic_class_callable_generators():
     user_callable_wrapper = _make_user_callable_wrapper()
-    await user_callable_wrapper.initialize_callable()
+    user_callable_wrapper.initialize_callable().result()
 
     result_list = []
 
@@ -223,28 +233,28 @@ async def test_basic_class_callable_generators():
     with pytest.raises(
         RayTaskError, match="Method 'call_generator' returned a generator."
     ):
-        await user_callable_wrapper.call_user_method(
+        user_callable_wrapper.call_user_method(
             request_metadata, (10,), dict(), generator_result_callback=append_to_list
-        )
+        ).result()
 
     # Call sync generator.
     request_metadata = _make_request_metadata(
         call_method="call_generator", is_streaming=True
     )
-    await user_callable_wrapper.call_user_method(
+    user_callable_wrapper.call_user_method(
         request_metadata, (10,), dict(), generator_result_callback=append_to_list
-    )
+    ).result()
     assert result_list == list(range(10))
     result_list.clear()
 
     # Call sync generator raising exception.
     with pytest.raises(RayTaskError, match="uh-oh"):
-        await user_callable_wrapper.call_user_method(
+        user_callable_wrapper.call_user_method(
             request_metadata,
             (10,),
             {"raise_exception": True},
             generator_result_callback=append_to_list,
-        )
+        ).result()
     assert result_list == [0]
     result_list.clear()
 
@@ -255,67 +265,65 @@ async def test_basic_class_callable_generators():
     with pytest.raises(
         RayTaskError, match="Method 'call_async_generator' returned a generator."
     ):
-        await user_callable_wrapper.call_user_method(
+        user_callable_wrapper.call_user_method(
             request_metadata, (10,), dict(), generator_result_callback=append_to_list
-        )
+        ).result()
 
     # Call async generator.
     request_metadata = _make_request_metadata(
         call_method="call_async_generator", is_streaming=True
     )
-    await user_callable_wrapper.call_user_method(
+    user_callable_wrapper.call_user_method(
         request_metadata, (10,), dict(), generator_result_callback=append_to_list
-    )
+    ).result()
     assert result_list == list(range(10))
     result_list.clear()
 
     # Call async generator raising exception.
     with pytest.raises(RayTaskError, match="uh-oh"):
-        await user_callable_wrapper.call_user_method(
+        user_callable_wrapper.call_user_method(
             request_metadata,
             (10,),
             {"raise_exception": True},
             generator_result_callback=append_to_list,
-        )
+        ).result()
     assert result_list == [0]
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("fn", [basic_sync_function, basic_async_function])
-async def test_basic_function_callable(fn: Callable):
+def test_basic_function_callable(fn: Callable):
     user_callable_wrapper = _make_user_callable_wrapper(fn)
-    await user_callable_wrapper.initialize_callable()
+    user_callable_wrapper.initialize_callable().result()
 
     # Call non-generator function with is_streaming.
     request_metadata = _make_request_metadata(is_streaming=True)
     with pytest.raises(RayTaskError, match="did not return a generator."):
-        await user_callable_wrapper.call_user_method(request_metadata, tuple(), dict())
+        user_callable_wrapper.call_user_method(request_metadata, tuple(), dict()).result()
 
     request_metadata = _make_request_metadata()
     assert (
-        await user_callable_wrapper.call_user_method(request_metadata, tuple(), dict())
+        user_callable_wrapper.call_user_method(request_metadata, tuple(), dict()).result()
     ) == "hi"
     assert (
-        await user_callable_wrapper.call_user_method(
+        user_callable_wrapper.call_user_method(
             request_metadata, ("-arg",), dict()
-        )
+        ).result()
     ) == "hi-arg"
     assert (
-        await user_callable_wrapper.call_user_method(
+        user_callable_wrapper.call_user_method(
             request_metadata, tuple(), {"suffix": "-kwarg"}
-        )
+        ).result()
     ) == "hi-kwarg"
     with pytest.raises(RayTaskError, match="uh-oh"):
-        await user_callable_wrapper.call_user_method(
+        user_callable_wrapper.call_user_method(
             request_metadata, tuple(), {"raise_exception": True}
-        )
+        ).result()
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("fn", [basic_sync_generator, basic_async_generator])
-async def test_basic_function_callable_generators(fn: Callable):
+def test_basic_function_callable_generators(fn: Callable):
     user_callable_wrapper = _make_user_callable_wrapper(fn)
-    await user_callable_wrapper.initialize_callable()
+    user_callable_wrapper.initialize_callable().result()
 
     result_list = []
 
@@ -327,28 +335,28 @@ async def test_basic_function_callable_generators(fn: Callable):
     with pytest.raises(
         RayTaskError, match=f"Method '{fn.__name__}' returned a generator."
     ):
-        await user_callable_wrapper.call_user_method(
+        user_callable_wrapper.call_user_method(
             request_metadata, (10,), dict(), generator_result_callback=append_to_list
-        )
+        ).result()
 
     # Call generator function.
     request_metadata = _make_request_metadata(
         call_method="call_generator", is_streaming=True
     )
-    await user_callable_wrapper.call_user_method(
+    user_callable_wrapper.call_user_method(
         request_metadata, (10,), dict(), generator_result_callback=append_to_list
-    )
+    ).result()
     assert result_list == list(range(10))
     result_list.clear()
 
     # Call generator function raising exception.
     with pytest.raises(RayTaskError, match="uh-oh"):
-        await user_callable_wrapper.call_user_method(
+        user_callable_wrapper.call_user_method(
             request_metadata,
             (10,),
             {"raise_exception": True},
             generator_result_callback=append_to_list,
-        )
+        ).result()
     assert result_list == [0]
 
 
@@ -375,20 +383,19 @@ async def test_user_code_runs_on_separate_loop():
             return user_method_loop
 
     user_callable_wrapper = _make_user_callable_wrapper(GetLoop)
-    await user_callable_wrapper.initialize_callable()
+    user_callable_wrapper.initialize_callable().result()
     request_metadata = _make_request_metadata()
-    user_code_loop = await user_callable_wrapper.call_user_method(
+    user_code_loop = user_callable_wrapper.call_user_method(
         request_metadata, tuple(), dict()
-    )
+    ).result()
     assert isinstance(user_code_loop, asyncio.AbstractEventLoop)
     assert user_code_loop != main_loop
 
     # `check_health` method asserts that it runs on the correct loop.
-    await user_callable_wrapper.call_user_health_check()
+    user_callable_wrapper.call_user_health_check().result()
 
 
-@pytest.mark.asyncio
-async def test_callable_with_async_init():
+def test_callable_with_async_init():
     class AsyncInitializer:
         async def __init__(self, msg: str):
             await asyncio.sleep(0.001)
@@ -402,16 +409,15 @@ async def test_callable_with_async_init():
         AsyncInitializer,
         msg,
     )
-    await user_callable_wrapper.initialize_callable()
+    user_callable_wrapper.initialize_callable().result()
     request_metadata = _make_request_metadata()
     assert (
-        await user_callable_wrapper.call_user_method(request_metadata, tuple(), dict())
+        user_callable_wrapper.call_user_method(request_metadata, tuple(), dict()).result()
     ) == msg
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("async_del", [False, True])
-async def test_destructor_only_called_once(async_del: bool):
+def test_destructor_only_called_once(async_del: bool):
     num_destructor_calls = 0
 
     if async_del:
@@ -431,16 +437,11 @@ async def test_destructor_only_called_once(async_del: bool):
     user_callable_wrapper = _make_user_callable_wrapper(
         DestroyerOfNothing,
     )
-    await user_callable_wrapper.initialize_callable()
+    user_callable_wrapper.initialize_callable().result()
 
     # Call `call_destructor` many times in parallel; only the first one should actually
     # run the `__del__` method.
-    await asyncio.gather(
-        *[
-            asyncio.ensure_future(user_callable_wrapper.call_destructor())
-            for _ in range(100)
-        ]
-    )
+    concurrent.futures.wait([user_callable_wrapper.call_destructor() for _ in range(100)])
     assert num_destructor_calls == 1
 
 
@@ -461,20 +462,22 @@ async def test_no_user_health_check_not_blocked():
     user_callable_wrapper = _make_user_callable_wrapper(
         LoopBlocker,
     )
-    await user_callable_wrapper.initialize_callable()
+    user_callable_wrapper.initialize_callable().result()
     request_metadata = _make_request_metadata()
     blocked_future = user_callable_wrapper.call_user_method(
         request_metadata, tuple(), dict()
     )
-    _, pending = await asyncio.wait([blocked_future], timeout=0.01)
+    _, pending = concurrent.futures.wait([blocked_future], timeout=0.01)
     assert len(pending) == 1
 
     for _ in range(100):
         # If this called something on the event loop, it'd be blocked.
-        await user_callable_wrapper.call_user_health_check()
+        # Instead, `user_callable_wrapper.call_user_health_check` returns None
+        # when there's no user health check configured.
+        assert user_callable_wrapper.call_user_health_check() is None
 
     sync_event.set()
-    assert await blocked_future == "Sorry I got stuck!"
+    assert blocked_future.result() == "Sorry I got stuck!"
 
 
 class gRPCClass:
@@ -486,19 +489,18 @@ class gRPCClass:
             yield serve_pb2.UserDefinedResponse(greeting=f"Hello {msg.greeting} {i}!")
 
 
-@pytest.mark.asyncio
-async def test_grpc_unary_request():
+def test_grpc_unary_request():
     user_callable_wrapper = _make_user_callable_wrapper(gRPCClass)
-    await user_callable_wrapper.initialize_callable()
+    user_callable_wrapper.initialize_callable().result()
 
     grpc_request = gRPCRequest(
         pickle.dumps(serve_pb2.UserDefinedResponse(greeting="world"))
     )
 
     request_metadata = _make_request_metadata(call_method="greet", is_grpc_request=True)
-    _, result_bytes = await user_callable_wrapper.call_user_method(
+    _, result_bytes = user_callable_wrapper.call_user_method(
         request_metadata, (grpc_request,), dict()
-    )
+    ).result()
     assert isinstance(result_bytes, bytes)
 
     result = serve_pb2.UserDefinedResponse()
@@ -507,9 +509,9 @@ async def test_grpc_unary_request():
 
 
 @pytest.mark.asyncio
-async def test_grpc_streaming_request():
+def test_grpc_streaming_request():
     user_callable_wrapper = _make_user_callable_wrapper(gRPCClass)
-    await user_callable_wrapper.initialize_callable()
+    user_callable_wrapper.initialize_callable()
 
     grpc_request = gRPCRequest(
         pickle.dumps(serve_pb2.UserDefinedResponse(greeting="world"))
@@ -523,12 +525,12 @@ async def test_grpc_streaming_request():
     request_metadata = _make_request_metadata(
         call_method="stream", is_grpc_request=True, is_streaming=True
     )
-    await user_callable_wrapper.call_user_method(
+    user_callable_wrapper.call_user_method(
         request_metadata,
         (grpc_request,),
         dict(),
         generator_result_callback=append_to_list,
-    )
+    ).result()
 
     assert len(result_list) == 10
     for i, (_, result_bytes) in enumerate(result_list):
@@ -556,11 +558,10 @@ class FastAPIRequestHandler:
         return PlainTextResponse(f"Hello {msg}!")
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("callable", [RawRequestHandler, FastAPIRequestHandler])
-async def test_http_handler(callable: Callable, monkeypatch):
+def test_http_handler(callable: Callable, monkeypatch):
     user_callable_wrapper = _make_user_callable_wrapper(callable)
-    await user_callable_wrapper.initialize_callable()
+    user_callable_wrapper.initialize_callable().result()
 
     @dataclass
     class MockReplicaContext:
@@ -611,12 +612,12 @@ async def test_http_handler(callable: Callable, monkeypatch):
         result_list.append(item)
 
     request_metadata = _make_request_metadata(is_http_request=True, is_streaming=True)
-    await user_callable_wrapper.call_user_method(
+    user_callable_wrapper.call_user_method(
         request_metadata,
         (http_request,),
         dict(),
         generator_result_callback=append_to_list,
-    )
+    ).result()
 
     assert result_list[0]["type"] == "http.response.start"
     assert result_list[0]["status"] == 200


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously, `UserCallableWrapper` wrapped results in an `asyncio.Future`. This was convenient for use in the replica, but this code will be re-used from a sync context for local testing mode, so I need access to the underlying `concurrent.futures.Future` instead.

Alternatively we could add a duplicate path that returns the concurrent future instead, but I actually prefer that this is more explicit that the code is running on a separate thread (will help defend against mistaken bugs in the future).

I've also moved the `_user_callable_thread` and event loop into instance attributes instead of class attributes. I must have missed something when implementing this previously because this was basically trivial.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
