### PR TITLE
[core] Add shared lru cache

### DIFF
--- a/src/ray/util/BUILD
+++ b/src/ray/util/BUILD
@@ -61,6 +61,7 @@ cc_library(
     hdrs = ["shared_lru.h"],
     visibility = ["//visibility:public"],
     deps = [
+        ":util",
         "@com_google_absl//absl/container:flat_hash_map",
     ],
 )

--- a/src/ray/util/BUILD
+++ b/src/ray/util/BUILD
@@ -62,6 +62,5 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "@com_google_absl//absl/container:flat_hash_map",
-        ":util",
     ],
 )

--- a/src/ray/util/BUILD
+++ b/src/ray/util/BUILD
@@ -55,3 +55,12 @@ cc_library(
     srcs = ["thread_checker.cc"],
     visibility = ["//visibility:public"],
 )
+
+cc_library(
+    name = "shared_lru",
+    hdrs = ["shared_lru.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_google_absl//absl/container:flat_hash_map",
+    ],
+)

--- a/src/ray/util/BUILD
+++ b/src/ray/util/BUILD
@@ -62,5 +62,6 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "@com_google_absl//absl/container:flat_hash_map",
+        ":util",
     ],
 )

--- a/src/ray/util/shared_lru.h
+++ b/src/ray/util/shared_lru.h
@@ -1,3 +1,17 @@
+// Copyright 2024 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 // SharedLruCache is a LRU cache, with all entries shared, which means a single entry
 // could be accessed by multiple getters. When `Get`, a copy of the value is returned, so
 // for heavy-loaded types it's suggested to wrap with `std::shared_ptr<>`.

