### PR TITLE
[Tune] Fix pbt restore in synch mode

### DIFF
--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -615,8 +615,8 @@ class PopulationBasedTraining(FIFOScheduler):
                     for t in tune_controller.get_trials()
                 ]
                 max_last_train_time = max(all_train_times)
-                self._next_perturbation_sync = max(
-                    self._next_perturbation_sync + self._perturbation_interval,
+                self._next_perturbation_sync = self._perturbation_interval + max(
+                    self._next_perturbation_sync,
                     max_last_train_time,
                 )
                 logger.debug(f"Next perturb at time {self._next_perturbation_sync}")


### PR DESCRIPTION
## Why are these changes needed?

If PBT was restored, the trial states will have `last_train_time` > 0, but the PBT's `_next_perturbation_sync` will be 0. This leads to the bug where PBT runs only a single iteration after restoring, because it sets `_next_perturbation_sync = max_last_train_time` and thus all trials remain in PAUSED state forever (a trial must have `last_train_time < _next_perturbation_sync` to get out of this state which can never happen).

This PR ensures that `_next_perturbation_sync` will always be greater than `max_last_train_time` (which I believe was the original intent behind that `max(...)` statement)

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
