### PR TITLE
[core] Provide option to disable redirection

### DIFF
--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -865,7 +865,8 @@ class Node:
             or `(None, None)` if output redirection is disabled.
         """
         if not self.should_redirect_logs():
-            return None, None
+            null_handle = open("/dev/null")
+            return null_handle, null_handle
 
         log_stdout = None
         log_stderr = None


### PR DESCRIPTION
Users complain to see excessive log for GCS: https://github.com/ray-project/ray/issues/45678

After investigation, I found we actually register two sinks via spdlog if log directory specified:
https://github.com/ray-project/ray/blob/824c29fe0569750f4a73969d386df8943dcc3f3e/src/ray/util/logging.cc#L324-L396

Example code: https://github.com/ray-project/ray/pull/48929
so all content written by `RAY_LOG` is actually produced twice, 
- One for sink file
- Another to stderr, but it's redirected to **one** certain file, for example, `gcs_server.out`

For GCS and raylet, both components have their redirected file: for example, this is how we start gcs https://github.com/ray-project/ray/blob/824c29fe0569750f4a73969d386df8943dcc3f3e/python/ray/_private/node.py#L1158
Unfortunately, we don't have any rotation applied no the redirected files.

The solution proposed here is, if redirection disabled, we simply discard the log, it's logged into file sink anyway.

Alternative considered:
- Use `RotatingFileHandler`, which already implements rotation
  + But have to wrap the rotating handler with other features implemented as well, logging level is also hard to reason; since we're doing only redirection but not logging