### PR TITLE
[docs] typo, attempt #2

### DIFF
--- a/doc/source/cluster/kubernetes/examples/rayjob-kueue-gang-scheduling.md
+++ b/doc/source/cluster/kubernetes/examples/rayjob-kueue-gang-scheduling.md
@@ -55,7 +55,7 @@ gcloud container node-pools create gpu-node-pool \
   --machine-type g2-standard-4
 ```
 
-This command creates a node pool which initially has zero nodes.
+This command creates a node pool, which initially has zero nodes.
 The `--enable-queued-provisioning` flag enables "queued provisioning" in the Kubernetes node autoscaler using the ProvisioningRequest API. More details are below.
 You need to use the `--reservation-affinity=none` flag because GKE doesn't support Node Reservations with ProvisioningRequest.
 


### PR DESCRIPTION
missing comma related to #48564
Had to try again because @can-anyscale suspects a rare ReadTheDocs failure and there's no easy way to kick off a rebuild from the browser.

