### PR TITLE
[core] Implement a scope guard for exit behaviors

### DIFF
--- a/src/ray/util/BUILD
+++ b/src/ray/util/BUILD
@@ -49,3 +49,18 @@ cc_library(
     srcs = ["thread_checker.cc"],
     visibility = ["//visibility:public"],
 )
+
+cc_library(
+    name = "meta",
+    hdrs = ["meta.h"],
+)
+
+cc_library(
+    name = "scope_guard",
+    hdrs = ["scope_guard.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":meta",
+        "@com_google_absl//absl/base:core_headers",
+    ],
+)

--- a/src/ray/util/meta.h
+++ b/src/ray/util/meta.h
@@ -1,3 +1,17 @@
+// Copyright 2024 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // A few util macros.
 
 #pragma once

--- a/src/ray/util/meta.h
+++ b/src/ray/util/meta.h
@@ -1,0 +1,11 @@
+// A few util macros.
+
+#pragma once
+
+// Need to have two macro invocation to allow [x] and [y] to be replaced.
+#define __RAY_CONCAT(x, y) x##y
+
+#define RAY_CONCAT(x, y) __RAY_CONCAT(x, y)
+
+// Macros which gets unique variable name (at best effort).
+#define RAY_UNIQUE_VARIABLE(base) RAY_CONCAT(base, __LINE__)

--- a/src/ray/util/scope_guard.h
+++ b/src/ray/util/scope_guard.h
@@ -1,3 +1,17 @@
+// Copyright 2024 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // SCOPE_EXIT is used to execute a series of registered functions when it goes
 // out of scope.
 // For details, refer to Andrei Alexandrescu's CppCon 2015 talk "Declarative

--- a/src/ray/util/scope_guard.h
+++ b/src/ray/util/scope_guard.h
@@ -1,0 +1,65 @@
+// SCOPE_EXIT is used to execute a series of registered functions when it goes
+// out of scope.
+// For details, refer to Andrei Alexandrescu's CppCon 2015 talk "Declarative
+// Control Flow"
+//
+// Examples:
+//   void Function() {
+//     FILE* fp = fopen("my_file.txt", "r");
+//     SCOPE_EXIT { fclose(fp); };
+//     // Do something.
+//   }  // fp will be closed at exit.
+//
+
+#pragma once
+
+#include <functional>
+#include <utility>
+
+#include "absl/base/attributes.h"
+#include "src/ray/util/meta.h"
+
+namespace ray {
+
+class ABSL_MUST_USE_RESULT ScopeGuard {
+ private:
+  using Func = std::function<void(void)>;
+
+ public:
+  ScopeGuard() : func_([]() {}) {}
+  explicit ScopeGuard(Func &&func) : func_(std::forward<Func>(func)) {}
+  ~ScopeGuard() noexcept { func_(); }
+
+  // Register a new function to be invoked at destruction.
+  // Execution will be performed at the reversed order they're registered.
+  ScopeGuard &operator+=(Func &&another_func) {
+    Func cur_func = std::move(func_);
+    func_ = [cur_func = std::move(cur_func), another_func = std::move(another_func)]() {
+      // Executed in the reverse order functions are registered.
+      another_func();
+      cur_func();
+    };
+    return *this;
+  }
+
+ private:
+  Func func_;
+};
+
+namespace internal {
+
+using ScopeGuardFunc = std::function<void(void)>;
+
+// Constructs a scope guard that calls 'fn' when it exits.
+enum class ScopeGuardOnExit {};
+inline auto operator+(ScopeGuardOnExit /*unused*/, ScopeGuardFunc fn) {
+  return ScopeGuard{std::move(fn)};
+}
+
+}  // namespace internal
+
+}  // namespace ray
+
+#define SCOPE_EXIT                                 \
+  auto RAY_UNIQUE_VARIABLE(SCOPE_EXIT_TEMP_EXIT) = \
+      ray::internal::ScopeGuardOnExit{} + [&]()

--- a/src/ray/util/tests/BUILD
+++ b/src/ray/util/tests/BUILD
@@ -176,9 +176,20 @@ cc_test(
     copts = COPTS,
     tags = ["team:core"],
     deps = [
-        # "//src/ray/util",
         "@boost//:range",
         "@com_google_googletest//:gtest_main",
         "//src/ray/protobuf:gcs_cc_proto",
+    ],
+)
+
+cc_test(
+    name = "scope_guard_test",
+    srcs = ["scope_guard_test.cc"],
+    copts = COPTS,
+    tags = ["team:core"],
+    size = "small",
+    deps = [
+        "//src/ray/util:scope_guard",
+        "@com_google_googletest//:gtest_main",
     ],
 )

--- a/src/ray/util/tests/scope_guard_test.cc
+++ b/src/ray/util/tests/scope_guard_test.cc
@@ -1,0 +1,29 @@
+#include "src/ray/util/scope_guard.h"
+
+#include <gtest/gtest.h>
+
+#include <future>
+
+namespace ray {
+
+namespace {
+
+TEST(ScopeGuardTest, BasicTest) {
+  std::promise<void> promise{};
+  {
+    ScopeGuard wg{[&]() { promise.set_value(); }};
+  }
+  promise.get_future().get();
+}
+
+TEST(ScopeGuardTest, MacroTest) {
+  std::promise<void> promise{};
+  {
+    SCOPE_EXIT { promise.set_value(); };
+  }
+  promise.get_future().get();
+}
+
+}  // namespace
+
+}  // namespace ray

--- a/src/ray/util/tests/scope_guard_test.cc
+++ b/src/ray/util/tests/scope_guard_test.cc
@@ -1,3 +1,17 @@
+// Copyright 2024 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "src/ray/util/scope_guard.h"
 
 #include <gtest/gtest.h>


### PR DESCRIPTION
A super useful util which I used almost on daily basis.
One concrete example, in [here](https://github.com/ray-project/ray/pull/47981/files#r1832169353) we have repeated `delete` at various entries, which is easy to forget and go wrong; scope guard eases dev's mind overhead.