### PR TITLE
[core] Logging investigation

### DIFF
--- a/src/ray/util/BUILD
+++ b/src/ray/util/BUILD
@@ -55,3 +55,11 @@ cc_library(
     srcs = ["thread_checker.cc"],
     visibility = ["//visibility:public"],
 )
+
+cc_binary(
+    name = "ray_logging_test",
+    srcs = ["ray_logging_test.cc"],
+    deps = [
+        ":util",
+    ],
+)

--- a/src/ray/util/ray_logging_test.cc
+++ b/src/ray/util/ray_logging_test.cc
@@ -1,0 +1,16 @@
+#include <cstdlib>
+
+#include "src/ray/util/logging.h"
+#include "src/ray/util/util.h"
+
+int main(int argc, char **argv) {
+  setenv("RAY_ROTATION_MAX_BYTES", "10", /*overwrite=*/1);
+  InitShutdownRAII ray_log_shutdown_raii(ray::RayLog::StartRayLog,
+                                         ray::RayLog::ShutDownRayLog,
+                                         argv[0],
+                                         ray::RayLogLevel::INFO,
+                                         /*log_dir=*/"/tmp/nov25_logging_test");
+  RAY_LOG(ERROR) << "helloworld";
+  RAY_LOG(ERROR) << "helloworld";
+  return 0;
+}


### PR DESCRIPTION
Conclusion:
- spdlog file size rotation is enough to chunk large logging output, meanwhile stdout/stderr displayed meanwhile
- The risk comes from redirected stream