### PR TITLE
[data] Fix performance degradation on iceberg data source when reading large iceberg table

### DIFF
--- a/python/ray/data/_internal/datasource/iceberg_datasource.py
+++ b/python/ray/data/_internal/datasource/iceberg_datasource.py
@@ -18,7 +18,9 @@ if TYPE_CHECKING:
     from pyiceberg.expressions import BooleanExpression
     from pyiceberg.io import FileIO
     from pyiceberg.manifest import DataFile, DataFileContent
-    from pyiceberg.table import DataScan, FileScanTask, Schema, Table, TableMetadata
+    from pyiceberg.schema import Schema
+    from pyiceberg.table import DataScan, FileScanTask, Table
+    from pyiceberg.table.metadata import TableMetadata
 
 logger = logging.getLogger(__name__)
 

--- a/python/ray/data/_internal/datasource/iceberg_datasource.py
+++ b/python/ray/data/_internal/datasource/iceberg_datasource.py
@@ -203,9 +203,11 @@ class IcebergDatasource(Datasource):
             )
 
         # Get required properties for reading tasks - table IO, table metadata,
-        # row filter, case sensitivity,limit and projected schema. pre-apply
-        # them to `_get_read_task` through partial to avoid `self` reference
-        # which causes perfromance degradation during serialization
+        # row filter, case sensitivity,limit and projected schema to pass
+        # them directly to `_get_read_task` to avoid capture of `self` reference
+        # within the closure carrying substantial overhead invoking these tasks
+        #
+        # See https://github.com/ray-project/ray/issues/49107 for more context
         table_io = self.table.io
         table_metadata = self.table.metadata
         row_filter = self._row_filter

--- a/python/ray/data/_internal/datasource/iceberg_datasource.py
+++ b/python/ray/data/_internal/datasource/iceberg_datasource.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from pyiceberg.expressions import BooleanExpression
     from pyiceberg.io import FileIO
     from pyiceberg.manifest import DataFile, DataFileContent
-    from pyiceberg.table import DataScan, FileScanTask, Schema, TableMetadata, Table
+    from pyiceberg.table import DataScan, FileScanTask, Schema, Table, TableMetadata
 
 logger = logging.getLogger(__name__)
 

--- a/python/ray/data/_internal/datasource/iceberg_datasource.py
+++ b/python/ray/data/_internal/datasource/iceberg_datasource.py
@@ -202,6 +202,8 @@ class IcebergDatasource(Datasource):
                 "number of files"
             )
 
+        # Get required properties for reading tasks - table IO, table metadata, row filter, case sensitivity, limit and projected schema
+        # pre-apply them to `_get_read_task` through partial to avoid `self` reference which causes perfromance degradation during serialization
         table_io = self.table.io
         table_metadata = self.table.metadata
         row_filter = self._row_filter

--- a/python/ray/data/_internal/datasource/iceberg_datasource.py
+++ b/python/ray/data/_internal/datasource/iceberg_datasource.py
@@ -5,6 +5,7 @@ Module to read an iceberg table into a Ray Dataset, by using the Ray Datasource 
 import heapq
 import itertools
 import logging
+from functools import partial
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 from ray.data._internal.util import _check_import
@@ -15,10 +16,37 @@ from ray.util.annotations import DeveloperAPI
 if TYPE_CHECKING:
     from pyiceberg.catalog import Catalog
     from pyiceberg.expressions import BooleanExpression
+    from pyiceberg.io import FileIO
     from pyiceberg.manifest import DataFile, DataFileContent
-    from pyiceberg.table import DataScan, FileScanTask, Schema
+    from pyiceberg.table import DataScan, FileScanTask, Schema, TableMetadata, Table
 
 logger = logging.getLogger(__name__)
+
+
+def _get_read_task(
+    tasks: Iterable["FileScanTask"],
+    table_io: FileIO,
+    table_metadata: TableMetadata,
+    row_filter: BooleanExpression,
+    case_sensitive: bool,
+    limit: Optional[int],
+    schema: "Schema",
+) -> Iterable[Block]:
+    from pyiceberg.io import pyarrow as pyi_pa_io
+
+    # Use the PyIceberg API to read only a single task (specifically, a
+    # FileScanTask) - note that this is not as simple as reading a single
+    # parquet file, as there might be delete files, etc. associated, so we
+    # must use the PyIceberg API for the projection.
+    yield pyi_pa_io.project_table(
+        tasks=tasks,
+        table_metadata=table_metadata,
+        io=table_io,
+        row_filter=row_filter,
+        projected_schema=schema,
+        case_sensitive=case_sensitive,
+        limit=limit,
+    )
 
 
 @DeveloperAPI
@@ -74,6 +102,10 @@ class IcebergDatasource(Datasource):
             self._scan_kwargs["snapshot_id"] = snapshot_id
 
         self._plan_files = None
+
+    def _get_table_from_catalog(self) -> Table:
+        catalog = self._get_catalog()
+        return catalog.load_table(self.table_identifier)
 
     def _get_catalog(self) -> "Catalog":
         from pyiceberg import catalog
@@ -143,33 +175,6 @@ class IcebergDatasource(Datasource):
     def get_read_tasks(self, parallelism: int) -> List[ReadTask]:
         from pyiceberg.io import pyarrow as pyi_pa_io
 
