### PR TITLE
Add perf metrics for 2.40.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 404.76672,
+    "_dashboard_memory_usage_mb": 429.38368,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.67,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n6527\t1.78GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n8101\t0.93GiB\tpython distributed/test_many_actors.py\n2545\t0.34GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1279\t0.25GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n6643\t0.22GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1026\t0.12GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n2450\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n6810\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n6812\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n6891\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
-    "actors_per_second": 591.3539212974848,
+    "_peak_memory": 3.73,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1250\t7.77GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4016\t1.85GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5453\t0.92GiB\tpython distributed/test_many_actors.py\n2144\t0.3GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4132\t0.24GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1033\t0.15GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3713\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4299\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n4301\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4383\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
+    "actors_per_second": 573.9193627849573,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 591.3539212974848
+            "perf_metric_value": 573.9193627849573
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 94.771
+            "perf_metric_value": 61.359
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2548.0
+            "perf_metric_value": 2647.381
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4095.457
+            "perf_metric_value": 4086.815
         }
     ],
     "success": "1",
-    "time": 16.91034698486328
+    "time": 17.4240505695343
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 217.985024,
+    "_dashboard_memory_usage_mb": 210.870272,
     "_dashboard_test_success": true,
-    "_peak_memory": 1.65,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3433\t0.5GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1225\t0.25GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2296\t0.24GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3549\t0.2GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n5772\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3716\t0.1GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n2555\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n5989\t0.08GiB\tray::StateAPIGeneratorActor.start\n3718\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3740\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
+    "_peak_memory": 1.67,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3497\t0.53GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1252\t0.24GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2647\t0.22GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3613\t0.19GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4584\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1047\t0.14GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3780\t0.1GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n2558\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4826\t0.08GiB\tray::StateAPIGeneratorActor.start\n3782\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 348.9277364300741
+            "perf_metric_value": 357.7562004234592
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4.736
+            "perf_metric_value": 4.011
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 25.612
+            "perf_metric_value": 17.241
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 96.658
+            "perf_metric_value": 85.322
         }
     ],
     "success": "1",
-    "tasks_per_second": 348.9277364300741,
-    "time": 302.86592292785645,
+    "tasks_per_second": 357.7562004234592,
+    "time": 302.79519963264465,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 170.061824,
+    "_dashboard_memory_usage_mb": 179.154944,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.19,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1251\t7.56GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3348\t0.93GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4791\t0.42GiB\tpython distributed/test_many_pgs.py\n2255\t0.27GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3464\t0.14GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1049\t0.13GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n2191\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3631\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n3633\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n1931\t0.07GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l",
+    "_peak_memory": 2.14,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1227\t6.99GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3385\t0.91GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4360\t0.43GiB\tpython distributed/test_many_pgs.py\n2443\t0.42GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1033\t0.15GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3501\t0.11GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2367\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3670\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n3672\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3696\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 20.71303274352877
+            "perf_metric_value": 22.55708308512839
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.812
+            "perf_metric_value": 3.755
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 8.286
+            "perf_metric_value": 30.541
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1002.78
+            "perf_metric_value": 351.637
         }
     ],
-    "pgs_per_second": 20.71303274352877,
+    "pgs_per_second": 22.55708308512839,
     "success": "1",
-    "time": 48.2787823677063
+    "time": 44.3319730758667
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 591.527936,
+    "_dashboard_memory_usage_mb": 785.780736,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.67,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3434\t1.1GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3550\t0.98GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n5459\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n1230\t0.24GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2463\t0.23GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3717\t0.1GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n2329\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n5673\t0.08GiB\tray::StateAPIGeneratorActor.start\n3719\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n5617\t0.07GiB\tray::DashboardTester.run",
+    "_peak_memory": 3.46,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1250\t7.37GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3426\t1.12GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3542\t0.78GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4331\t0.73GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n2099\t0.19GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1035\t0.15GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n2315\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3709\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n4604\t0.08GiB\tray::StateAPIGeneratorActor.start\n3711\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 469.18167402268733
+            "perf_metric_value": 563.3604483841477
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 134.62
+            "perf_metric_value": 112.338
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 574.298
+            "perf_metric_value": 506.419
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 790.008
+            "perf_metric_value": 759.07
         }
     ],
     "success": "1",
