### PR TITLE
[serve] remove deprecated args in handle options

### DIFF
--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -2,7 +2,6 @@ import asyncio
 import concurrent.futures
 import logging
 import time
-import warnings
 from typing import Any, AsyncIterator, Dict, Iterator, Optional, Tuple, Union
 
 import ray

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -160,7 +160,7 @@ class _DeploymentHandleBase:
         ):
             ServeUsageTag.DEPLOYMENT_HANDLE_API_USED.record("1")
 
-    def _options(self, _prefer_local_routing=DEFAULT.VALUE, **kwargs):
+    def _options(self, **kwargs):
         if kwargs.get("stream") is True and inside_ray_client_context():
             raise RuntimeError(
                 "Streaming DeploymentHandles are not currently supported when "
@@ -168,11 +168,6 @@ class _DeploymentHandleBase:
             )
 
         new_handle_options = self.handle_options.copy_and_update(**kwargs)
-
-        # TODO(zcin): remove when _prefer_local_routing is removed from options() path
-        if _prefer_local_routing != DEFAULT.VALUE:
-            self._init(_prefer_local_routing=_prefer_local_routing)
-
         if not self.is_initialized:
             self._init()
 
@@ -658,8 +653,6 @@ class DeploymentHandle(_DeploymentHandleBase):
         method_name: Union[str, DEFAULT] = DEFAULT.VALUE,
         multiplexed_model_id: Union[str, DEFAULT] = DEFAULT.VALUE,
         stream: Union[bool, DEFAULT] = DEFAULT.VALUE,
-        use_new_handle_api: Union[bool, DEFAULT] = DEFAULT.VALUE,
-        _prefer_local_routing: Union[bool, DEFAULT] = DEFAULT.VALUE,
     ) -> "DeploymentHandle":
         """Set options for this handle and return an updated copy of it.
 
@@ -672,23 +665,10 @@ class DeploymentHandle(_DeploymentHandleBase):
                 multiplexed_model_id="model:v1",
             ).remote()
         """
-        if use_new_handle_api is not DEFAULT.VALUE:
-            warnings.warn(
-                "Setting `use_new_handle_api` no longer has any effect. "
-                "This argument will be removed in a future version."
-            )
-
-        if _prefer_local_routing is not DEFAULT.VALUE:
-            warnings.warn(
-                "Modifying `_prefer_local_routing` with `options()` is "
-                "deprecated. Please use `init()` instead."
-            )
-
         return self._options(
             method_name=method_name,
             multiplexed_model_id=multiplexed_model_id,
             stream=stream,
-            _prefer_local_routing=_prefer_local_routing,
         )
 
     def remote(

--- a/python/ray/tests/test_client_library_integration.py
+++ b/python/ray/tests/test_client_library_integration.py
@@ -61,7 +61,7 @@ async def test_serve_handle(ray_start_regular):
             def hello():
                 return "hello"
 
-            handle = serve.run(hello.bind()).options(use_new_handle_api=True)
+            handle = serve.run(hello.bind())
             assert await handle.remote() == "hello"
 
 

--- a/python/ray/tests/test_runtime_env_working_dir_2.py
+++ b/python/ray/tests/test_runtime_env_working_dir_2.py
@@ -208,7 +208,7 @@ def test_ray_worker_dev_flow(start_cluster):
         def f():
             return "hi"
 
-        h = serve.run(f.bind()).options(use_new_handle_api=True)
+        h = serve.run(f.bind())
 
         assert h.remote().result() == "hi"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Remove `use_new_handle_api` which has had no effect for a while, and has been printing warnings for a few releases now. Also remove `_prefer_local_routing` which can no longer be configured through `options`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
