### PR TITLE
[core] Remove unnecessary dependency

### DIFF
--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -24,7 +24,6 @@
 #include <utility>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "ray/common/asio/instrumented_io_context.h"
 #include "ray/common/asio/periodical_runner.h"
 #include "ray/common/client_connection.h"


### PR DESCRIPTION
Remove unnecessary dependency `gtest`, which should never appear in production code.