### PR TITLE
[train] fix StartTracebackWithWorkerRank serialization

### DIFF
--- a/python/ray/air/_internal/util.py
+++ b/python/ray/air/_internal/util.py
@@ -40,6 +40,9 @@ class StartTracebackWithWorkerRank(StartTraceback):
         super().__init__()
         self.worker_rank = worker_rank
 
+    def __reduce__(self):
+        return (self.__class__, (self.worker_rank,))
+
 
 def skip_exceptions(exc: Optional[Exception]) -> Exception:
     """Skip all contained `StartTracebacks` to reduce traceback output.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

**Repro:**
```python
import ray
from ray.air._internal.util import StartTracebackWithWorkerRank

e = StartTracebackWithWorkerRank(worker_rank=0)

raise ray.get(ray.put(e))
```

**Before:**
```
Traceback (most recent call last):
  File "/home/ray/anaconda3/lib/python3.12/site-packages/ray/_private/serialization.py", line 460, in deserialize_objects
    obj = self._deserialize_object(data, metadata, object_ref)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.12/site-packages/ray/_private/serialization.py", line 317, in _deserialize_object
    return self._deserialize_msgpack_data(data, metadata_fields)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.12/site-packages/ray/_private/serialization.py", line 272, in _deserialize_msgpack_data
    python_objects = self._deserialize_pickle5_data(pickle5_data)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.12/site-packages/ray/_private/serialization.py", line 262, in _deserialize_pickle5_data
    obj = pickle.loads(in_band)
          ^^^^^^^^^^^^^^^^^^^^^
TypeError: StartTracebackWithWorkerRank.__init__() missing 1 required positional argument: 'worker_rank'
Traceback (most recent call last):
  File "/home/ray/default/repro.py", line 8, in <module>
    raise ray.get(ray.put(e))
          ^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.12/site-packages/ray/_private/auto_init_hook.py", line 21, in auto_init_wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.12/site-packages/ray/_private/client_mode_hook.py", line 103, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.12/site-packages/ray/_private/worker.py", line 2745, in get
    values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.12/site-packages/ray/_private/worker.py", line 903, in get_objects
    raise value
ray.exceptions.RaySystemError: System error: StartTracebackWithWorkerRank.__init__() missing 1 required positional argument: 'worker_rank'
traceback: Traceback (most recent call last):
  File "/home/ray/anaconda3/lib/python3.12/site-packages/ray/_private/serialization.py", line 460, in deserialize_objects
    obj = self._deserialize_object(data, metadata, object_ref)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.12/site-packages/ray/_private/serialization.py", line 317, in _deserialize_object
    return self._deserialize_msgpack_data(data, metadata_fields)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.12/site-packages/ray/_private/serialization.py", line 272, in _deserialize_msgpack_data
    python_objects = self._deserialize_pickle5_data(pickle5_data)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.12/site-packages/ray/_private/serialization.py", line 262, in _deserialize_pickle5_data
    obj = pickle.loads(in_band)
          ^^^^^^^^^^^^^^^^^^^^^
TypeError: StartTracebackWithWorkerRank.__init__() missing 1 required positional argument: 'worker_rank'
```

**After:**
```
Traceback (most recent call last):
  File "/home/ray/default/repro.py", line 8, in <module>
    raise ray.get(ray.put(e))
ray.air._internal.util.StartTracebackWithWorkerRank
```

**Reference:** https://docs.ray.io/en/latest/ray-core/objects/serialization.html#customized-serialization


## Related issue number

<!-- For example: "Closes #1234" -->
https://ray.slack.com/archives/CSX7HVB5L/p1730743351630549

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
