### PR TITLE
Add perf metrics for 2.40.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 404.76672,
+    "_dashboard_memory_usage_mb": 328.23296,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.67,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n6527\t1.78GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n8101\t0.93GiB\tpython distributed/test_many_actors.py\n2545\t0.34GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1279\t0.25GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n6643\t0.22GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1026\t0.12GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n2450\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n6810\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n6812\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n6891\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
-    "actors_per_second": 591.3539212974848,
+    "_peak_memory": 3.77,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1267\t7.62GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3420\t1.78GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4416\t0.96GiB\tpython distributed/test_many_actors.py\n2081\t0.32GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3536\t0.29GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1035\t0.15GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n2320\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3703\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n3705\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3730\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
+    "actors_per_second": 610.811601142429,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 591.3539212974848
+            "perf_metric_value": 610.811601142429
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 94.771
+            "perf_metric_value": 35.242
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2548.0
+            "perf_metric_value": 2353.069
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4095.457
+            "perf_metric_value": 3439.22
         }
     ],
     "success": "1",
-    "time": 16.91034698486328
+    "time": 16.371660232543945
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 217.985024,
+    "_dashboard_memory_usage_mb": 211.542016,
     "_dashboard_test_success": true,
-    "_peak_memory": 1.65,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3433\t0.5GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1225\t0.25GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2296\t0.24GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3549\t0.2GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n5772\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3716\t0.1GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n2555\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n5989\t0.08GiB\tray::StateAPIGeneratorActor.start\n3718\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3740\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
+    "_peak_memory": 1.66,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1249\t8.33GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3410\t0.53GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2177\t0.21GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3528\t0.19GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4494\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1035\t0.15GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3695\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n2415\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4736\t0.08GiB\tray::StateAPIGeneratorActor.start\n3697\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 348.9277364300741
+            "perf_metric_value": 362.73605971617656
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4.736
+            "perf_metric_value": 3.933
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 25.612
+            "perf_metric_value": 7.945
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 96.658
+            "perf_metric_value": 55.694
         }
     ],
     "success": "1",
-    "tasks_per_second": 348.9277364300741,
-    "time": 302.86592292785645,
+    "tasks_per_second": 362.73605971617656,
+    "time": 302.7568254470825,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 170.061824,
+    "_dashboard_memory_usage_mb": 156.40576,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.19,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1251\t7.56GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3348\t0.93GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4791\t0.42GiB\tpython distributed/test_many_pgs.py\n2255\t0.27GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3464\t0.14GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1049\t0.13GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n2191\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3631\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n3633\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n1931\t0.07GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l",
+    "_peak_memory": 2.13,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1260\t7.51GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3456\t0.92GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4362\t0.41GiB\tpython distributed/test_many_pgs.py\n2261\t0.41GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1033\t0.14GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3572\t0.11GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2187\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3739\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n3741\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3769\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 20.71303274352877
+            "perf_metric_value": 22.462815180756937
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.812
+            "perf_metric_value": 3.445
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 8.286
+            "perf_metric_value": 8.309
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1002.78
+            "perf_metric_value": 231.821
         }
     ],
-    "pgs_per_second": 20.71303274352877,
+    "pgs_per_second": 22.462815180756937,
     "success": "1",
-    "time": 48.2787823677063
+    "time": 44.518017530441284
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 591.527936,
+    "_dashboard_memory_usage_mb": 719.695872,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.67,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3434\t1.1GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3550\t0.98GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n5459\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1230\t0.24GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2463\t0.23GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3717\t0.1GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n2329\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n5673\t0.08GiB\tray::StateAPIGeneratorActor.start\n3719\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n5617\t0.07GiB\tray::DashboardTester.run",
+    "_peak_memory": 3.51,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1238\t8.25GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3395\t1.12GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3511\t0.81GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4330\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n2327\t0.22GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1030\t0.15GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3676\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n2317\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4558\t0.08GiB\tray::StateAPIGeneratorActor.start\n3678\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 469.18167402268733
+            "perf_metric_value": 569.8428469948077
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 134.62
+            "perf_metric_value": 100.109
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 574.298
+            "perf_metric_value": 474.515
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 790.008
+            "perf_metric_value": 732.957
         }
     ],
     "success": "1",
