### PR TITLE
[core][autoscaler] Make the head group name consistent with the head Pod's `ray.io/group` label.

### DIFF
--- a/doc/source/cluster/kubernetes/configs/ray-cluster.gpu.yaml
+++ b/doc/source/cluster/kubernetes/configs/ray-cluster.gpu.yaml
@@ -12,7 +12,7 @@ spec:
   ######################headGroupSpec#################################
   # head group template and specs, (perhaps 'group' is not needed in the name)
   headGroupSpec:
-    # logical group name, for this called head-group, also can be functional
+    # logical group name, for this called headgroup, also can be functional
     # pod type head or worker
     # rayNodeType: head # Not needed since it is under the headgroup
     # the following params are used to complete the ray start: ray start --head --block ...

--- a/python/ray/autoscaler/_private/kuberay/autoscaling_config.py
+++ b/python/ray/autoscaler/_private/kuberay/autoscaling_config.py
@@ -30,7 +30,7 @@ RAYCLUSTER_FETCH_RETRY_S = 5
 
 # Logical group name for the KubeRay head group.
 # Used as the name of the "head node type" by the autoscaler.
-_HEAD_GROUP_NAME = "head-group"
+_HEAD_GROUP_NAME = "headgroup"
 
 
 class AutoscalingConfigProducer:

--- a/python/ray/autoscaler/_private/kuberay/node_provider.py
+++ b/python/ray/autoscaler/_private/kuberay/node_provider.py
@@ -38,8 +38,6 @@ KUBERAY_KIND_HEAD = "head"
 # Kind label value indicating the pod is the worker.
 KUBERAY_KIND_WORKER = "worker"
 
-# Group name (node type) to use for the head.
-KUBERAY_TYPE_HEAD = "head-group"
 # KubeRay CRD version
 KUBERAY_CRD_VER = os.getenv("KUBERAY_CRD_VER", "v1alpha1")
 
