### PR TITLE
[Data] Fixing `DelegatingBlockBuilder` to avoid re-serializing objects multiple times

### DIFF
--- a/python/ray/data/_internal/delegating_block_builder.py
+++ b/python/ray/data/_internal/delegating_block_builder.py
@@ -1,10 +1,8 @@
 import collections
 from typing import Any, Mapping, Optional
 
-from ray.air.util.tensor_extensions.arrow import ArrowConversionError
 from ray.data._internal.arrow_block import ArrowBlockBuilder
 from ray.data._internal.block_builder import BlockBuilder
-from ray.data._internal.pandas_block import PandasBlockBuilder
 from ray.data.block import Block, BlockAccessor, BlockType, DataBatch
 
 

--- a/python/ray/data/_internal/delegating_block_builder.py
+++ b/python/ray/data/_internal/delegating_block_builder.py
@@ -23,17 +23,8 @@ class DelegatingBlockBuilder(BlockBuilder):
     def add(self, item: Mapping[str, Any]) -> None:
         assert isinstance(item, collections.abc.Mapping), item
 
-        import pyarrow
-
         if self._builder is None:
-            try:
-                check = ArrowBlockBuilder()
-                check.add(item)
-                check.build()
-                self._builder = ArrowBlockBuilder()
-            except (TypeError, pyarrow.lib.ArrowInvalid, ArrowConversionError):
-                # Can also handle nested Python objects, which Arrow cannot.
-                self._builder = PandasBlockBuilder()
+            self._builder = ArrowBlockBuilder()
 
         self._builder.add(item)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, we're serializing first row in every block twice when adding it t/h `DelegatingBlockBuilder`, carrying tangible overhead and impact on latency for large enough rows.

Provided that `ArrowBlockBuilder` is now able to handle arbitrary Python object we can just deprecate `DelegatingBlockBuilder` altogether.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
