### PR TITLE
Suppress unused function warning for 3rd party libraries

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -49,8 +49,8 @@ build:clang-cl --per_file_copt="-\\.(asm|S)$@-Werror"
 build:msvc-cl     --per_file_copt="-\\.(asm|S)$@-WX"
 # Ignore warnings for protobuf generated files and external projects.
 build --per_file_copt="\\.pb\\.cc$@-w"
-build:linux --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration"
-build:macos --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration"
+build:linux --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration,-Wno-error=unused-function"
+build:macos --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration,-Wno-error=unused-function"
 # Ignore warnings for host tools, which we generally can't control.
 # Ideally we only want to ignore warnings for external project
 # but the current bazel version doesn't support host_per_file_copt yet.


### PR DESCRIPTION
Getting some annoying compilation warnings from 3rd libraries, which I don't have any access except patch.
Example:
```
external/utf8_range/utf8_validity.cc:139:12: warning: unused function 'CodepointSkipBackwards' [-Wunused-function]
inline int CodepointSkipBackwards(int32_t codepoint_word) {
           ^
1 warning generated.
```