### PR TITLE
[docs] fix typo in fault-tolerance production guide

### DIFF
--- a/doc/source/serve/production-guide/fault-tolerance.md
+++ b/doc/source/serve/production-guide/fault-tolerance.md
@@ -590,9 +590,9 @@ $ python
 383
 ```
 
-### HTTPProxy failure
+### Proxy failure
 
-You can simulate HTTPProxy failures by manually killing `ProxyActor` actors. If you're running KubeRay, make sure to `exec` into a Ray pod before running these commands.
+You can simulate Proxy failures by manually killing `ProxyActor` actors. If you're running KubeRay, make sure to `exec` into a Ray pod before running these commands.
 
 ```console
 $ ray summary actors

--- a/doc/source/serve/production-guide/fault-tolerance.md
+++ b/doc/source/serve/production-guide/fault-tolerance.md
@@ -592,7 +592,7 @@ $ python
 
 ### HTTPProxy failure
 
-You can simulate HTTPProxy failures by manually killing HTTPProxy actors. If you're running KubeRay, make sure to `exec` into a Ray pod before running these commands.
+You can simulate HTTPProxy failures by manually killing `ProxyActor` actors. If you're running KubeRay, make sure to `exec` into a Ray pod before running these commands.
 
 ```console
 $ ray summary actors

--- a/doc/source/serve/production-guide/fault-tolerance.md
+++ b/doc/source/serve/production-guide/fault-tolerance.md
@@ -592,7 +592,7 @@ $ python
 
 ### HTTPProxy failure
 
-You can simulate HTTPProxy failures by manually killing deployment replicas. If you're running KubeRay, make sure to `exec` into a Ray pod before running these commands.
+You can simulate HTTPProxy failures by manually killing HTTPProxy actors. If you're running KubeRay, make sure to `exec` into a Ray pod before running these commands.
 
 ```console
 $ ray summary actors


### PR DESCRIPTION
Fixes a very small misstatement in the serve fault-tolerance docs guide 