### PR TITLE
[Dashboard] Fix dashboard NodeHead._update_node_stats check failure

### DIFF
--- a/python/ray/dashboard/modules/node/node_head.py
+++ b/python/ray/dashboard/modules/node/node_head.py
@@ -442,18 +442,15 @@ class NodeHead(dashboard_utils.DashboardHeadModule):
         #       from another async task)
         current_stub_node_id_tuples = list(self._stubs.items())
 
-        if current_stub_node_id_tuples:
-            node_ids, _ = zip(*current_stub_node_id_tuples)
-        else:
-            node_ids = []
-
+        node_ids = []
         get_node_stats_tasks = []
 
-        for i, (node_id, stub) in enumerate(current_stub_node_id_tuples):
+        for _, (node_id, stub) in enumerate(current_stub_node_id_tuples):
             node_info = DataSource.nodes.get(node_id)
             if node_info["state"] != "ALIVE":
                 continue
 
+            node_ids.append(node_id)
             get_node_stats_tasks.append(
                 stub.GetNodeStats(
                     node_manager_pb2.GetNodeStatsRequest(

--- a/python/ray/dashboard/modules/node/tests/test_node.py
+++ b/python/ray/dashboard/modules/node/tests/test_node.py
@@ -189,6 +189,7 @@ def test_multi_nodes_info(
                     assert detail["raylet"]["state"] == "ALIVE"
                 else:
                     assert detail["raylet"]["state"] == "DEAD"
+                    assert detail["raylet"].get("objectStoreAvailableMemory", 0) == 0
             response = requests.get(webui_url + "/test/dump?key=agents")
             response.raise_for_status()
             agents = response.json()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

```
# NOTE: Zip will silently truncate to shorter argument that potentially
        #       could lead to subtle hard to catch issues, hence the assertion
        assert len(node_ids) == len(responses)
```

will check fail if the node is dead.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
