### PR TITLE
[CI] Replace `flake8`, `isort`, `black` with `ruff`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,33 +29,13 @@ repos:
           )
       - id: check-toml
 
-  - repo: https://github.com/psf/black
-    rev: 22.10.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.7.4
     hooks:
-      - id: black
-        exclude: |
-          (?x)^(
-            python/ray/cloudpickle/|
-            python/build/|
-            python/ray/core/src/ray/gcs/|
-            python/ray/thirdparty_files/|
-            python/ray/_private/thirdparty/|
-            python/ray/serve/tests/test_config_files/syntax_error\.py|
-            python/ray/serve/_private/benchmarks/streaming/_grpc/test_server_pb2_grpc\.py|
-            doc/external/
-          )
+      - id: ruff
         types_or: [python]
-
-  - repo: https://github.com/pycqa/flake8
-    rev: 3.9.1
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          [
-            flake8-comprehensions==3.10.1,
-            flake8-quotes==2.0.0,
-            flake8-bugbear==21.9.2,
-          ]
+      - id: ruff-format
+        types_or: [python]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.3
@@ -82,13 +62,6 @@ repos:
           [
             types-PyYAML==6.0.12.2,
           ]
-
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        name: isort (python)
-        types_or: [python]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0

--- a/python/requirements/lint-requirements.txt
+++ b/python/requirements/lint-requirements.txt
@@ -14,3 +14,4 @@ shellcheck-py==0.7.1.1
 yq
 types-pycurl==7.45.3.20240421
 types-requests==2.31.0.6
+ruff==0.8.0

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,66 @@
+exclude = [
+    "python/ray/core/generated/",
+    "doc/source/conf.py",
+    "python/.eggs/",
+    "python/ray/core/src/ray/gcs/*",
+    "python/ray/workflow/tests/mock_server.py",
+    "python/ray/serve/tests/test_config_files/syntax_error.py",
+    "python/ray/serve/_private/benchmarks/streaming/_grpc/test_server_pb2_grpc.py",
+    "doc/*",
+    "python/ray/__init__.py",
+    "python/ray/setup-dev.py",
+    "python/build/*",
+    "python/ray/cloudpickle/*",
+    "python/ray/thirdparty_files/*",
+    "python/ray/_private/thirdparty/*",
+    "python/ray/_private/runtime_env/agent/thirdparty_files/*",
+    "python/ray/dag/*.py",
+    "ci/*",
+    "python/ray/_private/*",
+    "python/ray/includes/*",
+    "python/ray/internal/*",
+    "python/ray/ray_operator/*",
+    "python/ray/scripts/*",
+    "python/ray/serve/generated/serve_pb2.py",
+    "python/ray/streaming/*",
+    "python/ray/tests/*",
+    "python/ray/util/*",
+    "python/ray/workers/*",
+    "python/ray/workflow/*",
+    "rllib/*",
+    "release/*",
+    "doc/external/*",
+]
+
+[lint.pycodestyle]
+max-line-length = 88
+
+[lint.flake8-quotes]
+inline-quotes = "double"
+avoid-escape = false
+
+[lint]
+ignore = [
+    "B028",
+    "C408", "C417",
+    "E203",
+    "E226", "E24",
+    "W605",
+    "I", "N",
+    "B002", "B003", "B004", "B005",
+    "B007", "B008", "B009", "B010", "B011",
+    "B012", "B013", "B014", "B015", "B016",
+    "B017",
+]
+
+[lint.extend-per-file-ignores]
+"rllib/evaluation/worker_set.py" = ["E731"]
+"rllib/evaluation/sampler.py" = ["E731"]
+
+[lint.isort.sections]
+"afterray" = ["psutil", "setproctitle"]
+
+[lint.isort]
+known-local-folder = ["ray"]
+known-third-party = ["grpc"]
+section-order = ["future", "standard-library", "third-party", "first-party", "local-folder", "afterray"]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- Remove `E123`, `E126`, `E704`, `W503`, `W504`, and `B001`, as these rules are not included in Ruff.
- The remaining configurations follow the [.flake8](https://github.com/ray-project/ray/blob/master/.flake8) and [.isort.cfg](https://github.com/ray-project/ray/blob/master/.isort.cfg) files.

Ref: https://github.com/ray-project/ray/issues/48508

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
