### PR TITLE
[core] Remove internal flags in driver on job submission.

### DIFF
--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -453,6 +453,15 @@ DEFAULT_TASK_MAX_RETRIES = 3
 RAY_INTERNAL_NAMESPACE_PREFIX = "_ray_internal_"
 RAY_INTERNAL_DASHBOARD_NAMESPACE = f"{RAY_INTERNAL_NAMESPACE_PREFIX}dashboard"
 
+# Ray internal flags. These flags should not be set by users, and we strip them on job
+# submission.
+# This should be consistent with src/ray/common/ray_internal_flag_def.h
+RAY_INTERNAL_FLAGS = [
+    "RAY_JOB_ID",
+    "RAY_RAYLET_PID",
+    "RAY_OVERRIDE_NODE_ID_FOR_TESTING",
+]
+
 
 def gcs_actor_scheduling_enabled():
     return os.environ.get("RAY_gcs_actor_scheduling_enabled") == "true"

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1954,6 +1954,15 @@ def try_import_each_module(module_names_to_import: List[str]) -> None:
             logger.exception(f'Failed to preload the module "{module_to_preload}"')
 
 
+def remove_ray_internal_flags_from_env(env: dict):
+    """
+    Remove Ray internal flags from `env`.
+    Defined in ray/common/ray_internal_flag_def.h
+    """
+    for flag in ray_constants.RAY_INTERNAL_FLAGS:
+        env.pop(flag, None)
+
+
 def update_envs(env_vars: Dict[str, str]):
     """
     When updating the environment variable, if there is ${X},

--- a/python/ray/dashboard/modules/job/job_supervisor.py
+++ b/python/ray/dashboard/modules/job/job_supervisor.py
@@ -15,6 +15,7 @@ from ray._private.gcs_utils import GcsAioClient
 from ray._private.ray_logging.filters import CoreContextFilter
 from ray._private.ray_logging.formatters import JSONFormatter, TextFormatter
 from ray._private.runtime_env.constants import RAY_JOB_CONFIG_JSON_ENV_VAR
+from ray._private.utils import remove_ray_internal_flags_from_env
 from ray.actor import ActorHandle
 from ray.dashboard.modules.job.common import (
     JOB_ID_METADATA_KEY,
@@ -147,7 +148,7 @@ class JobSupervisor:
         """Used to check the health of the actor."""
         pass
 
-    def _exec_entrypoint(self, logs_path: str) -> subprocess.Popen:
+    def _exec_entrypoint(self, env: dict, logs_path: str) -> subprocess.Popen:
         """
         Runs the entrypoint command as a child process, streaming stderr &
         stdout to given log files.
@@ -176,6 +177,7 @@ class JobSupervisor:
                 start_new_session=True,
                 stdout=logs_file,
                 stderr=subprocess.STDOUT,
+                env=env,
                 # Ray intentionally blocks SIGINT in all processes, so if the user wants
                 # to stop job through SIGINT, we need to unblock it in the child process
                 preexec_fn=(
@@ -349,16 +351,21 @@ class JobSupervisor:
         )
 
         try:
-            # Configure environment variables for the child process. These
-            # will *not* be set in the runtime_env, so they apply to the driver
+            # Configure environment variables for the child process.
+            env = os.environ.copy()
+            # Remove internal Ray flags. They present because JobSuperVisor itself is
+            # a Ray worker process but we don't want to pass them to the driver.
+            remove_ray_internal_flags_from_env(env)
+            # These will *not* be set in the runtime_env, so they apply to the driver
             # only, not its tasks & actors.
-            os.environ.update(self._get_driver_env_vars(resources_specified))
+            env.update(self._get_driver_env_vars(resources_specified))
+
             self._logger.info(
                 "Submitting job with RAY_ADDRESS = "
                 f"{os.environ[ray_constants.RAY_ADDRESS_ENVIRONMENT_VARIABLE]}"
             )
             log_path = self._log_client.get_log_file_path(self._job_id)
-            child_process = self._exec_entrypoint(log_path)
+            child_process = self._exec_entrypoint(env, log_path)
             child_pid = child_process.pid
 
             polling_task = create_task(self._polling(child_process))

--- a/python/ray/dashboard/modules/job/job_supervisor.py
+++ b/python/ray/dashboard/modules/job/job_supervisor.py
@@ -362,7 +362,7 @@ class JobSupervisor:
 
             self._logger.info(
                 "Submitting job with RAY_ADDRESS = "
-                f"{os.environ[ray_constants.RAY_ADDRESS_ENVIRONMENT_VARIABLE]}"
+                f"{env[ray_constants.RAY_ADDRESS_ENVIRONMENT_VARIABLE]}"
             )
             log_path = self._log_client.get_log_file_path(self._job_id)
             child_process = self._exec_entrypoint(env, log_path)

