### PR TITLE
update test_locality_aware_backoff_skips_sleeps to have longer timeout

### DIFF
--- a/python/ray/serve/tests/unit/test_pow_2_replica_scheduler.py
+++ b/python/ray/serve/tests/unit/test_pow_2_replica_scheduler.py
@@ -1853,7 +1853,7 @@ async def test_locality_aware_backoff_skips_sleeps(pow_2_scheduler):
     s.update_replicas([r1, r2, r3])
 
     # The request should be served by r3 without added latency.
-    done, _ = await asyncio.wait([task], timeout=0.01)
+    done, _ = await asyncio.wait([task], timeout=1)
     assert len(done) == 1
     assert done.pop().result() == r3
 

--- a/python/ray/serve/tests/unit/test_pow_2_replica_scheduler.py
+++ b/python/ray/serve/tests/unit/test_pow_2_replica_scheduler.py
@@ -1853,6 +1853,8 @@ async def test_locality_aware_backoff_skips_sleeps(pow_2_scheduler):
     s.update_replicas([r1, r2, r3])
 
     # The request should be served by r3 without added latency.
+    # Since we set up the `backoff_sequence_s` to be 999s, this 1s timeout will still
+    # capture the extra delay if it was added between scheduling loop.
     done, _ = await asyncio.wait([task], timeout=1)
     assert len(done) == 1
     assert done.pop().result() == r3


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously 0.01s of timeout is too short for the request to get scheduled and caused the test to becoming flaky. Update the timeout to 1s to have higher chance of it getting scheduled. Since we have updated the backoff time to be 999s, this should still test the correct behavior of no additional delays between scheduling loop.

## Related issue number

deflake test: https://buildkite.com/ray-project/premerge/builds/30444#0192e2e1-de62-41f5-b39a-ceb240323a51/184-1868

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
