### PR TITLE
[WIP] [Precommit Hook] Update precommit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -136,6 +136,14 @@ repos:
 
   - repo: local
     hooks:
+      - id: clang-format
+        name: Check for coding style with clang format
+        entry: ./ci/lint/check-git-clang-format-output.sh
+        language: system
+        types: [bash]
+
+  - repo: local
+    hooks:
       - id: check-import-order
         name: Check for Ray import order violations
         entry: python ci/lint/check_import_order.py


### PR DESCRIPTION
One of my PR passes local precommit hook, but fails CI due to clang-format.
My personal preference is to add these cheap hooks (i.e. running less than 3 seconds) into precommit hook, so we don't rely on expensive CI to capture errors.

Pass example:
```
[~/ray] (hjiang/udpate-precommit-hook) 
ubuntu@hjiang-devbox$ fuck
git push --set-upstream origin hjiang/udpate-precommit-hook [enter/↑/↓/ctrl+c]
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check for added large files..............................................Passed
check python ast.....................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
black................................................(no files to check)Skipped
flake8...............................................(no files to check)Skipped
prettier.............................................(no files to check)Skipped
mypy.................................................(no files to check)Skipped
isort (python).......................................(no files to check)Skipped
rst directives end with two colons...................(no files to check)Skipped
rst ``inline code`` next to normal text..............(no files to check)Skipped
use logger.warning(..................................(no files to check)Skipped
check for not-real mock methods......................(no files to check)Skipped
ShellCheck v0.9.0....................................(no files to check)Skipped
clang-format.........................................(no files to check)Skipped
Google Java Formatter................................(no files to check)Skipped
Check for Ray docstyle violations....................(no files to check)Skipped
Check for coding style with clang format.............(no files to check)Skipped
Check for Ray import order violations................(no files to check)Skipped
```
