### PR TITLE
Move `shutdown` to upper level to avoid issue with `tmux`

### DIFF
--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -1153,16 +1153,15 @@ def exec_cluster(
         },
         docker_config=config.get("docker"),
     )
-    shutdown_after_run = False
     if cmd and stop:
         cmd = "; ".join(
             [
                 cmd,
                 "ray stop",
                 "ray teardown ~/ray_bootstrap_config.yaml --yes --workers-only",
+                "sudo shutdown -h now",
             ]
         )
-        shutdown_after_run = True
 
     result = _exec(
         updater,
@@ -1172,7 +1171,7 @@ def exec_cluster(
         port_forward=port_forward,
         with_output=with_output,
         run_env=run_env,
-        shutdown_after_run=shutdown_after_run,
+        shutdown_after_run=False,
         extra_screen_args=extra_screen_args,
     )
     if tmux or screen:


### PR DESCRIPTION
Fixes #48109

## Why are these changes needed?

See #48109.

## Related issue number

Fixes #48109.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(


## Notes
I've tested this PR manually and verified that it resolved the issue I reported in #48109. I spent quite a bit of time trying to get the cluster tests to run but couldn't figure out how to do that.
```sh
$ ray exec \
  --verbose \
  --start \
  --stop \
  --tmux \
  --no-config-cache \
  ./cluster-config.yml \
  'echo "start" && sleep 10 && echo "done"'

[...]

Running `tmux new -d bash -c 'echo "start" && sleep 10 && echo "done"; ray stop; ray teardown ~/ray_bootstrap_config.yaml --yes --workers-only; sudo shutdown -h now; exec bash'`
bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
Shared connection to 35.196.24.227 closed.
Run `ray attach ./cluster-config.yml --tmux` to check command status.
```