### PR TITLE
[Docs][KubeRay] Add doc for using RayJob with existing RayCluster

### DIFF
--- a/doc/source/cluster/kubernetes/getting-started/rayjob-quick-start.md
+++ b/doc/source/cluster/kubernetes/getting-started/rayjob-quick-start.md
@@ -28,6 +28,7 @@ To understand the following content better, you should understand the difference
 
 * RayCluster configuration
   * `rayClusterSpec` - Defines the **RayCluster** custom resource to run the Ray job on.
+  * `clusterSelector` - Use existing **RayCluster** custom resources to run the Ray job instead of creating a new one. See [ray-job.use-existing-raycluster.yaml](https://github.com/ray-project/kuberay/blob/master/ray-operator/config/samples/ray-job.use-existing-raycluster.yaml) for example configurations.
 * Ray job configuration
   * `entrypoint` - The submitter runs `ray job submit --address ... --submission-id ... -- $entrypoint` to submit a Ray job to the RayCluster.
   * `runtimeEnvYAML` (Optional): A runtime environment that describes the dependencies the Ray job needs to run, including files, packages, environment variables, and more. Provide the configuration as a multi-line YAML string.


### PR DESCRIPTION

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The `clusterSelector` config on `RayJob` spec is not well-documented. So this PR document it.

Sample yaml file is added in https://github.com/ray-project/kuberay/pull/2505

## Related issue number

<!-- For example: "Closes #1234" -->
Closes ray-project/kuberay#2429

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
