### PR TITLE
[core][autoscaler] Set timeout for requests sent to K8s API server

### DIFF
--- a/python/ray/autoscaler/_private/kuberay/autoscaling_config.py
+++ b/python/ray/autoscaler/_private/kuberay/autoscaling_config.py
@@ -13,10 +13,7 @@ from ray.autoscaler._private.constants import (
     WORKER_LIVENESS_CHECK_KEY,
     WORKER_RPC_DRAIN_KEY,
 )
-from ray.autoscaler._private.kuberay import (
-    node_provider,
-    utils,
-)
+from ray.autoscaler._private.kuberay import node_provider, utils
 from ray.autoscaler._private.util import validate_config
 
 logger = logging.getLogger(__name__)

--- a/python/ray/autoscaler/_private/kuberay/autoscaling_config.py
+++ b/python/ray/autoscaler/_private/kuberay/autoscaling_config.py
@@ -14,7 +14,6 @@ from ray.autoscaler._private.constants import (
     WORKER_RPC_DRAIN_KEY,
 )
 from ray.autoscaler._private.kuberay import (
-    KUBERAY_REQUEST_TIMEOUT_S,
     node_provider,
     utils,
 )
@@ -88,7 +87,7 @@ class AutoscalingConfigProducer:
         result = requests.get(
             self._ray_cr_url,
             headers=self._headers,
-            timeout=KUBERAY_REQUEST_TIMEOUT_S,
+            timeout=node_provider.KUBERAY_REQUEST_TIMEOUT_S,
             verify=self._verify,
         )
         if not result.status_code == 200:

--- a/python/ray/autoscaler/_private/kuberay/autoscaling_config.py
+++ b/python/ray/autoscaler/_private/kuberay/autoscaling_config.py
@@ -13,7 +13,11 @@ from ray.autoscaler._private.constants import (
     WORKER_LIVENESS_CHECK_KEY,
     WORKER_RPC_DRAIN_KEY,
 )
-from ray.autoscaler._private.kuberay import node_provider, utils
+from ray.autoscaler._private.kuberay import (
+    KUBERAY_REQUEST_TIMEOUT_S,
+    node_provider,
+    utils,
+)
 from ray.autoscaler._private.util import validate_config
 
 logger = logging.getLogger(__name__)
@@ -82,7 +86,10 @@ class AutoscalingConfigProducer:
 
     def _fetch_ray_cr_from_k8s(self) -> Dict[str, Any]:
         result = requests.get(
-            self._ray_cr_url, headers=self._headers, verify=self._verify
+            self._ray_cr_url,
+            headers=self._headers,
+            timeout=KUBERAY_REQUEST_TIMEOUT_S,
+            verify=self._verify,
         )
         if not result.status_code == 200:
             result.raise_for_status()

--- a/python/ray/autoscaler/_private/kuberay/node_provider.py
+++ b/python/ray/autoscaler/_private/kuberay/node_provider.py
@@ -43,6 +43,8 @@ KUBERAY_TYPE_HEAD = "head-group"
 # KubeRay CRD version
 KUBERAY_CRD_VER = os.getenv("KUBERAY_CRD_VER", "v1alpha1")
 
+KUBERAY_REQUEST_TIMEOUT_S = int(os.getenv("KUBERAY_REQUEST_TIMEOUT_S", 60))
+
 RAY_HEAD_POD_NAME = os.getenv("RAY_HEAD_POD_NAME")
 
 # Key for GKE label that identifies which multi-host replica a pod belongs to
@@ -268,7 +270,12 @@ class KubernetesHttpApiClient(IKubernetesHttpApiClient):
             path=path,
             kuberay_crd_version=self._kuberay_crd_version,
         )
-        result = requests.get(url, headers=self._headers, verify=self._verify)
+        result = requests.get(
+            url,
+            headers=self._headers,
+            timeout=KUBERAY_REQUEST_TIMEOUT_S,
+            verify=self._verify,
+        )
         if not result.status_code == 200:
             result.raise_for_status()
         return result.json()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

A user reports that the Ray Autoscaler is stuck, and they need to log into the head Pod and kill the process with PID 1 to restart the Ray Autoscaler container and make it work.

```
Thread 1 (idle): "MainThread"
    read (ssl.py:1159)
    recv_into (ssl.py:1303)
    readinto (socket.py:705)
    _read_status (http/client.py:279)
    begin (http/client.py:318)
    getresponse (http/client.py:1375)
    getresponse (urllib3/connection.py:507)
    _make_request (urllib3/connectionpool.py:538)
    urlopen (urllib3/connectionpool.py:805)
    send (requests/adapters.py:681)
    send (requests/sessions.py:703)
    request (requests/sessions.py:589)
    request (requests/api.py:59)
    get (requests/api.py:73)
    _fetch_ray_cr_from_k8s (ray/autoscaler/_private/kuberay/autoscaling_config.py:84)
    _fetch_ray_cr_from_k8s_with_retries (ray/autoscaler/_private/kuberay/autoscaling_config.py:70)
    __call__ (ray/autoscaler/_private/kuberay/autoscaling_config.py:58)
    reset (ray/autoscaler/_private/autoscaler.py:1035)
    update (ray/autoscaler/_private/autoscaler.py:376)
    _run (ray/autoscaler/_private/monitor.py:389)
    run (ray/autoscaler/_private/monitor.py:584)
    run_kuberay_autoscaler (ray/autoscaler/_private/kuberay/run_autoscaler.py:86)
    kuberay_autoscaler (ray/scripts/scripts.py:2338)
    invoke (click/core.py:782)
    invoke (click/core.py:1434)
    invoke (click/core.py:1688)
    main (click/core.py:1078)
    __call__ (click/core.py:1157)
    main (ray/scripts/scripts.py:2615)
    <module> (ray:8)
```

This PR adds `timeout` to `requests.get` in KubeRay NodeProvider.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

* Follow [this document](https://github.com/ray-project/ray/tree/master/python/ray/tests/kuberay) to build Ray image `rayproject/autoscaling_e2e_test_image`.
* Install a RayCluster with: https://gist.github.com/kevin85421/810fb0ae5101da0740a6e74c1703700b
* Set up iptable rule in the head Pod to drop the requests sent to K8s API server. In the following example, the ClusterIP of K8s API server is 10.96.0.1.
  ```sh
  sudo iptables -A OUTPUT -d 10.96.0.1 -j DROP
  ``` 
* Check Ray Autoscaler's log and it should stuck there.
* The Ray Autoscaler will throw an exception if the request can't finish in 60s.
  <img width="1411" alt="image" src="https://github.com/user-attachments/assets/fa48f6e0-1c15-4e05-a606-c66a14dffcdb">
* Delete the iptable rule
  ```sh
  sudo iptables -A OUTPUT -d 10.96.0.1 -j DROP
  ```
* Check the Ray Autoscaler log, and it should be working normally again (i.e., printing messages every 5 seconds).

* Note that: this simulation is not exactly the same as the user's issue. In my experiment, if we drop the request by setting `iptables`, `requests.get` without setting `timeout` will still throw an exception after a while (maybe 2 mins). I will try to figure out how to reproduce the same error message user provided, but adding `timeout` is definitely helpful to avoid this kind of issue.


- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
