### PR TITLE
[WIP][compiled graphs] Avoid extra data I/O if CPU data is static

### DIFF
--- a/python/ray/dag/tests/experimental/test_mocked_nccl_dag.py
+++ b/python/ray/dag/tests/experimental/test_mocked_nccl_dag.py
@@ -285,7 +285,9 @@ def test_p2p_direct_return_error(capsys, ray_start_cluster):
     # Test torch.Tensor sent between actors.
     with InputNode() as inp:
         dag = sender.send.bind(inp.shape, inp.dtype, inp.value, inp.send_as_dict)
-        dag = dag.with_type_hint(TorchTensorType(transport="nccl", _direct_return=True))
+        dag = dag.with_type_hint(
+            TorchTensorType(transport="nccl", _static_tensor_schema=True)
+        )
         dag = receiver.recv.bind(dag)
 
     compiled_dag = dag.experimental_compile()
@@ -313,8 +315,8 @@ def test_p2p_direct_return_error(capsys, ray_start_cluster):
     wait_for_condition(
         lambda: error_logged(
             capsys,
-            "Task annotated with _direct_return=True must "
-            "return a CUDA torch.Tensor",
+            "Expected CUDA torch.Tensor as direct return value for task "
+            "annotated with _static_tensor_schema=True",
         )
     )
 
@@ -352,7 +354,9 @@ def test_p2p_static_shape_and_direct_return(
     with InputNode() as inp:
         dag = sender.send.bind(inp.shape, inp.dtype, inp.value, inp.send_as_dict)
         dag = dag.with_type_hint(
-            TorchTensorType(transport="nccl", _static_shape=True, _direct_return=True)
+            TorchTensorType(
+                transport="nccl", _static_shape=True, _static_tensor_schema=True
+            )
         )
         dag = receiver.recv.bind(dag)
 
@@ -393,7 +397,8 @@ def test_p2p_static_shape_and_direct_return(
         )
     else:
         msg = (
-            "Task annotated with _direct_return=True must " "return a CUDA torch.Tensor"
+            "Expected CUDA torch.Tensor as direct return value for task "
+            "annotated with _static_tensor_schema=True"
         )
     wait_for_condition(lambda: error_logged(capsys, msg))
 

--- a/python/ray/dag/tests/experimental/test_mocked_nccl_dag.py
+++ b/python/ray/dag/tests/experimental/test_mocked_nccl_dag.py
@@ -226,9 +226,9 @@ def test_p2p_static_shape_error(capsys, ray_start_cluster, send_as_dict):
     ],
     indirect=True,
 )
-def test_p2p_direct_return(ray_start_cluster):
+def test_p2p_static_tensor_schema(ray_start_cluster):
     """
-    Test simple sender -> receiver pattern with _direct_return=True
+    Test simple sender -> receiver pattern with _static_tensor_schema=True
     """
     # Barrier name should be barrier-{lower rank}-{higher rank}.
     barrier = Barrier.options(name="barrier-0-1").remote()  # noqa
@@ -241,7 +241,9 @@ def test_p2p_direct_return(ray_start_cluster):
     # Test torch.Tensor sent between actors.
     with InputNode() as inp:
         dag = sender.send.bind(inp.shape, inp.dtype, inp.value, inp.send_as_dict)
-        dag = dag.with_type_hint(TorchTensorType(transport="nccl", _direct_return=True))
+        dag = dag.with_type_hint(
+            TorchTensorType(transport="nccl", _static_tensor_schema=True)
+        )
         dag = receiver.recv.bind(dag)
 
     compiled_dag = dag.experimental_compile()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This replaces the previous API:
```python
   with InputNode() as inp:
        dag = sender.send.bind(inp)
        dag = dag.with_type_hint(TorchTensorType(transport="nccl", _direct_return=True))
        dag = receiver.recv.bind(dag)
```

with a more general API:
```python
   with InputNode() as inp:
        dag = sender.send.bind(inp)
        dag = dag.with_type_hint(TorchTensorType(transport="nccl", _static_tensor_schema=True))
        dag = receiver.recv.bind(dag)
```

This type hint allows skipping sending CPU data in data structures that contain a mix of CPU and GPU data, if the user can ensure that the CPU data (the "tensor schema") is static. The new API supports this optimization for arbitrary data structures, instead of just tensors returned directly from a task.

Limitations:
- The tensor data can be nested as dictionary, list, tuple, or `__dict__` values. For example, tensor data stored as a dictionary key is not supported.
- The user is responsible for ensuring that they pass data using the same tensor schema. This PR will check that the same tensor "keys" are used, but doesn't check the rest of the CPU data.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
