### PR TITLE
[core][observability] Logs are duplicated if multiple nodes are running on same machine

### DIFF
--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -1078,6 +1078,18 @@ class Node:
 
     def start_log_monitor(self):
         """Start the log monitor."""
+        filename = ray_constants.LOG_MONITOR_LOG_FILE_NAME
+        file_path = os.path.join(self._logs_dir, filename)
+        # Avoid launching multiple log monitors on a single host.
+        # This can happen if the user starts multiple Ray nodes on the same host.
+        if os.path.isfile(file_path):
+            logger.debug(
+                f"File {file_path} exists, not starting log monitor again. "
+                "This can happen if the user starts multiple Ray nodes on "
+                "the same host."
+            )
+            return
+
         # Only redirect logs to .err. .err file is only useful when the
         # component has an unexpected output to stdout/stderr.
         _, stderr_file = self.get_log_file_handles(

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -495,6 +495,15 @@ class Node:
         )
         try_to_create_directory(self._runtime_env_dir)
 
+        # Create a file named created_by_head to indicate that this session
+        # directory was created by the head node.
+        if self.head:
+            created_by_head = os.path.join(
+                self._logs_dir, ray_constants.CREATED_BY_HEAD_FILE_NAME
+            )
+            with open(created_by_head, "w") as f:
+                f.write("This session directory was created by the head node.")
+
     def _get_node_labels(self):
         def merge_labels(env_override_labels, params_labels):
             """Merges two dictionaries, picking from the
@@ -1078,17 +1087,19 @@ class Node:
 
     def start_log_monitor(self):
         """Start the log monitor."""
-        filename = ray_constants.LOG_MONITOR_LOG_FILE_NAME
-        file_path = os.path.join(self._logs_dir, filename)
-        # Avoid launching multiple log monitors on a single host.
-        # This can happen if the user starts multiple Ray nodes on the same host.
-        if os.path.isfile(file_path):
-            logger.debug(
-                f"File {file_path} exists, not starting log monitor again. "
-                "This can happen if the user starts multiple Ray nodes on "
-                "the same host."
-            )
-            return
+        if not self.head:
+            filename = ray_constants.CREATED_BY_HEAD_FILE_NAME
+            file_path = os.path.join(self._logs_dir, filename)
+            # Avoid launching multiple log monitors on a single host.
+            # This can happen if the user starts multiple Ray nodes on the same host.
+            if os.path.isfile(file_path):
+                logger.debug(
+                    f"File {file_path} exists, indicating that the session directory "
+                    "was created by the head node. This worker node is colocated with "
+                    "the head node, so the log monitor should not be launched again to "
+                    "avoid duplicate log entries."
+                )
+                return
 
         # Only redirect logs to .err. .err file is only useful when the
         # component has an unexpected output to stdout/stderr.

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -262,6 +262,9 @@ PROCESS_TYPE_PYTHON_CORE_WORKER = "python-core-worker"
 MONITOR_LOG_FILE_NAME = f"{PROCESS_TYPE_MONITOR}.log"
 LOG_MONITOR_LOG_FILE_NAME = f"{PROCESS_TYPE_LOG_MONITOR}.log"
 
+# If the file exists, the session directory was created by the head node.
+CREATED_BY_HEAD_FILE_NAME = "created_by_head"
+
 # Enable log deduplication.
 RAY_DEDUP_LOGS = env_bool("RAY_DEDUP_LOGS", True)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Each Ray node has a LogMonitor, which watches logs under `/tmp/ray/$session_name/logs` and publishes them to GCS so that the driver process can access the logs.

However, when we launch two Ray nodes on a single host, both LogMonitor watch the same directory `/tmp/ray/$session_name/logs`.

## Related issue number

Closes #48642 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

```python
# example.py
import ray

@ray.remote
def foo():
    print('hello')


if __name__ == '__main__':
    ray.init()
    handle = foo.remote()
    ray.get(handle)
```

* Without this PR
  <img width="820" alt="Screenshot 2024-11-09 at 12 14 08 PM" src="https://github.com/user-attachments/assets/ac95654c-f1df-4c99-a259-17465cde6785">

* With this PR
  <img width="823" alt="Screenshot 2024-11-09 at 12 15 09 PM" src="https://github.com/user-attachments/assets/c940c582-b81f-4767-9920-8402a1ea6ef7">
