### PR TITLE
Add perf metrics for 2.39.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 399.106048,
+    "_dashboard_memory_usage_mb": 404.76672,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.74,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1260\t6.52GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3455\t1.88GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4401\t0.89GiB\tpython distributed/test_many_actors.py\n2284\t0.39GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3571\t0.23GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1040\t0.12GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n2409\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3739\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n3741\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3795\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
-    "actors_per_second": 550.7019220598719,
+    "_peak_memory": 3.67,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n6527\t1.78GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n8101\t0.93GiB\tpython distributed/test_many_actors.py\n2545\t0.34GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1279\t0.25GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n6643\t0.22GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1026\t0.12GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n2450\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n6810\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n6812\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n6891\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
+    "actors_per_second": 591.3539212974848,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 550.7019220598719
+            "perf_metric_value": 591.3539212974848
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 90.11
+            "perf_metric_value": 94.771
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3824.806
+            "perf_metric_value": 2548.0
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4641.532
+            "perf_metric_value": 4095.457
         }
     ],
     "success": "1",
-    "time": 18.15864372253418
+    "time": 16.91034698486328
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 207.106048,
+    "_dashboard_memory_usage_mb": 217.985024,
     "_dashboard_test_success": true,
-    "_peak_memory": 1.67,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3320\t0.53GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1971\t0.24GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1245\t0.22GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3438\t0.19GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4488\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1042\t0.11GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3605\t0.1GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n2148\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4712\t0.08GiB\tray::StateAPIGeneratorActor.start\n3607\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
+    "_peak_memory": 1.65,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3433\t0.5GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1225\t0.25GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2296\t0.24GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3549\t0.2GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n5772\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3716\t0.1GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n2555\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n5989\t0.08GiB\tray::StateAPIGeneratorActor.start\n3718\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3740\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 360.10290607052235
+            "perf_metric_value": 348.9277364300741
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4.308
+            "perf_metric_value": 4.736
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 8.773
+            "perf_metric_value": 25.612
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 84.553
+            "perf_metric_value": 96.658
         }
     ],
     "success": "1",
-    "tasks_per_second": 360.10290607052235,
-    "time": 302.77698397636414,
+    "tasks_per_second": 348.9277364300741,
+    "time": 302.86592292785645,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 156.89728,
+    "_dashboard_memory_usage_mb": 170.061824,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.14,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1274\t6.9GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3387\t0.92GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2115\t0.43GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4319\t0.42GiB\tpython distributed/test_many_pgs.py\n1043\t0.12GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3503\t0.11GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2363\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3668\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n3670\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3754\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
+    "_peak_memory": 2.19,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1251\t7.56GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3348\t0.93GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4791\t0.42GiB\tpython distributed/test_many_pgs.py\n2255\t0.27GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3464\t0.14GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1049\t0.13GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n2191\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3631\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n3633\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n1931\t0.07GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22.52798235601382
+            "perf_metric_value": 20.71303274352877
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4.026
+            "perf_metric_value": 3.812
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 8.371
+            "perf_metric_value": 8.286
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 362.19
+            "perf_metric_value": 1002.78
         }
     ],
-    "pgs_per_second": 22.52798235601382,
+    "pgs_per_second": 20.71303274352877,
     "success": "1",
-    "time": 44.38923931121826
+    "time": 48.2787823677063
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 717.922304,
+    "_dashboard_memory_usage_mb": 591.527936,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.8,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3462\t1.32GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3578\t0.91GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4441\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n2114\t0.22GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1266\t0.21GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n1048\t0.12GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3746\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n2331\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4639\t0.08GiB\tray::StateAPIGeneratorActor.start\n3748\t0.08GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
+    "_peak_memory": 3.67,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3434\t1.1GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3550\t0.98GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n5459\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1230\t0.24GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2463\t0.23GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3717\t0.1GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n2329\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n5673\t0.08GiB\tray::StateAPIGeneratorActor.start\n3719\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n5617\t0.07GiB\tray::DashboardTester.run",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 524.9117000820374
+            "perf_metric_value": 469.18167402268733
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 126.428
+            "perf_metric_value": 134.62
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 619.317
+            "perf_metric_value": 574.298
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 877.616
+            "perf_metric_value": 790.008
         }
     ],
     "success": "1",