-        def _get_read_task(
-            tasks: Iterable["FileScanTask"],
-            table_identifier: str,
-            schema: "Schema",
-        ) -> Iterable[Block]:
-            # Closure so we can pass this callable as an argument to ReadTask
-
-            # Both the catalog and tbl attributes cannot be pickled, which means they
-            # must be instantiated within this function (as opposed to being attributes
-            # of the IcebergDatasource class)
-            catalog = self._get_catalog()
-            tbl = catalog.load_table(table_identifier)
-
-            # Use the PyIceberg API to read only a single task (specifically, a
-            # FileScanTask) - note that this is not as simple as reading a single
-            # parquet file, as there might be delete files, etc. associated, so we
-            # must use the PyIceberg API for the projection.
-            yield pyi_pa_io.project_table(
-                tasks=tasks,
-                table_metadata=tbl.metadata,
-                io=tbl.io,
-                row_filter=self._row_filter,
-                projected_schema=schema,
-                case_sensitive=self._scan_kwargs.get("case_sensitive", True),
-                limit=self._scan_kwargs.get("limit"),
-            )
-
         # Get the PyIceberg scan
         data_scan = self._get_data_scan()
         # Get the plan files in this query
@@ -189,6 +194,23 @@ class IcebergDatasource(Datasource):
                 f"Reducing the parallelism to {parallelism}, as that is the"
                 "number of files"
             )
+
+        table = self._get_table_from_catalog()
+        table_io = table.io
+        table_metadata = table.metadata
+        row_filter = self._row_filter
+        case_sensitive = self._scan_kwargs.get("case_sensitive", True)
+        limit = self._scan_kwargs.get("limit")
+
+        get_read_task = partial(
+            _get_read_task,
+            table_io=table_io,
+            table_metadata=table_metadata,
+            row_filter=row_filter,
+            case_sensitive=case_sensitive,
+            limit=limit,
+            schema=projected_schema,
+        )
 
         read_tasks = []
         # Chunk the plan files based on the requested parallelism
@@ -218,11 +240,7 @@ class IcebergDatasource(Datasource):
             )
             read_tasks.append(
                 ReadTask(
-                    read_fn=lambda tasks=chunk_tasks: _get_read_task(
-                        tasks=tasks,
-                        table_identifier=self.table_identifier,
-                        schema=projected_schema,
-                    ),
+                    read_fn=lambda tasks=chunk_tasks: get_read_task(tasks),
                     metadata=metadata,
                 )
             )

--- a/python/ray/data/_internal/datasource/iceberg_datasource.py
+++ b/python/ray/data/_internal/datasource/iceberg_datasource.py
@@ -25,9 +25,9 @@ logger = logging.getLogger(__name__)
 
 def _get_read_task(
     tasks: Iterable["FileScanTask"],
-    table_io: FileIO,
-    table_metadata: TableMetadata,
-    row_filter: BooleanExpression,
+    table_io: "FileIO",
+    table_metadata: "TableMetadata",
+    row_filter: "BooleanExpression",
     case_sensitive: bool,
     limit: Optional[int],
     schema: "Schema",
@@ -103,7 +103,7 @@ class IcebergDatasource(Datasource):
 
         self._plan_files = None
 
-    def _get_table_from_catalog(self) -> Table:
+    def _get_table_from_catalog(self) -> "Table":
         catalog = self._get_catalog()
         return catalog.load_table(self.table_identifier)
 

--- a/python/ray/data/_internal/datasource/iceberg_datasource.py
+++ b/python/ray/data/_internal/datasource/iceberg_datasource.py
@@ -202,8 +202,10 @@ class IcebergDatasource(Datasource):
                 "number of files"
             )
 
-        # Get required properties for reading tasks - table IO, table metadata, row filter, case sensitivity, limit and projected schema
-        # pre-apply them to `_get_read_task` through partial to avoid `self` reference which causes perfromance degradation during serialization
+        # Get required properties for reading tasks - table IO, table metadata,
+        # row filter, case sensitivity,limit and projected schema. pre-apply
+        # them to `_get_read_task` through partial to avoid `self` reference
+        # which causes perfromance degradation during serialization
         table_io = self.table.io
         table_metadata = self.table.metadata
         row_filter = self._row_filter


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When reading a large iceberg table the `iceberg data source` hangs after creating the `read tasks`. The relevant log related to this issue from the console shown below. The threshold for the read function is 1MB and the actual function pickled shouldn't be bigger than a couple of KBs.

```
The serialized size of your read function named '<lambda>' is 6.3MB. This size relatively large. As a result, Ray might excessively spill objects during execution. To fix this issue, avoid accessing `self` or other large objects in '<lambda>'.
```

<!-- Please give a short summary of the change and the problem this solves. -->
This PR tries two issues
- The issue where the `_get_read_task` reference `self`, and cause the lambda function to be large in size when pickling/spilling to disk. This in term cause the iceberg data source to be extremely slow when reading large tables. The PR removes all the `self` reference in the `_get_read_task` function 

- The issue where `_get_read_task` lambda function excessively hit the metastore (on every task read) because `Table` is not pickle-able. While `Catalog` and `Table` are not pickle-able . The task reader doesn't need neither of the properties. It need `FileIO` and `TableMetadata` instead, which both happens to be pickle-able, so we are passing them explicitly to the function.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
