### PR TITLE
[Docs] Add user guide for configuring authentication for Ray clusters

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides.md
+++ b/doc/source/cluster/kubernetes/user-guides.md
@@ -27,6 +27,7 @@ user-guides/tls
 user-guides/k8s-autoscaler
 user-guides/static-ray-cluster-without-kuberay
 user-guides/kubectl-plugin
+user-guides/kuberay-auth
 ```
 
 
@@ -57,3 +58,4 @@ at the {ref}`introductory guide <kuberay-quickstart>` first.
 * {ref}`ray-k8s-autoscaler-comparison`
 * {ref}`deploy-a-static-ray-cluster-without-kuberay`
 * {ref}`kubectl-plugin`
+* {ref}`kuberay-auth`

--- a/doc/source/cluster/kubernetes/user-guides/kuberay-auth.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-auth.md
@@ -1,6 +1,6 @@
 (kuberay-auth)=
 
-# Configure Ray Clusters with Authentication and Access Control using KubeRay
+# Configure Ray clusters with authentication and access control using KubeRay
 
 This guide demonstrates how to secure Ray clusters deployed with KubeRay by enabling authentication and access control using Kubernetes Role-Based Access Control (RBAC). 
 
@@ -8,15 +8,15 @@ This guide demonstrates how to secure Ray clusters deployed with KubeRay by enab
 
 ## Prerequisites
 
-* A Kubernetes cluster (this guide uses GKE, but the concepts apply to other Kubernetes distributions).
+* A Kubernetes cluster. This guide uses GKE, but the concepts apply to other Kubernetes distributions.
 * `kubectl` installed and configured to interact with your cluster.
-* `gcloud` CLI installed and configured (if using GKE).
+* `gcloud` CLI installed and configured, if using GKE.
 * [Helm](https://helm.sh/) installed.
 * Ray installed locally.
 
-## Create a GKE Cluster (or use an existing cluster)
+## Create or use an existing GKE Cluster
 
-If you don't have a Kubernetes cluster, create one using the following command (or adapt it for your cloud provider):
+If you don't have a Kubernetes cluster, create one using the following command, or adapt it for your cloud provider:
 
 ```bash
 gcloud container clusters create kuberay-cluster \
@@ -27,7 +27,7 @@ gcloud container clusters create kuberay-cluster \
 
 Follow [Deploy a KubeRay operator](kuberay-operator-deploy) to install the latest stable KubeRay operator from the Helm repository.
 
-## Deploy a Ray Cluster with Authentication Enabled
+## Deploy a Ray cluster with authentication enabled
 
 Deploy a RayCluster configured with `kube-rbac-proxy` for authentication and authorization:
 
@@ -40,7 +40,7 @@ This command deploys:
 * A `ConfigMap` for kube-rbac-proxy, containing resource attributes required for authorization.
 * A `ServiceAccount`, `ClusterRole`, and `ClusterRoleBinding` that allow the `kube-rbac-proxy` to access the Kubernetes TokenReview and SubjectAccessReview APIs.
 
-## Verify Initial Unauthorized Access
+## Verify initial unauthorized access
 
 Attempt to submit a Ray job to the cluster to verify that authentication is required. You should receive a `401 Unauthorized` error:
 
@@ -49,16 +49,16 @@ kubectl port-forward svc/ray-cluster-with-auth-head-svc 8265:8265 &
 ray job submit --address http://localhost:8265  -- python -c "import ray; ray.init(); print(ray.cluster_resources())"
 ```
 
-You'll see an error similar to this:
+You may see an error similar to this:
 
 ```
 ...
 requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: http://localhost:8265/api/version
 ```
 
-This confirms that the Ray cluster requires authentication.
+This error confirms that the Ray cluster requires authentication.
 
-## Configure Kubernetes RBAC for Access Control
+## Configure Kubernetes RBAC for access control
 
 To access the RayCluster, you need:
 *  **Authentication:** Provide a valid authentication token (e.g., a Kubernetes service account token or a cloud IAM token) in the request headers.
@@ -66,15 +66,15 @@ To access the RayCluster, you need:
 
 This guide demonstrates granting access using a Kubernetes service account, but the same principles apply to individual Kubernetes users or cloud IAM users.
 
-### Create a Kubernetes Service Account
+### Create a Kubernetes service account
 
-Create a service account that will represent your Ray job submitter:
+Create a service account that represents your Ray job submitter:
 
 ```bash
 kubectl create serviceaccount ray-user
 ```
 
-Confirm that the service account currently cannot access the `RayCluster` resource:
+Confirm that the service account currently can't access the `RayCluster` resource:
 
 ```bash
 kubectl auth can-i get rayclusters.ray.io/ray-cluster-with-auth --as=system:serviceaccount:default:ray-user
@@ -82,7 +82,7 @@ kubectl auth can-i get rayclusters.ray.io/ray-cluster-with-auth --as=system:serv
 
 The output should be `no`.
 
-### Grant Access using Kubernetes RBAC
+### Grant access using Kubernetes RBAC
 
 Create a `Role` and `RoleBinding` to grant the necessary permissions to the `ray-user` service account:
 
