### PR TITLE
[core] [1/N] Pass last update timestamp functor

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -308,7 +308,10 @@ void GcsServer::InitGcsHealthCheckManager(const GcsInitData &gcs_init_data) {
   };
 
   gcs_healthcheck_manager_ = std::make_unique<GcsHealthCheckManager>(
-      io_context_provider_.GetDefaultIOContext(), node_death_callback);
+      io_context_provider_.GetDefaultIOContext(),
+      // TODO(hjiang): Fill in node update state timestamp from [gcs_resource_manager_].
+      [](const NodeID &) { return absl::InfinitePast(); },
+      node_death_callback);
   for (const auto &item : gcs_init_data.Nodes()) {
     if (item.second.state() == rpc::GcsNodeInfo::ALIVE) {
       rpc::Address remote_address;


### PR DESCRIPTION
Resolves issue: https://github.com/ray-project/ray/issues/48837

The purpose for the change, is to reduce heartbeat health check between GCS and raylet if possible.
The intuition is: resource manager also interact between GCS and raylet, the successful communication of which already indicates nodes' liveness, no need to send repeated rpc.

The solution proposed here is to pass a functor, which returns last update timestamp, so health check manager could decide themselves whether it's necessary to have another request.

The followup PR would be, GCS server pass down the functor to health check manager.