### PR TITLE
[core] Make absl::StrCat import explicit to avoid build failures when using modern absl

### DIFF
--- a/src/ray/object_manager/common.cc
+++ b/src/ray/object_manager/common.cc
@@ -15,8 +15,8 @@
 #include "ray/object_manager/common.h"
 
 #include "absl/functional/bind_front.h"
-#include "absl/strings/str_format.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 
 namespace ray {
 

--- a/src/ray/object_manager/common.cc
+++ b/src/ray/object_manager/common.cc
@@ -16,6 +16,7 @@
 
 #include "absl/functional/bind_front.h"
 #include "absl/strings/str_format.h"
+#include "absl/strings/str_cat.h"
 
 namespace ray {
 


### PR DESCRIPTION
## Why are these changes needed?

In [src/ray/object_manager/common.cc](https://github.com/ray-project/ray/blob/e393a716d8742a987a36df555defb2ca90bb94d4/src/ray/object_manager/common.cc) we extensively use `absl::StrCat` without explicitely importing the associated header `absl/strings/str_cat.h`. It worked fine previously, as `absl/strings/str_format.h` transitively included that via absl internal headers. However, somewhere in 2023-2024, absl has been cleaned up from unintentional transitive includes, breaking `ray` builds against modern absl. This PR fixes that.

## Effect on backward/forward compatability
None. Builds against older absl versions will continue to work as before, as `absl::StrCat` was always declared in `str_cat.h` and including that was always the intended way to import this symbol. 

## Related issues/PRs:
+ https://github.com/ray-project/ray/pull/48667


