### PR TITLE
[train][lightgbm] Rewrite `get_network_params` implementation

### DIFF
--- a/python/ray/train/lightgbm/__init__.py
+++ b/python/ray/train/lightgbm/__init__.py
@@ -8,4 +8,5 @@ __all__ = [
     "LightGBMCheckpoint",
     "LightGBMPredictor",
     "LightGBMTrainer",
+    "get_network_params",
 ]

--- a/python/ray/train/lightgbm/__init__.py
+++ b/python/ray/train/lightgbm/__init__.py
@@ -8,5 +8,4 @@ __all__ = [
     "LightGBMCheckpoint",
     "LightGBMPredictor",
     "LightGBMTrainer",
-    "get_network_params",
 ]

--- a/python/ray/train/lightgbm/config.py
+++ b/python/ray/train/lightgbm/config.py
@@ -1,6 +1,6 @@
-from dataclasses import dataclass
 import logging
 import threading
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 import ray
@@ -45,9 +45,9 @@ def _set_network_params(
 
     with _lightgbm_network_params_lock:
         assert (
-            network_params is None
+            _lightgbm_network_params is None
         ), "LightGBM network params are already initialized."
-        network_params = dict(
+        _lightgbm_network_params = dict(
             num_machines=num_machines,
             local_listen_port=local_listen_port,
             machines=machines,

--- a/python/ray/train/lightgbm/config.py
+++ b/python/ray/train/lightgbm/config.py
@@ -23,13 +23,14 @@ def get_network_params() -> Dict[str, Any]:
     with _lightgbm_network_params_lock:
         if not _lightgbm_network_params:
             logger.warning(
-                "`ray.train.lightgbm.get_network_params` was called outside the context "
-                "of a `ray.train.lightgbm.LightGBMTrainer`. "
-                "The current process has no knowledge of the distributed training group, "
-                "so returning an empty dict. Please call this within the training loop "
-                "of a `ray.train.lightgbm.LightGBMTrainer`. "
-                "If you are actually calling this within a `LightGBMTrainer`, "
-                "this is unexpected -- please file a bug report to the Ray Team."
+                "`ray.train.lightgbm.get_network_params` was called outside "
+                "the context of a `ray.train.lightgbm.LightGBMTrainer`. "
+                "The current process has no knowledge of the distributed training "
+                "worker group, so this method will return an empty dict. "
+                "Please call this within the training loop of a "
+                "`ray.train.lightgbm.LightGBMTrainer`. "
+                "If you are in fact calling this within a `LightGBMTrainer`, "
+                "this is unexpected: please file a bug report to the Ray Team."
             )
             return {}
 

--- a/python/ray/train/lightgbm/v2.py
+++ b/python/ray/train/lightgbm/v2.py
@@ -4,34 +4,10 @@ from typing import Any, Callable, Dict, Optional, Union
 import ray.train
 from ray.train import Checkpoint
 from ray.train.data_parallel_trainer import DataParallelTrainer
-from ray.train.lightgbm.config import NETWORK_PARAMS_KEY, LightGBMConfig
+from ray.train.lightgbm.config import LightGBMConfig, get_network_params
 from ray.train.trainer import GenDataset
 
 logger = logging.getLogger(__name__)
-
-
-def get_network_params() -> dict:
-    from ray.train._internal.session import get_session
-
-    session = get_session()
-    if not session:
-        logger.warning(
-            "`ray.train.lightgbm.get_network_params` was called outside the context "
-            "of a `ray.train.lightgbm.LightGBMTrainer`. "
-            "The current process has no knowledge of the distributed training group, "
-            "so returning an empty dict. Please call this within the training loop "
-            "of a `ray.train.lightgbm.LightGBMTrainer`."
-        )
-        return {}
-
-    network_params = session.get_state(NETWORK_PARAMS_KEY)
-    assert network_params is not None, (
-        f"`LightGBMConfig.backend_cls` must set '{NETWORK_PARAMS_KEY}' "
-        "in the session state in `on_training_start`. "
-        "Please fix this if you provided a custom `LightGBMConfig` subclass."
-        "Otherwise, please file a bug report to the Ray Team."
-    )
-    return network_params.copy()
 
 
 class LightGBMTrainer(DataParallelTrainer):

--- a/python/ray/train/lightgbm/v2.py
+++ b/python/ray/train/lightgbm/v2.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Dict, Optional, Union
 import ray.train
 from ray.train import Checkpoint
 from ray.train.data_parallel_trainer import DataParallelTrainer
-from ray.train.lightgbm.config import LightGBMConfig, get_network_params
+from ray.train.lightgbm.config import LightGBMConfig, get_network_params  # noqa: F401
 from ray.train.trainer import GenDataset
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Remove the dependence of the new LightGBM `get_network_params` API on the global `session` variable to make this module more self-contained.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