@@ -121,7 +121,7 @@ Apply the RBAC configuration:
 kubectl apply -f ray-cluster-rbac.yaml
 ```
 
-### Verify Access
+### Verify access
 
 Confirm that the service account now has access to the `RayCluster` resource:
 
@@ -131,7 +131,7 @@ kubectl auth can-i get rayclusters.ray.io/ray-cluster-with-auth --as=system:serv
 
 The output should be `yes`.
 
-## Submit a Ray Job with Authentication
+## Submit a Ray job with authentication
 
 Now you can submit a Ray job using the service account's authentication token.
 
@@ -149,7 +149,7 @@ Submit the Ray job:
 ray job submit --address http://localhost:8265  -- python -c "import ray; ray.init(); print(ray.cluster_resources())"
 ```
 
-The job should now succeed, and you'll see output similar to this:
+The job should now succeed, and you should see output similar to this:
 
 ```bash
 Job submission server address: http://localhost:8265
@@ -176,9 +176,9 @@ Job 'raysubmit_...' succeeded
 ------------------------------------------
 ```
 
-## Verify Access Using Cloud IAM (Optional)
+## Verify access using cloud IAM (Optional)
 
-Most cloud providers allow you to authenticate to your Kubernetes cluster as your cloud IAM user. This is a convenient way to interact with the cluster without managing separate Kubernetes credentials.
+Most cloud providers allow you to authenticate to the Kubernetes cluster as your cloud IAM user. This method is a convenient way to interact with the cluster without managing separate Kubernetes credentials.
 
 **Example using Google Cloud (GKE):**
 
