### PR TITLE
[Data] Relax timeout on TFRecords benchmark

### DIFF
--- a/release/nightly_tests/dataset/read_tfrecords_benchmark.py
+++ b/release/nightly_tests/dataset/read_tfrecords_benchmark.py
@@ -67,11 +67,10 @@ def generate_random_tfrecords(
         features = {k: v for (k, v) in features.items() if len(v) > 0}
         return pa.table(features)
 
-    ds = ray.data.range(num_rows).map_batches(generate_features)
-    assert ds.count() == num_rows, ds.count()
-
     tfrecords_dir = tempfile.mkdtemp()
-    ds.write_tfrecords(tfrecords_dir)
+    ray.data.range(num_rows).map_batches(generate_features).write_tfrecords(
+        tfrecords_dir
+    )
     return tfrecords_dir
 
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4343,7 +4343,7 @@
 
   run:
     # Expect the benchmark to finish around 22 minutes.
-    timeout: 1800
+    timeout: 2700
     script: python read_tfrecords_benchmark.py
 
   variations:

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4342,6 +4342,7 @@
     cluster_compute: single_node_benchmark_compute.yaml
 
   run:
+    # Expect the benchmark to finish around 30 minutes.
     timeout: 2700
     script: python read_tfrecords_benchmark.py
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4342,7 +4342,6 @@
     cluster_compute: single_node_benchmark_compute.yaml
 
   run:
-    # Expect the benchmark to finish around 22 minutes.
     timeout: 2700
     script: python read_tfrecords_benchmark.py
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The TFRecords release tests typically takes around 1680-1750s to complete. Because the timeout is set to 1800s, if there's minor variation in the job runtime, the job can timeout.

To avoid flakiness, this PR relaxes the timeout.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
