### PR TITLE
[DRAFT] [RFC] Initial physical mode implementation scratch code

### DIFF
--- a/python/ray/_private/runtime_env/BUILD
+++ b/python/ray/_private/runtime_env/BUILD
@@ -6,3 +6,16 @@ py_library(
     name = "validation",
     srcs = ["validation.py"],
 )
+
+py_library(
+    name = "physical_mode_context",
+    srcs = ["physical_mode_context.py"],
+)
+
+py_library(
+    name = "physical_mode_execution_utils",
+    srcs = ["physical_mode_execution_utils.py"],
+    deps = [
+        ":physical_mode_context",
+    ],
+)

--- a/python/ray/_private/runtime_env/agent/runtime_env_agent.py
+++ b/python/ray/_private/runtime_env/agent/runtime_env_agent.py
@@ -513,6 +513,7 @@ class RuntimeEnvAgent:
                 creation_time_ms,
             )
             # Reply the RPC
+            # TODO(hjiang): Fill in physical mode execution context in response.
             return runtime_env_agent_pb2.GetOrCreateRuntimeEnvReply(
                 status=agent_manager_pb2.AGENT_RPC_STATUS_OK
                 if successful
@@ -521,6 +522,7 @@ class RuntimeEnvAgent:
                 error_message=error_message,
             )
 
