### PR TITLE
[core] Make `include_log_monitor` configurable in the `ray start` command

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -626,8 +626,10 @@ Windows powershell users need additional escaping:
     "--include-log-monitor",
     default=None,
     type=bool,
-    help="If set to True or left unset, a log monitor will start to monitor "
-    "the log files of all processes on this node and push their contents to GCS.",
+    help="If set to True or left unset, a log monitor will start monitoring "
+    "the log files of all processes on this node and push their contents to GCS. "
+    "Only one log monitor should be started per physical host to avoid log "
+    "duplication on the driver process.",
 )
 @add_click_logging_options
 @PublicAPI

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -622,6 +622,13 @@ Windows powershell users need additional escaping:
     type=str,
     help="a JSON serialized dictionary mapping label name to label value.",
 )
+@click.option(
+    "--include-log-monitor",
+    default=None,
+    type=bool,
+    help="If set to True or left unset, a log monitor will start to monitor "
+    "the log files of all processes on this node and push their contents to GCS.",
+)
 @add_click_logging_options
 @PublicAPI
 def start(
@@ -668,6 +675,7 @@ def start(
     ray_debugger_external,
     disable_usage_stats,
     labels,
+    include_log_monitor,
 ):
     """Start Ray processes manually on the local machine."""
 
@@ -757,6 +765,7 @@ def start(
         no_monitor=no_monitor,
         tracing_startup_hook=tracing_startup_hook,
         ray_debugger_external=ray_debugger_external,
+        include_log_monitor=include_log_monitor,
     )
 
     if ray_constants.RAY_START_HOOK in os.environ:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In #48642, the user creates two Ray nodes in the local environment, causing both the head and worker nodes to launch a log monitor process. As a result, the logs are printed in the driver process twice.

This PR makes `--include-log-monitor` configurable, allowing users to launch a log monitor process only when starting the head node, preventing duplicate logs.


```python
# test.py
import ray

@ray.remote
def foo():
    print('hello')


if __name__ == '__main__':
    ray.init()
    handle = foo.remote()
    ray.get(handle)
```


<img width="1440" alt="image" src="https://github.com/user-attachments/assets/8d14ce63-bca6-48a0-b957-21965fbcfe2a">


## Related issue number

Closes #48642

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
