### PR TITLE
[runtime env]: Integrating ROCm Systems Profiler to Ray worker process

### DIFF
--- a/python/ray/_private/runtime_env/agent/runtime_env_agent.py
+++ b/python/ray/_private/runtime_env/agent/runtime_env_agent.py
@@ -28,6 +28,7 @@ from ray._private.runtime_env.plugin import (
 )
 from ray._private.runtime_env.py_executable import PyExecutablePlugin
 from ray._private.runtime_env.py_modules import PyModulesPlugin
+from ray._private.runtime_env.rocprof_sys import RocProfSysPlugin
 from ray._private.runtime_env.uv import UvPlugin
 from ray._private.runtime_env.working_dir import WorkingDirPlugin
 from ray._raylet import GcsClient
@@ -217,6 +218,7 @@ class RuntimeEnvAgent:
         # TODO(jonathan-anyscale): change the plugin to ProfilerPlugin
         # and unify with nsight and other profilers.
         self._nsight_plugin = NsightPlugin(self._runtime_env_dir)
+        self._rocprof_sys_plugin = RocProfSysPlugin(self._runtime_env_dir)
         self._mpi_plugin = MPIPlugin()
         self._image_uri_plugin = get_image_uri_plugin_cls()(temp_dir)
 
@@ -233,6 +235,7 @@ class RuntimeEnvAgent:
             self._java_jars_plugin,
             self._container_plugin,
             self._nsight_plugin,
+            self._rocprof_sys_plugin,
             self._mpi_plugin,
             self._image_uri_plugin,
         ]

--- a/python/ray/_private/runtime_env/rocprof_sys.py
+++ b/python/ray/_private/runtime_env/rocprof_sys.py
@@ -7,9 +7,9 @@ import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+from ray._common.utils import try_to_create_directory
 from ray._private.runtime_env.context import RuntimeEnvContext
 from ray._private.runtime_env.plugin import RuntimeEnvPlugin
-from ray._common.utils import try_to_create_directory
 from ray.exceptions import RuntimeEnvSetupError
 
 default_logger = logging.getLogger(__name__)

