### PR TITLE
[release] set golden_notebook_torch_tune_serve_test frequency to manual

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1469,7 +1469,7 @@
   group: Golden Notebook tests
   working_dir: golden_notebook_tests
 
-  frequency: nightly-3x
+  frequency: manual
   team: ml
 
   cluster:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Current test is failing due to spot instance unavailability.

Converting this test to manual right now.

Future options:
1. Update instance type to something with more availability (g4 or g5?)
2. Remove this test entirely

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #48773

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
