### PR TITLE
Pass logging_config to controller global logger

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -474,6 +474,7 @@ def _run(
     else:
         client = _private_api.serve_start(
             http_options={"location": "EveryNode"},
+            global_logging_config=logging_config,
         )
         # Record after Ray has been started.
         ServeUsageTag.API_VERSION.record("v2")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Currently in serve.run the logging_config is not passed to controller. This PR add this arguments into the function call so the logging_config can be correctly specified for system-level logging. 

## Related issue number
Closes #48652 
<!-- For example: "Closes #1234" -->


### Example
```
logging_config = {"log_level": "DEBUG", "logs_dir": "./mimi_debug"}
handle: DeploymentHandle = serve.run(app, logging_config=logging_config)
```

### Before
controller logs aren't saved in the specified logs_dir

<img width="326" alt="image" src="https://github.com/user-attachments/assets/0d316428-e7a7-48e0-8d9d-1692a3045a4a">

### After
controller logs are correctly configured

<img width="325" alt="image" src="https://github.com/user-attachments/assets/e05aba0b-75cd-4cd4-9a92-4ef8cdd84cce">


## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
