### PR TITLE
[core][autoscaler] Fix incorrectly terminating nodes misclassified as idle in autoscaler v1

### DIFF
--- a/python/ray/autoscaler/_private/load_metrics.py
+++ b/python/ray/autoscaler/_private/load_metrics.py
@@ -102,7 +102,6 @@ class LoadMetrics:
         self.static_resources_by_ip[ip] = static_resources
         self.raylet_id_by_ip[ip] = raylet_id
         self.cluster_full_of_actors_detected = cluster_full_of_actors_detected
-        self.ray_nodes_last_used_time_by_ip[ip] = node_last_used_time_s
 
         if not waiting_bundles:
             waiting_bundles = []
@@ -122,6 +121,9 @@ class LoadMetrics:
         self.dynamic_resources_by_ip[ip] = dynamic_resources_update
 
         now = time.time()
+        self.ray_nodes_last_used_time_by_ip[ip] = (
+            node_last_used_time_s if node_last_used_time_s else now
+        )
         self.last_heartbeat_time_by_ip[ip] = now
         self.waiting_bundles = waiting_bundles
         self.infeasible_bundles = infeasible_bundles

--- a/python/ray/autoscaler/_private/load_metrics.py
+++ b/python/ray/autoscaler/_private/load_metrics.py
@@ -2,7 +2,7 @@ import logging
 import time
 from collections import Counter
 from functools import reduce
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from ray._private.gcs_utils import PlacementGroupTableData
 from ray.autoscaler._private.constants import (
@@ -93,11 +93,11 @@ class LoadMetrics:
         raylet_id: bytes,
         static_resources: Dict[str, Dict],
         dynamic_resources: Dict[str, Dict],
+        node_idle_duration_s: float,
         waiting_bundles: List[Dict[str, float]] = None,
         infeasible_bundles: List[Dict[str, float]] = None,
         pending_placement_groups: List[PlacementGroupTableData] = None,
         cluster_full_of_actors_detected: bool = False,
-        node_last_used_time_s: Optional[float] = None,
     ):
         self.static_resources_by_ip[ip] = static_resources
         self.raylet_id_by_ip[ip] = raylet_id
@@ -121,9 +121,7 @@ class LoadMetrics:
         self.dynamic_resources_by_ip[ip] = dynamic_resources_update
 
         now = time.time()
-        self.ray_nodes_last_used_time_by_ip[ip] = (
-            node_last_used_time_s if node_last_used_time_s else now
-        )
+        self.ray_nodes_last_used_time_by_ip[ip] = now - node_idle_duration_s
         self.last_heartbeat_time_by_ip[ip] = now
         self.waiting_bundles = waiting_bundles
         self.infeasible_bundles = infeasible_bundles

--- a/python/ray/autoscaler/_private/load_metrics.py
+++ b/python/ray/autoscaler/_private/load_metrics.py
@@ -2,7 +2,7 @@ import logging
 import time
 from collections import Counter
 from functools import reduce
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from ray._private.gcs_utils import PlacementGroupTableData
 from ray.autoscaler._private.constants import (
@@ -97,7 +97,7 @@ class LoadMetrics:
         infeasible_bundles: List[Dict[str, float]] = None,
         pending_placement_groups: List[PlacementGroupTableData] = None,
         cluster_full_of_actors_detected: bool = False,
-        node_last_used_time_s: float = time.time(),
+        node_last_used_time_s: Optional[float] = None,
     ):
         self.static_resources_by_ip[ip] = static_resources
         self.raylet_id_by_ip[ip] = raylet_id

--- a/python/ray/autoscaler/_private/load_metrics.py
+++ b/python/ray/autoscaler/_private/load_metrics.py
@@ -70,7 +70,6 @@ class LoadMetrics:
     """
 
     def __init__(self):
-        self.last_used_time_by_ip = {}
         self.last_heartbeat_time_by_ip = {}
         self.static_resources_by_ip = {}
         self.dynamic_resources_by_ip = {}
@@ -80,6 +79,7 @@ class LoadMetrics:
         self.pending_placement_groups = []
         self.resource_requests = []
         self.cluster_full_of_actors_detected = False
+        self.ray_nodes_idle_duration_ms_by_ip = {}
 
     def __bool__(self):
         """A load metrics instance is Falsey iff the autoscaler process
