### PR TITLE
[rllib] fix yml linter issue

### DIFF
--- a/.buildkite/linux_aarch64.rayci.yml
+++ b/.buildkite/linux_aarch64.rayci.yml
@@ -99,7 +99,7 @@ steps:
     tags: linux_wheels
     instance_type: medium-arm64
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //doc/... core 
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //doc/... core
         --build-type wheel-aarch64
         --build-name oss-ci-base_build-aarch64
         --parallelism-per-worker 3
@@ -115,7 +115,7 @@ steps:
     tags: linux_wheels
     instance_type: medium-arm64
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/... //doc/... serve 
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/... //doc/... serve
         --build-type wheel-aarch64
         --build-name oss-ci-base_build-aarch64
         --parallelism-per-worker 3

--- a/.buildkite/rllib.rayci.yml
+++ b/.buildkite/rllib.rayci.yml
@@ -25,7 +25,7 @@ steps:
     parallelism: 4
     instance_type: large
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --except-tags learning_tests,memory_leak_tests,examples,tests_dir,documentation,multi_gpu,no_cpu,torch_2.x_only_benchmark,manual
         --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
@@ -36,12 +36,12 @@ steps:
     parallelism: 5
     instance_type: large
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --only-tags fake_gpus,learning_tests_discrete,crashing_cartpole,stateless_cartpole,learning_tests_continuous
         --except-tags tf_only,tf2_only,gpu,multi_gpu,learning_tests_pytorch_use_all_core
         --test-arg --framework=torch
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
         --only-tags learning_tests_pytorch_use_all_core
         --except-tags tf_only,tf2_only,gpu,multi_gpu
@@ -54,16 +54,16 @@ steps:
     parallelism: 5
     instance_type: large
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 2
         --only-tags examples
-        --except-tags multi_gpu,gpu,examples_use_all_core 
+        --except-tags multi_gpu,gpu,examples_use_all_core
         --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
         --only-tags examples_use_all_core
         --skip-ray-installation
-        --except-tags multi_gpu,gpu 
+        --except-tags multi_gpu,gpu
         --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
     depends_on: rllibbuild
 
@@ -72,7 +72,7 @@ steps:
     parallelism: 2
     instance_type: large
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --only-tags tests_dir
         --except-tags multi_gpu,manual
@@ -80,17 +80,17 @@ steps:
     depends_on: rllibbuild
 
   - label: ":brain: rllib: gpu tests"
-    tags: 
+    tags:
       - rllib_gpu
       - gpu
     parallelism: 5
     instance_type: gpu
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
         --build-name rllibgpubuild
         --only-tags gpu
-        --test-env=RAY_USE_MULTIPROCESSING_CPU_COUNT=1 
+        --test-env=RAY_USE_MULTIPROCESSING_CPU_COUNT=1
         --test-env=RLLIB_NUM_GPUS=1
     depends_on: rllibgpubuild
 
@@ -102,14 +102,14 @@ steps:
     instance_type: large
     commands:
       # learning tests pytorch
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib
         --parallelism-per-worker 3
         --only-tags learning_tests_with_ray_data
         --except-tags multi_gpu,gpu,tf_only,tf2_only
         --test-arg --framework=torch
 
       # rllib unittests
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib
         --parallelism-per-worker 3
         --only-tags ray_data
         --except-tags learning_tests_with_ray_data,multi_gpu,gpu
@@ -127,36 +127,36 @@ steps:
     tags: rllib
     instance_type: medium
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib
         --only-tags memory_leak_tests
         --except-tags flaky
         --test-arg --framework=torch
     depends_on: rllibbuild
 
   - label: ":brain: rllib: doc tests"
-    tags: 
+    tags:
       - rllib_directly
       - doc
     instance_type: medium
     commands:
       # doc tests
