### PR TITLE
[gce launcher] change nightly and latest tests to manual

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5067,7 +5067,7 @@
   stable: true
 
   env: gce
-  frequency: nightly
+  frequency: manual
   team: clusters
   cluster:
     byod: {}
@@ -5084,7 +5084,7 @@
   stable: true
 
   env: gce
-  frequency: nightly
+  frequency: manual
   team: clusters
   cluster:
     byod: {}


### PR DESCRIPTION
they are not testing against release candidate
