### PR TITLE
[metrics][prometheus] Support `ray metrics shutdown-prometheus`

### DIFF
--- a/doc/source/cluster/metrics.md
+++ b/doc/source/cluster/metrics.md
@@ -67,7 +67,17 @@ ray_dashboard_api_requests_count_requests_total
 
 You can then see the number of requests to the Ray Dashboard API over time.
 
-To stop Prometheus, run `kill <PID>` where `<PID>` is the PID of the Prometheus process that was printed out when you ran the command. To find the PID, you can also run `ps aux | grep prometheus`.
+To stop Prometheus, run the following commands:
+
+```sh
+# case 1: Ray > 2.40
+ray metrics shutdown-prometheus
+
+# case 2: Otherwise
+# Run `ps aux | grep prometheus` to find the PID of the Prometheus process. Then, kill the process.
+kill <PID>
+```
+
 
 ### [Optional] Manual: Running Prometheus locally
 

--- a/python/ray/dashboard/modules/metrics/install_and_start_prometheus.py
+++ b/python/ray/dashboard/modules/metrics/install_and_start_prometheus.py
@@ -90,6 +90,7 @@ def start_prometheus(prometheus_dir):
         f"{prometheus_dir}/prometheus",
         "--config.file",
         str(config_file),
+        "--web.enable-lifecycle",
     ]
     try:
         process = subprocess.Popen(prometheus_cmd)
@@ -104,6 +105,7 @@ def print_shutdown_message(process_id):
     message = (
         f"Prometheus is running with PID {process_id}.\n"
         "To stop Prometheus, use the command: "
+        "`ray metrics shutdown-prometheus`, "
         f"'kill {process_id}', or if you need to force stop, "
         f"use 'kill -9 {process_id}'."
     )

--- a/python/ray/dashboard/modules/tests/test_metrics_integration.py
+++ b/python/ray/dashboard/modules/tests/test_metrics_integration.py
@@ -1,13 +1,14 @@
 import subprocess
 import sys
+import time
 
 import pytest
+from click.testing import CliRunner
 
 from ray.dashboard.consts import PROMETHEUS_CONFIG_INPUT_PATH
 from ray.dashboard.modules.metrics import install_and_start_prometheus
 from ray.dashboard.modules.metrics.templates import PROMETHEUS_YML_TEMPLATE
-
-from click.testing import CliRunner
+from ray.scripts.scripts import metrics_group
 
 
 @pytest.mark.parametrize(
@@ -45,7 +46,9 @@ def test_e2e(capsys):
 def test_shutdown_prometheus():
     install_and_start_prometheus.main()
     runner = CliRunner()
-    from ray.scripts.scripts import metrics_group
+    # Sleep for a few seconds to make sure Prometheus is running
+    # before we try to shut it down.
+    time.sleep(5)
     result = runner.invoke(metrics_group, ["shutdown-prometheus"])
     assert result.exit_code == 0
 

--- a/python/ray/dashboard/modules/tests/test_metrics_integration.py
+++ b/python/ray/dashboard/modules/tests/test_metrics_integration.py
@@ -7,6 +7,8 @@ from ray.dashboard.consts import PROMETHEUS_CONFIG_INPUT_PATH
 from ray.dashboard.modules.metrics import install_and_start_prometheus
 from ray.dashboard.modules.metrics.templates import PROMETHEUS_YML_TEMPLATE
 
+from click.testing import CliRunner
+
 
 @pytest.mark.parametrize(
     "os_type,architecture",
@@ -38,6 +40,14 @@ def test_e2e(capsys):
     # Find the PID from the output: "To stop Prometheus, use the command: 'kill 22790'"
     pid = int(captured.out.split("kill ")[1].split("'")[0])
     subprocess.run(["kill", str(pid)])
+
+
+def test_shutdown_prometheus():
+    install_and_start_prometheus.main()
+    runner = CliRunner()
+    from ray.scripts.scripts import metrics_group
+    result = runner.invoke(metrics_group, ["shutdown-prometheus"])
+    assert result.exit_code == 0
 
 
 def test_prometheus_config_content():

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from typing import Optional, Set, List, Tuple
 from ray.dashboard.modules.metrics import install_and_start_prometheus
 from ray.util.check_open_ports import check_open_ports
+import requests
 
 import click
 import psutil
@@ -2581,6 +2582,15 @@ def metrics_group():
 @metrics_group.command(name="launch-prometheus")
 def launch_prometheus():
     install_and_start_prometheus.main()
+
+
+@metrics_group.command(name="shutdown-prometheus")
+def shutdown_prometheus():
+    try:
+        requests.post("http://localhost:9090/-/quit")
+    except requests.exceptions.RequestException as e:
+        print(f"An error occurred: {e}")
+        sys.exit(1)
 
 
 def add_command_alias(command, name, hidden):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Users need to run `kill <PID>` to shut down Prometheus launched by `ray metrics launch-prometheus`.

This PR enables the Prometheus lifecycle API and implements `ray metrics shutdown-prometheus`, which sends a POST request to `http://localhost:9090/-/quit` to gracefully shut down Prometheus.

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/016d028a-2a1d-4503-829e-3e3a7f28714e">


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
