### PR TITLE
[Serve] Handle multiple changed objects per `LongPollHost.listen_for_change` RPC

### DIFF
--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -226,8 +226,7 @@ class ServeController:
         self.global_logging_config = global_logging_config
 
         self.long_poll_host.notify_changed(
-            LongPollNamespace.GLOBAL_LOGGING_CONFIG,
-            global_logging_config,
+            {LongPollNamespace.GLOBAL_LOGGING_CONFIG: global_logging_config}
         )
         configure_component_logger(
             component_name="controller",

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -1448,16 +1448,17 @@ class DeploymentState:
             return
 
         self._long_poll_host.notify_changed(
-            (LongPollNamespace.RUNNING_REPLICAS, self._id),
-            running_replica_infos,
-        )
-        # NOTE(zcin): notify changed for Java routers. Since Java only
-        # supports 1.x API, there is no concept of applications in Java,
-        # so the key should remain a string describing the deployment
-        # name. If there are no Java routers, this is a no-op.
-        self._long_poll_host.notify_changed(
-            (LongPollNamespace.RUNNING_REPLICAS, self._id.name),
-            running_replica_infos,
+            {
+                (LongPollNamespace.RUNNING_REPLICAS, self._id): running_replica_infos,
+                # NOTE(zcin): notify changed for Java routers. Since Java only
+                # supports 1.x API, there is no concept of applications in Java,
+                # so the key should remain a string describing the deployment
+                # name. If there are no Java routers, this is a no-op.
+                (
+                    LongPollNamespace.RUNNING_REPLICAS,
+                    self._id.name,
+                ): running_replica_infos,
+            }
         )
         self._last_broadcasted_running_replica_infos = running_replica_infos
         self._multiplexed_model_ids_updated = False
@@ -1473,8 +1474,7 @@ class DeploymentState:
             return
 
         self._long_poll_host.notify_changed(
-            (LongPollNamespace.DEPLOYMENT_CONFIG, self._id),
-            current_deployment_config,
+            {(LongPollNamespace.DEPLOYMENT_CONFIG, self._id): current_deployment_config}
         )
 
         self._last_broadcasted_deployment_config = current_deployment_config

--- a/python/ray/serve/_private/endpoint_state.py
+++ b/python/ray/serve/_private/endpoint_state.py
@@ -46,7 +46,7 @@ class EndpointState:
 
     def _notify_route_table_changed(self):
         self._long_poll_host.notify_changed(
-            LongPollNamespace.ROUTE_TABLE, self._endpoints
+            {LongPollNamespace.ROUTE_TABLE: self._endpoints}
         )
 
     def _get_endpoint_for_route(self, route: str) -> Optional[DeploymentID]:

--- a/python/ray/serve/tests/test_long_poll.py
+++ b/python/ray/serve/tests/test_long_poll.py
@@ -38,7 +38,7 @@ def test_notifier_events_cleared_without_update(serve_instance):
     host = ray.remote(LongPollHost).remote(
         listen_for_change_request_timeout_s=(0.1, 0.1)
     )
-    ray.get(host.notify_changed.remote("key_1", 999))
+    ray.get(host.notify_changed.remote({"key_1": 999}))
 
     # Get an initial object snapshot for the key.
     object_ref = host.listen_for_change.remote({"key_1": -1})
@@ -60,8 +60,8 @@ def test_host_standalone(serve_instance):
     host = ray.remote(LongPollHost).remote()
 
     # Write two values
-    ray.get(host.notify_changed.remote("key_1", 999))
-    ray.get(host.notify_changed.remote("key_2", 999))
+    ray.get(host.notify_changed.remote({"key_1": 999}))
+    ray.get(host.notify_changed.remote({"key_2": 999}))
     object_ref = host.listen_for_change.remote({"key_1": -1, "key_2": -1})
 
     # We should be able to get the result immediately
@@ -77,7 +77,7 @@ def test_host_standalone(serve_instance):
     assert len(not_done) == 1
 
     # Now update the value, we should immediately get updated value
-    ray.get(host.notify_changed.remote("key_2", 999))
+    ray.get(host.notify_changed.remote({"key_2": 999}))
     result = ray.get(object_ref)
     assert len(result) == 1
     assert "key_2" in result
@@ -88,13 +88,13 @@ def test_long_poll_wait_for_keys(serve_instance):
     # are set.
     host = ray.remote(LongPollHost).remote()
     object_ref = host.listen_for_change.remote({"key_1": -1, "key_2": -1})
-    ray.get(host.notify_changed.remote("key_1", 999))
-    ray.get(host.notify_changed.remote("key_2", 999))
 
-    # We should be able to get the one of the result immediately
+    ray.get(host.notify_changed.remote({"key_1": 123, "key_2": 456}))
+
+    # We should be able to get the both results immediately
     result: Dict[str, UpdatedObject] = ray.get(object_ref)
-    assert set(result.keys()).issubset({"key_1", "key_2"})
-    assert {v.object_snapshot for v in result.values()} == {999}
+    assert result.keys() == {"key_1", "key_2"}
+    assert {v.object_snapshot for v in result.values()} == {123, 456}
 
 
 def test_long_poll_restarts(serve_instance):
@@ -106,7 +106,7 @@ def test_long_poll_restarts(serve_instance):
         def __init__(self) -> None:
             print("actor started")
             self.host = LongPollHost()
-            self.host.notify_changed("timer", time.time())
+            self.host.notify_changed({"timer": time.time()})
             self.should_exit = False
 
         async def listen_for_change(self, key_to_ids):
@@ -142,8 +142,8 @@ async def test_client_callbacks(serve_instance):
     host = ray.remote(LongPollHost).remote()
 
     # Write two values
-    ray.get(host.notify_changed.remote("key_1", 100))
-    ray.get(host.notify_changed.remote("key_2", 999))
+    ray.get(host.notify_changed.remote({"key_1": 100}))
+    ray.get(host.notify_changed.remote({"key_2": 999}))
 
     callback_results = dict()
 
@@ -167,7 +167,7 @@ async def test_client_callbacks(serve_instance):
         timeout=1,
     )
 
