### PR TITLE
Revert "[Observability] Added object refs Task is dependent on to `TaskInfoEntry` (#48234)"

### DIFF
--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -23,7 +23,7 @@ import ray
 import ray.dashboard.consts as dashboard_consts
 import ray._private.state as global_state
 import ray._private.ray_constants as ray_constants
-from ray._raylet import ActorID, ObjectRef
+from ray._raylet import ActorID
 from ray._private.test_utils import (
     run_string_as_driver,
     wait_for_condition,
@@ -1015,7 +1015,6 @@ async def test_api_manager_list_tasks_events(state_api_manager):
     data_source_client.get_all_task_info = AsyncMock()
     id = b"1234"
     func_or_class = "f"
-    arg_ref = ObjectRef.from_random()
 
     # Generate a task event.
 
@@ -1024,10 +1023,8 @@ async def test_api_manager_list_tasks_events(state_api_manager):
         name=func_or_class,
         func_or_class_name=func_or_class,
         type=TaskType.NORMAL_TASK,
-        args_object_ids=[arg_ref.binary()],
     )
-
-    current = 0
+    current = time.time_ns()
     second = int(1e9)
     state_updates = TaskStateUpdate(
         node_id=node_id.binary(),
@@ -1051,42 +1048,31 @@ async def test_api_manager_list_tasks_events(state_api_manager):
     )
     data_source_client.get_all_task_info.side_effect = [generate_task_data([events])]
     result = await state_api_manager.list_tasks(option=create_api_options(detail=True))
