### PR TITLE
[data] Expression support for filters

### DIFF
--- a/python/ray/data/BUILD
+++ b/python/ray/data/BUILD
@@ -642,3 +642,11 @@ py_test(
     tags = ["team:data", "exclusive"],
     deps = ["//:ray_lib", ":conftest"],
 )
+
+py_test(
+    name = "test_expression_evaluator",
+    size = "small",
+    srcs = ["tests/test_expression_evaluator.py"],
+    tags = ["team:data", "exclusive"],
+    deps = ["//:ray_lib", ":conftest"],
+)

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -1,6 +1,6 @@
 import inspect
 import logging
-from typing import Any, Callable, Dict, Iterable, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Union
 
 from ray.data._internal.compute import ComputeStrategy, TaskPoolStrategy
 from ray.data._internal.logical.interfaces import LogicalOperator
@@ -8,6 +8,10 @@ from ray.data._internal.logical.operators.one_to_one_operator import AbstractOne
 from ray.data.block import UserDefinedFunction
 from ray.data.context import DEFAULT_BATCH_SIZE
 from ray.data.preprocessor import Preprocessor
+
+if TYPE_CHECKING:
+    import pyarrow as pa
+
 
 logger = logging.getLogger(__name__)
 
@@ -215,15 +219,21 @@ class Filter(AbstractUDFMap):
     def __init__(
         self,
         input_op: LogicalOperator,
-        fn: UserDefinedFunction,
+        fn: Optional[UserDefinedFunction] = None,
+        filter_expr: Optional["pa.dataset.Expression"] = None,
         compute: Optional[Union[str, ComputeStrategy]] = None,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         ray_remote_args: Optional[Dict[str, Any]] = None,
     ):
