### PR TITLE
[vm launcher] pin gcp image to a working version in release tests

### DIFF
--- a/python/ray/autoscaler/gcp/example-full.yaml
+++ b/python/ray/autoscaler/gcp/example-full.yaml
@@ -70,7 +70,7 @@ available_node_types:
                 initializeParams:
                   diskSizeGb: 50
                   # See https://cloud.google.com/compute/docs/images for more images
-                  sourceImage: projects/deeplearning-platform-release/global/images/family/common-cpu
+                  sourceImage: projects/deeplearning-platform-release/global/images/common-cpu-v20240922
 
             # Additional options can be found in in the compute docs at
             # https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert
@@ -105,7 +105,7 @@ available_node_types:
                 initializeParams:
                   diskSizeGb: 50
                   # See https://cloud.google.com/compute/docs/images for more images
-                  sourceImage: projects/deeplearning-platform-release/global/images/family/common-cpu
+                  sourceImage: projects/deeplearning-platform-release/global/images/common-cpu-v20240922
             # Run workers on preemtible instance by default.
             # Comment this out to use on-demand.
             scheduling:

--- a/python/ray/autoscaler/gcp/example-minimal-pinned.yaml
+++ b/python/ray/autoscaler/gcp/example-minimal-pinned.yaml
@@ -1,0 +1,36 @@
+auth:
+  ssh_user: ubuntu
+cluster_name: minimal
+provider:
+  availability_zone: us-west1-a
+  project_id: null # TODO: set your GCP project ID here
+  region: us-west1
+  type: gcp
+
+# Needs to pin the VM images for stability..
+available_node_types:
+    ray_head_default:
+        resources: {"CPU": 2}
+        node_config:
+            machineType: n1-standard-2
+            disks:
+              - boot: true
+                autoDelete: true
+                type: PERSISTENT
+                initializeParams:
+                  diskSizeGb: 50
+                  sourceImage: projects/deeplearning-platform-release/global/images/common-cpu-v20240922
+    ray_worker_small:
+        min_workers: 0
+        resources: {"CPU": 2}
+        node_config:
+            machineType: n1-standard-2
+            disks:
+              - boot: true
+                autoDelete: true
+                type: PERSISTENT
+                initializeParams:
+                  diskSizeGb: 50
+                  sourceImage: projects/deeplearning-platform-release/global/images/common-cpu-v20240922
+            scheduling:
+              - preemptible: true

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4131,7 +4131,7 @@
 
   run:
     timeout: 1200
-    script: python launch_and_verify_cluster.py gcp/example-minimal.yaml
+    script: python launch_and_verify_cluster.py gcp/example-minimal-pinned.yaml
 
 - name: gcp_cluster_launcher_full
   group: cluster-launcher-test


### PR DESCRIPTION
the latest version of the image changes the default user from ubuntu to jupyter.
