### PR TITLE
[Dashboard] Add memory graphs optimized for OOM debugging

### DIFF
--- a/python/ray/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/python/ray/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -150,6 +150,10 @@ const METRICS_CONFIG: MetricsSectionConfig[] = [
         pathParams: "orgId=1&theme=light&panelId=4",
       },
       {
+        title: "Node Memory Percentage (heap + object store)",
+        pathParams: "orgId=1&theme=light&panelId=48",
+      },
+      {
         title: "Node GPU (hardware utilization)",
         pathParams: "orgId=1&theme=light&panelId=8",
       },

--- a/python/ray/dashboard/modules/metrics/dashboards/default_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/default_dashboard_panels.py
@@ -282,20 +282,12 @@ DEFAULT_GRAFANA_PANELS = [
         unit="%",
         targets=[
             Target(
-                expr='ray_node_mem_used{{instance=~"$Instance", IsHeadNode="false", {global_filters}}}/ray_node_mem_total{{instance=~"$Instance", IsHeadNode="false", {global_filters}}} * 100 < 80',
-                legend="Memory Used: {{instance}} < 80%",
+                expr='ray_node_mem_used{{instance=~"$Instance", IsHeadNode="false", {global_filters}}}/ray_node_mem_total{{instance=~"$Instance", IsHeadNode="false", {global_filters}}} * 100',
+                legend="Memory Used: {{instance}}",
             ),
             Target(
-                expr='ray_node_mem_used{{instance=~"$Instance", IsHeadNode="true", {global_filters}}}/ray_node_mem_total{{instance=~"$Instance", IsHeadNode="true", {global_filters}}} * 100 < 80',
-                legend="Memory Used: {{instance}} < 80% (head)",
-            ),
-            Target(
-                expr='ray_node_mem_used{{instance=~"$Instance", IsHeadNode="false", {global_filters}}}/ray_node_mem_total{{instance=~"$Instance", IsHeadNode="false", {global_filters}}} * 100 > 80',
-                legend="Memory Used: {{instance}} > 80%",
-            ),
-            Target(
-                expr='ray_node_mem_used{{instance=~"$Instance", IsHeadNode="true", {global_filters}}}/ray_node_mem_total{{instance=~"$Instance", IsHeadNode="true", {global_filters}}} * 100 > 80',
-                legend="Memory Used: {{instance}} > 80% (head)",
+                expr='ray_node_mem_used{{instance=~"$Instance", IsHeadNode="true", {global_filters}}}/ray_node_mem_total{{instance=~"$Instance", IsHeadNode="true", {global_filters}}} * 100',
+                legend="Memory Used: {{instance}} (head)",
             ),
         ],
         fill=0,

--- a/python/ray/dashboard/modules/metrics/dashboards/default_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/default_dashboard_panels.py
@@ -276,6 +276,30 @@ DEFAULT_GRAFANA_PANELS = [
         ],
     ),
     Panel(
+        id=48,
+        title="Node Memory Percentage (heap + object store)",
+        description="The percentage of physical (hardware) memory usage for each node.",
+        unit="%",
+        targets=[
+            Target(
+                expr='ray_node_mem_used{{instance=~"$Instance", IsHeadNode="false", {global_filters}}}/ray_node_mem_total{{instance=~"$Instance", IsHeadNode="false", {global_filters}}} * 100 < 80',
+                legend="Memory Used: {{instance}} < 80%",
+            ),
+            Target(
+                expr='ray_node_mem_used{{instance=~"$Instance", IsHeadNode="true", {global_filters}}}/ray_node_mem_total{{instance=~"$Instance", IsHeadNode="true", {global_filters}}} * 100 < 80',
+                legend="Memory Used: {{instance}} < 80% (head)",
+            ),
+            Target(
+                expr='ray_node_mem_used{{instance=~"$Instance", IsHeadNode="false", {global_filters}}}/ray_node_mem_total{{instance=~"$Instance", IsHeadNode="false", {global_filters}}} * 100 > 80',
+                legend="Memory Used: {{instance}} > 80%",
+            ),
+            Target(
+                expr='ray_node_mem_used{{instance=~"$Instance", IsHeadNode="true", {global_filters}}}/ray_node_mem_total{{instance=~"$Instance", IsHeadNode="true", {global_filters}}} * 100 > 80',
+                legend="Memory Used: {{instance}} > 80% (head)",
+            ),
+        ],
+    ),
+    Panel(
         id=44,
         title="Node Out of Memory Failures by Name",
         description="The number of tasks and actors killed by the Ray Out of Memory killer due to high memory pressure. Metrics are broken down by IP and the name. https://docs.ray.io/en/master/ray-core/scheduling/ray-oom-prevention.html.",

--- a/python/ray/dashboard/modules/metrics/dashboards/default_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/default_dashboard_panels.py
@@ -298,6 +298,8 @@ DEFAULT_GRAFANA_PANELS = [
                 legend="Memory Used: {{instance}} > 80% (head)",
             ),
         ],
+        fill=0,
+        stack=False,
     ),
     Panel(
         id=44,

--- a/python/ray/dashboard/modules/metrics/grafana_dashboard_factory.py
+++ b/python/ray/dashboard/modules/metrics/grafana_dashboard_factory.py
@@ -93,6 +93,13 @@ PANEL_TEMPLATE = {
             "fill": 0,
             "stack": False,
         },
+        {
+            "$$hashKey": "object:2987",
+            "alias": "/.*> 80%.*/",
+            "fill": 0,
+            "stack": False,
+            "linewidth": 4,
+        },
     ],
     "spaceLength": 10,
     "stack": True,

--- a/python/ray/dashboard/modules/metrics/grafana_dashboard_factory.py
+++ b/python/ray/dashboard/modules/metrics/grafana_dashboard_factory.py
@@ -93,13 +93,6 @@ PANEL_TEMPLATE = {
             "fill": 0,
             "stack": False,
         },
-        {
-            "$$hashKey": "object:2987",
-            "alias": "/.*> 80%.*/",
-            "fill": 0,
-            "stack": False,
-            "linewidth": 4,
-        },
     ],
     "spaceLength": 10,
     "stack": True,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The current graph shows memory usage of each node along side the MAX memory across the cluster.
For oom debugging, we care more about memory utilization (percentage) on each node. 

<img width="504" alt="image" src="https://github.com/user-attachments/assets/a3d9138d-1b32-4e73-9602-7622a4a4d46f">

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #47007
## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