-    "tasks_per_second": 469.18167402268733,
-    "time": 321.31370544433594,
+    "tasks_per_second": 569.8428469948077,
+    "time": 317.5486979484558,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.39.0"}
+{"release_version": "2.40.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8898.74161889686,
-        138.6655714305418
+        8406.054594491414,
+        291.92446043278716
     ],
     "1_1_actor_calls_concurrent": [
-        5596.612088571596,
-        178.34652642393664
+        5574.264537476383,
+        181.40881249963473
     ],
     "1_1_actor_calls_sync": [
-        2019.1192214380333,
-        37.040749344832754
+        2087.0883324113634,
+        10.396959324142186
     ],
     "1_1_async_actor_calls_async": [
-        5128.909004080372,
-        159.91353744375118
+        4634.622610628061,
+        246.61685472875908
     ],
     "1_1_async_actor_calls_sync": [
-        1541.090559096205,
-        34.01263723112063
+        1496.8313514335857,
+        42.45699109577986
     ],
     "1_1_async_actor_calls_with_args_async": [
-        3278.2411157746983,
-        74.5104314525387
+        3123.7321716596866,
+        132.73443670780497
     ],
     "1_n_actor_calls_async": [
-        8405.676715400055,
-        224.3640255547966
+        8312.7769172799,
+        150.96384831260096
     ],
     "1_n_async_actor_calls_async": [
-        7853.325955437287,
-        65.25928329465697
+        7792.374370155593,
+        86.46740107601153
     ],
     "client__1_1_actor_calls_async": [
-        980.7790835269525,
-        23.96411393720468
+        1043.3296010219708,
+        8.035971592481292
     ],
     "client__1_1_actor_calls_concurrent": [
-        974.1707706196564,
-        15.394990388473797
+        1047.7835914296222,
+        8.738117551289973
     ],
     "client__1_1_actor_calls_sync": [
-        526.7457465833909,
-        6.812388197544875
+        535.027220414796,
+        3.622936132413555
     ],
     "client__get_calls": [
-        1066.7684719081053,
-        65.14242679850064
+        997.4243643841575,
+        53.6906776563184
     ],
     "client__put_calls": [
-        862.5855312761047,
-        20.73389580269158
+        801.6438142195469,
+        46.18748503055418
     ],
     "client__put_gigabytes": [
-        0.15371223612909402,
-        0.0008936587803616917
+        0.1511670911986308,
+        0.0006081888837103882
     ],
     "client__tasks_and_get_batch": [
-        0.9201563674628591,
-        0.010465748439443982
+        0.9672617157522876,
+        0.01781828778285319
     ],
     "client__tasks_and_put_batch": [
-        14405.107490454913,
-        249.95568080534107
+        14268.002424842036,
+        282.8938231847822
     ],
     "multi_client_put_calls_Plasma_Store": [
-        16647.860352850137,
-        277.3955850318771
+        15710.940881780856,
+        192.78875792024306
     ],
     "multi_client_put_gigabytes": [
-        42.866645929309996,
-        2.606701622343488
+        48.46986379957417,
+        4.716362152545525
     ],
     "multi_client_tasks_async": [
-        21823.517428742365,
-        2553.680181642446
+        23713.784059029313,
+        2759.0699297247866
     ],
     "n_n_actor_calls_async": [
-        26933.018765424662,
-        650.9070636285601
+        26462.5203698443,
+        636.4207355323053
     ],
     "n_n_actor_calls_with_arg_async": [
-        2719.6626076209245,
-        10.139893876803306
+        2795.9326336101585,
+        7.660848885864043
     ],
     "n_n_async_actor_calls_async": [
-        22994.669871663224,
-        483.38033980705643
+        23562.931563500868,
+        679.9901259111042
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10650.27690749274
+            "perf_metric_value": 10619.35631461194
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5122.443353616408
+            "perf_metric_value": 4902.8590729793395
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 16647.860352850137
+            "perf_metric_value": 15710.940881780856
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 17.176054266128194
+            "perf_metric_value": 16.723303680382777
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7.780451969433976
+            "perf_metric_value": 7.787568114090216
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 42.866645929309996
+            "perf_metric_value": 48.46986379957417
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.047828247398513
+            "perf_metric_value": 13.732460308807838
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.25614136017588
+            "perf_metric_value": 5.335827997441243
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1001.5048485799107
+            "perf_metric_value": 966.9330051031666
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7850.804688217522
+            "perf_metric_value": 7867.164206607655
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 21823.517428742365
+            "perf_metric_value": 23713.784059029313
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2019.1192214380333
+            "perf_metric_value": 2087.0883324113634
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8898.74161889686
+            "perf_metric_value": 8406.054594491414
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5596.612088571596
+            "perf_metric_value": 5574.264537476383
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8405.676715400055
+            "perf_metric_value": 8312.7769172799
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 26933.018765424662
+            "perf_metric_value": 26462.5203698443
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2719.6626076209245
+            "perf_metric_value": 2795.9326336101585
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1541.090559096205
+            "perf_metric_value": 1496.8313514335857
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5128.909004080372
+            "perf_metric_value": 4634.622610628061
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3278.2411157746983
+            "perf_metric_value": 3123.7321716596866
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7853.325955437287
+            "perf_metric_value": 7792.374370155593
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22994.669871663224
+            "perf_metric_value": 23562.931563500868
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 845.3611380520398
+            "perf_metric_value": 767.0130987847887
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1066.7684719081053
+            "perf_metric_value": 997.4243643841575
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 862.5855312761047
+            "perf_metric_value": 801.6438142195469
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.15371223612909402
+            "perf_metric_value": 0.1511670911986308
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 14405.107490454913
+            "perf_metric_value": 14268.002424842036
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 526.7457465833909
+            "perf_metric_value": 535.027220414796
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 980.7790835269525
+            "perf_metric_value": 1043.3296010219708
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 974.1707706196564
+            "perf_metric_value": 1047.7835914296222
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.9201563674628591
+            "perf_metric_value": 0.9672617157522876
         }
     ],
     "placement_group_create/removal": [
-        845.3611380520398,
-        4.0458509846316035
+        767.0130987847887,
+        13.736685071027063
     ],
     "single_client_get_calls_Plasma_Store": [
-        10650.27690749274,
-        283.37824970347975
+        10619.35631461194,
+        276.4943413062039
     ],
     "single_client_get_object_containing_10k_refs": [
-        12.047828247398513,
-        0.1590129957048486
+        13.732460308807838,
+        0.0889364558408371
     ],
     "single_client_put_calls_Plasma_Store": [
-        5122.443353616408,
-        36.962835635679255
+        4902.8590729793395,
+        131.27774442056725
     ],
     "single_client_put_gigabytes": [
-        17.176054266128194,
-        8.701531437848233
+        16.723303680382777,
+        8.494199960278612
     ],
     "single_client_tasks_and_get_batch": [
-        7.780451969433976,
-        0.258606635032534
+        7.787568114090216,
+        0.40354728276018254
     ],
     "single_client_tasks_async": [
-        7850.804688217522,
-        446.47204973582666
+        7867.164206607655,
+        450.5518482583444
     ],
     "single_client_tasks_sync": [
-        1001.5048485799107,
-        7.62224014215156
+        966.9330051031666,
+        13.866889753006443
     ],
     "single_client_wait_1k_refs": [
-        5.25614136017588,
-        0.10011402273807728
+        5.335827997441243,
+        0.06831765033960081
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 61.879495881000025,
+    "broadcast_time": 12.839908613999995,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 61.879495881000025
+            "perf_metric_value": 12.839908613999995
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.524066807000004,
-    "get_time": 23.672960529000008,
+    "args_time": 17.511716985999996,
+    "get_time": 24.150369112999982,
     "large_object_size": 107374182400,
-    "large_object_time": 31.510281453000005,
+    "large_object_time": 29.438074932999996,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.524066807000004
+            "perf_metric_value": 17.511716985999996
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.869913475000004
+            "perf_metric_value": 5.7928083279999925
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.672960529000008
+            "perf_metric_value": 24.150369112999982
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 189.086426824
+            "perf_metric_value": 190.24024886400002
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 31.510281453000005
+            "perf_metric_value": 29.438074932999996
         }
     ],
