### PR TITLE
[core] Fix gtest inclusion

### DIFF
--- a/src/ray/object_manager/plasma/common.h
+++ b/src/ray/object_manager/plasma/common.h
@@ -17,13 +17,13 @@
 
 #pragma once
 
+#include <gtest/gtest_prod.h>
 #include <stddef.h>
 
 #include <memory>
 #include <string>
 #include <unordered_map>
 
-#include "gtest/gtest.h"
 #include "ray/common/id.h"
 #include "ray/object_manager/common.h"
 #include "ray/object_manager/plasma/compat.h"


### PR DESCRIPTION
`<gtest/gtest.h>` should never appear in production and non-test-only code.
`<gtest/gtest_prod.h>` is enough for `FRIEND_TEST`.