### PR TITLE
[core] Use ref hash to avoid key copy

### DIFF
--- a/src/ray/util/BUILD
+++ b/src/ray/util/BUILD
@@ -57,10 +57,16 @@ cc_library(
 )
 
 cc_library(
+    name = "map_utils",
+    hdrs = ["map_utils.h"],
+)
+
+cc_library(
     name = "shared_lru",
     hdrs = ["shared_lru.h"],
     visibility = ["//visibility:public"],
     deps = [
+        ":map_utils",
         ":util",
         "@com_google_absl//absl/container:flat_hash_map",
     ],

--- a/src/ray/util/map_utils.h
+++ b/src/ray/util/map_utils.h
@@ -1,0 +1,82 @@
+// Copyright 2024 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SharedLruCache is a LRU cache, with all entries shared, which means a single entry
+// could be accessed by multiple getters. All values are wrapped with shared pointer to
+// avoid copy at get operation, meanwhile also useful to maintain memory validity at any
+// time.
+//
+// This file provides utils for hash map related utils.
+
+#pragma once
+
+#include <functional>
+#include <utility>
+
+template <typename Hash>
+struct RefHash : Hash {
+  RefHash() = default;
+  template <typename H>
+  RefHash(H &&h) : Hash(std::forward<H>(h)) {}  // NOLINT
+
+  RefHash(const RefHash &) = default;
+  RefHash(RefHash &&) noexcept = default;
+  RefHash &operator=(const RefHash &) = default;
+  RefHash &operator=(RefHash &&) noexcept = default;
+
+  template <typename T>
+  size_t operator()(std::reference_wrapper<const T> val) const {
+    return Hash::operator()(val.get());
+  }
+  template <typename T>
+  size_t operator()(const T &val) const {
+    return Hash::operator()(val);
+  }
+};
+
+template <typename Hash>
+RefHash(Hash &&) -> RefHash<std::remove_reference_t<Hash>>;
+
+template <typename Equal>
+struct RefEq : Equal {
+  RefEq() = default;
+  template <typename Eq>
+  RefEq(Eq &&eq) : Equal(std::forward<Eq>(eq)) {}  // NOLINT
+
+  RefEq(const RefEq &) = default;
+  RefEq(RefEq &&) noexcept = default;
+  RefEq &operator=(const RefEq &) = default;
+  RefEq &operator=(RefEq &&) noexcept = default;
+
+  template <typename T1, typename T2>
+  bool operator()(std::reference_wrapper<const T1> lhs,
+                  std::reference_wrapper<const T2> rhs) const {
+    return Equal::operator()(lhs.get(), rhs.get());
+  }
+  template <typename T1, typename T2>
+  bool operator()(const T1 &lhs, std::reference_wrapper<const T2> rhs) const {
+    return Equal::operator()(lhs, rhs.get());
+  }
+  template <typename T1, typename T2>
+  bool operator()(std::reference_wrapper<const T1> lhs, const T2 &rhs) const {
+    return Equal::operator()(lhs.get(), rhs);
+  }
+  template <typename T1, typename T2>
+  bool operator()(const T1 &lhs, const T2 &rhs) const {
+    return Equal::operator()(lhs, rhs);
+  }
+};
+
+template <typename Equal>
+RefEq(Equal &&) -> RefEq<std::remove_reference_t<Equal>>;

--- a/src/ray/util/map_utils.h
+++ b/src/ray/util/map_utils.h
@@ -24,6 +24,8 @@
 #include <functional>
 #include <utility>
 
+namespace ray::utils::container {
+
 template <typename Hash>
 struct RefHash : Hash {
   RefHash() = default;
@@ -80,3 +82,5 @@ struct RefEq : Equal {
 
 template <typename Equal>
 RefEq(Equal &&) -> RefEq<std::remove_reference_t<Equal>>;
+
+}  // namespace ray::utils::container

--- a/src/ray/util/map_utils.h
+++ b/src/ray/util/map_utils.h
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// SharedLruCache is a LRU cache, with all entries shared, which means a single entry
-// could be accessed by multiple getters. All values are wrapped with shared pointer to
-// avoid copy at get operation, meanwhile also useful to maintain memory validity at any
-// time.
-//
 // This file provides utils for hash map related utils.
 
 #pragma once

--- a/src/ray/util/map_utils.h
+++ b/src/ray/util/map_utils.h
@@ -21,6 +21,7 @@
 
 namespace ray::utils::container {
 
+// A hash wrapper made for `std::reference_wrapper`.
 template <typename Hash>
 struct RefHash : Hash {
   RefHash() = default;
@@ -45,6 +46,7 @@ struct RefHash : Hash {
 template <typename Hash>
 RefHash(Hash &&) -> RefHash<std::remove_reference_t<Hash>>;
 
+// A hash equal wrapper made for `std::reference_wrapper`.
 template <typename Equal>
 struct RefEq : Equal {
   RefEq() = default;

--- a/src/ray/util/shared_lru.h
+++ b/src/ray/util/shared_lru.h
@@ -64,7 +64,7 @@ class SharedLruCache final {
   // the same key.
   void Put(Key key, std::shared_ptr<Val> value) {
     RAY_CHECK(value != nullptr);
-    auto iter = cache_.find(std::cref(key));
+    auto iter = cache_.find(key);
     if (iter != cache_.end()) {
       lru_list_.splice(lru_list_.begin(), lru_list_, iter->second.lru_iterator);
       iter->second.value = std::move(value);
@@ -89,7 +89,7 @@ class SharedLruCache final {
   // with key `key` existed after the call.
   template <typename KeyLike>
   bool Delete(KeyLike &&key) {
-    auto it = cache_.find(std::cref(key));
+    auto it = cache_.find(key);
     if (it == cache_.end()) {
       return false;
     }


### PR DESCRIPTION
For the current implementation, each key is stored twice in LRU cache, one in list, another in list.
But considering the invariant that, as long as the entry exists in LRU cache, the address of the key never changes (since we're using `std::list`), we could use our self-defined hash wrapper to store key reference in hash map instead of value.