### PR TITLE
[core] install core prerelease deps together

### DIFF
--- a/ci/env/install-core-prerelease-dependencies.sh
+++ b/ci/env/install-core-prerelease-dependencies.sh
@@ -5,7 +5,5 @@ set -e
 # install all unbounded dependencies in setup.py for ray core
 # TOOD(scv119) reenable grpcio once https://github.com/grpc/grpc/issues/31885 is fixed.
 # TOOD(scv119) reenable jsonschema once https://github.com/ray-project/ray/issues/33411 is fixed.
-for dependency in aiosignal frozenlist requests protobuf
-do
-    python -m pip install -U --pre --upgrade-strategy=eager $dependency
-done
+DEPS=(aiosignal frozenlist requests protobuf)
+python -m pip install -U --pre --upgrade-strategy=eager "${DEPS[@]}"


### PR DESCRIPTION
don't install one by one; otherwise, they might run into unintended dependency conflicts between each other.