-    "tasks_per_second": 524.9117000820374,
-    "time": 319.0508232116699,
+    "tasks_per_second": 469.18167402268733,
+    "time": 321.31370544433594,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.38.0"}
+{"release_version": "2.39.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8761.346295795662,
-        146.13285936998864
+        8898.74161889686,
+        138.6655714305418
     ],
     "1_1_actor_calls_concurrent": [
-        5144.113336604505,
-        129.05069261153022
+        5596.612088571596,
+        178.34652642393664
     ],
     "1_1_actor_calls_sync": [
-        1934.5421437875898,
-        16.93762447499762
+        2019.1192214380333,
+        37.040749344832754
     ],
     "1_1_async_actor_calls_async": [
-        5004.950764496762,
-        171.43189175368792
+        5128.909004080372,
+        159.91353744375118
     ],
     "1_1_async_actor_calls_sync": [
-        1400.8372649801115,
-        46.91695798495167
+        1541.090559096205,
+        34.01263723112063
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2973.2069419443774,
-        237.27631176013963
+        3278.2411157746983,
+        74.5104314525387
     ],
     "1_n_actor_calls_async": [
-        8623.73827147855,
-        108.35090143743467
+        8405.676715400055,
+        224.3640255547966
     ],
     "1_n_async_actor_calls_async": [
-        7649.232495352423,
-        95.6555511663449
+        7853.325955437287,
+        65.25928329465697
     ],
     "client__1_1_actor_calls_async": [
-        1045.2530250056586,
-        17.729751774775785
+        980.7790835269525,
+        23.96411393720468
     ],
     "client__1_1_actor_calls_concurrent": [
-        1051.493235107139,
-        8.4794310593275
+        974.1707706196564,
+        15.394990388473797
     ],
     "client__1_1_actor_calls_sync": [
-        516.4913813381004,
-        13.142786387066948
+        526.7457465833909,
+        6.812388197544875
     ],
     "client__get_calls": [
-        988.8125976441822,
-        33.09181567140517
+        1066.7684719081053,
+        65.14242679850064
     ],
     "client__put_calls": [
-        802.299977782532,
-        40.98963980585926
+        862.5855312761047,
+        20.73389580269158
     ],
     "client__put_gigabytes": [
-        0.14687557695990644,
-        0.0006998145552218933
+        0.15371223612909402,
+        0.0008936587803616917
     ],
     "client__tasks_and_get_batch": [
-        0.8869040099758512,
-        0.0584252596679036
+        0.9201563674628591,
+        0.010465748439443982
     ],
     "client__tasks_and_put_batch": [
-        12975.586508330278,
-        276.9399014147757
+        14405.107490454913,
+        249.95568080534107
     ],
     "multi_client_put_calls_Plasma_Store": [
-        14827.86504165783,
-        271.2989306333634
+        16647.860352850137,
+        277.3955850318771
     ],
     "multi_client_put_gigabytes": [
-        46.31338079710033,
-        3.3758082719395563
+        42.866645929309996,
+        2.606701622343488
     ],
     "multi_client_tasks_async": [
-        22222.678238606593,
-        2560.621756569957
+        21823.517428742365,
+        2553.680181642446
     ],
     "n_n_actor_calls_async": [
-        27090.36785253979,
-        639.2205723009032
+        26933.018765424662,
+        650.9070636285601
     ],
     "n_n_actor_calls_with_arg_async": [
-        2665.0370523783936,
-        17.183930355396907
+        2719.6626076209245,
+        10.139893876803306
     ],
     "n_n_async_actor_calls_async": [
-        23929.36598717011,
-        574.0572010106606
+        22994.669871663224,
+        483.38033980705643
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10411.918620150123
+            "perf_metric_value": 10650.27690749274
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4961.71788771872
+            "perf_metric_value": 5122.443353616408
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 14827.86504165783
+            "perf_metric_value": 16647.860352850137
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 17.802093535903047
+            "perf_metric_value": 17.176054266128194
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7.649152573279892
+            "perf_metric_value": 7.780451969433976
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 46.31338079710033
+            "perf_metric_value": 42.866645929309996
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.639316158564123
+            "perf_metric_value": 12.047828247398513
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.188428041790279
+            "perf_metric_value": 5.25614136017588
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 942.3396753458368
+            "perf_metric_value": 1001.5048485799107
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7997.547070810859
+            "perf_metric_value": 7850.804688217522
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22222.678238606593
+            "perf_metric_value": 21823.517428742365
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1934.5421437875898
+            "perf_metric_value": 2019.1192214380333
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8761.346295795662
+            "perf_metric_value": 8898.74161889686
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5144.113336604505
+            "perf_metric_value": 5596.612088571596
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8623.73827147855
+            "perf_metric_value": 8405.676715400055
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 27090.36785253979
+            "perf_metric_value": 26933.018765424662
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2665.0370523783936
+            "perf_metric_value": 2719.6626076209245
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1400.8372649801115
+            "perf_metric_value": 1541.090559096205
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5004.950764496762
+            "perf_metric_value": 5128.909004080372
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2973.2069419443774
+            "perf_metric_value": 3278.2411157746983
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7649.232495352423
+            "perf_metric_value": 7853.325955437287
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23929.36598717011
+            "perf_metric_value": 22994.669871663224
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 752.3917651242742
+            "perf_metric_value": 845.3611380520398
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 988.8125976441822
+            "perf_metric_value": 1066.7684719081053
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 802.299977782532
+            "perf_metric_value": 862.5855312761047
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.14687557695990644
+            "perf_metric_value": 0.15371223612909402
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12975.586508330278
+            "perf_metric_value": 14405.107490454913
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 516.4913813381004
+            "perf_metric_value": 526.7457465833909
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1045.2530250056586
+            "perf_metric_value": 980.7790835269525
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1051.493235107139
+            "perf_metric_value": 974.1707706196564
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.8869040099758512
+            "perf_metric_value": 0.9201563674628591
         }
     ],
     "placement_group_create/removal": [
-        752.3917651242742,
-        12.692354477421576
+        845.3611380520398,
+        4.0458509846316035
     ],
     "single_client_get_calls_Plasma_Store": [
-        10411.918620150123,
-        158.6907007041028
+        10650.27690749274,
+        283.37824970347975
     ],
     "single_client_get_object_containing_10k_refs": [
-        12.639316158564123,
-        0.2958386011889404
+        12.047828247398513,
+        0.1590129957048486
     ],
     "single_client_put_calls_Plasma_Store": [
-        4961.71788771872,
-        166.79751523747402
+        5122.443353616408,
+        36.962835635679255
     ],
     "single_client_put_gigabytes": [
-        17.802093535903047,
-        8.360672252708738
+        17.176054266128194,
+        8.701531437848233
     ],
     "single_client_tasks_and_get_batch": [
-        7.649152573279892,
-        0.3523349920439091
+        7.780451969433976,
+        0.258606635032534
     ],
     "single_client_tasks_async": [
-        7997.547070810859,
-        252.5625668857314
+        7850.804688217522,
+        446.47204973582666
     ],
     "single_client_tasks_sync": [
-        942.3396753458368,
-        9.920445637439315
+        1001.5048485799107,
+        7.62224014215156
     ],
     "single_client_wait_1k_refs": [
-        5.188428041790279,
-        0.09193312352347874
+        5.25614136017588,
+        0.10011402273807728
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 31.073800462999998,
+    "broadcast_time": 61.879495881000025,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 31.073800462999998
+            "perf_metric_value": 61.879495881000025
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 18.011296372000004,
-    "get_time": 24.694264806000007,
+    "args_time": 17.524066807000004,
+    "get_time": 23.672960529000008,
     "large_object_size": 107374182400,
-    "large_object_time": 28.976551088000008,
+    "large_object_time": 31.510281453000005,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 18.011296372000004
+            "perf_metric_value": 17.524066807000004
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.854871097
+            "perf_metric_value": 5.869913475000004
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 24.694264806000007
+            "perf_metric_value": 23.672960529000008
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 201.18022255099999
+            "perf_metric_value": 189.086426824
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 28.976551088000008
+            "perf_metric_value": 31.510281453000005
         }
     ],
