### PR TITLE
[doc] Add hpu resource description in ray serve docs

### DIFF
--- a/doc/source/serve/getting_started.md
+++ b/doc/source/serve/getting_started.md
@@ -101,7 +101,7 @@ parameters in the `@serve.deployment` decorator. The example configures a few co
 * `ray_actor_options`: a dictionary containing configuration options for each replica.
     * `num_cpus`: a float representing the logical number of CPUs each replica should reserve. You can make this a fraction to pack multiple replicas together on a machine with fewer CPUs than replicas.
     * `num_gpus`: a float representing the logical number of GPUs each replica should reserve. You can make this a fraction to pack multiple replicas together on a machine with fewer GPUs than replicas.
-    * `resources`: if you want to reserve HPUs resources for each replica, please set this parameter in ray_actor_options, like `ray_actor_options={"resources": {"HPU": 1}}`. The value of `HPU` needs to be an integer which represents the logical number of HPUs each replica should reserve.
+    * `resources`: a dictionary containing other resource requirements for the replicate, such as non-GPU accelerators like HPUs or TPUs.
 
 All these parameters are optional, so feel free to omit them:
 

--- a/doc/source/serve/getting_started.md
+++ b/doc/source/serve/getting_started.md
@@ -101,6 +101,7 @@ parameters in the `@serve.deployment` decorator. The example configures a few co
 * `ray_actor_options`: a dictionary containing configuration options for each replica.
     * `num_cpus`: a float representing the logical number of CPUs each replica should reserve. You can make this a fraction to pack multiple replicas together on a machine with fewer CPUs than replicas.
     * `num_gpus`: a float representing the logical number of GPUs each replica should reserve. You can make this a fraction to pack multiple replicas together on a machine with fewer GPUs than replicas.
+    * `resources`: if you want to reserve HPUs resources for each replica, please set this parameter in ray_actor_options, like `ray_actor_options={"resources": {"HPU": 1}}`. The value of `HPU` needs to be an integer which represents the logical number of HPUs each replica should reserve.
 
 All these parameters are optional, so feel free to omit them:
 

--- a/doc/source/serve/resource-allocation.md
+++ b/doc/source/serve/resource-allocation.md
@@ -6,14 +6,14 @@ This guide helps you configure Ray Serve to:
 
 - Scale your deployments horizontally by specifying a number of replicas
 - Scale up and down automatically to react to changing traffic
-- Allocate hardware resources (CPUs, GPUs, etc) for each deployment
+- Allocate hardware resources (CPUs, GPUs, HPUs, etc) for each deployment
 
 
 (serve-cpus-gpus)=
 
-## Resource management (CPUs, GPUs)
+## Resource management (CPUs, GPUs, HPUs)
 
-You may want to specify a deployment's resource requirements to reserve cluster resources like GPUs.  To assign hardware resources per replica, you can pass resource requirements to
+You may want to specify a deployment's resource requirements to reserve cluster resources like GPUs or HPUs.  To assign hardware resources per replica, you can pass resource requirements to
 `ray_actor_options`.
 By default, each replica reserves one CPU.
 To learn about options to pass in, take a look at the [Resources with Actors guide](actor-resource-guide).
@@ -25,6 +25,14 @@ following:
 @serve.deployment(ray_actor_options={"num_gpus": 1})
 def func(*args):
     return do_something_with_my_gpu()
+```
+
+Or if you want to create a deployment where each replica uses a single HPU, follow the code below:
+
+```python
+@serve.deployment(ray_actor_options={"resources": {"HPU": 1}})
+def func(*args):
+    return do_something_with_my_hpu()
 ```
 
 (serve-fractional-resources-guide)=

--- a/doc/source/serve/resource-allocation.md
+++ b/doc/source/serve/resource-allocation.md
@@ -27,7 +27,7 @@ def func(*args):
     return do_something_with_my_gpu()
 ```
 
-Or if you want to create a deployment where each replica uses a single HPU, follow the code below:
+Or if you want to create a deployment where each replica uses a single HPU, follow the example below:
 
 ```python
 @serve.deployment(ray_actor_options={"resources": {"HPU": 1}})

--- a/doc/source/serve/resource-allocation.md
+++ b/doc/source/serve/resource-allocation.md
@@ -6,14 +6,14 @@ This guide helps you configure Ray Serve to:
 
 - Scale your deployments horizontally by specifying a number of replicas
 - Scale up and down automatically to react to changing traffic
-- Allocate hardware resources (CPUs, GPUs, HPUs, etc) for each deployment
+- Allocate hardware resources (CPUs, GPUs, other accelerators, etc) for each deployment
 
 
 (serve-cpus-gpus)=
 
-## Resource management (CPUs, GPUs, HPUs)
+## Resource management (CPUs, GPUs, accelerators)
 
-You may want to specify a deployment's resource requirements to reserve cluster resources like GPUs or HPUs.  To assign hardware resources per replica, you can pass resource requirements to
+You may want to specify a deployment's resource requirements to reserve cluster resources like GPUs or other accelerators.  To assign hardware resources per replica, you can pass resource requirements to
 `ray_actor_options`.
 By default, each replica reserves one CPU.
 To learn about options to pass in, take a look at the [Resources with Actors guide](actor-resource-guide).
@@ -27,7 +27,7 @@ def func(*args):
     return do_something_with_my_gpu()
 ```
 
-Or if you want to create a deployment where each replica uses a single HPU, follow the example below:
+Or if you want to create a deployment where each replica uses another type of accelerator such as an HPU, follow the example below:
 
 ```python
 @serve.deployment(ray_actor_options={"resources": {"HPU": 1}})


### PR DESCRIPTION
HPU resource is already supported in Ray, and there are many examples to guide users to use HPU device in Ray, so this PR adds some instructions for HPU device to the Ray Serve related documents.