### PR TITLE
fix docs: typo in saving-data.rst

### DIFF
--- a/doc/source/data/saving-data.rst
+++ b/doc/source/data/saving-data.rst
@@ -64,7 +64,7 @@ To write data to formats other than Parquet, read the :ref:`Input/Output referen
 
             ds.write_parquet("s3://my-bucket/my-folder")
 
-        Ray Data relies on PyArrow for authenticaion with Amazon S3. For more on how to configure
+        Ray Data relies on PyArrow to authenticate with Amazon S3. For more on how to configure
         your credentials to be compatible with PyArrow, see their
         `S3 Filesytem docs <https://arrow.apache.org/docs/python/filesystems.html#s3>`_.
 


### PR DESCRIPTION
fix typo and simplify prose

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