-    "tasks_per_second": 469.18167402268733,
-    "time": 321.31370544433594,
+    "tasks_per_second": 563.3604483841477,
+    "time": 317.7506248950958,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.39.0"}
+{"release_version": "2.40.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8898.74161889686,
-        138.6655714305418
+        8670.630812242769,
+        106.83987787916737
     ],
     "1_1_actor_calls_concurrent": [
-        5596.612088571596,
-        178.34652642393664
+        5349.871656557709,
+        262.76145872329056
     ],
     "1_1_actor_calls_sync": [
-        2019.1192214380333,
-        37.040749344832754
+        2100.531675221624,
+        45.884459150638435
     ],
     "1_1_async_actor_calls_async": [
-        5128.909004080372,
-        159.91353744375118
+        4641.857377193749,
+        229.84033542194967
     ],
     "1_1_async_actor_calls_sync": [
-        1541.090559096205,
-        34.01263723112063
+        1470.5838167142256,
+        61.994313956259205
     ],
     "1_1_async_actor_calls_with_args_async": [
-        3278.2411157746983,
-        74.5104314525387
+        2994.804100896146,
+        72.1671038495112
     ],
     "1_n_actor_calls_async": [
-        8405.676715400055,
-        224.3640255547966
+        8118.8880400901135,
+        51.66079706586818
     ],
     "1_n_async_actor_calls_async": [
-        7853.325955437287,
-        65.25928329465697
+        7265.632549025338,
+        100.08002254309318
     ],
     "client__1_1_actor_calls_async": [
-        980.7790835269525,
-        23.96411393720468
+        927.7378599556337,
+        32.80234721559512
     ],
     "client__1_1_actor_calls_concurrent": [
-        974.1707706196564,
-        15.394990388473797
+        968.0008238131173,
+        29.311573682343898
     ],
     "client__1_1_actor_calls_sync": [
-        526.7457465833909,
-        6.812388197544875
+        528.8636206448897,
+        6.436001638898678
     ],
     "client__get_calls": [
-        1066.7684719081053,
-        65.14242679850064
+        1004.2954376391058,
+        76.06541415192476
     ],
     "client__put_calls": [
-        862.5855312761047,
-        20.73389580269158
+        796.6672485266845,
+        42.64509793165841
     ],
     "client__put_gigabytes": [
-        0.15371223612909402,
-        0.0008936587803616917
+        0.1523218281420353,
+        0.0017062706720517254
     ],
     "client__tasks_and_get_batch": [
-        0.9201563674628591,
-        0.010465748439443982
+        0.9840492186511862,
+        0.010660110600558213
     ],
     "client__tasks_and_put_batch": [
-        14405.107490454913,
-        249.95568080534107
+        13963.575440510822,
+        302.4709584876189
     ],
     "multi_client_put_calls_Plasma_Store": [
-        16647.860352850137,
-        277.3955850318771
+        16018.142349512491,
+        110.30685859732601
     ],
     "multi_client_put_gigabytes": [
-        42.866645929309996,
-        2.606701622343488
+        47.90805309960038,
+        3.9883369373484028
     ],
     "multi_client_tasks_async": [
-        21823.517428742365,
-        2553.680181642446
+        21860.338179655857,
+        3613.2906958577523
     ],
     "n_n_actor_calls_async": [
-        26933.018765424662,
-        650.9070636285601
+        26065.409129685446,
+        842.8691955339091
     ],
     "n_n_actor_calls_with_arg_async": [
-        2719.6626076209245,
-        10.139893876803306
+        2674.014821048363,
+        20.95074522247394
     ],
     "n_n_async_actor_calls_async": [
-        22994.669871663224,
-        483.38033980705643
+        22620.58710137489,
+        453.05171495223664
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10650.27690749274
+            "perf_metric_value": 10758.691758375035
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5122.443353616408
+            "perf_metric_value": 4873.791178055619
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 16647.860352850137
+            "perf_metric_value": 16018.142349512491
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 17.176054266128194
+            "perf_metric_value": 16.370163798832593
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7.780451969433976
+            "perf_metric_value": 7.259983498667911
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 42.866645929309996
+            "perf_metric_value": 47.90805309960038
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.047828247398513
+            "perf_metric_value": 10.715440745783182
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.25614136017588
+            "perf_metric_value": 5.367130240055254
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1001.5048485799107
+            "perf_metric_value": 975.2895608656044
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7850.804688217522
+            "perf_metric_value": 7133.343594327644
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 21823.517428742365
+            "perf_metric_value": 21860.338179655857
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2019.1192214380333
+            "perf_metric_value": 2100.531675221624
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8898.74161889686
+            "perf_metric_value": 8670.630812242769
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5596.612088571596
+            "perf_metric_value": 5349.871656557709
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8405.676715400055
+            "perf_metric_value": 8118.8880400901135
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 26933.018765424662
+            "perf_metric_value": 26065.409129685446
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2719.6626076209245
+            "perf_metric_value": 2674.014821048363
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1541.090559096205
+            "perf_metric_value": 1470.5838167142256
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5128.909004080372
+            "perf_metric_value": 4641.857377193749
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3278.2411157746983
+            "perf_metric_value": 2994.804100896146
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7853.325955437287
+            "perf_metric_value": 7265.632549025338
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22994.669871663224
+            "perf_metric_value": 22620.58710137489
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 845.3611380520398
+            "perf_metric_value": 766.4710772352788
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1066.7684719081053
+            "perf_metric_value": 1004.2954376391058
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 862.5855312761047
+            "perf_metric_value": 796.6672485266845
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.15371223612909402
+            "perf_metric_value": 0.1523218281420353
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 14405.107490454913
+            "perf_metric_value": 13963.575440510822
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 526.7457465833909
+            "perf_metric_value": 528.8636206448897
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 980.7790835269525
+            "perf_metric_value": 927.7378599556337
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 974.1707706196564
+            "perf_metric_value": 968.0008238131173
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.9201563674628591
+            "perf_metric_value": 0.9840492186511862
         }
     ],
     "placement_group_create/removal": [
-        845.3611380520398,
-        4.0458509846316035
+        766.4710772352788,
+        9.525367147478727
     ],
     "single_client_get_calls_Plasma_Store": [
-        10650.27690749274,
-        283.37824970347975
+        10758.691758375035,
+        161.37868389449068
     ],
     "single_client_get_object_containing_10k_refs": [
-        12.047828247398513,
-        0.1590129957048486
+        10.715440745783182,
+        0.03423213641168171
     ],
     "single_client_put_calls_Plasma_Store": [
-        5122.443353616408,
-        36.962835635679255
+        4873.791178055619,
+        93.39872186416422
     ],
     "single_client_put_gigabytes": [
-        17.176054266128194,
-        8.701531437848233
+        16.370163798832593,
+        8.28607777964688
     ],
     "single_client_tasks_and_get_batch": [
-        7.780451969433976,
-        0.258606635032534
+        7.259983498667911,
+        0.25823170234335685
     ],
     "single_client_tasks_async": [
-        7850.804688217522,
-        446.47204973582666
+        7133.343594327644,
+        421.3215558940858
     ],
     "single_client_tasks_sync": [
-        1001.5048485799107,
-        7.62224014215156
+        975.2895608656044,
+        15.938596328864557
     ],
     "single_client_wait_1k_refs": [
-        5.25614136017588,
-        0.10011402273807728
+        5.367130240055254,
+        0.12488840214033954
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 61.879495881000025,
+    "broadcast_time": 12.7140335,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 61.879495881000025
+            "perf_metric_value": 12.7140335
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.524066807000004,
-    "get_time": 23.672960529000008,
+    "args_time": 17.54721164899999,
+    "get_time": 24.133820766,
     "large_object_size": 107374182400,
-    "large_object_time": 31.510281453000005,
+    "large_object_time": 29.832562440000004,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.524066807000004
+            "perf_metric_value": 17.54721164899999
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.869913475000004
+            "perf_metric_value": 5.791661208000008
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.672960529000008
+            "perf_metric_value": 24.133820766
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 189.086426824
+            "perf_metric_value": 189.11093958500004
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 31.510281453000005
+            "perf_metric_value": 29.832562440000004
         }
     ],
