### PR TITLE
[core] Fix vector assignment

### DIFF
--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -288,7 +288,6 @@ void ServerConnection::WriteMessageAsync(
   write_buffer->write_cookie = RayConfig::instance().ray_cookie();
   write_buffer->write_type = type;
   write_buffer->write_length = length;
-  write_buffer->write_message.resize(length);
   write_buffer->write_message.assign(message, message + length);
   write_buffer->handler = handler;
 


### PR DESCRIPTION
`std::vector<T>::assign` replace the whole vector's content, which includes two procedures:
- Destruct existing items within the vector;
- Reserve and resize to the proper size without initialization;
- Copy from input iterators.

Code reference:
- https://github.com/gcc-mirror/gcc/blob/7c8f36b420d4dd70702855c69f5b749b04e09dfd/libstdc%2B%2B-v3/include/bits/stl_vector.h#L909-L928
- https://gcc.gnu.org/onlinedocs/libstdc++/libstdc++-html-USERS-4.3/a02085.html