+    # TODO(hjiang): Delete cgroup is necessary.
     async def DeleteRuntimeEnvIfPossible(self, request):
         self._logger.info(
             f"Got request from {request.source_process} to decrease "

--- a/python/ray/_private/runtime_env/agent/runtime_env_agent.py
+++ b/python/ray/_private/runtime_env/agent/runtime_env_agent.py
@@ -361,7 +361,8 @@ class RuntimeEnvAgent:
             Args:
                 runtime_env: The instance of RuntimeEnv class.
                 serialized_runtime_env: The serialized runtime env.
-                setup_timeout_seconds: The timeout of runtime environment creation.
+                setup_timeout_seconds: The timeout of runtime environment creation for
+                each attempt.
 
             Returns:
                 a tuple which contains result (bool), runtime env context (str), error

--- a/python/ray/_private/runtime_env/physical_mode_context.py
+++ b/python/ray/_private/runtime_env/physical_mode_context.py
@@ -1,0 +1,34 @@
+"""Context for physial mode execution.
+
+Refer to design doc:
+https://docs.google.com/document/d/1oNG1U3FZhTO2o876M_UJm0IwA_QSfYNZ9ep4087Yjgc/edit?tab=t.0
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class PhysicalModeExecutionContext:
+    """Specs for physical mode execution."""
+
+    # Memory related spec.
+    #
+    # Whether this particular memory context is shared with other processes.
+    # As the initial version, we only supports two forms:
+    # 1. Exclusive, which means we place one process into a cgroup control memory usage
+    # 2. Shared, which means a bunch of processes are grouped into one cgroup.
+    # UUID here is to indicate cgroup path, it's necessary to enable cgroup-based
+    # memory control.
+    memory_cgroup_uuid: str = None
+    # Unit: bytes. Corresponds to cgroup V2 `memory.high`, which is used to trigger
+    # reclamation for unreferenced memory.
+    high_memory: int = None
+    # Unit: bytes. Corresponds to cgroup V2 `memory.max`, which enforces hard cap on
+    # max memory consumption.
+    max_memory: int = None
+    # Unit: bytes. Corresponds to cgroup V2 `memory.low`, which is used to prevent
+    # reclamation for unreferenced memory.
+    low_memory: int = None
+    # Unit: bytes. Corresponds to cgroup V2 `memory.min`, which enforces hard cap on
+    # min memory reservation.
+    min_memory: int = None

--- a/python/ray/_private/runtime_env/physical_mode_execution_utils.py
+++ b/python/ray/_private/runtime_env/physical_mode_execution_utils.py
@@ -1,0 +1,64 @@
+"""A few util functions for physical mode execution.
+
+NOTE:
+1. It should be only used under linux environment; for other platforms, all functions
+are no-op.
+2. It assumes cgroup v2 has been mounted.
+"""
+# TODO(hjiang):
+# 1. Consider whether we need to support V1.
+# 2. Check the existence for cgroup V2.
+
+from ray._private.runtime_env import physical_mode_context
+
+import sys
+import os
+
+
+def setup_cgroup_for_memory(
+    physical_exec_ctx: physical_mode_context.PhysicalModeExecutionContext,
+) -> None:
+    """Setup cgroup for memory consumption."""
+    if not physical_exec_ctx.memory_cgroup_uuid:
+        return True
+
+    cgroup_path = f"/sys/fs/cgroup/{physical_exec_ctx.memory_cgroup_uuid}"
+    os.makedirs(cgroup_path, exist_ok=True)
+    pid = os.getpid()
+
+    with open(f"{cgroup_path}/cgroup.procs", "w") as f:
+        f.write(str(pid))
+
+    if physical_exec_ctx.low_memory:
+        with open(f"{cgroup_path}/memory.low", "w") as f:
+            f.write(str(physical_exec_ctx.low_memory))
+
+    if physical_exec_ctx.min_memory:
+        with open(f"{cgroup_path}/memory.min", "w") as f:
+            f.write(str(physical_exec_ctx.min_memory))
+
+    if physical_exec_ctx.high_memory:
+        with open(f"{cgroup_path}/memory.high", "w") as f:
+            f.write(str(physical_exec_ctx.high_memory))
+
+    if physical_exec_ctx.max_memory:
+        with open(f"{cgroup_path}/memory.max", "w") as f:
+            f.write(str(physical_exec_ctx.max_memory))
+
+    return True
+
+
+def setup_cgroup(
+    physical_exec_ctx: physical_mode_context.PhysicalModeExecutionContext,
+) -> bool:
+    """Setup cgroup for the partcular execution context.
+
+    If an error happens, the function will log the error and return False.
+    """
+    if sys.platform == "win32":
+        return True
+
+    if not setup_cgroup_for_memory:
+        return False
+
+    return True

--- a/python/ray/_private/runtime_env/physical_mode_execution_utils_test.py
+++ b/python/ray/_private/runtime_env/physical_mode_execution_utils_test.py
@@ -1,0 +1,86 @@
+import uuid
+import pytest
+from datetime import datetime
+import sys
+import os
+
+_TIMES = 100000
+
+
+class PhysicalModeExecutionContext:
+    """Specs for physical mode execution."""
+
+    # Memory related spec.
+    #
+    # Whether this particular memory context is shared with other processes.
+    # As the initial version, we only supports two forms:
+    # 1. Exclusive, which means we place one process into a cgroup control memory usage
+    # 2. Shared, which means a bunch of processes are grouped into one cgroup.
+    # UUID here is to indicate cgroup path, it's necessary to enable cgroup-based
+    # memory control.
+    memory_cgroup_uuid: str = None
+    # Unit: bytes. Corresponds to cgroup V2 `memory.high`, which is used to trigger
+    # reclamation for unreferenced memory.
+    high_memory: int = None
+    # Unit: bytes. Corresponds to cgroup V2 `memory.max`, which enforces hard cap on
+    # max memory consumption.
+    max_memory: int = None
+    # Unit: bytes. Corresponds to cgroup V2 `memory.low`, which is used to prevent
+    # reclamation for unreferenced memory.
+    low_memory: int = None
+    # Unit: bytes. Corresponds to cgroup V2 `memory.min`, which enforces hard cap on
+    # min memory reservation.
+    min_memory: int = None
+
+
+def setup_cgroup_for_memory(
+    physical_exec_ctx: PhysicalModeExecutionContext,
+) -> None:
+    """Setup cgroup for memory consumption."""
+    if not physical_exec_ctx.memory_cgroup_uuid:
+        return True
+
+    cgroup_path = f"/sys/fs/cgroup/{physical_exec_ctx.memory_cgroup_uuid}"
+    os.makedirs(cgroup_path, exist_ok=True)
+    pid = os.getpid()
+
+    with open(f"{cgroup_path}/cgroup.procs", "w") as f:
+        f.write(str(pid))
+
+    if physical_exec_ctx.low_memory:
+        with open(f"{cgroup_path}/memory.low", "w") as f:
+            f.write(str(physical_exec_ctx.low_memory))
+
+    if physical_exec_ctx.min_memory:
+        with open(f"{cgroup_path}/memory.min", "w") as f:
+            f.write(str(physical_exec_ctx.min_memory))
+
+    if physical_exec_ctx.high_memory:
+        with open(f"{cgroup_path}/memory.high", "w") as f:
+            f.write(str(physical_exec_ctx.high_memory))
+
+    if physical_exec_ctx.max_memory:
+        with open(f"{cgroup_path}/memory.max", "w") as f:
+            f.write(str(physical_exec_ctx.max_memory))
+
+    return True
+
+
+class TestRuntime:
+    def test_runtime(self):
+        current_timestamp = datetime.now().timestamp()
+        print(current_timestamp)
+
+        for _ in range(_TIMES):
+            unique_id = uuid.uuid4()
+            ctx = PhysicalModeExecutionContext()
+            ctx.memory_cgroup_uuid = unique_id
+            ctx.high_memory = 1024 * 1024
+            setup_cgroup_for_memory(ctx)
+
+        current_timestamp = datetime.now().timestamp()
+        print(current_timestamp)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-vv", __file__]))

--- a/src/ray/protobuf/runtime_env_agent.proto
+++ b/src/ray/protobuf/runtime_env_agent.proto
@@ -23,7 +23,7 @@ import "src/ray/protobuf/agent_manager.proto";
 
 message GetOrCreateRuntimeEnvRequest {
   /// Json serialized [RuntimeEnv].
-  /// For details, checkout "//python/ray/_private/runtime_env/runtime_env.py".
+  /// For details, checkout "//python/ray/runtime_env/runtime_env.py".
   string serialized_runtime_env = 1;
 
   RuntimeEnvConfig runtime_env_config = 2;

--- a/src/ray/protobuf/runtime_env_agent.proto
+++ b/src/ray/protobuf/runtime_env_agent.proto
@@ -31,6 +31,10 @@ message GetOrCreateRuntimeEnvRequest {
   /// For details, checkout "//src/ray/common/id.h".
   bytes job_id = 3;
   string source_process = 4;
+
+  /// A UUID used to indicate a unique context for physical mode execution in control of memory.
+  /// The UUID should be the same as [DeleteRuntimeEnvIfPossibleRequest].
+  string physical_mode_execution_context_uuid_memory = 5;
 }
 
 message GetOrCreateRuntimeEnvReply {
@@ -45,6 +49,10 @@ message DeleteRuntimeEnvIfPossibleRequest {
   /// Json serialized [RuntimeEnv].
   string serialized_runtime_env = 1;
   string source_process = 2;
+
+  /// A UUID used to indicate a unique context for physical mode execution in control of memory.
+  /// The UUID should be the same as [DeleteRuntimeEnvIfPossibleRequest].
+  string physical_mode_execution_context_memory_uuid_memory = 3;
 }
 
 message DeleteRuntimeEnvIfPossibleReply {

--- a/src/ray/protobuf/runtime_env_agent.proto
+++ b/src/ray/protobuf/runtime_env_agent.proto
@@ -22,8 +22,13 @@ import "src/ray/protobuf/runtime_env_common.proto";
 import "src/ray/protobuf/agent_manager.proto";
 
 message GetOrCreateRuntimeEnvRequest {
+  /// Json serialized [RuntimeEnv].
+  /// For details, checkout "//python/ray/_private/runtime_env/runtime_env.py".
   string serialized_runtime_env = 1;
+
   RuntimeEnvConfig runtime_env_config = 2;
+  /// Hex format of [JobId].
+  /// For details, checkout "//src/ray/common/id.h".
   bytes job_id = 3;
   string source_process = 4;
 }
@@ -31,10 +36,13 @@ message GetOrCreateRuntimeEnvRequest {
 message GetOrCreateRuntimeEnvReply {
   AgentRpcStatus status = 1;
   string error_message = 2;
+  /// Json serialized [RuntimeEnvContext].
+  /// For details, checkeout "//python/ray/_private/runtime_env/context.py".
   string serialized_runtime_env_context = 3;
 }
 
 message DeleteRuntimeEnvIfPossibleRequest {
+  /// Json serialized [RuntimeEnv].
   string serialized_runtime_env = 1;
   string source_process = 2;
 }

--- a/src/ray/raylet/runtime_env_agent_client.cc
+++ b/src/ray/raylet/runtime_env_agent_client.cc
@@ -235,7 +235,7 @@ class SessionPool {
         this->remove_session_from_running(session);
       });
     } else {
-      pending_sessions_.push(session);
+      pending_sessions_.emplace(std::move(session));
     }
   }
 
@@ -244,10 +244,10 @@ class SessionPool {
   // enqueue one.
   void remove_session_from_running(std::shared_ptr<Session> session) {
     running_sessions_.erase(session);
-    if (pending_sessions_.size() > 0) {
-      auto pending = pending_sessions_.front();
+    if (!pending_sessions_.empty()) {
+      auto pending = std::move(pending_sessions_.front());
       pending_sessions_.pop();
-      enqueue(pending);
+      enqueue(std::move(pending));
     }
   }
 
@@ -281,7 +281,7 @@ class HttpRuntimeEnvAgentClient : public RuntimeEnvAgentClient {
         shutdown_raylet_gracefully_(shutdown_raylet_gracefully),
         agent_register_timeout_ms_(agent_register_timeout_ms),
         agent_manager_retry_interval_ms_(agent_manager_retry_interval_ms) {}
-  ~HttpRuntimeEnvAgentClient() = default;
+  ~HttpRuntimeEnvAgentClient() override = default;
 
   template <typename T>
   using SuccCallback = std::function<void(T)>;
@@ -436,7 +436,7 @@ class HttpRuntimeEnvAgentClient : public RuntimeEnvAgentClient {
           }
         },
         fail_callback);
-    session_pool_.enqueue(session);
+    session_pool_.enqueue(std::move(session));
   }
 
   // Making HTTP call.
@@ -448,7 +448,7 @@ class HttpRuntimeEnvAgentClient : public RuntimeEnvAgentClient {
         [=](SuccCallback<rpc::DeleteRuntimeEnvIfPossibleReply> succ_callback,
             FailCallback fail_callback) {
           return TryDeleteRuntimeEnvIfPossible(
-              serialized_runtime_env, succ_callback, fail_callback);
+              serialized_runtime_env, std::move(succ_callback), std::move(fail_callback));
         },
         /*succ_callback=*/
         [=](rpc::DeleteRuntimeEnvIfPossibleReply reply) {
@@ -503,7 +503,7 @@ class HttpRuntimeEnvAgentClient : public RuntimeEnvAgentClient {
           }
         },
         fail_callback);
-    session_pool_.enqueue(session);
+    session_pool_.enqueue(std::move(session));
   }
 
  private:

--- a/src/ray/raylet/runtime_env_agent_client.h
+++ b/src/ray/raylet/runtime_env_agent_client.h
@@ -58,7 +58,7 @@ class RuntimeEnvAgentClient {
       uint32_t agent_manager_retry_interval_ms =
           RayConfig::instance().agent_manager_retry_interval_ms());
 
-  virtual ~RuntimeEnvAgentClient() {}
+  virtual ~RuntimeEnvAgentClient() = default;
 
   /// Request agent to increase the runtime env reference. This API is not idempotent. The
   /// client automatically retries on network errors.

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -1656,12 +1656,10 @@ void WorkerPool::GetOrCreateRuntimeEnv(const std::string &serialized_runtime_env
       job_id,
       serialized_runtime_env,
       runtime_env_config,
-      [job_id,
-       serialized_runtime_env = std::move(serialized_runtime_env),
-       runtime_env_config = std::move(runtime_env_config),
-       callback](bool successful,
-                 const std::string &serialized_runtime_env_context,
-                 const std::string &setup_error_message) {
+      [job_id, serialized_runtime_env, runtime_env_config, callback](
+          bool successful,
+          const std::string &serialized_runtime_env_context,
+          const std::string &setup_error_message) {
         if (successful) {
           callback(true, serialized_runtime_env_context, "");
         } else {
@@ -1669,7 +1667,9 @@ void WorkerPool::GetOrCreateRuntimeEnv(const std::string &serialized_runtime_env
                            << ".";
           RAY_LOG(DEBUG) << "Runtime env for job " << job_id << ": "
                          << serialized_runtime_env;
-          callback(false, "", setup_error_message);
+          callback(/*successful=*/false,
+                   /*serialized_runtime_env_context=*/"",
+                   /*setup_error_message=*/setup_error_message);
         }
       });
 }

--- a/src/ray/util/BUILD
+++ b/src/ray/util/BUILD
@@ -49,3 +49,11 @@ cc_library(
     srcs = ["thread_checker.cc"],
     visibility = ["//visibility:public"],
 )
+
+cc_binary(
+    name = "cgroup_utils",
+    srcs = ["cgroup_utils.cc"],
+    deps = [
+        "@com_google_absl//absl/strings:str_format",
+    ],
+)

--- a/src/ray/util/cgroup_utils.cc
+++ b/src/ray/util/cgroup_utils.cc
@@ -1,0 +1,106 @@
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include "absl/strings/str_format.h"
+
+const int TIMES = 100000;
+
+class PhysicalModeExecutionContext {
+ public:
+  std::string memory_cgroup_uuid = "";
+  long long high_memory = 0;
+  long long max_memory = 0;
+  long long low_memory = 0;
+  long long min_memory = 0;
+};
+
+bool setup_cgroup_for_memory(PhysicalModeExecutionContext &physical_exec_ctx) {
+  if (physical_exec_ctx.memory_cgroup_uuid.empty()) {
+    return true;
+  }
+
+  std::string cgroup_path = "/sys/fs/cgroup/" + physical_exec_ctx.memory_cgroup_uuid;
+
+  try {
+    std::filesystem::create_directories(cgroup_path);
+  } catch (const std::exception &e) {
+    std::cerr << "Error creating cgroup directory: " << e.what() << std::endl;
+    return false;
+  }
+
+  pid_t pid = getpid();
+
+  std::ofstream cgroup_procs(cgroup_path + "/cgroup.procs");
+  if (cgroup_procs.is_open()) {
+    cgroup_procs << pid;
+  } else {
+    std::cerr << "Failed to open cgroup.procs" << std::endl;
+    return false;
+  }
+
+  // if (physical_exec_ctx.low_memory > 0) {
+  //     std::ofstream low_memory(cgroup_path + "/memory.low");
+  //     if (low_memory.is_open()) {
+  //         low_memory << physical_exec_ctx.low_memory;
+  //     }
+  // }
+
+  // if (physical_exec_ctx.min_memory > 0) {
+  //     std::ofstream min_memory(cgroup_path + "/memory.min");
+  //     if (min_memory.is_open()) {
+  //         min_memory << physical_exec_ctx.min_memory;
+  //     }
+  // }
+
+  // if (physical_exec_ctx.high_memory > 0) {
+  //     std::ofstream high_memory(cgroup_path + "/memory.high");
+  //     if (high_memory.is_open()) {
+  //         high_memory << physical_exec_ctx.high_memory;
+  //     }
+  // }
+
+  if (physical_exec_ctx.max_memory > 0) {
+    std::ofstream max_memory(cgroup_path + "/memory.max");
+    if (max_memory.is_open()) {
+      max_memory << physical_exec_ctx.max_memory;
+    }
+  }
+
+  return true;
+}
+
+void test_runtime() {
+  auto current_timestamp = std::chrono::system_clock::now();
+  auto current_time = std::chrono::duration_cast<std::chrono::milliseconds>(
+                          current_timestamp.time_since_epoch())
+                          .count();
+  std::cout << "Start timestamp: " << current_time << std::endl;
+
+  for (int i = 0; i < TIMES; ++i) {
+    std::string unique_id = absl::StrFormat("uuid-hjiang-%d", i);
+    PhysicalModeExecutionContext ctx;
+    ctx.memory_cgroup_uuid = unique_id;
+    ctx.high_memory = 1024 * 1024;  // 1MB for example
+    setup_cgroup_for_memory(ctx);
+  }
+
+  current_timestamp = std::chrono::system_clock::now();
+  current_time = std::chrono::duration_cast<std::chrono::milliseconds>(
+                     current_timestamp.time_since_epoch())
+                     .count();
+  std::cout << "End timestamp: " << current_time << std::endl;
+}
+
+int main() {
+  test_runtime();
+  return 0;
+}

--- a/src/ray/util/util.cc
+++ b/src/ray/util/util.cc
@@ -358,23 +358,25 @@ std::shared_ptr<absl::flat_hash_map<std::string, std::string>> ParseURL(std::str
   url.erase(0, pos + delimiter.length());
   const std::string query_delimeter = "&";
 
-  auto parse_key_value_with_equal_delimter = [](std::string_view key_value) {
+  auto parse_key_value_with_equal_delimter =
+      [](std::string_view key_value) -> std::pair<std::string_view, std::string_view> {
     // Parse the query key value pair.
     const std::string key_value_delimter = "=";
     size_t key_value_pos = key_value.find(key_value_delimter);
     std::string_view key = key_value.substr(0, key_value_pos);
-    return std::make_pair(std::string{key}, key_value.substr(key.size() + 1));
+    return std::make_pair(key, key_value.substr(key.size() + 1));
   };
 
   while ((pos = url.find(query_delimeter)) != std::string::npos) {
     std::string_view token = std::string_view{url}.substr(0, pos);
     auto key_value_pair = parse_key_value_with_equal_delimter(token);
-    result->emplace(std::move(key_value_pair.first), std::move(key_value_pair.second));
+    result->emplace(std::string(key_value_pair.first),
+                    std::string(key_value_pair.second));
     url.erase(0, pos + delimiter.length());
   }
   std::string_view token = std::string_view{url}.substr(0, pos);
   auto key_value_pair = parse_key_value_with_equal_delimter(token);
-  result->emplace(std::move(key_value_pair.first), std::move(key_value_pair.second));
+  result->emplace(std::string(key_value_pair.first), std::string(key_value_pair.second));
   return result;
 }
 


### PR DESCRIPTION
The initial implementation to show how I plan to implement.

In short words:
1. (C++) worker pool generates a UUID for this particular job, which is used to decide the unique cgroup path;
2. (python) runtime env is parsed and translated to runtime env context, which includes an addition field `PhysicalModeExecutionContext`;
3. (python) Before process execution, we set the cgroup;
4. (C++) When process finishes, worker pool requests to delete runtime env;
5. (python) delete the runtime env if necessary.

For now, we only support memory constraint, but we could add more in the future.