### PR TITLE
[core] Fix building Ray against modern Protobuf versions

### DIFF
--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -1236,8 +1236,12 @@ TEST_F(GcsActorManagerTest, TestGetAllActorInfoFilters) {
     rpc::GetAllActorInfoRequest request;
     request.mutable_filters()->set_actor_id(actor->GetActorID().Binary());
 
+#if GOOGLE_PROTOBUF_VERSION < 5029000
     auto &reply =
         *google::protobuf::Arena::CreateMessage<rpc::GetAllActorInfoReply>(&arena);
+#else
+    auto &reply = *google::protobuf::Arena::Create<rpc::GetAllActorInfoReply>(&arena);
+#endif
     gcs_actor_manager_->HandleGetAllActorInfo(request, &reply, callback);
     ASSERT_EQ(reply.actor_table_data().size(), 1);
     ASSERT_EQ(reply.total(), 1 + num_other_actors);
@@ -1249,8 +1253,12 @@ TEST_F(GcsActorManagerTest, TestGetAllActorInfoFilters) {
     rpc::GetAllActorInfoRequest request;
     request.mutable_filters()->set_job_id(job_id.Binary());
 
+#if GOOGLE_PROTOBUF_VERSION < 5029000
     auto &reply =
         *google::protobuf::Arena::CreateMessage<rpc::GetAllActorInfoReply>(&arena);
+#else
+    auto &reply = *google::protobuf::Arena::Create<rpc::GetAllActorInfoReply>(&arena);
+#endif
     gcs_actor_manager_->HandleGetAllActorInfo(request, &reply, callback);
     ASSERT_EQ(reply.actor_table_data().size(), 1);
     ASSERT_EQ(reply.num_filtered(), num_other_actors);
@@ -1261,8 +1269,12 @@ TEST_F(GcsActorManagerTest, TestGetAllActorInfoFilters) {
     rpc::GetAllActorInfoRequest request;
     request.mutable_filters()->set_state(rpc::ActorTableData::ALIVE);
 
+#if GOOGLE_PROTOBUF_VERSION < 5029000
     auto &reply =
         *google::protobuf::Arena::CreateMessage<rpc::GetAllActorInfoReply>(&arena);
+#else
+    auto &reply = *google::protobuf::Arena::Create<rpc::GetAllActorInfoReply>(&arena);
+#endif
     gcs_actor_manager_->HandleGetAllActorInfo(request, &reply, callback);
     ASSERT_EQ(reply.actor_table_data().size(), 1);
     ASSERT_EQ(reply.num_filtered(), num_other_actors);
@@ -1274,8 +1286,12 @@ TEST_F(GcsActorManagerTest, TestGetAllActorInfoFilters) {
     request.mutable_filters()->set_state(rpc::ActorTableData::ALIVE);
     request.mutable_filters()->set_job_id(job_id.Binary());
 
+#if GOOGLE_PROTOBUF_VERSION < 5029000
     auto &reply =
         *google::protobuf::Arena::CreateMessage<rpc::GetAllActorInfoReply>(&arena);
+#else
+    auto &reply = *google::protobuf::Arena::Create<rpc::GetAllActorInfoReply>(&arena);
+#endif
     gcs_actor_manager_->HandleGetAllActorInfo(request, &reply, callback);
     ASSERT_EQ(reply.actor_table_data().size(), 1);
     ASSERT_EQ(reply.num_filtered(), num_other_actors);
@@ -1285,8 +1301,12 @@ TEST_F(GcsActorManagerTest, TestGetAllActorInfoFilters) {
     request.mutable_filters()->set_state(rpc::ActorTableData::DEAD);
     request.mutable_filters()->set_job_id(job_id.Binary());
 
+#if GOOGLE_PROTOBUF_VERSION < 5029000
     auto &reply =
         *google::protobuf::Arena::CreateMessage<rpc::GetAllActorInfoReply>(&arena);
+#else
+    auto &reply = *google::protobuf::Arena::Create<rpc::GetAllActorInfoReply>(&arena);
+#endif
     gcs_actor_manager_->HandleGetAllActorInfo(request, &reply, callback);
     ASSERT_EQ(reply.num_filtered(), num_other_actors + 1);
     ASSERT_EQ(reply.actor_table_data().size(), 0);
@@ -1308,8 +1328,12 @@ TEST_F(GcsActorManagerTest, TestGetAllActorInfoLimit) {
 
   {
     rpc::GetAllActorInfoRequest request;
+#if GOOGLE_PROTOBUF_VERSION < 5029000
     auto &reply =
         *google::protobuf::Arena::CreateMessage<rpc::GetAllActorInfoReply>(&arena);
+#else
+    auto &reply = *google::protobuf::Arena::Create<rpc::GetAllActorInfoReply>(&arena);
+#endif
     auto callback = [](Status status,
                        std::function<void()> success,
                        std::function<void()> failure) {};
@@ -1317,8 +1341,12 @@ TEST_F(GcsActorManagerTest, TestGetAllActorInfoLimit) {
     ASSERT_EQ(reply.actor_table_data().size(), 3);
 
     request.set_limit(2);
+#if GOOGLE_PROTOBUF_VERSION < 5029000
     auto &reply_2 =
         *google::protobuf::Arena::CreateMessage<rpc::GetAllActorInfoReply>(&arena);
+#else
+    auto &reply_2 = *google::protobuf::Arena::Create<rpc::GetAllActorInfoReply>(&arena);
+#endif
     gcs_actor_manager_->HandleGetAllActorInfo(request, &reply_2, callback);
     ASSERT_EQ(reply_2.actor_table_data().size(), 2);
     ASSERT_EQ(reply_2.total(), 3);

--- a/src/ray/raylet_client/raylet_client.cc
+++ b/src/ray/raylet_client/raylet_client.cc
@@ -339,8 +339,12 @@ void raylet::RayletClient::RequestWorkerLease(
     const int64_t backlog_size,
     const bool is_selected_based_on_locality) {
   google::protobuf::Arena arena;
+#if GOOGLE_PROTOBUF_VERSION < 5029000
   auto request =
       google::protobuf::Arena::CreateMessage<rpc::RequestWorkerLeaseRequest>(&arena);
+#else
+  auto request = google::protobuf::Arena::Create<rpc::RequestWorkerLeaseRequest>(&arena);
+#endif
   // The unsafe allocating here is actually safe because the life-cycle of
   // task_spec is longer than request.
   // Request will be sent before the end of this call, and after that, it won't be

--- a/src/ray/rpc/server_call.h
+++ b/src/ray/rpc/server_call.h
@@ -190,7 +190,11 @@ class ServerCallImpl : public ServerCall {
         cluster_id_(cluster_id),
         start_time_(0),
         record_metrics_(record_metrics) {
+#if GOOGLE_PROTOBUF_VERSION < 5029000
     reply_ = google::protobuf::Arena::CreateMessage<Reply>(&arena_);
+#else
+    reply_ = google::protobuf::Arena::Create<Reply>(&arena_);
+#endif
     // TODO call_name_ sometimes get corrunpted due to memory issues.
     RAY_CHECK(!call_name_.empty()) << "Call name is empty";
     if (record_metrics_) {

--- a/src/ray/util/event.cc
+++ b/src/ray/util/event.cc
@@ -133,7 +133,11 @@ std::string LogEventReporter::ExportEventToString(const rpc::ExportEvent &export
   google::protobuf::util::JsonPrintOptions options;
   options.preserve_proto_field_names = true;
   // Required so enum with value 0 is not omitted
+#if GOOGLE_PROTOBUF_VERSION < 5028000
   options.always_print_primitive_fields = true;
+#else
+  options.always_print_fields_with_no_presence = true;
+#endif
   if (export_event.has_task_event_data()) {
     RAY_CHECK(google::protobuf::util::MessageToJsonString(
                   export_event.task_event_data(), &event_data_as_string, options)


### PR DESCRIPTION
## Why are these changes needed?

Recent Protobuf releases introduced a few breaking changes, which are incompatible with Ray code:
1. v5.28.0 removed deprecated `JSONPrintOptions.always_print_primitive_fields` in favor of recently added `JSONPrintOptions. always_print_without_presence_fields`. Please, check the associated Protobuf issues/PRs for more details: 
   1. https://github.com/protocolbuffers/protobuf/pull/15682
   2. https://github.com/protocolbuffers/protobuf/pull/15674
   3. https://github.com/protocolbuffers/protobuf/issues/17437
4. v5.27.0 deprecated and upcoming v5.29.0 will remove `google::protobuf::Arena::CreateMessage` in favor of `google::protobuf::Arena::Create`:
   1. https://github.com/protocolbuffers/protobuf/pull/18937

This PR adopts Ray code to build with these changes, still preserving compatability with older Protobuf versions. 

## Effect on backward/forward compatability
All changes to the Ray code are guarded with checks against `GOOGLE_PROTOBUF_VERSION` per Google's guidelines.
 
In theory, we can replace `CreateMessage` occurences with `Create` without any guards, as `Create` has been introduced in Protobuf `v3.0.0`, but I haven't tested that yet.