### PR TITLE
[data] update codeowners to use a group instead

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -69,8 +69,8 @@
 # ==== Libraries and frameworks ====
 
 # Ray data.
-/python/ray/data/ @scottjlee @bveeramani @raulchen @stephanie-wang @omatthew98 @alexeykudinkin @srinathk10
-/doc/source/data/ @scottjlee @bveeramani @raulchen @stephanie-wang @omatthew98 @alexeykudinkin @srinathk10
+/python/ray/data/ @ray-project/ray-data
+/doc/source/data/ @ray-project/ray-data
 
 # Ray workflows.
 /python/ray/workflow/ @stephanie-wang


### PR DESCRIPTION
## Why are these changes needed?

use a github org group instead of listing all the github ids

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(