### PR TITLE
[core] Enable STDERR custom formatting

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides/logging.md
+++ b/doc/source/cluster/kubernetes/user-guides/logging.md
@@ -258,7 +258,7 @@ If you need these features, consider using the {ref}`Fluent Bit solution <kubera
 For clusters on VMs, don't redirect logs to stderr. Instead, follow {ref}`this guide <vm-logging>` to persist logs.
 ```
 
-Redirecting logging to stderr also prepends a `({component})` prefix, for example, `(raylet)`, to each log record message.
+By default, redirecting logging to stderr also prepends a `({component})` prefix, for example, `(raylet)`, to each log record message.
 
 ```bash
 [2022-01-24 19:42:02,978 I 1829336 1829336] (gcs_server) grpc_server.cc:103: GcsServer server started, listening on port 50009.
@@ -268,6 +268,8 @@ Redirecting logging to stderr also prepends a `({component})` prefix, for exampl
 ```
 
 These prefixes allow you to filter the stderr stream of logs by the component of interest. Note, however, that multi-line log records **don't** have this component marker at the beginning of each line.
+
+You may provide a custom stderr log format through the ``RAY_LOG_TO_STDERR_FORMAT`` environmental variable. This format will be applied to all logs passing through stderr. The template value `{component}` may be included in your custom log format. If so, it is substituted at runtime with the correct component name. For example: ``RAY_LOG_TO_STDERR_FORMAT={component} - %(message)`` would resolve to `raylet - %(message)` while ``RAY_LOG_TO_STDERR_FORMAT=%(message)`` would provide no additional formatting. 
 
 Follow the steps below to set the environment variable ``RAY_LOG_TO_STDERR=1`` on all Ray nodes
 

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -236,7 +236,8 @@ LOGGING_REDIRECT_STDERR_ENVIRONMENT_VARIABLE = "RAY_LOG_TO_STDERR"
 LOGGER_FORMAT_STDERR_ENVIRONMENTAL_VARIABLE = "RAY_LOG_TO_STDERR_FORMAT"
 # Default logging format when logging stderr. Should not be used directly,
 # use `ray._private.ray_logging.formatters._get_logging_redirect_stderr_format()`
-# to resolve with the user-provided format string - `LOGGER_FORMAT_STDERR_ENVIRONMENTAL_VARIABLE` if it exists.
+# to resolve with the user-provided format string - 
+# `LOGGER_FORMAT_STDERR_ENVIRONMENTAL_VARIABLE` if it exists.
 LOGGER_FORMAT_STDERR_DEFAULT = (
     "%(asctime)s\t%(levelname)s ({component}) %(filename)s:%(lineno)s -- %(message)s"
 )

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -232,11 +232,12 @@ LOGGING_ROTATE_BYTES = 512 * 1024 * 1024  # 512MB.
 LOGGING_ROTATE_BACKUP_COUNT = 5  # 5 Backup files at max.
 
 LOGGING_REDIRECT_STDERR_ENVIRONMENT_VARIABLE = "RAY_LOG_TO_STDERR"
