### PR TITLE
[Core] Remove duplicate task status event during task resubmission

### DIFF
--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -1420,14 +1420,10 @@ void TaskManager::MarkTaskWaitingForExecution(const TaskID &task_id,
 }
 
 void TaskManager::MarkTaskRetryOnResubmit(TaskEntry &task_entry) {
-  // Record the old attempt status as FINISHED.
-  RAY_UNUSED(
-      task_event_buffer_.RecordTaskStatusEventIfNeeded(task_entry.spec.TaskId(),
-                                                       task_entry.spec.JobId(),
-                                                       task_entry.spec.AttemptNumber(),
-                                                       task_entry.spec,
-                                                       rpc::TaskStatus::FINISHED));
-  task_entry.MarkRetryOnResubmit();
+  RAY_CHECK(!task_entry.IsPending())
+      << "Only finished tasks can be resubmitted: " << task_entry.spec.TaskId();
+
+  task_entry.MarkRetry();
 
   // Mark the new status and also include task spec info for the new attempt.
   task_entry.SetStatus(rpc::TaskStatus::PENDING_ARGS_AVAIL);
@@ -1445,16 +1441,11 @@ void TaskManager::MarkTaskRetryOnResubmit(TaskEntry &task_entry) {
 
 void TaskManager::MarkTaskRetryOnFailed(TaskEntry &task_entry,
                                         const rpc::RayErrorInfo &error_info) {
+  RAY_CHECK(task_entry.IsPending());
+
   // Record the old attempt status as FAILED.
-  RAY_UNUSED(task_event_buffer_.RecordTaskStatusEventIfNeeded(
-      task_entry.spec.TaskId(),
-      task_entry.spec.JobId(),
-      task_entry.spec.AttemptNumber(),
-      task_entry.spec,
-      rpc::TaskStatus::FAILED,
-      /* include_task_info */ false,
-      worker::TaskStatusEvent::TaskStateUpdate(error_info)));
-  task_entry.MarkRetryOnFailed();
+  SetTaskStatus(task_entry, rpc::TaskStatus::FAILED, error_info);
+  task_entry.MarkRetry();
 
   // Mark the new status and also include task spec info for the new attempt.
   task_entry.SetStatus(rpc::TaskStatus::PENDING_ARGS_AVAIL);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We only resubmit a finished task for lineage reconstruction so the FINISHED task status event should have already been recorded when the task finished so we don't need to do it again during `MarkTaskRetryOnResubmit()`.

Also change the metrics counter to make it clear that FINISHED and FAILED states are monotonically increasing. Current way of achieving this is double incrementing:
1. When task finishes, we call `SetStatus(FINISHED)` which increments the counter for FINISHED.
2. During `MarkRetryOnResubmit`, we first increment the counter for FINISHED again then call `SetStatus(PENING_ARGS_AVIL)` which decrements the counter for FINISHED.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