@@ -194,7 +194,7 @@ Submit a Ray job using the IAM token:
 ray job submit --address http://localhost:8265  -- python -c "import ray; ray.init(); print(ray.cluster_resources())"
 ```
 
-The job should succeed if your cloud user has the necessary Kubernetes RBAC permissions (you may need to configure additional RBAC rules for your cloud user).
+The job should succeed if your cloud user has the necessary Kubernetes RBAC permissions. You may need to configure additional RBAC rules for your cloud user.
 
 ## View the Ray dashboard (optional)
 

--- a/doc/source/cluster/kubernetes/user-guides/kuberay-auth.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-auth.md
@@ -1,0 +1,171 @@
+(kuberay-auth)=
+
+# Configure Ray cluster authentication and access control using Kubernetes RBAC
+
+This guide demonstrates how to configure authentication and access control for Ray clusters using KubeRay and Kubernetes RBAC.
+
+## Create a GKE cluster
+
+Create a GKE cluster
+```
+gcloud container clusters create kuberay-cluster \
+    --num-nodes=2 --zone=us-west1-b --machine-type e2-standard-4
+```
+
+## Install the KubeRay operator
+
+Follow [Deploy a KubeRay operator](kuberay-operator-deploy) to install the latest stable KubeRay operator from the Helm repository.
+
+## Deploy a RayCluster with kube-rbac-proxy
+
+Create a RayCluster resource running a kube-rbac-proxy sidecar container:
+```
+kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/refs/heads/master/ray-operator/config/samples/ray-cluster.auth.yaml
+``` 
+
+This step deploys the following:
+1. A RayCluster resource running a kube-rbac-proxy sidecar container for authentication/authorization on the Head Pod.
+2. A kube-rbac-proxy ConfigMap containing resource attributes required for authorization
+3. A ServiceAccount, ClusterRole and ClusterRoleBinding used by kube-rbac-proxy to access the TokenReview and SubjectAcceessReview APIs
+
+## Verify 401 unauthorized error when accessing Ray cluster
+
+Submit a Ray job and verify that 401 unauthorized error is returned
+```
+$ kubectl port-forward svc/ray-cluster-with-auth-head-svc 8265:8265 &
+$ ray job submit --address http://localhost:8265  -- python -c "import ray; ray.init(); print(ray.cluster_resources())"
+...
+...
+requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: http://localhost:8265/api/version
+```
+
+## Configure Kubernetes RBAC for access control
+
+The following is required in order to access the RayCluster:
+* **Authentication**: you must provide an authentication token (via headers) to authenticate your Kubernetes user  
+* **Authorization**: your user must be authorized (via Kubernetes RBAC) to access the RayCluster resource
+
+In most Kubernetes offerings, you can authenticate to your Kubernetes cluster using your cloud user and authorization is granted by an admin
+who can modify Kubernetes RBAC rules. This guide will use a Kubernetes service account to demonstrate how to grant access to an unauthorized
+subject. The same steps can be applied to grant access to Kubernetes users.  
+
+Create a Kubernetes service account:
+```
+$ kubectl create serviceaccount ray-user
+serviceaccount/ray-user created
+```
+
+Verify that the service account cannot access RayCluster resources:
+```bash
+$ kubectl auth can-i get rayclusters.ray.io/ray-cluster-with-auth --as=system:serviceaccount:default:ray-user
+no
+```
+
+Grant the ServiceAccount access to the RayCluster resource used in this guide:
+```yaml
+# ray-cluster-rbac.yaml
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ray-user
+  namespace: default
+rules:
+- apiGroups: ["ray.io"]
+  resources:
+  - 'rayclusters'
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1  
+kind: RoleBinding
+metadata:
+  name: ray-user
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ray-user
+subjects:
+- kind: ServiceAccount
+  name: ray-user
+  namespace: default
+```
+
+Verify that the service account can access RayCluster resources
+```bash
+$ kubectl auth can-i get rayclusters.ray.io/ray-cluster-with-auth --as=system:serviceaccount:default:ray-user
+yes
+```
+
+## Submit a job
+
+Set the `RAY_JOB_HEADERS` environment variable containing a token from the Kubernetes service account:
+```bash
+$ export RAY_JOB_HEADERS="{\"Authorization\": \"Bearer $(kubectl create token ray-user)\"}"
+```
+
+Submit a Ray job:
+```bash
+$ ray job submit --address http://localhost:8265  -- python -c "import ray; ray.init(); print(ray.cluster_resources())"
+Job submission server address: http://localhost:8265
+
+-------------------------------------------------------
+Job 'raysubmit_n2fq2Ui7cbh3p2Js' submitted successfully
+-------------------------------------------------------
+
+Next steps
+  Query the logs of the job:
+    ray job logs raysubmit_n2fq2Ui7cbh3p2Js
+  Query the status of the job:
+    ray job status raysubmit_n2fq2Ui7cbh3p2Js
+  Request the job to be stopped:
+    ray job stop raysubmit_n2fq2Ui7cbh3p2Js
+
+Tailing logs until the job exits (disable with --no-wait):
+
+2024-12-04 12:21:02,613	INFO job_manager.py:530 -- Runtime env is setting up.
+2024-12-04 12:21:04,182	INFO worker.py:1494 -- Using address 10.112.0.52:6379 set in the environment variable RAY_ADDRESS
+2024-12-04 12:21:04,183	INFO worker.py:1634 -- Connecting to existing Ray cluster at address: 10.112.0.52:6379...
+2024-12-04 12:21:04,198	INFO worker.py:1810 -- Connected to Ray cluster. View the dashboard at 127.0.0.1:8443
+{'node:10.112.0.52': 1.0, 'memory': 12884901888.0, 'node:__internal_head__': 1.0, 'object_store_memory': 3708144844.0, 'CPU': 4.0, 'node:10.112.1.49': 1.0, 'node:10.112.2.36': 1.0}
+
+------------------------------------------
+Job 'raysubmit_n2fq2Ui7cbh3p2Js' succeeded
+------------------------------------------
+```
+
+## Verify access using cloud IAM (optional)
+
+Most cloud providers support authenticating to your Kubernetes cluster as your cloud IAM user. For example, on GKE you can authenticate as your Google Cloud user using `gcloud auth print-access-token`:
+```bash
+$ export RAY_JOB_HEADERS="{\"Authorization\": \"Bearer $(gcloud auth print-access-token)\"}"
+```
+
+Submit a Ray job:
+```bash
+$ ray job submit --address http://localhost:8265  -- python -c "import ray; ray.init(); print(ray.cluster_resources())"
+Job submission server address: http://localhost:8265
+
+-------------------------------------------------------
+Job 'raysubmit_L8D1bBiTP9CYsA5P' submitted successfully
+-------------------------------------------------------
+
+Next steps
+  Query the logs of the job:
+    ray job logs raysubmit_L8D1bBiTP9CYsA5P
+  Query the status of the job:
+    ray job status raysubmit_L8D1bBiTP9CYsA5P
+  Request the job to be stopped:
+    ray job stop raysubmit_L8D1bBiTP9CYsA5P
+
+Tailing logs until the job exits (disable with --no-wait):
+2024-12-04 12:26:39,949	INFO job_manager.py:530 -- Runtime env is setting up.
+2024-12-04 12:26:41,119	INFO worker.py:1494 -- Using address 10.112.0.52:6379 set in the environment variable RAY_ADDRESS
+2024-12-04 12:26:41,120	INFO worker.py:1634 -- Connecting to existing Ray cluster at address: 10.112.0.52:6379...
+2024-12-04 12:26:41,130	INFO worker.py:1810 -- Connected to Ray cluster. View the dashboard at 127.0.0.1:8443
+{'memory': 12884901888.0, 'node:__internal_head__': 1.0, 'CPU': 4.0, 'object_store_memory': 3708144844.0, 'node:10.112.0.52': 1.0, 'node:10.112.1.49': 1.0, 'node:10.112.2.36': 1.0}
+
+------------------------------------------
+Job 'raysubmit_L8D1bBiTP9CYsA5P' succeeded
+------------------------------------------
+```


### PR DESCRIPTION
## Why are these changes needed?

Add a user guide for configuring authenticadtion and access control for Ray clusters using KubeRay and Kubernetes RBAC.

## Related issue number

Based on REP: https://github.com/ray-project/enhancements/blob/main/reps/2024-05-21-kuberay-authentication.md

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
