### PR TITLE
[serve] Set `forwarded_allow_ips="*"` by default

### DIFF
--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -1380,6 +1380,11 @@ class ProxyActor:
             log_level="warning",
             access_log=False,
             timeout_keep_alive=self.keep_alive_timeout_s,
+            # These flags must be set in order for redirects to work properly when
+            # behind a proxy that terminates TLS.
+            # See: https://github.com/fastapi/fastapi/discussions/9328.
+            proxy_headers=True,
+            forwarded_allow_ips=os.environ.get("FORWARDED_ALLOW_IPS", "*"),
         )
         self._uvicorn_server = uvicorn.Server(config=config)
         # TODO(edoakes): we need to override install_signal_handlers here


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Without this, redirects behind a proxy that terminates TLS will go to `http://`.

See https://github.com/fastapi/fastapi/discussions/9328 for more discussion.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