-    "queued_time": 189.086426824,
-    "returns_time": 5.869913475000004,
+    "queued_time": 190.24024886400002,
+    "returns_time": 5.7928083279999925,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.0812901997566222,
-    "max_iteration_time": 3.0475189685821533,
-    "min_iteration_time": 0.5083305835723877,
+    "avg_iteration_time": 0.6807765531539917,
+    "max_iteration_time": 2.8090779781341553,
+    "min_iteration_time": 0.15198683738708496,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.0812901997566222
+            "perf_metric_value": 0.6807765531539917
         }
     ],
     "success": 1,
-    "total_time": 108.12925601005554
+    "total_time": 68.07778573036194
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 9.837347507476807
+            "perf_metric_value": 7.564013957977295
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 25.959900307655335
+            "perf_metric_value": 12.360708832740784
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 80.91288795471192
+            "perf_metric_value": 38.88832421302796
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.8206799030303955
+            "perf_metric_value": 1.0955898761749268
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3413.631863594055
+            "perf_metric_value": 2052.948767900467
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.32116315011886526
+            "perf_metric_value": 0.21789345420794765
         }
     ],
-    "stage_0_time": 9.837347507476807,
-    "stage_1_avg_iteration_time": 25.959900307655335,
-    "stage_1_max_iteration_time": 26.58783769607544,
-    "stage_1_min_iteration_time": 25.21652603149414,
-    "stage_1_time": 259.59910821914673,
-    "stage_2_avg_iteration_time": 80.91288795471192,
-    "stage_2_max_iteration_time": 130.10139632225037,
-    "stage_2_min_iteration_time": 67.79082655906677,
-    "stage_2_time": 404.5656635761261,
-    "stage_3_creation_time": 1.8206799030303955,
-    "stage_3_time": 3413.631863594055,
-    "stage_4_spread": 0.32116315011886526,
+    "stage_0_time": 7.564013957977295,
+    "stage_1_avg_iteration_time": 12.360708832740784,
+    "stage_1_max_iteration_time": 12.839155912399292,
+    "stage_1_min_iteration_time": 10.923007011413574,
+    "stage_1_time": 123.60716223716736,
+    "stage_2_avg_iteration_time": 38.88832421302796,
+    "stage_2_max_iteration_time": 39.25933122634888,
+    "stage_2_min_iteration_time": 38.21737813949585,
+    "stage_2_time": 194.44226789474487,
+    "stage_3_creation_time": 1.0955898761749268,
+    "stage_3_time": 2052.948767900467,
+    "stage_4_spread": 0.21789345420794765,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 0.9711981891879983,
-    "avg_pg_remove_time_ms": 0.9386635615607924,
+    "avg_pg_create_time_ms": 1.5887834309311288,
+    "avg_pg_remove_time_ms": 1.1723600825828608,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9711981891879983
+            "perf_metric_value": 1.5887834309311288
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9386635615607924
+            "perf_metric_value": 1.1723600825828608
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 9.64%: 1_1_async_actor_calls_async (THROUGHPUT) regresses from 5128.909004080372 to 4634.622610628061 in microbenchmark.json
REGRESSION 9.27%: placement_group_create/removal (THROUGHPUT) regresses from 845.3611380520398 to 767.0130987847887 in microbenchmark.json
REGRESSION 7.07%: client__put_calls (THROUGHPUT) regresses from 862.5855312761047 to 801.6438142195469 in microbenchmark.json
REGRESSION 6.50%: client__get_calls (THROUGHPUT) regresses from 1066.7684719081053 to 997.4243643841575 in microbenchmark.json
REGRESSION 5.63%: multi_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 16647.860352850137 to 15710.940881780856 in microbenchmark.json
REGRESSION 5.54%: 1_1_actor_calls_async (THROUGHPUT) regresses from 8898.74161889686 to 8406.054594491414 in microbenchmark.json
REGRESSION 4.71%: 1_1_async_actor_calls_with_args_async (THROUGHPUT) regresses from 3278.2411157746983 to 3123.7321716596866 in microbenchmark.json
REGRESSION 4.29%: single_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 5122.443353616408 to 4902.8590729793395 in microbenchmark.json
REGRESSION 3.45%: single_client_tasks_sync (THROUGHPUT) regresses from 1001.5048485799107 to 966.9330051031666 in microbenchmark.json
REGRESSION 2.87%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1541.090559096205 to 1496.8313514335857 in microbenchmark.json
REGRESSION 2.64%: single_client_put_gigabytes (THROUGHPUT) regresses from 17.176054266128194 to 16.723303680382777 in microbenchmark.json
REGRESSION 1.75%: n_n_actor_calls_async (THROUGHPUT) regresses from 26933.018765424662 to 26462.5203698443 in microbenchmark.json
REGRESSION 1.66%: client__put_gigabytes (THROUGHPUT) regresses from 0.15371223612909402 to 0.1511670911986308 in microbenchmark.json
REGRESSION 1.11%: 1_n_actor_calls_async (THROUGHPUT) regresses from 8405.676715400055 to 8312.7769172799 in microbenchmark.json
REGRESSION 0.95%: client__tasks_and_put_batch (THROUGHPUT) regresses from 14405.107490454913 to 14268.002424842036 in microbenchmark.json
REGRESSION 0.78%: 1_n_async_actor_calls_async (THROUGHPUT) regresses from 7853.325955437287 to 7792.374370155593 in microbenchmark.json
REGRESSION 0.40%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 5596.612088571596 to 5574.264537476383 in microbenchmark.json
REGRESSION 0.29%: single_client_get_calls_Plasma_Store (THROUGHPUT) regresses from 10650.27690749274 to 10619.35631461194 in microbenchmark.json
REGRESSION 63.59%: avg_pg_create_time_ms (LATENCY) regresses from 0.9711981891879983 to 1.5887834309311288 in stress_tests/stress_test_placement_group.json
REGRESSION 24.90%: avg_pg_remove_time_ms (LATENCY) regresses from 0.9386635615607924 to 1.1723600825828608 in stress_tests/stress_test_placement_group.json
REGRESSION 2.02%: 10000_get_time (LATENCY) regresses from 23.672960529000008 to 24.150369112999982 in scalability/single_node.json
REGRESSION 0.61%: 1000000_queued_time (LATENCY) regresses from 189.086426824 to 190.24024886400002 in scalability/single_node.json
REGRESSION 0.28%: dashboard_p95_latency_ms (LATENCY) regresses from 8.286 to 8.309 in benchmarks/many_pgs.json
```