### PR TITLE
[Data] Cleaned up & streamlined boundary sampling sequence to avoid conversion from Numpy to Python objects

### DIFF
--- a/python/ray/data/_internal/planner/exchange/sort_task_spec.py
+++ b/python/ray/data/_internal/planner/exchange/sort_task_spec.py
@@ -197,7 +197,9 @@ class SortTaskSpec(ExchangeTaskSpec):
 
         # Sort rows lexicographically
         record_dtype = [(k, v.dtype) for k, v in samples_dict.items()]
-        sampled_rows_array = np.array(list(zip(*samples_dict.values())), dtype=record_dtype)
+        sampled_rows_array = np.array(
+            list(zip(*samples_dict.values())), dtype=record_dtype
+        )
 
         sampled_rows_array.sort()
         sorted_rows_array = sampled_rows_array

--- a/python/ray/data/_internal/planner/exchange/sort_task_spec.py
+++ b/python/ray/data/_internal/planner/exchange/sort_task_spec.py
@@ -196,11 +196,11 @@ class SortTaskSpec(ExchangeTaskSpec):
         samples_dict = BlockAccessor.for_block(samples_table).to_numpy(columns=columns)
 
         # Sort rows lexicographically
-        columns = list(samples_dict.values())
-        sorted_rows_indices = np.lexsort(tuple(reversed(columns)))
-        # Stack columns to transpose from list of columns to an array of row-like arrays
-        sampled_rows_array = np.column_stack(columns)
-        sorted_rows_array = sampled_rows_array[sorted_rows_indices]
+        record_dtype = [(k, v.dtype) for k, v in samples_dict.items()]
+        sampled_rows_array = np.array(list(zip(*samples_dict.values())), dtype=record_dtype)
+
+        sampled_rows_array.sort()
+        sorted_rows_array = sampled_rows_array
 
         # Each boundary corresponds to a quantile of the data.
         quantile_indices = [

--- a/python/ray/data/tests/test_sort.py
+++ b/python/ray/data/tests/test_sort.py
@@ -54,7 +54,8 @@ def test_sort_with_specified_boundaries(ray_start_regular, descending, boundarie
 def test_sort_multiple_keys_produces_equally_sized_blocks(ray_start_regular):
     # Test for https://github.com/ray-project/ray/issues/45303.
     ds = ray.data.from_items(
-        [{"a": i, "b": f'{j}'} for i in range(2) for j in range(5)], override_num_blocks=5
+        [{"a": i, "b": f"{j}"} for i in range(2) for j in range(5)],
+        override_num_blocks=5,
     )
 
     ds_sorted = ds.sort(["a", "b"])

--- a/python/ray/data/tests/test_sort.py
+++ b/python/ray/data/tests/test_sort.py
@@ -54,7 +54,7 @@ def test_sort_with_specified_boundaries(ray_start_regular, descending, boundarie
 def test_sort_multiple_keys_produces_equally_sized_blocks(ray_start_regular):
     # Test for https://github.com/ray-project/ray/issues/45303.
     ds = ray.data.from_items(
-        [{"a": i, "b": j} for i in range(2) for j in range(5)], override_num_blocks=5
+        [{"a": i, "b": f'{j}'} for i in range(2) for j in range(5)], override_num_blocks=5
     )
 
     ds_sorted = ds.sort(["a", "b"])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Cleaned up & streamlined boundary sampling sequence to avoid conversion from Numpy to Python objects.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
