### PR TITLE
[core][autoscaler] Autoscaler v2 does not honor minReplicas/replicas count of the worker nodes and constantly terminates after idletimeout 

### DIFF
--- a/python/ray/autoscaler/v2/scheduler.py
+++ b/python/ray/autoscaler/v2/scheduler.py
@@ -1604,6 +1604,7 @@ class ResourceDemandScheduler(IResourceScheduler):
                     )
                 continue
 
+            # Honor the min_worker_nodes setting for the node type.
             min_count = 0
             node_type = node.node_type
             if node_type in node_type_configs:

--- a/python/ray/autoscaler/v2/scheduler.py
+++ b/python/ray/autoscaler/v2/scheduler.py
@@ -1597,7 +1597,7 @@ class ResourceDemandScheduler(IResourceScheduler):
                 # Skip it.
                 if node.idle_duration_ms > ctx.get_idle_timeout_s() * s_to_ms:
                     logger.debug(
-                        "Node {}(idle for {} secs) is needed by the cluster resource "
+                        "Node {} (idle for {} secs) is needed by the cluster resource "
                         "constraints, skip idle termination.".format(
                             node.ray_node_id, node.idle_duration_ms / s_to_ms
                         )
@@ -1614,6 +1614,12 @@ class ResourceDemandScheduler(IResourceScheduler):
                 - terminate_nodes_by_type[node_type]
                 <= min_count
             ):
+                logger.info(
+                    "Node {} (idle for {} secs) belongs to node_type {} and is "
+                    "required by min_worker_nodes, skipping idle termination.".format(
+                        node.ray_node_id, node.idle_duration_ms / s_to_ms, node_type
+                    )
+                )
                 continue
 
             terminate_nodes_by_type[node.node_type] += 1

--- a/python/ray/autoscaler/v2/tests/test_scheduler.py
+++ b/python/ray/autoscaler/v2/tests/test_scheduler.py
@@ -1349,7 +1349,8 @@ def test_idle_termination(idle_timeout_s, has_resource_constraints):
         assert len(to_terminate) == 0
 
 
-def test_idle_termination_with_min_worker():
+@pytest.mark.parametrize("min_workers", [0, 1])
+def test_idle_termination_with_min_worker(min_workers):
     """
     Test that idle nodes are terminated.
     """
@@ -1361,7 +1362,7 @@ def test_idle_termination_with_min_worker():
         "type_cpu": NodeTypeConfig(
             name="type_cpu",
             resources={"CPU": 1},
-            min_worker_nodes=1,
+            min_worker_nodes=min_workers,
             max_worker_nodes=5,
             launch_config_hash="hash1",
         ),
@@ -1382,40 +1383,40 @@ def test_idle_termination_with_min_worker():
         instances=[
             make_autoscaler_instance(
                 im_instance=Instance(
-                    instance_id="i-2",
+                    instance_id="i-1",
                     instance_type="type_cpu",
                     status=Instance.RAY_RUNNING,
                     launch_config_hash="hash1",
-                    node_id="r-2",
+                    node_id="r-1",
                 ),
                 ray_node=NodeState(
                     ray_node_type_name="type_cpu",
-                    node_id=b"r-2",
+                    node_id=b"r-1",
                     available_resources={"CPU": 1},
                     total_resources={"CPU": 1},
                     idle_duration_ms=idle_time_s * 1000,
                     status=NodeStatus.IDLE,
                 ),
-                cloud_instance_id="c-2",
+                cloud_instance_id="c-1",
             ),
             make_autoscaler_instance(
                 im_instance=Instance(
-                    instance_id="i-3",
+                    instance_id="i-2",
                     instance_type="head_node",
                     status=Instance.RAY_RUNNING,
                     launch_config_hash="hash2",
                     node_kind=NodeKind.HEAD,
-                    node_id="r-3",
+                    node_id="r-2",
                 ),
                 ray_node=NodeState(
                     ray_node_type_name="head_node",
-                    node_id=b"r-3",
+                    node_id=b"r-2",
                     available_resources={"CPU": 0},
                     total_resources={"CPU": 0},
                     idle_duration_ms=999 * 1000,  # idle
                     status=NodeStatus.IDLE,
                 ),
-                cloud_instance_id="c-3",
+                cloud_instance_id="c-2",
             ),
         ],
         idle_timeout_s=idle_timeout_s,
@@ -1425,7 +1426,12 @@ def test_idle_termination_with_min_worker():
     reply = scheduler.schedule(request)
     _, to_terminate = _launch_and_terminate(reply)
     assert idle_timeout_s <= idle_time_s
-    assert len(to_terminate) == 0
+    if min_workers == 0:
+        assert len(to_terminate) == 1
+        assert to_terminate == [("i-1", "r-1", TerminationRequest.Cause.IDLE)]
+    else:
+        assert min_workers > 0
+        assert len(to_terminate) == 0
 
 
 def test_gang_scheduling():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, Autoscaler V2 deletes idle nodes without considering `min_worker_nodes`. This PR skips termination if the current number of nodes of that type is less than or equal to `min_worker_nodes`.

### Reproduce

* Install KubeRay v1.2.2
* Create a RayCluster
  * Autoscaler V2 enabled
  * `minReplicas` is 2 
  * https://gist.github.com/kevin85421/1a167abb14b9ffa142359d825849567b
* The 2 worker Pods will be deleted and recreated every minute.

## Related issue number

Change the image with this PR.

<img width="1437" alt="image" src="https://github.com/user-attachments/assets/8febfe03-1366-4842-a970-88f8448a5812">

Note that the screenshot is INFO, but this PR uses DEBUG

<img width="1436" alt="image" src="https://github.com/user-attachments/assets/c818b4cd-cac1-419f-9af7-b14f04202a5f">


Closes #47578

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