+        # Ensure exactly one of fn or filter_expr is provided
+        if not ((fn is None) ^ (filter_expr is None)):
+            raise ValueError("Exactly one of 'fn' or 'filter_expr' must be provided")
+        self._filter_expr = filter_expr
+
         super().__init__(
             "Filter",
             input_op,
-            fn,
+            fn=fn,
             compute=compute,
             ray_remote_args_fn=ray_remote_args_fn,
             ray_remote_args=ray_remote_args,

--- a/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
+++ b/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
@@ -1,0 +1,232 @@
+import ast
+import logging
+from typing import Any, List, Union
+
+import pyarrow as pa
+import pyarrow.compute as pc
+
+logger = logging.getLogger(__name__)
+
+
+# NOTE: (srinathk) There are 3 distinct stages of handling passed in exprs:
+# 1. Parsing it (as text)
+# 2. Resolving unbound names (to schema)
+# 3. Converting resolved expressions to PA ones
+# Need to break up the abstraction provided by ExpressionEvaluator.
+
+
+class ExpressionEvaluator:
+    def get_filters(self, expression: str) -> pc.Expression:
+        """Parse and evaluate the expression to generate a filter condition.
+
+        Args:
+            expression: A string representing the filter expression to parse.
+
+        Returns:
+            A PyArrow compute expression for filtering data.
+
+        """
+        try:
+            tree = ast.parse(expression, mode="eval")
+            return self._build_filter_condition(tree.body)
+        except SyntaxError as e:
+            raise ValueError(f"Invalid syntax in the expression: {expression}") from e
+        except Exception as e:
+            logger.exception(f"Error processing expression: {e}")
+            raise
+
+    def _build_filter_condition(self, node) -> Union[pc.Expression, List[Any], str]:
+        """Recursively evaluate an AST node to build the filter condition.
+
+        Args:
+            node: The AST node to evaluate, representing part of the expression.
+
+        Returns:
+            The evaluated result for the node, which could be a
+                filter condition, list, or field name.
+        """
+        visitor = _ConvertToArrowExpressionVisitor()
+        return visitor.visit(node)
+
+
+class _ConvertToArrowExpressionVisitor(ast.NodeVisitor):
+    def visit_Compare(self, node: ast.Compare) -> pc.Expression:
+        """Handle comparison operations (e.g., a == b, a < b, a in b).
+
+        Args:
+            node: The AST node representing a comparison operation.
+
+        Returns:
+            An expression representing the comparison.
+        """
+        # Handle left operand
+        # TODO Validate columns
+        if isinstance(node.left, ast.Attribute):
+            left_expr = self.visit(node.left)  # Visit and handle attributes
+        elif isinstance(node.left, ast.Name):
+            left_expr = self.visit(node.left)  # Treat as a simple field
+        elif isinstance(node.left, ast.Constant):
+            left_expr = node.left.value  # Constant values are used directly
+        else:
+            raise ValueError(f"Unsupported left operand type: {type(node.left)}")
+
+        comparators = [self.visit(comp) for comp in node.comparators]
+
+        op = node.ops[0]
+        if isinstance(op, ast.In):
+            return left_expr.isin(comparators[0])
+        elif isinstance(op, ast.NotIn):
+            return ~left_expr.isin(comparators[0])
+        elif isinstance(op, ast.Eq):
+            return left_expr == comparators[0]
+        elif isinstance(op, ast.NotEq):
+            return left_expr != comparators[0]
+        elif isinstance(op, ast.Lt):
+            return left_expr < comparators[0]
+        elif isinstance(op, ast.LtE):
+            return left_expr <= comparators[0]
+        elif isinstance(op, ast.Gt):
+            return left_expr > comparators[0]
+        elif isinstance(op, ast.GtE):
+            return left_expr >= comparators[0]
+        else:
+            raise ValueError(f"Unsupported operator type: {op}")
+
+    def visit_BoolOp(self, node: ast.BoolOp) -> pc.Expression:
+        """Handle logical operations (e.g., a and b, a or b).
+
+        Args:
+            node: The AST node representing a boolean operation.
+
+        Returns:
+            An expression representing the logical operation.
+        """
+        conditions = [self.visit(value) for value in node.values]
+        combined_expr = conditions[0]
+
+        for condition in conditions[1:]:
+            if isinstance(node.op, ast.And):
+                # Combine conditions with logical AND
+                combined_expr &= condition
+            elif isinstance(node.op, ast.Or):
+                # Combine conditions with logical OR
+                combined_expr |= condition
+            else:
+                raise ValueError(
+                    f"Unsupported logical operator: {type(node.op).__name__}"
+                )
+
+        return combined_expr
+
+    def visit_Name(self, node: ast.Name) -> pc.Expression:
+        """Handle variable (name) nodes and return them as pc.Expression.
+
+        Even if the name contains periods, it's treated as a single string.
+
+        Args:
+            node: The AST node representing a variable.
+
+        Returns:
+            The variable wrapped as a pc.Expression.
+        """
+        field_name = (
+            node.id
+        )  # Directly use the field name as a string (even if it contains periods)
+        return pc.field(field_name)
+
+    def visit_Attribute(self, node: ast.Attribute) -> object:
+        """Handle attribute access (e.g., np.nan).
+
+        Args:
+            node: The AST node representing an attribute access.
+
+        Returns:
+            object: The attribute value.
+
+        Raises:
+            ValueError: If the attribute is unsupported.
+        """
+        # Recursively visit the left side (base object or previous attribute)
+        if isinstance(node.value, ast.Attribute):
+            # If the value is an attribute, recursively resolve it
+            left_expr = self.visit(node.value)
+            return pc.field(f"{left_expr}.{node.attr}")
+
+        elif isinstance(node.value, ast.Name):
+            # If the value is a name (e.g., "foo"), we can directly return the field
+            left_name = node.value.id  # The base name, e.g., "foo"
+            return pc.field(f"{left_name}.{node.attr}")
+
+        raise ValueError(f"Unsupported attribute: {node.attr}")
+
+    def visit_List(self, node: ast.List) -> pc.Expression:
+        """Handle list literals.
+
+        Args:
+            node: The AST node representing a list.
+
+        Returns:
+            The list of elements wrapped as a pc.Expression.
+        """
+        elements = [self.visit(elt) for elt in node.elts]
+        return pa.array(elements)
+
+    # TODO (srinathk) Note that visit_Constant does not return pc.Expression
+    # because to support function in() which takes in a List, the elements in the List
+    # needs to values instead of pc.Expression per pyarrow.dataset.Expression
+    # specification. May be down the road, we can update it as Arrow relaxes this
+    # constraint.
+    def visit_Constant(self, node: ast.Constant) -> object:
+        """Handle constant values (e.g., numbers, strings).
+
+        Args:
+            node: The AST node representing a constant value.
+
+        Returns:
+            object: The constant value itself (e.g., number, string, or boolean).
+        """
+        return node.value  # Return the constant value directly.
+
+    def visit_Call(self, node: ast.Call) -> pc.Expression:
+        """Handle function calls (e.g., is_nan(a), is_valid(b)).
+
+        Args:
+            node: The AST node representing a function call.
+
+        Returns:
+            The corresponding expression based on the function called.
+
+        Raises:
+            ValueError: If the function is unsupported or has incorrect arguments.
+        """
+        func_name = node.func.id
+        function_map = {
+            "is_nan": lambda arg: arg.is_nan(),
+            "is_null": lambda arg, nan_is_null=False: arg.is_null(
+                nan_is_null=nan_is_null
+            ),
+            "is_valid": lambda arg: arg.is_valid(),
+            "isin": lambda arg1, arg2: arg1.isin(arg2),
+        }
+
+        if func_name in function_map:
+            # Visit all arguments of the function call
+            args = [self.visit(arg) for arg in node.args]
+            # Handle the "is_null" function with one or two arguments
+            if func_name == "is_null":
+                if len(args) == 1:
+                    return function_map[func_name](args[0])
+                elif len(args) == 2:
+                    return function_map[func_name](args[0], args[1])
+                else:
+                    raise ValueError("is_null function requires one or two arguments.")
+            # Handle the "isin" function with exactly two arguments
+            elif func_name == "isin" and len(args) != 2:
+                raise ValueError("isin function requires two arguments.")
+            # Ensure the function has one argument (for functions like is_valid)
+            elif func_name != "isin" and len(args) != 1:
+                raise ValueError(f"{func_name} function requires exactly one argument.")
+            # Call the corresponding function with the arguments
+            return function_map[func_name](*args)
+        else:
+            raise ValueError(f"Unsupported function: {func_name}")

--- a/python/ray/data/_internal/planner/planner.py
+++ b/python/ray/data/_internal/planner/planner.py
@@ -43,6 +43,7 @@ def _register_default_plan_logical_op_fns():
     from ray.data._internal.logical.operators.input_data_operator import InputData
     from ray.data._internal.logical.operators.map_operator import (
         AbstractUDFMap,
+        Filter,
         Project,
     )
     from ray.data._internal.logical.operators.n_ary_operator import Union, Zip
@@ -52,6 +53,7 @@ def _register_default_plan_logical_op_fns():
     from ray.data._internal.planner.plan_all_to_all_op import plan_all_to_all_op
     from ray.data._internal.planner.plan_read_op import plan_read_op
     from ray.data._internal.planner.plan_udf_map_op import (
+        plan_filter_op,
         plan_project_op,
         plan_udf_map_op,
     )
@@ -80,6 +82,10 @@ def _register_default_plan_logical_op_fns():
         return InputDataBuffer(op.input_data)
 
     register_plan_logical_op_fn(AbstractFrom, plan_from_op)
+    # Filter is also a AbstractUDFMap, so it needs to resolve
+    # before the AbstractUDFMap plan
+    # TODO(rliaw): Break up plan_udf_map_op
+    register_plan_logical_op_fn(Filter, plan_filter_op)
     register_plan_logical_op_fn(AbstractUDFMap, plan_udf_map_op)
     register_plan_logical_op_fn(AbstractAllToAll, plan_all_to_all_op)
 

--- a/python/ray/data/tests/test_expression_evaluator.py
+++ b/python/ray/data/tests/test_expression_evaluator.py
@@ -1,0 +1,324 @@
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from ray.data._internal.planner.plan_expression.expression_evaluator import (
+    ExpressionEvaluator,
+)
+
+
+@pytest.fixture(scope="module")
+def sample_data(tmpdir_factory):
+    """Fixture to create and yield sample Parquet data, and clean up afterwards."""
+    # Sample data for testing purposes
+    data = {
+        "age": [
+            25,
+            32,
+            45,
+            29,
+            40,
+            np.nan,
+        ],  # List of ages, including a None value for testing
+        "city": [
+            "New York",
+            "San Francisco",
+            "Los Angeles",
+            "Los Angeles",
+            "San Francisco",
+            "San Jose",
+        ],
+        "is_student": [False, True, False, False, True, None],  # Including a None value
+    }
+
+    # Create a PyArrow table from the sample data
+    table = pa.table(data)
+
+    # Use tmpdir_factory to create a temporary directory
+    temp_dir = tmpdir_factory.mktemp("data")
+    parquet_file = temp_dir.join("sample_data.parquet")
+
+    # Write the table to a Parquet file in the temporary directory
+    pq.write_table(table, str(parquet_file))
+
+    # Yield the path to the Parquet file for testing
+    yield str(parquet_file)
+
+
+expressions_and_expected_data = [
+    # Parameterized test cases with expressions and their expected results
+    # Comparison Ops
+    (
+        "40 > age",
+        [
+            {"age": 25, "city": "New York", "is_student": False},
+            {"age": 32, "city": "San Francisco", "is_student": True},
+            {"age": 29, "city": "Los Angeles", "is_student": False},
+        ],
+    ),
+    (
+        "40 >= age",
+        [
+            {"age": 25, "city": "New York", "is_student": False},
+            {"age": 32, "city": "San Francisco", "is_student": True},
+            {"age": 29, "city": "Los Angeles", "is_student": False},
+            {"age": 40, "city": "San Francisco", "is_student": True},
+        ],
+    ),
+    (
+        "30 < age",
+        [
+            {"age": 32, "city": "San Francisco", "is_student": True},
+            {"age": 45, "city": "Los Angeles", "is_student": False},
+            {"age": 40, "city": "San Francisco", "is_student": True},
+        ],
+    ),
+    (
+        "age >= 30",
+        [
+            {"age": 32, "city": "San Francisco", "is_student": True},
+            {"age": 45, "city": "Los Angeles", "is_student": False},
+            {"age": 40, "city": "San Francisco", "is_student": True},
+        ],
+    ),
+    (
+        "age == 40",
+        [{"age": 40, "city": "San Francisco", "is_student": True}],
+    ),
+    (
+        "is_student != True",
+        [
+            {"age": 25, "city": "New York", "is_student": False},
+            {"age": 45, "city": "Los Angeles", "is_student": False},
+            {"age": 29, "city": "Los Angeles", "is_student": False},
+        ],
+    ),
+    (
+        "age < 0",
+        [],
+    ),
+    (
+        "is_student == True",
+        [
+            {"age": 32, "city": "San Francisco", "is_student": True},
+            {"age": 40, "city": "San Francisco", "is_student": True},
+        ],
+    ),
+    (
+        "is_student == False",
+        [
+            {"age": 25, "city": "New York", "is_student": False},
+            {"age": 45, "city": "Los Angeles", "is_student": False},
+            {"age": 29, "city": "Los Angeles", "is_student": False},
+        ],
+    ),
+    # Op 'in'
+    (
+        "city in ['Los Angeles', 'New York']",
+        [
+            {"age": 25, "city": "New York", "is_student": False},
+            {"age": 45, "city": "Los Angeles", "is_student": False},
+            {"age": 29, "city": "Los Angeles", "is_student": False},
+        ],
+    ),
+    (
+        "city in ['Los Angeles']",
+        [
+            {"age": 45, "city": "Los Angeles", "is_student": False},
+            {"age": 29, "city": "Los Angeles", "is_student": False},
+        ],
+    ),
+    (
+        "city in ['New York', 'San Francisco']",
+        [
+            {"age": 25, "city": "New York", "is_student": False},
+            {"age": 32, "city": "San Francisco", "is_student": True},
+            {"age": 40, "city": "San Francisco", "is_student": True},
+        ],
+    ),
+    (
+        "age in []",
+        [],
+    ),
+    (
+        "age in [25, 32, 45, 29, 40]",
+        [
+            {"age": 25, "city": "New York", "is_student": False},
+            {"age": 32, "city": "San Francisco", "is_student": True},
+            {"age": 45, "city": "Los Angeles", "is_student": False},
+            {"age": 29, "city": "Los Angeles", "is_student": False},
+            {"age": 40, "city": "San Francisco", "is_student": True},
+        ],
+    ),
+    (
+        "age in [25, 32, None]",
+        [
+            {"age": 25, "city": "New York", "is_student": False},
+            {"age": 32, "city": "San Francisco", "is_student": True},
+        ],
+    ),
+    # Op 'not in'
+    (
+        "is_student not in [None]",
+        [
+            {"age": 25, "city": "New York", "is_student": False},
+            {"age": 32, "city": "San Francisco", "is_student": True},
+            {"age": 45, "city": "Los Angeles", "is_student": False},
+            {"age": 29, "city": "Los Angeles", "is_student": False},
+            {"age": 40, "city": "San Francisco", "is_student": True},
+        ],
+    ),
+    (
+        "is_student not in [True, None]",
+        [
+            {"age": 25, "city": "New York", "is_student": False},
+            {"age": 45, "city": "Los Angeles", "is_student": False},
+            {"age": 29, "city": "Los Angeles", "is_student": False},
+        ],
+    ),
+    # Logical Ops 'and'
+    (
+        "age > 30 and is_student == True",
+        [
+            {"age": 32, "city": "San Francisco", "is_student": True},
+            {"age": 40, "city": "San Francisco", "is_student": True},
+        ],
+    ),
+    (
+        "city == 'Los Angeles' and age < 40",
+        [
+            {"age": 29, "city": "Los Angeles", "is_student": False},
+        ],
+    ),
+    (
+        "age < 40 and city in ['New York', 'Los Angeles']",
+        [
+            {"age": 25, "city": "New York", "is_student": False},
+            {"age": 29, "city": "Los Angeles", "is_student": False},
+        ],
+    ),
+    # Logical Ops 'or'
+    (
+        "age < 30 or is_student == True",
+        [
+            {"age": 25, "city": "New York", "is_student": False},
+            {"age": 32, "city": "San Francisco", "is_student": True},
+            {"age": 29, "city": "Los Angeles", "is_student": False},
+            {"age": 40, "city": "San Francisco", "is_student": True},
+        ],
+    ),
+    (
+        "city == 'New York' or city == 'San Francisco'",
+        [
+            {"age": 25, "city": "New York", "is_student": False},
+            {"age": 32, "city": "San Francisco", "is_student": True},
+            {"age": 40, "city": "San Francisco", "is_student": True},
+        ],
+    ),
+    (
+        "age < 30 or age > 40",
+        [
+            {"age": 25, "city": "New York", "is_student": False},
+            {"age": 45, "city": "Los Angeles", "is_student": False},
+            {"age": 29, "city": "Los Angeles", "is_student": False},
+        ],
+    ),
+    # Logical Ops combination 'and' and 'or'
+    (
+        "(age < 30 or age > 40) and is_student != True",
+        [
+            {"age": 25, "city": "New York", "is_student": False},
+            {"age": 45, "city": "Los Angeles", "is_student": False},
+            {"age": 29, "city": "Los Angeles", "is_student": False},
+        ],
+    ),
+    # Op 'is_null'
+    (
+        "is_null(is_student)",
+        [
+            {"age": None, "city": "San Jose", "is_student": None},
+        ],
+    ),
+    (
+        "age < 40 or is_null(is_student)",
+        [
+            {"age": 25, "city": "New York", "is_student": False},
+            {"age": 32, "city": "San Francisco", "is_student": True},
+            {"age": 29, "city": "Los Angeles", "is_student": False},
+            {"age": None, "city": "San Jose", "is_student": None},
+        ],
+    ),
+    # Op 'is_nan'
+    (
+        "is_nan(age)",
+        [
+            {"age": None, "city": "San Jose", "is_student": None},
+        ],
+    ),
+    (
+        "city in ['San Jose', 'Los Angeles'] and is_nan(age)",
+        [
+            {"age": None, "city": "San Jose", "is_student": None},
+        ],
+    ),
+    # Op 'is_valid'
+    (
+        "is_valid(is_student)",
+        [
+            {"age": 25, "city": "New York", "is_student": False},
+            {"age": 32, "city": "San Francisco", "is_student": True},
+            {"age": 45, "city": "Los Angeles", "is_student": False},
+            {"age": 29, "city": "Los Angeles", "is_student": False},
+            {"age": 40, "city": "San Francisco", "is_student": True},
+        ],
+    ),
+    (
+        "is_valid(is_student) and is_valid(age)",
+        [
+            {"age": 25, "city": "New York", "is_student": False},
+            {"age": 32, "city": "San Francisco", "is_student": True},
+            {"age": 45, "city": "Los Angeles", "is_student": False},
+            {"age": 29, "city": "Los Angeles", "is_student": False},
+            {"age": 40, "city": "San Francisco", "is_student": True},
+        ],
+    ),
+]
+
+
+@pytest.mark.parametrize("expression, expected_data", expressions_and_expected_data)
+def test_filter(sample_data, expression, expected_data):
+    """Test the filter functionality of the ExpressionEvaluator."""
+    # Instantiate the ExpressionEvaluator with valid column names
+    evaluator = ExpressionEvaluator()
+
+    filters = evaluator.get_filters(expression)
+
+    # Read the table from the Parquet file with the applied filters
+    filtered_table = pq.read_table(sample_data, filters=filters)
+
+    # Convert the filtered table back to a list of dictionaries for comparison
+    result = filtered_table.to_pandas().to_dict(orient="records")
+
+    def convert_nan_to_none(data):
+        return [
+            {k: (None if pd.isna(v) else v) for k, v in record.items()}
+            for record in data
+        ]
+
+    # Convert NaN to None for comparison
+    result_converted = convert_nan_to_none(result)
+
+    assert result_converted == expected_data
+
+
+def test_filter_bad_expression(sample_data):
+    evaluator = ExpressionEvaluator()
+    with pytest.raises(ValueError, match="Invalid syntax in the expression"):
+        evaluator.get_filters("bad filter")
+
+    filters = evaluator.get_filters("hi > 3")
+
+    with pytest.raises(pa.ArrowInvalid):
+        pq.read_table(sample_data, filters=filters)

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -436,6 +436,113 @@ def test_rename_columns(ray_start_regular_shared, names):
     assert renamed_ds.schema().names == ["foo", "bar"]
 
 
+def test_filter_mutex(ray_start_regular_shared, tmp_path):
+    """Test filter op."""
+
+    # Generate sample data
+    data = {
+        "sepal.length": [4.8, 5.1, 5.7, 6.3, 7.0],
+        "sepal.width": [3.0, 3.3, 3.5, 3.2, 2.8],
+        "petal.length": [1.4, 1.7, 4.2, 5.4, 6.1],
+        "petal.width": [0.2, 0.4, 1.5, 2.1, 2.4],
+    }
+    df = pd.DataFrame(data)
+
+    # Define the path for the Parquet file in the tmp_path directory
+    parquet_file = tmp_path / "sample_data.parquet"
+
+    # Write DataFrame to a Parquet file
+    table = pa.Table.from_pandas(df)
+    pq.write_table(table, parquet_file)
+
+    # Load parquet dataset
+    parquet_ds = ray.data.read_parquet(str(parquet_file))
+
+    # Filter using lambda (UDF)
+    with pytest.raises(ValueError, match="Exactly one of 'fn' or 'expr'"):
+        parquet_ds.filter(
+            fn=lambda r: r["sepal.length"] > 5.0, expr="sepal.length > 5.0"
+        )
+
+    with pytest.raises(ValueError, match="must be a UserDefinedFunction"):
+        parquet_ds.filter(fn="sepal.length > 5.0")
+
+
+def test_filter_with_expressions(ray_start_regular_shared, tmp_path):
+    """Test filtering with expressions."""
+
+    # Generate sample data
+    data = {
+        "sepal.length": [4.8, 5.1, 5.7, 6.3, 7.0],
+        "sepal.width": [3.0, 3.3, 3.5, 3.2, 2.8],
+        "petal.length": [1.4, 1.7, 4.2, 5.4, 6.1],
+        "petal.width": [0.2, 0.4, 1.5, 2.1, 2.4],
+    }
+    df = pd.DataFrame(data)
+
+    # Define the path for the Parquet file in the tmp_path directory
+    parquet_file = tmp_path / "sample_data.parquet"
+
+    # Write DataFrame to a Parquet file
+    table = pa.Table.from_pandas(df)
+    pq.write_table(table, parquet_file)
+
+    # Load parquet dataset
+    parquet_ds = ray.data.read_parquet(str(parquet_file))
+
+    # Filter using lambda (UDF)
+    filtered_udf_ds = parquet_ds.filter(lambda r: r["sepal.length"] > 5.0)
+    filtered_udf_data = filtered_udf_ds.to_pandas()
+
+    # Filter using expressions
+    filtered_expr_ds = parquet_ds.filter(expr="sepal.length > 5.0")
+    filtered_expr_data = filtered_expr_ds.to_pandas()
+
+    # Assert the filtered data is the same
+    assert set(filtered_udf_data["sepal.length"]) == set(
+        filtered_expr_data["sepal.length"]
+    )
+    assert len(filtered_udf_data) == len(filtered_expr_data)
+
+    # Verify correctness of filtered results: only rows with 'sepal.length' > 5.0
+    assert all(
+        filtered_expr_data["sepal.length"] > 5.0
+    ), "Filtered data contains rows with 'sepal.length' <= 5.0"
+    assert all(
+        filtered_udf_data["sepal.length"] > 5.0
+    ), "UDF-filtered data contains rows with 'sepal.length' <= 5.0"
+
+
+def test_filter_with_invalid_expression(ray_start_regular_shared, tmp_path):
+    """Test filtering with invalid expressions."""
+
+    # Generate sample data
+    data = {
+        "sepal.length": [4.8, 5.1, 5.7, 6.3, 7.0],
+        "sepal.width": [3.0, 3.3, 3.5, 3.2, 2.8],
+        "petal.length": [1.4, 1.7, 4.2, 5.4, 6.1],
+        "petal.width": [0.2, 0.4, 1.5, 2.1, 2.4],
+    }
+    df = pd.DataFrame(data)
+
+    # Define the path for the Parquet file in the tmp_path directory
+    parquet_file = tmp_path / "sample_data.parquet"
+
+    # Write DataFrame to a Parquet file
+    table = pa.Table.from_pandas(df)
+    pq.write_table(table, parquet_file)
+
+    # Load parquet dataset
+    parquet_ds = ray.data.read_parquet(str(parquet_file))
+
+    with pytest.raises(ValueError, match="Invalid syntax in the expression"):
+        parquet_ds.filter(expr="fake_news super fake")
+
+    fake_column_ds = parquet_ds.filter(expr="sepal_length_123 > 1")
+    with pytest.raises(UserCodeException):
+        fake_column_ds.to_pandas()
+
+
 def test_drop_columns(ray_start_regular_shared, tmp_path):
     df = pd.DataFrame({"col1": [1, 2, 3], "col2": [2, 3, 4], "col3": [3, 4, 5]})
     ds1 = ray.data.from_pandas(df)


### PR DESCRIPTION
## Why are these changes needed?

Optimizes filtering in Ray Data, and introduces a new expression-based syntax for filtering.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
