### PR TITLE
[core][autoscaler] record v2 usage

### DIFF
--- a/python/ray/autoscaler/v2/monitor.py
+++ b/python/ray/autoscaler/v2/monitor.py
@@ -66,6 +66,9 @@ class AutoscalerMonitor:
         log_dir: Optional[str] = None,
         monitor_ip: Optional[str] = None,
     ):
+        # Record v2 usage (we do this as early as possible to capture usage)
+        record_autoscaler_v2_usage(GcsClient(address))
+
         self.gcs_address = address
         worker = ray._private.worker.global_worker
         # TODO: eventually plumb ClusterID through to here
@@ -279,9 +282,6 @@ if __name__ == "__main__":
     gcs_address = args.gcs_address
     if gcs_address is None:
         raise ValueError("--gcs-address must be set!")
-
-    # Record v2 usage (we do this as early as possible to capture usage)
-    record_autoscaler_v2_usage(GcsClient(gcs_address))
 
     if not args.autoscaling_config:
         logger.info("No autoscaling config provided: use read only node provider.")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, `record_autoscaler_v2_usage` is not in the code path of the KubeRay Autoscaler. Move the function to the constructor of `AutoscalerMonitor` so that it is part of the common path for the KubeRay Autoscaler and other node providers.



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
