### PR TITLE
[serve] async shutdown for handles

### DIFF
--- a/python/ray/serve/_private/local_testing_mode.py
+++ b/python/ray/serve/_private/local_testing_mode.py
@@ -310,4 +310,6 @@ class LocalRouter(Router):
         return noop_future
 
     def shutdown(self):
-        pass
+        noop_future = concurrent.futures.Future()
+        noop_future.set_result(None)
+        return noop_future

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -327,7 +327,7 @@ class Router(ABC):
         pass
 
     @abstractmethod
-    def shutdown(self):
+    def shutdown(self) -> concurrent.futures.Future:
         pass
 
 
@@ -680,7 +680,7 @@ class SingletonThreadRouter(Router):
             loop=self._asyncio_loop,
         )
 
-    def shutdown(self):
-        asyncio.run_coroutine_threadsafe(
+    def shutdown(self) -> concurrent.futures.Future:
+        return asyncio.run_coroutine_threadsafe(
             self._asyncio_router.shutdown(), loop=self._asyncio_loop
-        ).result()
+        )

--- a/python/ray/serve/tests/test_handle_2.py
+++ b/python/ray/serve/tests/test_handle_2.py
@@ -472,5 +472,30 @@ async def test_max_ongoing_requests_enforced(serve_instance):
         tasks = pending
 
 
+def test_shutdown(serve_instance):
+    @serve.deployment
+    class Hi:
+        def __call__(self):
+            return "hi"
+
+    h = serve.run(Hi.bind())
+    assert h.remote().result() == "hi"
+
+    h.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_async(serve_instance):
+    @serve.deployment
+    class Hi:
+        def __call__(self):
+            return "hi"
+
+    h = serve.run(Hi.bind())
+    assert await h.remote() == "hi"
+
+    await h.shutdown_async()
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/test_multiplex.py
+++ b/python/ray/serve/tests/test_multiplex.py
@@ -21,7 +21,7 @@ from ray.serve.multiplex import _ModelMultiplexWrapper
 def _get_replica_scheduler(handle: DeploymentHandle) -> ReplicaScheduler:
     # TODO(edoakes): we shouldn't be reaching into private fields, but better
     # to isolate it to one place (this function).
-    return handle._get_or_create_router()._asyncio_router._replica_scheduler
+    return handle._router._asyncio_router._replica_scheduler
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Why are these changes needed?

Add async shutdown for handles.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
