### PR TITLE
[core] Use override for dtor and rename a function

### DIFF
--- a/src/ray/rpc/retryable_grpc_client.cc
+++ b/src/ray/rpc/retryable_grpc_client.cc
@@ -39,12 +39,12 @@ void RetryableGrpcClient::SetupCheckTimer() {
   std::weak_ptr<RetryableGrpcClient> weak_self = weak_from_this();
   timer_.async_wait([weak_self](boost::system::error_code error) {
     if (auto self = weak_self.lock(); self && (error == boost::system::errc::success)) {
-      self->CheckChannelStatus();
+      self->UpdateStatus();
     }
   });
 }
 
-void RetryableGrpcClient::CheckChannelStatus(bool reset_timer) {
+void RetryableGrpcClient::UpdateStatus(bool reset_timer) {
   // We need to cleanup all the pending requests which are timeout.
   const auto now = absl::Now();
   while (!pending_requests_.empty()) {
@@ -140,7 +140,7 @@ void RetryableGrpcClient::Retry(std::shared_ptr<RetryableGrpcRequest> request) {
         break;
       }
 
-      CheckChannelStatus(false);
+      UpdateStatus(/*reset_timer=*/false);
     }
     request->CallMethod();
     return;

--- a/src/ray/rpc/retryable_grpc_client.h
+++ b/src/ray/rpc/retryable_grpc_client.h
@@ -146,7 +146,7 @@ class RetryableGrpcClient : public std::enable_shared_from_this<RetryableGrpcCli
   // Return the number of pending requests waiting for retry.
   size_t NumPendingRequests() const { return pending_requests_.size(); }
 
-  ~RetryableGrpcClient();
+  ~RetryableGrpcClient() override;
 
  private:
   RetryableGrpcClient(std::shared_ptr<grpc::Channel> channel,
@@ -167,10 +167,11 @@ class RetryableGrpcClient : public std::enable_shared_from_this<RetryableGrpcCli
             std::move(server_unavailable_timeout_callback)),
         server_name_(std::move(server_name)) {}
 
-  // Set up the timer to run CheckChannelStatus.
+  // Set up the timer to update client status periodically.
   void SetupCheckTimer();
 
-  void CheckChannelStatus(bool reset_timer = true);
+  // Update retriable grpc client status.
+  void UpdateStatus(bool reset_timer = true);
 
   instrumented_io_context &io_context_;
   boost::asio::deadline_timer timer_;


### PR DESCRIPTION
Two things:
- Use `override` on destructor for classes with inheritance
- `CheckChannelStatus` is confusing. `Check` itself doesn't imply update; (2) we not only check grpc channel, but also client data member status.