### PR TITLE
[core] Add source location to status

### DIFF
--- a/src/ray/common/BUILD
+++ b/src/ray/common/BUILD
@@ -280,9 +280,6 @@ ray_cc_library(
     name = "source_location",
     srcs = ["source_location.cc"],
     hdrs = ["source_location.h"],
-    deps = [
-        "@com_google_absl//absl/strings:str_format",
-    ],
 )
 
 ray_cc_test(

--- a/src/ray/common/BUILD
+++ b/src/ray/common/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:ray.bzl", "ray_cc_library")
+load("//bazel:ray.bzl", "ray_cc_library", "ray_cc_test")
 
 ray_cc_library(
     name = "constants",
@@ -272,5 +272,26 @@ ray_cc_library(
     ],
     deps = [
         "//src/ray/util",
+        ":source_location",
+    ],
+)
+
+ray_cc_library(
+    name = "source_location",
+    srcs = ["source_location.cc"],
+    hdrs = ["source_location.h"],
+    deps = [
+        "@com_google_absl//absl/strings:str_format",
+    ],
+)
+
+ray_cc_test(
+    name = "source_location_test",
+    size = "small",
+    srcs = ["source_location_test.cc"],
+    tags = ["team:core"],
+    deps = [
+        ":source_location",
+        "@com_google_googletest//:gtest_main",
     ],
 )

--- a/src/ray/common/source_location.cc
+++ b/src/ray/common/source_location.cc
@@ -1,4 +1,4 @@
-// Copyright 2017 The Ray Authors.
+// Copyright 2024 The Ray Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,15 +14,13 @@
 
 #include "ray/common/source_location.h"
 
-#include "absl/strings/str_format.h"
-
 namespace ray {
 
 bool IsValidSourceLoc(const SourceLocation &loc) { return !loc.filename.empty(); }
 
 std::ostream &operator<<(std::ostream &os, const SourceLocation &loc) {
   if (IsValidSourceLoc(loc)) {
-    os << absl::StreamFormat("%s:%d", loc.filename, loc.line_no);
+    os << loc.filename << ":" << loc.line_no;
   }
   return os;
 }

--- a/src/ray/common/source_location.cc
+++ b/src/ray/common/source_location.cc
@@ -1,0 +1,30 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/common/source_location.h"
+
+#include "absl/strings/str_format.h"
+
+namespace ray {
+
+bool IsValidSourceLoc(const SourceLocation &loc) { return !loc.filename.empty(); }
+
+std::ostream &operator<<(std::ostream &os, const SourceLocation &loc) {
+  if (IsValidSourceLoc(loc)) {
+    os << absl::StreamFormat("%s:%d", loc.filename, loc.line_no);
+  }
+  return os;
+}
+
+}  // namespace ray

--- a/src/ray/common/source_location.h
+++ b/src/ray/common/source_location.h
@@ -1,0 +1,37 @@
+// Copyright 2017 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// A struct which represents source code location (aka. filename and line
+// number).
+
+#pragma once
+
+#include <iostream>
+
+namespace ray {
+
+struct SourceLocation {
+  std::string_view filename;
+  int line_no = 0;
+};
+
+// Whether given [loc] indicates a valid source code location.
+bool IsValidSourceLoc(const SourceLocation &loc);
+
+std::ostream &operator<<(std::ostream &os, const SourceLocation &loc);
+
+}  // namespace ray
+
+#define RAY_LOC() \
+  ray::SourceLocation { .filename = __FILE__, .line_no = __LINE__, }

--- a/src/ray/common/source_location.h
+++ b/src/ray/common/source_location.h
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// A struct which represents source code location (aka. filename and line
-// number).
 
 #pragma once
 
@@ -22,7 +19,10 @@
 
 namespace ray {
 
+// A struct which represents source code location (aka. filename and line
+// number), expected to use only via internal macros.
 struct SourceLocation {
+  // Via `__FILE__` macros, memory ownership lies in data segment and never destructs.
   std::string_view filename;
   int line_no = 0;
 };

--- a/src/ray/common/source_location.h
+++ b/src/ray/common/source_location.h
@@ -1,4 +1,4 @@
-// Copyright 2017 The Ray Authors.
+// Copyright 2024 The Ray Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ray/common/source_location.h
+++ b/src/ray/common/source_location.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <iostream>
+#include <string_view>
 
 namespace ray {
 

--- a/src/ray/common/source_location_test.cc
+++ b/src/ray/common/source_location_test.cc
@@ -1,0 +1,30 @@
+#include "ray/common/source_location.h"
+
+#include <gtest/gtest.h>
+
+#include <sstream>
+
+namespace ray {
+
+namespace {
+
+TEST(SourceLocationTest, StringifyTest) {
+  // Default source location.
+  {
+    std::stringstream ss{};
+    ss << SourceLocation();
+    EXPECT_EQ(ss.str(), "");
+  }
+
+  // Initialized source location.
+  {
+    auto loc = RAY_LOC();
+    std::stringstream ss{};
+    ss << loc;
+    EXPECT_EQ(ss.str(), "src/ray/common/source_location_test.cc:21");
+  }
+}
+
+}  // namespace
+
+}  // namespace ray

--- a/src/ray/common/source_location_test.cc
+++ b/src/ray/common/source_location_test.cc
@@ -1,3 +1,17 @@
+// Copyright 2024 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "ray/common/source_location.h"
 
 #include <gtest/gtest.h>
@@ -21,7 +35,7 @@ TEST(SourceLocationTest, StringifyTest) {
     auto loc = RAY_LOC();
     std::stringstream ss{};
     ss << loc;
-    EXPECT_EQ(ss.str(), "src/ray/common/source_location_test.cc:21");
+    EXPECT_EQ(ss.str(), "src/ray/common/source_location_test.cc:35");
   }
 }
 

--- a/src/ray/common/status.cc
+++ b/src/ray/common/status.cc
@@ -28,9 +28,9 @@
 
 #include "ray/common/status.h"
 
-#include <assert.h>
-
 #include <boost/system/error_code.hpp>
+#include <cassert>
+#include <sstream>
 
 #include "absl/container/flat_hash_map.h"
 
@@ -119,11 +119,18 @@ const absl::flat_hash_map<std::string, StatusCode> kStrToCode = []() {
 
 }  // namespace
 
-Status::Status(StatusCode code, const std::string &msg, int rpc_code) {
+Status::Status(StatusCode code, const std::string &msg, int rpc_code)
+    : Status(code, msg, SourceLocation{}, rpc_code) {}
+
+Status::Status(StatusCode code,
+               const std::string &msg,
+               SourceLocation loc,
+               int rpc_code) {
   assert(code != StatusCode::OK);
   state_ = new State;
   state_->code = code;
   state_->msg = msg;
+  state_->loc = loc;
   state_->rpc_code = rpc_code;
 }
 
@@ -163,8 +170,17 @@ std::string Status::ToString() const {
   if (state_ == nullptr) {
     return result;
   }
+
   result += ": ";
   result += state_->msg;
+
+  if (IsValidSourceLoc(state_->loc)) {
+    std::stringstream ss;
+    ss << state_->loc;
+    result += " at ";
+    result += ss.str();
+    ;
+  }
   return result;
 }
 

--- a/src/ray/common/status.cc
+++ b/src/ray/common/status.cc
@@ -179,7 +179,6 @@ std::string Status::ToString() const {
     ss << state_->loc;
     result += " at ";
     result += ss.str();
-    ;
   }
   return result;
 }

--- a/src/ray/common/status.h
+++ b/src/ray/common/status.h
@@ -32,6 +32,7 @@
 #include <iosfwd>
 #include <string>
 
+#include "ray/common/source_location.h"
 #include "ray/util/logging.h"
 #include "ray/util/macros.h"
 #include "ray/util/visibility.h"
@@ -133,6 +134,7 @@ class RAY_EXPORT Status {
   ~Status() { delete state_; }
 
   Status(StatusCode code, const std::string &msg, int rpc_code = -1);
+  Status(StatusCode code, const std::string &msg, SourceLocation loc, int rpc_code = -1);
 
   // Copy the specified status.
   Status(const Status &s);
@@ -334,6 +336,7 @@ class RAY_EXPORT Status {
   struct State {
     StatusCode code;
     std::string msg;
+    SourceLocation loc;
     // If code is RpcError, this contains the RPC error code
     int rpc_code;
   };


### PR DESCRIPTION
Current implementation for `ray::Status` is not good enough, it lacks the ability to pinpoint error location, which is also the reason why some prefer exception, which propagate source and stacktrace automatically.

This PR is the first step for status improvement, will followup with other PRs to make a few macros for error status propagation, which automatically fills in the `RAY_LOC`.
Example,
- `RAY_THROW_IF_ERROR`
- `RAY_RETURN_IF_ERROR`