--- a/src/ray/util/shared_lru.h
+++ b/src/ray/util/shared_lru.h
@@ -129,6 +129,7 @@ class SharedLruCache final {
 template <typename K, typename V>
 using SharedLruConstCache = SharedLruCache<K, const V>;
 
+// Same interface and functionality as `SharedLruCache`, but thread-safe version.
 template <typename Key, typename Val>
 class ThreadSafeSharedLruCache final {
  public:

--- a/src/ray/util/shared_lru.h
+++ b/src/ray/util/shared_lru.h
@@ -102,16 +102,8 @@ class SharedLruCache final {
     if (cache_iter == cache_.end()) {
       return std::nullopt;
     }
-    Val value = std::move(cache_iter->second.value);
-    lru_list_.erase(cache_iter->second.lru_iterator);
-    cache_.erase(cache_iter);
-
-    // Re-insert into the cache, no need to check capacity.
-    lru_list_.emplace_front(key);
-    Entry new_entry{value, lru_list_.begin()};
-    cache_[key] = std::move(new_entry);
-
-    return value;
+    lru_list_.splice(lru_list_.begin(), lru_list_, cache_iter->second.lru_iterator);
+    return cache_iter->second.value;
   }
 
   // Clear the cache.

--- a/src/ray/util/shared_lru.h
+++ b/src/ray/util/shared_lru.h
@@ -13,8 +13,9 @@
 // limitations under the License.
 //
 // SharedLruCache is a LRU cache, with all entries shared, which means a single entry
-// could be accessed by multiple getters. When `Get`, a copy of the value is returned, so
-// for heavy-loaded types it's suggested to wrap with `std::shared_ptr<>`.
+// could be accessed by multiple getters. All values are wrapped with shared pointer to
+// avoid copy at get operation, meanwhile also useful to maintain memory validity at any
+// time.
 //
 // Example usage:
 // SharedLruCache<std::string, std::string> cache{cap};

--- a/src/ray/util/shared_lru.h
+++ b/src/ray/util/shared_lru.h
@@ -48,7 +48,7 @@ class SharedLruCache final {
     std::lock_guard lck(mu_);
     lru_list_.emplace_front(key);
     Entry new_entry{std::move(value), lru_list_.begin()};
-    cache_[key] = std::move(new_entry);
+    cache_[std::move(key)] = std::move(new_entry);
 
     if (max_entries_ > 0 && lru_list_.size() > max_entries_) {
       const auto &stale_key = lru_list_.back();

--- a/src/ray/util/shared_lru.h
+++ b/src/ray/util/shared_lru.h
@@ -1,0 +1,135 @@
+// SharedLruCache is a LRU cache, with all entries shared, which means a single entry
+// could be accessed by multiple getters. When `Get`, a copy of the value is returned, so
+// for heavy-loaded types it's suggested to wrap with `std::shared_ptr<>`.
+//
+// Example usage:
+// SharedLruCache<std::string, std::string> cache{cap};
+// // Put a key-value pair into cache.
+// cache.Put("key", "val");
+//
+// // Get a key-value pair from cache.
+// auto val = ache.Get("key");
+// // Check and consume `val`.
+//
+// TODO(hjiang):
+// 1. Add template arguments for key hash and key equal, to pass into absl::flat_hash_map.
+// 2. Provide a key hash wrapper to save a copy.
+// 3. flat hash map supports heterogeneous lookup, expose `KeyLike` templated interface.
+
+#pragma once
+
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "absl/container/flat_hash_map.h"
+
+namespace ray::utils::container {
+
+template <typename Key, typename Val>
+class SharedLruCache final {
+ public:
+  using key_type = Key;
+  using mapped_type = Val;
+
+  // A `max_entries` of 0 means that there is no limit on the number of entries
+  // in the cache.
+  explicit SharedLruCache(size_t max_entries) : max_entries_(max_entries) {}
+
+  ~SharedLruCache() = default;
+
+  // Insert `value` with key `key`. This will replace any previous entry with
+  // the same key.
+  void Put(Key key, Val value) {
+    std::lock_guard lck(mu_);
+    lru_list_.emplace_front(key);
+    Entry new_entry{std::move(value), lru_list_.begin()};
+    cache_[key] = std::move(new_entry);
+
+    if (max_entries_ > 0 && lru_list_.size() > max_entries_) {
+      const auto &stale_key = lru_list_.back();
+      cache_.erase(stale_key);
+      lru_list_.pop_back();
+    }
+  }
+
+  // Delete the entry with key `key`. Return true if the entry was found for
+  // `key`, false if the entry was not found. In both cases, there is no entry
+  // with key `key` existed after the call.
+  bool Delete(const Key &key) {
+    std::lock_guard lck(mu_);
+    auto it = cache_.find(key);
+    if (it == cache_.end()) {
+      return false;
+    }
+    cache_.erase(it);
+    return true;
+  }
+
+  // Look up the entry with key `key`. Return std::nullopt if key doesn't exist.
+  // If found, return a copy for the value.
+  std::optional<Val> Get(const Key &key) {
+    std::lock_guard lck(mu_);
+    const auto cache_iter = cache_.find(key);
+    if (cache_iter == cache_.end()) {
+      return std::nullopt;
+    }
+    Val value = std::move(cache_iter->second.value);
+    lru_list_.erase(cache_iter->second.lru_iterator);
+    cache_.erase(cache_iter);
+
+    // Re-insert into the cache, no need to check capacity.
+    lru_list_.emplace_front(key);
+    Entry new_entry{value, lru_list_.begin()};
+    cache_[key] = std::move(new_entry);
+
+    return value;
+  }
+
+  // Clear the cache.
+  void Clear() {
+    std::lock_guard lck(mu_);
+    cache_.clear();
+    lru_list_.clear();
+  }
+
+  // Accessors for cache parameters.
+  size_t max_entries() const { return max_entries_; }
+
+ private:
+  struct Entry {
+    // The entry's value.
+    Val value;
+
+    // A list iterator pointing to the entry's position in the LRU list.
+    typename std::list<Key>::iterator lru_iterator;
+  };
+
+  using EntryMap = absl::flat_hash_map<Key, Entry>;
+
+  // The maximum number of entries in the cache. A value of 0 means there is no
+  // limit on entry count.
+  const size_t max_entries_;
+
+  // Guards access to the cache and the LRU list.
+  std::mutex mu_;
+
+  // All keys are stored as refernce (`std::reference_wrapper`), and the
+  // ownership lies in `lru_list_`.
+  EntryMap cache_;
+
+  // The LRU list of entries. The front of the list identifies the most
+  // recently accessed entry.
+  std::list<Key> lru_list_;
+};
+
+// Same interfaces as `SharedLruCache`, but all cached values are
+// `const`-specified to avoid concurrent updates.
+template <typename K, typename V>
+using SharedLruConstCache = SharedLruCache<K, const V>;
+
+}  // namespace ray::utils::container

--- a/src/ray/util/shared_lru.h
+++ b/src/ray/util/shared_lru.h
@@ -71,11 +71,12 @@ class SharedLruCache final {
     if (iter != cache_.end()) {
       lru_list_.splice(lru_list_.begin(), lru_list_, iter->second.lru_iterator);
       iter->second.value = std::move(value);
-    } else {
-      lru_list_.emplace_front(key);
-      Entry new_entry{std::move(value), lru_list_.begin()};
-      cache_[std::move(key)] = std::move(new_entry);
+      return;
     }
+
+    lru_list_.emplace_front(key);
+    Entry new_entry{std::move(value), lru_list_.begin()};
+    cache_[std::move(key)] = std::move(new_entry);
 
     if (max_entries_ > 0 && lru_list_.size() > max_entries_) {
       const auto &stale_key = lru_list_.back();

--- a/src/ray/util/shared_lru.h
+++ b/src/ray/util/shared_lru.h
@@ -66,6 +66,7 @@ class SharedLruCache final {
     if (it == cache_.end()) {
       return false;
     }
+    lru_list_.erase(it->second.lru_iterator);
     cache_.erase(it);
     return true;
   }

--- a/src/ray/util/shared_lru.h
+++ b/src/ray/util/shared_lru.h
@@ -29,6 +29,8 @@
 // 1. Add template arguments for key hash and key equal, to pass into absl::flat_hash_map.
 // 2. Provide a key hash wrapper to save a copy.
 // 3. flat hash map supports heterogeneous lookup, expose `KeyLike` templated interface.
+// 4. Add a `GetOrCreate` interface, which takes factory function to creation value.
+// 5. For thread-safe cache, add a sharded container wrapper to reduce lock contention.
 
 #pragma once
 

--- a/src/ray/util/tests/BUILD
+++ b/src/ray/util/tests/BUILD
@@ -194,3 +194,15 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "shared_lru_test",
+    srcs = ["shared_lru_test.cc"],
+    deps = [
+        "//src/ray/util:shared_lru",
+        "@com_google_googletest//:gtest_main",
+    ],
+    size = "small",
+    copts = COPTS,
+    tags = ["team:core"],
+)

--- a/src/ray/util/tests/shared_lru_test.cc
+++ b/src/ray/util/tests/shared_lru_test.cc
@@ -1,3 +1,17 @@
+// Copyright 2024 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "src/ray/util/shared_lru.h"
 
 #include <gtest/gtest.h>

--- a/src/ray/util/tests/shared_lru_test.cc
+++ b/src/ray/util/tests/shared_lru_test.cc
@@ -11,7 +11,7 @@ constexpr size_t kTestCacheSz = 1;
 }  // namespace
 
 TEST(SharedLruCache, PutAndGet) {
-  SharedLruCache<std::string, std::string> cache{kTestCacheSz};
+  ThreadSafeSharedLruCache<std::string, std::string> cache{kTestCacheSz};
 
   // No value initially.
   auto val = cache.Get("1");

--- a/src/ray/util/tests/shared_lru_test.cc
+++ b/src/ray/util/tests/shared_lru_test.cc
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include <string>
+#include <type_traits>
 
 namespace ray::utils::container {
 
@@ -65,6 +66,11 @@ TEST(SharedLruCache, SameKeyTest) {
   val = cache.Get(1);
   EXPECT_TRUE(val.has_value());
   EXPECT_EQ(2, *val);
+}
+
+TEST(SharedLruConstCache, TypeAliasAssertion) {
+  static_assert(
+      std::is_same_v<SharedLruConstCache<int, int>, SharedLruCache<int, const int>>);
 }
 
 }  // namespace ray::utils::container

--- a/src/ray/util/tests/shared_lru_test.cc
+++ b/src/ray/util/tests/shared_lru_test.cc
@@ -1,0 +1,41 @@
+#include "src/ray/util/shared_lru.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace ray::utils::container {
+
+namespace {
+constexpr size_t kTestCacheSz = 1;
+}  // namespace
+
+TEST(SharedLruCache, PutAndGet) {
+  SharedLruCache<std::string, std::string> cache{kTestCacheSz};
+
+  // No value initially.
+  auto val = cache.Get("1");
+  EXPECT_FALSE(val.has_value());
+
+  // Check put and get.
+  cache.Put("1", "1");
+  val = cache.Get("1");
+  EXPECT_TRUE(val.has_value());
+  EXPECT_EQ(*val, "1");
+
+  // Check key eviction.
+  cache.Put("2", "2");
+  val = cache.Get("1");
+  EXPECT_FALSE(val.has_value());
+  val = cache.Get("2");
+  EXPECT_TRUE(val.has_value());
+  EXPECT_EQ(*val, "2");
+
+  // Check deletion.
+  EXPECT_FALSE(cache.Delete("1"));
+  EXPECT_TRUE(cache.Delete("2"));
+  val = cache.Get("2");
+  EXPECT_FALSE(val.has_value());
+}
+
+}  // namespace ray::utils::container

--- a/src/ray/util/tests/shared_lru_test.cc
+++ b/src/ray/util/tests/shared_lru_test.cc
@@ -52,4 +52,19 @@ TEST(SharedLruCache, PutAndGet) {
   EXPECT_FALSE(val.has_value());
 }
 
+// Testing senario: push multiple same keys into the cache.
+TEST(SharedLruCache, SameKeyTest) {
+  ThreadSafeSharedLruCache<int, int> cache{2};
+
+  cache.Put(1, 1);
+  auto val = cache.Get(1);
+  EXPECT_TRUE(val.has_value());
+  EXPECT_EQ(1, *val);
+
+  cache.Put(1, 2);
+  val = cache.Get(1);
+  EXPECT_TRUE(val.has_value());
+  EXPECT_EQ(2, *val);
+}
+
 }  // namespace ray::utils::container

--- a/src/ray/util/tests/shared_lru_test.cc
+++ b/src/ray/util/tests/shared_lru_test.cc
@@ -30,41 +30,41 @@ TEST(SharedLruCache, PutAndGet) {
 
   // No value initially.
   auto val = cache.Get("1");
-  EXPECT_FALSE(val.has_value());
+  EXPECT_EQ(val, nullptr);
 
   // Check put and get.
-  cache.Put("1", "1");
+  cache.Put("1", std::make_shared<std::string>("1"));
   val = cache.Get("1");
-  EXPECT_TRUE(val.has_value());
+  EXPECT_NE(val, nullptr);
   EXPECT_EQ(*val, "1");
 
   // Check key eviction.
-  cache.Put("2", "2");
+  cache.Put("2", std::make_shared<std::string>("2"));
   val = cache.Get("1");
-  EXPECT_FALSE(val.has_value());
+  EXPECT_EQ(val, nullptr);
   val = cache.Get("2");
-  EXPECT_TRUE(val.has_value());
+  EXPECT_NE(val, nullptr);
   EXPECT_EQ(*val, "2");
 
   // Check deletion.
   EXPECT_FALSE(cache.Delete("1"));
   EXPECT_TRUE(cache.Delete("2"));
   val = cache.Get("2");
-  EXPECT_FALSE(val.has_value());
+  EXPECT_EQ(val, nullptr);
 }
 
 // Testing senario: push multiple same keys into the cache.
 TEST(SharedLruCache, SameKeyTest) {
   ThreadSafeSharedLruCache<int, int> cache{2};
 
-  cache.Put(1, 1);
+  cache.Put(1, std::make_shared<int>(1));
   auto val = cache.Get(1);
-  EXPECT_TRUE(val.has_value());
+  EXPECT_NE(val, nullptr);
   EXPECT_EQ(1, *val);
 
-  cache.Put(1, 2);
+  cache.Put(1, std::make_shared<int>(2));
   val = cache.Get(1);
-  EXPECT_TRUE(val.has_value());
+  EXPECT_NE(val, nullptr);
   EXPECT_EQ(2, *val);
 }
 


### PR DESCRIPTION
A shared lru cache is needed for my PR: https://github.com/ray-project/ray/pull/48928

Alternative considered:
- Boost does provide a LRU cache implementation, but fails to compile due to missing dependency on CI
  + Failed CI link: https://buildkite.com/ray-project/premerge/builds/31413#01936711-a88c-43fe-be71-3a5455f1a807
  + The only viable way to patch boost is via patching build rules for boost (not the boost repository, but another repository which provides bazel wrapper)
  + Spent several hours on it with no result, implementing a shared LRU myself seems way easier

BUILD target for boost for reference:
```
boost_library(
    name = "compute",
    linkopts = selects.with_or({
        # OpenCL (required for Boost.Compute) is deprecated on macOS and not supported on other Apple OSs.
        # This will at least produce the right error message, indicating that OpenCL is not present
        ("@platforms//os:osx", "@platforms//os:ios", "@platforms//os:watchos", "@platforms//os:tvos"): [
            "-framework OpenCL",
        ],
        "//conditions:default": [
            "-lOpenCL",
        ],
    }),
    deps = [
        ":algorithm",
        ":chrono",
        ":config",
        ":throw_exception",
    ],
)
```