### PR TITLE
[core][autoscaler] make logging level configurable

### DIFF
--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -222,6 +222,9 @@ LOGGER_FORMAT = "%(asctime)s\t%(levelname)s %(filename)s:%(lineno)s -- %(message
 LOGGER_FORMAT_ESCAPE = json.dumps(LOGGER_FORMAT.replace("%", "%%"))
 LOGGER_FORMAT_HELP = f"The logging format. default={LOGGER_FORMAT_ESCAPE}"
 # Configure the default logging levels for various Ray components.
+# TODO (kevin85421): Currently, I don't encourage Ray users to configure
+# `RAY_LOGGER_LEVEL` until its scope and expected behavior are clear and
+# easy to understand. Now, only Ray developers should use it.
 LOGGER_LEVEL = os.environ.get("RAY_LOGGER_LEVEL", "info")
 LOGGER_LEVEL_CHOICES = ["debug", "info", "warning", "error", "critical"]
 LOGGER_LEVEL_HELP = (

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -69,6 +69,9 @@ DEBUG_AUTOSCALING_STATUS_LEGACY = "__autoscaling_status_legacy"
 AUTOSCALER_V2_ENABLED_KEY = "__autoscaler_v2_enabled"
 AUTOSCALER_NAMESPACE = "__autoscaler"
 
+# Log level for the autoscaler.
+AUTOSCALER_LOG_LEVEL = os.environ.get("RAY_AUTOSCALER_LOG_LEVEL", "INFO")
+
 ID_SIZE = 28
 
 # The default maximum number of bytes to allocate to the object store unless

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -69,9 +69,6 @@ DEBUG_AUTOSCALING_STATUS_LEGACY = "__autoscaling_status_legacy"
 AUTOSCALER_V2_ENABLED_KEY = "__autoscaler_v2_enabled"
 AUTOSCALER_NAMESPACE = "__autoscaler"
 
-# Log level for the autoscaler.
-AUTOSCALER_LOG_LEVEL = os.environ.get("RAY_AUTOSCALER_LOG_LEVEL", "INFO")
-
 ID_SIZE = 28
 
 # The default maximum number of bytes to allocate to the object store unless
@@ -224,7 +221,8 @@ DISABLE_DASHBOARD_LOG_INFO = env_integer("RAY_DISABLE_DASHBOARD_LOG_INFO", 0)
 LOGGER_FORMAT = "%(asctime)s\t%(levelname)s %(filename)s:%(lineno)s -- %(message)s"
 LOGGER_FORMAT_ESCAPE = json.dumps(LOGGER_FORMAT.replace("%", "%%"))
 LOGGER_FORMAT_HELP = f"The logging format. default={LOGGER_FORMAT_ESCAPE}"
-LOGGER_LEVEL = "info"
+# Configure the default logging levels for various Ray components.
+LOGGER_LEVEL = os.environ.get("RAY_LOGGER_LEVEL", "info")
 LOGGER_LEVEL_CHOICES = ["debug", "info", "warning", "error", "critical"]
 LOGGER_LEVEL_HELP = (
     "The logging level threshold, choices=['debug', 'info',"

--- a/python/ray/autoscaler/_private/kuberay/run_autoscaler.py
+++ b/python/ray/autoscaler/_private/kuberay/run_autoscaler.py
@@ -96,11 +96,9 @@ def _setup_logging() -> None:
     # The director should already exist, but try (safely) to create it just in case.
     try_to_create_directory(log_dir)
 
-    logging_level = ray_constants.AUTOSCALER_LOG_LEVEL
-
     # Write logs at info level to monitor.log.
     setup_component_logger(
-        logging_level=logging_level,
+        logging_level=ray_constants.LOGGER_LEVEL,
         logging_format=ray_constants.LOGGER_FORMAT,
         log_dir=log_dir,
         filename=ray_constants.MONITOR_LOG_FILE_NAME,  # monitor.log
@@ -110,7 +108,7 @@ def _setup_logging() -> None:
 
     # For the autoscaler, the root logger _also_ needs to write to stderr, not just
     # ray_constants.MONITOR_LOG_FILE_NAME.
-    level = logging.getLevelName(logging_level.upper())
+    level = logging.getLevelName(ray_constants.LOGGER_LEVEL.upper())
     stderr_handler = logging._StderrHandler()
     stderr_handler.setFormatter(logging.Formatter(ray_constants.LOGGER_FORMAT))
     stderr_handler.setLevel(level)

--- a/python/ray/autoscaler/_private/kuberay/run_autoscaler.py
+++ b/python/ray/autoscaler/_private/kuberay/run_autoscaler.py
@@ -96,9 +96,11 @@ def _setup_logging() -> None:
     # The director should already exist, but try (safely) to create it just in case.
     try_to_create_directory(log_dir)
 
+    logging_level = ray_constants.AUTOSCALER_LOG_LEVEL
+
     # Write logs at info level to monitor.log.
     setup_component_logger(
-        logging_level=ray_constants.LOGGER_LEVEL,  # info
+        logging_level=logging_level,
         logging_format=ray_constants.LOGGER_FORMAT,
         log_dir=log_dir,
         filename=ray_constants.MONITOR_LOG_FILE_NAME,  # monitor.log
@@ -108,7 +110,7 @@ def _setup_logging() -> None:
 
     # For the autoscaler, the root logger _also_ needs to write to stderr, not just
     # ray_constants.MONITOR_LOG_FILE_NAME.
-    level = logging.getLevelName(ray_constants.LOGGER_LEVEL.upper())
+    level = logging.getLevelName(logging_level.upper())
     stderr_handler = logging._StderrHandler()
     stderr_handler.setFormatter(logging.Formatter(ray_constants.LOGGER_FORMAT))
     stderr_handler.setLevel(level)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There is no way to configure logging level for KubeRay Autoscaler. This PR makes it configurable.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

1. Deploy a RayCluster using https://gist.github.com/kevin85421/3d48b2c36d46b826cf4299677d8d75d8, which sets the autoscaler log level to `DEBUG`.

2. Check Autoscaler logs
  <img width="1409" alt="image" src="https://github.com/user-attachments/assets/c9029a30-8a3b-4795-b027-11b01dc68a6a">



- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