-# Logging format when logging stderr. This should be formatted with the
-# component before setting the formatter, e.g. via
-#   format = LOGGER_FORMAT_STDERR.format(component="dashboard")
-#   handler.setFormatter(logging.Formatter(format))
-LOGGER_FORMAT_STDERR = (
+
+LOGGER_FORMAT_STDERR_ENVIRONMENTAL_VARIABLE = "RAY_LOG_TO_STDERR_FORMAT"
+# Default logging format when logging stderr. Should not be used directly,
+# use `ray._private.ray_logging.formatters._get_logging_redirect_stderr_format()`
+# to resolve with the user-provided format string - `LOGGER_FORMAT_STDERR_ENVIRONMENTAL_VARIABLE` if it exists.
+LOGGER_FORMAT_STDERR_DEFAULT = (
     "%(asctime)s\t%(levelname)s ({component}) %(filename)s:%(lineno)s -- %(message)s"
 )
 

--- a/python/ray/_private/ray_logging/formatters.py
+++ b/python/ray/_private/ray_logging/formatters.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, Optional
 
 
 def _get_logging_redirect_stderr_format(component: Optional[str]) -> str:
-    """Get the format string for redirecting stderr.
+    """Get the logging format for logs redirected to stderr.
 
     Use the users format string if it is set, otherwise use the default format string.
     Format with the component if it is provided and present in the format string.
@@ -27,7 +27,7 @@ def _get_logging_redirect_stderr_format(component: Optional[str]) -> str:
 
     if component is not None:
         # this is a no-op if `{component}` is not in the str
-        desired_format.format(component=component)
+        desired_format = desired_format.format(component=component)
 
     return desired_format
 

--- a/python/ray/_private/ray_logging/formatters.py
+++ b/python/ray/_private/ray_logging/formatters.py
@@ -1,12 +1,35 @@
 import logging
+import os
 import json
 from ray._private.ray_logging.constants import (
     LogKey,
     LOGRECORD_STANDARD_ATTRS,
     LOGGER_FLATTEN_KEYS,
 )
-from ray._private.ray_constants import LOGGER_FORMAT
-from typing import Any, Dict
+from ray._private.ray_constants import (
+    LOGGER_FORMAT,
+    LOGGER_FORMAT_STDERR_ENVIRONMENTAL_VARIABLE,
+    LOGGER_FORMAT_STDERR_DEFAULT,
+)
+from typing import Any, Dict, Optional
+
+
+def _get_logging_redirect_stderr_format(component: Optional[str]) -> str:
+    """Get the format string for redirecting stderr.
+
+    Use the users format string if it is set, otherwise use the default format string.
+    Format with the component if it is provided and present in the format string.
+    """
+
+    desired_format = os.environ.get(
+        LOGGER_FORMAT_STDERR_ENVIRONMENTAL_VARIABLE, LOGGER_FORMAT_STDERR_DEFAULT
+    )
+
+    if component is not None:
+        # this is a no-op if `{component}` is not in the str
+        desired_format.format(component=component)
+
+    return desired_format
 
 
 def _append_flatten_attributes(formatted_attrs: Dict[str, Any], key: str, value: Any):

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -27,6 +27,7 @@ import ray._private.ray_constants as ray_constants
 from ray._raylet import GcsClient, GcsClientOptions
 from ray.core.generated.common_pb2 import Language
 from ray._private.ray_constants import RAY_NODE_IP_FILENAME
+from ray._private.ray_logging import formatters as ray_logging_formatters
 
 resource = None
 if sys.platform != "win32":
@@ -1141,8 +1142,8 @@ def start_log_monitor(
         # If not redirecting logging to files, unset log filename.
         # This will cause log records to go to stderr.
         command.append("--logging-filename=")
-        # Use stderr log format with the component name as a message prefix.
-        logging_format = ray_constants.LOGGER_FORMAT_STDERR.format(
+
+        logging_format = ray_logging_formatters._get_logging_redirect_stderr_format(
             component=ray_constants.PROCESS_TYPE_LOG_MONITOR
         )
         command.append(f"--logging-format={logging_format}")
@@ -1289,8 +1290,8 @@ def start_api_server(
             # If not redirecting logging to files, unset log filename.
             # This will cause log records to go to stderr.
             command.append("--logging-filename=")
-            # Use stderr log format with the component name as a message prefix.
-            logging_format = ray_constants.LOGGER_FORMAT_STDERR.format(
+
+            logging_format = ray_logging_formatters._get_logging_redirect_stderr_format(
                 component=ray_constants.PROCESS_TYPE_DASHBOARD
             )
             command.append(f"--logging-format={logging_format}")
@@ -1746,8 +1747,8 @@ def start_raylet(
         # If not redirecting logging to files, unset log filename.
         # This will cause log records to go to stderr.
         dashboard_agent_command.append("--logging-filename=")
-        # Use stderr log format with the component name as a message prefix.
-        logging_format = ray_constants.LOGGER_FORMAT_STDERR.format(
+
+        logging_format = ray_logging_formatters._get_logging_redirect_stderr_format(
             component=ray_constants.PROCESS_TYPE_DASHBOARD_AGENT
         )
         dashboard_agent_command.append(f"--logging-format={logging_format}")
@@ -2146,8 +2147,8 @@ def start_monitor(
         # If not redirecting logging to files, unset log filename.
         # This will cause log records to go to stderr.
         command.append("--logging-filename=")
-        # Use stderr log format with the component name as a message prefix.
-        logging_format = ray_constants.LOGGER_FORMAT_STDERR.format(
+
+        logging_format = ray_logging_formatters._get_logging_redirect_stderr_format(
             component=ray_constants.PROCESS_TYPE_MONITOR
         )
         command.append(f"--logging-format={logging_format}")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This enables better support for external observability tools by allowing non-formatted logging to STDERR. 

Operating in a K8s environment, we set `RAY_LOG_TO_STDERR=1` and disable logging to the driver to delegate log collections to a standard external observability stack (ex. Grafana / Promtail). Our pipeline outputs in structured logging. Currently, ray stderr handling will re-format these logs to add a prefix. This prevents straightforward structured parsing. 

## Related issue number

-  https://github.com/ray-project/ray/pull/21767 - initial `RAY_LOG_TO_STDERR` implementation
- https://github.com/ray-project/ray/issues/47354 - issue requesting stdout has no prefixes. 
- https://github.com/ray-project/ray/issues/30544 - issue noting undesired stderr formatting
- 


## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ N/A ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests - based on previous implemented
   - [ ] Release tests
   - [ ] This PR is not tested :(
