### PR TITLE
[Core] Fix token expiration for ray autoscaler

### DIFF
--- a/python/ray/autoscaler/_private/kuberay/autoscaling_config.py
+++ b/python/ray/autoscaler/_private/kuberay/autoscaling_config.py
@@ -49,10 +49,10 @@ class AutoscalingConfigProducer:
     """
 
     def __init__(self, ray_cluster_name, ray_cluster_namespace):
-        self._headers, self._verify = node_provider.load_k8s_secrets()
-        self._ray_cr_url = node_provider.url_from_resource(
-            namespace=ray_cluster_namespace, path=f"rayclusters/{ray_cluster_name}"
+        self.kubernetes_api_client = node_provider.KubernetesHttpApiClient(
+            namespace=ray_cluster_namespace
         )
+        self._ray_cr_path = f"rayclusters/{ray_cluster_name}"
 
     def __call__(self):
         ray_cr = self._fetch_ray_cr_from_k8s_with_retries()
@@ -67,7 +67,7 @@ class AutoscalingConfigProducer:
         """
         for i in range(1, MAX_RAYCLUSTER_FETCH_TRIES + 1):
             try:
-                return self._fetch_ray_cr_from_k8s()
+                return self.kubernetes_api_client.get(self._ray_cr_path)
             except requests.HTTPError as e:
                 if i < MAX_RAYCLUSTER_FETCH_TRIES:
                     logger.exception(
@@ -79,18 +79,6 @@ class AutoscalingConfigProducer:
 
         # This branch is inaccessible. Raise to satisfy mypy.
         raise AssertionError
-
-    def _fetch_ray_cr_from_k8s(self) -> Dict[str, Any]:
-        result = requests.get(
-            self._ray_cr_url,
-            headers=self._headers,
-            timeout=node_provider.KUBERAY_REQUEST_TIMEOUT_S,
-            verify=self._verify,
-        )
-        if not result.status_code == 200:
-            result.raise_for_status()
-        ray_cr = result.json()
-        return ray_cr
 
 
 def _derive_autoscaling_config_from_ray_cr(ray_cr: Dict[str, Any]) -> Dict[str, Any]:
@@ -179,7 +167,7 @@ def _generate_legacy_autoscaling_config_fields() -> Dict[str, Any]:
 
 
 def _generate_available_node_types_from_ray_cr_spec(
-    ray_cr_spec: Dict[str, Any]
+    ray_cr_spec: Dict[str, Any],
 ) -> Dict[str, Any]:
     """Formats autoscaler "available_node_types" field based on the Ray CR's group
     specs.

--- a/python/ray/autoscaler/_private/kuberay/node_provider.py
+++ b/python/ray/autoscaler/_private/kuberay/node_provider.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import logging
 import os
@@ -53,6 +54,8 @@ KUBERNETES_SERVICE_PORT = os.getenv("KUBERNETES_SERVICE_PORT_HTTPS", "443")
 KUBERNETES_HOST = f"{KUBERNETES_SERVICE_HOST}:{KUBERNETES_SERVICE_PORT}"
 # Key for GKE label that identifies which multi-host replica a pod belongs to
 REPLICA_INDEX_KEY = "replicaIndex"
+
+TOKEN_REFRESH_PERIOD = datetime.timedelta(minutes=1)
 
 # Design:
 
@@ -264,7 +267,19 @@ class KubernetesHttpApiClient(IKubernetesHttpApiClient):
     def __init__(self, namespace: str, kuberay_crd_version: str = KUBERAY_CRD_VER):
         self._kuberay_crd_version = kuberay_crd_version
         self._namespace = namespace
-        self._headers, self._verify = load_k8s_secrets()
+        self._token_expires_at = datetime.datetime.now() + TOKEN_REFRESH_PERIOD
+        self._headers, self._verify = None, None
+
+    def _get_refreshed_headers_and_verify(self):
+        if (datetime.datetime.now() >= self._token_expires_at) or (
+            self._headers is None or self._verify is None
+        ):
+            logger.info("Refreshing K8s API client token and certs.")
+            self._headers, self._verify = load_k8s_secrets()
+            self._token_expires_at = datetime.datetime.now() + TOKEN_REFRESH_PERIOD
+            return self._headers, self._verify
+        else:
+            return self._headers, self._verify
 
     def get(self, path: str) -> Dict[str, Any]:
         """Wrapper for REST GET of resource with proper headers.
@@ -283,11 +298,13 @@ class KubernetesHttpApiClient(IKubernetesHttpApiClient):
             path=path,
             kuberay_crd_version=self._kuberay_crd_version,
         )
+
+        headers, verify = self._get_refreshed_headers_and_verify()
         result = requests.get(
             url,
-            headers=self._headers,
+            headers=headers,
             timeout=KUBERAY_REQUEST_TIMEOUT_S,
-            verify=self._verify,
+            verify=verify,
         )
         if not result.status_code == 200:
             result.raise_for_status()
@@ -311,11 +328,12 @@ class KubernetesHttpApiClient(IKubernetesHttpApiClient):
             path=path,
             kuberay_crd_version=self._kuberay_crd_version,
         )
+        headers, verify = self._get_refreshed_headers_and_verify()
         result = requests.patch(
             url,
             json.dumps(payload),
-            headers={**self._headers, "Content-type": "application/json-patch+json"},
-            verify=self._verify,
+            headers={**headers, "Content-type": "application/json-patch+json"},
+            verify=verify,
         )
         if not result.status_code == 200:
             result.raise_for_status()

--- a/python/ray/tests/kuberay/test_autoscaling_config.py
+++ b/python/ray/tests/kuberay/test_autoscaling_config.py
@@ -395,16 +395,21 @@ def test_autoscaling_config_fetch_retries(exception, num_exceptions):
     AutoscalingConfigProducer._fetch_ray_cr_from_k8s_with_retries.
     """
 
-    class MockAutoscalingConfigProducer(AutoscalingConfigProducer):
-        def __init__(self, *args, **kwargs):
+    class MockKubernetesHttpApiClient:
+        def __init__(self):
             self.exception_counter = 0
 
-        def _fetch_ray_cr_from_k8s(self) -> Dict[str, Any]:
+        def get(self, *args, **kwargs):
             if self.exception_counter < num_exceptions:
                 self.exception_counter += 1
                 raise exception
             else:
                 return {"ok-key": "ok-value"}
+
+    class MockAutoscalingConfigProducer(AutoscalingConfigProducer):
+        def __init__(self, *args, **kwargs):
+            self.kubernetes_api_client = MockKubernetesHttpApiClient()
+            self._ray_cr_path = "rayclusters/mock"
 
     config_producer = MockAutoscalingConfigProducer()
     # Patch retry backoff period.


### PR DESCRIPTION
## Why are these changes needed?

On AKS 1.30 Ray autoscaler fails after an hour of activity due to AKS new token policy. Check issue for more details

## Related issue number

closes https://github.com/ray-project/kuberay/issues/2324

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