-
-    assert {
-        "state": "FINISHED",
-        "type": "NORMAL_TASK",
-        "name": "f",
-        "error_message": None,
-        "events": [
-            {"state": "PENDING_ARGS_AVAIL", "created_ms": 0.0},
-            {"state": "SUBMITTED_TO_WORKER", "created_ms": 1000.0},
-            {"state": "RUNNING", "created_ms": 2000.0},
-            {"state": "FINISHED", "created_ms": 3000.0},
-        ],
-        "runtime_env_info": None,
-        "end_time_ms": 3000.0,
-        "job_id": "30303031",
-        "error_type": None,
-        "func_or_class_name": "f",
-        "attempt_number": 0,
-        "node_id": node_id.hex(),
-        "required_resources": {},
-        "worker_pid": None,
-        "language": "PYTHON",
-        "placement_group_id": None,
-        "creation_time_ms": 0.0,
-        "worker_id": None,
-        "task_log_info": None,
-        "profiling_data": {},
-        "actor_id": None,
-        "is_debugger_paused": None,
-        "start_time_ms": 2000.0,
-        "task_id": "31323334",
-        "parent_task_id": "",
-        "args_object_ids": [
-            arg_ref.hex(),
-        ],
-    } == result.result[0]
+    result = result.result[0]
+    assert "events" in result
+    assert result["state"] == "FINISHED"
+    expected_events = [
+        {
+            "state": "PENDING_ARGS_AVAIL",
+            "created_ms": current // 1e6,
+        },
+        {
+            "state": "SUBMITTED_TO_WORKER",
+            "created_ms": (current + second) // 1e6,
+        },
+        {
+            "state": "RUNNING",
+            "created_ms": (current + 2 * second) // 1e6,
+        },
+        {
+            "state": "FINISHED",
+            "created_ms": (current + 3 * second) // 1e6,
+        },
+    ]
+    for actual, expected in zip(result["events"], expected_events):
+        assert actual == expected
+    assert result["start_time_ms"] == (current + 2 * second) // 1e6
+    assert result["end_time_ms"] == (current + 3 * second) // 1e6
 
     """
     Test only start_time_ms is updated.

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -760,9 +760,6 @@ class TaskState(StateSchema):
     error_message: Optional[str] = state_column(detail=True, filterable=False)
     # Is task paused by the debugger
     is_debugger_paused: Optional[bool] = state_column(detail=True, filterable=True)
-    # List of objects (passed in by ref as arguments) this task
-    # is dependent on
-    args_object_ids: List[str] = state_column(detail=True, filterable=False)
 
 
 @dataclass(init=not IS_PYDANTIC_2)
@@ -1552,8 +1549,6 @@ def protobuf_to_task_state_dict(message: TaskEvents) -> dict:
             "worker_id",
             "placement_group_id",
             "component_id",
-            "object_id",
-            "args_object_ids",
         ],
     )
 
@@ -1584,7 +1579,6 @@ def protobuf_to_task_state_dict(message: TaskEvents) -> dict:
                 "runtime_env_info",
                 "parent_task_id",
                 "placement_group_id",
-                "args_object_ids",
             ],
         ),
         (task_attempt, ["task_id", "attempt_number", "job_id"]),

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -640,7 +640,6 @@ CoreWorker::CoreWorker(const CoreWorkerOptions &options, const WorkerID &worker_
         [this] {
           RAY_LOG(INFO) << "Event stats:\n\n"
                         << io_service_.stats().StatsString() << "\n\n"
-                        << task_execution_service_.stats().StatsString() << "\n\n"
                         << "-----------------\n"
                         << "Task execution event stats:\n"
                         << task_execution_service_.stats().StatsString() << "\n\n"

--- a/src/ray/gcs/pb_util.h
+++ b/src/ray/gcs/pb_util.h
@@ -252,16 +252,8 @@ inline void FillTaskInfo(rpc::TaskInfoEntry *task_info,
                                                   resources_map.end());
   task_info->mutable_runtime_env_info()->CopyFrom(task_spec.RuntimeEnvInfo());
   const auto &pg_id = task_spec.PlacementGroupBundleId().first;
-
   if (!pg_id.IsNil()) {
     task_info->set_placement_group_id(pg_id.Binary());
-  }
-
-  // Fill in task args
-  for (size_t i = 0; i < task_spec.NumArgs(); i++) {
-    if (task_spec.ArgByRef(i)) {
-      task_info->add_args_object_ids(task_spec.ArgRef(i).object_id());
-    }
   }
 }
 

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -589,13 +589,6 @@ message TaskInfoEntry {
   // If the task/actor is created within a placement group,
   // this value is configured.
   optional bytes placement_group_id = 26;
-  // Tasks arguments passed in as (object) references.
-  //
-  // NOTE: This list only contains `ObjectReference`s passed in as arguments
-  //       this task is dependent on and does NOT contain
-  //        - Args passed by value (inlined)
-  //        - ObjectRefs of the args passed by value
-  repeated bytes args_object_ids = 27;
 }
 
 message Bundle {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This reverts commit cacb54c8e52c99b31dd3d3854f53f3c0d11eb01d.

CoreWorker launches a thread to send events to GCS ([code](https://sourcegraph.com/github.com/ray-project/ray@d0af8622f6b5d0668d521e20539b7d76426ceb5f/-/blob/src/ray/core_worker/task_event_buffer.cc?L286:49-286:60)). #48234 adds the following logic in `pb_util.h`:

```cpp
  // Fill in task args
  for (size_t i = 0; i < task_spec.NumArgs(); i++) {
    if (task_spec.ArgByRef(i)) {
      task_info->add_args_object_ids(task_spec.ArgRef(i).object_id());
    }
  }
```

However, it is possible for another thread to call [clear_object_ref](https://sourcegraph.com/github.com/ray-project/ray@d0af8622f6b5d0668d521e20539b7d76426ceb5f/-/blob/src/ray/core_worker/transport/dependency_resolver.cc?L36-38) between `if (task_spec.ArgByRef(i)) {` and `task_spec.ArgRef(i)`. In this case, `RAY_CHECK` ([code](https://sourcegraph.com/github.com/ray-project/ray@d0af8622f6b5d0668d521e20539b7d76426ceb5f/-/blob/src/ray/common/task/task_spec.cc?L279)) in `ArgRef` will fail.

Error message:

<img width="1864" alt="image" src="https://github.com/user-attachments/assets/5401b6ef-959a-4afe-beea-daf4e1577b0d">

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
