### PR TITLE
[Data] Relax type check in `add_column`

### DIFF
--- a/python/ray/data/_internal/planner/exchange/sort_task_spec.py
+++ b/python/ray/data/_internal/planner/exchange/sort_task_spec.py
@@ -81,8 +81,9 @@ class SortKey:
             for column in self._columns:
                 if column not in schema_names_set:
                     raise ValueError(
-                        "The column '{}' does not exist in the "
-                        "schema '{}'.".format(column, schema)
+                        f"You specified the column '{column}', but there's no such "
+                        "column in the dataset. The dataset has columns: "
+                        f"{schema_names_set}"
                     )
 
     @property

--- a/python/ray/data/_internal/planner/exchange/sort_task_spec.py
+++ b/python/ray/data/_internal/planner/exchange/sort_task_spec.py
@@ -81,9 +81,8 @@ class SortKey:
             for column in self._columns:
                 if column not in schema_names_set:
                     raise ValueError(
-                        f"You specified the column '{column}', but there's no such "
-                        "column in the dataset. The dataset has columns: "
-                        f"{schema_names_set}"
+                        "The column '{}' does not exist in the "
+                        "schema '{}'.".format(column, schema)
                     )
 
     @property

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -765,6 +765,9 @@ class Dataset:
                 f"got: {batch_format}"
             )
 
+        def _raise_duplicate_column_error(col: str):
+            raise ValueError(f"Trying to add an existing column with name {col!r}")
+
         def add_column(batch: DataBatch) -> DataBatch:
             column = fn(batch)
             if batch_format == "pandas":
@@ -775,9 +778,7 @@ class Dataset:
                     f"Series or sequence, got: {type(column)}"
                 )
                 if col in batch:
-                    raise ValueError(
-                        f"Trying to add an existing column with name: {col!r}"
-                    )
+                    _raise_duplicate_column_error(col)
                 batch.loc[:, col] = column
                 return batch
             elif batch_format == "pyarrow":
@@ -799,9 +800,7 @@ class Dataset:
                     # Append the column to the table
                     return batch.append_column(col, column)
                 else:
-                    raise ValueError(
-                        f"Trying to add an existing column with name {col}"
-                    )
+                    _raise_duplicate_column_error(col)
 
             else:
                 # batch format is assumed to be numpy since we checked at the
@@ -811,9 +810,7 @@ class Dataset:
                     f"numpy.ndarray, got: {type(column)}"
                 )
                 if col in batch:
-                    raise ValueError(
-                        f"Trying to add an existing column with name" f" {col}"
-                    )
+                    _raise_duplicate_column_error(col)
                 batch[col] = column
                 return batch
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -5,6 +5,7 @@ import itertools
 import logging
 import time
 import warnings
+from collections.abc import Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -769,13 +770,13 @@ class Dataset:
             if batch_format == "pandas":
                 import pandas as pd
 
-                assert isinstance(column, pd.Series), (
+                assert isinstance(column, (pd.Series, Sequence)), (
                     f"For pandas batch format, the function must return a pandas "
-                    f"Series, got: {type(column)}"
+                    f"Series or sequence, got: {type(column)}"
                 )
                 if col in batch:
                     raise ValueError(
-                        f"Trying to add an existing column with name" f" {col}"
+                        f"Trying to add an existing column with name: {col!r}"
                     )
                 batch.loc[:, col] = column
                 return batch

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -353,7 +353,7 @@ def test_add_column(ray_start_regular_shared):
     # Adding a column that is already there should result in an error
     with pytest.raises(
         ray.exceptions.UserCodeException,
-        match="Trying to add an existing column with name id",
+        match="Trying to add an existing column with name 'id'",
     ):
         ds = ray.data.range(5).add_column(
             "id", lambda x: pc.add(x["id"], 1), batch_format="pyarrow"
@@ -362,7 +362,7 @@ def test_add_column(ray_start_regular_shared):
 
     # Adding a column in the wrong format should result in an error
     with pytest.raises(
-        ray.exceptions.UserCodeException, match="For pyarrow batch " "format"
+        ray.exceptions.UserCodeException, match="For pyarrow batch format"
     ):
         ds = ray.data.range(5).add_column("id", lambda x: [1], batch_format="pyarrow")
         assert ds.take(2) == [{"id": 1}, {"id": 2}]
@@ -381,7 +381,7 @@ def test_add_column(ray_start_regular_shared):
     # Adding a column that is already there should result in an error
     with pytest.raises(
         ray.exceptions.UserCodeException,
-        match="Trying to add an existing column with name id",
+        match="Trying to add an existing column with name 'id'",
     ):
         ds = ray.data.range(5).add_column(
             "id", lambda x: np.add(x["id"], 1), batch_format="numpy"
@@ -390,7 +390,7 @@ def test_add_column(ray_start_regular_shared):
 
     # Adding a column in the wrong format should result in an error
     with pytest.raises(
-        ray.exceptions.UserCodeException, match="For numpy batch " "format"
+        ray.exceptions.UserCodeException, match="For numpy batch format"
     ):
         ds = ray.data.range(5).add_column("id", lambda x: [1], batch_format="numpy")
         assert ds.take(2) == [{"id": 1}, {"id": 2}]
@@ -405,16 +405,18 @@ def test_add_column(ray_start_regular_shared):
     # Adding a column that is already there should result in an error
     with pytest.raises(
         ray.exceptions.UserCodeException,
-        match="Trying to add an existing column with name id",
+        match="Trying to add an existing column with name 'id'",
     ):
         ds = ray.data.range(5).add_column("id", lambda x: x["id"] + 1)
         assert ds.take(2) == [{"id": 1}, {"id": 2}]
 
     # Adding a column in the wrong format should result in an error
     with pytest.raises(
-        ray.exceptions.UserCodeException, match="For pandas batch " "format"
+        ray.exceptions.UserCodeException, match="For pandas batch format"
     ):
-        ds = ray.data.range(5).add_column("id", lambda x: [1], batch_format="pandas")
+        ds = ray.data.range(5).add_column(
+            "id", lambda x: np.array([1]), batch_format="pandas"
+        )
         assert ds.take(2) == [{"id": 1}, {"id": 2}]
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Previously, you could add a column with a list like this:
```
ds.add_column("zeros", lambda batch: [0] * len(batch))
```

However, after https://github.com/ray-project/ray/pull/48140, this behavior isn't supported. 

To avoid breaking tests and user code, this PR re-adds support for lists.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
