### PR TITLE
[Core] Fix Ascend NPU discovery to support 8+ cards per node

### DIFF
--- a/python/ray/_private/accelerators/npu.py
+++ b/python/ray/_private/accelerators/npu.py
@@ -60,7 +60,7 @@ class NPUAcceleratorManager(AcceleratorManager):
             logger.debug("Could not import AscendCL: %s", e)
 
         try:
-            npu_files = glob.glob("/dev/davinci?")
+            npu_files = glob.glob("/dev/davinci[0-9]*")
             return len(npu_files)
         except Exception as e:
             logger.debug("Failed to detect number of NPUs: %s", e)

--- a/python/ray/tests/accelerators/test_npu.py
+++ b/python/ray/tests/accelerators/test_npu.py
@@ -11,8 +11,8 @@ from ray._private.accelerators import NPUAcceleratorManager as Accelerator
 def test_autodetect_num_npus(mock_glob):
     with patch.dict(sys.modules):
         sys.modules["acl"] = None
-        mock_glob.return_value = [f"/dev/davinci{i}" for i in range(4)]
-        assert Accelerator.get_current_node_num_accelerators() == 4
+        mock_glob.return_value = [f"/dev/davinci{i}" for i in range(64)]
+        assert Accelerator.get_current_node_num_accelerators() == 64
 
 
 @patch("glob.glob")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR resolves an issue in NPU device discovery, enabling support for 8+ cards per node. The test case has been updated to cover the maximum number of cards.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