-    "queued_time": 201.18022255099999,
-    "returns_time": 5.854871097,
+    "queued_time": 189.086426824,
+    "returns_time": 5.869913475000004,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.186143352985382,
-    "max_iteration_time": 2.8529767990112305,
-    "min_iteration_time": 0.41348743438720703,
+    "avg_iteration_time": 1.0812901997566222,
+    "max_iteration_time": 3.0475189685821533,
+    "min_iteration_time": 0.5083305835723877,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.186143352985382
+            "perf_metric_value": 1.0812901997566222
         }
     ],
     "success": 1,
-    "total_time": 118.6146011352539
+    "total_time": 108.12925601005554
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 8.909741163253784
+            "perf_metric_value": 9.837347507476807
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 26.390845274925233
+            "perf_metric_value": 25.959900307655335
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 66.36001825332642
+            "perf_metric_value": 80.91288795471192
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2.8864474296569824
+            "perf_metric_value": 1.8206799030303955
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3249.9383351802826
+            "perf_metric_value": 3413.631863594055
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.3168361946930436
+            "perf_metric_value": 0.32116315011886526
         }
     ],
-    "stage_0_time": 8.909741163253784,
-    "stage_1_avg_iteration_time": 26.390845274925233,
-    "stage_1_max_iteration_time": 28.665843725204468,
-    "stage_1_min_iteration_time": 24.76340889930725,
-    "stage_1_time": 263.90854692459106,
-    "stage_2_avg_iteration_time": 66.36001825332642,
-    "stage_2_max_iteration_time": 69.15732741355896,
-    "stage_2_min_iteration_time": 64.64686346054077,
-    "stage_2_time": 331.8009421825409,
-    "stage_3_creation_time": 2.8864474296569824,
-    "stage_3_time": 3249.9383351802826,
-    "stage_4_spread": 0.3168361946930436,
+    "stage_0_time": 9.837347507476807,
+    "stage_1_avg_iteration_time": 25.959900307655335,
+    "stage_1_max_iteration_time": 26.58783769607544,
+    "stage_1_min_iteration_time": 25.21652603149414,
+    "stage_1_time": 259.59910821914673,
+    "stage_2_avg_iteration_time": 80.91288795471192,
+    "stage_2_max_iteration_time": 130.10139632225037,
+    "stage_2_min_iteration_time": 67.79082655906677,
+    "stage_2_time": 404.5656635761261,
+    "stage_3_creation_time": 1.8206799030303955,
+    "stage_3_time": 3413.631863594055,
+    "stage_4_spread": 0.32116315011886526,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 1.0143646081080508,
-    "avg_pg_remove_time_ms": 1.0055548888891201,
+    "avg_pg_create_time_ms": 0.9711981891879983,
+    "avg_pg_remove_time_ms": 0.9386635615607924,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.0143646081080508
+            "perf_metric_value": 0.9711981891879983
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.0055548888891201
+            "perf_metric_value": 0.9386635615607924
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 10.62%: tasks_per_second (THROUGHPUT) regresses from 524.9117000820374 to 469.18167402268733 in benchmarks/many_tasks.json
REGRESSION 8.06%: pgs_per_second (THROUGHPUT) regresses from 22.52798235601382 to 20.71303274352877 in benchmarks/many_pgs.json
REGRESSION 7.44%: multi_client_put_gigabytes (THROUGHPUT) regresses from 46.31338079710033 to 42.866645929309996 in microbenchmark.json
REGRESSION 7.35%: client__1_1_actor_calls_concurrent (THROUGHPUT) regresses from 1051.493235107139 to 974.1707706196564 in microbenchmark.json
REGRESSION 6.17%: client__1_1_actor_calls_async (THROUGHPUT) regresses from 1045.2530250056586 to 980.7790835269525 in microbenchmark.json
REGRESSION 4.68%: single_client_get_object_containing_10k_refs (THROUGHPUT) regresses from 12.639316158564123 to 12.047828247398513 in microbenchmark.json
REGRESSION 3.91%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 23929.36598717011 to 22994.669871663224 in microbenchmark.json
REGRESSION 3.52%: single_client_put_gigabytes (THROUGHPUT) regresses from 17.802093535903047 to 17.176054266128194 in microbenchmark.json
REGRESSION 3.10%: tasks_per_second (THROUGHPUT) regresses from 360.10290607052235 to 348.9277364300741 in benchmarks/many_nodes.json
REGRESSION 2.53%: 1_n_actor_calls_async (THROUGHPUT) regresses from 8623.73827147855 to 8405.676715400055 in microbenchmark.json
REGRESSION 1.83%: single_client_tasks_async (THROUGHPUT) regresses from 7997.547070810859 to 7850.804688217522 in microbenchmark.json
REGRESSION 1.80%: multi_client_tasks_async (THROUGHPUT) regresses from 22222.678238606593 to 21823.517428742365 in microbenchmark.json
REGRESSION 0.58%: n_n_actor_calls_async (THROUGHPUT) regresses from 27090.36785253979 to 26933.018765424662 in microbenchmark.json
REGRESSION 191.94%: dashboard_p95_latency_ms (LATENCY) regresses from 8.773 to 25.612 in benchmarks/many_nodes.json
REGRESSION 176.87%: dashboard_p99_latency_ms (LATENCY) regresses from 362.19 to 1002.78 in benchmarks/many_pgs.json
REGRESSION 99.14%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 31.073800462999998 to 61.879495881000025 in scalability/object_store.json
REGRESSION 21.93%: stage_2_avg_iteration_time (LATENCY) regresses from 66.36001825332642 to 80.91288795471192 in stress_tests/stress_test_many_tasks.json
REGRESSION 14.32%: dashboard_p99_latency_ms (LATENCY) regresses from 84.553 to 96.658 in benchmarks/many_nodes.json
REGRESSION 10.41%: stage_0_time (LATENCY) regresses from 8.909741163253784 to 9.837347507476807 in stress_tests/stress_test_many_tasks.json
REGRESSION 9.94%: dashboard_p50_latency_ms (LATENCY) regresses from 4.308 to 4.736 in benchmarks/many_nodes.json
REGRESSION 8.74%: 107374182400_large_object_time (LATENCY) regresses from 28.976551088000008 to 31.510281453000005 in scalability/single_node.json
REGRESSION 6.48%: dashboard_p50_latency_ms (LATENCY) regresses from 126.428 to 134.62 in benchmarks/many_tasks.json
REGRESSION 5.17%: dashboard_p50_latency_ms (LATENCY) regresses from 90.11 to 94.771 in benchmarks/many_actors.json
REGRESSION 5.04%: stage_3_time (LATENCY) regresses from 3249.9383351802826 to 3413.631863594055 in stress_tests/stress_test_many_tasks.json
REGRESSION 1.37%: stage_4_spread (LATENCY) regresses from 0.3168361946930436 to 0.32116315011886526 in stress_tests/stress_test_many_tasks.json
REGRESSION 0.26%: 3000_returns_time (LATENCY) regresses from 5.854871097 to 5.869913475000004 in scalability/single_node.json
```