### PR TITLE
[release/doc] Update Dask version in doc for Ray 2.40.0

### DIFF
--- a/doc/source/ray-more-libs/dask-on-ray.rst
+++ b/doc/source/ray-more-libs/dask-on-ray.rst
@@ -31,7 +31,10 @@ workload. Using the Dask-on-Ray scheduler, the entire Dask ecosystem can be exec
 
      * - Ray Version
        - Dask Version
-     * - ``2.34.0`` or above
+     * - ``2.40.0`` or above
+       - | ``2022.10.2 (Python version < 3.12)``
+         | ``2024.6.0 (Python version >= 3.12)``
+     * - ``2.34.0`` to ``2.39.0``
        - | ``2022.10.1 (Python version < 3.12)``
          | ``2024.6.0 (Python version >= 3.12)``
      * - ``2.8.0`` to ``2.33.x``


### PR DESCRIPTION
Change doc to update that Dask is upgrade to `2022.10.2` for Python version < 3.12 on Ray 2.40.0