### PR TITLE
[serve] combine proxy routers

### DIFF
--- a/python/ray/serve/_private/default_impl.py
+++ b/python/ray/serve/_private/default_impl.py
@@ -6,12 +6,7 @@ from ray.serve._private.cluster_node_info_cache import (
     ClusterNodeInfoCache,
     DefaultClusterNodeInfoCache,
 )
-from ray.serve._private.common import (
-    DeploymentHandleSource,
-    DeploymentID,
-    EndpointInfo,
-    RequestProtocol,
-)
+from ray.serve._private.common import DeploymentHandleSource, DeploymentID, EndpointInfo
 from ray.serve._private.constants import (
     RAY_SERVE_ENABLE_QUEUE_LENGTH_CACHE,
     RAY_SERVE_ENABLE_STRICT_MAX_ONGOING_REQUESTS,

--- a/python/ray/serve/_private/default_impl.py
+++ b/python/ray/serve/_private/default_impl.py
@@ -1,8 +1,6 @@
 from typing import Callable, Optional, Tuple
 
 import ray
-
-# from ray import serve
 from ray._raylet import GcsClient
 from ray.serve._private.cluster_node_info_cache import (
     ClusterNodeInfoCache,

--- a/python/ray/serve/_private/default_impl.py
+++ b/python/ray/serve/_private/default_impl.py
@@ -135,6 +135,8 @@ def add_grpc_address(grpc_server: gRPCServer, server_address: str):
 
 
 def get_proxy_handle(endpoint: DeploymentID, info: EndpointInfo):
+    # NOTE(zcin): needs to be lazy import due to a circular dependency.
+    # We should not be importing from application_state in context.
     from ray.serve.context import _get_global_client
 
     client = _get_global_client()

--- a/python/ray/serve/_private/handle_options.py
+++ b/python/ray/serve/_private/handle_options.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, fields
 
 import ray
-from ray.serve._private.common import DeploymentHandleSource, RequestProtocol
+from ray.serve._private.common import DeploymentHandleSource
 from ray.serve._private.utils import DEFAULT
 
 

--- a/python/ray/serve/_private/handle_options.py
+++ b/python/ray/serve/_private/handle_options.py
@@ -52,7 +52,6 @@ class DynamicHandleOptionsBase(ABC):
     method_name: str = "__call__"
     multiplexed_model_id: str = ""
     stream: bool = False
-    _request_protocol: str = RequestProtocol.UNDEFINED
 
     def copy_and_update(self, **kwargs) -> "DynamicHandleOptionsBase":
         new_kwargs = {}

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -6,7 +6,7 @@ import pickle
 import socket
 import time
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Dict, Generator, List, Optional, Set, Tuple, Type
+from typing import Any, Callable, Dict, Generator, List, Optional, Set, Tuple
 
 import grpc
 import starlette

--- a/python/ray/serve/_private/proxy_router.py
+++ b/python/ray/serve/_private/proxy_router.py
@@ -1,12 +1,7 @@
 import logging
 from typing import Callable, Dict, List, Optional, Tuple
 
-from ray.serve._private.common import (
-    ApplicationName,
-    DeploymentID,
-    EndpointInfo,
-    RequestProtocol,
-)
+from ray.serve._private.common import ApplicationName, DeploymentID, EndpointInfo
 from ray.serve._private.constants import SERVE_LOGGER_NAME
 from ray.serve.handle import DeploymentHandle
 

--- a/python/ray/serve/_private/proxy_router.py
+++ b/python/ray/serve/_private/proxy_router.py
@@ -1,18 +1,13 @@
 import logging
-from abc import ABC, abstractmethod
 from typing import Callable, Dict, List, Optional, Tuple
 
 from ray.serve._private.common import (
     ApplicationName,
-    DeploymentHandleSource,
     DeploymentID,
     EndpointInfo,
     RequestProtocol,
 )
-from ray.serve._private.constants import (
-    RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING,
-    SERVE_LOGGER_NAME,
-)
+from ray.serve._private.constants import SERVE_LOGGER_NAME
 from ray.serve.handle import DeploymentHandle
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
@@ -21,27 +16,32 @@ NO_ROUTES_MESSAGE = "Route table is not populated yet."
 NO_REPLICAS_MESSAGE = "No replicas are available yet."
 
 
-class ProxyRouter(ABC):
+class ProxyRouter:
     """Router interface for the proxy to use."""
 
     def __init__(
         self,
         get_handle: Callable[[str, str], DeploymentHandle],
-        protocol: RequestProtocol,
     ):
         # Function to get a handle given a name. Used to mock for testing.
         self._get_handle = get_handle
-        # Protocol to config handle
-        self._protocol = protocol
         # Contains a ServeHandle for each endpoint.
         self.handles: Dict[DeploymentID, DeploymentHandle] = dict()
         # Flipped to `True` once the route table has been updated at least once.
         # The proxy router is not ready for traffic until the route table is populated
         self._route_table_populated = False
 
-    @abstractmethod
-    def update_routes(self, endpoints: Dict[DeploymentID, EndpointInfo]):
-        raise NotImplementedError
+        # Info used for HTTP proxy
+        # Routes sorted in order of decreasing length.
+        self.sorted_routes: List[str] = list()
+        # Endpoints associated with the routes.
+        self.route_info: Dict[str, DeploymentID] = dict()
+        # Map of application name to is_cross_language.
+        self.app_to_is_cross_language: Dict[ApplicationName, bool] = dict()
+
+        # Info used for gRPC proxy
+        # Endpoints info associated with endpoints.
+        self.endpoints: Dict[DeploymentID, EndpointInfo] = dict()
 
     def ready_for_traffic(self, is_head: bool) -> Tuple[bool, str]:
         """Whether the proxy router is ready to serve traffic.
@@ -72,25 +72,11 @@ class ProxyRouter(ABC):
 
         return False, NO_REPLICAS_MESSAGE
 
-
-class LongestPrefixRouter(ProxyRouter):
-    """Router that performs longest prefix matches on incoming routes."""
-
-    def __init__(
+    def update_routes(
         self,
-        get_handle: Callable[[str, str], DeploymentHandle],
+        endpoints: Dict[DeploymentID, EndpointInfo],
         protocol: RequestProtocol,
-    ):
-        super().__init__(get_handle, protocol)
-
-        # Routes sorted in order of decreasing length.
-        self.sorted_routes: List[str] = list()
-        # Endpoints associated with the routes.
-        self.route_info: Dict[str, DeploymentID] = dict()
-        # Map of application name to is_cross_language.
-        self.app_to_is_cross_language: Dict[ApplicationName, bool] = dict()
-
-    def update_routes(self, endpoints: Dict[DeploymentID, EndpointInfo]) -> None:
+    ) -> None:
         logger.info(
             f"Got updated endpoints: {endpoints}.", extra={"log_to_stderr": False}
         )
@@ -108,19 +94,7 @@ class LongestPrefixRouter(ProxyRouter):
             if endpoint in self.handles:
                 existing_handles.remove(endpoint)
             else:
-                handle = self._get_handle(endpoint.name, endpoint.app_name)
-                # NOTE(zcin): since the router is eagerly initialized here,
-                # it will receive the replica set from the controller early.
-                if not handle.is_initialized:
-                    handle._init(
-                        _prefer_local_routing=RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING,
-                        _source=DeploymentHandleSource.PROXY,
-                    )
-                handle._set_request_protocol(self._protocol)
-                # Streaming codepath isn't supported for Java.
-                self.handles[endpoint] = handle.options(
-                    stream=not info.app_is_cross_language
-                )
+                self.handles[endpoint] = self._get_handle(endpoint, info, protocol)
 
         # Clean up any handles that are no longer used.
         if len(existing_handles) > 0:
@@ -172,53 +146,6 @@ class LongestPrefixRouter(ProxyRouter):
                     )
 
         return None
-
-
-class EndpointRouter(ProxyRouter):
-    """Router that matches endpoint to return the handle."""
-
-    def __init__(self, get_handle: Callable, protocol: RequestProtocol):
-        super().__init__(get_handle, protocol)
-
-        # Endpoints info associated with endpoints.
-        self.endpoints: Dict[DeploymentID, EndpointInfo] = dict()
-
-    def update_routes(self, endpoints: Dict[DeploymentID, EndpointInfo]):
-        logger.info(
-            f"Got updated endpoints: {endpoints}.", extra={"log_to_stderr": False}
-        )
-        if endpoints:
-            self._route_table_populated = True
-
-        self.endpoints = endpoints
-
-        existing_handles = set(self.handles.keys())
-        for endpoint, info in endpoints.items():
-            if endpoint in self.handles:
-                existing_handles.remove(endpoint)
-            else:
-                handle = self._get_handle(endpoint.name, endpoint.app_name)
-                # NOTE(zcin): since the router is eagerly initialized here,
-                # it will receive the replica set from the controller early.
-                if not handle.is_initialized:
-                    handle._init(
-                        _prefer_local_routing=RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING,
-                        _source=DeploymentHandleSource.PROXY,
-                    )
-                handle._set_request_protocol(self._protocol)
-                # Streaming codepath isn't supported for Java.
-                self.handles[endpoint] = handle.options(
-                    stream=not info.app_is_cross_language
-                )
-
-        # Clean up any handles that are no longer used.
-        if len(existing_handles) > 0:
-            logger.info(
-                f"Deleting {len(existing_handles)} unused handles.",
-                extra={"log_to_stderr": False},
-            )
-        for endpoint in existing_handles:
-            del self.handles[endpoint]
 
     def get_handle_for_endpoint(
         self, target_app_name: str

--- a/python/ray/serve/_private/proxy_router.py
+++ b/python/ray/serve/_private/proxy_router.py
@@ -160,7 +160,6 @@ class ProxyRouter:
             (route, handle, is_cross_language) for the single app if there
             is only one, else find the app and handle for exact match. Else return None.
         """
-        print("handles", self.handles)
         for endpoint_tag, handle in self.handles.items():
             # If the target_app_name matches with the endpoint or if
             # there is only one endpoint.

--- a/python/ray/serve/_private/proxy_router.py
+++ b/python/ray/serve/_private/proxy_router.py
@@ -72,13 +72,9 @@ class ProxyRouter:
 
         return False, NO_REPLICAS_MESSAGE
 
-    def update_routes(
-        self,
-        endpoints: Dict[DeploymentID, EndpointInfo],
-        protocol: RequestProtocol,
-    ) -> None:
+    def update_routes(self, endpoints: Dict[DeploymentID, EndpointInfo]):
         logger.info(
-            f"Got updated endpoints: {endpoints}.", extra={"log_to_stderr": False}
+            f"Got updated endpoints: {endpoints}.", extra={"log_to_stderr": True}
         )
         if endpoints:
             self._route_table_populated = True
@@ -96,7 +92,7 @@ class ProxyRouter:
             if endpoint in self.handles:
                 existing_handles.remove(endpoint)
             else:
-                self.handles[endpoint] = self._get_handle(endpoint, info, protocol)
+                self.handles[endpoint] = self._get_handle(endpoint, info)
 
         # Clean up any handles that are no longer used.
         if len(existing_handles) > 0:

--- a/python/ray/serve/_private/proxy_router.py
+++ b/python/ray/serve/_private/proxy_router.py
@@ -83,6 +83,8 @@ class ProxyRouter:
         if endpoints:
             self._route_table_populated = True
 
+        self.endpoints = endpoints
+
         existing_handles = set(self.handles.keys())
         routes = []
         route_info = {}
@@ -155,9 +157,10 @@ class ProxyRouter:
         Args:
             target_app_name: app_name to match against.
         Returns:
-            (route, handle, app_name, is_cross_language) for the single app if there
+            (route, handle, is_cross_language) for the single app if there
             is only one, else find the app and handle for exact match. Else return None.
         """
+        print("handles", self.handles)
         for endpoint_tag, handle in self.handles.items():
             # If the target_app_name matches with the endpoint or if
             # there is only one endpoint.

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -152,7 +152,7 @@ class _DeploymentHandleBase:
         self.init_options = create_init_handle_options(**kwargs)
         self._get_or_create_router()
 
-        # Record telemetry when not in the proxy
+        # Record handle api telemetry when not in the proxy
         if (
             self.init_handle_options._source != DeploymentHandleSource.PROXY
             and self.__class__ == DeploymentHandle

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -153,6 +153,7 @@ class _DeploymentHandleBase:
         to initialize a handle with custom init options, you must do it
         before calling `.options()` or `.remote()`.
         """
+        print("cindy init!!!")
         if self._router is not None:
             raise RuntimeError(
                 "Handle has already been initialized. Note that a handle is implicitly "
@@ -729,6 +730,14 @@ class DeploymentHandle(_DeploymentHandleBase):
                 remote method call.
         """
         _request_context = ray.serve.context._serve_request_context.get()
+
+        if _request_context.is_http_request:
+            request_protocol = RequestProtocol.HTTP
+        elif _request_context.grpc_context:
+            request_protocol = RequestProtocol.GRPC
+        else:
+            request_protocol = RequestProtocol.UNDEFINED
+
         request_metadata = RequestMetadata(
             request_id=_request_context.request_id
             if _request_context.request_id
@@ -741,7 +750,7 @@ class DeploymentHandle(_DeploymentHandleBase):
             app_name=self.app_name,
             multiplexed_model_id=self.handle_options.multiplexed_model_id,
             is_streaming=self.handle_options.stream,
-            _request_protocol=self.handle_options._request_protocol,
+            _request_protocol=request_protocol,
             grpc_context=_request_context.grpc_context,
         )
 

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -155,7 +155,7 @@ class _DeploymentHandleBase:
 
         # Record handle api telemetry when not in the proxy
         if (
-            self.init_handle_options._source != DeploymentHandleSource.PROXY
+            self.init_options._source != DeploymentHandleSource.PROXY
             and self.__class__ == DeploymentHandle
         ):
             ServeUsageTag.DEPLOYMENT_HANDLE_API_USED.record("1")

--- a/python/ray/serve/tests/test_handle_1.py
+++ b/python/ray/serve/tests/test_handle_1.py
@@ -7,7 +7,7 @@ import pytest
 
 import ray
 from ray import serve
-from ray.serve._private.common import DeploymentHandleSource, RequestProtocol
+from ray.serve._private.common import DeploymentHandleSource
 from ray.serve._private.constants import (
     RAY_SERVE_FORCE_LOCAL_TESTING_MODE,
     SERVE_DEFAULT_APP_NAME,

--- a/python/ray/serve/tests/test_handle_1.py
+++ b/python/ray/serve/tests/test_handle_1.py
@@ -265,37 +265,6 @@ def test_handle_options_with_same_router(serve_instance):
     assert handle2._router is handle._router
 
 
-def test_set_request_protocol(serve_instance):
-    """Test setting request protocol for a handle.
-
-    When a handle is created, it's _request_protocol is undefined. When calling
-    `_set_request_protocol()`, _request_protocol is set to the specified protocol.
-    When chaining options, the _request_protocol on the new handle is copied over.
-    When calling `_set_request_protocol()` on the new handle, _request_protocol
-    on the new handle is changed accordingly, while _request_protocol on the
-    original handle remains unchanged.
-    """
-
-    @serve.deployment
-    def echo(name: str):
-        return f"Hi {name}"
-
-    handle = serve.run(echo.bind())
-    assert handle.handle_options._request_protocol == RequestProtocol.UNDEFINED
-
-    handle._set_request_protocol(RequestProtocol.HTTP)
-    assert handle.handle_options._request_protocol == RequestProtocol.HTTP
-
-    multiplexed_model_id = "fake-multiplexed_model_id"
-    new_handle = handle.options(multiplexed_model_id=multiplexed_model_id)
-    assert new_handle.handle_options.multiplexed_model_id == multiplexed_model_id
-    assert new_handle.handle_options._request_protocol == RequestProtocol.HTTP
-
-    new_handle._set_request_protocol(RequestProtocol.GRPC)
-    assert new_handle.handle_options._request_protocol == RequestProtocol.GRPC
-    assert handle.handle_options._request_protocol == RequestProtocol.HTTP
-
-
 def test_init(serve_instance):
     @serve.deployment
     def f():

--- a/python/ray/serve/tests/unit/test_handle_options.py
+++ b/python/ray/serve/tests/unit/test_handle_options.py
@@ -2,7 +2,7 @@ import sys
 
 import pytest
 
-from ray.serve._private.common import DeploymentHandleSource, RequestProtocol
+from ray.serve._private.common import DeploymentHandleSource
 from ray.serve._private.handle_options import DynamicHandleOptions, InitHandleOptions
 from ray.serve._private.utils import DEFAULT
 
@@ -12,53 +12,45 @@ def test_dynamic_handle_options():
     assert default_options.method_name == "__call__"
     assert default_options.multiplexed_model_id == ""
     assert default_options.stream is False
-    assert default_options._request_protocol == RequestProtocol.UNDEFINED
 
     # Test setting method name.
     only_set_method = default_options.copy_and_update(method_name="hi")
     assert only_set_method.method_name == "hi"
     assert only_set_method.multiplexed_model_id == ""
     assert only_set_method.stream is False
-    assert default_options._request_protocol == RequestProtocol.UNDEFINED
 
     # Existing options should be unmodified.
     assert default_options.method_name == "__call__"
     assert default_options.multiplexed_model_id == ""
     assert default_options.stream is False
-    assert default_options._request_protocol == RequestProtocol.UNDEFINED
 
     # Test setting model ID.
     only_set_model_id = default_options.copy_and_update(multiplexed_model_id="hi")
     assert only_set_model_id.method_name == "__call__"
     assert only_set_model_id.multiplexed_model_id == "hi"
     assert only_set_model_id.stream is False
-    assert default_options._request_protocol == RequestProtocol.UNDEFINED
 
     # Existing options should be unmodified.
     assert default_options.method_name == "__call__"
     assert default_options.multiplexed_model_id == ""
     assert default_options.stream is False
-    assert default_options._request_protocol == RequestProtocol.UNDEFINED
 
     # Test setting stream.
     only_set_stream = default_options.copy_and_update(stream=True)
     assert only_set_stream.method_name == "__call__"
     assert only_set_stream.multiplexed_model_id == ""
     assert only_set_stream.stream is True
-    assert default_options._request_protocol == RequestProtocol.UNDEFINED
 
     # Existing options should be unmodified.
     assert default_options.method_name == "__call__"
     assert default_options.multiplexed_model_id == ""
     assert default_options.stream is False
-    assert default_options._request_protocol == RequestProtocol.UNDEFINED
 
     # Test setting multiple.
     set_multiple = default_options.copy_and_update(method_name="hi", stream=True)
     assert set_multiple.method_name == "hi"
     assert set_multiple.multiplexed_model_id == ""
     assert set_multiple.stream is True
-    assert default_options._request_protocol == RequestProtocol.UNDEFINED
 
 
 def test_init_handle_options():

--- a/python/ray/serve/tests/unit/test_proxy.py
+++ b/python/ray/serve/tests/unit/test_proxy.py
@@ -7,12 +7,7 @@ from unittest.mock import AsyncMock
 import grpc
 import pytest
 
-from ray.serve._private.common import (
-    DeploymentID,
-    EndpointInfo,
-    RequestMetadata,
-    RequestProtocol,
-)
+from ray.serve._private.common import DeploymentID, EndpointInfo, RequestMetadata
 from ray.serve._private.proxy import (
     DRAINING_MESSAGE,
     HEALTHY_MESSAGE,

--- a/python/ray/serve/tests/unit/test_proxy_router.py
+++ b/python/ray/serve/tests/unit/test_proxy_router.py
@@ -20,7 +20,7 @@ def get_handle_function(router: ProxyRouter) -> Callable:
 
 @pytest.fixture
 def mock_router():
-    def mock_get_handle(endpoint, info, protocol):
+    def mock_get_handle(endpoint, info):
         return MockDeploymentHandle(endpoint.name, endpoint.app_name)
 
     yield ProxyRouter(mock_get_handle)
@@ -37,7 +37,6 @@ def test_no_match(mock_router: ProxyRouter):
                 route="/hello2"
             ),
         },
-        RequestProtocol.UNDEFINED,
     )
     assert router.match_route("/nonexistent") is None
     assert router.get_handle_for_endpoint("/nonexistent") is None
@@ -54,7 +53,6 @@ def test_default_route(mock_router: ProxyRouter):
                 route="/endpoint2"
             ),
         },
-        RequestProtocol.UNDEFINED,
     )
 
     # Route based matching
@@ -82,7 +80,6 @@ def test_trailing_slash(mock_router: ProxyRouter):
                 route="/test"
             )
         },
-        RequestProtocol.UNDEFINED,
     )
 
     route, handle, _ = router.match_route("/test/")
@@ -94,7 +91,6 @@ def test_trailing_slash(mock_router: ProxyRouter):
                 route="/test/"
             )
         },
-        RequestProtocol.UNDEFINED,
     )
 
     assert router.match_route("/test") is None
@@ -112,7 +108,6 @@ def test_prefix_match(mock_router):
             ),
             DeploymentID(name="endpoint3", app_name="default"): EndpointInfo(route="/"),
         },
-        RequestProtocol.UNDEFINED,
     )
 
     route, handle, _ = router.match_route("/test/test2/subpath")
@@ -139,7 +134,6 @@ def test_update_routes(mock_router):
     router = mock_router
     router.update_routes(
         {DeploymentID("endpoint", "app1"): EndpointInfo(route="/endpoint")},
-        RequestProtocol.UNDEFINED,
     )
 
     route, handle, app_is_cross_language = router.match_route("/endpoint")
@@ -163,7 +157,6 @@ def test_update_routes(mock_router):
                 app_is_cross_language=True,
             ),
         },
-        RequestProtocol.UNDEFINED,
     )
 
     assert router.match_route("/endpoint") == None
@@ -199,9 +192,7 @@ class TestReadyForTraffic:
         """
 
         d_id = DeploymentID(name="A", app_name="B")
-        mock_router.update_routes(
-            {d_id: EndpointInfo(route="/")}, RequestProtocol.UNDEFINED
-        )
+        mock_router.update_routes({d_id: EndpointInfo(route="/")})
         mock_router.handles[d_id].set_running_replicas_populated(False)
 
         ready_for_traffic, msg = mock_router.ready_for_traffic(is_head=True)
@@ -216,9 +207,7 @@ class TestReadyForTraffic:
         """
 
         d_id = DeploymentID(name="A", app_name="B")
-        mock_router.update_routes(
-            {d_id: EndpointInfo(route="/")}, RequestProtocol.UNDEFINED
-        )
+        mock_router.update_routes({d_id: EndpointInfo(route="/")})
         mock_router.handles[d_id].set_running_replicas_populated(False)
 
         ready_for_traffic, msg = mock_router.ready_for_traffic(is_head=False)
@@ -233,9 +222,7 @@ class TestReadyForTraffic:
         """
 
         d_id = DeploymentID(name="A", app_name="B")
-        mock_router.update_routes(
-            {d_id: EndpointInfo(route="/")}, RequestProtocol.UNDEFINED
-        )
+        mock_router.update_routes({d_id: EndpointInfo(route="/")})
         mock_router.handles[d_id].set_running_replicas_populated(True)
 
         ready_for_traffic, msg = mock_router.ready_for_traffic(is_head=is_head)

--- a/python/ray/serve/tests/unit/test_proxy_router.py
+++ b/python/ray/serve/tests/unit/test_proxy_router.py
@@ -11,13 +11,6 @@ from ray.serve._private.proxy_router import (  # LongestPrefixRouter,
 from ray.serve._private.test_utils import MockDeploymentHandle
 
 
-def get_handle_function(router: ProxyRouter) -> Callable:
-    if isinstance(router, LongestPrefixRouter):
-        return router.match_route
-    else:
-        return router.get_handle_for_endpoint
-
-
 @pytest.fixture
 def mock_router():
     def mock_get_handle(endpoint, info):

--- a/python/ray/serve/tests/unit/test_proxy_router.py
+++ b/python/ray/serve/tests/unit/test_proxy_router.py
@@ -1,9 +1,7 @@
-from typing import Callable
-
 import pytest
 
-from ray.serve._private.common import DeploymentID, EndpointInfo, RequestProtocol
-from ray.serve._private.proxy_router import (  # LongestPrefixRouter,
+from ray.serve._private.common import DeploymentID, EndpointInfo
+from ray.serve._private.proxy_router import (
     NO_REPLICAS_MESSAGE,
     NO_ROUTES_MESSAGE,
     ProxyRouter,

--- a/python/ray/serve/tests/unit/test_proxy_router.py
+++ b/python/ray/serve/tests/unit/test_proxy_router.py
@@ -3,11 +3,9 @@ from typing import Callable
 import pytest
 
 from ray.serve._private.common import DeploymentID, EndpointInfo, RequestProtocol
-from ray.serve._private.proxy_router import (
+from ray.serve._private.proxy_router import (  # LongestPrefixRouter,
     NO_REPLICAS_MESSAGE,
     NO_ROUTES_MESSAGE,
-    EndpointRouter,
-    LongestPrefixRouter,
     ProxyRouter,
 )
 from ray.serve._private.test_utils import MockDeploymentHandle
@@ -21,26 +19,15 @@ def get_handle_function(router: ProxyRouter) -> Callable:
 
 
 @pytest.fixture
-def mock_longest_prefix_router() -> LongestPrefixRouter:
-    def mock_get_handle(deployment_name, app_name, *args, **kwargs):
-        return MockDeploymentHandle(deployment_name, app_name)
+def mock_router():
+    def mock_get_handle(endpoint, info, protocol):
+        return MockDeploymentHandle(endpoint.name, endpoint.app_name)
 
-    yield LongestPrefixRouter(mock_get_handle, RequestProtocol.HTTP)
-
-
-@pytest.fixture
-def mock_endpoint_router() -> EndpointRouter:
-    def mock_get_handle(deployment_name, app_name, *args, **kwargs):
-        return MockDeploymentHandle(deployment_name, app_name)
-
-    yield EndpointRouter(mock_get_handle, RequestProtocol.GRPC)
+    yield ProxyRouter(mock_get_handle)
 
 
-@pytest.mark.parametrize(
-    "mocked_router", ["mock_longest_prefix_router", "mock_endpoint_router"]
-)
-def test_no_match(mocked_router, request):
-    router = request.getfixturevalue(mocked_router)
+def test_no_match(mock_router: ProxyRouter):
+    router = mock_router
     router.update_routes(
         {
             DeploymentID(name="endpoint", app_name="default"): EndpointInfo(
@@ -49,20 +36,15 @@ def test_no_match(mocked_router, request):
             DeploymentID(name="endpoint2", app_name="app2"): EndpointInfo(
                 route="/hello2"
             ),
-        }
+        },
+        RequestProtocol.UNDEFINED,
     )
-    assert get_handle_function(router)("/nonexistent") is None
+    assert router.match_route("/nonexistent") is None
+    assert router.get_handle_for_endpoint("/nonexistent") is None
 
 
-@pytest.mark.parametrize(
-    "mocked_router, target_route",
-    [
-        ("mock_longest_prefix_router", "/endpoint"),
-        ("mock_endpoint_router", "default"),
-    ],
-)
-def test_default_route(mocked_router, target_route, request):
-    router = request.getfixturevalue(mocked_router)
+def test_default_route(mock_router: ProxyRouter):
+    router = mock_router
     router.update_routes(
         {
             DeploymentID(name="endpoint", app_name="default"): EndpointInfo(
@@ -71,28 +53,39 @@ def test_default_route(mocked_router, target_route, request):
             DeploymentID(name="endpoint2", app_name="app2"): EndpointInfo(
                 route="/endpoint2"
             ),
-        }
+        },
+        RequestProtocol.UNDEFINED,
     )
 
-    assert get_handle_function(router)("/nonexistent") is None
+    # Route based matching
+    assert router.match_route("/nonexistent") is None
 
-    route, handle, app_is_cross_language = get_handle_function(router)(target_route)
-    assert all(
-        [
-            route == "/endpoint",
-            handle == ("endpoint", "default"),
-            not app_is_cross_language,
-        ]
-    )
+    route, handle, app_is_cross_language = router.match_route("/endpoint")
+    assert route == "/endpoint"
+    assert handle == ("endpoint", "default")
+    assert not app_is_cross_language
+
+    # Endpoint based matching
+    assert router.get_handle_for_endpoint("/nonexistent") is None
+
+    route, handle, app_is_cross_language = router.get_handle_for_endpoint("default")
+    assert route == "/endpoint"
+    assert handle == ("endpoint", "default")
+    assert not app_is_cross_language
 
 
-def test_trailing_slash(mock_longest_prefix_router):
-    router = mock_longest_prefix_router
+def test_trailing_slash(mock_router: ProxyRouter):
+    router = mock_router
     router.update_routes(
-        {DeploymentID(name="endpoint", app_name="default"): EndpointInfo(route="/test")}
+        {
+            DeploymentID(name="endpoint", app_name="default"): EndpointInfo(
+                route="/test"
+            )
+        },
+        RequestProtocol.UNDEFINED,
     )
 
-    route, handle, _ = get_handle_function(router)("/test/")
+    route, handle, _ = router.match_route("/test/")
     assert route == "/test" and handle == ("endpoint", "default")
 
     router.update_routes(
@@ -100,14 +93,15 @@ def test_trailing_slash(mock_longest_prefix_router):
             DeploymentID(name="endpoint", app_name="default"): EndpointInfo(
                 route="/test/"
             )
-        }
+        },
+        RequestProtocol.UNDEFINED,
     )
 
-    assert get_handle_function(router)("/test") is None
+    assert router.match_route("/test") is None
 
 
-def test_prefix_match(mock_longest_prefix_router):
-    router = mock_longest_prefix_router
+def test_prefix_match(mock_router):
+    router = mock_router
     router.update_routes(
         {
             DeploymentID(name="endpoint1", app_name="default"): EndpointInfo(
@@ -117,54 +111,46 @@ def test_prefix_match(mock_longest_prefix_router):
                 route="/test"
             ),
             DeploymentID(name="endpoint3", app_name="default"): EndpointInfo(route="/"),
-        }
+        },
+        RequestProtocol.UNDEFINED,
     )
 
-    route, handle, _ = get_handle_function(router)("/test/test2/subpath")
+    route, handle, _ = router.match_route("/test/test2/subpath")
     assert route == "/test/test2" and handle == ("endpoint1", "default")
-    route, handle, _ = get_handle_function(router)("/test/test2/")
+    route, handle, _ = router.match_route("/test/test2/")
     assert route == "/test/test2" and handle == ("endpoint1", "default")
-    route, handle, _ = get_handle_function(router)("/test/test2")
+    route, handle, _ = router.match_route("/test/test2")
     assert route == "/test/test2" and handle == ("endpoint1", "default")
 
-    route, handle, _ = get_handle_function(router)("/test/subpath")
+    route, handle, _ = router.match_route("/test/subpath")
     assert route == "/test" and handle == ("endpoint2", "default")
-    route, handle, _ = get_handle_function(router)("/test/")
+    route, handle, _ = router.match_route("/test/")
     assert route == "/test" and handle == ("endpoint2", "default")
-    route, handle, _ = get_handle_function(router)("/test")
+    route, handle, _ = router.match_route("/test")
     assert route == "/test" and handle == ("endpoint2", "default")
 
-    route, handle, _ = get_handle_function(router)("/test2")
+    route, handle, _ = router.match_route("/test2")
     assert route == "/" and handle == ("endpoint3", "default")
-    route, handle, _ = get_handle_function(router)("/")
+    route, handle, _ = router.match_route("/")
     assert route == "/" and handle == ("endpoint3", "default")
 
 
-@pytest.mark.parametrize(
-    "mocked_router, target_route1, target_route2",
-    [
-        ("mock_longest_prefix_router", "/endpoint", "/endpoint2"),
-        ("mock_endpoint_router", "app1_endpoint", "app2"),
-    ],
-)
-def test_update_routes(mocked_router, target_route1, target_route2, request):
-    router = request.getfixturevalue(mocked_router)
+def test_update_routes(mock_router):
+    router = mock_router
     router.update_routes(
-        {
-            DeploymentID(name="endpoint", app_name="app1"): EndpointInfo(
-                route="/endpoint"
-            )
-        }
+        {DeploymentID("endpoint", "app1"): EndpointInfo(route="/endpoint")},
+        RequestProtocol.UNDEFINED,
     )
 
-    route, handle, app_is_cross_language = get_handle_function(router)(target_route1)
-    assert all(
-        [
-            route == "/endpoint",
-            handle == ("endpoint", "app1"),
-            not app_is_cross_language,
-        ]
-    )
+    route, handle, app_is_cross_language = router.match_route("/endpoint")
+    assert route == "/endpoint"
+    assert handle == ("endpoint", "app1")
+    assert not app_is_cross_language
+
+    route, handle, app_is_cross_language = router.get_handle_for_endpoint("app1")
+    assert route == "/endpoint"
+    assert handle == ("endpoint", "app1")
+    assert not app_is_cross_language
 
     router.update_routes(
         {
@@ -176,33 +162,36 @@ def test_update_routes(mocked_router, target_route1, target_route2, request):
                 route="/endpoint3",
                 app_is_cross_language=True,
             ),
-        }
+        },
+        RequestProtocol.UNDEFINED,
     )
 
-    assert get_handle_function(router)(target_route1) is None
+    assert router.match_route("/endpoint") == None
+    assert router.match_route("app1") == None
 
-    route, handle, app_is_cross_language = get_handle_function(router)(target_route2)
-    assert all(
-        [route == "/endpoint2", handle == ("endpoint2", "app2"), app_is_cross_language]
-    )
+    route, handle, app_is_cross_language = router.match_route("/endpoint2")
+    assert route == "/endpoint2"
+    assert handle == ("endpoint2", "app2")
+    assert app_is_cross_language
+
+    route, handle, app_is_cross_language = router.get_handle_for_endpoint("app2")
+    assert route == "/endpoint2"
+    assert handle == ("endpoint2", "app2")
+    assert app_is_cross_language
 
 
 class TestReadyForTraffic:
     @pytest.mark.parametrize("is_head", [False, True])
-    def test_route_table_not_populated(
-        self, mock_endpoint_router: EndpointRouter, is_head: bool
-    ):
+    def test_route_table_not_populated(self, mock_router, is_head: bool):
         """Proxy router should NOT be ready for traffic if:
         - it has not received route table from controller
         """
 
-        ready_for_traffic, msg = mock_endpoint_router.ready_for_traffic(is_head=is_head)
+        ready_for_traffic, msg = mock_router.ready_for_traffic(is_head=is_head)
         assert not ready_for_traffic
         assert msg == NO_ROUTES_MESSAGE
 
-    def test_head_route_table_populated_no_replicas(
-        self, mock_endpoint_router: EndpointRouter
-    ):
+    def test_head_route_table_populated_no_replicas(self, mock_router):
         """Proxy router should be ready for traffic if:
         - it has received route table from controller
         - it hasn't received any replicas yet
@@ -210,16 +199,16 @@ class TestReadyForTraffic:
         """
 
         d_id = DeploymentID(name="A", app_name="B")
-        mock_endpoint_router.update_routes({d_id: EndpointInfo(route="/")})
-        mock_endpoint_router.handles[d_id].set_running_replicas_populated(False)
+        mock_router.update_routes(
+            {d_id: EndpointInfo(route="/")}, RequestProtocol.UNDEFINED
+        )
+        mock_router.handles[d_id].set_running_replicas_populated(False)
 
-        ready_for_traffic, msg = mock_endpoint_router.ready_for_traffic(is_head=True)
+        ready_for_traffic, msg = mock_router.ready_for_traffic(is_head=True)
         assert ready_for_traffic
         assert not msg
 
-    def test_worker_route_table_populated_no_replicas(
-        self, mock_endpoint_router: EndpointRouter
-    ):
+    def test_worker_route_table_populated_no_replicas(self, mock_router):
         """Proxy router should NOT be ready for traffic if:
         - it has received route table from controller
         - it hasn't received any replicas yet
@@ -227,27 +216,29 @@ class TestReadyForTraffic:
         """
 
         d_id = DeploymentID(name="A", app_name="B")
-        mock_endpoint_router.update_routes({d_id: EndpointInfo(route="/")})
-        mock_endpoint_router.handles[d_id].set_running_replicas_populated(False)
+        mock_router.update_routes(
+            {d_id: EndpointInfo(route="/")}, RequestProtocol.UNDEFINED
+        )
+        mock_router.handles[d_id].set_running_replicas_populated(False)
 
-        ready_for_traffic, msg = mock_endpoint_router.ready_for_traffic(is_head=False)
+        ready_for_traffic, msg = mock_router.ready_for_traffic(is_head=False)
         assert not ready_for_traffic
         assert msg == NO_REPLICAS_MESSAGE
 
     @pytest.mark.parametrize("is_head", [False, True])
-    def test_route_table_populated_with_replicas(
-        self, mock_endpoint_router: EndpointRouter, is_head: bool
-    ):
+    def test_route_table_populated_with_replicas(self, mock_router, is_head: bool):
         """Proxy router should be ready for traffic if:
         - it has received route table from controller
         - it has received replicas from controller
         """
 
         d_id = DeploymentID(name="A", app_name="B")
-        mock_endpoint_router.update_routes({d_id: EndpointInfo(route="/")})
-        mock_endpoint_router.handles[d_id].set_running_replicas_populated(True)
+        mock_router.update_routes(
+            {d_id: EndpointInfo(route="/")}, RequestProtocol.UNDEFINED
+        )
+        mock_router.handles[d_id].set_running_replicas_populated(True)
 
-        ready_for_traffic, msg = mock_endpoint_router.ready_for_traffic(is_head=is_head)
+        ready_for_traffic, msg = mock_router.ready_for_traffic(is_head=is_head)
         assert ready_for_traffic
         assert not msg
 

--- a/python/ray/serve/tests/unit/test_proxy_router.py
+++ b/python/ray/serve/tests/unit/test_proxy_router.py
@@ -150,8 +150,8 @@ def test_update_routes(mock_router):
         },
     )
 
-    assert router.match_route("/endpoint") == None
-    assert router.match_route("app1") == None
+    assert router.match_route("/endpoint") is None
+    assert router.match_route("app1") is None
 
     route, handle, app_is_cross_language = router.match_route("/endpoint2")
     assert route == "/endpoint2"


### PR DESCRIPTION
## Why are these changes needed?

- Combine the endpoint router and the longest prefix router. The two differed in that one used `match_route` to get a handle, and one used `get_handle_for_endpoint` to get a handle (for HTTP and gRPC respectively). We can just have a single proxy router class that have both of these methods.
  - This is nice in that we only have one cached set of handles.
- Add a default `get_proxy_handle` function in `default_impl.py`, which can be used to control how a handle is fetched and how it is initialized.
- Infer request protocol from request context, which should deterministically indicate whether the request is an http request or a gRPC request. This then removes the need to set request protocol in the handle, which makes sense since request protocol is more metadata than handle configuration.

## Related issue number

<!-- For example: "Closes #1234" -->