@@ -97,10 +97,12 @@ class LoadMetrics:
         infeasible_bundles: List[Dict[str, float]] = None,
         pending_placement_groups: List[PlacementGroupTableData] = None,
         cluster_full_of_actors_detected: bool = False,
+        idle_duration_ms: int = 0,
     ):
         self.static_resources_by_ip[ip] = static_resources
         self.raylet_id_by_ip[ip] = raylet_id
         self.cluster_full_of_actors_detected = cluster_full_of_actors_detected
+        self.ray_nodes_idle_duration_ms_by_ip[ip] = idle_duration_ms
 
         if not waiting_bundles:
             waiting_bundles = []
@@ -120,11 +122,6 @@ class LoadMetrics:
         self.dynamic_resources_by_ip[ip] = dynamic_resources_update
 
         now = time.time()
-        if (
-            ip not in self.last_used_time_by_ip
-            or self.static_resources_by_ip[ip] != self.dynamic_resources_by_ip[ip]
-        ):
-            self.last_used_time_by_ip[ip] = now
         self.last_heartbeat_time_by_ip[ip] = now
         self.waiting_bundles = waiting_bundles
         self.infeasible_bundles = infeasible_bundles
@@ -167,7 +164,7 @@ class LoadMetrics:
                 )
             assert not (unwanted_ips & set(mapping))
 
-        prune(self.last_used_time_by_ip, should_log=True)
+        prune(self.ray_nodes_idle_duration_ms_by_ip, should_log=True)
         prune(self.static_resources_by_ip, should_log=False)
         prune(self.raylet_id_by_ip, should_log=False)
         prune(self.dynamic_resources_by_ip, should_log=False)
@@ -337,7 +334,7 @@ class LoadMetrics:
         resources_used, resources_total = self._get_resource_usage()
 
         now = time.time()
