### PR TITLE
[core][autoscaler] Remove local dependencies on Ray for KubeRay autoscaling e2e tests

### DIFF
--- a/python/ray/tests/kuberay/README.md
+++ b/python/ray/tests/kuberay/README.md
@@ -24,6 +24,7 @@ together run these things for you.
 3. Finally, make sure that the `Dockerfile` is using the same python version as
    what you're using to run the test. By default, this dockerfile is built using
    the `rayproject/ray:nightly-py310` build.
+4. Modify `EXAMPLE_CLUSTER_PATH` in `test_autoscaling_e2e.py`.
 
 Now you're ready to run the test.
 

--- a/python/ray/tests/kuberay/scripts/scale_up_custom.py
+++ b/python/ray/tests/kuberay/scripts/scale_up_custom.py
@@ -1,9 +1,4 @@
-import os
-
-import pytest
-
 import ray
-
 import time
 
 
@@ -13,10 +8,6 @@ def main():
     Also, validates runtime env data submitted with the Ray Job that executes
     this script.
     """
-    # The next two lines validate the runtime env in which this code runs.
-    # (See the function ray_job_submit() in tests/kuberay/utils.py)
-    assert pytest.__version__ == "6.0.0"
-    assert os.getenv("key_foo") == "value_bar"
 
     # Workers and head are annotated as having 5 "Custom2" capacity each,
     # so this should trigger upscaling of two workers.

--- a/python/ray/tests/kuberay/utils.py
+++ b/python/ray/tests/kuberay/utils.py
@@ -12,9 +12,6 @@ from typing import Any, Dict, Generator, List, Optional
 import yaml
 import os
 
-import ray
-from ray.job_submission import JobStatus, JobSubmissionClient
-
 
 logger = logging.getLogger(__name__)
 
@@ -426,88 +423,6 @@ def _kubectl_port_forward(
         yield local_port
     finally:
         terminate_process()
-
-
-@contextlib.contextmanager
-def ray_client_port_forward(
-    head_service: str,
-    k8s_namespace: str = "default",
-    ray_namespace: Optional[str] = None,
-    ray_client_port: int = 10001,
-):
-    """Context manager which manages a Ray client connection using kubectl port-forward.
-
-    Args:
-        head_service: The name of the Ray head K8s service.
-        k8s_namespace: K8s namespace the Ray cluster belongs to.
-        ray_namespace: The Ray namespace to connect to.
-        ray_client_port: The port on which the Ray head is running the Ray client
-            server.
-    """
-    with _kubectl_port_forward(
-        service=head_service, namespace=k8s_namespace, target_port=ray_client_port
-    ) as local_port:
-        with ray.init(f"ray://127.0.0.1:{local_port}", namespace=ray_namespace):
-            yield
-
-
-def ray_job_submit(
-    script_name: str,
-    head_service: str,
-    k8s_namespace: str = "default",
-    ray_dashboard_port: int = 8265,
-) -> str:
-    """Submits a Python script via the Ray Job Submission API, using the Python SDK.
-    Waits for successful completion of the job and returns the job logs as a string.
-
-    Uses `kubectl port-forward` to access the Ray head's dashboard port.
-
-    Scripts live in `tests/kuberay/scripts`. This directory is used as the working
-    dir for the job.
-
-    Args:
-        script_name: The name of the script to submit.
-        head_service: The name of the Ray head K8s service.
-        k8s_namespace: K8s namespace the Ray cluster belongs to.
-        ray_dashboard_port: The port on which the Ray head is running the Ray dashboard.
-    """
-    with _kubectl_port_forward(
-        service=head_service, namespace=k8s_namespace, target_port=ray_dashboard_port
-    ) as local_port:
-        # It takes a bit of time to establish the connection.
-        # Try a few times to instantiate the JobSubmissionClient, as the client's
-        # instantiation does not retry on connection errors.
-        for trie in range(1, 7):
-            time.sleep(5)
-            try:
-                client = JobSubmissionClient(f"http://127.0.0.1:{local_port}")
-            except ConnectionError as e:
-                if trie < 6:
-                    logger.info("Job client connection failed. Retrying in 5 seconds.")
-                else:
-                    raise e from None
-        job_id = client.submit_job(
-            entrypoint=f"python {script_name}",
-            runtime_env={
-                "working_dir": SCRIPTS_DIR,
-                # Throw in some extra data for fun, to validate runtime envs.
-                "pip": ["pytest==6.0.0"],
-                "env_vars": {"key_foo": "value_bar"},
-            },
-        )
-        # Wait for the job to complete successfully.
-        # This logic is copied from the Job Submission docs.
-        start = time.time()
-        timeout = 60
-        while time.time() - start <= timeout:
-            status = client.get_job_status(job_id)
-            print(f"status: {status}")
-            if status in {JobStatus.SUCCEEDED, JobStatus.STOPPED, JobStatus.FAILED}:
-                break
-            time.sleep(5)
-
-        assert status == JobStatus.SUCCEEDED
-        return client.get_job_logs(job_id)
 
 
 def kubectl_patch(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It’s challenging to run KubeRay autoscaling e2e tests locally because:

1. Ray needs to be compiled before running the tests.
2. The local Python version must match the Python version in the image.
3. The Ray commit must match the Ray commit in the image.
4. If we use port forwarding along with JobSubmission or the Ray client to run Ray applications, certain dependencies are required in the local environment.

This PR removes (2)(3)(4) by always executing commands via `kubectl exec`.

The functionalities of `JobSubmission` and Ray client should not be tested by KubeRay.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