--- a/python/ray/_private/runtime_env/rocprof_sys.py
+++ b/python/ray/_private/runtime_env/rocprof_sys.py
@@ -1,0 +1,173 @@
+import asyncio
+import copy
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from ray._private.runtime_env.context import RuntimeEnvContext
+from ray._private.runtime_env.plugin import RuntimeEnvPlugin
+from ray._common.utils import try_to_create_directory
+from ray.exceptions import RuntimeEnvSetupError
+
+default_logger = logging.getLogger(__name__)
+
+# rocprof-sys config used when runtime_env={"_rocprof_sys": "default"}
+# Refer to the following link for more information on rocprof-sys options
+# https://rocm.docs.amd.com/projects/rocprofiler-systems/en/docs-6.4.0/how-to/understanding-rocprof-sys-output.html
+ROCPROFSYS_DEFAULT_CONFIG = {
+    "env": {
+        "ROCPROFSYS_TIME_OUTPUT": "false",
+        "ROCPROFSYS_OUTPUT_PREFIX": "worker_process_%p",
+    },
+    "args": {
+        "F": "true",
+    },
+}
+
+
+def parse_rocprof_sys_config(
+    rocprof_sys_config: Dict[str, str]
+) -> Tuple[List[str], List[str]]:
+    """
+    Function to convert dictionary of rocprof-sys options into
+    rocprof-sys-python command line
+
+    The function returns:
+    - List[str]: rocprof-sys-python cmd line split into list of str
+    """
+    rocprof_sys_cmd = ["rocprof-sys-python"]
+    rocprof_sys_env = {}
+    if "args" in rocprof_sys_config:
+        # Parse rocprof-sys arg options
+        for option, option_val in rocprof_sys_config["args"].items():
+            # option standard based on
+            # https://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
+            if len(option) > 1:
+                rocprof_sys_cmd.append(f"--{option}={option_val}")
+            else:
+                rocprof_sys_cmd += [f"-{option}", option_val]
+    if "env" in rocprof_sys_config:
+        rocprof_sys_env = rocprof_sys_config["env"]
+    rocprof_sys_cmd.append("--")
+    return rocprof_sys_cmd, rocprof_sys_env
+
+
+class RocProfSysPlugin(RuntimeEnvPlugin):
+    name = "_rocprof_sys"
+
+    def __init__(self, resources_dir: str):
+        self.rocprof_sys_cmd = []
+        self.rocprof_sys_env = {}
+
+        # replace this with better way to get logs dir
+        session_dir, runtime_dir = os.path.split(resources_dir)
+        self._rocprof_sys_dir = Path(session_dir) / "logs" / "rocprof_sys"
+        try_to_create_directory(self._rocprof_sys_dir)
+
+    async def _check_rocprof_sys_script(
+        self, rocprof_sys_config: Dict[str, str]
+    ) -> Tuple[bool, str]:
+        """
+        Function to validate if rocprof_sys_config is a valid rocprof_sys profile options
+        Args:
+            rocprof_sys_config: dictionary mapping rocprof_sys option to it's value
+        Returns:
+            a tuple consists of a boolean indicating if the rocprof_sys_config
+            is valid option and an error message if the rocprof_sys_config is invalid
+        """
+
+        # use empty as rocprof_sys report test filename
+        test_folder = str(Path(self._rocprof_sys_dir) / "test")
+        rocprof_sys_cmd, rocprof_sys_env = parse_rocprof_sys_config(rocprof_sys_config)
+        rocprof_sys_env_copy = copy.deepcopy(rocprof_sys_env)
+        rocprof_sys_env_copy["ROCPROFSYS_OUTPUT_PATH"] = test_folder
+        rocprof_sys_env_copy.update(os.environ)
+        try_to_create_directory(test_folder)
+
+        # Create a test python file to run rocprof_sys
+        with open(f"{test_folder}/test.py", "w") as f:
+            f.write("import time\n")
+        try:
+            rocprof_sys_cmd = rocprof_sys_cmd + [f"{test_folder}/test.py"]
+            process = await asyncio.create_subprocess_exec(
+                *rocprof_sys_cmd,
+                env=rocprof_sys_env_copy,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            stdout, stderr = await process.communicate()
+            error_msg = stderr.strip() if stderr.strip() != "" else stdout.strip()
+
+            # cleanup temp file
+            clean_up_cmd = ["rm", "-r", test_folder]
+            cleanup_process = await asyncio.create_subprocess_exec(
+                *clean_up_cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            _, _ = await cleanup_process.communicate()
+            if process.returncode == 0:
+                return True, None
+            else:
+                return False, error_msg
+        except FileNotFoundError:
+            return False, ("rocprof_sys is not installed")
+
+    async def create(
+        self,
+        uri: Optional[str],
+        runtime_env: "RuntimeEnv",  # noqa: F821
+        context: RuntimeEnvContext,
+        logger: logging.Logger = default_logger,
+    ) -> int:
+        rocprof_sys_config = runtime_env.rocprof_sys()
+        if not rocprof_sys_config:
+            return 0
+
+        if rocprof_sys_config and sys.platform != "linux":
+            raise RuntimeEnvSetupError("rocprof-sys CLI is only available in Linux.\n")
+
+        if isinstance(rocprof_sys_config, str):
+            if rocprof_sys_config == "default":
+                rocprof_sys_config = ROCPROFSYS_DEFAULT_CONFIG
+            else:
+                raise RuntimeEnvSetupError(
+                    f"Unsupported rocprof_sys config: {rocprof_sys_config}. "
+                    "The supported config is 'default' or "
+                    "Dictionary of rocprof_sys options"
+                )
+
+        is_valid_rocprof_sys_config, error_msg = await self._check_rocprof_sys_script(
+            rocprof_sys_config
+        )
+        if not is_valid_rocprof_sys_config:
+            logger.warning(error_msg)
+            raise RuntimeEnvSetupError(
+                "rocprof-sys profile failed to run with the following "
+                f"error message:\n {error_msg}"
+            )
+        # add set output path to logs dir
+        if "env" not in rocprof_sys_config:
+            rocprof_sys_config["env"] = {}
+        rocprof_sys_config["env"]["ROCPROFSYS_OUTPUT_PATH"] = str(
+            Path(self._rocprof_sys_dir)
+        )
+
+        self.rocprof_sys_cmd, self.rocprof_sys_env = parse_rocprof_sys_config(
+            rocprof_sys_config
+        )
+        return 0
+
+    def modify_context(
+        self,
+        uris: List[str],
+        runtime_env: "RuntimeEnv",  # noqa: F821
+        context: RuntimeEnvContext,
+        logger: Optional[logging.Logger] = default_logger,
+    ):
+        logger.info("Running rocprof-sys profiler")
+        context.py_executable = " ".join(self.rocprof_sys_cmd)
+        context.env_vars.update(self.rocprof_sys_env)

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -105,11 +105,17 @@ class RemoteFunction:
         # When gpu is used, set the task non-recyclable by default.
         # https://github.com/ray-project/ray/issues/29624 for more context.
         # Note: Ray task worker process is not being reused when nsight
-        # profiler is running, as nsight generate report once the process exit.
+        # profiler is running, as nsight/rocprof-sys generate report
+        # once the process exit.
         num_gpus = self._default_options.get("num_gpus") or 0
         if (
             num_gpus > 0 and self._default_options.get("max_calls", None) is None
-        ) or "nsight" in (self._default_options.get("runtime_env") or {}):
+        ) or any(
+            [
+                s in (self._default_options.get(s) or {})
+                for s in ["nsight", "rocprof-sys"]
+            ]
+        ):
             self._default_options["max_calls"] = 1
 
         # TODO(suquark): This is a workaround for class attributes of options.

--- a/python/ray/runtime_env/runtime_env.py
+++ b/python/ray/runtime_env/runtime_env.py
@@ -272,6 +272,8 @@ class RuntimeEnv(dict):
             When a runtime env is specified by job submission API,
             only a module name (string) is allowed.
         nsight: Dictionary mapping nsight profile option name to it's value.
+        rocprof_sys: Dictionary mapping rocprof-sys profile option name and environment
+                   variables to it's value.
         config: config for runtime environment. Either
             a dict or a RuntimeEnvConfig. Field: (1) setup_timeout_seconds, the
             timeout of runtime environment creation,  timeout is in seconds.
@@ -297,6 +299,7 @@ class RuntimeEnv(dict):
         "config",
         "worker_process_setup_hook",
         "_nsight",
+        "_rocprof_sys",
         "mpi",
         "image_uri",
     }
