### PR TITLE
[lint] Add B028 to flake8 ignore list

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -14,6 +14,7 @@ exclude =
 max-line-length = 88
 inline-quotes = "
 ignore =
+  B028
   C408
   C417
   E121


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I've recently started seeing lint errors like this locally:
```
python/ray/serve/handle.py:788:13: B028 No explicit stacklevel argument found. The warn method from the warnings module uses a stacklevel of 1 by default. This
 will only show a stack trace for the line on which the warn method is called. It is therefore recommended to use a stacklevel of 2 or greater to provide more
information to the user.
```

We use `warnings` for deprecation messages and don't want to include stack traces in them, so ignoring this lint error.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
