### PR TITLE
Another cleanup for test main

### DIFF
--- a/src/ray/common/test/BUILD
+++ b/src/ray/common/test/BUILD
@@ -117,7 +117,7 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/common:task_common",
-        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/src/ray/common/test/asio_defer_test.cc
+++ b/src/ray/common/test/asio_defer_test.cc
@@ -43,8 +43,3 @@ TEST(AsioChaosTest, WithGlobal) {
   ASSERT_TRUE(EnsureBelow("method2", 20, 30));
   ASSERT_TRUE(EnsureBelow("others", 100, 200));
 }
-
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/ray/common/test/bundle_location_index_test.cc
+++ b/src/ray/common/test/bundle_location_index_test.cc
@@ -91,8 +91,3 @@ TEST_F(BundleLocationIndexTest, BesicTest) {
 }
 
 }  // namespace ray
-
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/ray/common/test/client_connection_test.cc
+++ b/src/ray/common/test/client_connection_test.cc
@@ -256,8 +256,3 @@ TEST_F(ClientConnectionTest, ProcessBadMessage) {
 }  // namespace raylet
 
 }  // namespace ray
-
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/ray/common/test/event_stats_test.cc
+++ b/src/ray/common/test/event_stats_test.cc
@@ -53,8 +53,3 @@ TEST(EventStatsTest, TestRecordExecution) {
   ASSERT_GE(event_stats.cum_execution_time, 200000000);
   ASSERT_GE(event_stats.cum_queue_time, 100000000);
 }
-
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/ray/common/test/id_test.cc
+++ b/src/ray/common/test/id_test.cc
@@ -159,8 +159,3 @@ TEST(PlacementGroupIDTest, TestPlacementGroup) {
 }
 
 }  // namespace ray
-
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/ray/common/test/memory_monitor_test.cc
+++ b/src/ray/common/test/memory_monitor_test.cc
@@ -479,8 +479,3 @@ TEST_F(MemoryMonitorTest, TestGetProcessMemoryUsageFiltersBadPids) {
 }
 
 }  // namespace ray
-
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/ray/common/test/ray_config_test.cc
+++ b/src/ray/common/test/ray_config_test.cc
@@ -29,8 +29,3 @@ TEST_F(RayConfigTest, ConvertValueTrimsVectorElements) {
 }
 
 }  // namespace ray
-
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/ray/common/test/resource_request_test.cc
+++ b/src/ray/common/test/resource_request_test.cc
@@ -200,8 +200,3 @@ TEST_F(TaskResourceInstancesTest, TestBasic) {
 }
 
 }  // namespace ray
-
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/ray/common/test/resource_set_test.cc
+++ b/src/ray/common/test/resource_set_test.cc
@@ -87,8 +87,3 @@ TEST_F(NodeResourceSetTest, TestExplicitResourceIds) {
 }
 
 }  // namespace ray
-
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/ray/common/test/status_test.cc
+++ b/src/ray/common/test/status_test.cc
@@ -63,8 +63,3 @@ TEST_F(StatusTest, GrpcStatusToRayStatus) {
 }
 
 }  // namespace ray
-
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/ray/common/test/task_spec_test.cc
+++ b/src/ray/common/test/task_spec_test.cc
@@ -252,8 +252,3 @@ TEST(TaskSpecTest, TestNodeLabelSchedulingStrategy) {
                std::hash<rpc::SchedulingStrategy>()(scheduling_strategy_5));
 }
 }  // namespace ray
-
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}


### PR DESCRIPTION
Our usage for gtest and dependency is incorrect, in short, we shouldn't declare `@com_google_googletest//:gtest_main` as dependency and **meanwhile** have main function defined in the test.

One weird behavior I noticed is, `SetUp` overriden function will be invoked twice somehow.
Similar to https://github.com/ray-project/ray/pull/48892