### PR TITLE
[serve] Add FF to run sync methods in a threadpool

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -357,7 +357,6 @@ RAY_SERVE_FORCE_LOCAL_TESTING_MODE = (
 )
 
 # Run sync methods defined in the replica in a thread pool by default.
-# XXX: off by default.
 RAY_SERVE_RUN_SYNC_IN_THREADPOOL = (
-    os.environ.get("RAY_SERVE_RUN_SYNC_IN_THREADPOOL", "1") == "1"
+    os.environ.get("RAY_SERVE_RUN_SYNC_IN_THREADPOOL", "0") == "1"
 )

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -355,3 +355,9 @@ RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY = (
 RAY_SERVE_FORCE_LOCAL_TESTING_MODE = (
     os.environ.get("RAY_SERVE_FORCE_LOCAL_TESTING_MODE", "0") == "1"
 )
+
+# Run sync methods defined in the replica in a thread pool by default.
+# XXX: off by default.
+RAY_SERVE_RUN_SYNC_IN_THREADPOOL = (
+        os.environ.get("RAY_SERVE_RUN_SYNC_IN_THREADPOOL", "1") == "1"
+)

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -360,3 +360,12 @@ RAY_SERVE_FORCE_LOCAL_TESTING_MODE = (
 RAY_SERVE_RUN_SYNC_IN_THREADPOOL = (
     os.environ.get("RAY_SERVE_RUN_SYNC_IN_THREADPOOL", "0") == "1"
 )
+
+RAY_SERVE_RUN_SYNC_IN_THREADPOOL_WARNING = (
+    "Calling sync method '{method_name}' directly on the "
+    "asyncio loop. In a future version, sync methods will be run in a "
+    "threadpool by default. Ensure your sync methods are thread safe "
+    "or keep the existing behavior by making them `async def`. Opt "
+    "into the new behavior by setting "
+    "RAY_SERVE_RUN_SYNC_IN_THREADPOOL=1."
+)

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -359,5 +359,5 @@ RAY_SERVE_FORCE_LOCAL_TESTING_MODE = (
 # Run sync methods defined in the replica in a thread pool by default.
 # XXX: off by default.
 RAY_SERVE_RUN_SYNC_IN_THREADPOOL = (
-        os.environ.get("RAY_SERVE_RUN_SYNC_IN_THREADPOOL", "1") == "1"
+    os.environ.get("RAY_SERVE_RUN_SYNC_IN_THREADPOOL", "1") == "1"
 )

--- a/python/ray/serve/_private/local_testing_mode.py
+++ b/python/ray/serve/_private/local_testing_mode.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Coroutine, Dict, Optional, Tuple, Union
 import ray
 from ray import cloudpickle
 from ray.serve._private.common import DeploymentID, RequestMetadata
-from ray.serve._private.constants import SERVE_LOGGER_NAME
+from ray.serve._private.constants import SERVE_LOGGER_NAME, RAY_SERVE_RUN_SYNC_IN_THREADPOOL
 from ray.serve._private.replica import UserCallableWrapper
 from ray.serve._private.replica_result import ReplicaResult
 from ray.serve._private.router import Router
@@ -66,6 +66,7 @@ def make_local_deployment_handle(
         deployment.init_args,
         deployment.init_kwargs,
         deployment_id=deployment_id,
+        run_sync_methods_in_threadpool=RAY_SERVE_RUN_SYNC_IN_THREADPOOL,
     )
     try:
         logger.info(f"Initializing local replica class for {deployment_id}.")

--- a/python/ray/serve/_private/local_testing_mode.py
+++ b/python/ray/serve/_private/local_testing_mode.py
@@ -10,7 +10,10 @@ from typing import Any, Callable, Coroutine, Dict, Optional, Tuple, Union
 import ray
 from ray import cloudpickle
 from ray.serve._private.common import DeploymentID, RequestMetadata
-from ray.serve._private.constants import SERVE_LOGGER_NAME, RAY_SERVE_RUN_SYNC_IN_THREADPOOL
+from ray.serve._private.constants import (
+    RAY_SERVE_RUN_SYNC_IN_THREADPOOL,
+    SERVE_LOGGER_NAME,
+)
 from ray.serve._private.replica import UserCallableWrapper
 from ray.serve._private.replica_result import ReplicaResult
 from ray.serve._private.router import Router

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1158,7 +1158,8 @@ class UserCallableWrapper:
             result = await to_thread.run_sync(set_serve_context_and_run)
         else:
             if (
-                is_sync_method and not self._warned_about_sync_method_change
+                is_sync_method
+                and not self._warned_about_sync_method_change
                 and run_sync_methods_in_threadpool_override is None
             ):
                 self._warned_about_sync_method_change = True

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -22,8 +22,8 @@ from typing import (
     Union,
 )
 
-from anyio import to_thread
 import starlette.responses
+from anyio import to_thread
 from starlette.types import ASGIApp, Message
 
 import ray

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1144,10 +1144,14 @@ class UserCallableWrapper:
             is_generator = inspect.isgeneratorfunction(callable)
             if is_generator:
                 sync_gen_consumed = True
-                assert generator_result_callback is not None, (
-                    f"Tried to call generator user method '{callable.__name__}' "
-                    "but no generator result callback was provided."
-                )
+                if generator_result_callback is None:
+                    # TODO(edoakes): make this check less redundant with the one in
+                    # _handle_user_method_result.
+                    raise TypeError(
+                        f"Method '{callable.__name__}' returned a generator. "
+                        "You must use `handle.options(stream=True)` to call "
+                        "generators on a deployment."
+                    )
 
             def run_callable():
                 result = callable(*args, **kwargs)

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1088,7 +1088,9 @@ class UserCallableWrapper:
             await Response(result).send(scope, receive, send)
 
     async def _call_func_or_gen(
-        self, callable: Callable, *,
+        self,
+        callable: Callable,
+        *,
         args: Optional[Tuple[Any]] = None,
         kwargs: Optional[Dict[str, Any]] = None,
         generator_result_callback: Optional[Callable] = None,
@@ -1110,7 +1112,10 @@ class UserCallableWrapper:
         if (
             run_sync_in_threadpool
             and (inspect.isfunction(callable) or inspect.ismethod(callable))
-            and not (inspect.iscoroutinefunction(callable) or inspect.isasyncgenfunction(callable))
+            and not (
+                inspect.iscoroutinefunction(callable)
+                or inspect.isasyncgenfunction(callable)
+            )
         ):
             is_generator = inspect.isgeneratorfunction(callable)
             if is_generator:
@@ -1120,6 +1125,7 @@ class UserCallableWrapper:
                 )
 
             curr_context = ray.serve.context._serve_request_context.get()
+
             def set_serve_context_and_run():
                 ray.serve.context._serve_request_context.set(curr_context)
                 result = callable(*args, **kwargs)

--- a/python/ray/serve/tests/BUILD
+++ b/python/ray/serve/tests/BUILD
@@ -467,3 +467,25 @@ py_test_module_list(
         "//python/ray/serve:serve_lib",
     ],
 )
+
+
+# Test currently off-by-default behavior to run replica sync methods in a threadpool.
+# TODO(edoakes): remove this once the FF is flipped on by default.
+py_test_module_list(
+    size = "small",
+    env = {"RAY_SERVE_RUN_SYNC_IN_THREADPOOL": "1"},
+    files = [
+        "test_replica_sync_methods.py",
+    ],
+    name_suffix = "_with_run_sync_in_threadpool",
+    tags = [
+        "exclusive",
+        "no_windows",
+        "team:serve",
+    ],
+    deps = [
+        ":common",
+        ":conftest",
+        "//python/ray/serve:serve_lib",
+    ],
+)

--- a/python/ray/serve/tests/test_replica_sync_methods.py
+++ b/python/ray/serve/tests/test_replica_sync_methods.py
@@ -1,0 +1,127 @@
+import asyncio
+import sys
+
+import pytest
+import requests
+from anyio import to_thread
+from fastapi import FastAPI
+from starlette.responses import PlainTextResponse
+
+import ray
+from ray import serve
+from ray._private.test_utils import SignalActor, wait_for_condition
+from ray.serve._private.constants import RAY_SERVE_RUN_SYNC_IN_THREADPOOL
+
+
+@pytest.mark.skipif(
+    not RAY_SERVE_RUN_SYNC_IN_THREADPOOL,
+    reason="Run sync method in threadpool FF disabled.",
+)
+@pytest.mark.parametrize("use_fastapi", [False, True])
+def test_not_running_in_asyncio_loop(serve_instance, use_fastapi: bool):
+    if use_fastapi:
+        fastapi_app = FastAPI()
+
+        @serve.deployment
+        @serve.ingress(fastapi_app)
+        class D:
+            @fastapi_app.get("/")
+            def root(self):
+                with pytest.raises(RuntimeError, match="no running event loop"):
+                    asyncio.get_running_loop()
+
+    else:
+
+        @serve.deployment
+        class D:
+            def __call__(self) -> str:
+                with pytest.raises(RuntimeError, match="no running event loop"):
+                    asyncio.get_running_loop()
+
+    serve.run(D.bind())
+    # Would error if the check fails.
+    requests.get("http://localhost:8000/").raise_for_status()
+
+
+@pytest.mark.skipif(
+    not RAY_SERVE_RUN_SYNC_IN_THREADPOOL,
+    reason="Run sync method in threadpool FF disabled.",
+)
+def test_concurrent_execution(serve_instance):
+    signal_actor = SignalActor.remote()
+
+    @serve.deployment
+    class D:
+        def do_sync(self):
+            ray.get(signal_actor.wait.remote())
+
+        async def do_async(self):
+            await signal_actor.wait.remote()
+
+    h = serve.run(D.bind())
+
+    sync_results = [h.do_sync.remote(), h.do_sync.remote()]
+    async_results = [h.do_async.remote(), h.do_async.remote()]
+
+    wait_for_condition(lambda: ray.get(signal_actor.cur_num_waiters.remote()) == 4)
+    ray.get(signal_actor.send.remote())
+    [r.result() for r in sync_results + async_results]
+
+
+@pytest.mark.skipif(
+    not RAY_SERVE_RUN_SYNC_IN_THREADPOOL,
+    reason="Run sync method in threadpool FF disabled.",
+)
+@pytest.mark.parametrize("use_fastapi", [False, True])
+def test_context_vars_propagated(serve_instance, use_fastapi: bool):
+    if use_fastapi:
+        fastapi_app = FastAPI()
+
+        @serve.deployment
+        @serve.ingress(fastapi_app)
+        class D:
+            @fastapi_app.get("/")
+            def root(self):
+                return PlainTextResponse(
+                    serve.context._serve_request_context.get().request_id
+                )
+
+    else:
+
+        @serve.deployment
+        class D:
+            def __call__(self) -> str:
+                return PlainTextResponse(
+                    serve.context._serve_request_context.get().request_id
+                )
+
+    serve.run(D.bind())
+
+    r = requests.get("http://localhost:8000/", headers={"X-Request-Id": "TEST-ID"})
+    r.raise_for_status()
+    # If context vars weren't propagated, the request ID would be empty.
+    assert r.text == "TEST-ID"
+
+
+@pytest.mark.skipif(
+    not RAY_SERVE_RUN_SYNC_IN_THREADPOOL,
+    reason="Run sync method in threadpool FF disabled.",
+)
+def test_thread_limit_set_to_max_ongoing_requests(serve_instance):
+    @serve.deployment
+    class D:
+        async def __call__(self):
+            return to_thread.current_default_thread_limiter().total_tokens
+
+    h = serve.run(D.bind())
+
+    # Check that it's set if max_ongoing_requests is defaulted.
+    assert h.remote().result() == 5
+
+    # Update to a custom value, check again.
+    h = serve.run(D.options(max_ongoing_requests=10).bind())
+    assert h.remote().result() == 10
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/unit/test_user_callable_wrapper.py
+++ b/python/ray/serve/tests/unit/test_user_callable_wrapper.py
@@ -4,7 +4,7 @@ import pickle
 import sys
 import threading
 from dataclasses import dataclass
-from typing import AsyncGenerator, Callable, Generator, Optional, Tuple, Dict, Any
+from typing import Any, AsyncGenerator, Callable, Dict, Generator, Optional, Tuple
 
 import pytest
 from fastapi import FastAPI
@@ -90,7 +90,11 @@ async def basic_async_generator(n: int, raise_exception: bool = False):
 
 
 def _make_user_callable_wrapper(
-    callable: Optional[Callable] = None, *, init_args: Optional[Tuple[Any]] = None, init_kwargs: Optional[Dict[str, Any]] = None, run_sync_methods_in_threadpool: bool = False
+    callable: Optional[Callable] = None,
+    *,
+    init_args: Optional[Tuple[Any]] = None,
+    init_kwargs: Optional[Dict[str, Any]] = None,
+    run_sync_methods_in_threadpool: bool = False,
 ) -> UserCallableWrapper:
     return UserCallableWrapper(
         callable if callable is not None else BasicClass,
@@ -147,7 +151,9 @@ def test_calling_methods_before_initialize():
 
 @pytest.mark.parametrize("run_sync_methods_in_threadpool", [False, True])
 def test_basic_class_callable(run_sync_methods_in_threadpool: bool):
-    user_callable_wrapper = _make_user_callable_wrapper(run_sync_methods_in_threadpool=run_sync_methods_in_threadpool)
+    user_callable_wrapper = _make_user_callable_wrapper(
+        run_sync_methods_in_threadpool=run_sync_methods_in_threadpool
+    )
 
     user_callable_wrapper.initialize_callable().result()
 
@@ -219,7 +225,9 @@ def test_basic_class_callable(run_sync_methods_in_threadpool: bool):
 
 @pytest.mark.parametrize("run_sync_methods_in_threadpool", [False, True])
 def test_basic_class_callable_generators(run_sync_methods_in_threadpool: bool):
-    user_callable_wrapper = _make_user_callable_wrapper(run_sync_methods_in_threadpool=run_sync_methods_in_threadpool)
+    user_callable_wrapper = _make_user_callable_wrapper(
+        run_sync_methods_in_threadpool=run_sync_methods_in_threadpool
+    )
     user_callable_wrapper.initialize_callable().result()
 
     result_list = []
@@ -235,6 +243,7 @@ def test_basic_class_callable_generators(run_sync_methods_in_threadpool: bool):
             request_metadata,
             (10,),
             dict(),
+            generator_result_callback=result_list.append,
         ).result()
 
     # Call sync generator.
@@ -293,9 +302,12 @@ def test_basic_class_callable_generators(run_sync_methods_in_threadpool: bool):
     assert result_list == [0]
 
 
+@pytest.mark.parametrize("run_sync_methods_in_threadpool", [False, True])
 @pytest.mark.parametrize("fn", [basic_sync_function, basic_async_function])
-def test_basic_function_callable(fn: Callable):
-    user_callable_wrapper = _make_user_callable_wrapper(fn)
+def test_basic_function_callable(fn: Callable, run_sync_methods_in_threadpool: bool):
+    user_callable_wrapper = _make_user_callable_wrapper(
+        fn, run_sync_methods_in_threadpool=run_sync_methods_in_threadpool
+    )
     user_callable_wrapper.initialize_callable().result()
 
     # Call non-generator function with is_streaming.
@@ -327,9 +339,14 @@ def test_basic_function_callable(fn: Callable):
         ).result()
 
 
+@pytest.mark.parametrize("run_sync_methods_in_threadpool", [False, True])
 @pytest.mark.parametrize("fn", [basic_sync_generator, basic_async_generator])
-def test_basic_function_callable_generators(fn: Callable):
-    user_callable_wrapper = _make_user_callable_wrapper(fn)
+def test_basic_function_callable_generators(
+    fn: Callable, run_sync_methods_in_threadpool: bool
+):
+    user_callable_wrapper = _make_user_callable_wrapper(
+        fn, run_sync_methods_in_threadpool=run_sync_methods_in_threadpool
+    )
     user_callable_wrapper.initialize_callable().result()
 
     result_list = []
@@ -368,35 +385,67 @@ def test_basic_function_callable_generators(fn: Callable):
 
 
 @pytest.mark.asyncio
-async def test_user_code_runs_on_separate_loop():
+@pytest.mark.parametrize("run_sync_methods_in_threadpool", [False, True])
+async def test_user_code_runs_on_separate_loop(run_sync_methods_in_threadpool: bool):
     main_loop = asyncio.get_running_loop()
 
     class GetLoop:
         def __init__(self):
             self._constructor_loop = asyncio.get_running_loop()
 
-        def check_health(self):
+        async def check_health(self):
             check_health_loop = asyncio.get_running_loop()
             assert (
                 check_health_loop == self._constructor_loop
             ), "User constructor and health check should run on the same loop."
             return check_health_loop
 
-        def __call__(self) -> asyncio.AbstractEventLoop:
+        async def call_async(self) -> Optional[asyncio.AbstractEventLoop]:
             user_method_loop = asyncio.get_running_loop()
             assert (
                 user_method_loop == self._constructor_loop
             ), "User constructor and other methods should run on the same loop."
+
             return user_method_loop
 
-    user_callable_wrapper = _make_user_callable_wrapper(GetLoop)
+        def call_sync(self):
+            if run_sync_methods_in_threadpool:
+                with pytest.raises(RuntimeError, match="no running event loop"):
+                    asyncio.get_running_loop()
+
+                user_method_loop = None
+            else:
+                user_method_loop = asyncio.get_running_loop()
+                assert (
+                    user_method_loop == self._constructor_loop
+                ), "User constructor and other methods should run on the same loop."
+
+            return user_method_loop
+
+    user_callable_wrapper = _make_user_callable_wrapper(
+        GetLoop, run_sync_methods_in_threadpool=run_sync_methods_in_threadpool
+    )
     user_callable_wrapper.initialize_callable().result()
-    request_metadata = _make_request_metadata()
+
+    # Async methods should all run on the same loop.
+    request_metadata = _make_request_metadata(call_method="call_async")
     user_code_loop = user_callable_wrapper.call_user_method(
         request_metadata, tuple(), dict()
     ).result()
     assert isinstance(user_code_loop, asyncio.AbstractEventLoop)
     assert user_code_loop != main_loop
+
+    # Sync methods should run on the same loop if run_sync_methods_in_threadpool is off,
+    # else run in no asyncio loop.
+    request_metadata = _make_request_metadata(call_method="call_sync")
+    user_code_loop = user_callable_wrapper.call_user_method(
+        request_metadata, tuple(), dict()
+    ).result()
+    if run_sync_methods_in_threadpool:
+        assert user_code_loop is None
+    else:
+        assert isinstance(user_code_loop, asyncio.AbstractEventLoop)
+        assert user_code_loop != main_loop
 
     # `check_health` method asserts that it runs on the correct loop.
     user_callable_wrapper.call_user_health_check().result()
@@ -500,8 +549,11 @@ class gRPCClass:
             yield serve_pb2.UserDefinedResponse(greeting=f"Hello {msg.greeting} {i}!")
 
 
-def test_grpc_unary_request():
-    user_callable_wrapper = _make_user_callable_wrapper(gRPCClass)
+@pytest.mark.parametrize("run_sync_methods_in_threadpool", [False, True])
+def test_grpc_unary_request(run_sync_methods_in_threadpool: bool):
+    user_callable_wrapper = _make_user_callable_wrapper(
+        gRPCClass, run_sync_methods_in_threadpool=run_sync_methods_in_threadpool
+    )
     user_callable_wrapper.initialize_callable().result()
 
     grpc_request = gRPCRequest(
@@ -520,8 +572,11 @@ def test_grpc_unary_request():
 
 
 @pytest.mark.asyncio
-def test_grpc_streaming_request():
-    user_callable_wrapper = _make_user_callable_wrapper(gRPCClass)
+@pytest.mark.parametrize("run_sync_methods_in_threadpool", [False, True])
+def test_grpc_streaming_request(run_sync_methods_in_threadpool: bool):
+    user_callable_wrapper = _make_user_callable_wrapper(
+        gRPCClass, run_sync_methods_in_threadpool=run_sync_methods_in_threadpool
+    )
     user_callable_wrapper.initialize_callable()
 
     grpc_request = gRPCRequest(

--- a/python/ray/serve/tests/unit/test_user_callable_wrapper.py
+++ b/python/ray/serve/tests/unit/test_user_callable_wrapper.py
@@ -97,6 +97,7 @@ def _make_user_callable_wrapper(
         init_args,
         init_kwargs,
         deployment_id=DeploymentID(name="test_name"),
+        run_sync_methods_in_threadpool=False,
     )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds a feature flag to run sync user-defined methods in a threadpool by default. This matches the existing behavior when using a FastAPI ingress.

This should address a lot of user confusion and make it easier to write performant code by default. For example, just sticking a torch model call in a sync method will now provide reasonable performance out of the box.

However, there may be some existing user code that is not thread safe, so we need to do a gentle migration. This PR introduces the behavior behind a feature flag and warns users about the upcoming change and how to opt into the new behavior or maintain existing behavior once it does (just adding `async def` will do it).

I've opted to set the max thread pool size to `max_ongoing_requests`, which seems like a reasonable policy. If needed we can add a user-facing API for this in the future.

TODO before merging:

- [x] Get it working for sync generators.
- [x] Add warning for default change (people can keep behavior by changing to async def).
- [x] Add/update UserCallableWrapper tests.
- [x] Add/update some integration tests (verify that request context is set correctly!).
- [x] Set maximum thread pool size.

## Related issue number

Closes https://github.com/ray-project/ray/issues/44354
Closes https://github.com/ray-project/ray/issues/44403
Closes https://github.com/ray-project/ray/issues/48903

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
