### PR TITLE
[Data] Don't test against schema order for `test_parquet_read_partitioned_with_partition_filter` 

### DIFF
--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -620,15 +620,13 @@ def test_parquet_read_partitioned_with_partition_filter(
         ),
     )
 
-    assert ds.schema() == Schema(
-        pa.schema(
-            [
-                ("x", pa.string()),
-                ("y", pa.string()),
-                ("z", pa.float64()),
-            ]
-        )
-    )
+    # Where we insert partition columns is an implementation detail, so we don't check
+    # the order of the columns.
+    assert sorted(zip(ds.schema().names, ds.schema().types)) == [
+        ("x", pa.string()),
+        ("y", pa.string()),
+        ("z", pa.float64()),
+    ]
 
     values = [[s["x"], s["y"], s["z"]] for s in ds.take()]
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Where we insert partition columns in an implementation detail. So, this PR updates the test to not check for a specific schema order.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
