### PR TITLE
[core][autoscaler] Health check logs are not visible in the autoscaler container's stdout

### DIFF
--- a/python/ray/autoscaler/_private/kuberay/run_autoscaler.py
+++ b/python/ray/autoscaler/_private/kuberay/run_autoscaler.py
@@ -44,12 +44,12 @@ def run_kuberay_autoscaler(cluster_name: str, cluster_namespace: str):
                     "--skip-version-check",
                 ]
             )
-            # Logging is not ready yet. Print to stdout for now.
-            print("The Ray head is ready. Starting the autoscaler.")
+            logger.info("The Ray head is ready. Starting the autoscaler.")
             break
         except subprocess.CalledProcessError:
-            print("The Ray head is not yet ready.")
-            print(f"Will check again in {BACKOFF_S} seconds.")
+            logger.info(
+                f"The Ray head is not ready. Will check again in {BACKOFF_S} seconds."
+            )
             time.sleep(BACKOFF_S)
 
     # The Ray head container sets up the log directory. Thus, we set up logging

--- a/python/ray/autoscaler/_private/kuberay/run_autoscaler.py
+++ b/python/ray/autoscaler/_private/kuberay/run_autoscaler.py
@@ -47,7 +47,7 @@ def run_kuberay_autoscaler(cluster_name: str, cluster_namespace: str):
             logger.info("The Ray head is ready. Starting the autoscaler.")
             break
         except subprocess.CalledProcessError:
-            logger.info(
+            logger.warning(
                 f"The Ray head is not ready. Will check again in {BACKOFF_S} seconds."
             )
             time.sleep(BACKOFF_S)

--- a/python/ray/autoscaler/v2/instance_manager/instance_manager.py
+++ b/python/ray/autoscaler/v2/instance_manager/instance_manager.py
@@ -58,7 +58,7 @@ class InstanceManager:
         """
         Updates the instance manager state.
 
-        If there's a any failure, no updates would be made and the reply
+        If there's any failure, no updates would be made and the reply
         would contain the latest version of the instance manager state,
         and the error info.
 
@@ -80,7 +80,7 @@ class InstanceManager:
                 f"Version mismatch: expected: {request.expected_version}, "
                 f"actual: {version}"
             )
-            logger.warn(err_str)
+            logger.warning(err_str)
             return self._get_update_im_state_reply(
                 StatusCode.VERSION_MISMATCH,
                 version,
@@ -110,7 +110,7 @@ class InstanceManager:
                 err_str = (
                     f"Version mismatch: expected: {version}, actual: {result.version}"
                 )
-                logger.warn(err_str)
+                logger.warning(err_str)
                 return self._get_update_im_state_reply(
                     StatusCode.VERSION_MISMATCH, result.version, err_str
                 )

--- a/python/ray/autoscaler/v2/monitor.py
+++ b/python/ray/autoscaler/v2/monitor.py
@@ -17,6 +17,7 @@ import ray._private.utils
 from ray._private.event.event_logger import get_event_logger
 from ray._private.ray_logging import setup_component_logger
 from ray._private.usage.usage_lib import record_extra_usage_tag
+from ray._private.worker import SCRIPT_MODE
 from ray._raylet import GcsClient
 from ray.autoscaler._private.constants import (
     AUTOSCALER_METRIC_PORT,
@@ -77,7 +78,7 @@ class AutoscalerMonitor:
             )
         self._session_name = self._get_session_name(self.gcs_client)
         logger.info(f"session_name: {self._session_name}")
-        worker.mode = 0
+        worker.set_mode(SCRIPT_MODE)
         head_node_ip = self.gcs_address.split(":")[0]
 
         self.autoscaler = None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* The Autoscaler container doesn't display information like `print("The Ray head is ready. Starting the autoscaler.")` in STDOUT/STDERR for some reason. To display logs to STDOUT/STDERR, we need to explicitly specify `flush` in `print()` or use the logging module. I don't know why the flush isn't triggered. The default end of `print` is `\n`, which should trigger a line-buffered flush.

* Change `logging.warn` to `logging.warning` because `logging.warn` is deprecated. See [this doc](https://docs.python.org/3/library/logging.html#logging.Logger.warning) for more details.

<img width="794" alt="image" src="https://github.com/user-attachments/assets/12796aaa-ae7e-4986-96c8-94a0a42591b6">

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
