### PR TITLE
[core] [easy] Cleanup shared pointer for runtime env client

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -377,7 +377,7 @@ NodeManager::NodeManager(
   dashboard_agent_manager_ = CreateDashboardAgentManager(self_node_id, config);
   runtime_env_agent_manager_ = CreateRuntimeEnvAgentManager(self_node_id, config);
 
-  runtime_env_agent_client_ = RuntimeEnvAgentClient::Create(
+  auto runtime_env_agent_client = RuntimeEnvAgentClient::Create(
       io_service_,
       config.node_manager_address,
       config.runtime_env_agent_port, /*delay_executor=*/
@@ -387,7 +387,7 @@ NodeManager::NodeManager(
       },
       shutdown_raylet_gracefully_);
 
-  worker_pool_.SetRuntimeEnvAgentClient(runtime_env_agent_client_);
+  worker_pool_.SetRuntimeEnvAgentClient(std::move(runtime_env_agent_client));
   worker_pool_.Start();
   periodical_runner_.RunFnPeriodically([this]() { GCTaskFailureReason(); },
                                        RayConfig::instance().task_failure_entry_ttl_ms(),

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -777,9 +777,6 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   /// The node manager RPC service.
   rpc::NodeManagerGrpcService node_manager_service_;
 
-  /// Wrapper client for RuntimeEnvManager. Always non-null.
-  std::shared_ptr<RuntimeEnvAgentClient> runtime_env_agent_client_;
-
   /// Manages all local objects that are pinned (primary
   /// copies), freed, and/or spilled.
   LocalObjectManager local_object_manager_;

--- a/src/ray/raylet/runtime_env_agent_client.cc
+++ b/src/ray/raylet/runtime_env_agent_client.cc
@@ -519,7 +519,7 @@ class HttpRuntimeEnvAgentClient : public RuntimeEnvAgentClient {
 };
 }  // namespace
 
-std::shared_ptr<RuntimeEnvAgentClient> RuntimeEnvAgentClient::Create(
+std::unique_ptr<RuntimeEnvAgentClient> RuntimeEnvAgentClient::Create(
     instrumented_io_context &io_context,
     const std::string &address,
     int port,
@@ -528,7 +528,7 @@ std::shared_ptr<RuntimeEnvAgentClient> RuntimeEnvAgentClient::Create(
     std::function<void(const rpc::NodeDeathInfo &)> shutdown_raylet_gracefully,
     uint32_t agent_register_timeout_ms,
     uint32_t agent_manager_retry_interval_ms) {
-  return std::make_shared<HttpRuntimeEnvAgentClient>(io_context,
+  return std::make_unique<HttpRuntimeEnvAgentClient>(io_context,
                                                      address,
                                                      port,
                                                      delay_executor,

--- a/src/ray/raylet/runtime_env_agent_client.h
+++ b/src/ray/raylet/runtime_env_agent_client.h
@@ -45,7 +45,7 @@ class RuntimeEnvAgentClient {
  public:
   // Creates a concrete Client that can make HTTP requests to address:port.
   // Retries all requests every `agent_manager_retry_interval_ms` on NotFound.
-  static std::shared_ptr<RuntimeEnvAgentClient> Create(
+  static std::unique_ptr<RuntimeEnvAgentClient> Create(
       instrumented_io_context &io_context,
       const std::string &address,
       int port,

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -186,7 +186,7 @@ void WorkerPool::SetNodeManagerPort(int node_manager_port) {
 }
 
 void WorkerPool::SetRuntimeEnvAgentClient(
-    std::shared_ptr<RuntimeEnvAgentClient> runtime_env_agent_client) {
+    std::unique_ptr<RuntimeEnvAgentClient> runtime_env_agent_client) {
   if (!runtime_env_agent_client) {
     RAY_LOG(FATAL) << "SetRuntimeEnvAgentClient requires non empty pointer";
   }

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <boost/asio/io_service.hpp>
 #include <boost/functional/hash.hpp>
+#include <memory>
 #include <queue>
 #include <string_view>
 #include <unordered_set>
@@ -229,7 +230,7 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
 
   /// Set Runtime Env Manager Client.
   void SetRuntimeEnvAgentClient(
-      std::shared_ptr<RuntimeEnvAgentClient> runtime_env_agent_client);
+      std::unique_ptr<RuntimeEnvAgentClient> runtime_env_agent_client);
 
   /// Handles the event that a job is started.
   ///
@@ -794,7 +795,7 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   /// A callback to get the current time.
   const std::function<double()> get_time_;
   /// Runtime env manager client.
-  std::shared_ptr<RuntimeEnvAgentClient> runtime_env_agent_client_;
+  std::unique_ptr<RuntimeEnvAgentClient> runtime_env_agent_client_;
   /// Stats
   int64_t process_failed_job_config_missing_ = 0;
   int64_t process_failed_rate_limited_ = 0;

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -425,7 +425,7 @@ class WorkerPoolTest : public ::testing::Test {
       io_service_.run();
     }));
     promise.get_future().get();
-    worker_pool_->SetRuntimeEnvAgentClient(std::make_shared<MockRuntimeEnvAgentClient>());
+    worker_pool_->SetRuntimeEnvAgentClient(std::make_unique<MockRuntimeEnvAgentClient>());
   }
 
   void TearDown() override {


### PR DESCRIPTION
Shared pointer is wide-spread our codebase, which makes ownership justification and tracing hard.
To make things worse, new code has to confirm the same interface, which means more shared pointer.

Would like to spend some time to cleanup, start with something simple.