-    "queued_time": 189.086426824,
-    "returns_time": 5.869913475000004,
+    "queued_time": 189.11093958500004,
+    "returns_time": 5.791661208000008,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.0812901997566222,
-    "max_iteration_time": 3.0475189685821533,
-    "min_iteration_time": 0.5083305835723877,
+    "avg_iteration_time": 0.726184561252594,
+    "max_iteration_time": 2.2697196006774902,
+    "min_iteration_time": 0.08619499206542969,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.0812901997566222
+            "perf_metric_value": 0.726184561252594
         }
     ],
     "success": 1,
-    "total_time": 108.12925601005554
+    "total_time": 72.6185929775238
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 9.837347507476807
+            "perf_metric_value": 7.508195400238037
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 25.959900307655335
+            "perf_metric_value": 12.552423691749572
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 80.91288795471192
+            "perf_metric_value": 38.96002230644226
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.8206799030303955
+            "perf_metric_value": 1.3092761039733887
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3413.631863594055
+            "perf_metric_value": 2052.3795640468597
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.32116315011886526
+            "perf_metric_value": 0.20646123231684818
         }
     ],
-    "stage_0_time": 9.837347507476807,
-    "stage_1_avg_iteration_time": 25.959900307655335,
-    "stage_1_max_iteration_time": 26.58783769607544,
-    "stage_1_min_iteration_time": 25.21652603149414,
-    "stage_1_time": 259.59910821914673,
-    "stage_2_avg_iteration_time": 80.91288795471192,
-    "stage_2_max_iteration_time": 130.10139632225037,
-    "stage_2_min_iteration_time": 67.79082655906677,
-    "stage_2_time": 404.5656635761261,
-    "stage_3_creation_time": 1.8206799030303955,
-    "stage_3_time": 3413.631863594055,
-    "stage_4_spread": 0.32116315011886526,
+    "stage_0_time": 7.508195400238037,
+    "stage_1_avg_iteration_time": 12.552423691749572,
+    "stage_1_max_iteration_time": 13.073823690414429,
+    "stage_1_min_iteration_time": 11.235809803009033,
+    "stage_1_time": 125.52429366111755,
+    "stage_2_avg_iteration_time": 38.96002230644226,
+    "stage_2_max_iteration_time": 40.04894542694092,
+    "stage_2_min_iteration_time": 38.31258225440979,
+    "stage_2_time": 194.8006236553192,
+    "stage_3_creation_time": 1.3092761039733887,
+    "stage_3_time": 2052.3795640468597,
+    "stage_4_spread": 0.20646123231684818,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 0.9711981891879983,
-    "avg_pg_remove_time_ms": 0.9386635615607924,
+    "avg_pg_create_time_ms": 1.5375056531531037,
+    "avg_pg_remove_time_ms": 1.3262595690691725,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9711981891879983
+            "perf_metric_value": 1.5375056531531037
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.9386635615607924
+            "perf_metric_value": 1.3262595690691725
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 11.06%: single_client_get_object_containing_10k_refs (THROUGHPUT) regresses from 12.047828247398513 to 10.715440745783182 in microbenchmark.json
REGRESSION 9.50%: 1_1_async_actor_calls_async (THROUGHPUT) regresses from 5128.909004080372 to 4641.857377193749 in microbenchmark.json
REGRESSION 9.33%: placement_group_create/removal (THROUGHPUT) regresses from 845.3611380520398 to 766.4710772352788 in microbenchmark.json
REGRESSION 9.14%: single_client_tasks_async (THROUGHPUT) regresses from 7850.804688217522 to 7133.343594327644 in microbenchmark.json
REGRESSION 8.65%: 1_1_async_actor_calls_with_args_async (THROUGHPUT) regresses from 3278.2411157746983 to 2994.804100896146 in microbenchmark.json
REGRESSION 7.64%: client__put_calls (THROUGHPUT) regresses from 862.5855312761047 to 796.6672485266845 in microbenchmark.json
REGRESSION 7.48%: 1_n_async_actor_calls_async (THROUGHPUT) regresses from 7853.325955437287 to 7265.632549025338 in microbenchmark.json
REGRESSION 6.69%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 7.780451969433976 to 7.259983498667911 in microbenchmark.json
REGRESSION 5.86%: client__get_calls (THROUGHPUT) regresses from 1066.7684719081053 to 1004.2954376391058 in microbenchmark.json
REGRESSION 5.41%: client__1_1_actor_calls_async (THROUGHPUT) regresses from 980.7790835269525 to 927.7378599556337 in microbenchmark.json
REGRESSION 4.85%: single_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 5122.443353616408 to 4873.791178055619 in microbenchmark.json
REGRESSION 4.69%: single_client_put_gigabytes (THROUGHPUT) regresses from 17.176054266128194 to 16.370163798832593 in microbenchmark.json
REGRESSION 4.58%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1541.090559096205 to 1470.5838167142256 in microbenchmark.json
REGRESSION 4.41%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 5596.612088571596 to 5349.871656557709 in microbenchmark.json
REGRESSION 3.78%: multi_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 16647.860352850137 to 16018.142349512491 in microbenchmark.json
REGRESSION 3.41%: 1_n_actor_calls_async (THROUGHPUT) regresses from 8405.676715400055 to 8118.8880400901135 in microbenchmark.json
REGRESSION 3.22%: n_n_actor_calls_async (THROUGHPUT) regresses from 26933.018765424662 to 26065.409129685446 in microbenchmark.json
REGRESSION 3.07%: client__tasks_and_put_batch (THROUGHPUT) regresses from 14405.107490454913 to 13963.575440510822 in microbenchmark.json
REGRESSION 2.95%: actors_per_second (THROUGHPUT) regresses from 591.3539212974848 to 573.9193627849573 in benchmarks/many_actors.json
REGRESSION 2.62%: single_client_tasks_sync (THROUGHPUT) regresses from 1001.5048485799107 to 975.2895608656044 in microbenchmark.json
REGRESSION 2.56%: 1_1_actor_calls_async (THROUGHPUT) regresses from 8898.74161889686 to 8670.630812242769 in microbenchmark.json
REGRESSION 1.68%: n_n_actor_calls_with_arg_async (THROUGHPUT) regresses from 2719.6626076209245 to 2674.014821048363 in microbenchmark.json
REGRESSION 1.63%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 22994.669871663224 to 22620.58710137489 in microbenchmark.json
REGRESSION 0.90%: client__put_gigabytes (THROUGHPUT) regresses from 0.15371223612909402 to 0.1523218281420353 in microbenchmark.json
REGRESSION 0.63%: client__1_1_actor_calls_concurrent (THROUGHPUT) regresses from 974.1707706196564 to 968.0008238131173 in microbenchmark.json
REGRESSION 268.59%: dashboard_p95_latency_ms (LATENCY) regresses from 8.286 to 30.541 in benchmarks/many_pgs.json
REGRESSION 58.31%: avg_pg_create_time_ms (LATENCY) regresses from 0.9711981891879983 to 1.5375056531531037 in stress_tests/stress_test_placement_group.json
REGRESSION 41.29%: avg_pg_remove_time_ms (LATENCY) regresses from 0.9386635615607924 to 1.3262595690691725 in stress_tests/stress_test_placement_group.json
REGRESSION 3.90%: dashboard_p95_latency_ms (LATENCY) regresses from 2548.0 to 2647.381 in benchmarks/many_actors.json
REGRESSION 1.95%: 10000_get_time (LATENCY) regresses from 23.672960529000008 to 24.133820766 in scalability/single_node.json
REGRESSION 0.13%: 10000_args_time (LATENCY) regresses from 17.524066807000004 to 17.54721164899999 in scalability/single_node.json
REGRESSION 0.01%: 1000000_queued_time (LATENCY) regresses from 189.086426824 to 189.11093958500004 in scalability/single_node.json
```