### PR TITLE
[Data] Fix block accessors' combine handling of duplicate columns

### DIFF
--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -525,6 +525,13 @@ class ArrowBlockAccessor(TableBlockAccessor):
                 "on Arrow blocks, but "
                 f"got: {type(key)}."
             )
+        if isinstance(key, list):
+            previous_keys = set()
+            for k in key:
+                if k in previous_keys:
+                    raise ValueError(f"key contains duplicate columns: {k}")
+                previous_keys.add(k)
+
 
         def iter_groups() -> Iterator[Tuple[KeyType, Block]]:
             """Creates an iterator over zero-copy group views."""
@@ -562,6 +569,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
 
             # Build the row.
             row = {}
+            count = collections.defaultdict(int)
             if key is not None:
                 if isinstance(key, list):
                     keys = key
@@ -571,24 +579,21 @@ class ArrowBlockAccessor(TableBlockAccessor):
                     group_keys = [group_key]
 
                 for k, gk in zip(keys, group_keys):
+                    assert count[k] == 0, f"column {k} already present in row"
+                    count[k] += 1
                     row[k] = gk
 
-            count = collections.defaultdict(int)
             for agg, accumulator in zip(aggs, accumulators):
                 name = agg.name
                 # Check for conflicts with existing aggregation name.
                 if count[name] > 0:
                     name = self._munge_conflict(name, count[name])
-                count[name] += 1
+                count[agg.name] += 1
                 row[name] = accumulator
 
             builder.add(row)
 
         return builder.build()
-
-    @staticmethod
-    def _munge_conflict(name, count):
-        return f"{name}_{count+1}"
 
     @staticmethod
     def merge_sorted_blocks(

--- a/python/ray/data/_internal/table_block.py
+++ b/python/ray/data/_internal/table_block.py
@@ -307,3 +307,7 @@ class TableBlockAccessor(BlockAccessor):
                 "with block normalization."
             )
         return results
+
+    @staticmethod
+    def _munge_conflict(name, count):
+        return f"{name}_{count+1}"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

There were several bugs in the BlockAccessors' `combine` method involving duplicate columns names. This was causing very confusing failures when running something like `ds.groupby(col).aggregate( AggregateFn(..., name=col) )`.

* If the groupby key contains duplicate columns, (ie. `ds.groupby([col, col])`), the assumption that `row.columns[:len(keys)] == keys` is violated.
  * I have added an error message in this case.
* If the groupby key overlapped with one of the aggregation names, the grouping value would be overwritten. If the aggregation value was comparable, the result may succeed with incorrect results, and if it was not comparable, it would fail with a confusing error message.
   * I have fixed this by applying the same munging behavior for duplicate aggregation names to the grouping keys.
* Using three or more aggregations with duplicate names silently dropped aggregations, because the munging counter was incremented *after* munging the column. 
  * I have fixed this by using the original aggregation name for the munging lookup, rather than the munged column.
* Duplicate aggregations with Pandas blocks was broken, as the `_munge_conflict` method was missing.
   * I have moved the `_munge_conflict` into the parent `TableBlockAccessor` class so that it can be accessed from both PandasBlockAccessor and ArrowBlockAccessor.

## Related issue number

<!-- For example: "Closes #1234" -->

I have not created any issues.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [X] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
