### PR TITLE
[data] provide more messages when webdataset format is error

### DIFF
--- a/python/ray/data/_internal/datasource/webdataset_datasource.py
+++ b/python/ray/data/_internal/datasource/webdataset_datasource.py
@@ -163,7 +163,7 @@ def _group_by_keys(
         if suffix in current_sample:
             raise ValueError(
                 f"{fname}: duplicate file name in tar file "
-                + f"{suffix} {current_sample.keys()}"
+                + f"{suffix} {current_sample.keys()}, tar is {meta['__url__']}"
             )
         if suffixes is None or _check_suffix(suffix, suffixes):
             current_sample[suffix] = value


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
When the dataset of webdataset consists of many tar files, if there is a failure in reading one of the files, it is necessary to print the name of the failed file.

before this pr:
```
ValueError: fx001.jpg: duplicate file name in tar file jpg dict_keys(['__key__', 'jpg', 'json'])
```

after this pr:

```
ValueError: fx001.jpg: duplicate file name in tar file jpg dict_keys(['__key__', 'jpg', 'json']), in emr-autotest/datasets/jkj_10/1b63122e734064926c47a2ccdcbaafd3.tar
```



<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
