### PR TITLE
[core] Change m4's to m6i's for core release tests

### DIFF
--- a/release/benchmarks/object_store.yaml
+++ b/release/benchmarks/object_store.yaml
@@ -5,14 +5,14 @@ max_workers: 49
 
 head_node_type:
     name: head_node
-    instance_type: m4.16xlarge
+    instance_type: m5.16xlarge
     resources:
       custom_resources:
         node: 1
 
 worker_node_types:
     - name: worker_node
-      instance_type: m4.2xlarge
+      instance_type: m5.2xlarge
       min_workers: 49
       max_workers: 49
       use_spot: false

--- a/release/benchmarks/object_store.yaml
+++ b/release/benchmarks/object_store.yaml
@@ -5,14 +5,14 @@ max_workers: 49
 
 head_node_type:
     name: head_node
-    instance_type: m5.16xlarge
+    instance_type: m6i.16xlarge
     resources:
       custom_resources:
         node: 1
 
 worker_node_types:
     - name: worker_node
-      instance_type: m5.2xlarge
+      instance_type: m6i.2xlarge
       min_workers: 49
       max_workers: 49
       use_spot: false

--- a/release/nightly_tests/stress_tests/placement_group_tests_compute.yaml
+++ b/release/nightly_tests/stress_tests/placement_group_tests_compute.yaml
@@ -12,18 +12,17 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: m4.16xlarge
+    instance_type: m5.16xlarge
     resources:
       cpu: 64
 
 worker_node_types:
    - name: worker_node
-     instance_type: m4.large
+     instance_type: m5.large
      min_workers: 5
      max_workers: 5
      use_spot: false
      resources:
-      cpu: 2 
+      cpu: 2
       custom_resources:
         pg_custom: 666
-

--- a/release/nightly_tests/stress_tests/placement_group_tests_compute.yaml
+++ b/release/nightly_tests/stress_tests/placement_group_tests_compute.yaml
@@ -12,13 +12,13 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: m5.16xlarge
+    instance_type: m6i.16xlarge
     resources:
       cpu: 64
 
 worker_node_types:
    - name: worker_node
-     instance_type: m5.large
+     instance_type: m6i.large
      min_workers: 5
      max_workers: 5
      use_spot: false

--- a/release/nightly_tests/stress_tests/smoke_test_compute.yaml
+++ b/release/nightly_tests/stress_tests/smoke_test_compute.yaml
@@ -12,11 +12,11 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: m4.4xlarge
+    instance_type: m5.4xlarge
 
 worker_node_types:
    - name: worker_node
-     instance_type: m4.large
+     instance_type: m5.large
      min_workers: 4
      max_workers: 4
      use_spot: false

--- a/release/nightly_tests/stress_tests/smoke_test_compute.yaml
+++ b/release/nightly_tests/stress_tests/smoke_test_compute.yaml
@@ -12,11 +12,11 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: m5.4xlarge
+    instance_type: m6i.4xlarge
 
 worker_node_types:
    - name: worker_node
-     instance_type: m5.large
+     instance_type: m6i.large
      min_workers: 4
      max_workers: 4
      use_spot: false

--- a/release/nightly_tests/stress_tests/stress_tests_compute.yaml
+++ b/release/nightly_tests/stress_tests/stress_tests_compute.yaml
@@ -12,13 +12,13 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: m5.16xlarge
+    instance_type: m6i.16xlarge
     resources:
       cpu: 64
 
 worker_node_types:
    - name: worker_node
-     instance_type: m5.large
+     instance_type: m6i.large
      min_workers: 100
      max_workers: 100
      use_spot: false

--- a/release/nightly_tests/stress_tests/stress_tests_compute.yaml
+++ b/release/nightly_tests/stress_tests/stress_tests_compute.yaml
@@ -12,13 +12,13 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: m4.16xlarge
+    instance_type: m5.16xlarge
     resources:
       cpu: 64
 
 worker_node_types:
    - name: worker_node
-     instance_type: m4.large
+     instance_type: m5.large
      min_workers: 100
      max_workers: 100
      use_spot: false

--- a/release/nightly_tests/stress_tests/stress_tests_compute_large.yaml
+++ b/release/nightly_tests/stress_tests/stress_tests_compute_large.yaml
@@ -12,13 +12,13 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: m5.16xlarge
+    instance_type: m6i.16xlarge
     resources:
       cpu: 64
 
 worker_node_types:
    - name: worker_node
-     instance_type: m5.16xlarge
+     instance_type: m6i.16xlarge
      min_workers: 6
      max_workers: 6
      use_spot: false

--- a/release/nightly_tests/stress_tests/stress_tests_compute_large.yaml
+++ b/release/nightly_tests/stress_tests/stress_tests_compute_large.yaml
@@ -12,13 +12,13 @@ aws:
 
 head_node_type:
     name: head_node
-    instance_type: m4.16xlarge
+    instance_type: m5.16xlarge
     resources:
       cpu: 64
 
 worker_node_types:
    - name: worker_node
-     instance_type: m4.16xlarge
+     instance_type: m5.16xlarge
      min_workers: 6
      max_workers: 6
      use_spot: false

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3318,7 +3318,7 @@
     cluster_compute: stress_tests/stress_tests_compute.yaml
 
   run:
-    timeout: 14400
+    timeout: 7200
     wait_for_nodes:
       num_nodes: 101
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -3318,7 +3318,7 @@
     cluster_compute: stress_tests/stress_tests_compute.yaml
 
   run:
-    timeout: 7200
+    timeout: 14400
     wait_for_nodes:
       num_nodes: 101
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Some ray core release tests would fail to acquire nodes before timing out.m4 nodes are old, m6 nodes are newer, should be easier to acquire, a lot of the other existing tests use them.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#48657 #48647 #48646 
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