@@ -319,6 +322,7 @@ class RuntimeEnv(dict):
         env_vars: Optional[Dict[str, str]] = None,
         worker_process_setup_hook: Optional[Union[Callable, str]] = None,
         nsight: Optional[Union[str, Dict[str, str]]] = None,
+        rocprof_sys: Optional[Union[str, Dict[str, Dict[str, str]]]] = None,
         config: Optional[Union[Dict, RuntimeEnvConfig]] = None,
         _validate: bool = True,
         mpi: Optional[Dict] = None,
@@ -343,6 +347,8 @@ class RuntimeEnv(dict):
             runtime_env["conda"] = conda
         if nsight is not None:
             runtime_env["_nsight"] = nsight
+        if rocprof_sys is not None:
+            runtime_env["_rocprof_sys"] = rocprof_sys
         if container is not None:
             runtime_env["container"] = container
         if env_vars is not None:
@@ -528,6 +534,9 @@ class RuntimeEnv(dict):
 
     def nsight(self) -> Optional[Union[str, Dict[str, str]]]:
         return self.get("_nsight", None)
+
+    def rocprof_sys(self) -> Optional[Union[str, Dict[str, Dict[str, str]]]]:
+        return self.get("_rocprof_sys", None)
 
     def env_vars(self) -> Dict:
         return self.get("env_vars", {})


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Reference https://github.com/ray-project/ray/pull/39998

ROCm Systems Profiler is an AMD profiling tool for AMD based GPUs and CPUs.

This PR adds ROCm Systems Profiler integration with Ray using runtime_env. Similar to nsight, Currently rocprof-sys-python can't profile the GPU usage from Ray tasks/actors since the processes that can be traced by rocprof-sys-python must be driver processes and it's subprocesses, whereas Ray tasks/actors are run by worker process. Thus, we added rocprof-sys-python native to runtime_env in order to modify the worker process to run with rocprof-sys-python which can produce the report for each worker processes once it exits.

Unlike nsight, since the options of ROCm Systems Profiler can be controlled by both environment variables and CLI arguments, and they are not overlapping, we introduced "env" and "args" to the flags to make this possible.

Refactoring the code so that we share the same code between nsight and ROCm Systems Profiler is also possible, but since this will introduce breaking changes to the flags design, this will need approval from the maintainers to proceed.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