-      - bazel run //ci/ray_ci:test_in_docker -- python/ray/... //doc/... rllib 
+      - bazel run //ci/ray_ci:test_in_docker -- python/ray/... //doc/... rllib
         --except-tags gpu
         --only-tags doctest
         --parallelism-per-worker 2
       # doc examples
-      - bazel run //ci/ray_ci:test_in_docker -- //doc/... rllib 
+      - bazel run //ci/ray_ci:test_in_docker -- //doc/... rllib
         --except-tags gpu,post_wheel_build,timeseries_libs,doctest
         --parallelism-per-worker 2
         --skip-ray-installation
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib
         --only-tags documentation
         --parallelism-per-worker 2
         --skip-ray-installation
     depends_on: rllibbuild
 
   - label: ":brain: rllib: multi-gpu tests"
-    tags: 
+    tags:
       - rllib_gpu
       - gpu
     parallelism: 5
@@ -172,7 +172,7 @@ steps:
 
   - label: ":brain: rllib: flaky multi-gpu tests"
     key: rllib_flaky_multi_gpu_tests
-    tags: 
+    tags:
       - rllib_gpu
       - gpu
       - skip-on-premerge
@@ -188,7 +188,7 @@ steps:
 
   - label: ":brain: rllib: flaky gpu tests"
     key: rllib_flaky_gpu_tests
-    tags: 
+    tags:
       - rllib_gpu
       - gpu
       - skip-on-premerge
@@ -197,14 +197,14 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib --run-flaky-tests
         --build-name rllibgpubuild
         --only-tags gpu
-        --test-env=RAY_USE_MULTIPROCESSING_CPU_COUNT=1 
+        --test-env=RAY_USE_MULTIPROCESSING_CPU_COUNT=1
         --test-env=RLLIB_NUM_GPUS=1
     depends_on: rllibgpubuild
     soft_fail: true
 
   - label: ":brain: rllib: flaky tests (learning tests)"
     key: rllib_flaky_tests_01
-    tags: 
+    tags:
       - rllib
       - skip-on-premerge
     instance_type: large
@@ -233,7 +233,7 @@ steps:
 
   - label: ":brain: rllib: flaky tests (examples/rlmodule/models/tests_dir)"
     key: rllib_flaky_tests_02
-    tags: 
+    tags:
       - rllib
       - skip-on-premerge
     instance_type: large
@@ -241,7 +241,7 @@ steps:
       # examples
       - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib  --run-flaky-tests --parallelism-per-worker 3
         --only-tags examples
-        --except-tags multi_gpu,gpu 
+        --except-tags multi_gpu,gpu
         --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
 
       # rlmodule tests
@@ -269,12 +269,12 @@ steps:
 
   - label: ":brain: rllib: flaky tests (memory leak)"
     key: rllib_flaky_tests_03
-    tags: 
+    tags:
       - rllib
       - skip-on-premerge
     instance_type: medium
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib 
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib
         --run-flaky-tests
         --only-tags memory_leak_tests
         --except-tags flaky,gpu,multi_gpu


### PR DESCRIPTION
I added linter into precommit hook, which automatically checks trailing whitespace and autofixes.
```
git push --set-upstream origin hjiang/fix-yml-linter [enter/↑/↓/ctrl+c]
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check for added large files..............................................Passed
check python ast.....................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
black................................................(no files to check)Skipped
flake8...............................................(no files to check)Skipped
prettier.............................................(no files to check)Skipped
mypy.................................................(no files to check)Skipped
isort (python).......................................(no files to check)Skipped
rst directives end with two colons...................(no files to check)Skipped
rst ``inline code`` next to normal text..............(no files to check)Skipped
use logger.warning(..................................(no files to check)Skipped
check for not-real mock methods......................(no files to check)Skipped
ShellCheck v0.9.0....................................(no files to check)Skipped
clang-format.........................................(no files to check)Skipped
Google Java Formatter................................(no files to check)Skipped
Check for Ray docstyle violations....................(no files to check)Skipped
Check for Ray import order violations................(no files to check)Skipped
```