### PR TITLE
[dashboard] add actor pid to dashboard

### DIFF
--- a/python/ray/dashboard/client/src/pages/actor/ActorDetail.tsx
+++ b/python/ray/dashboard/client/src/pages/actor/ActorDetail.tsx
@@ -134,7 +134,7 @@ const ActorDetailPage = () => {
               : { value: "-" },
           },
           {
-            label: "Actor PID",
+            label: "PID",
             content: actorDetail.pid
               ? {
                   value: `${actorDetail.pid}`,

--- a/python/ray/dashboard/client/src/pages/actor/ActorDetail.tsx
+++ b/python/ray/dashboard/client/src/pages/actor/ActorDetail.tsx
@@ -134,6 +134,15 @@ const ActorDetailPage = () => {
               : { value: "-" },
           },
           {
+            label: "Actor PID",
+            content: actorDetail.pid
+              ? {
+                  value: `${actorDetail.pid}`,
+                  copyableValue: `${actorDetail.pid}`,
+                }
+              : { value: "-" },
+          },
+          {
             label: "Started at",
             content: {
               value: actorDetail.startTime


### PR DESCRIPTION
Add actor PID to ray dashboard, as requested by @rynewang 

Test:
- CI
- https://console.anyscale-staging.com/v2/cld_kvedZWag2qA8i5BjxUevf5i7/prj_qC3ZfndQWYYjx2cz8KWGNUL4/jobs/prodjob_t4ypxualxjk73pryekjrh433i6?job-logs-section-tabs=application_logs&job-tab=ray-dashboard

<img width="1915" alt="Screenshot 2024-11-19 at 10 08 25 AM" src="https://github.com/user-attachments/assets/45f14e29-31aa-4af6-a6a4-54d5a08b4f98">
