### PR TITLE
[serve] small test change

### DIFF
--- a/python/ray/serve/tests/test_batching.py
+++ b/python/ray/serve/tests/test_batching.py
@@ -51,7 +51,7 @@ def test_batching_exception(serve_instance):
     # Set the max batch size.
     handle = serve.run(NoListReturned.bind())
 
-    with pytest.raises(ray.exceptions.RayTaskError):
+    with pytest.raises(TypeError):
         assert handle.remote(1).result()
 
 

--- a/python/ray/serve/tests/test_batching.py
+++ b/python/ray/serve/tests/test_batching.py
@@ -7,7 +7,6 @@ import pytest
 import requests
 from starlette.responses import StreamingResponse
 
-import ray
 from ray import serve
 
 


### PR DESCRIPTION
## Why are these changes needed?

Match for the more specific error that is raised, in this case `TypeError`, instead of matching for generic `RayTaskError`.