--- a/python/ray/tests/test_job.py
+++ b/python/ray/tests/test_job.py
@@ -235,6 +235,17 @@ print("result:", get_entrypoint_name())
     assert line_exists(outputs, ".*result: \(interactive_shell\).*ipython")
 
 
+def test_removed_internal_flags(shutdown_only):
+    ray.init()
+    address = ray._private.worker._global_node.webui_url
+    address = format_web_url(address)
+    client = JobSubmissionClient(address)
+
+    job_submission_id = client.submit_job(entrypoint='echo "${#RAY_JOB_ID}"')
+    env_len = client.get_job_logs(job_submission_id)
+    assert env_len == "0"
+
+
 def test_entrypoint_field(shutdown_only):
     """Make sure the entrypoint field is correctly set for jobs."""
     driver = """

--- a/python/ray/tests/test_job.py
+++ b/python/ray/tests/test_job.py
@@ -22,7 +22,7 @@ from ray._private.test_utils import (
     wait_for_pid_to_exit,
 )
 from ray.job_config import JobConfig, LoggingConfig
-from ray.job_submission import JobSubmissionClient
+from ray.job_submission import JobStatus, JobSubmissionClient
 from ray.dashboard.modules.job.pydantic_models import JobDetails
 
 
@@ -241,9 +241,22 @@ def test_removed_internal_flags(shutdown_only):
     address = format_web_url(address)
     client = JobSubmissionClient(address)
 
-    job_submission_id = client.submit_job(entrypoint='echo "${#RAY_JOB_ID}"')
-    env_len = client.get_job_logs(job_submission_id)
-    assert env_len == "0"
+    # Tests this env var is not set.
+    job_submission_id = client.submit_job(
+        entrypoint='[ -z "${RAY_JOB_ID+x}" ] && '
+        'echo "RAY_JOB_ID is not set" || '
+        '{ echo "RAY_JOB_ID is set to $RAY_JOB_ID"; return 1; }'
+    )
+
+    def job_finished():
+        status = client.get_job_status(job_submission_id)
+        assert status != JobStatus.FAILED
+        return status == JobStatus.SUCCEEDED
+
+    wait_for_condition(job_finished)
+
+    all_logs = client.get_job_logs(job_submission_id)
+    assert "RAY_JOB_ID is not set" in all_logs
 
 
 def test_entrypoint_field(shutdown_only):

--- a/src/ray/common/ray_internal_flag_def.h
+++ b/src/ray/common/ray_internal_flag_def.h
@@ -22,6 +22,9 @@
 // Macro definition format: RAY_INTERNAL_FLAG(type, name, default_value).
 // NOTE: This file should NOT be included in any file other than ray_config.h.
 
+// WARNING: if you update this file, please also update RAY_INTERNAL_FLAGS in
+// ray_constants.py.
+
 /// Ray Job ID.
 RAY_INTERNAL_FLAG(std::string, JOB_ID, "")
 


### PR DESCRIPTION
Now, when a Ray job is submitted, JobHead starts a Ray actor namely `JobSupervisor` which fork-and-exec a subprocess with the entrypoint. It bears all environment variables from the JobSupervisor, with some additional ones via `_get_driver_env_vars`. However we also want to *remove* some env vars, specifically the Ray internal ones including `RAY_JOB_ID` and `RAY_RAYLET_ID` because they are meant for the JobSupervisor, not for the job we submit. For example, in the entrypoint `$RAY_JOB_ID` can be set to  `01000000` because that's the job id of the JobSupervisor, while the entrypoint really is for job 08000000.

This did not show up as a bug because these environment variables are not read by the driver core workers. However we find a user pattern that they collect all env vars in the driver process and pass it to tasks/actors via `env_vars`. If they do so, the started workers get confused by the stale job ids and crash.

Removes those env vars on JobSupervisor for-and-exec to hide them from the user entrypoint.

Next steps: we should check for internal flags in `env_vars` and raise Exceptions for internal flags; and/or we can have an option to auto-remove them for the users. something like:

```py
@ray.remote(runtime_env={
    "env_vars":os.environ, 
    # can be "raise", "allow_debugonly", "remove", default to "raise"
    "env_vars_config":{"internal_flags": "remove"},
})
```