### PR TITLE
[core][compiled-graphs] Don't persist input_nodes in _CollectiveOperation to avoid wrong understanding about DAGs

### DIFF
--- a/python/ray/dag/collective_node.py
+++ b/python/ray/dag/collective_node.py
@@ -37,14 +37,13 @@ class _CollectiveOperation:
         op: _CollectiveOp,
         transport: Optional[Union[str, GPUCommunicator]] = None,
     ):
-        self._input_nodes: List[DAGNode] = input_nodes
-        if len(self._input_nodes) == 0:
+        if len(input_nodes) == 0:
             raise ValueError("Expected input nodes for a collective operation")
-        if len(set(self._input_nodes)) != len(self._input_nodes):
+        if len(set(input_nodes)) != len(input_nodes):
             raise ValueError("Expected unique input nodes for a collective operation")
 
         self._actor_handles: List["ray.actor.ActorHandle"] = []
-        for input_node in self._input_nodes:
+        for input_node in input_nodes:
             actor_handle = input_node._get_actor_handle()
             if actor_handle is None:
                 raise ValueError("Expected an actor handle from the input node")
@@ -52,7 +51,7 @@ class _CollectiveOperation:
         if len(set(self._actor_handles)) != len(self._actor_handles):
             invalid_input_nodes = [
                 input_node
-                for input_node in self._input_nodes
+                for input_node in input_nodes
                 if self._actor_handles.count(input_node._get_actor_handle()) > 1
             ]
             raise ValueError(
@@ -76,7 +75,6 @@ class _CollectiveOperation:
     def __str__(self) -> str:
         return (
             f"CollectiveGroup("
-            f"_input_nodes={self._input_nodes}, "
             f"_actor_handles={self._actor_handles}, "
             f"_op={self._op}, "
             f"_type_hint={self._type_hint})"

--- a/python/ray/dag/dag_node.py
+++ b/python/ray/dag/dag_node.py
@@ -79,6 +79,11 @@ class DAGNode(DAGNodeBase):
         """
         Retrieve upstream nodes and update their downstream dependencies.
 
+        Currently, the DAG assumes that all DAGNodes in `args`, `kwargs`, and
+        `other_args_to_resolve` are upstream nodes. However, Ray Compiled Graphs
+        builds the upstream/downstream relationship based only on args. Be cautious
+        when persisting DAGNodes in `other_args_to_resolve` and kwargs in the future.
+
         TODO (kevin85421): Currently, the upstream nodes and downstream nodes have
         circular references. Therefore, it relies on the garbage collector to clean
         them up instead of reference counting. We should consider using weak references


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If we persist `input_nodes` in `_CollectiveOperation`, all `input_nodes` will be added to the [upstream_nodes](https://github.com/ray-project/ray/blob/f44890f90284c41c4d26a2d1e3b36b3ce4a8f4ff/python/ray/dag/dag_node.py#L88) when building the DAG. However, not all `input_nodes` belong to the args of the DAG node. This could potentially cause issues when compiling the graph.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
