### PR TITLE
[core] Use m6i.large for distributed/many_nodes_tests/compute_config.…

### DIFF
--- a/release/benchmarks/distributed/many_nodes_tests/compute_config.yaml
+++ b/release/benchmarks/distributed/many_nodes_tests/compute_config.yaml
@@ -23,7 +23,7 @@ head_node_type:
 
 worker_node_types:
   - name: worker_node
-    instance_type: m5.large
+    instance_type: m6i.large
     min_workers: 500
     max_workers: 2000
     use_spot: false


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Test failed due to insufficient instances. Using m6i.large instead of m5.large, which is newer and should be more available.

The pricing seems to be the same.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #48845

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
