### PR TITLE
[vm launcher] change nightly and latest launcher test to manual

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4956,7 +4956,7 @@
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
 
-  frequency: nightly
+  frequency: manual
   team: clusters
   cluster:
     byod: {}
@@ -4971,7 +4971,7 @@
   group: cluster-launcher-test
   working_dir: ../python/ray/autoscaler/
 
-  frequency: nightly
+  frequency: manual
   team: clusters
   cluster:
     byod: {}


### PR DESCRIPTION
nightly is inherently unstable, and latest is just last stable release. neither of them should block releases