@@ -104,12 +102,12 @@ def kind_and_type(pod: Dict[str, Any]) -> Tuple[NodeKind, NodeType]:
     from a Ray pod's labels.
     """
     labels = pod["metadata"]["labels"]
-    if labels[KUBERAY_LABEL_KEY_KIND] == KUBERAY_KIND_HEAD:
-        kind = NODE_KIND_HEAD
-        type = KUBERAY_TYPE_HEAD
-    else:
-        kind = NODE_KIND_WORKER
-        type = labels[KUBERAY_LABEL_KEY_TYPE]
+    kind = (
+        NODE_KIND_HEAD
+        if labels[KUBERAY_LABEL_KEY_KIND] == KUBERAY_KIND_HEAD
+        else NODE_KIND_WORKER
+    )
+    type = labels[KUBERAY_LABEL_KEY_TYPE]
     return kind, type
 
 

--- a/python/ray/autoscaler/kuberay/ray-cluster.complete.yaml
+++ b/python/ray/autoscaler/kuberay/ray-cluster.complete.yaml
@@ -18,7 +18,7 @@ spec:
     serviceType: ClusterIP
     # the pod replicas in this group typed head (assuming there could be more than 1 in the future)
     replicas: 1
-    # logical group name, for this called head-group, also can be functional
+    # logical group name, for this called headgroup, also can be functional
     # pod type head or worker
     # rayNodeType: head # Not needed since it is under the headgroup
     # the following params are used to complete the ray start: ray start --head --block --port=6379 ...

--- a/python/ray/autoscaler/v2/tests/test_node_provider.py
+++ b/python/ray/autoscaler/v2/tests/test_node_provider.py
@@ -19,10 +19,7 @@ from ray.autoscaler._private.constants import (
     AUTOSCALER_MAX_LAUNCH_BATCH,
 )
 from ray.autoscaler._private.fake_multi_node.node_provider import FakeMultiNodeProvider
-from ray.autoscaler._private.kuberay.node_provider import (
-    KUBERAY_TYPE_HEAD,
-    IKubernetesHttpApiClient,
-)
+from ray.autoscaler._private.kuberay.node_provider import IKubernetesHttpApiClient
 from ray.autoscaler.v2.instance_manager.cloud_providers.kuberay.cloud_provider import (
     KubeRayProvider,
 )
@@ -372,7 +369,7 @@ class KubeRayProviderIntegrationTest(unittest.TestCase):
             cluster_name="test",
             provider_config={
                 "namespace": "default",
-                "head_node_type": KUBERAY_TYPE_HEAD,
+                "head_node_type": "headgroup",
             },
             k8s_api_client=self.mock_client,
         )
@@ -389,7 +386,7 @@ class KubeRayProviderIntegrationTest(unittest.TestCase):
                 "raycluster-autoscaler-head-8zsc8": CloudInstance(
                     cloud_instance_id="raycluster-autoscaler-head-8zsc8",
                     node_kind=NodeKind.HEAD,
-                    node_type="head-group",
+                    node_type="headgroup",
                     is_running=True,
                 ),  # up-to-date status because the Ray container is in running status
                 "raycluster-autoscaler-worker-small-group-dkz2r": CloudInstance(

--- a/python/ray/tests/kuberay/test_autoscaling_config.py
+++ b/python/ray/tests/kuberay/test_autoscaling_config.py
@@ -69,7 +69,7 @@ def _get_basic_autoscaling_config() -> dict:
             "type": "kuberay",
         },
         "available_node_types": {
-            "head-group": {
+            "headgroup": {
                 "max_workers": 0,
                 "min_workers": 0,
                 "node_config": {},
@@ -125,7 +125,7 @@ def _get_basic_autoscaling_config() -> dict:
         "cluster_synced_files": [],
         "file_mounts": {},
         "file_mounts_sync_continuously": False,
-        "head_node_type": "head-group",
+        "head_node_type": "headgroup",
         "head_setup_commands": [],
         "head_start_ray_commands": [],
         "idle_timeout_minutes": 1.0,

--- a/python/ray/tests/kuberay/test_kuberay_node_provider.py
+++ b/python/ray/tests/kuberay/test_kuberay_node_provider.py
@@ -126,7 +126,7 @@ def test_create_node_cap_at_max(
             {
                 "raycluster-autoscaler-head-8zsc8": NodeData(
                     kind="head",
-                    type="head-group",
+                    type="headgroup",
                     replica_index=None,
                     ip="10.4.2.6",
                     status="up-to-date",
@@ -149,7 +149,7 @@ def test_create_node_cap_at_max(
             {
                 "raycluster-autoscaler-head-8zsc8": NodeData(
                     kind="head",
-                    type="head-group",
+                    type="headgroup",
                     replica_index=None,
                     ip="10.4.2.6",
                     status="up-to-date",
@@ -217,7 +217,7 @@ def test_get_node_data(podlist_file: str, expected_node_data):
             {
                 "raycluster-autoscaler-head-8zsc8": NodeData(
                     kind="head",
-                    type="head-group",
+                    type="headgroup",
                     replica_index=None,
                     ip="10.4.2.6",
                     status="up-to-date",

--- a/release/k8s_tests/ray_v1alpha1_rayservice_template.yaml
+++ b/release/k8s_tests/ray_v1alpha1_rayservice_template.yaml
@@ -126,7 +126,7 @@ spec:
       serviceType: ClusterIP
       # the pod replicas in this group typed head (assuming there could be more than 1 in the future)
       replicas: 1
-      # logical group name, for this called head-group, also can be functional
+      # logical group name, for this called headgroup, also can be functional
       # pod type head or worker
       # rayNodeType: head # Not needed since it is under the headgroup
       # the following params are used to complete the ray start: ray start --head --block --redis-port=6379 ...


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The value of the `ray.io/group` label in the head Pod is `headgroup`, whereas `KUBERAY_TYPE_HEAD` is `head-group`.

<img width="502" alt="image" src="https://github.com/user-attachments/assets/9a06e643-d235-4237-a16a-ce131f3d9666">


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
