### PR TITLE
[CLI] Remove monkey-patching of `logging.Logger.makeRecord`

### DIFF
--- a/python/ray/autoscaler/_private/cli_logger.py
+++ b/python/ray/autoscaler/_private/cli_logger.py
@@ -113,39 +113,6 @@ cf = _ColorfulProxy()
 colorama.init(strip=False)
 
 
-def _patched_makeRecord(
-    self, name, level, fn, lno, msg, args, exc_info, func=None, extra=None, sinfo=None
-):
-    """Monkey-patched version of logging.Logger.makeRecord
-    We have to patch default loggers so they use the proper frame for
-    line numbers and function names (otherwise everything shows up as
-    e.g. cli_logger:info() instead of as where it was called from).
-
-    In Python 3.8 we could just use stacklevel=2, but we have to support
-    Python 3.6 and 3.7 as well.
-
-    The solution is this Python magic superhack.
-
-    The default makeRecord will deliberately check that we don't override
-    any existing property on the LogRecord using `extra`,
-    so we remove that check.
-
-    This patched version is otherwise identical to the one in the standard
-    library.
-
-    TODO: Remove this magic superhack. Find a more responsible workaround.
-    """
-    rv = logging._logRecordFactory(
-        name, level, fn, lno, msg, args, exc_info, func, sinfo
-    )
-    if extra is not None:
-        rv.__dict__.update(extra)
-    return rv
-
-
-logging.Logger.makeRecord = _patched_makeRecord
-
-
 def _external_caller_info():
     """Get the info from the caller frame.
 

--- a/python/ray/tests/test_cli_logger.py
+++ b/python/ray/tests/test_cli_logger.py
@@ -1,4 +1,6 @@
 from ray.autoscaler._private import cli_logger
+import io
+from unittest.mock import patch
 import pytest
 
 
@@ -12,6 +14,14 @@ def test_colorful_mock_with_style():
 def test_colorful_mock_random_function():
     cm = cli_logger._ColorfulMock()
     assert cm.bold("abc") == "abc"
+
+
+def test_pathname():
+    # Ensure that the `pathname` of the `LogRecord` points to the
+    # caller of `cli_logger`, not `cli_logger` itself.
+    with patch("sys.stdout", new=io.StringIO()) as mock_stdout:
+        cli_logger.cli_logger.info("123")
+        assert "test_cli_logger.py" in mock_stdout.getvalue()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In #9984, the caller's `lineno` and `filename` are added to the `extra` argument of functions like `info`, `warning`, etc. However, the default implementation of [makeRecord](https://github.com/python/cpython/blob/v3.14.0a1/Lib/logging/__init__.py#L1635) in CPython raises an exception if a field in `extra` already exists in `LogRecord`. Therefore, the PR uses a monkey-patched implementation of `makeRecord`.

However, the caller's `lineno` and `filename` are no longer added to `extra`. Instead, this information is passed directly to the `LogRecord` constructor. See [the code](https://github.com/ray-project/ray/blob/7a07263e9e7eb3ffe11d3805a4c0ad55877c0aa0/python/ray/autoscaler/_private/cli_logger.py#L422-L438) for more details. That's why `_patched_makeRecord` is unnecessary.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
