### PR TITLE
[data] skip tensorflow tests for python 3.12

### DIFF
--- a/python/ray/data/tests/test_consumption.py
+++ b/python/ray/data/tests/test_consumption.py
@@ -1254,6 +1254,9 @@ def test_union(ray_start_regular_shared):
     assert ds2.count() == 210
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12), reason="No tensorflow for Python 3.12+"
+)
 def test_iter_tf_batches_emits_deprecation_warning(ray_start_regular_shared):
     with pytest.warns(DeprecationWarning):
         ray.data.range(1).iter_tf_batches()


### PR DESCRIPTION
https://github.com/ray-project/ray/pull/48693/files#diff-81d7373cd5567e997c002b244c491e6b3498d206b12c093f4dc4d30e9b5848af added a test that uses tensorflow. We currently need to skip all tensorflow-related tests for python 3.12 since we don't support tensorflow for python 3.12. 

Also this is a test for the deprecation of tensorflow ;)

Test:
- CI