### PR TITLE
[RLlib] Cleanup examples folder vol 32: Enable RLlib + Serve example in CI and translate to new API stack.

### DIFF
--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -2979,7 +2979,7 @@ py_test(
     tags = ["team:rllib", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/ray_serve/ray_serve_with_rllib.py"],
-    args = ["--train-iters=2", "--serve-episodes=2", "--no-render"]
+    args = ["--stop-iters=2", "--num-episodes-served=2", "--no-render", "--port=12345"]
 )
 
 # subdirectory: ray_tune/

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -2979,6 +2979,7 @@ py_test(
     tags = ["team:rllib", "exclusive", "examples"],
     size = "medium",
     srcs = ["examples/ray_serve/ray_serve_with_rllib.py"],
+    data = glob(["examples/ray_serve/classes/**"]),
     args = ["--stop-iters=2", "--num-episodes-served=2", "--no-render", "--port=12345"]
 )
 

--- a/rllib/BUILD
+++ b/rllib/BUILD
@@ -2973,15 +2973,14 @@ py_test(
 
 # subdirectory: ray_serve/
 # ....................................
-# TODO (sven): Uncomment once the problem with the path on BAZEL is solved.
-# py_test(
-#    name = "examples/ray_serve/ray_serve_with_rllib",
-#    main = "examples/ray_serve/ray_serve_with_rllib.py",
-#    tags = ["team:rllib", "exclusive", "examples"],
-#    size = "medium",
-#    srcs = ["examples/ray_serve/ray_serve_with_rllib.py"],
-#    args = ["--train-iters=2", "--serve-episodes=2", "--no-render"]
-# )
+py_test(
+    name = "examples/ray_serve/ray_serve_with_rllib",
+    main = "examples/ray_serve/ray_serve_with_rllib.py",
+    tags = ["team:rllib", "exclusive", "examples"],
+    size = "medium",
+    srcs = ["examples/ray_serve/ray_serve_with_rllib.py"],
+    args = ["--train-iters=2", "--serve-episodes=2", "--no-render"]
+)
 
 # subdirectory: ray_tune/
 # ....................................

--- a/rllib/examples/ray_serve/classes/cartpole_deployment.py
+++ b/rllib/examples/ray_serve/classes/cartpole_deployment.py
@@ -1,17 +1,17 @@
 import json
 from typing import Dict
 
+import numpy as np
 from starlette.requests import Request
+import torch
 
 from ray import serve
+from ray.rllib.core import Columns
+from ray.rllib.core.rl_module.rl_module import RLModule
 from ray.serve.schema import LoggingConfig
-from ray.rllib.algorithms.algorithm import Algorithm
 
 
-@serve.deployment(
-    route_prefix="/rllib-rlmodule",
-    logging_config=LoggingConfig(log_level="WARN"),
-)
+@serve.deployment(logging_config=LoggingConfig(log_level="WARN"))
 class ServeRLlibRLModule:
     """Callable class used by Ray Serve to handle async requests.
 
@@ -21,8 +21,8 @@ class ServeRLlibRLModule:
       (with a current observation).
     """
 
-    def __init__(self, checkpoint):
-        self.algo = Algorithm.from_checkpoint(checkpoint)
+    def __init__(self, rl_module_checkpoint):
+        self.rl_module = RLModule.from_checkpoint(rl_module_checkpoint)
 
     async def __call__(self, starlette_request: Request) -> Dict:
         request = await starlette_request.body()
@@ -30,13 +30,20 @@ class ServeRLlibRLModule:
         request = json.loads(request)
         obs = request["observation"]
 
-        # Compute and return the action for the given observation.
-        action = self.algo.compute_single_action(obs)
+        # Compute and return the action for the given observation (create a batch
+        # with B=1 and convert to torch).
+        output = self.rl_module.forward_inference(
+            batch={"obs": torch.from_numpy(np.array([obs], np.float32))}
+        )
+        # Extract action logits and unbatch.
+        logits = output[Columns.ACTION_DIST_INPUTS][0]
+        # Act greedily (argmax).
+        action = int(np.argmax(logits))
 
-        return {"action": int(action)}
+        return {"action": action}
 
 
 # Defining the builder function. This is so we can start our deployment via:
 # `serve run [this py module]:rl_module checkpoint=[some algo checkpoint path]`
 def rl_module(args: Dict[str, str]):
-    return ServeRLlibRLModule.bind(args["checkpoint"])
+    return ServeRLlibRLModule.bind(args["rl_module_checkpoint"])

--- a/rllib/examples/ray_serve/classes/cartpole_deployment.py
+++ b/rllib/examples/ray_serve/classes/cartpole_deployment.py
@@ -46,4 +46,5 @@ class ServeRLlibRLModule:
 # Defining the builder function. This is so we can start our deployment via:
 # `serve run [this py module]:rl_module checkpoint=[some algo checkpoint path]`
 def rl_module(args: Dict[str, str]):
+    serve.start(http_options={"host": "0.0.0.0", "port": args.get("port", 12345)})
     return ServeRLlibRLModule.bind(args["rl_module_checkpoint"])

--- a/rllib/examples/ray_serve/ray_serve_with_rllib.py
+++ b/rllib/examples/ray_serve/ray_serve_with_rllib.py
@@ -36,7 +36,33 @@ You can visualize experiment results in ~/ray_results using TensorBoard.
 Results to expect
 -----------------
 
-TODO
+You should see something similar to the following on the command line when using the
+options: `--stop-reward=250.0`, `--num-episodes-served=2`, and `--port=12345`:
+
+[First, the RLModule is trained through PPO]
+
++-----------------------------+------------+-----------------+--------+
+| Trial name                  | status     | loc             |   iter |
+|                             |            |                 |        |
+|-----------------------------+------------+-----------------+--------+
+| PPO_CartPole-v1_84778_00000 | TERMINATED | 127.0.0.1:40411 |      1 |
++-----------------------------+------------+-----------------+--------+
++------------------+---------------------+------------------------+
+|   total time (s) | episode_return_mean |   num_env_steps_sample |
+|                  |                     |             d_lifetime |
+|------------------+---------------------|------------------------|
+|          2.87052 |               253.2 |                  12000 |
++------------------+---------------------+------------------------+
+
+[The RLModule is deployed through Ray Serve on port 12345]
+
+Started Ray Serve with PID: 40458
+
+[A few episodes are played through using the policy service (w/ greedy, non-exploratory
+actions)]
+
+Episode R=500.0
+Episode R=500.0
 """
 
 import atexit


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Cleanup examples folder vol 32: Enable RLlib + Serve example in CI and translate to new API stack.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
