### PR TITLE
[core][autoscaler] Remove unused deprecated flags for AutoscalerMonitor

### DIFF
--- a/python/ray/autoscaler/_private/monitor.py
+++ b/python/ray/autoscaler/_private/monitor.py
@@ -605,16 +605,6 @@ if __name__ == "__main__":
         "--gcs-address", required=False, type=str, help="The address (ip:port) of GCS."
     )
     parser.add_argument(
-        "--redis-address", required=False, type=str, help="This is deprecated"
-    )
-    parser.add_argument(
-        "--redis-password",
-        required=False,
-        type=str,
-        default=None,
-        help="This is deprecated",
-    )
-    parser.add_argument(
         "--autoscaling-config",
         required=False,
         type=str,

--- a/python/ray/autoscaler/v2/monitor.py
+++ b/python/ray/autoscaler/v2/monitor.py
@@ -198,16 +198,6 @@ if __name__ == "__main__":
         "--gcs-address", required=False, type=str, help="The address (ip:port) of GCS."
     )
     parser.add_argument(
-        "--redis-address", required=False, type=str, help="This is deprecated"
-    )
-    parser.add_argument(
-        "--redis-password",
-        required=False,
-        type=str,
-        default=None,
-        help="This is deprecated",
-    )
-    parser.add_argument(
         "--autoscaling-config",
         required=False,
         type=str,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There are two ways to launch Autoscaler Monitor

* `start_monitor`: Execute a command to launch a monitor process. However, there is no way to configure flags `--redis-address` and `--redis-password`.
  * https://github.com/ray-project/ray/blob/ba8674ac946c39487714e49a2a26ed155143b7dd/python/ray/_private/services.py#L2099

* Monitor's constructor (KubeRay only): The Monitor's constructor doesn't configure flags `--redis-address` and `--redis-password`.

Therefore, these two flags are unused.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
