### PR TITLE
[data] cleanup: use SortKey instead of mixed typing in aggregation

### DIFF
--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -509,7 +509,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
         This assumes the block is already sorted by key in ascending order.
 
         Args:
-            key: A column name or list of column names.
+            sort_key: A column name or list of column names.
             If this is ``None``, place all rows in a single group.
 
             aggs: The aggregations to do.
@@ -612,7 +612,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
 
         Args:
             blocks: A list of partially combined and sorted blocks.
-            key: The column name of key or None for global aggregation.
+            sort_key: The column name of key or None for global aggregation.
             aggs: The aggregations to do.
             finalize: Whether to finalize the aggregation. This is used as an
                 optimization for cases where we repeatedly combine partially

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -650,7 +650,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
                 if next_row is None:
                     next_row = next(iter)
                 next_keys = key_fn(next_row)
-                next_key_names = keys
+                next_key_columns = keys
 
                 def gen():
                     nonlocal iter
@@ -690,8 +690,8 @@ class ArrowBlockAccessor(TableBlockAccessor):
                 # Build the row.
                 row = {}
                 if keys:
-                    for next_key, next_key_name in zip(next_keys, next_key_names):
-                        row[next_key_name] = next_key
+                    for col_name, next_key in zip(next_key_columns, next_keys):
+                        row[col_name] = next_key
 
                 for agg, agg_name, accumulator in zip(
                     aggs, resolved_agg_names, accumulators

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -630,7 +630,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
 
         def key_fn(r):
             if keys:
-                return tuple(r[k] for k in keys if k in r)
+                return tuple(r[keys])
             else:
                 return (0,)
 

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -525,7 +525,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
             """Creates an iterator over zero-copy group views."""
             if not keys:
                 # Global aggregation consists of a single "group", so we short-circuit.
-                yield None, self.to_block()
+                yield tuple(), self.to_block()
                 return
 
             start = end = 0

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -502,7 +502,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
 
         return find_partitions(table, boundaries, sort_key)
 
-    def combine(self, key: Union[str, List[str]], aggs: Tuple["AggregateFn"]) -> Block:
+    def combine(self, sort_key: "SortKey", aggs: Tuple["AggregateFn"]) -> Block:
         """Combine rows with the same key into an accumulator.
 
         This assumes the block is already sorted by key in ascending order.
@@ -519,16 +519,11 @@ class ArrowBlockAccessor(TableBlockAccessor):
             aggregation.
             If key is None then the k column is omitted.
         """
-        if key is not None and not isinstance(key, (str, list)):
-            raise ValueError(
-                "key must be a string, list of strings or None when aggregating "
-                "on Arrow blocks, but "
-                f"got: {type(key)}."
-            )
+        keys = sort_key.get_columns()
 
         def iter_groups() -> Iterator[Tuple[KeyType, Block]]:
             """Creates an iterator over zero-copy group views."""
-            if key is None:
+            if not keys:
                 # Global aggregation consists of a single "group", so we short-circuit.
                 yield None, self.to_block()
                 return
@@ -540,8 +535,8 @@ class ArrowBlockAccessor(TableBlockAccessor):
                 try:
                     if next_row is None:
                         next_row = next(iter)
-                    next_key = next_row[key]
-                    while next_row[key] == next_key:
+                    next_key = next_row[keys]
+                    while next_row[keys] == next_key:
                         end += 1
                         try:
                             next_row = next(iter)
@@ -554,22 +549,15 @@ class ArrowBlockAccessor(TableBlockAccessor):
                     break
 
         builder = ArrowBlockBuilder()
-        for group_key, group_view in iter_groups():
+        for group_keys, group_view in iter_groups():
             # Aggregate.
-            accumulators = [agg.init(group_key) for agg in aggs]
+            accumulators = [agg.init(group_keys) for agg in aggs]
             for i in range(len(aggs)):
                 accumulators[i] = aggs[i].accumulate_block(accumulators[i], group_view)
 
             # Build the row.
             row = {}
-            if key is not None:
-                if isinstance(key, list):
-                    keys = key
-                    group_keys = group_key
-                else:
-                    keys = [key]
-                    group_keys = [group_key]
-
+            if keys:
                 for k, gk in zip(keys, group_keys):
                     row[k] = gk
 
@@ -608,7 +596,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
     @staticmethod
     def aggregate_combined_blocks(
         blocks: List[Block],
-        key: Union[str, List[str]],
+        sort_key: "SortKey",
         aggs: Tuple["AggregateFn"],
         finalize: bool,
     ) -> Tuple[Block, BlockMetadata]:
@@ -633,13 +621,13 @@ class ArrowBlockAccessor(TableBlockAccessor):
         """
 
         stats = BlockExecStats.builder()
+        keys = sort_key.get_columns()
 
-        keys = key if isinstance(key, list) else [key]
-        key_fn = (
-            (lambda r: tuple(r[r._row.schema.names[: len(keys)]]))
-            if key is not None
-            else (lambda r: (0,))
-        )
+        def key_fn(r):
+            if sort_key is not None:
+                return tuple(r[k] for k in keys if k in r)
+            else:
+                return (0,)
 
         # Handle blocks of different types.
         blocks = TableBlockAccessor.normalize_block_types(blocks, "arrow")
@@ -658,9 +646,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
                 if next_row is None:
                     next_row = next(iter)
                 next_keys = key_fn(next_row)
-                next_key_names = (
-                    next_row._row.schema.names[: len(keys)] if key is not None else None
-                )
+                next_key_names = keys
 
                 def gen():
                     nonlocal iter
@@ -699,7 +685,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
                             )
                 # Build the row.
                 row = {}
-                if key is not None:
+                if keys:
                     for next_key, next_key_name in zip(next_keys, next_key_names):
                         row[next_key_name] = next_key
 

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -10,6 +10,7 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Sequence,
     Tuple,
     TypeVar,
     Union,
@@ -519,9 +520,9 @@ class ArrowBlockAccessor(TableBlockAccessor):
             aggregation.
             If key is None then the k column is omitted.
         """
-        keys = sort_key.get_columns()
+        keys: List[str] = sort_key.get_columns()
 
-        def iter_groups() -> Iterator[Tuple[Tuple[KeyType], Block]]:
+        def iter_groups() -> Iterator[Tuple[Sequence[KeyType], Block]]:
             """Creates an iterator over zero-copy group views."""
             if not keys:
                 # Global aggregation consists of a single "group", so we short-circuit.

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -561,7 +561,7 @@ class PandasBlockAccessor(TableBlockAccessor):
                 if next_row is None:
                     next_row = next(iter)
                 next_keys = key_fn(next_row)
-                next_key_names = keys
+                next_key_columns = keys
 
                 def gen():
                     nonlocal iter
@@ -601,8 +601,8 @@ class PandasBlockAccessor(TableBlockAccessor):
                 # Build the row.
                 row = {}
                 if keys:
-                    for next_key, next_key_name in zip(next_keys, next_key_names):
-                        row[next_key_name] = next_key
+                    for col_name, next_key in zip(next_key_columns, next_keys):
+                        row[col_name] = next_key
 
                 for agg, agg_name, accumulator in zip(
                     aggs, resolved_agg_names, accumulators

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -544,7 +544,7 @@ class PandasBlockAccessor(TableBlockAccessor):
 
         def key_fn(r):
             if keys:
-                return tuple(r[k] for k in keys if k in r)
+                return tuple(r[keys])
             else:
                 return (0,)
 

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -451,7 +451,7 @@ class PandasBlockAccessor(TableBlockAccessor):
                 try:
                     if next_row is None:
                         next_row = next(iter)
-                    next_keys = tuple(next_row[keys])
+                    next_keys = next_row[keys]
                     while np.all(next_row[keys] == next_keys):
                         end += 1
                         try:

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -435,7 +435,7 @@ class PandasBlockAccessor(TableBlockAccessor):
         """
         keys: List[str] = sort_key.get_columns()
 
-        def iter_groups() -> Iterator[Tuple[KeyType, Block]]:
+        def iter_groups() -> Iterator[Tuple[Tuple[KeyType], Block]]:
             """Creates an iterator over zero-copy group views."""
             if not keys:
                 # Global aggregation consists of a single "group", so we short-circuit.
@@ -449,15 +449,15 @@ class PandasBlockAccessor(TableBlockAccessor):
                 try:
                     if next_row is None:
                         next_row = next(iter)
-                    next_key = next_row[keys]
-                    while np.all(next_row[keys] == next_key):
+                    next_keys = next_row[keys]
+                    while np.all(next_row[keys] == next_keys):
                         end += 1
                         try:
                             next_row = next(iter)
                         except StopIteration:
                             next_row = None
                             break
-                    yield next_key, self.slice(start, end, copy=False)
+                    yield next_keys, self.slice(start, end, copy=False)
                     start = end
                 except StopIteration:
                     break
@@ -465,7 +465,10 @@ class PandasBlockAccessor(TableBlockAccessor):
         builder = PandasBlockBuilder()
         for group_keys, group_view in iter_groups():
             # Aggregate.
-            accumulators = [agg.init(group_keys) for agg in aggs]
+            init_vals = group_keys
+            if len(group_keys) == 1:
+                init_vals = group_keys[0]
+            accumulators = [agg.init(init_vals) for agg in aggs]
             for i in range(len(aggs)):
                 accumulators[i] = aggs[i].accumulate_block(accumulators[i], group_view)
 
@@ -536,7 +539,7 @@ class PandasBlockAccessor(TableBlockAccessor):
         keys = sort_key.get_columns()
 
         def key_fn(r):
-            if sort_key is not None:
+            if keys:
                 return tuple(r[k] for k in keys if k in r)
             else:
                 return (0,)

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -439,7 +439,7 @@ class PandasBlockAccessor(TableBlockAccessor):
             """Creates an iterator over zero-copy group views."""
             if not keys:
                 # Global aggregation consists of a single "group", so we short-circuit.
-                yield None, self.to_block()
+                yield tuple(), self.to_block()
                 return
 
             start = end = 0
@@ -449,7 +449,7 @@ class PandasBlockAccessor(TableBlockAccessor):
                 try:
                     if next_row is None:
                         next_row = next(iter)
-                    next_keys = next_row[keys]
+                    next_keys = tuple(next_row[keys])
                     while np.all(next_row[keys] == next_keys):
                         end += 1
                         try:

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -423,7 +423,7 @@ class PandasBlockAccessor(TableBlockAccessor):
         This assumes the block is already sorted by key in ascending order.
 
         Args:
-            key: A SortKey object which holds column names/keys.
+            sort_key: A SortKey object which holds column names/keys.
             If this is ``None``, place all rows in a single group.
 
             aggs: The aggregations to do.
@@ -526,7 +526,7 @@ class PandasBlockAccessor(TableBlockAccessor):
 
         Args:
             blocks: A list of partially combined and sorted blocks.
-            key: The column name of key or None for global aggregation.
+            sort_key: The column name of key or None for global aggregation.
             aggs: The aggregations to do.
             finalize: Whether to finalize the aggregation. This is used as an
                 optimization for cases where we repeatedly combine partially

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -8,6 +8,7 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Sequence,
     Tuple,
     TypeVar,
     Union,
@@ -434,8 +435,9 @@ class PandasBlockAccessor(TableBlockAccessor):
             If key is None then the k column is omitted.
         """
         keys: List[str] = sort_key.get_columns()
+        pd = lazy_import_pandas()
 
-        def iter_groups() -> Iterator[Tuple[Tuple[KeyType], Block]]:
+        def iter_groups() -> Iterator[Tuple[Sequence[KeyType], Block]]:
             """Creates an iterator over zero-copy group views."""
             if not keys:
                 # Global aggregation consists of a single "group", so we short-circuit.
@@ -457,6 +459,8 @@ class PandasBlockAccessor(TableBlockAccessor):
                         except StopIteration:
                             next_row = None
                             break
+                    if isinstance(next_keys, pd.Series):
+                        next_keys = next_keys.values
                     yield next_keys, self.slice(start, end, copy=False)
                     start = end
                 except StopIteration:

--- a/python/ray/data/_internal/planner/aggregate.py
+++ b/python/ray/data/_internal/planner/aggregate.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 from ray.data._internal.execution.interfaces import (
     AllToAllTransformFn,
@@ -22,7 +22,7 @@ from ray.data.context import DataContext
 
 
 def generate_aggregate_fn(
-    key: Optional[str],
+    key: Optional[Union[str, List[str]]],
     aggs: List[AggregateFn],
     _debug_limit_shuffle_execution_to_num_blocks: Optional[int] = None,
 ) -> AllToAllTransformFn:
@@ -49,6 +49,8 @@ def generate_aggregate_fn(
 
         num_mappers = len(blocks)
 
+        sort_key = SortKey(key)
+
         if key is None:
             num_outputs = 1
             boundaries = []
@@ -60,12 +62,12 @@ def generate_aggregate_fn(
             ]
             # Sample boundaries for aggregate key.
             boundaries = SortTaskSpec.sample_boundaries(
-                blocks, SortKey(key), num_outputs, sample_bar
+                blocks, sort_key, num_outputs, sample_bar
             )
 
         agg_spec = SortAggregateTaskSpec(
             boundaries=boundaries,
-            key=key,
+            key=sort_key,
             aggs=aggs,
         )
         if DataContext.get_current().use_push_based_shuffle:

--- a/python/ray/data/_internal/planner/exchange/aggregate_task_spec.py
+++ b/python/ray/data/_internal/planner/exchange/aggregate_task_spec.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple, Union
+from typing import List, Tuple, Union
 
 from ray.data._internal.aggregate import Count, _AggregateOnKeyBase
 from ray.data._internal.planner.exchange.interfaces import ExchangeTaskSpec
@@ -27,7 +27,7 @@ class SortAggregateTaskSpec(ExchangeTaskSpec):
     def __init__(
         self,
         boundaries: List[KeyType],
-        key: Optional[str],
+        key: SortKey,
         aggs: List[AggregateFn],
     ):
         super().__init__(
@@ -41,26 +41,26 @@ class SortAggregateTaskSpec(ExchangeTaskSpec):
         block: Block,
         output_num_blocks: int,
         boundaries: List[KeyType],
-        key: Union[str, List[str], None],
+        sort_key: SortKey,
         aggs: List[AggregateFn],
     ) -> List[Union[BlockMetadata, Block]]:
         stats = BlockExecStats.builder()
 
-        block = SortAggregateTaskSpec._prune_unused_columns(block, key, aggs)
-        if key is None:
-            partitions = [block]
-        else:
+        block = SortAggregateTaskSpec._prune_unused_columns(block, sort_key, aggs)
+        if sort_key.get_columns():
             partitions = BlockAccessor.for_block(block).sort_and_partition(
                 boundaries,
-                SortKey(key),
+                sort_key,
             )
-        parts = [BlockAccessor.for_block(p).combine(key, aggs) for p in partitions]
+        else:
+            partitions = [block]
+        parts = [BlockAccessor.for_block(p).combine(sort_key, aggs) for p in partitions]
         meta = BlockAccessor.for_block(block).get_metadata(exec_stats=stats.build())
         return parts + [meta]
 
     @staticmethod
     def reduce(
-        key: Optional[str],
+        key: SortKey,
         aggs: List[AggregateFn],
         *mapper_outputs: List[Block],
         partial_reduce: bool = False,
@@ -72,12 +72,13 @@ class SortAggregateTaskSpec(ExchangeTaskSpec):
     @staticmethod
     def _prune_unused_columns(
         block: Block,
-        key: Union[str, List[str]],
+        sort_key: SortKey,
         aggs: Tuple[AggregateFn],
     ) -> Block:
         """Prune unused columns from block before aggregate."""
         prune_columns = True
         columns = set()
+        key = sort_key.get_columns()
 
         if isinstance(key, str):
             columns.add(key)

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -437,7 +437,7 @@ class BlockAccessor:
         """Return a list of sorted partitions of this block."""
         raise NotImplementedError
 
-    def combine(self, key: "SortKey", agg: "AggregateFn") -> Block:
+    def combine(self, key: "SortKey", aggs: Tuple["AggregateFn"]) -> Block:
         """Combine rows with the same key into an accumulator."""
         raise NotImplementedError
 
@@ -450,7 +450,7 @@ class BlockAccessor:
 
     @staticmethod
     def aggregate_combined_blocks(
-        blocks: List[Block], key: Optional[str], agg: "AggregateFn"
+        blocks: List[Block], sort_key: "SortKey", aggs: Tuple["AggregateFn"]
     ) -> Tuple[Block, BlockMetadata]:
         """Aggregate partially combined and sorted blocks."""
         raise NotImplementedError

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -437,7 +437,7 @@ class BlockAccessor:
         """Return a list of sorted partitions of this block."""
         raise NotImplementedError
 
-    def combine(self, key: Optional[str], agg: "AggregateFn") -> Block:
+    def combine(self, key: "SortKey", agg: "AggregateFn") -> Block:
         """Combine rows with the same key into an accumulator."""
         raise NotImplementedError
 

--- a/python/ray/data/tests/test_all_to_all.py
+++ b/python/ray/data/tests/test_all_to_all.py
@@ -134,6 +134,12 @@ def test_groupby_arrow(ray_start_regular_shared, use_push_based_shuffle):
     assert agg_ds.count() == 0
 
 
+def test_groupby_none(ray_start_regular_shared):
+    ds = ray.data.range(10)
+    assert ds.groupby(None).min().take_all() == [{"min(id)": 0}]
+    assert ds.groupby(None).max().take_all() == [{"max(id)": 9}]
+
+
 def test_groupby_errors(ray_start_regular_shared):
     ds = ray.data.range(100)
     ds.groupby(None).count().show()  # OK

--- a/python/ray/data/tests/test_all_to_all.py
+++ b/python/ray/data/tests/test_all_to_all.py
@@ -208,6 +208,46 @@ def test_groupby_large_udf_returns(ray_start_regular_shared):
     ds.take(1)
 
 
+@pytest.mark.parametrize("keys", ["A", ["A", "B"]])
+def test_agg_inputs(ray_start_regular_shared, keys):
+    from ray.data._internal.aggregate import Max
+
+    xs = list(range(100))
+    ds = ray.data.from_items([{"A": (x % 3), "B": x, "C": (x % 2)} for x in xs])
+
+    def check_init(k):
+        if len(keys) == 2:
+            assert isinstance(k, tuple), k
+            assert len(k) == 2
+        elif len(keys) == 1:
+            assert isinstance(k, int)
+        return 1
+
+    def check_finalize(v):
+        assert v == 1
+
+    def check_accumulate_merge(a, r):
+        assert a == 1
+        if isinstance(r, int):
+            return 1
+        elif len(r) == 3:
+            assert all(x in r for x in ["A", "B", "C"])
+        else:
+            assert False, r
+        return 1
+
+    output = ds.groupby(keys).aggregate(
+        AggregateFn(
+            init=check_init,
+            accumulate_row=check_accumulate_merge,
+            merge=check_accumulate_merge,
+            finalize=check_finalize,
+            name="foo",
+        )
+    )
+    output.take_all()
+
+
 def test_agg_errors(ray_start_regular_shared):
     from ray.data._internal.aggregate import Max
 

--- a/python/ray/data/tests/test_all_to_all.py
+++ b/python/ray/data/tests/test_all_to_all.py
@@ -210,8 +210,6 @@ def test_groupby_large_udf_returns(ray_start_regular_shared):
 
 @pytest.mark.parametrize("keys", ["A", ["A", "B"]])
 def test_agg_inputs(ray_start_regular_shared, keys):
-    from ray.data._internal.aggregate import Max
-
     xs = list(range(100))
     ds = ray.data.from_items([{"A": (x % 3), "B": x, "C": (x % 2)} for x in xs])
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This makes SortAggregate more consistent by unifying the API on the SortKey object, similar to how SortTaskSpec is implemented.

This is related to #42776 and https://github.com/ray-project/ray/issues/42142

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(