### PR TITLE
[core] Avoid parsing env exception

### DIFF
--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -31,6 +31,7 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <string_view>
 
 #include "absl/debugging/failure_signal_handler.h"
 #include "absl/debugging/stacktrace.h"
@@ -302,10 +303,8 @@ void RayLog::InitLogFormat() {
   log_format_json_ = false;
   log_format_pattern_ = kLogFormatTextPattern;
 
-  const char *var_value = std::getenv("RAY_BACKEND_LOG_JSON");
-  if (var_value != nullptr) {
-    std::string data = var_value;
-    if (data == "1") {
+  if (const char *var_value = std::getenv("RAY_BACKEND_LOG_JSON"); var_value != nullptr) {
+    if (std::string_view{var_value} == std::string_view{"1"}) {
       log_format_json_ = true;
       log_format_pattern_ = kLogFormatJsonPattern;
     }

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -346,8 +346,8 @@ void RayLog::StartRayLog(const std::string &app_name,
 #endif
     // Reset log pattern and level and we assume a log file can be rotated with
     // 10 files in max size 512M by default.
-    const char *ray_rotation_max_bytes = std::getenv("RAY_ROTATION_MAX_BYTES");
-    if (ray_rotation_max_bytes != nullptr) {
+    if (const char *ray_rotation_max_bytes = std::getenv("RAY_ROTATION_MAX_BYTES");
+        ray_rotation_max_bytes != nullptr) {
       long max_size = 0;
       if (absl::SimpleAtoi(ray_rotation_max_bytes, &max_size) && max_size > 0) {
         // 0 means no log rotation in python, but not in spdlog. We just use the default
@@ -356,8 +356,8 @@ void RayLog::StartRayLog(const std::string &app_name,
       }
     }
 
-    const char *ray_rotation_backup_count = std::getenv("RAY_ROTATION_BACKUP_COUNT");
-    if (ray_rotation_backup_count != nullptr) {
+    if (const char *ray_rotation_backup_count = std::getenv("RAY_ROTATION_BACKUP_COUNT");
+        ray_rotation_backup_count != nullptr) {
       long file_num = 0;
       if (absl::SimpleAtoi(ray_rotation_backup_count, &file_num) && file_num > 0) {
         log_rotation_file_num_ = file_num;

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -35,6 +35,7 @@
 #include "absl/debugging/failure_signal_handler.h"
 #include "absl/debugging/stacktrace.h"
 #include "absl/debugging/symbolize.h"
+#include "absl/strings/numbers.h"
 #include "absl/strings/str_format.h"
 #include "nlohmann/json.hpp"
 #include "ray/util/event_label.h"
@@ -343,17 +344,20 @@ void RayLog::StartRayLog(const std::string &app_name,
 #endif
     // Reset log pattern and level and we assume a log file can be rotated with
     // 10 files in max size 512M by default.
-    if (std::getenv("RAY_ROTATION_MAX_BYTES")) {
-      long max_size = std::atol(std::getenv("RAY_ROTATION_MAX_BYTES"));
-      // 0 means no log rotation in python, but not in spdlog. We just use the default
-      // value here.
-      if (max_size != 0) {
+    const char *ray_rotation_max_bytes = std::getenv("RAY_ROTATION_MAX_BYTES");
+    if (ray_rotation_max_bytes != nullptr) {
+      long max_size = 0;
+      if (absl::SimpleAtoi(ray_rotation_max_bytes, &max_size) && max_size > 0) {
+        // 0 means no log rotation in python, but not in spdlog. We just use the default
+        // value here.
         log_rotation_max_size_ = max_size;
       }
     }
-    if (std::getenv("RAY_ROTATION_BACKUP_COUNT")) {
-      long file_num = std::atol(std::getenv("RAY_ROTATION_BACKUP_COUNT"));
-      if (file_num != 0) {
+
+    const char *ray_rotation_backup_count = std::getenv("RAY_ROTATION_BACKUP_COUNT");
+    if (ray_rotation_backup_count != nullptr) {
+      long file_num = 0;
+      if (absl::SimpleAtoi(ray_rotation_backup_count, &file_num) && file_num > 0) {
         log_rotation_file_num_ = file_num;
       }
     }


### PR DESCRIPTION
A small change to use `absl::SimpleAtoi` to avoid integer casting to throw exception;
Also avoid double map lookup and ignore all invalid values (i.e. negative values).