### PR TITLE
[RLlib] Fix Algorithm with tune

### DIFF
--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -75,7 +75,6 @@ from ray.rllib.utils.typing import (
 )
 from ray.tune.logger import Logger
 from ray.tune.registry import get_trainable_cls
-from ray.tune.result import TRIAL_INFO
 from ray.tune.tune import _Config
 
 Space = gym.Space
@@ -711,11 +710,6 @@ class AlgorithmConfig(_Config):
         # Modify our properties one by one.
         for key, value in config_dict.items():
             key = self._translate_special_keys(key, warn_deprecated=False)
-
-            # Ray Tune saves additional data under this magic keyword.
-            # This should not get treated as AlgorithmConfig field.
-            if key == TRIAL_INFO:
-                continue
 
             if key in ["_enable_new_api_stack"]:
                 # We've dealt with this above.


### PR DESCRIPTION
`Algorithm.__init__()` removes `TRIAL_INFO ` from the config before calling `super().__init__()`, but it's actually [needed by Trainable](https://github.com/ray-project/ray/blob/ray-2.38.0/python/ray/tune/trainable/trainable.py#L616-L618).

I noticed it because `self.trial_id` incorrectly returns `"default"` within a tune experiment. Many other tune-related properties are surely broken as well.

This PR essentially reverts a change made 2y ago: https://github.com/ray-project/ray/pull/30042, which may have solved some issue back then, but now it just causes one.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
