### PR TITLE
[ray metrics launch-prometheus] Map aarch64 to arm64 in get_system_info function for Prometheus download

### DIFF
--- a/python/ray/dashboard/modules/metrics/install_and_start_prometheus.py
+++ b/python/ray/dashboard/modules/metrics/install_and_start_prometheus.py
@@ -26,6 +26,9 @@ def get_system_info():
     if architecture == "x86_64":
         # In the Prometheus filename, it's called amd64
         architecture = "amd64"
+    elif architecture == "aarch64":
+        # In the Prometheus filename, it's called arm64
+        architecture = "arm64"
     return os_type, architecture
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- Fixes incorrect URL for aarch64 architecture in Prometheus download.

## Related issue number

Closes #48755

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