-        idle_times = [now - t for t in self.last_used_time_by_ip.values()]
+        idle_times = self.ray_nodes_idle_duration_ms_by_ip.values()
         heartbeat_times = [now - t for t in self.last_heartbeat_time_by_ip.values()]
         most_delayed_heartbeats = sorted(
             self.last_heartbeat_time_by_ip.items(), key=lambda pair: pair[1]

--- a/python/ray/autoscaler/_private/monitor.py
+++ b/python/ray/autoscaler/_private/monitor.py
@@ -320,7 +320,13 @@ class Monitor:
             else:
                 ip = resource_message.node_manager_address
 
-            idle_duration_ms = ray_nodes_idle_duration_ms_by_id[node_id]
+            idle_duration_ms = 0.0
+            if node_id in ray_nodes_idle_duration_ms_by_id:
+                idle_duration_ms = ray_nodes_idle_duration_ms_by_id[node_id]
+            else:
+                logger.warning(
+                    f"node_id {node_id} not found in ray_nodes_idle_duration_ms_by_id"
+                )
 
             self.load_metrics.update(
                 ip,
@@ -331,7 +337,9 @@ class Monitor:
                 infeasible_bundles,
                 pending_placement_groups,
                 cluster_full,
-                time.time() - idle_duration_ms / 1000,  # last_used_time
+                time.time()
+                - idle_duration_ms
+                / 1000,  # node_last_used_time_s = now - idle_duration
             )
         if self.readonly_config:
             self.readonly_config["available_node_types"].update(mirror_node_types)

--- a/python/ray/autoscaler/_private/monitor.py
+++ b/python/ray/autoscaler/_private/monitor.py
@@ -30,8 +30,8 @@ from ray.autoscaler._private.event_summarizer import EventSummarizer
 from ray.autoscaler._private.load_metrics import LoadMetrics
 from ray.autoscaler._private.prom_metrics import AutoscalerPrometheusMetrics
 from ray.autoscaler._private.util import format_readonly_node_type
+from ray.autoscaler.v2.sdk import get_cluster_resource_state
 from ray.core.generated import gcs_pb2
-from ray.core.generated.autoscaler_pb2 import GetClusterResourceStateReply
 from ray.core.generated.event_pb2 import Event as RayEvent
 from ray.experimental.internal_kv import (
     _initialize_internal_kv,
@@ -239,15 +239,6 @@ class Monitor:
             prom_metrics=self.prom_metrics,
         )
 
-    def get_cluster_resource_state(self):
-        """
-        Get the cluster resource state from GCS.
-        """
-        str_reply = self.gcs_client.get_cluster_resource_state()
-        reply = GetClusterResourceStateReply()
-        reply.ParseFromString(str_reply)
-        return reply.cluster_resource_state
-
     def update_load_metrics(self):
         """Fetches resource usage data from GCS and updates load metrics."""
 
@@ -257,9 +248,8 @@ class Monitor:
 
         # This is a workaround to get correct idle_duration_ms
         # from "get_cluster_resource_state"
-        # reason: https://github.com/ray-project/ray/pull/48519#issuecomment-2481659346
-        # TODO(mimi): use idle_duration_ms from "get_all_resource_usage"
-        cluster_resource_state = self.get_cluster_resource_state()
+        # ref: https://github.com/ray-project/ray/pull/48519#issuecomment-2481659346
+        cluster_resource_state = get_cluster_resource_state(self.gcs_client)
         ray_node_states = cluster_resource_state.node_states
         ray_nodes_idle_duration_ms_by_id = {
             node.node_id: node.idle_duration_ms for node in ray_node_states
@@ -341,7 +331,7 @@ class Monitor:
                 infeasible_bundles,
                 pending_placement_groups,
                 cluster_full,
-                idle_duration_ms,
+                time.time() - idle_duration_ms / 1000,  # last_used_time
             )
         if self.readonly_config:
             self.readonly_config["available_node_types"].update(mirror_node_types)

--- a/python/ray/autoscaler/_private/monitor.py
+++ b/python/ray/autoscaler/_private/monitor.py
@@ -320,9 +320,9 @@ class Monitor:
             else:
                 ip = resource_message.node_manager_address
 
-            idle_duration_ms = 0.0
+            idle_duration_s = 0.0
             if node_id in ray_nodes_idle_duration_ms_by_id:
-                idle_duration_ms = ray_nodes_idle_duration_ms_by_id[node_id]
+                idle_duration_s = ray_nodes_idle_duration_ms_by_id[node_id] / 1000
             else:
                 logger.warning(
                     f"node_id {node_id} not found in ray_nodes_idle_duration_ms_by_id"
@@ -333,13 +333,11 @@ class Monitor:
                 node_id,
                 total_resources,
                 available_resources,
+                idle_duration_s,
                 waiting_bundles,
                 infeasible_bundles,
                 pending_placement_groups,
                 cluster_full,
-                time.time()
-                - idle_duration_ms
-                / 1000,  # node_last_used_time_s = now - idle_duration
             )
         if self.readonly_config:
             self.readonly_config["available_node_types"].update(mirror_node_types)

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -320,6 +320,12 @@ MULTI_WORKER_CLUSTER = dict(
     SMALL_CLUSTER, **{"available_node_types": TYPES_A, "head_node_type": "empty_node"}
 )
 
+# `DUMMY_IDLE_DURATION_S` is used as a dummy value for
+# `node_idle_duration_s` in load_metrics.update()
+# when we want to simulate worker node's idle duration
+# (`total_resources` == `available_resources`),
+# but don't want to cause autoscaler downscaling.
+# (`DUMMY_IDLE_DURATION_S` < `idle_timeout_minutes`).
 DUMMY_IDLE_DURATION_S = 3
 
 exc_info = None

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -70,7 +70,6 @@ from ray.tests.test_batch_node_provider_unit import (
 )
 from ray.exceptions import RpcError
 
-from ray.core.generated import autoscaler_pb2
 
 WORKER_FILTER = {TAG_RAY_NODE_KIND: NODE_KIND_WORKER}
 
@@ -111,8 +110,6 @@ class MockGcsClient:
         # Tracks how many times DrainNode returned a successful RPC response.
         self.drain_node_reply_success = 0
 
-        self.custom_cluster_state = None
-
     def drain_nodes(self, raylet_ids_to_drain, timeout: int):
         """Simulate NodeInfo stub's DrainNode call.
 
@@ -145,17 +142,6 @@ class MockGcsClient:
         else:
             # Shouldn't land here.
             assert False, "Possible drain node outcomes exhausted."
-
-    def get_cluster_resource_state(self):
-        """Mock get_cluster_resource_state to return a ClusterResourceState.
-
-        Returns an empty state by default or custom state if provided.
-        """
-        if self.custom_cluster_state is not None:
-            return self.custom_cluster_state.SerializeToString()
-
-        # Default empty ClusterResourceState
-        return autoscaler_pb2.ClusterResourceState().SerializeToString()
 
 
 def mock_raylet_id() -> bytes:

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -70,6 +70,7 @@ from ray.tests.test_batch_node_provider_unit import (
 )
 from ray.exceptions import RpcError
 
+from ray.core.generated import autoscaler_pb2
 
 WORKER_FILTER = {TAG_RAY_NODE_KIND: NODE_KIND_WORKER}
 
@@ -110,6 +111,8 @@ class MockGcsClient:
         # Tracks how many times DrainNode returned a successful RPC response.
         self.drain_node_reply_success = 0
 
+        self.custom_cluster_state = None
+
     def drain_nodes(self, raylet_ids_to_drain, timeout: int):
         """Simulate NodeInfo stub's DrainNode call.
 
@@ -142,6 +145,17 @@ class MockGcsClient:
         else:
             # Shouldn't land here.
             assert False, "Possible drain node outcomes exhausted."
+
+    def get_cluster_resource_state(self):
+        """Mock get_cluster_resource_state to return a ClusterResourceState.
+
+        Returns an empty state by default or custom state if provided.
+        """
+        if self.custom_cluster_state is not None:
+            return self.custom_cluster_state.SerializeToString()
+
+        # Default empty ClusterResourceState
+        return autoscaler_pb2.ClusterResourceState().SerializeToString()
 
 
 def mock_raylet_id() -> bytes:

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -3593,6 +3593,54 @@ class AutoscalingTest(unittest.TestCase):
                     break
             assert status_log_found is bool(status_log_enabled_env)
 
+    def testScaleDownIdleTimeOut(self):
+        config = copy.deepcopy(SMALL_CLUSTER)
+        config["available_node_types"]["worker"]["min_workers"] = 1
+        config_path = self.write_config(config)
+
+        self.provider = MockProvider()
+        self.provider.create_node(
+            {},
+            {
+                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
+                TAG_RAY_USER_NODE_TYPE: "head",
+            },
+            1,
+        )
+
+        runner = MockProcessRunner()
+        lm = LoadMetrics()
+        mock_gcs_client = MockGcsClient()
+        autoscaler = MockAutoscaler(
+            config_path,
+            lm,
+            mock_gcs_client,
+            max_failures=0,
+            process_runner=runner,
+            update_interval_s=0,
+        )
+
+        autoscaler.update()
+        self.waitForNodes(1, tag_filters=WORKER_FILTER)
+
+        # Reduce cluster size to 1
+        new_config = copy.deepcopy(SMALL_CLUSTER)
+        new_config["available_node_types"]["worker"]["min_workers"] = 0
+        new_config["idle_timeout_minutes"] = 0.1
+        self.write_config(new_config)
+        autoscaler.update()
+
+        worker_ip = self.provider.non_terminated_node_ips(WORKER_FILTER)[0]
+        # Mark the node as idle
+        lm.update(worker_ip, mock_raylet_id(), {"CPU": 1}, {"CPU": 1}, 20)
+        autoscaler.update()
+        assert self.provider.internal_ip("1") == worker_ip
+        events = autoscaler.event_summarizer.summary()
+        assert "Removing 1 nodes of type worker (idle)." in events, events
+        autoscaler.update()
+        assert mock_gcs_client.drain_node_call_count == 1
+
 
 def test_import():
     """This test ensures that all the autoscaler imports work as expected to

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -320,6 +320,8 @@ MULTI_WORKER_CLUSTER = dict(
     SMALL_CLUSTER, **{"available_node_types": TYPES_A, "head_node_type": "empty_node"}
 )
 
+DUMMY_IDLE_DURATION_S = 3
+
 exc_info = None
 try:
     raise Exception("Test exception.")
@@ -331,7 +333,7 @@ assert exc_info is not None
 class LoadMetricsTest(unittest.TestCase):
     def testHeartbeat(self):
         lm = LoadMetrics()
-        lm.update("1.1.1.1", mock_raylet_id(), {"CPU": 2}, {"CPU": 1})
+        lm.update("1.1.1.1", mock_raylet_id(), {"CPU": 2}, {"CPU": 1}, 0)
         lm.mark_active("2.2.2.2")
         assert "1.1.1.1" in lm.last_heartbeat_time_by_ip
         assert "2.2.2.2" in lm.last_heartbeat_time_by_ip
@@ -339,9 +341,9 @@ class LoadMetricsTest(unittest.TestCase):
 
     def testDebugString(self):
         lm = LoadMetrics()
-        lm.update("1.1.1.1", mock_raylet_id(), {"CPU": 2}, {"CPU": 0})
+        lm.update("1.1.1.1", mock_raylet_id(), {"CPU": 2}, {"CPU": 0}, 0)
         lm.update(
-            "2.2.2.2", mock_raylet_id(), {"CPU": 2, "GPU": 16}, {"CPU": 2, "GPU": 2}
+            "2.2.2.2", mock_raylet_id(), {"CPU": 2, "GPU": 16}, {"CPU": 2, "GPU": 2}, 0
         )
         lm.update(
             "3.3.3.3",
@@ -354,6 +356,7 @@ class LoadMetricsTest(unittest.TestCase):
                 "memory": 0,
                 "object_store_memory": 1.05 * 1024 * 1024 * 1024,
             },
+            0,
         )
         debug = lm.info_string()
         assert (
@@ -1556,7 +1559,7 @@ class AutoscalingTest(unittest.TestCase):
                 },
                 1,
             )
-        lm.update("172.0.0.0", mock_raylet_id(), {"CPU": 1}, {"CPU": 0})
+        lm.update("172.0.0.0", mock_raylet_id(), {"CPU": 1}, {"CPU": 0}, 0)
         autoscaler = MockAutoscaler(
             config_path,
             lm,
@@ -1619,7 +1622,9 @@ class AutoscalingTest(unittest.TestCase):
         worker_ip = self.provider.non_terminated_node_ips(
             tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER},
         )[0]
-        lm.update(worker_ip, mock_raylet_id(), {"CPU": 1}, {"CPU": 1})
+        lm.update(
+            worker_ip, mock_raylet_id(), {"CPU": 1}, {"CPU": 1}, DUMMY_IDLE_DURATION_S
+        )
 
         autoscaler.update()
         # TODO(rickyx): This is a hack to avoid running into race conditions
@@ -1647,90 +1652,91 @@ class AutoscalingTest(unittest.TestCase):
     # def testAggressiveAutoscalingWithForegroundLauncher(self):
     #     self._aggressiveAutoscalingHelper(foreground_node_launcher=True)
 
-    def _aggressiveAutoscalingHelper(self, foreground_node_launcher: bool = False):
-        config = copy.deepcopy(SMALL_CLUSTER)
-        config["available_node_types"]["worker"]["min_workers"] = 0
-        config["available_node_types"]["worker"]["max_workers"] = 10
-        config["max_workers"] = 10
-        config["idle_timeout_minutes"] = 0
-        config["upscaling_speed"] = config["available_node_types"]["worker"][
-            "max_workers"
-        ]
-        if foreground_node_launcher:
-            config["provider"][FOREGROUND_NODE_LAUNCH_KEY] = True
-        config_path = self.write_config(config)
+    # def _aggressiveAutoscalingHelper(self, foreground_node_launcher: bool = False):
+    #     config = copy.deepcopy(SMALL_CLUSTER)
+    #     config["available_node_types"]["worker"]["min_workers"] = 0
+    #     config["available_node_types"]["worker"]["max_workers"] = 10
+    #     config["max_workers"] = 10
+    #     config["idle_timeout_minutes"] = 0
+    #     config["upscaling_speed"] = config["available_node_types"]["worker"][
+    #         "max_workers"
+    #     ]
+    #     if foreground_node_launcher:
+    #         config["provider"][FOREGROUND_NODE_LAUNCH_KEY] = True
+    #     config_path = self.write_config(config)
 
-        self.provider = MockProvider()
-        self.provider.create_node(
-            {},
-            {
-                TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
-                TAG_RAY_USER_NODE_TYPE: "head",
-            },
-            1,
-        )
-        head_ip = self.provider.non_terminated_node_ips(
-            tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_HEAD},
-        )[0]
-        runner = MockProcessRunner()
-        runner.respond_to_call("json .Config.Env", ["[]" for i in range(11)])
-        lm = LoadMetrics()
+    #     self.provider = MockProvider()
+    #     self.provider.create_node(
+    #         {},
+    #         {
+    #             TAG_RAY_NODE_KIND: NODE_KIND_HEAD,
+    #             TAG_RAY_USER_NODE_TYPE: "head",
+    #         },
+    #         1,
+    #     )
+    #     head_ip = self.provider.non_terminated_node_ips(
+    #         tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_HEAD},
+    #     )[0]
+    #     runner = MockProcessRunner()
+    #     runner.respond_to_call("json .Config.Env", ["[]" for i in range(11)])
+    #     lm = LoadMetrics()
 
-        autoscaler = MockAutoscaler(
-            config_path,
-            lm,
-            MockGcsClient(),
-            max_launch_batch=5,
-            max_concurrent_launches=5,
-            max_failures=0,
-            process_runner=runner,
-            update_interval_s=0,
-        )
+    #     autoscaler = MockAutoscaler(
+    #         config_path,
+    #         lm,
+    #         MockGcsClient(),
+    #         max_launch_batch=5,
+    #         max_concurrent_launches=5,
+    #         max_failures=0,
+    #         process_runner=runner,
+    #         update_interval_s=0,
+    #     )
 
-        self.waitForNodes(1)
-        lm.update(
-            head_ip,
-            mock_raylet_id(),
-            {"CPU": 1},
-            {"CPU": 0},
-            waiting_bundles=[{"CPU": 1}] * 7,
-            infeasible_bundles=[{"CPU": 1}] * 3,
-        )
-        autoscaler.update()
+    #     self.waitForNodes(1)
+    #     lm.update(
+    #         head_ip,
+    #         mock_raylet_id(),
+    #         {"CPU": 1},
+    #         {"CPU": 0},
+    #         waiting_bundles=[{"CPU": 1}] * 7,
+    #         infeasible_bundles=[{"CPU": 1}] * 3,
+    #     )
+    #     autoscaler.update()
 
-        if foreground_node_launcher:
-            # No wait if node launch is blocking and happens in the foreground.
-            assert self.num_nodes() == 11
-        else:
-            self.waitForNodes(11)
-        self.worker_node_thread_check(foreground_node_launcher)
+    #     if foreground_node_launcher:
+    #         # No wait if node launch is blocking and happens in the foreground.
+    #         assert self.num_nodes() == 11
+    #     else:
+    #         self.waitForNodes(11)
+    #     self.worker_node_thread_check(foreground_node_launcher)
 
-        worker_ips = self.provider.non_terminated_node_ips(
-            tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER},
-        )
-        for ip in worker_ips:
-            # Mark workers inactive.
-            lm.last_used_time_by_ip[ip] = 0
-        # Clear the resource demands.
-        # Otherwise in "foreground launcher" mode, workers would be deleted
-        # for being idle and instantly re-created due to resource demand!
-        lm.update(
-            head_ip,
-            mock_raylet_id(),
-            {},
-            {},
-            waiting_bundles=[],
-            infeasible_bundles=[],
-        )
-        autoscaler.update()
-        self.waitForNodes(1)  # only the head node
-        # Make sure they don't get overwritten.
-        assert autoscaler.resource_demand_scheduler.node_types["head"]["resources"] == {
-            "CPU": 1
-        }
-        assert autoscaler.resource_demand_scheduler.node_types["worker"][
-            "resources"
-        ] == {"CPU": 1}
+    #     worker_ips = self.provider.non_terminated_node_ips(
+    #         tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER},
+    #     )
+    #     for ip in worker_ips:
+    #         # Mark workers inactive.
+    #         lm.last_used_time_by_ip[ip] = 0
+    #     # Clear the resource demands.
+    #     # Otherwise in "foreground launcher" mode, workers would be deleted
+    #     # for being idle and instantly re-created due to resource demand!
+    #     lm.update(
+    #         head_ip,
+    #         mock_raylet_id(),
+    #         {},
+    #         {},
+    #         waiting_bundles=[],
+    #         infeasible_bundles=[],
+    #     )
+    #     autoscaler.update()
+    #     self.waitForNodes(1)  # only the head node
+    #     # Make sure they don't get overwritten.
+    #     assert autoscaler.resource_demand_scheduler.node_types["head"]["resources"]
+    #     == {
+    #         "CPU": 1
+    #     }
+    #     assert autoscaler.resource_demand_scheduler.node_types["worker"][
+    #         "resources"
+    #     ] == {"CPU": 1}
 
     def testUnmanagedNodes(self):
         config = copy.deepcopy(SMALL_CLUSTER)
@@ -1779,8 +1785,14 @@ class AutoscalingTest(unittest.TestCase):
         autoscaler.update()
         self.waitForNodes(2)
         # This node has num_cpus=0
-        lm.update(head_ip, mock_raylet_id(), {"CPU": 1}, {"CPU": 0})
-        lm.update(unmanaged_ip, mock_raylet_id(), {"CPU": 0}, {"CPU": 0})
+        lm.update(head_ip, mock_raylet_id(), {"CPU": 1}, {"CPU": 0}, 0)
+        lm.update(
+            unmanaged_ip,
+            mock_raylet_id(),
+            {"CPU": 0},
+            {"CPU": 0},
+            DUMMY_IDLE_DURATION_S,
+        )
         autoscaler.update()
         self.waitForNodes(2)
         # 1 CPU task cannot be scheduled.
@@ -1789,6 +1801,7 @@ class AutoscalingTest(unittest.TestCase):
             mock_raylet_id(),
             {"CPU": 0},
             {"CPU": 0},
+            DUMMY_IDLE_DURATION_S,
             waiting_bundles=[{"CPU": 1}],
         )
         autoscaler.update()
@@ -1821,9 +1834,6 @@ class AutoscalingTest(unittest.TestCase):
         unmanaged_ip = self.provider.non_terminated_node_ips(
             tag_filters={TAG_RAY_NODE_KIND: "unmanaged"},
         )[0]
-        unmanaged_ip = self.provider.non_terminated_node_ips(
-            tag_filters={TAG_RAY_NODE_KIND: "unmanaged"},
-        )[0]
 
         runner = MockProcessRunner()
 
@@ -1841,8 +1851,14 @@ class AutoscalingTest(unittest.TestCase):
             update_interval_s=0,
         )
 
-        lm.update(head_ip, mock_raylet_id(), {"CPU": 1}, {"CPU": 0})
-        lm.update(unmanaged_ip, mock_raylet_id(), {"CPU": 0}, {"CPU": 0})
+        lm.update(head_ip, mock_raylet_id(), {"CPU": 1}, {"CPU": 0}, 0)
+        lm.update(
+            unmanaged_ip,
+            mock_raylet_id(),
+            {"CPU": 0},
+            {"CPU": 0},
+            DUMMY_IDLE_DURATION_S,
+        )
 
         # Note that we shouldn't autoscale here because the resource demand
         # vector is not set and target utilization fraction = 1.
@@ -1896,6 +1912,7 @@ class AutoscalingTest(unittest.TestCase):
             mock_raylet_id(),
             {"CPU": 1},
             {"CPU": 0},
+            0,
             waiting_bundles=[{"CPU": 1}] * 2,
         )
         autoscaler.update()
@@ -2096,7 +2113,7 @@ class AutoscalingTest(unittest.TestCase):
             1,
         )
         lm = LoadMetrics()
-        lm.update("172.0.0.0", mock_raylet_id(), {"CPU": 1}, {"CPU": 0})
+        lm.update("172.0.0.0", mock_raylet_id(), {"CPU": 1}, {"CPU": 0}, 0)
         mock_metrics = Mock(spec=AutoscalerPrometheusMetrics())
         autoscaler = MockAutoscaler(
             config_path,
@@ -2141,7 +2158,9 @@ class AutoscalingTest(unittest.TestCase):
         )[0]
         # Because one worker already started, the scheduler waits for its
         # resources to be updated before it launches the remaining min_workers.
-        lm.update(worker_ip, mock_raylet_id(), {"CPU": 1}, {"CPU": 1})
+        lm.update(
+            worker_ip, mock_raylet_id(), {"CPU": 1}, {"CPU": 1}, DUMMY_IDLE_DURATION_S
+        )
         autoscaler.update()
         self.waitForNodes(10, tag_filters={TAG_RAY_NODE_KIND: NODE_KIND_WORKER})
         assert mock_metrics.drain_node_exceptions.inc.call_count == 0
@@ -2432,7 +2451,7 @@ class AutoscalingTest(unittest.TestCase):
     def testFalseyLoadMetrics(self):
         lm = LoadMetrics()
         assert not lm
-        lm.update("172.0.0.0", mock_raylet_id(), {"CPU": 1}, {"CPU": 0})
+        lm.update("172.0.0.0", mock_raylet_id(), {"CPU": 1}, {"CPU": 0}, 0)
         assert lm
 
     def testRecoverUnhealthyWorkers(self):

--- a/python/ray/tests/test_autoscaling_policy.py
+++ b/python/ray/tests/test_autoscaling_policy.py
@@ -372,6 +372,7 @@ class Simulator:
                 raylet_id=node.raylet_id,
                 static_resources=node.total_resources,
                 dynamic_resources=node.available_resources,
+                node_idle_duration_s=0,
                 waiting_bundles=waiting_bundles,
                 infeasible_bundles=infeasible_bundles,
                 pending_placement_groups=placement_groups,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

In autoscaler v1,  nodes are incorrectly classified as idle based solely on their resource usage metrics. This misclassification can occur under the following conditions:
1. Tasks running on the node do not have assigned resources.
2. All tasks on the node are blocked on get or wait operations.


This will lead to the incorrect termination of nodes during downscaling.

To resolve this issue, use the `idle_duration_ms` reported by raylet instead, which already considers the aforementioned conditions. ref: https://github.com/ray-project/ray/pull/39582

### Before: NodeDiedError
![image](https://github.com/user-attachments/assets/a126af98-7950-40c4-ad43-2448f4b0d71a)
### After
![image](https://github.com/user-attachments/assets/ae5f6c74-6b7a-4684-a126-66e9a562149c)

### Reproduction Script (on local fake nodes)
- Setting: 
  head_nodes: < 10 cpus, worker nodes: 10 cpus
- Code: 
  ```
  import ray
  import time
  import os
  import random
  
  @ray.remote(max_retries=5, num_cpus=10)
  def inside_ray_task_with_outside():
      print('start inside_ray_task_with_outside')
      sleep_time = 15 
      start_time = time.perf_counter()
      while True:
          if(time.perf_counter() - start_time < sleep_time):
              time.sleep(0.001)
          else:
              break
  
  @ray.remote(max_retries=5, num_cpus=10)
  def inside_ray_task_without_outside():
      print('start inside_ray_task_without_outside task')
      sleep_time = 50 
      start_time = time.perf_counter()
      while True:
          if(time.perf_counter() - start_time < sleep_time):
              time.sleep(0.001)
          else:
              break
  
  @ray.remote(max_retries=0, num_cpus=10)
  def outside_ray_task():
      print('start outside_ray_task task')
      future_list = [inside_ray_task_with_outside.remote(), 
                          inside_ray_task_without_outside.remote()]
      ray.get(future_list)
  
  
  if __name__ == '__main__':
      ray.init()
      ray.get(outside_ray_task.remote())
  ```



## Related issue number

<!-- For example: "Closes #1234" -->
Closes #46492 
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
