### PR TITLE
[doc] document the right dask version

### DIFF
--- a/doc/source/ray-more-libs/dask-on-ray.rst
+++ b/doc/source/ray-more-libs/dask-on-ray.rst
@@ -31,7 +31,10 @@ workload. Using the Dask-on-Ray scheduler, the entire Dask ecosystem can be exec
 
      * - Ray Version
        - Dask Version
-     * - ``2.8.0`` or above
+     * - ``2.34.0`` or above
+       - | ``2022.10.1 (Python version < 3.12)``
+         | ``2024.6.0 (Python version >= 3.12)``
+     * - ``2.8.0`` to ``2.33.x``
        - ``2022.10.1``
      * - ``2.5.0`` to ``2.7.x``
        - | ``2022.2.0 (Python version < 3.8)``


### PR DESCRIPTION
2024.6.0 is used since ray 2.34