### PR TITLE
[Arrow] Unifying Arrow conversion handling, fixing handling of >2Gb objects

### DIFF
--- a/python/ray/air/BUILD
+++ b/python/ray/air/BUILD
@@ -47,6 +47,14 @@ py_test(
 )
 
 py_test(
+    name = "test_arrow",
+    size = "small",
+    srcs = ["tests/test_arrow.py"],
+    tags = ["team:ml", "team:data", "ray_data", "exclusive"],
+    deps = [":ml_lib"]
+)
+
+py_test(
     name = "test_air_usage",
     size = "small",
     srcs = ["tests/test_air_usage.py"],

--- a/python/ray/air/tests/test_arrow.py
+++ b/python/ray/air/tests/test_arrow.py
@@ -1,0 +1,18 @@
+import pyarrow as pa
+
+from ray.air.util.tensor_extensions.arrow import _infer_pyarrow_type
+from ray.air.util.tensor_extensions.utils import create_ragged_ndarray
+
+
+def test_pa_infer_type():
+    class UserObj:
+        pass
+
+    # Represent a single column that will be using `ArrowPythonObjectExtension` type
+    # to ser/de native Python objects into bytes
+    column_vals = create_ragged_ndarray(["hi", 1, None, [[[[]]]], {"a": [[{"b": 2, "c": UserObj()}]]}, UserObj()])
+
+    inferred_dtype = _infer_pyarrow_type(column_vals)
+
+    # Arrow (17.0) seem to fallback to assume the dtype of the first element
+    assert pa.string().equals(inferred_dtype)

--- a/python/ray/air/tests/test_arrow.py
+++ b/python/ray/air/tests/test_arrow.py
@@ -1,18 +1,40 @@
-import pyarrow as pa
+from dataclasses import dataclass, field
 
-from ray.air.util.tensor_extensions.arrow import _infer_pyarrow_type
+import pyarrow as pa
+import pytest
+
+from ray.air.util.tensor_extensions.arrow import _infer_pyarrow_type, _convert_to_pyarrow_native_array, \
+    ArrowConversionError, convert_to_pyarrow_array
 from ray.air.util.tensor_extensions.utils import create_ragged_ndarray
 
 
-def test_pa_infer_type():
-    class UserObj:
-        pass
+@dataclass
+class UserObj:
+    i: int = field()
 
+
+def test_pa_infer_type_failing_to_infer():
     # Represent a single column that will be using `ArrowPythonObjectExtension` type
     # to ser/de native Python objects into bytes
-    column_vals = create_ragged_ndarray(["hi", 1, None, [[[[]]]], {"a": [[{"b": 2, "c": UserObj()}]]}, UserObj()])
+    column_vals = create_ragged_ndarray(["hi", 1, None, [[[[]]]], {"a": [[{"b": 2, "c": UserObj(i=123)}]]}, UserObj(i=456)])
 
     inferred_dtype = _infer_pyarrow_type(column_vals)
 
     # Arrow (17.0) seem to fallback to assume the dtype of the first element
     assert pa.string().equals(inferred_dtype)
+
+
+def test_convert_to_pyarrow_array_object_ext_type_fallback():
+    column_values = create_ragged_ndarray(["hi", 1, None, [[[[]]]], {"a": [[{"b": 2, "c": UserObj(i=123)}]]}, UserObj(i=456)])
+    column_name = "py_object_column"
+
+    # First, assert that straightforward conversion into Arrow native types fails
+    with pytest.raises(ArrowConversionError) as exc_info:
+        _convert_to_pyarrow_native_array(column_values, column_name)
+
+    assert str(exc_info.value) == "Error converting data to Arrow: ['hi' 1 None list([[[[]]]]) {'a': [[{'b': 2, 'c': UserObj(i=123)}]]}\n UserObj(i=456)]"
+
+    # Subsequently, assert that fallback to `ArrowObjectExtensionType` succeeds
+    pa_array = convert_to_pyarrow_array(column_values, column_name)
+
+    assert pa_array.to_pylist() == column_values.tolist()

--- a/python/ray/air/tests/test_arrow.py
+++ b/python/ray/air/tests/test_arrow.py
@@ -63,3 +63,9 @@ def test_convert_to_pyarrow_array_object_ext_type_fallback():
     pa_array = convert_to_pyarrow_array(column_values, column_name)
 
     assert pa_array.to_pylist() == column_values.tolist()
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", "-x", __file__]))

--- a/python/ray/air/tests/test_arrow.py
+++ b/python/ray/air/tests/test_arrow.py
@@ -3,8 +3,12 @@ from dataclasses import dataclass, field
 import pyarrow as pa
 import pytest
 
-from ray.air.util.tensor_extensions.arrow import _infer_pyarrow_type, _convert_to_pyarrow_native_array, \
-    ArrowConversionError, convert_to_pyarrow_array
+from ray.air.util.tensor_extensions.arrow import (
+    ArrowConversionError,
+    _convert_to_pyarrow_native_array,
+    _infer_pyarrow_type,
+    convert_to_pyarrow_array,
+)
 from ray.air.util.tensor_extensions.utils import create_ragged_ndarray
 
 
@@ -16,7 +20,16 @@ class UserObj:
 def test_pa_infer_type_failing_to_infer():
     # Represent a single column that will be using `ArrowPythonObjectExtension` type
     # to ser/de native Python objects into bytes
-    column_vals = create_ragged_ndarray(["hi", 1, None, [[[[]]]], {"a": [[{"b": 2, "c": UserObj(i=123)}]]}, UserObj(i=456)])
+    column_vals = create_ragged_ndarray(
+        [
+            "hi",
+            1,
+            None,
+            [[[[]]]],
+            {"a": [[{"b": 2, "c": UserObj(i=123)}]]},
+            UserObj(i=456),
+        ]
+    )
 
     inferred_dtype = _infer_pyarrow_type(column_vals)
 
@@ -25,14 +38,26 @@ def test_pa_infer_type_failing_to_infer():
 
 
 def test_convert_to_pyarrow_array_object_ext_type_fallback():
-    column_values = create_ragged_ndarray(["hi", 1, None, [[[[]]]], {"a": [[{"b": 2, "c": UserObj(i=123)}]]}, UserObj(i=456)])
+    column_values = create_ragged_ndarray(
+        [
+            "hi",
+            1,
+            None,
+            [[[[]]]],
+            {"a": [[{"b": 2, "c": UserObj(i=123)}]]},
+            UserObj(i=456),
+        ]
+    )
     column_name = "py_object_column"
 
     # First, assert that straightforward conversion into Arrow native types fails
     with pytest.raises(ArrowConversionError) as exc_info:
         _convert_to_pyarrow_native_array(column_values, column_name)
 
-    assert str(exc_info.value) == "Error converting data to Arrow: ['hi' 1 None list([[[[]]]]) {'a': [[{'b': 2, 'c': UserObj(i=123)}]]}\n UserObj(i=456)]"
+    assert (
+        str(exc_info.value)
+        == "Error converting data to Arrow: ['hi' 1 None list([[[[]]]]) {'a': [[{'b': 2, 'c': UserObj(i=123)}]]}\n UserObj(i=456)]"  # noqa: E501
+    )
 
     # Subsequently, assert that fallback to `ArrowObjectExtensionType` succeeds
     pa_array = convert_to_pyarrow_array(column_values, column_name)

--- a/python/ray/air/tests/test_object_extension.py
+++ b/python/ray/air/tests/test_object_extension.py
@@ -7,13 +7,13 @@ import pytest
 from ray.air.util.object_extensions.arrow import (
     ArrowPythonObjectArray,
     ArrowPythonObjectType,
-    object_extension_type_allowed,
+    _object_extension_type_allowed,
 )
 from ray.air.util.object_extensions.pandas import PythonObjectArray
 
 
 @pytest.mark.skipif(
-    not object_extension_type_allowed(), reason="Object extension not supported."
+    not _object_extension_type_allowed(), reason="Object extension not supported."
 )
 def test_object_array_validation():
     # Test unknown input type raises TypeError.
@@ -25,7 +25,7 @@ def test_object_array_validation():
 
 
 @pytest.mark.skipif(
-    not object_extension_type_allowed(), reason="Object extension not supported."
+    not _object_extension_type_allowed(), reason="Object extension not supported."
 )
 def test_arrow_scalar_object_array_roundtrip():
     arr = np.array(
@@ -41,7 +41,7 @@ def test_arrow_scalar_object_array_roundtrip():
 
 
 @pytest.mark.skipif(
-    not object_extension_type_allowed(), reason="Object extension not supported."
+    not _object_extension_type_allowed(), reason="Object extension not supported."
 )
 def test_arrow_python_object_array_slice():
     arr = np.array(["test", 20, "test2", 40, "test3", 60], dtype=object)
@@ -51,7 +51,7 @@ def test_arrow_python_object_array_slice():
 
 
 @pytest.mark.skipif(
-    not object_extension_type_allowed(), reason="Object extension not supported."
+    not _object_extension_type_allowed(), reason="Object extension not supported."
 )
 def test_arrow_pandas_roundtrip():
     obj = types.SimpleNamespace(a=1, b="test")

--- a/python/ray/air/util/object_extensions/arrow.py
+++ b/python/ray/air/util/object_extensions/arrow.py
@@ -11,7 +11,6 @@ from ray._private.utils import _get_pyarrow_version
 from ray.util.annotations import PublicAPI
 
 MIN_PYARROW_VERSION_SCALAR_SUBCLASS = parse_version("9.0.0")
-MIN_PYARROW_VERSION_LIST_VIEW_TYPE = parse_version("16.0.0")
 
 _VER = _get_pyarrow_version()
 PYARROW_VERSION = None if _VER is None else parse_version(_VER)
@@ -21,13 +20,6 @@ def _object_extension_type_allowed() -> bool:
     return (
         PYARROW_VERSION is not None
         and PYARROW_VERSION >= MIN_PYARROW_VERSION_SCALAR_SUBCLASS
-    )
-
-
-def _list_view_type_present() -> bool:
-    return (
-        PYARROW_VERSION is not None
-        and PYARROW_VERSION >= MIN_PYARROW_VERSION_LIST_VIEW_TYPE
     )
 
 

--- a/python/ray/air/util/object_extensions/arrow.py
+++ b/python/ray/air/util/object_extensions/arrow.py
@@ -112,7 +112,7 @@ class ArrowPythonObjectArray(pa.ExtensionArray):
         arr = pa.array(all_dumped_bytes, type=type_.storage_type)
         return ArrowPythonObjectArray.from_storage(type_, arr)
 
-    def to_numpy(self, zero_copy_only: bool = False) -> np.ndarray:
+    def to_numpy(self, zero_copy_only: bool = False, writable: bool = False) -> np.ndarray:
         arr = np.empty(len(self), dtype=object)
         arr[:] = self.to_pylist()
         return arr

--- a/python/ray/air/util/object_extensions/arrow.py
+++ b/python/ray/air/util/object_extensions/arrow.py
@@ -11,6 +11,7 @@ from ray._private.utils import _get_pyarrow_version
 from ray.util.annotations import PublicAPI
 
 MIN_PYARROW_VERSION_SCALAR_SUBCLASS = parse_version("9.0.0")
+MIN_PYARROW_VERSION_LIST_VIEW_TYPE = parse_version("14.0.0")
 
 _VER = _get_pyarrow_version()
 PYARROW_VERSION = None if _VER is None else parse_version(_VER)
@@ -20,6 +21,13 @@ def object_extension_type_allowed() -> bool:
     return (
         PYARROW_VERSION is not None
         and PYARROW_VERSION >= MIN_PYARROW_VERSION_SCALAR_SUBCLASS
+    )
+
+
+def list_view_type_present() -> bool:
+    return (
+        PYARROW_VERSION is not None
+        and PYARROW_VERSION >= MIN_PYARROW_VERSION_LIST_VIEW_TYPE
     )
 
 

--- a/python/ray/air/util/object_extensions/arrow.py
+++ b/python/ray/air/util/object_extensions/arrow.py
@@ -11,7 +11,7 @@ from ray._private.utils import _get_pyarrow_version
 from ray.util.annotations import PublicAPI
 
 MIN_PYARROW_VERSION_SCALAR_SUBCLASS = parse_version("9.0.0")
-MIN_PYARROW_VERSION_LIST_VIEW_TYPE = parse_version("14.0.0")
+MIN_PYARROW_VERSION_LIST_VIEW_TYPE = parse_version("16.0.0")
 
 _VER = _get_pyarrow_version()
 PYARROW_VERSION = None if _VER is None else parse_version(_VER)

--- a/python/ray/air/util/object_extensions/arrow.py
+++ b/python/ray/air/util/object_extensions/arrow.py
@@ -17,14 +17,14 @@ _VER = _get_pyarrow_version()
 PYARROW_VERSION = None if _VER is None else parse_version(_VER)
 
 
-def object_extension_type_allowed() -> bool:
+def _object_extension_type_allowed() -> bool:
     return (
         PYARROW_VERSION is not None
         and PYARROW_VERSION >= MIN_PYARROW_VERSION_SCALAR_SUBCLASS
     )
 
 
-def list_view_type_present() -> bool:
+def _list_view_type_present() -> bool:
     return (
         PYARROW_VERSION is not None
         and PYARROW_VERSION >= MIN_PYARROW_VERSION_LIST_VIEW_TYPE

--- a/python/ray/air/util/object_extensions/arrow.py
+++ b/python/ray/air/util/object_extensions/arrow.py
@@ -112,7 +112,9 @@ class ArrowPythonObjectArray(pa.ExtensionArray):
         arr = pa.array(all_dumped_bytes, type=type_.storage_type)
         return ArrowPythonObjectArray.from_storage(type_, arr)
 
-    def to_numpy(self, zero_copy_only: bool = False, writable: bool = False) -> np.ndarray:
+    def to_numpy(
+        self, zero_copy_only: bool = False, writable: bool = False
+    ) -> np.ndarray:
         arr = np.empty(len(self), dtype=object)
         arr[:] = self.to_pylist()
         return arr

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -11,6 +11,7 @@ from packaging.version import parse as parse_version
 
 from ray._private.utils import _get_pyarrow_version
 from ray.air.constants import MAX_REPR_LENGTH
+from ray.air.util.object_extensions.arrow import list_view_type_present
 from ray.air.util.tensor_extensions.utils import (
     _is_ndarray_variable_shaped_tensor,
     create_ragged_ndarray,
@@ -125,7 +126,7 @@ def deduce_pyarrow_dtype(column_values: List[Any]) -> Optional[pa.DataType]:
         return pa.large_string()
     elif isinstance(inferred_pa_dtype, pa.ListType):
         return pa.large_list(inferred_pa_dtype.value_type)
-    elif isinstance(inferred_pa_dtype, pa.ListViewType):
+    elif list_view_type_present() and isinstance(inferred_pa_dtype, pa.ListViewType):
         return pa.large_list_view(inferred_pa_dtype.value_type)
 
     return inferred_pa_dtype

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -13,7 +13,7 @@ from ray._private.utils import _get_pyarrow_version
 from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.air.util.tensor_extensions.utils import (
     _is_ndarray_variable_shaped_tensor,
-    create_ragged_ndarray,
+    create_ragged_ndarray, _is_ndarray_tensor,
 )
 from ray.data._internal.util import GiB
 from ray.util.annotations import DeveloperAPI, PublicAPI
@@ -99,7 +99,10 @@ def convert_to_pyarrow_array(column_values: np.ndarray, column_name: str) -> pa.
     """
 
     try:
-        if column_name == TENSOR_COLUMN_NAME or column_values.ndim > 1:
+        # Since Arrow does NOT support tensors (aka multidimensional arrays) natively,
+        # we have to make sure that we handle this case utilizing `ArrowTensorArray`
+        # extension type
+        if column_name == TENSOR_COLUMN_NAME or _is_ndarray_tensor(column_values):
             from ray.data.extensions.tensor_extension import ArrowTensorArray
 
             return ArrowTensorArray.from_numpy(

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -87,13 +87,16 @@ def pyarrow_table_from_pydict(
 
 
 @DeveloperAPI(stability="alpha")
-def convert_to_pyarrow_array(column_values: np.ndarray) -> pa.Array:
+def convert_to_pyarrow_array(column_values: np.ndarray, column_name: str) -> pa.Array:
     try:
         # NOTE: We explicitly infer PyArrow `DataType` so that
         #       we can perform upcasting to be able to accommodate
         #       blocks that are larger than 2Gb in size (limited
         #       by int32 offsets used by Arrow internally)
         dtype = _infer_pyarrow_type(column_values)
+
+        logger.debug(f"Inferred dtype of '{dtype}' for column '{column_name}'")
+
         return pa.array(column_values, type=dtype)
     except Exception as e:
         raise ArrowConversionError(str(column_values)) from e

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -113,7 +113,7 @@ def deduce_pyarrow_dtype(column_values: List[Any]) -> Optional[pa.DataType]:
         column values
     """
 
-    if not column_values:
+    if len(column_values) == 0:
         return None
 
     inferred_pa_dtype = pa.infer_type(column_values)

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -128,8 +128,8 @@ def _infer_pyarrow_type(column_values: np.ndarray) -> Optional[pa.DataType]:
 
     inferred_pa_dtype = pa.infer_type(column_values)
 
-    def _lt_2gb(o: Union[bytes, str]) -> bool:
-        return len(o) > 2 * GiB
+    def _lt_2gb(o: Union[bytes, str, None]) -> bool:
+        return o is not None and len(o) > 2 * GiB
 
     if inferred_pa_dtype.equals(pa.binary()) and any(
         [_lt_2gb(v) for v in column_values]

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -97,7 +97,7 @@ def convert_to_pyarrow_array(column_values: np.ndarray) -> pa.Array:
         dtype = _infer_pyarrow_type(column_values)
         return pa.array(column_values, type=dtype)
     except Exception as e:
-        raise ArrowConversionError(str(column_values)[:MAX_REPR_LENGTH]) from e
+        raise ArrowConversionError(str(column_values)) from e
 
 
 def _infer_pyarrow_type(column_values: np.ndarray) -> Optional[pa.DataType]:

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -87,7 +87,9 @@ def pyarrow_table_from_pydict(
 
 
 @DeveloperAPI(stability="alpha")
-def convert_to_pyarrow_array(column_values: np.ndarray, dtype: Optional[pa.DataType] = None) -> pa.Array:
+def convert_to_pyarrow_array(
+    column_values: np.ndarray, dtype: Optional[pa.DataType] = None
+) -> pa.Array:
     try:
         return pa.array(column_values, type=dtype)
     except Exception as e:

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -144,7 +144,9 @@ def convert_to_pyarrow_array(column_values: np.ndarray, column_name: str) -> pa.
         #       only going to be logged in following cases
         #           - When fallback is disabled, or
         #           - It's being logged for the first time
-        if not should_serialize_as_object_ext_type or log_once("_fallback_to_arrow_object_extension_type_warning"):
+        if not should_serialize_as_object_ext_type or log_once(
+            "_fallback_to_arrow_object_extension_type_warning"
+        ):
             logger.warning(
                 f"Failed to convert column '{column_name}' into pyarrow "
                 f"array due to: {ace}; {object_ext_type_detail}",

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -199,11 +199,11 @@ def _infer_pyarrow_type(column_values: np.ndarray) -> Optional[pa.DataType]:
 
         return False
 
-    if inferred_pa_dtype.equals(pa.binary()) and any(
+    if pa.types.is_binary(inferred_pa_dtype) and any(
         [_lt_2gb(v) for v in column_values]
     ):
         return pa.large_binary()
-    elif inferred_pa_dtype.equals(pa.string()) and any(
+    elif pa.types.is_string(inferred_pa_dtype) and any(
         [_lt_2gb(v) for v in column_values]
     ):
         return pa.large_string()

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -166,7 +166,7 @@ def _convert_to_pyarrow_native_array(
         #       by int32 offsets used by Arrow internally)
         dtype = _infer_pyarrow_type(column_values)
 
-        logger.debug(f"Inferred dtype of '{dtype}' for column '{column_name}'")
+        logger.log(logging.getLevelName("TRACE"), f"Inferred dtype of '{dtype}' for column '{column_name}'")
 
         return pa.array(column_values, type=dtype)
     except Exception as e:

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -11,7 +11,7 @@ from packaging.version import parse as parse_version
 
 from ray._private.utils import _get_pyarrow_version
 from ray.air.constants import MAX_REPR_LENGTH
-from ray.air.util.object_extensions.arrow import list_view_type_present
+from ray.air.util.object_extensions.arrow import _list_view_type_present
 from ray.air.util.tensor_extensions.utils import (
     _is_ndarray_variable_shaped_tensor,
     create_ragged_ndarray,
@@ -126,7 +126,7 @@ def deduce_pyarrow_dtype(column_values: List[Any]) -> Optional[pa.DataType]:
         return pa.large_string()
     elif isinstance(inferred_pa_dtype, pa.ListType):
         return pa.large_list(inferred_pa_dtype.value_type)
-    elif list_view_type_present() and isinstance(inferred_pa_dtype, pa.ListViewType):
+    elif _list_view_type_present() and isinstance(inferred_pa_dtype, pa.ListViewType):
         return pa.large_list_view(inferred_pa_dtype.value_type)
 
     return inferred_pa_dtype

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -166,7 +166,10 @@ def _convert_to_pyarrow_native_array(
         #       by int32 offsets used by Arrow internally)
         dtype = _infer_pyarrow_type(column_values)
 
-        logger.log(logging.getLevelName("TRACE"), f"Inferred dtype of '{dtype}' for column '{column_name}'")
+        logger.log(
+            logging.getLevelName("TRACE"),
+            f"Inferred dtype of '{dtype}' for column '{column_name}'",
+        )
 
         return pa.array(column_values, type=dtype)
     except Exception as e:

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -10,7 +10,6 @@ import pyarrow as pa
 from packaging.version import parse as parse_version
 
 from ray._private.utils import _get_pyarrow_version
-from ray.air.constants import MAX_REPR_LENGTH
 from ray.air.util.tensor_extensions.utils import (
     _is_ndarray_variable_shaped_tensor,
     create_ragged_ndarray,

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -11,7 +11,6 @@ from packaging.version import parse as parse_version
 
 from ray._private.utils import _get_pyarrow_version
 from ray.air.constants import MAX_REPR_LENGTH
-from ray.air.util.object_extensions.arrow import _list_view_type_present
 from ray.air.util.tensor_extensions.utils import (
     _is_ndarray_variable_shaped_tensor,
     create_ragged_ndarray,
@@ -132,9 +131,13 @@ def _infer_pyarrow_type(column_values: np.ndarray) -> Optional[pa.DataType]:
     def _lt_2gb(o: Union[bytes, str]) -> bool:
         return len(o) > 2 * GiB
 
-    if inferred_pa_dtype.equals(pa.binary()) and any([_lt_2gb(v) for v in column_values]):
+    if inferred_pa_dtype.equals(pa.binary()) and any(
+        [_lt_2gb(v) for v in column_values]
+    ):
         return pa.large_binary()
-    elif inferred_pa_dtype.equals(pa.string()) and any([_lt_2gb(v) for v in column_values]):
+    elif inferred_pa_dtype.equals(pa.string()) and any(
+        [_lt_2gb(v) for v in column_values]
+    ):
         return pa.large_string()
 
     return inferred_pa_dtype

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -200,7 +200,7 @@ def _infer_pyarrow_type(column_values: np.ndarray) -> Optional[pa.DataType]:
 
     inferred_pa_dtype = pa.infer_type(column_values)
 
-    def _lt_2gb(obj: Any) -> bool:
+    def _gt_2gb(obj: Any) -> bool:
         # NOTE: This utility could be seeing objects other than strings or bytes in
         #       cases when column contains non-scalar non-homogeneous object types as
         #       column values, therefore making Arrow unable to infer corresponding
@@ -214,11 +214,11 @@ def _infer_pyarrow_type(column_values: np.ndarray) -> Optional[pa.DataType]:
         return False
 
     if pa.types.is_binary(inferred_pa_dtype) and any(
-        [_lt_2gb(v) for v in column_values]
+        [_gt_2gb(v) for v in column_values]
     ):
         return pa.large_binary()
     elif pa.types.is_string(inferred_pa_dtype) and any(
-        [_lt_2gb(v) for v in column_values]
+        [_gt_2gb(v) for v in column_values]
     ):
         return pa.large_string()
 

--- a/python/ray/air/util/tensor_extensions/utils.py
+++ b/python/ray/air/util/tensor_extensions/utils.py
@@ -69,7 +69,7 @@ def _create_possibly_ragged_ndarray(
 
 
 @PublicAPI(stability="alpha")
-def create_ragged_ndarray(values: Sequence[np.ndarray]) -> np.ndarray:
+def create_ragged_ndarray(values: Sequence[Any]) -> np.ndarray:
     """Create an array that contains arrays of different length
 
     If you're working with variable-length arrays like images, use this function to

--- a/python/ray/air/util/tensor_extensions/utils.py
+++ b/python/ray/air/util/tensor_extensions/utils.py
@@ -20,7 +20,9 @@ def _is_ndarray_tensor(arr: np.ndarray) -> bool:
         return True
 
     # Case of ragged tensor (as produced by `create_ragged_ndarray` utility)
-    elif arr.dtype.type is np.object_ and len(arr) > 0 and isinstance(arr[0], np.ndarray):
+    elif (
+        arr.dtype.type is np.object_ and len(arr) > 0 and isinstance(arr[0], np.ndarray)
+    ):
         return True
 
     return False

--- a/python/ray/air/util/tensor_extensions/utils.py
+++ b/python/ray/air/util/tensor_extensions/utils.py
@@ -9,9 +9,26 @@ if TYPE_CHECKING:
     from pandas.core.dtypes.generic import ABCSeries
 
 
+def _is_ndarray_tensor(arr: np.ndarray) -> bool:
+    """Return whether the provided NumPy ndarray is comprised of tensors.
+
+    NOTE: Tensor is defined as a NumPy array such that `len(arr.shape) > 1`
+    """
+
+    # Case of uniform-shaped (ie non-ragged) tensor
+    if arr.ndim > 1:
+        return True
+
+    # Case of ragged tensor (as produced by `create_ragged_ndarray` utility)
+    elif arr.dtype.type is np.object_ and len(arr) > 0 and isinstance(arr[0], np.ndarray):
+        return True
+
+    return False
+
+
 def _is_ndarray_variable_shaped_tensor(arr: np.ndarray) -> bool:
-    """Return whether the provided NumPy ndarray is representing a variable-shaped
-    tensor.
+    """Return whether the provided NumPy ndarray is comprised of variable-shaped
+    tensors.
 
     NOTE: This is an O(rows) check.
     """

--- a/python/ray/data/BUILD
+++ b/python/ray/data/BUILD
@@ -163,7 +163,7 @@ py_test(
 
 py_test(
     name = "test_binary",
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_binary.py"],
     tags = ["team:data", "exclusive"],
     deps = ["//:ray_lib", ":conftest"],

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -166,7 +166,8 @@ class ArrowBlockBuilder(TableBlockBuilder):
                     pa_cols[col_names] = convert_to_pyarrow_array(np_col_vals, dtype=pa_dtype)
 
             except ArrowConversionError as e:
-                logger.warning(f"Failed to convert column '{col_names}' into pyarrow array due to: {e}", exc_info=e)
+                logger.warning(f"Failed to convert column '{col_names}' into pyarrow array due to: {e}; "
+                               f"falling back to serialize as pickled python objects", exc_info=e)
 
                 from ray.data.extensions.object_extension import (
                     ArrowPythonObjectArray,

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -21,8 +21,9 @@ from ray._private.utils import _get_pyarrow_version
 from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.air.util.tensor_extensions.arrow import (
     ArrowConversionError,
-    convert_list_to_pyarrow_array,
+    convert_to_pyarrow_array,
     pyarrow_table_from_pydict,
+    deduce_pyarrow_dtype,
 )
 from ray.data._internal.arrow_ops import transform_polars, transform_pyarrow
 from ray.data._internal.numpy_support import (
@@ -161,7 +162,9 @@ class ArrowBlockBuilder(TableBlockBuilder):
 
                     pa_cols[col_names] = ArrowTensorArray.from_numpy(np_col_vals, col_names)
                 else:
-                    pa_cols[col_names] = convert_list_to_pyarrow_array(np_col_vals)
+                    pa_dtype = deduce_pyarrow_dtype(col_vals)
+                    pa_cols[col_names] = convert_to_pyarrow_array(np_col_vals, dtype=pa_dtype)
+
             except ArrowConversionError as e:
                 logger.warning(f"Failed to convert column '{col_names}' into pyarrow array due to: {e}", exc_info=e)
 

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -26,7 +26,7 @@ from ray.air.util.tensor_extensions.arrow import (
 )
 from ray.data._internal.arrow_ops import transform_polars, transform_pyarrow
 from ray.data._internal.numpy_support import (
-    convert_udf_returns_to_numpy,
+    convert_to_numpy,
     validate_numpy_batch,
 )
 from ray.data._internal.row import TableRow
@@ -153,7 +153,7 @@ class ArrowBlockBuilder(TableBlockBuilder):
         pa_cols: Dict[str, pyarrow.Array] = dict()
 
         for col_names, col_vals in columns.items():
-            np_col_vals = convert_udf_returns_to_numpy(col_vals)
+            np_col_vals = convert_to_numpy(col_vals)
 
             try:
                 if col_names == TENSOR_COLUMN_NAME or np_col_vals.ndim > 1:

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -22,7 +22,6 @@ from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.air.util.tensor_extensions.arrow import (
     ArrowConversionError,
     convert_to_pyarrow_array,
-    deduce_pyarrow_dtype,
     pyarrow_table_from_pydict,
 )
 from ray.data._internal.arrow_ops import transform_polars, transform_pyarrow
@@ -161,10 +160,7 @@ class ArrowBlockBuilder(TableBlockBuilder):
                         np_col_vals, col_names
                     )
                 else:
-                    pa_dtype = deduce_pyarrow_dtype(col_vals)
-                    pa_cols[col_names] = convert_to_pyarrow_array(
-                        np_col_vals, dtype=pa_dtype
-                    )
+                    pa_cols[col_names] = convert_to_pyarrow_array(np_col_vals)
 
             except ArrowConversionError as e:
                 logger.warning(

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -176,10 +176,10 @@ class ArrowBlockBuilder(TableBlockBuilder):
 
                 from ray.data.extensions.object_extension import (
                     ArrowPythonObjectArray,
-                    object_extension_type_allowed,
+                    _object_extension_type_allowed,
                 )
 
-                if object_extension_type_allowed() and is_object_fixable_error(e):
+                if _object_extension_type_allowed() and is_object_fixable_error(e):
                     pa_cols[col_names] = ArrowPythonObjectArray.from_objects(
                         np_col_vals
                     )

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -20,8 +20,8 @@ import numpy as np
 from ray._private.utils import _get_pyarrow_version
 from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.air.util.tensor_extensions.arrow import (
-    _convert_to_pyarrow_native_array,
-    pyarrow_table_from_pydict, convert_to_pyarrow_array,
+    convert_to_pyarrow_array,
+    pyarrow_table_from_pydict,
 )
 from ray.data._internal.arrow_ops import transform_polars, transform_pyarrow
 from ray.data._internal.numpy_support import convert_to_numpy

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -150,22 +150,22 @@ class ArrowBlockBuilder(TableBlockBuilder):
     def _table_from_pydict(columns: Dict[str, List[Any]]) -> Block:
         pa_cols: Dict[str, pyarrow.Array] = dict()
 
-        for col_names, col_vals in columns.items():
+        for col_name, col_vals in columns.items():
             np_col_vals = convert_to_numpy(col_vals)
 
             try:
-                if col_names == TENSOR_COLUMN_NAME or np_col_vals.ndim > 1:
+                if col_name == TENSOR_COLUMN_NAME or np_col_vals.ndim > 1:
                     from ray.data.extensions.tensor_extension import ArrowTensorArray
 
-                    pa_cols[col_names] = ArrowTensorArray.from_numpy(
-                        np_col_vals, col_names
+                    pa_cols[col_name] = ArrowTensorArray.from_numpy(
+                        np_col_vals, col_name
                     )
                 else:
-                    pa_cols[col_names] = convert_to_pyarrow_array(np_col_vals)
+                    pa_cols[col_name] = convert_to_pyarrow_array(np_col_vals, col_name)
 
             except ArrowConversionError as e:
                 logger.warning(
-                    f"Failed to convert column '{col_names}' into pyarrow "
+                    f"Failed to convert column '{col_name}' into pyarrow "
                     f"array due to: {e}; falling back to serialize as pickled "
                     f"python objects",
                     exc_info=e,
@@ -177,7 +177,7 @@ class ArrowBlockBuilder(TableBlockBuilder):
                 )
 
                 if _object_extension_type_allowed() and is_object_fixable_error(e):
-                    pa_cols[col_names] = ArrowPythonObjectArray.from_objects(
+                    pa_cols[col_name] = ArrowPythonObjectArray.from_objects(
                         np_col_vals
                     )
                 else:

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -65,6 +65,7 @@ ARROW_OBJECT_FIXABLE_ERRORS = (
     pyarrow.lib.ArrowTypeError,
     pyarrow.lib.ArrowNotImplementedError,
     pyarrow.lib.ArrowInvalid,
+    pyarrow.lib.ArrowCapacityError,
 )
 
 

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -61,6 +61,7 @@ ARROW_OBJECT_FIXABLE_ERRORS = (
     pyarrow.lib.ArrowNotImplementedError,
     pyarrow.lib.ArrowInvalid,
     pyarrow.lib.ArrowCapacityError,
+    OverflowError,
 )
 
 

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -235,6 +235,7 @@ def concat(blocks: List["pyarrow.Table"]) -> "pyarrow.Table":
         schema = unify_schemas(schemas_to_unify)
     except Exception as e:
         raise ArrowConversionError(str(blocks)) from e
+
     if (
         any(isinstance(type_, pa.ExtensionType) for type_ in schema.types)
         or cols_with_null_list
@@ -245,6 +246,7 @@ def concat(blocks: List["pyarrow.Table"]) -> "pyarrow.Table":
             col_chunked_arrays = []
             for block in blocks:
                 col_chunked_arrays.append(block.column(col_name))
+
             if isinstance(schema.field(col_name).type, tensor_types):
                 # For our tensor extension types, manually construct a chunked array
                 # containing chunks from all blocks. This is to handle

--- a/python/ray/data/_internal/numpy_support.py
+++ b/python/ray/data/_internal/numpy_support.py
@@ -123,11 +123,19 @@ def convert_to_numpy(column_values: Any) -> np.ndarray:
                 elif not np.isscalar(e):
                     has_object = True
 
+            # When column values are
+            #   - Arrays of heterogeneous shapes
+            #   - Byte-strings (viewed as arrays of heterogeneous shapes)
+            #   - Non-scalar objects (tuples, lists, arbitrary object types)
+            #
+            # Custom "ragged ndarray" is created, represented as an array of
+            # references (ie ndarray with dtype=object)
             if has_object or len(shapes) > 1:
                 # This util works around some limitations of np.array(dtype=object).
                 return create_ragged_ndarray(column_values)
             else:
                 return np.array(column_values)
+
         except Exception as e:
             logger.error(
                 f"Failed to convert column values to numpy array: "
@@ -155,5 +163,7 @@ def convert_to_numpy(column_values: Any) -> np.ndarray:
                 f"({_truncated_repr(column_values)}): {e}."
             )
     else:
+        print(">>> [DBG] convert_to_numpy else ")
+
         # TODO assert unreachable
         return column_values

--- a/python/ray/data/_internal/numpy_support.py
+++ b/python/ray/data/_internal/numpy_support.py
@@ -147,6 +147,7 @@ def convert_to_numpy(column_values: Any) -> np.ndarray:
                 "Failed to convert column values to numpy array: "
                 f"({_truncated_repr(column_values)}): {e}."
             )
+
     elif is_array_like(column_values):
         # Converts other array-like objects such as torch.Tensor.
         try:
@@ -163,8 +164,6 @@ def convert_to_numpy(column_values: Any) -> np.ndarray:
                 "Failed to convert column values to numpy array: "
                 f"({_truncated_repr(column_values)}): {e}."
             )
-    else:
-        print(">>> [DBG] convert_to_numpy else ")
 
-        # TODO assert unreachable
+    else:
         return column_values

--- a/python/ray/data/_internal/numpy_support.py
+++ b/python/ray/data/_internal/numpy_support.py
@@ -100,12 +100,9 @@ def convert_to_numpy(column_values: Any) -> np.ndarray:
         # NOTE: we don't cast generic iterables, since types like
         # `str` are also Iterable.
         try:
-            # Try to cast the inner scalars to numpy as well, to avoid unnecessarily
-            # creating an inefficient array of array of object dtype.
-            # But don't convert if the list is nested. Because if sub-lists have
-            # heterogeneous shapes, we need to create a ragged ndarray.
-            if not is_nested_list(column_values) and all(
-                is_valid_udf_return(e) for e in column_values
+            # Convert array-like objects (like torch.Tensor) to `np.ndarray`s
+            if all(
+                is_array_like(e) for e in column_values
             ):
                 # Use np.asarray() instead of np.array() to avoid copying if possible.
                 column_values = [np.asarray(e) for e in column_values]

--- a/python/ray/data/_internal/numpy_support.py
+++ b/python/ray/data/_internal/numpy_support.py
@@ -8,7 +8,7 @@ import numpy as np
 from ray.air.util.tensor_extensions.utils import create_ragged_ndarray
 from ray.data._internal.util import _truncated_repr
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 def is_array_like(value: Any) -> bool:

--- a/python/ray/data/_internal/numpy_support.py
+++ b/python/ray/data/_internal/numpy_support.py
@@ -147,10 +147,11 @@ def convert_to_numpy(column_values: Any) -> np.ndarray:
                 "Failed to convert column values to numpy array: "
                 f"({_truncated_repr(column_values)}): {e}."
             )
-    elif hasattr(column_values, "__array__"):
+    elif is_array_like(column_values):
         # Converts other array-like objects such as torch.Tensor.
         try:
-            return np.array(column_values)
+            # Use np.asarray() instead of np.array() to avoid copying if possible.
+            return np.asarray(column_values)
         except Exception as e:
             logger.error(
                 f"Failed to convert column values to numpy array: "

--- a/python/ray/data/_internal/numpy_support.py
+++ b/python/ray/data/_internal/numpy_support.py
@@ -101,9 +101,7 @@ def convert_to_numpy(column_values: Any) -> np.ndarray:
         # `str` are also Iterable.
         try:
             # Convert array-like objects (like torch.Tensor) to `np.ndarray`s
-            if all(
-                is_array_like(e) for e in column_values
-            ):
+            if all(is_array_like(e) for e in column_values):
                 # Use np.asarray() instead of np.array() to avoid copying if possible.
                 column_values = [np.asarray(e) for e in column_values]
 

--- a/python/ray/data/_internal/numpy_support.py
+++ b/python/ray/data/_internal/numpy_support.py
@@ -8,7 +8,6 @@ import numpy as np
 from ray.air.util.tensor_extensions.utils import create_ragged_ndarray
 from ray.data._internal.util import _truncated_repr
 
-
 logger = logging.getLogger(__file__)
 
 
@@ -133,7 +132,11 @@ def convert_to_numpy(column_values: Any) -> np.ndarray:
             else:
                 return np.array(column_values)
         except Exception as e:
-            logger.error(f"Failed to convert column values to numpy array: {_truncated_repr(column_values)}", exc_info=e)
+            logger.error(
+                f"Failed to convert column values to numpy array: "
+                f"{_truncated_repr(column_values)}",
+                exc_info=e,
+            )
 
             raise ValueError(
                 "Failed to convert column values to numpy array: "
@@ -144,7 +147,11 @@ def convert_to_numpy(column_values: Any) -> np.ndarray:
         try:
             return np.array(column_values)
         except Exception as e:
-            logger.error(f"Failed to convert column values to numpy array: {_truncated_repr(column_values)}", exc_info=e)
+            logger.error(
+                f"Failed to convert column values to numpy array: "
+                f"{_truncated_repr(column_values)}",
+                exc_info=e,
+            )
 
             raise ValueError(
                 "Failed to convert column values to numpy array: "

--- a/python/ray/data/_internal/numpy_support.py
+++ b/python/ray/data/_internal/numpy_support.py
@@ -1,4 +1,5 @@
 import collections
+import logging
 from datetime import datetime
 from typing import Any, Dict, List, Union
 
@@ -6,6 +7,9 @@ import numpy as np
 
 from ray.air.util.tensor_extensions.utils import create_ragged_ndarray
 from ray.data._internal.util import _truncated_repr
+
+
+logger = logging.getLogger(__file__)
 
 
 def is_array_like(value: Any) -> bool:
@@ -128,6 +132,8 @@ def convert_udf_returns_to_numpy(udf_return_col: Any) -> Any:
             else:
                 udf_return_col = np.array(udf_return_col)
         except Exception as e:
+            logger.error(f"Failed to convert column values to numpy array: {_truncated_repr(udf_return_col)}", exc_info=e)
+
             raise ValueError(
                 "Failed to convert column values to numpy array: "
                 f"({_truncated_repr(udf_return_col)}): {e}."
@@ -137,6 +143,8 @@ def convert_udf_returns_to_numpy(udf_return_col: Any) -> Any:
         try:
             udf_return_col = np.array(udf_return_col)
         except Exception as e:
+            logger.error(f"Failed to convert column values to numpy array: {_truncated_repr(udf_return_col)}", exc_info=e)
+
             raise ValueError(
                 "Failed to convert column values to numpy array: "
                 f"({_truncated_repr(udf_return_col)}): {e}."

--- a/python/ray/data/_internal/numpy_support.py
+++ b/python/ray/data/_internal/numpy_support.py
@@ -144,7 +144,7 @@ def convert_to_numpy(column_values: Any) -> np.ndarray:
             raise ValueError(
                 "Failed to convert column values to numpy array: "
                 f"({_truncated_repr(column_values)}): {e}."
-            )
+            ) from e
 
     elif is_array_like(column_values):
         # Converts other array-like objects such as torch.Tensor.
@@ -161,7 +161,7 @@ def convert_to_numpy(column_values: Any) -> np.ndarray:
             raise ValueError(
                 "Failed to convert column values to numpy array: "
                 f"({_truncated_repr(column_values)}): {e}."
-            )
+            ) from e
 
     else:
         return column_values

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -16,10 +16,7 @@ from typing import (
 import numpy as np
 
 from ray.air.constants import TENSOR_COLUMN_NAME
-from ray.data._internal.numpy_support import (
-    convert_to_numpy,
-    validate_numpy_batch,
-)
+from ray.data._internal.numpy_support import convert_to_numpy, validate_numpy_batch
 from ray.data._internal.row import TableRow
 from ray.data._internal.table_block import TableBlockAccessor, TableBlockBuilder
 from ray.data._internal.util import find_partitions

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -17,7 +17,7 @@ import numpy as np
 
 from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.data._internal.numpy_support import (
-    convert_udf_returns_to_numpy,
+    convert_to_numpy,
     validate_numpy_batch,
 )
 from ray.data._internal.row import TableRow
@@ -117,7 +117,7 @@ class PandasBlockBuilder(TableBlockBuilder):
         pd_columns: Dict[str, Any] = dict()
 
         for column_name, column_values in columns.items():
-            np_column_values = convert_udf_returns_to_numpy(column_values)
+            np_column_values = convert_to_numpy(column_values)
 
             if column_name == TENSOR_COLUMN_NAME or np_column_values.ndim > 1:
                 from ray.data.extensions.tensor_extension import TensorArray

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -16,6 +16,7 @@ from typing import (
 import numpy as np
 
 from ray.air.constants import TENSOR_COLUMN_NAME
+from ray.air.util.tensor_extensions.utils import _is_ndarray_tensor
 from ray.data._internal.numpy_support import convert_to_numpy, validate_numpy_batch
 from ray.data._internal.row import TableRow
 from ray.data._internal.table_block import TableBlockAccessor, TableBlockBuilder
@@ -116,7 +117,7 @@ class PandasBlockBuilder(TableBlockBuilder):
         for column_name, column_values in columns.items():
             np_column_values = convert_to_numpy(column_values)
 
-            if column_name == TENSOR_COLUMN_NAME or np_column_values.ndim > 1:
+            if column_name == TENSOR_COLUMN_NAME or _is_ndarray_tensor(column_values):
                 from ray.data.extensions.tensor_extension import TensorArray
 
                 pd_columns[column_name] = TensorArray(np_column_values)

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -112,7 +112,7 @@ class PandasBlockBuilder(TableBlockBuilder):
     def _table_from_pydict(columns: Dict[str, List[Any]]) -> "pandas.DataFrame":
         pandas = lazy_import_pandas()
 
-        pd_columns: Dict[str, Any] = dict()
+        pd_columns: Dict[str, Any] = {}
 
         for col_name, col_vals in columns.items():
             np_col_vals = convert_to_numpy(col_vals)

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -114,15 +114,15 @@ class PandasBlockBuilder(TableBlockBuilder):
 
         pd_columns: Dict[str, Any] = dict()
 
-        for column_name, column_values in columns.items():
-            np_column_values = convert_to_numpy(column_values)
+        for col_name, col_vals in columns.items():
+            np_col_vals = convert_to_numpy(col_vals)
 
-            if column_name == TENSOR_COLUMN_NAME or _is_ndarray_tensor(column_values):
+            if col_name == TENSOR_COLUMN_NAME or _is_ndarray_tensor(np_col_vals):
                 from ray.data.extensions.tensor_extension import TensorArray
 
-                pd_columns[column_name] = TensorArray(np_column_values)
+                pd_columns[col_name] = TensorArray(np_col_vals)
             else:
-                pd_columns[column_name] = np_column_values
+                pd_columns[col_name] = np_col_vals
 
         return pandas.DataFrame(pd_columns)
 

--- a/python/ray/data/_internal/table_block.py
+++ b/python/ray/data/_internal/table_block.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.data._internal.block_builder import BlockBuilder
-from ray.data._internal.numpy_support import convert_udf_returns_to_numpy, is_array_like
+from ray.data._internal.numpy_support import is_array_like
 from ray.data._internal.row import TableRow
 from ray.data._internal.size_estimator import SizeEstimator
 from ray.data.block import Block, BlockAccessor

--- a/python/ray/data/_internal/table_block.py
+++ b/python/ray/data/_internal/table_block.py
@@ -18,6 +18,7 @@ from ray.data._internal.block_builder import BlockBuilder
 from ray.data._internal.numpy_support import is_array_like
 from ray.data._internal.row import TableRow
 from ray.data._internal.size_estimator import SizeEstimator
+from ray.data._internal.util import MiB
 from ray.data.block import Block, BlockAccessor
 
 if TYPE_CHECKING:
@@ -25,8 +26,6 @@ if TYPE_CHECKING:
 
 
 T = TypeVar("T")
-
-MiB = 1024 * 1024
 
 # The max size of Python tuples to buffer before compacting them into a
 # table in the BlockBuilder.

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -41,6 +41,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+KiB = 1024 # bytes
+MiB = 1024 * KiB
+GiB = 1024 * MiB
+
+
 # NOTE: Make sure that these lower and upper bounds stay in sync with version
 # constraints given in python/setup.py.
 # Inclusive minimum pyarrow version.

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-KiB = 1024 # bytes
+KiB = 1024  # bytes
 MiB = 1024 * KiB
 GiB = 1024 * MiB
 

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -26,7 +26,6 @@ import numpy as np
 
 import ray
 from ray._private.utils import _get_pyarrow_version
-from ray.data._internal.arrow_ops.transform_pyarrow import unify_schemas
 from ray.data.context import DEFAULT_READ_OP_MIN_NUM_BLOCKS, WARN_PREFIX, DataContext
 
 if TYPE_CHECKING:
@@ -691,6 +690,7 @@ def unify_block_metadata_schema(
     """
     # Some blocks could be empty, in which case we cannot get their schema.
     # TODO(ekl) validate schema is the same across different blocks.
+    from ray.data._internal.arrow_ops.transform_pyarrow import unify_schemas
 
     # First check if there are blocks with computed schemas, then unify
     # valid schemas from all such blocks.

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -60,6 +60,7 @@ Block = Union["pyarrow.Table", "pandas.DataFrame"]
 
 logger = logging.getLogger(__file__)
 
+
 @DeveloperAPI
 class BlockType(Enum):
     ARROW = "arrow"
@@ -377,7 +378,10 @@ class BlockAccessor:
                 try:
                     return cls.batch_to_arrow_block(batch)
                 except ArrowConversionError as e:
-                    logger.warning(f"Failed to convert batch to Arrow due to: {e}; falling back to Pandas block")
+                    logger.warning(
+                        f"Failed to convert batch to Arrow due to: {e}; "
+                        f"falling back to Pandas block"
+                    )
 
                     if block_type is None:
                         return cls.batch_to_pandas_block(batch)

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -58,7 +58,7 @@ AggType = TypeVar("AggType")
 Block = Union["pyarrow.Table", "pandas.DataFrame"]
 
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 @DeveloperAPI

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -26,6 +26,7 @@ from ray import DynamicObjectRefGenerator
 from ray.air.util.tensor_extensions.arrow import ArrowConversionError
 from ray.data._internal.util import _check_pyarrow_version, _truncated_repr
 from ray.types import ObjectRef
+from ray.util import log_once
 from ray.util.annotations import DeveloperAPI
 
 import psutil
@@ -378,10 +379,11 @@ class BlockAccessor:
                 try:
                     return cls.batch_to_arrow_block(batch)
                 except ArrowConversionError as e:
-                    logger.warning(
-                        f"Failed to convert batch to Arrow due to: {e}; "
-                        f"falling back to Pandas block"
-                    )
+                    if log_once("_fallback_to_pandas_block_warning"):
+                        logger.warning(
+                            f"Failed to convert batch to Arrow due to: {e}; "
+                            f"falling back to Pandas block"
+                        )
 
                     if block_type is None:
                         return cls.batch_to_pandas_block(batch)

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -386,9 +386,9 @@ class BlockAccessor:
     @classmethod
     def batch_to_arrow_block(cls, batch: Dict[str, Any]) -> Block:
         """Create an Arrow block from user-facing data formats."""
-        from ray.data._internal.arrow_block import ArrowBlockAccessor
+        from ray.data._internal.arrow_block import ArrowBlockBuilder
 
-        return ArrowBlockAccessor.numpy_to_block(batch)
+        return ArrowBlockBuilder._table_from_pydict(batch)
 
     @classmethod
     def batch_to_pandas_block(cls, batch: Dict[str, Any]) -> Block:

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -1,4 +1,5 @@
 import collections
+import logging
 import os
 import time
 from dataclasses import dataclass
@@ -56,6 +57,8 @@ AggType = TypeVar("AggType")
 # ``ArrowBlockAccessor``.
 Block = Union["pyarrow.Table", "pandas.DataFrame"]
 
+
+logger = logging.getLogger(__file__)
 
 @DeveloperAPI
 class BlockType(Enum):
@@ -374,6 +377,8 @@ class BlockAccessor:
                 try:
                     return cls.batch_to_arrow_block(batch)
                 except ArrowConversionError as e:
+                    logger.warning(f"Failed to convert batch to Arrow due to: {e}; falling back to Pandas block")
+
                     if block_type is None:
                         return cls.batch_to_pandas_block(batch)
                     else:

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -301,7 +301,9 @@ class DataContext:
     read_op_min_num_blocks: int = DEFAULT_READ_OP_MIN_NUM_BLOCKS
     enable_tensor_extension_casting: bool = DEFAULT_ENABLE_TENSOR_EXTENSION_CASTING
     use_arrow_tensor_v2: bool = DEFAULT_USE_ARROW_TENSOR_V2
-    enable_fallback_to_arrow_object_ext_type = DEFAULT_ENABLE_FALLBACK_TO_ARROW_OBJECT_EXT_TYPE
+    enable_fallback_to_arrow_object_ext_type = (
+        DEFAULT_ENABLE_FALLBACK_TO_ARROW_OBJECT_EXT_TYPE
+    )
     enable_auto_log_stats: bool = DEFAULT_AUTO_LOG_STATS
     verbose_stats_logs: bool = DEFAULT_VERBOSE_STATS_LOG
     trace_allocations: bool = DEFAULT_TRACE_ALLOCATIONS

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -80,6 +80,8 @@ DEFAULT_ENABLE_TENSOR_EXTENSION_CASTING = True
 #       V2 in turn relies on int64 offsets, therefore having a limit of ~9Eb (exabytes)
 DEFAULT_USE_ARROW_TENSOR_V2 = env_bool("RAY_DATA_USE_ARROW_TENSOR_V2", False)
 
+DEFAULT_ENABLE_FALLBACK_TO_ARROW_OBJECT_EXT_TYPE = True
+
 DEFAULT_AUTO_LOG_STATS = False
 
 DEFAULT_VERBOSE_STATS_LOG = False
@@ -222,6 +224,12 @@ class DataContext:
         read_op_min_num_blocks: Minimum number of read output blocks for a dataset.
         enable_tensor_extension_casting: Whether to automatically cast NumPy ndarray
             columns in Pandas DataFrames to tensor extension columns.
+        use_arrow_tensor_v2: Config enabling V2 version of ArrowTensorArray supporting
+            tensors > 2Gb in size (off by default)
+        enable_fallback_to_arrow_object_ext_type: Enables fallback to serialize column
+            values not suppported by Arrow natively (like user-defined custom Python
+            classes for ex, etc) using `ArrowPythonObjectType` (simply serializing
+            these as bytes)
         enable_auto_log_stats: Whether to automatically log stats after execution. If
             disabled, you can still manually print stats with ``Dataset.stats()``.
         verbose_stats_logs: Whether stats logs should be verbose. This includes fields
@@ -293,6 +301,7 @@ class DataContext:
     read_op_min_num_blocks: int = DEFAULT_READ_OP_MIN_NUM_BLOCKS
     enable_tensor_extension_casting: bool = DEFAULT_ENABLE_TENSOR_EXTENSION_CASTING
     use_arrow_tensor_v2: bool = DEFAULT_USE_ARROW_TENSOR_V2
+    enable_fallback_to_arrow_object_ext_type = DEFAULT_ENABLE_FALLBACK_TO_ARROW_OBJECT_EXT_TYPE
     enable_auto_log_stats: bool = DEFAULT_AUTO_LOG_STATS
     verbose_stats_logs: bool = DEFAULT_VERBOSE_STATS_LOG
     trace_allocations: bool = DEFAULT_TRACE_ALLOCATIONS

--- a/python/ray/data/extensions/__init__.py
+++ b/python/ray/data/extensions/__init__.py
@@ -8,7 +8,7 @@ from ray.data.extensions.object_extension import (
     ArrowPythonObjectType,
     PythonObjectArray,
     PythonObjectDtype,
-    object_extension_type_allowed,
+    _object_extension_type_allowed,
 )
 from ray.data.extensions.tensor_extension import (
     ArrowConversionError,
@@ -40,6 +40,6 @@ __all__ = [
     "ArrowPythonObjectScalar",
     "PythonObjectArray",
     "PythonObjectDtype",
-    "object_extension_type_allowed",
+    "_object_extension_type_allowed",
     "get_arrow_extension_tensor_types",
 ]

--- a/python/ray/data/extensions/object_extension.py
+++ b/python/ray/data/extensions/object_extension.py
@@ -2,7 +2,7 @@ from ray.air.util.object_extensions.arrow import (  # noqa: F401
     ArrowPythonObjectArray,
     ArrowPythonObjectScalar,
     ArrowPythonObjectType,
-    object_extension_type_allowed,
+    _object_extension_type_allowed,
 )
 from ray.air.util.object_extensions.pandas import (  # noqa: F401
     PythonObjectArray,

--- a/python/ray/data/tests/preprocessors/test_encoder.py
+++ b/python/ray/data/tests/preprocessors/test_encoder.py
@@ -298,7 +298,7 @@ def test_one_hot_encoder_with_max_categories():
     expected_df = pd.DataFrame(
         {
             "A": col_a,
-            "B": [[0, 1], [1, 0], [0, 0], [1, 0]],
+            "B": [[0, 0], [1, 0], [0, 1], [1, 0]],
             "C": [[1, 0, 0], [0, 0, 1], [0, 1, 0], [0, 0, 1]],
         }
     )

--- a/python/ray/data/tests/test_arrow_block.py
+++ b/python/ray/data/tests/test_arrow_block.py
@@ -7,7 +7,7 @@ import pytest
 import ray
 from ray._private.test_utils import run_string_as_driver
 from ray.data._internal.arrow_block import ArrowBlockAccessor
-from ray.data.extensions.object_extension import object_extension_type_allowed
+from ray.data.extensions.object_extension import _object_extension_type_allowed
 
 
 def test_append_column(ray_start_regular_shared):
@@ -46,7 +46,7 @@ assert str(schema) == \"\"\"{1}\"\"\"
 
 
 @pytest.mark.skipif(
-    not object_extension_type_allowed(), reason="Object extension type not supported."
+    not _object_extension_type_allowed(), reason="Object extension type not supported."
 )
 def test_dict_doesnt_fallback_to_pandas_block(ray_start_regular_shared):
     # If the UDF returns a column with dict, previously, we would

--- a/python/ray/data/tests/test_arrow_serialization.py
+++ b/python/ray/data/tests/test_arrow_serialization.py
@@ -26,7 +26,7 @@ from ray._private.arrow_serialization import (
 from ray._private.utils import _get_pyarrow_version
 from ray.data.extensions.object_extension import (
     ArrowPythonObjectArray,
-    object_extension_type_allowed,
+    _object_extension_type_allowed,
 )
 from ray.data.extensions.tensor_extension import (
     ArrowTensorArray,
@@ -423,7 +423,7 @@ pytest_custom_serialization_arrays = [
     (lazy_fixture("complex_nested_array"), 0.1),
 ]
 
-if object_extension_type_allowed():
+if _object_extension_type_allowed():
     pytest_custom_serialization_arrays.append(
         # Array of pickled objects
         (lazy_fixture("pickled_objects_array"), 0.1),
@@ -550,7 +550,7 @@ def test_arrow_scalar_conversion(ray_start_regular_shared):
 
 
 @pytest.mark.skipif(
-    not object_extension_type_allowed(), reason="Object extension not supported."
+    not _object_extension_type_allowed(), reason="Object extension not supported."
 )
 def test_arrow_object_and_array_support(ray_start_regular_shared):
     obj = types.SimpleNamespace(some_attribute="test")

--- a/python/ray/data/tests/test_binary.py
+++ b/python/ray/data/tests/test_binary.py
@@ -198,7 +198,9 @@ def test_read_binary_snappy_partitioned_with_filter(
     )
 
 
-def _gen_chunked_binary(dir_path: str, total_size: int, max_file_size: Optional[int] = None):
+def _gen_chunked_binary(
+    dir_path: str, total_size: int, max_file_size: Optional[int] = None
+):
     chunk_size = max_file_size or 256 * MiB
     num_chunks = total_size // chunk_size
     remainder = total_size % chunk_size
@@ -221,15 +223,17 @@ def _gen_chunked_binary(dir_path: str, total_size: int, max_file_size: Optional[
             if remainder:
                 f.write(b"a" * remainder)
 
-
     print(f">>> Wrote chunked dataset at: {dir_path}")
 
 
-@pytest.mark.parametrize("col_name", [
-    "bytes",
-    # TODO fix numpy conversion
-    # "text",
-])
+@pytest.mark.parametrize(
+    "col_name",
+    [
+        "bytes",
+        # TODO fix numpy conversion
+        # "text",
+    ],
+)
 def test_single_row_lt_2gb(ray_start_regular_shared, col_name):
     with TemporaryDirectory() as tmp_dir:
         target_binary_size_gb = 2.1

--- a/python/ray/data/tests/test_binary.py
+++ b/python/ray/data/tests/test_binary.py
@@ -201,6 +201,8 @@ def test_read_binary_snappy_partitioned_with_filter(
 def _gen_chunked_binary(
     dir_path: str, total_size: int, max_file_size: Optional[int] = None
 ):
+    # NOTE: This util is primed to be writing even single large binary files
+    #       in chunks to reduce memory requirements while doing so
     chunk_size = max_file_size or 256 * MiB
     num_chunks = total_size // chunk_size
     remainder = total_size % chunk_size

--- a/python/ray/data/tests/test_binary.py
+++ b/python/ray/data/tests/test_binary.py
@@ -1,5 +1,7 @@
 import os
 from io import BytesIO
+from tempfile import TemporaryDirectory
+from typing import Optional
 
 import pandas as pd
 import pyarrow as pa
@@ -9,6 +11,7 @@ import snappy
 
 import ray
 from ray.data import Schema
+from ray.data._internal.util import GiB, MiB
 from ray.data.datasource import (
     BaseFileMetadataProvider,
     FastFileMetadataProvider,
@@ -193,6 +196,59 @@ def test_read_binary_snappy_partitioned_with_filter(
         sorted_values=[b"1 a\n1 b\n1 c", b"3 e\n3 f\n3 g"],
         ds_take_transform_fn=lambda t: extract_values("bytes", t),
     )
+
+
+def _gen_chunked_binary(dir_path: str, total_size: int, max_file_size: Optional[int] = None):
+    chunk_size = max_file_size or 256 * MiB
+    num_chunks = total_size // chunk_size
+    remainder = total_size % chunk_size
+
+    if max_file_size is not None and max_file_size < total_size:
+        for i in range(num_chunks):
+            filename = f"part_{i}.bin"
+            with open(f"{dir_path}/{filename}", "wb") as f:
+                f.write(b"a" * chunk_size)
+
+                print(f">>> Written file: {filename}")
+
+    else:
+        with open(f"{dir_path}/chunk.bin", "wb") as f:
+            for i in range(num_chunks):
+                f.write(b"a" * chunk_size)
+
+                print(f">>> Written chunk #{i}")
+
+            if remainder:
+                f.write(b"a" * remainder)
+
+
+    print(f">>> Wrote chunked dataset at: {dir_path}")
+
+
+@pytest.mark.parametrize("col_name", [
+    "text",
+    "bytes",
+])
+def test_single_row_lt_2gb(ray_start_regular_shared, col_name):
+    with TemporaryDirectory() as tmp_dir:
+        target_binary_size_gb = 2.1
+
+        # Write out single file > 2Gb
+        _gen_chunked_binary(tmp_dir, total_size=int(target_binary_size_gb * GiB))
+
+        def _id(row):
+            bs = row[col_name]
+            assert round(len(bs) / GiB, 1) == target_binary_size_gb
+            return row
+
+        if col_name == "text":
+            ds = ray.data.read_text(tmp_dir)
+        elif col_name == "bytes":
+            ds = ray.data.read_binary_files(tmp_dir)
+
+        total = ds.map(_id).count()
+
+        assert total == 1
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_binary.py
+++ b/python/ray/data/tests/test_binary.py
@@ -229,7 +229,7 @@ def _gen_chunked_binary(
 
 
 @pytest.mark.parametrize(
-    "col_name,max_file_size",
+    "col_name",
     [
         "bytes",
         # TODO fix numpy conversion

--- a/python/ray/data/tests/test_binary.py
+++ b/python/ray/data/tests/test_binary.py
@@ -226,8 +226,9 @@ def _gen_chunked_binary(dir_path: str, total_size: int, max_file_size: Optional[
 
 
 @pytest.mark.parametrize("col_name", [
-    "text",
     "bytes",
+    # TODO fix numpy conversion
+    # "text",
 ])
 def test_single_row_lt_2gb(ray_start_regular_shared, col_name):
     with TemporaryDirectory() as tmp_dir:

--- a/python/ray/data/tests/test_binary.py
+++ b/python/ray/data/tests/test_binary.py
@@ -227,7 +227,7 @@ def _gen_chunked_binary(
 
 
 @pytest.mark.parametrize(
-    "col_name",
+    "col_name,max_file_size",
     [
         "bytes",
         # TODO fix numpy conversion

--- a/python/ray/data/tests/test_binary.py
+++ b/python/ray/data/tests/test_binary.py
@@ -234,7 +234,7 @@ def _gen_chunked_binary(
         # "text",
     ],
 )
-def test_single_row_lt_2gb(ray_start_regular_shared, col_name):
+def test_single_row_gt_2gb(ray_start_regular_shared, col_name):
     with TemporaryDirectory() as tmp_dir:
         target_binary_size_gb = 2.1
 

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -10,7 +10,7 @@ import pytest
 
 import ray
 from ray.data import Dataset
-from ray.data._internal.arrow_block import ArrowBlockAccessor
+from ray.data._internal.arrow_block import ArrowBlockAccessor, ArrowBlockBuilder
 from ray.data._internal.datasource.csv_datasource import CSVDatasource
 from ray.data.block import BlockMetadata
 from ray.data.datasource import Datasource
@@ -68,7 +68,7 @@ class RandomBytesDatasource(Datasource):
                             (self.num_rows_per_batch, self.row_size), dtype=np.uint8
                         )
                     }
-                    block = ArrowBlockAccessor.numpy_to_block(batch)
+                    block = ArrowBlockBuilder._table_from_pydict(batch)
                     yield block
                 else:
                     yield pd.DataFrame(

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -23,6 +23,8 @@ from ray.data.tests.conftest import (
 )
 from ray.tests.conftest import *  # noqa
 
+ray.remote
+
 
 # Data source generates random bytes data
 class RandomBytesDatasource(Datasource):

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -23,8 +23,6 @@ from ray.data.tests.conftest import (
 )
 from ray.tests.conftest import *  # noqa
 
-ray.remote
-
 
 # Data source generates random bytes data
 class RandomBytesDatasource(Datasource):

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -10,7 +10,7 @@ import pytest
 
 import ray
 from ray.data import Dataset
-from ray.data._internal.arrow_block import ArrowBlockAccessor, ArrowBlockBuilder
+from ray.data._internal.arrow_block import ArrowBlockBuilder
 from ray.data._internal.datasource.csv_datasource import CSVDatasource
 from ray.data.block import BlockMetadata
 from ray.data.datasource import Datasource

--- a/python/ray/data/tests/test_numpy_support.py
+++ b/python/ray/data/tests/test_numpy_support.py
@@ -130,14 +130,14 @@ def test_list_of_array_like(ray_start_regular_shared, restore_data_context):
     assert_structure_equals(output, np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float32))
 
 
-def test_ragged_array_like(ray_start_regular_shared, restore_data_context):
+def test_ragged_tensors_map_batches(ray_start_regular_shared, restore_data_context):
     # Disable (automatic) fallback to `ArrowPythonObjectType` extension type
     DataContext.get_current().enable_fallback_to_arrow_object_ext_type = False
 
     data = [torch.Tensor([1, 2, 3]), torch.Tensor([1, 2])]
     output = do_map_batches(data)
     assert_structure_equals(
-        output, np.array([np.array([1, 2, 3]), np.array([1, 2])], dtype=object)
+        output, create_ragged_ndarray([np.array([1, 2, 3]), np.array([1, 2])])
     )
 
     data = [torch.zeros((3, 5, 10)), torch.zeros((3, 8, 8))]
@@ -153,7 +153,8 @@ def test_scalar_nested_arrays(ray_start_regular_shared, restore_data_context):
 
     data = [[[1]], [[2]]]
     output = do_map_batches(data)
-    assert_structure_equals(output, create_ragged_ndarray(data))
+
+    assert_structure_equals(output, create_ragged_ndarray([np.array([1], dtype=np.object_), np.array([2], dtype=np.object_)]))
 
 
 def test_scalar_lists_not_converted(ray_start_regular_shared, restore_data_context):
@@ -162,11 +163,11 @@ def test_scalar_lists_not_converted(ray_start_regular_shared, restore_data_conte
 
     data = [[1, 2], [1, 2]]
     output = do_map_batches(data)
-    assert_structure_equals(output, create_ragged_ndarray([[1, 2], [1, 2]]))
+    assert_structure_equals(output, create_ragged_ndarray([np.array([1, 2]), np.array([1, 2])]))
 
     data = [[1, 2, 3], [1, 2]]
     output = do_map_batches(data)
-    assert_structure_equals(output, create_ragged_ndarray([[1, 2, 3], [1, 2]]))
+    assert_structure_equals(output, create_ragged_ndarray([np.array([1, 2, 3]), np.array([1, 2])]))
 
 
 def test_scalar_numpy(ray_start_regular_shared, restore_data_context):
@@ -272,7 +273,13 @@ def test_complex_ragged_arrays(ray_start_regular_shared, restore_data_context):
 
     data = [[{"a": 1}, {"a": 2}, {"a": 3}], [{"b": 1}]]
     output = do_map_batches(data)
-    assert_structure_equals(output, create_ragged_ndarray(data))
+
+    # Assert resulting objects are coerced to appropriate shape, following
+    # table's schema
+    assert_structure_equals(output, create_ragged_ndarray([
+        np.array([{"a": 1, "b": None}, {"a": 2, "b": None}, {"a": 3, "b": None}]),
+        np.array([{"a": None, "b": 1}]),
+    ]))
 
     data = ["hi", 1, None, [[[[]]]], {"a": [[{"b": 2, "c": UserObj()}]]}, UserObj()]
     output = do_map_batches(data)

--- a/python/ray/data/tests/test_numpy_support.py
+++ b/python/ray/data/tests/test_numpy_support.py
@@ -6,6 +6,7 @@ import torch
 
 import ray
 from ray.air.util.tensor_extensions.utils import create_ragged_ndarray
+from ray.data import DataContext
 from ray.data.tests.conftest import *  # noqa
 from ray.tests.conftest import *  # noqa
 
@@ -27,16 +28,22 @@ def assert_structure_equals(a, b):
     assert a.dtype == b.dtype
     assert a.shape == b.shape
     for i in range(len(a)):
-        assert np.array_equal(a[i], b[i]), (i, a, b)
+        assert np.array_equal(a[i], b[i]), (i, a[i], b[i])
 
 
-def test_list_of_scalars(ray_start_regular_shared):
+def test_list_of_scalars(ray_start_regular_shared, restore_data_context):
+    # Disable (automatic) fallback to `ArrowPythonObjectType` extension type
+    DataContext.get_current().enable_fallback_to_arrow_object_ext_type = False
+
     data = [1, 2, 3]
     output = do_map_batches(data)
     assert_structure_equals(output, np.array([1, 2, 3], dtype=np.int64))
 
 
-def test_list_of_numpy_scalars(ray_start_regular_shared):
+def test_list_of_numpy_scalars(ray_start_regular_shared, restore_data_context):
+    # Disable (automatic) fallback to `ArrowPythonObjectType` extension type
+    DataContext.get_current().enable_fallback_to_arrow_object_ext_type = False
+
     data = [np.int64(1), np.int64(2), np.int64(3)]
     output = do_map_batches(data)
     assert_structure_equals(output, np.array([1, 2, 3], dtype=np.int64))
@@ -88,30 +95,45 @@ DATETIME64_MICROSEC_PRECISION = np.datetime64("2024-01-01T00:00:00.000001")
         ),
     ],
 )
-def test_list_of_datetimes(data, expected_output, ray_start_regular_shared):
+def test_list_of_datetimes(data, expected_output, ray_start_regular_shared, restore_data_context):
+    # Disable (automatic) fallback to `ArrowPythonObjectType` extension type
+    DataContext.get_current().enable_fallback_to_arrow_object_ext_type = False
+
     output = do_map_batches(data)
     assert_structure_equals(output, expected_output)
 
 
-def test_array_like(ray_start_regular_shared):
+def test_array_like(ray_start_regular_shared, restore_data_context):
+    # Disable (automatic) fallback to `ArrowPythonObjectType` extension type
+    DataContext.get_current().enable_fallback_to_arrow_object_ext_type = False
+
     data = torch.Tensor([1, 2, 3])
     output = do_map_batches(data)
     assert_structure_equals(output, np.array([1.0, 2.0, 3.0], dtype=np.float32))
 
 
-def test_list_of_arrays(ray_start_regular_shared):
+def test_list_of_arrays(ray_start_regular_shared, restore_data_context):
+    # Disable (automatic) fallback to `ArrowPythonObjectType` extension type
+    DataContext.get_current().enable_fallback_to_arrow_object_ext_type = False
+
     data = [np.array([1, 2, 3]), np.array([4, 5, 6])]
     output = do_map_batches(data)
     assert_structure_equals(output, np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64))
 
 
-def test_list_of_array_like(ray_start_regular_shared):
+def test_list_of_array_like(ray_start_regular_shared, restore_data_context):
+    # Disable (automatic) fallback to `ArrowPythonObjectType` extension type
+    DataContext.get_current().enable_fallback_to_arrow_object_ext_type = False
+
     data = [torch.Tensor([1, 2, 3]), torch.Tensor([4, 5, 6])]
     output = do_map_batches(data)
     assert_structure_equals(output, np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float32))
 
 
-def test_ragged_array_like(ray_start_regular_shared):
+def test_ragged_array_like(ray_start_regular_shared, restore_data_context):
+    # Disable (automatic) fallback to `ArrowPythonObjectType` extension type
+    DataContext.get_current().enable_fallback_to_arrow_object_ext_type = False
+
     data = [torch.Tensor([1, 2, 3]), torch.Tensor([1, 2])]
     output = do_map_batches(data)
     assert_structure_equals(
@@ -125,13 +147,19 @@ def test_ragged_array_like(ray_start_regular_shared):
     )
 
 
-def test_scalar_nested_arrays(ray_start_regular_shared):
+def test_scalar_nested_arrays(ray_start_regular_shared, restore_data_context):
+    # Disable (automatic) fallback to `ArrowPythonObjectType` extension type
+    DataContext.get_current().enable_fallback_to_arrow_object_ext_type = False
+
     data = [[[1]], [[2]]]
     output = do_map_batches(data)
     assert_structure_equals(output, create_ragged_ndarray(data))
 
 
-def test_scalar_lists_not_converted(ray_start_regular_shared):
+def test_scalar_lists_not_converted(ray_start_regular_shared, restore_data_context):
+    # Disable (automatic) fallback to `ArrowPythonObjectType` extension type
+    DataContext.get_current().enable_fallback_to_arrow_object_ext_type = False
+
     data = [[1, 2], [1, 2]]
     output = do_map_batches(data)
     assert_structure_equals(output, create_ragged_ndarray([[1, 2], [1, 2]]))
@@ -141,7 +169,10 @@ def test_scalar_lists_not_converted(ray_start_regular_shared):
     assert_structure_equals(output, create_ragged_ndarray([[1, 2, 3], [1, 2]]))
 
 
-def test_scalar_numpy(ray_start_regular_shared):
+def test_scalar_numpy(ray_start_regular_shared, restore_data_context):
+    # Disable (automatic) fallback to `ArrowPythonObjectType` extension type
+    DataContext.get_current().enable_fallback_to_arrow_object_ext_type = False
+
     data = np.int64(1)
     ds = ray.data.range(2, override_num_blocks=1)
     ds = ds.map(lambda x: {"output": data})
@@ -149,7 +180,10 @@ def test_scalar_numpy(ray_start_regular_shared):
     assert_structure_equals(output, np.array([1, 1], dtype=np.int64))
 
 
-def test_scalar_arrays(ray_start_regular_shared):
+def test_scalar_arrays(ray_start_regular_shared, restore_data_context):
+    # Disable (automatic) fallback to `ArrowPythonObjectType` extension type
+    DataContext.get_current().enable_fallback_to_arrow_object_ext_type = False
+
     data = np.array([1, 2, 3])
     ds = ray.data.range(2, override_num_blocks=1)
     ds = ds.map(lambda x: {"output": data})
@@ -157,7 +191,10 @@ def test_scalar_arrays(ray_start_regular_shared):
     assert_structure_equals(output, np.array([[1, 2, 3], [1, 2, 3]], dtype=np.int64))
 
 
-def test_bytes(ray_start_regular_shared):
+def test_bytes(ray_start_regular_shared, restore_data_context):
+    # Disable (automatic) fallback to `ArrowPythonObjectType` extension type
+    DataContext.get_current().enable_fallback_to_arrow_object_ext_type = False
+
     """Tests that bytes are converted to object dtype instead of zero-terminated."""
     data = b"\x1a\n\x00\n\x1a"
     ds = ray.data.range(1, override_num_blocks=1)
@@ -166,7 +203,10 @@ def test_bytes(ray_start_regular_shared):
     assert_structure_equals(output, np.array([b"\x1a\n\x00\n\x1a"], dtype=object))
 
 
-def test_scalar_array_like(ray_start_regular_shared):
+def test_uniform_tensors(ray_start_regular_shared, restore_data_context):
+    # Disable (automatic) fallback to `ArrowPythonObjectType` extension type
+    DataContext.get_current().enable_fallback_to_arrow_object_ext_type = False
+
     data = torch.Tensor([1, 2, 3])
     ds = ray.data.range(2, override_num_blocks=1)
     ds = ds.map(lambda x: {"output": data})
@@ -174,17 +214,24 @@ def test_scalar_array_like(ray_start_regular_shared):
     assert_structure_equals(output, np.array([[1, 2, 3], [1, 2, 3]], dtype=np.float32))
 
 
-def test_scalar_ragged_arrays(ray_start_regular_shared):
+def test_scalar_ragged_arrays(ray_start_regular_shared, restore_data_context):
+    # Disable (automatic) fallback to `ArrowPythonObjectType` extension type
+    DataContext.get_current().enable_fallback_to_arrow_object_ext_type = False
+
     data = [np.array([1, 2, 3]), np.array([1, 2])]
     ds = ray.data.range(2, override_num_blocks=1)
     ds = ds.map(lambda x: {"output": data[x["id"]]})
     output = ds.take_batch()["output"]
+
     assert_structure_equals(
         output, np.array([np.array([1, 2, 3]), np.array([1, 2])], dtype=object)
     )
 
 
-def test_scalar_ragged_array_like(ray_start_regular_shared):
+def test_ragged_tensors(ray_start_regular_shared, restore_data_context):
+    # Disable (automatic) fallback to `ArrowPythonObjectType` extension type
+    DataContext.get_current().enable_fallback_to_arrow_object_ext_type = False
+
     data = [torch.Tensor([1, 2, 3]), torch.Tensor([1, 2])]
     ds = ray.data.range(2, override_num_blocks=1)
     ds = ds.map(lambda x: {"output": data[x["id"]]})
@@ -202,7 +249,10 @@ def test_scalar_ragged_array_like(ray_start_regular_shared):
     )
 
 
-def test_nested_ragged_arrays(ray_start_regular_shared):
+def test_nested_ragged_arrays(ray_start_regular_shared, restore_data_context):
+    # Disable (automatic) fallback to `ArrowPythonObjectType` extension type
+    DataContext.get_current().enable_fallback_to_arrow_object_ext_type = False
+
     data = [
         {"a": [[1], [2, 3]]},
         {"a": [[4, 5], [6]]},
@@ -216,7 +266,10 @@ def test_nested_ragged_arrays(ray_start_regular_shared):
 
 
 # https://github.com/ray-project/ray/issues/35340
-def test_complex_ragged_arrays(ray_start_regular_shared):
+def test_complex_ragged_arrays(ray_start_regular_shared, restore_data_context):
+    # Disable (automatic) fallback to `ArrowPythonObjectType` extension type
+    DataContext.get_current().enable_fallback_to_arrow_object_ext_type = False
+
     data = [[{"a": 1}, {"a": 2}, {"a": 3}], [{"b": 1}]]
     output = do_map_batches(data)
     assert_structure_equals(output, create_ragged_ndarray(data))

--- a/python/ray/data/tests/test_numpy_support.py
+++ b/python/ray/data/tests/test_numpy_support.py
@@ -49,7 +49,10 @@ def test_list_of_numpy_scalars(ray_start_regular_shared, restore_data_context):
     assert_structure_equals(output, np.array([1, 2, 3], dtype=np.int64))
 
 
-def test_list_of_objects(ray_start_regular_shared):
+def test_list_of_objects(ray_start_regular_shared, restore_data_context):
+    # NOTE: Fallback is enabled by default, this is purely for notational purposes
+    DataContext.get_current().enable_fallback_to_arrow_object_ext_type = True
+
     data = [1, 2, 3, UserObj()]
     output = do_map_batches(data)
     assert_structure_equals(output, np.array([1, 2, 3, UserObj()]))

--- a/python/ray/data/tests/test_numpy_support.py
+++ b/python/ray/data/tests/test_numpy_support.py
@@ -95,7 +95,9 @@ DATETIME64_MICROSEC_PRECISION = np.datetime64("2024-01-01T00:00:00.000001")
         ),
     ],
 )
-def test_list_of_datetimes(data, expected_output, ray_start_regular_shared, restore_data_context):
+def test_list_of_datetimes(
+    data, expected_output, ray_start_regular_shared, restore_data_context
+):
     # Disable (automatic) fallback to `ArrowPythonObjectType` extension type
     DataContext.get_current().enable_fallback_to_arrow_object_ext_type = False
 
@@ -154,7 +156,12 @@ def test_scalar_nested_arrays(ray_start_regular_shared, restore_data_context):
     data = [[[1]], [[2]]]
     output = do_map_batches(data)
 
-    assert_structure_equals(output, create_ragged_ndarray([np.array([1], dtype=np.object_), np.array([2], dtype=np.object_)]))
+    assert_structure_equals(
+        output,
+        create_ragged_ndarray(
+            [np.array([1], dtype=np.object_), np.array([2], dtype=np.object_)]
+        ),
+    )
 
 
 def test_scalar_lists_not_converted(ray_start_regular_shared, restore_data_context):
@@ -163,11 +170,15 @@ def test_scalar_lists_not_converted(ray_start_regular_shared, restore_data_conte
 
     data = [[1, 2], [1, 2]]
     output = do_map_batches(data)
-    assert_structure_equals(output, create_ragged_ndarray([np.array([1, 2]), np.array([1, 2])]))
+    assert_structure_equals(
+        output, create_ragged_ndarray([np.array([1, 2]), np.array([1, 2])])
+    )
 
     data = [[1, 2, 3], [1, 2]]
     output = do_map_batches(data)
-    assert_structure_equals(output, create_ragged_ndarray([np.array([1, 2, 3]), np.array([1, 2])]))
+    assert_structure_equals(
+        output, create_ragged_ndarray([np.array([1, 2, 3]), np.array([1, 2])])
+    )
 
 
 def test_scalar_numpy(ray_start_regular_shared, restore_data_context):
@@ -276,10 +287,17 @@ def test_complex_ragged_arrays(ray_start_regular_shared, restore_data_context):
 
     # Assert resulting objects are coerced to appropriate shape, following
     # table's schema
-    assert_structure_equals(output, create_ragged_ndarray([
-        np.array([{"a": 1, "b": None}, {"a": 2, "b": None}, {"a": 3, "b": None}]),
-        np.array([{"a": None, "b": 1}]),
-    ]))
+    assert_structure_equals(
+        output,
+        create_ragged_ndarray(
+            [
+                np.array(
+                    [{"a": 1, "b": None}, {"a": 2, "b": None}, {"a": 3, "b": None}]
+                ),
+                np.array([{"a": None, "b": 1}]),
+            ]
+        ),
+    )
 
     data = ["hi", 1, None, [[[[]]]], {"a": [[{"b": 2, "c": UserObj()}]]}, UserObj()]
     output = do_map_batches(data)

--- a/python/ray/data/tests/test_numpy_support.py
+++ b/python/ray/data/tests/test_numpy_support.py
@@ -27,7 +27,7 @@ def assert_structure_equals(a, b):
     assert a.dtype == b.dtype
     assert a.shape == b.shape
     for i in range(len(a)):
-        assert np.array_equiv(a[i], b[i]), (i, a, b)
+        assert np.array_equal(a[i], b[i]), (i, a, b)
 
 
 def test_list_of_scalars(ray_start_regular_shared):

--- a/python/ray/data/tests/test_pandas_block.py
+++ b/python/ray/data/tests/test_pandas_block.py
@@ -4,7 +4,7 @@ import pytest
 import ray
 import ray.data
 from ray.data._internal.pandas_block import PandasBlockAccessor
-from ray.data.extensions.object_extension import object_extension_type_allowed
+from ray.data.extensions.object_extension import _object_extension_type_allowed
 
 
 def test_append_column(ray_start_regular_shared):
@@ -20,7 +20,7 @@ def test_append_column(ray_start_regular_shared):
 
 
 @pytest.mark.skipif(
-    object_extension_type_allowed(), reason="Objects can be put into Arrow"
+    _object_extension_type_allowed(), reason="Objects can be put into Arrow"
 )
 def test_dict_fallback_to_pandas_block(ray_start_regular_shared):
     # If the UDF returns a column with dict, this throws

--- a/python/ray/data/tests/test_strict_mode.py
+++ b/python/ray/data/tests/test_strict_mode.py
@@ -181,7 +181,7 @@ def test_strict_schema(ray_start_regular_shared):
     from ray.data._internal.pandas_block import PandasBlockSchema
     from ray.data.extensions.object_extension import (
         ArrowPythonObjectType,
-        object_extension_type_allowed,
+        _object_extension_type_allowed,
     )
     from ray.data.extensions.tensor_extension import ArrowTensorType
 
@@ -199,7 +199,7 @@ def test_strict_schema(ray_start_regular_shared):
 
     ds = ray.data.from_items([{"x": 2, "y": object(), "z": [1, 2]}])
     schema = ds.schema()
-    if object_extension_type_allowed():
+    if _object_extension_type_allowed():
         assert isinstance(schema.base_schema, pa.lib.Schema)
         assert schema.names == ["x", "y", "z"]
         assert schema.types == [

--- a/python/ray/data/tests/test_transform_pyarrow.py
+++ b/python/ray/data/tests/test_transform_pyarrow.py
@@ -446,9 +446,12 @@ def _create_dataset(op, data):
         assert op == "map_batches"
 
         def map_batches(x):
+            row_id = x["id"][0]
             return {
                 "id": x["id"],
-                "my_data": data[x["id"][0]],
+                "my_data": [
+                    data[row_id]
+                ],
             }
 
         ds = ds.map_batches(map_batches, batch_size=None)
@@ -466,8 +469,8 @@ def _create_dataset(op, data):
     "op, data",
     [
         ("map", [UnsupportedType(), 1]),
-        ("map_batches", [[None], [1]]),
-        ("map_batches", [[{"a": 1}], [{"a": 2}]]),
+        ("map_batches", [None, 1]),
+        ("map_batches", [{"a": 1}, {"a": 2}]),
     ],
 )
 def test_fallback_to_pandas_on_incompatible_data(
@@ -487,8 +490,8 @@ def test_fallback_to_pandas_on_incompatible_data(
 @pytest.mark.parametrize(
     "op, data, should_fail",
     [
-        ("map", [1, 2**100], False),
-        ("map_batches", [[1.0], [2**4]], True),
+        ("map_batches", [1, 2**100], False),
+        ("map_batches", [1.0, 2**4], True),
     ],
 )
 def test_pyarrow_conversion_error_handling(

--- a/python/ray/data/tests/test_transform_pyarrow.py
+++ b/python/ray/data/tests/test_transform_pyarrow.py
@@ -16,7 +16,7 @@ from ray.data.extensions import (
     ArrowTensorArray,
     ArrowTensorType,
     ArrowVariableShapedTensorType,
-    object_extension_type_allowed,
+    _object_extension_type_allowed,
 )
 
 
@@ -187,7 +187,7 @@ def test_arrow_concat_tensor_extension_uniform_but_different():
 
 
 @pytest.mark.skipif(
-    not object_extension_type_allowed(), reason="Object extension type not supported."
+    not _object_extension_type_allowed(), reason="Object extension type not supported."
 )
 def test_arrow_concat_with_objects():
     obj = types.SimpleNamespace(a=1, b="test")
@@ -460,7 +460,7 @@ def _create_dataset(op, data):
 
 
 @pytest.mark.skipif(
-    object_extension_type_allowed(), reason="Arrow table supports pickled objects"
+    _object_extension_type_allowed(), reason="Arrow table supports pickled objects"
 )
 @pytest.mark.parametrize(
     "op, data",

--- a/python/ray/data/tests/test_transform_pyarrow.py
+++ b/python/ray/data/tests/test_transform_pyarrow.py
@@ -511,7 +511,7 @@ def test_pyarrow_conversion_error_handling(
     # These tests simulate following scenarios
     #   1. (Case A) Type of the value of the first block is deduced as Arrow scalar
     #      type, but second block carries value that overflows pa.int64 representation,
-    #      abd column henceforth will be serialized as `ArrowPythonObjectExtensionType`
+    #      and column henceforth will be serialized as `ArrowPythonObjectExtensionType`
     #      coercing first block to it as well
     #
     #   2. (Case B) Both blocks carry proper Arrow scalars which, however, have

--- a/python/ray/util/iter.py
+++ b/python/ray/util/iter.py
@@ -956,7 +956,7 @@ class LocalIterator(Generic[T]):
             self.shared_metrics,
             self.local_transforms + [apply_shuffle],
             name=self.name
-                 + ".shuffle(shuffle_buffer_size={}, seed={})".format(
+            + ".shuffle(shuffle_buffer_size={}, seed={})".format(
                 shuffle_buffer_size, str(seed) if seed is not None else "None"
             ),
         )

--- a/python/ray/util/iter.py
+++ b/python/ray/util/iter.py
@@ -956,7 +956,7 @@ class LocalIterator(Generic[T]):
             self.shared_metrics,
             self.local_transforms + [apply_shuffle],
             name=self.name
-            + ".shuffle(shuffle_buffer_size={}, seed={})".format(
+                 + ".shuffle(shuffle_buffer_size={}, seed={})".format(
                 shuffle_buffer_size, str(seed) if seed is not None else "None"
             ),
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Addresses #48419

Currently, we defer to Pyarrow to infer corresponding data-type to represent column values returned by the Map-based operators.

However, Arrow is somehow not inferring the `large_*` kinds of types even in somewhat trivial cases of strings, byte-strings etc. resulting in `ArrowCapacityError` when you try to add a single string/byte-string >2Gb.

This change addresses that by 

 - Unifying handling of conversion to Numpy/Arrow in a single place (unifying it across different code-paths)
 - Fixing incorrect fallbacks to `ArrowPythonObjectType`
 - Upscaling `binary`, `string` to their Large counterparts (ie `large_list`, etc) if objects we're adding to the Arrow array > 2Gb

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
