### PR TITLE
[Doc] Logging: Specify the Helm chart version in the Persist KubeRay Operator Logs doc

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides/persist-kuberay-operator-logs.md
+++ b/doc/source/cluster/kubernetes/user-guides/persist-kuberay-operator-logs.md
@@ -19,7 +19,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 helm repo update
 
 # Install Loki with single replica mode
-helm install loki grafana/loki -f https://raw.githubusercontent.com/grafana/loki/refs/heads/main/production/helm/loki/single-binary-values.yaml
+helm install loki grafana/loki --version 6.21.0 -f https://raw.githubusercontent.com/grafana/loki/refs/heads/main/production/helm/loki/single-binary-values.yaml
 ```
 
 ### Configure log processing
@@ -48,7 +48,7 @@ Deploy the Fluent Bit deployment with the [Helm chart repository](https://github
 helm repo add fluent https://fluent.github.io/helm-charts
 helm repo update
 
-helm install fluent-bit fluent/fluent-bit -f fluent-bit-config.yaml
+helm install fluent-bit fluent/fluent-bit --version 0.48.2 -f fluent-bit-config.yaml
 ```
 
 ### Install the KubeRay Operator
@@ -75,7 +75,7 @@ Deploy the Grafana deployment with the [Helm chart repository](https://github.co
 helm repo add grafana https://grafana.github.io/helm-charts
 helm repo update
 
-helm install grafana grafana/grafana -f datasource-config.yaml
+helm install grafana grafana/grafana --version 8.6.2 -f datasource-config.yaml
 ```
 
 ### Check the Grafana Dashboard


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Specify the Helm chart version for each tool mentioned in the Persist KubeRay Operator Logs document to prevent issues caused by newer versions that might affect the current configuration.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