-    ray.get(host.notify_changed.remote("key_2", 1999))
+    ray.get(host.notify_changed.remote({"key_2": 1999}))
 
     await async_wait_for_condition(
         lambda: callback_results == {"key_1": 100, "key_2": 999},
@@ -178,7 +178,7 @@ async def test_client_callbacks(serve_instance):
 @pytest.mark.asyncio
 async def test_client_threadsafe(serve_instance):
     host = ray.remote(LongPollHost).remote()
-    ray.get(host.notify_changed.remote("key_1", 100))
+    ray.get(host.notify_changed.remote({"key_1": 100}))
 
     e = asyncio.Event()
 
@@ -198,7 +198,7 @@ async def test_client_threadsafe(serve_instance):
 
 def test_listen_for_change_java(serve_instance):
     host = ray.remote(LongPollHost).remote()
-    ray.get(host.notify_changed.remote("key_1", 999))
+    ray.get(host.notify_changed.remote({"key_1": 999}))
     request_1 = {"keys_to_snapshot_ids": {"key_1": -1}}
     object_ref = host.listen_for_change_java.remote(
         LongPollRequest(**request_1).SerializeToString()
@@ -211,7 +211,7 @@ def test_listen_for_change_java(serve_instance):
     endpoints: Dict[DeploymentID, EndpointInfo] = dict()
     endpoints["deployment_name"] = EndpointInfo(route="/test/xlang/poll")
     endpoints["deployment_name1"] = EndpointInfo(route="/test/xlang/poll1")
-    ray.get(host.notify_changed.remote(LongPollNamespace.ROUTE_TABLE, endpoints))
+    ray.get(host.notify_changed.remote({LongPollNamespace.ROUTE_TABLE: endpoints}))
     object_ref_2 = host.listen_for_change_java.remote(
         LongPollRequest(**request_2).SerializeToString()
     )

--- a/python/ray/serve/tests/test_long_poll.py
+++ b/python/ray/serve/tests/test_long_poll.py
@@ -240,7 +240,7 @@ def test_listen_for_change_java(serve_instance):
     ]
     ray.get(
         host.notify_changed.remote(
-            (LongPollNamespace.RUNNING_REPLICAS, "deployment_name"), replicas
+            {(LongPollNamespace.RUNNING_REPLICAS, "deployment_name"): replicas}
         )
     )
     object_ref_3 = host.listen_for_change_java.remote(

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -1581,7 +1581,7 @@ def test_long_poll_host_sends_counted(serve_instance):
     )
 
     # Write a value.
-    ray.get(host.notify_changed.remote("key_1", 999))
+    ray.get(host.notify_changed.remote({"key_1": 999}))
     object_ref = host.listen_for_change.remote({"key_1": -1})
 
     # Check that the result's size is reported.
@@ -1595,8 +1595,8 @@ def test_long_poll_host_sends_counted(serve_instance):
     )
 
     # Write two new values.
-    ray.get(host.notify_changed.remote("key_1", 1000))
-    ray.get(host.notify_changed.remote("key_2", 1000))
+    ray.get(host.notify_changed.remote({"key_1": 1000}))
+    ray.get(host.notify_changed.remote({"key_2": 1000}))
     object_ref = host.listen_for_change.remote(
         {"key_1": result_1["key_1"].snapshot_id, "key_2": -1}
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, in the `LongPollHost`/`LongPollClient`, if multiple objects are updated that a `listen_for_change` request is waiting for *before the async task in the host can run again*, only one of those updated objects will be returned. This is inefficient because the `LongPollClient` will immediately do a `listen_for_change` RPC again, and that will see outdated snapshot IDs for the updates that weren't returned and get all of the missed updates.

This is because of an asymmetry between https://github.com/ray-project/ray/blob/b75cb793e437aa617d61dcb13e5f5d2fcc83ee68/python/ray/serve/_private/long_poll.py#L252-L272 , which looks for *all* outdated keys, and https://github.com/ray-project/ray/blob/b75cb793e437aa617d61dcb13e5f5d2fcc83ee68/python/ray/serve/_private/long_poll.py#L309 , which only looks at a single complete `Event`, even if multiple events completed during the [`wait`](https://github.com/ray-project/ray/blob/b75cb793e437aa617d61dcb13e5f5d2fcc83ee68/python/ray/serve/_private/long_poll.py#L289-L293).

To prove that the `wait` can indeed see multiple completed `Event`s, see this example:
```python
from asyncio import wait, Event, run, create_task, FIRST_COMPLETED


async def main():
    a = Event()
    b = Event()

    wait_for_a = create_task(a.wait())
    wait_for_b = create_task(b.wait())

    a.set()
    b.set()

    done, pending = await wait([wait_for_a, wait_for_b], return_when=FIRST_COMPLETED)

    print(f"{len(done)=}")
    print(f"{len(pending)=}")

run(main())

# len(done)=2
# len(pending)=0
```

Generally this won't be a big issue because most `listen_for_change` requests in the current Serve setup are asking for a very small number of keys and are likely to only get one key update anyway. But, as I've been discussing with @edoakes and @zcin on Slack, I'd like to group up the `DeploymentHandle` `listen_for_change` RPCs under a single `LongPollClient`, which will be requesting many keys and is therefore more likely to hit this situation.

To complement this change, I also changed `LongPollHost.notify_changed` so that it takes multiple updates at the same time.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
