### PR TITLE
[data] Fix DataContext sealing for multiple datasets. 

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -414,7 +414,7 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
     @property
     def obj_store_mem_max_pending_output_per_task(self) -> Optional[float]:
         """Estimated size in bytes of output blocks in a task's generator buffer."""
-        context = ray.data.DataContext.get_current()
+        context = self._op.data_context
         if context._max_num_blocks_in_streaming_gen_buffer is None:
             return None
 
@@ -560,7 +560,7 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
             input_size,
         )
 
-        ctx = ray.data.context.DataContext.get_current()
+        ctx = self._op.data_context
         if ctx.enable_get_object_locations_for_metrics:
             locations = ray.experimental.get_object_locations(inputs.block_refs)
             for block, meta in inputs.blocks:

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -191,9 +191,17 @@ class PhysicalOperator(Operator):
         # The LogicalOperator(s) which were translated to create this PhysicalOperator.
         # Set via `PhysicalOperator.set_logical_operators()`.
         self._logical_operators: List[LogicalOperator] = []
+        self._data_context = DataContext.get_current()
 
     def __reduce__(self):
         raise ValueError("Operator is not serializable.")
+
+    @property
+    def data_context(self) -> DataContext:
+        return self._data_context
+
+    def set_data_context(self, data_context: DataContext):
+        self._data_context = data_context
 
     # Override the following 3 methods to correct type hints.
 
@@ -229,7 +237,7 @@ class PhysicalOperator(Operator):
         """
         target_max_block_size = self._target_max_block_size
         if target_max_block_size is None:
-            target_max_block_size = DataContext.get_current().target_max_block_size
+            target_max_block_size = self.data_context.target_max_block_size
         return target_max_block_size
 
     def set_target_max_block_size(self, target_max_block_size: Optional[int]):

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -173,6 +173,7 @@ class PhysicalOperator(Operator):
         self,
         name: str,
         input_dependencies: List["PhysicalOperator"],
+        data_context: DataContext,
         target_max_block_size: Optional[int],
     ):
         super().__init__(name, input_dependencies)
@@ -191,7 +192,7 @@ class PhysicalOperator(Operator):
         # The LogicalOperator(s) which were translated to create this PhysicalOperator.
         # Set via `PhysicalOperator.set_logical_operators()`.
         self._logical_operators: List[LogicalOperator] = []
-        self._data_context = DataContext.get_current()
+        self._data_context = data_context
 
     def __reduce__(self):
         raise ValueError("Operator is not serializable.")
@@ -199,9 +200,6 @@ class PhysicalOperator(Operator):
     @property
     def data_context(self) -> DataContext:
         return self._data_context
-
-    def set_data_context(self, data_context: DataContext):
-        self._data_context = data_context
 
     # Override the following 3 methods to correct type hints.
 

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -49,6 +49,7 @@ class ActorPoolMapOperator(MapOperator):
         self,
         map_transformer: MapTransformer,
         input_op: PhysicalOperator,
+        data_context: DataContext,
         target_max_block_size: Optional[int],
         compute_strategy: ActorPoolStrategy,
         name: str = "ActorPoolMap",
@@ -83,6 +84,7 @@ class ActorPoolMapOperator(MapOperator):
         super().__init__(
             map_transformer,
             input_op,
+            data_context,
             name,
             target_max_block_size,
             min_rows_per_bundle,

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -107,7 +107,9 @@ class ActorPoolMapOperator(MapOperator):
             )
         self._min_rows_per_bundle = min_rows_per_bundle
         self._ray_remote_args_fn = ray_remote_args_fn
-        self._ray_remote_args = self._apply_default_remote_args(self._ray_remote_args)
+        self._ray_remote_args = self._apply_default_remote_args(
+            self._ray_remote_args, data_context
+        )
 
         self._actor_pool = _ActorPool(compute_strategy, self._start_actor)
         # A queue of bundles awaiting dispatch to actors.
@@ -324,12 +326,13 @@ class ActorPoolMapOperator(MapOperator):
         return res
 
     @staticmethod
-    def _apply_default_remote_args(ray_remote_args: Dict[str, Any]) -> Dict[str, Any]:
+    def _apply_default_remote_args(
+        ray_remote_args: Dict[str, Any], data_context: DataContext
+    ) -> Dict[str, Any]:
         """Apply defaults to the actor creation remote args."""
         ray_remote_args = ray_remote_args.copy()
         if "scheduling_strategy" not in ray_remote_args:
-            ctx = self.data_context
-            ray_remote_args["scheduling_strategy"] = ctx.scheduling_strategy
+            ray_remote_args["scheduling_strategy"] = data_context.scheduling_strategy
         # Enable actor fault tolerance by default, with infinite actor recreations and
         # up to N retries per task. The user can customize this in map_batches via
         # extra kwargs (e.g., map_batches(..., max_restarts=0) to disable).

--- a/python/ray/data/_internal/execution/operators/aggregate_num_rows.py
+++ b/python/ray/data/_internal/execution/operators/aggregate_num_rows.py
@@ -3,6 +3,7 @@ from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.execution.interfaces import PhysicalOperator, RefBundle
 from ray.data._internal.stats import StatsDict
 from ray.data.block import BlockAccessor
+from ray.data.context import DataContext
 
 
 class AggregateNumRows(PhysicalOperator):
@@ -12,9 +13,17 @@ class AggregateNumRows(PhysicalOperator):
     block metadata. It outputs a single row with the specified column name.
     """
 
-    def __init__(self, input_dependencies, column_name: str):
+    def __init__(
+        self,
+        input_dependencies,
+        data_context: DataContext,
+        column_name: str,
+    ):
         super().__init__(
-            "AggregateNumRows", input_dependencies, target_max_block_size=None
+            "AggregateNumRows",
+            input_dependencies,
+            data_context,
+            target_max_block_size=None,
         )
 
         self._column_name = column_name

--- a/python/ray/data/_internal/execution/operators/input_data_buffer.py
+++ b/python/ray/data/_internal/execution/operators/input_data_buffer.py
@@ -6,6 +6,7 @@ from ray.data._internal.execution.interfaces import (
     RefBundle,
 )
 from ray.data._internal.stats import StatsDict
+from ray.data.context import DataContext
 
 
 class InputDataBuffer(PhysicalOperator):
@@ -17,6 +18,7 @@ class InputDataBuffer(PhysicalOperator):
 
     def __init__(
         self,
+        data_context: DataContext,
         input_data: Optional[List[RefBundle]] = None,
         input_data_factory: Optional[Callable[[int], List[RefBundle]]] = None,
         num_output_blocks: Optional[int] = None,
@@ -29,7 +31,7 @@ class InputDataBuffer(PhysicalOperator):
             num_output_blocks: The number of output blocks. If not specified, progress
                 bars total will be set based on num output bundles instead.
         """
-        super().__init__("Input", [], target_max_block_size=None)
+        super().__init__("Input", [], data_context, target_max_block_size=None)
         if input_data is not None:
             assert input_data_factory is None
             # Copy the input data to avoid mutating the original list.

--- a/python/ray/data/_internal/execution/operators/limit_operator.py
+++ b/python/ray/data/_internal/execution/operators/limit_operator.py
@@ -10,6 +10,7 @@ from ray.data._internal.execution.operators.base_physical_operator import (
 from ray.data._internal.remote_fn import cached_remote_fn
 from ray.data._internal.stats import StatsDict
 from ray.data.block import Block, BlockAccessor, BlockMetadata
+from ray.data.context import DataContext
 from ray.types import ObjectRef
 
 
@@ -20,6 +21,7 @@ class LimitOperator(OneToOneOperator):
         self,
         limit: int,
         input_op: PhysicalOperator,
+        data_context: DataContext,
     ):
         self._limit = limit
         self._consumed_rows = 0
@@ -27,7 +29,7 @@ class LimitOperator(OneToOneOperator):
         self._name = f"limit={limit}"
         self._output_metadata: List[BlockMetadata] = []
         self._cur_output_bundles = 0
-        super().__init__(self._name, input_op, target_max_block_size=None)
+        super().__init__(self._name, input_op, data_context, target_max_block_size=None)
         if self._limit <= 0:
             self.mark_execution_completed()
 

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -281,9 +281,9 @@ class MapOperator(OneToOneOperator, ABC):
         if "scheduling_strategy" not in ray_remote_args:
             ctx = self.data_context
             if input_bundle and input_bundle.size_bytes() > ctx.large_args_threshold:
-                ray_remote_args["scheduling_strategy"] = (
-                    ctx.scheduling_strategy_large_args
-                )
+                ray_remote_args[
+                    "scheduling_strategy"
+                ] = ctx.scheduling_strategy_large_args
                 # Takes precedence over small args case. This is to let users know
                 # when the large args case is being triggered.
                 self._remote_args_for_metrics = copy.deepcopy(ray_remote_args)

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -63,6 +63,7 @@ class MapOperator(OneToOneOperator, ABC):
         self,
         map_transformer: MapTransformer,
         input_op: PhysicalOperator,
+        data_context: DataContext,
         name: str,
         target_max_block_size: Optional[int],
         min_rows_per_bundle: Optional[int],
@@ -95,7 +96,7 @@ class MapOperator(OneToOneOperator, ABC):
         self._metadata_tasks: Dict[int, MetadataOpTask] = {}
         self._next_metadata_task_idx = 0
         # Keep track of all finished streaming generators.
-        super().__init__(name, input_op, target_max_block_size)
+        super().__init__(name, input_op, data_context, target_max_block_size)
 
         # If set, then all output blocks will be split into
         # this many sub-blocks. This is to avoid having
@@ -123,6 +124,7 @@ class MapOperator(OneToOneOperator, ABC):
         cls,
         map_transformer: MapTransformer,
         input_op: PhysicalOperator,
+        data_context: DataContext,
         target_max_block_size: Optional[int] = None,
         name: str = "Map",
         # TODO(ekl): slim down ComputeStrategy to only specify the compute
@@ -172,6 +174,7 @@ class MapOperator(OneToOneOperator, ABC):
             return TaskPoolMapOperator(
                 map_transformer,
                 input_op,
+                data_context,
                 name=name,
                 target_max_block_size=target_max_block_size,
                 min_rows_per_bundle=min_rows_per_bundle,
@@ -188,6 +191,7 @@ class MapOperator(OneToOneOperator, ABC):
             return ActorPoolMapOperator(
                 map_transformer,
                 input_op,
+                data_context,
                 target_max_block_size=target_max_block_size,
                 compute_strategy=compute_strategy,
                 name=name,

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -275,11 +275,11 @@ class MapOperator(OneToOneOperator, ABC):
         # compute load-balancing. For tasks with large args, we will use DEFAULT to
         # allow the Ray locality scheduler a chance to optimize task placement.
         if "scheduling_strategy" not in ray_remote_args:
-            ctx = DataContext.get_current()
+            ctx = self.data_context
             if input_bundle and input_bundle.size_bytes() > ctx.large_args_threshold:
-                ray_remote_args[
-                    "scheduling_strategy"
-                ] = ctx.scheduling_strategy_large_args
+                ray_remote_args["scheduling_strategy"] = (
+                    ctx.scheduling_strategy_large_args
+                )
                 # Takes precedence over small args case. This is to let users know
                 # when the large args case is being triggered.
                 self._remote_args_for_metrics = copy.deepcopy(ray_remote_args)

--- a/python/ray/data/_internal/execution/operators/output_splitter.py
+++ b/python/ray/data/_internal/execution/operators/output_splitter.py
@@ -13,6 +13,7 @@ from ray.data._internal.execution.util import locality_string
 from ray.data._internal.remote_fn import cached_remote_fn
 from ray.data._internal.stats import StatsDict
 from ray.data.block import Block, BlockAccessor, BlockMetadata
+from ray.data.context import DataContext
 from ray.types import ObjectRef
 
 
@@ -36,10 +37,14 @@ class OutputSplitter(PhysicalOperator):
         input_op: PhysicalOperator,
         n: int,
         equal: bool,
+        data_context: DataContext,
         locality_hints: Optional[List[NodeIdStr]] = None,
     ):
         super().__init__(
-            f"split({n}, equal={equal})", [input_op], target_max_block_size=None
+            f"split({n}, equal={equal})",
+            [input_op],
+            data_context,
+            target_max_block_size=None,
         )
         self._equal = equal
         # Buffer of bundles not yet assigned to output splits.

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -10,7 +10,6 @@ from ray.data._internal.execution.interfaces import (
 from ray.data._internal.execution.operators.map_operator import MapOperator, _map_task
 from ray.data._internal.execution.operators.map_transformer import MapTransformer
 from ray.data._internal.remote_fn import cached_remote_fn
-from ray.data.context import DataContext
 
 
 class TaskPoolMapOperator(MapOperator):
@@ -83,7 +82,7 @@ class TaskPoolMapOperator(MapOperator):
         dynamic_ray_remote_args = self._get_runtime_ray_remote_args(input_bundle=bundle)
         dynamic_ray_remote_args["name"] = self.name
 
-        data_context = DataContext.get_current()
+        data_context = self.data_context
         if data_context._max_num_blocks_in_streaming_gen_buffer is not None:
             # The `_generator_backpressure_num_objects` parameter should be
             # `2 * _max_num_blocks_in_streaming_gen_buffer` because we yield

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -10,6 +10,7 @@ from ray.data._internal.execution.interfaces import (
 from ray.data._internal.execution.operators.map_operator import MapOperator, _map_task
 from ray.data._internal.execution.operators.map_transformer import MapTransformer
 from ray.data._internal.remote_fn import cached_remote_fn
+from ray.data.context import DataContext
 
 
 class TaskPoolMapOperator(MapOperator):
@@ -19,6 +20,7 @@ class TaskPoolMapOperator(MapOperator):
         self,
         map_transformer: MapTransformer,
         input_op: PhysicalOperator,
+        data_context: DataContext,
         target_max_block_size: Optional[int],
         name: str = "TaskPoolMap",
         min_rows_per_bundle: Optional[int] = None,
@@ -53,6 +55,7 @@ class TaskPoolMapOperator(MapOperator):
         super().__init__(
             map_transformer,
             input_op,
+            data_context,
             name,
             target_max_block_size,
             min_rows_per_bundle,

--- a/python/ray/data/_internal/execution/operators/union_operator.py
+++ b/python/ray/data/_internal/execution/operators/union_operator.py
@@ -7,6 +7,7 @@ from ray.data._internal.execution.interfaces import (
 )
 from ray.data._internal.execution.operators.base_physical_operator import NAryOperator
 from ray.data._internal.stats import StatsDict
+from ray.data.context import DataContext
 
 
 class UnionOperator(NAryOperator):
@@ -15,6 +16,7 @@ class UnionOperator(NAryOperator):
 
     def __init__(
         self,
+        data_context: DataContext,
         *input_ops: PhysicalOperator,
     ):
         """Create a UnionOperator.
@@ -38,7 +40,7 @@ class UnionOperator(NAryOperator):
 
         self._output_buffer: List[RefBundle] = []
         self._stats: StatsDict = {"Union": []}
-        super().__init__(*input_ops)
+        super().__init__(data_context, *input_ops)
 
     def start(self, options: ExecutionOptions):
         # Whether to preserve the order of the input data (both the

--- a/python/ray/data/_internal/execution/operators/zip_operator.py
+++ b/python/ray/data/_internal/execution/operators/zip_operator.py
@@ -14,6 +14,7 @@ from ray.data.block import (
     BlockMetadata,
     BlockPartition,
 )
+from ray.data.context import DataContext
 
 
 class ZipOperator(PhysicalOperator):
@@ -28,6 +29,7 @@ class ZipOperator(PhysicalOperator):
         self,
         left_input_op: PhysicalOperator,
         right_input_op: PhysicalOperator,
+        data_context: DataContext,
     ):
         """Create a ZipOperator.
 
@@ -40,7 +42,10 @@ class ZipOperator(PhysicalOperator):
         self._output_buffer: List[RefBundle] = []
         self._stats: StatsDict = {}
         super().__init__(
-            "Zip", [left_input_op, right_input_op], target_max_block_size=None
+            "Zip",
+            [left_input_op, right_input_op],
+            data_context,
+            target_max_block_size=None,
         )
 
     def num_outputs_total(self) -> Optional[int]:

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -158,9 +158,9 @@ class ResourceManager:
             f = (1.0 + num_ops_so_far) / max(1.0, num_ops_total - 1.0)
             num_ops_so_far += 1
             self._downstream_fraction[op] = min(1.0, f)
-            self._downstream_object_store_memory[op] = (
-                self._global_usage.object_store_memory
-            )
+            self._downstream_object_store_memory[
+                op
+            ] = self._global_usage.object_store_memory
 
             # Update operator's object store usage, which is used by
             # DatasetStats and updated on the Ray Data dashboard.
@@ -557,8 +557,8 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
     def _get_downstream_eligible_ops(
         self, op: PhysicalOperator
     ) -> Iterable[PhysicalOperator]:
-        """Get the downstream eligible operators of the given operator, ignoring intermediate
-        ineligible operators.
+        """Get the downstream eligible operators of the given operator, ignoring
+        intermediate ineligible operators.
 
         E.g.,
           - "cur_map->downstream_map" will return [downstream_map].

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -10,7 +10,6 @@ from ray.data._internal.execution.backpressure_policy import (
     get_backpressure_policies,
 )
 from ray.data._internal.execution.interfaces import (
-    ExecutionOptions,
     ExecutionResources,
     Executor,
     OutputIterator,
@@ -53,7 +52,8 @@ class StreamingExecutor(Executor, threading.Thread):
     a way that maximizes throughput under resource constraints.
     """
 
-    def __init__(self, options: ExecutionOptions, dataset_tag: str = "unknown_dataset"):
+    def __init__(self, data_context: DataContext, dataset_tag: str = "unknown_dataset"):
+        self._data_context = data_context
         self._start_time: Optional[float] = None
         self._initial_stats: Optional[DatasetStats] = None
         self._final_stats: Optional[DatasetStats] = None
@@ -77,12 +77,12 @@ class StreamingExecutor(Executor, threading.Thread):
         # Stores if an operator is completed,
         # used for marking when an op has just completed.
         self._has_op_completed: Optional[Dict[PhysicalOperator, bool]] = None
-        self._max_errored_blocks = DataContext.get_current().max_errored_blocks
+        self._max_errored_blocks = self._data_context.max_errored_blocks
         self._num_errored_blocks = 0
 
         self._last_debug_log_time = 0
 
-        Executor.__init__(self, options)
+        Executor.__init__(self, self._data_context.execution_options)
         thread_name = f"StreamingExecutor-{self._execution_id}"
         threading.Thread.__init__(self, daemon=True, name=thread_name)
 
@@ -99,8 +99,7 @@ class StreamingExecutor(Executor, threading.Thread):
         self._start_time = time.perf_counter()
 
         if not isinstance(dag, InputDataBuffer):
-            context = DataContext.get_current()
-            if context.print_on_execution_start:
+            if self._data_context.print_on_execution_start:
                 message = "Starting execution of Dataset."
                 log_path = get_log_directory()
                 if log_path is not None:
@@ -173,7 +172,6 @@ class StreamingExecutor(Executor, threading.Thread):
         self.shutdown()
 
     def shutdown(self, execution_completed: bool = True):
-        context = DataContext.get_current()
         global _num_shutdown
 
         with self._shutdown_lock:
@@ -196,7 +194,7 @@ class StreamingExecutor(Executor, threading.Thread):
             stats_summary_string = self._final_stats.to_summary().to_string(
                 include_parent=False
             )
-            if context.enable_auto_log_stats:
+            if self._data_context.enable_auto_log_stats:
                 logger.info(stats_summary_string)
             # Close the progress bars from top to bottom to avoid them jumping
             # around in the console after completion.

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -121,6 +121,11 @@ class StreamingExecutor(Executor, threading.Thread):
 
         # Setup the streaming DAG topology and start the runner thread.
         self._topology, _ = build_streaming_topology(dag, self._options)
+
+        # Set DataContext for each op.
+        for op in self._topology:
+            op.set_data_context(self._data_context)
+
         self._resource_manager = ResourceManager(
             self._topology,
             self._options,

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -125,6 +125,7 @@ class StreamingExecutor(Executor, threading.Thread):
             self._topology,
             self._options,
             lambda: self._autoscaler.get_total_resources(),
+            self._data_context,
         )
         self._backpressure_policies = get_backpressure_policies(self._topology)
         self._autoscaler = create_autoscaler(

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -121,11 +121,6 @@ class StreamingExecutor(Executor, threading.Thread):
 
         # Setup the streaming DAG topology and start the runner thread.
         self._topology, _ = build_streaming_topology(dag, self._options)
-
-        # Set DataContext for each op.
-        for op in self._topology:
-            op.set_data_context(self._data_context)
-
         self._resource_manager = ResourceManager(
             self._topology,
             self._options,

--- a/python/ray/data/_internal/iterator/stream_split_iterator.py
+++ b/python/ray/data/_internal/iterator/stream_split_iterator.py
@@ -74,13 +74,13 @@ class StreamSplitDataIterator(DataIterator):
             cur_epoch = ray.get(
                 self._coord_actor.start_epoch.remote(self._output_split_idx)
             )
-            future: ObjectRef[Optional[ObjectRef[Block]]] = (
-                self._coord_actor.get.remote(cur_epoch, self._output_split_idx)
-            )
+            future: ObjectRef[
+                Optional[ObjectRef[Block]]
+            ] = self._coord_actor.get.remote(cur_epoch, self._output_split_idx)
             while True:
-                block_ref_and_md: Optional[Tuple[ObjectRef[Block], BlockMetadata]] = (
-                    ray.get(future)
-                )
+                block_ref_and_md: Optional[
+                    Tuple[ObjectRef[Block], BlockMetadata]
+                ] = ray.get(future)
                 if not block_ref_and_md:
                     break
                 else:

--- a/python/ray/data/_internal/logical/interfaces/plan.py
+++ b/python/ray/data/_internal/logical/interfaces/plan.py
@@ -21,5 +21,5 @@ class Plan:
         raise NotImplementedError
 
     @property
-    def context(self) -> Operator:
+    def context(self) -> "DataContext":
         return self._context

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -316,9 +316,11 @@ class OperatorFusionRule(Rule):
         input_op = input_deps[0]
 
         # Fused physical map operator.
+        assert up_op.data_context == down_op.data_context
         op = MapOperator.create(
             up_op.get_map_transformer().fuse(down_op.get_map_transformer()),
             input_op,
+            up_op.data_context,
             target_max_block_size=target_max_block_size,
             name=name,
             compute_strategy=compute,

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -216,7 +216,9 @@ class OperatorFusionRule(Rule):
             return False
 
         if not self._can_merge_target_max_block_size(
-            up_op.target_max_block_size, down_op.target_max_block_size
+            up_op.target_max_block_size,
+            down_op.target_max_block_size,
+            up_op.data_context,
         ):
             return False
 
@@ -227,14 +229,13 @@ class OperatorFusionRule(Rule):
         self,
         up_target_max_block_size: Optional[int],
         down_target_max_block_size: Optional[int],
+        data_context: DataContext,
     ):
         # If the upstream op overrode the target max block size, only fuse if
         # they are equal.
         if up_target_max_block_size is not None:
             if down_target_max_block_size is None:
-                down_target_max_block_size = (
-                    DataContext.get_current().target_max_block_size
-                )
+                down_target_max_block_size = data_context.target_max_block_size
             if up_target_max_block_size != down_target_max_block_size:
                 return False
         return True

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -317,7 +317,7 @@ class OperatorFusionRule(Rule):
         input_op = input_deps[0]
 
         # Fused physical map operator.
-        assert up_op.data_context == down_op.data_context
+        assert up_op.data_context is down_op.data_context
         op = MapOperator.create(
             up_op.get_map_transformer().fuse(down_op.get_map_transformer()),
             input_op,
@@ -406,9 +406,11 @@ class OperatorFusionRule(Rule):
             up_op.target_max_block_size, down_op.target_max_block_size
         )
 
+        assert up_op.data_context is down_op.data_context
         op = AllToAllOperator(
             fused_all_to_all_transform_fn,
             input_op,
+            up_op.data_context,
             target_max_block_size=target_max_block_size,
             num_outputs=down_op._num_outputs,
             # Transfer over the existing sub-progress bars from

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -420,7 +420,7 @@ class ExecutionPlan:
         from ray.data._internal.execution.streaming_executor import StreamingExecutor
 
         metrics_tag = create_dataset_tag(self._dataset_name, self._dataset_uuid)
-        executor = StreamingExecutor(copy.deepcopy(ctx.execution_options), metrics_tag)
+        executor = StreamingExecutor(ctx, metrics_tag)
         bundle_iter = execute_to_legacy_bundle_iterator(executor, self)
         # Since the generator doesn't run any code until we try to fetch the first
         # value, force execution of one bundle before we call get_stats().
@@ -492,7 +492,7 @@ class ExecutionPlan:
 
                 metrics_tag = create_dataset_tag(self._dataset_name, self._dataset_uuid)
                 executor = StreamingExecutor(
-                    copy.deepcopy(context.execution_options),
+                    context,
                     metrics_tag,
                 )
                 blocks = execute_to_legacy_block_list(

--- a/python/ray/data/_internal/planner/plan_all_to_all_op.py
+++ b/python/ray/data/_internal/planner/plan_all_to_all_op.py
@@ -21,7 +21,9 @@ from ray.data.context import DataContext
 
 
 def plan_all_to_all_op(
-    op: AbstractAllToAll, physical_children: List[PhysicalOperator]
+    op: AbstractAllToAll,
+    physical_children: List[PhysicalOperator],
+    data_context: DataContext,
 ) -> AllToAllOperator:
     """Get the corresponding physical operators DAG for AbstractAllToAll operators.
 
@@ -37,10 +39,8 @@ def plan_all_to_all_op(
         # Randomize block order does not actually compute anything, so we
         # want to inherit the upstream op's target max block size.
     elif isinstance(op, RandomShuffle):
-        debug_limit_shuffle_execution_to_num_blocks = (
-            DataContext.get_current().get_config(
-                "debug_limit_shuffle_execution_to_num_blocks", None
-            )
+        debug_limit_shuffle_execution_to_num_blocks = data_context.get_config(
+            "debug_limit_shuffle_execution_to_num_blocks", None
         )
         fn = generate_random_shuffle_fn(
             op._seed,
@@ -48,17 +48,13 @@ def plan_all_to_all_op(
             op._ray_remote_args,
             debug_limit_shuffle_execution_to_num_blocks,
         )
-        target_max_block_size = DataContext.get_current().target_shuffle_max_block_size
+        target_max_block_size = data_context.target_shuffle_max_block_size
     elif isinstance(op, Repartition):
         debug_limit_shuffle_execution_to_num_blocks = None
         if op._shuffle:
-            target_max_block_size = (
-                DataContext.get_current().target_shuffle_max_block_size
-            )
-            debug_limit_shuffle_execution_to_num_blocks = (
-                DataContext.get_current().get_config(
-                    "debug_limit_shuffle_execution_to_num_blocks", None
-                )
+            target_max_block_size = data_context.target_shuffle_max_block_size
+            debug_limit_shuffle_execution_to_num_blocks = data_context.get_config(
+                "debug_limit_shuffle_execution_to_num_blocks", None
             )
         fn = generate_repartition_fn(
             op._num_outputs,
@@ -66,20 +62,16 @@ def plan_all_to_all_op(
             debug_limit_shuffle_execution_to_num_blocks,
         )
     elif isinstance(op, Sort):
-        debug_limit_shuffle_execution_to_num_blocks = (
-            DataContext.get_current().get_config(
-                "debug_limit_shuffle_execution_to_num_blocks", None
-            )
+        debug_limit_shuffle_execution_to_num_blocks = data_context.get_config(
+            "debug_limit_shuffle_execution_to_num_blocks", None
         )
         fn = generate_sort_fn(
             op._sort_key, op._batch_format, debug_limit_shuffle_execution_to_num_blocks
         )
-        target_max_block_size = DataContext.get_current().target_shuffle_max_block_size
+        target_max_block_size = data_context.target_shuffle_max_block_size
     elif isinstance(op, Aggregate):
-        debug_limit_shuffle_execution_to_num_blocks = (
-            DataContext.get_current().get_config(
-                "debug_limit_shuffle_execution_to_num_blocks", None
-            )
+        debug_limit_shuffle_execution_to_num_blocks = data_context.get_config(
+            "debug_limit_shuffle_execution_to_num_blocks", None
         )
         fn = generate_aggregate_fn(
             op._key,
@@ -87,13 +79,14 @@ def plan_all_to_all_op(
             op._batch_format,
             debug_limit_shuffle_execution_to_num_blocks,
         )
-        target_max_block_size = DataContext.get_current().target_shuffle_max_block_size
+        target_max_block_size = data_context.target_shuffle_max_block_size
     else:
         raise ValueError(f"Found unknown logical operator during planning: {op}")
 
     return AllToAllOperator(
         fn,
         input_physical_dag,
+        data_context,
         target_max_block_size=target_max_block_size,
         num_outputs=op._num_outputs,
         sub_progress_bar_names=op._sub_progress_bar_names,

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -18,6 +18,7 @@ from ray.data._internal.execution.util import memory_string
 from ray.data._internal.logical.operators.read_operator import Read
 from ray.data._internal.util import _warn_on_high_parallelism
 from ray.data.block import Block, BlockMetadata
+from ray.data.context import DataContext
 from ray.data.datasource.datasource import ReadTask
 from ray.experimental.locations import get_local_object_locations
 from ray.util.debug import log_once
@@ -56,7 +57,9 @@ def cleaned_metadata(read_task: ReadTask, read_task_ref) -> BlockMetadata:
 
 
 def plan_read_op(
-    op: Read, physical_children: List[PhysicalOperator]
+    op: Read,
+    physical_children: List[PhysicalOperator],
+    data_context: DataContext,
 ) -> PhysicalOperator:
     """Get the corresponding DAG of physical operators for Read.
 
@@ -94,6 +97,7 @@ def plan_read_op(
         return ret
 
     inputs = InputDataBuffer(
+        data_context,
         input_data_factory=get_input_data,
     )
 
@@ -112,6 +116,7 @@ def plan_read_op(
     return MapOperator.create(
         map_transformer,
         inputs,
+        data_context,
         name=op.name,
         target_max_block_size=None,
         compute_strategy=TaskPoolStrategy(op._concurrency),

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -80,7 +80,9 @@ class _MapActorContext:
 
 
 def plan_project_op(
-    op: Project, physical_children: List[PhysicalOperator]
+    op: Project,
+    physical_children: List[PhysicalOperator],
+    data_context: DataContext,
 ) -> MapOperator:
     assert len(physical_children) == 1
     input_physical_dag = physical_children[0]
@@ -105,6 +107,7 @@ def plan_project_op(
     return MapOperator.create(
         map_transformer,
         input_physical_dag,
+        data_context,
         name=op.name,
         compute_strategy=compute,
         ray_remote_args=op._ray_remote_args,
@@ -113,7 +116,9 @@ def plan_project_op(
 
 
 def plan_filter_op(
-    op: Filter, physical_children: List[PhysicalOperator]
+    op: Filter,
+    physical_children: List[PhysicalOperator],
+    data_context: DataContext,
 ) -> MapOperator:
     assert len(physical_children) == 1
     input_physical_dag = physical_children[0]
@@ -145,6 +150,7 @@ def plan_filter_op(
     return MapOperator.create(
         map_transformer,
         input_physical_dag,
+        data_context,
         name=op.name,
         compute_strategy=compute,
         ray_remote_args=op._ray_remote_args,
@@ -153,7 +159,9 @@ def plan_filter_op(
 
 
 def plan_udf_map_op(
-    op: AbstractUDFMap, physical_children: List[PhysicalOperator]
+    op: AbstractUDFMap,
+    physical_children: List[PhysicalOperator],
+    data_context: DataContext,
 ) -> MapOperator:
     """Get the corresponding physical operators DAG for AbstractUDFMap operators.
 
@@ -190,6 +198,7 @@ def plan_udf_map_op(
     return MapOperator.create(
         map_transformer,
         input_physical_dag,
+        data_context,
         name=op.name,
         target_max_block_size=None,
         compute_strategy=compute,

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -596,7 +596,6 @@ def generate_map_batches_fn(
         *fn_args,
         **fn_kwargs,
     ) -> Iterator[Block]:
-
         def _batch_fn(batch):
             return batch_fn(batch, *fn_args, **fn_kwargs)
 

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -547,14 +547,12 @@ def generate_map_rows_fn(
     target_max_block_size: int,
 ) -> Callable[[Iterator[Block], TaskContext, UserDefinedFunction], Iterator[Block]]:
     """Generate function to apply the UDF to each record of blocks."""
-    context = DataContext.get_current()
 
     def fn(
         blocks: Iterator[Block],
         ctx: TaskContext,
         row_fn: UserDefinedFunction,
     ) -> Iterator[Block]:
-        DataContext._set_current(context)
         transform_fn = _generate_transform_fn_for_map_rows(row_fn)
         map_transformer = _create_map_transformer_for_row_based_map_op(transform_fn)
         map_transformer.set_target_max_block_size(target_max_block_size)
@@ -570,14 +568,11 @@ def generate_flat_map_fn(
     and then flatten results.
     """
 
-    context = DataContext.get_current()
-
     def fn(
         blocks: Iterator[Block],
         ctx: TaskContext,
         row_fn: UserDefinedFunction,
     ) -> Iterator[Block]:
-        DataContext._set_current(context)
         transform_fn = _generate_transform_fn_for_flat_map(row_fn)
         map_transformer = _create_map_transformer_for_row_based_map_op(transform_fn)
         map_transformer.set_target_max_block_size(target_max_block_size)
@@ -593,7 +588,6 @@ def generate_map_batches_fn(
     zero_copy_batch: bool = False,
 ) -> Callable[[Iterator[Block], TaskContext, UserDefinedFunction], Iterator[Block]]:
     """Generate function to apply the batch UDF to blocks."""
-    context = DataContext.get_current()
 
     def fn(
         blocks: Iterable[Block],
@@ -602,7 +596,6 @@ def generate_map_batches_fn(
         *fn_args,
         **fn_kwargs,
     ) -> Iterator[Block]:
-        DataContext._set_current(context)
 
         def _batch_fn(batch):
             return batch_fn(batch, *fn_args, **fn_kwargs)

--- a/python/ray/data/_internal/planner/planner.py
+++ b/python/ray/data/_internal/planner/planner.py
@@ -6,12 +6,13 @@ from ray.data._internal.logical.interfaces import (
     LogicalPlan,
     PhysicalPlan,
 )
+from ray.data.context import DataContext
 from ray.util.annotations import DeveloperAPI
 
 LogicalOperatorType = TypeVar("LogicalOperatorType", bound=LogicalOperator)
 
 PlanLogicalOpFn = Callable[
-    [LogicalOperatorType, List[PhysicalOperator]], PhysicalOperator
+    [LogicalOperatorType, List[PhysicalOperator], DataContext], PhysicalOperator
 ]
 
 # A list of registered plan functions for logical operators.
@@ -62,12 +63,15 @@ def _register_default_plan_logical_op_fns():
     register_plan_logical_op_fn(Read, plan_read_op)
 
     def plan_input_data_op(
-        logical_op: InputData, physical_children: List[PhysicalOperator]
+        logical_op: InputData,
+        physical_children: List[PhysicalOperator],
+        data_context: DataContext,
     ) -> PhysicalOperator:
         """Get the corresponding DAG of physical operators for InputData."""
         assert len(physical_children) == 0
 
         return InputDataBuffer(
+            data_context,
             input_data=logical_op.input_data,
             input_data_factory=logical_op.input_data_factory,
         )
@@ -76,10 +80,12 @@ def _register_default_plan_logical_op_fns():
     register_plan_logical_op_fn(Write, plan_write_op)
 
     def plan_from_op(
-        op: AbstractFrom, physical_children: List[PhysicalOperator]
+        op: AbstractFrom,
+        physical_children: List[PhysicalOperator],
+        data_context: DataContext,
     ) -> PhysicalOperator:
         assert len(physical_children) == 0
-        return InputDataBuffer(op.input_data)
+        return InputDataBuffer(data_context, op.input_data)
 
     register_plan_logical_op_fn(AbstractFrom, plan_from_op)
     # Filter is also a AbstractUDFMap, so it needs to resolve
@@ -89,27 +95,29 @@ def _register_default_plan_logical_op_fns():
     register_plan_logical_op_fn(AbstractUDFMap, plan_udf_map_op)
     register_plan_logical_op_fn(AbstractAllToAll, plan_all_to_all_op)
 
-    def plan_zip_op(_, physical_children):
+    def plan_zip_op(_, physical_children, data_context):
         assert len(physical_children) == 2
-        return ZipOperator(physical_children[0], physical_children[1])
+        return ZipOperator(physical_children[0], physical_children[1], data_context)
 
     register_plan_logical_op_fn(Zip, plan_zip_op)
 
-    def plan_union_op(_, physical_children):
+    def plan_union_op(_, physical_children, data_context):
         assert len(physical_children) >= 2
-        return UnionOperator(*physical_children)
+        return UnionOperator(data_context, *physical_children)
 
     register_plan_logical_op_fn(Union, plan_union_op)
 
-    def plan_limit_op(logical_op, physical_children):
+    def plan_limit_op(logical_op, physical_children, data_context):
         assert len(physical_children) == 1
-        return LimitOperator(logical_op._limit, physical_children[0])
+        return LimitOperator(logical_op._limit, physical_children[0], data_context)
 
     register_plan_logical_op_fn(Limit, plan_limit_op)
 
-    def plan_count_op(logical_op, physical_children):
+    def plan_count_op(logical_op, physical_children, data_context):
         assert len(physical_children) == 1
-        return AggregateNumRows([physical_children[0]], column_name=Count.COLUMN_NAME)
+        return AggregateNumRows(
+            [physical_children[0]], data_context, column_name=Count.COLUMN_NAME
+        )
 
     register_plan_logical_op_fn(Count, plan_count_op)
 
@@ -131,7 +139,7 @@ class Planner:
 
     def plan(self, logical_plan: LogicalPlan) -> PhysicalPlan:
         """Convert logical to physical operators recursively in post-order."""
-        physical_dag = self._plan(logical_plan.dag)
+        physical_dag = self._plan(logical_plan.dag, logical_plan.context)
         physical_plan = PhysicalPlan(
             physical_dag,
             self._physical_op_to_logical_op,
@@ -139,18 +147,20 @@ class Planner:
         )
         return physical_plan
 
-    def _plan(self, logical_op: LogicalOperator) -> PhysicalOperator:
+    def _plan(
+        self, logical_op: LogicalOperator, data_context: DataContext
+    ) -> PhysicalOperator:
         # Plan the input dependencies first.
         physical_children = []
         for child in logical_op.input_dependencies:
-            physical_children.append(self._plan(child))
+            physical_children.append(self._plan(child, data_context))
 
         physical_op = None
         for op_type, plan_fn in PLAN_LOGICAL_OP_FNS:
             if isinstance(logical_op, op_type):
                 # We will call `set_logical_operators()` in the following for-loop,
                 # no need to do it here.
-                physical_op = plan_fn(logical_op, physical_children)
+                physical_op = plan_fn(logical_op, physical_children, data_context)
                 break
 
         if physical_op is None:

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -324,9 +324,9 @@ class DataContext:
     )
     write_file_retry_on_errors: List[str] = DEFAULT_WRITE_FILE_RETRY_ON_ERRORS
     warn_on_driver_memory_usage_bytes: int = DEFAULT_WARN_ON_DRIVER_MEMORY_USAGE_BYTES
-    actor_task_retry_on_errors: Union[bool, List[BaseException]] = (
-        DEFAULT_ACTOR_TASK_RETRY_ON_ERRORS
-    )
+    actor_task_retry_on_errors: Union[
+        bool, List[BaseException]
+    ] = DEFAULT_ACTOR_TASK_RETRY_ON_ERRORS
     op_resource_reservation_enabled: bool = DEFAULT_ENABLE_OP_RESOURCE_RESERVATION
     op_resource_reservation_ratio: float = DEFAULT_OP_RESOURCE_RESERVATION_RATIO
     max_errored_blocks: int = DEFAULT_MAX_ERRORED_BLOCKS

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -324,9 +324,9 @@ class DataContext:
     )
     write_file_retry_on_errors: List[str] = DEFAULT_WRITE_FILE_RETRY_ON_ERRORS
     warn_on_driver_memory_usage_bytes: int = DEFAULT_WARN_ON_DRIVER_MEMORY_USAGE_BYTES
-    actor_task_retry_on_errors: Union[
-        bool, List[BaseException]
-    ] = DEFAULT_ACTOR_TASK_RETRY_ON_ERRORS
+    actor_task_retry_on_errors: Union[bool, List[BaseException]] = (
+        DEFAULT_ACTOR_TASK_RETRY_ON_ERRORS
+    )
     op_resource_reservation_enabled: bool = DEFAULT_ENABLE_OP_RESOURCE_RESERVATION
     op_resource_reservation_ratio: float = DEFAULT_OP_RESOURCE_RESERVATION_RATIO
     max_errored_blocks: int = DEFAULT_MAX_ERRORED_BLOCKS
@@ -393,10 +393,31 @@ class DataContext:
 
     @staticmethod
     def get_current() -> "DataContext":
-        """Get or create a singleton context.
+        """Get or create the current DataContext.
 
-        If the context has not yet been created in this process, it will be
-        initialized with default settings.
+        When a Dataset is created, the current DataContext will be sealed.
+        Changes to `DataContext.get_current()` will not impact existing Datasets.
+
+        Examples:
+
+            .. testcode::
+                import ray
+
+                context = ray.data.DataContext.get_current()
+
+                context.target_max_block_size = 100 * 1024 ** 2
+                ds1 = ray.data.range(1)
+                context.target_max_block_size = 1 * 1024 ** 2
+                ds2 = ray.data.range(1)
+
+                # ds1's target_max_block_size will be 100MB
+                ds1.take_all()
+                # ds2's target_max_block_size will be 1MB
+                ds2.take_all()
+
+        Developer notes: Avoid using `DataContext.get_current()` in data
+        internal components, use the DataContext object captured in the
+        Dataset and pass it around as arguments.
         """
 
         global _default_context

--- a/python/ray/data/tests/test_backpressure_policies.py
+++ b/python/ray/data/tests/test_backpressure_policies.py
@@ -16,6 +16,7 @@ from ray.data._internal.execution.operators.input_data_buffer import InputDataBu
 from ray.data._internal.execution.operators.task_pool_map_operator import (
     TaskPoolMapOperator,
 )
+from ray.data.context import DataContext
 
 
 class TestConcurrencyCapBackpressurePolicy(unittest.TestCase):
@@ -39,7 +40,7 @@ class TestConcurrencyCapBackpressurePolicy(unittest.TestCase):
 
     def test_basic(self):
         concurrency = 16
-        input_op = InputDataBuffer(input_data=[MagicMock()])
+        input_op = InputDataBuffer(DataContext.get_current(), input_data=[MagicMock()])
         map_op_no_concurrency = TaskPoolMapOperator(
             map_transformer=MagicMock(),
             input_op=input_op,

--- a/python/ray/data/tests/test_backpressure_policies.py
+++ b/python/ray/data/tests/test_backpressure_policies.py
@@ -43,11 +43,13 @@ class TestConcurrencyCapBackpressurePolicy(unittest.TestCase):
         input_op = InputDataBuffer(DataContext.get_current(), input_data=[MagicMock()])
         map_op_no_concurrency = TaskPoolMapOperator(
             map_transformer=MagicMock(),
+            data_context=DataContext.get_current(),
             input_op=input_op,
             target_max_block_size=None,
         )
         map_op = TaskPoolMapOperator(
             map_transformer=MagicMock(),
+            data_context=DataContext.get_current(),
             input_op=map_op_no_concurrency,
             target_max_block_size=None,
             concurrency=concurrency,

--- a/python/ray/data/tests/test_context_propagation.py
+++ b/python/ray/data/tests/test_context_propagation.py
@@ -8,7 +8,6 @@ from ray.data.context import DataContext
 from ray.data.datasource import Datasource, ReadTask
 from ray.tests.conftest import *  # noqa
 
-
 # Auto-use `restore_data_context` for each test.
 pytestmark = pytest.mark.usefixtures("restore_data_context")
 
@@ -67,7 +66,6 @@ def test_read(
 ):
     class CustomDatasource(Datasource):
         def prepare_read(self, parallelism: int):
-
             def read_fn():
                 value = DataContext.get_current().get_config("foo")
                 return [pd.DataFrame({"id": [value]})]

--- a/python/ray/data/tests/test_context_propagation.py
+++ b/python/ray/data/tests/test_context_propagation.py
@@ -51,30 +51,15 @@ def test_context_saved_when_dataset_created(
     assert d2.context.get_config("foo") == 1
 
 
-def test_multiple_datasets_propagation(
-    ray_start_regular_shared,
-):
-    """Test that DataContext propagation works correctly with multiple datasets."""
-    ctx = DataContext.get_current()
-
-    def map(_):
-        ctx = DataContext.get_current()
-        return {"foo": ctx.get_config("foo")}
-
-    ctx.set_config("foo", 1)
-    # ds1's DataContext should be sealed as soon as
-    # it's created.
-    ds1 = ray.data.range(1)
-    ds1 = ds1.map(map)
-
-    # Updating DataContext again should only affect
-    # ds2, but not ds1.
-    ctx.set_config("foo", 2)
-    ds2 = ray.data.range(1)
-    ds2 = ds1.map(map)
-
-    assert ds1.take_all() == [{"foo": 1}]
-    assert ds2.take_all() == [{"foo": 2}]
+def _test_updating_context_after_dataset_creation(gen_ds):
+    context = DataContext.get_current()
+    context.set_config("foo", 1)
+    ds = gen_ds()
+    assert ds.take_all()[0]["id"] == 1
+    # DataContext is supposed to be sealed when a Dataset is created.
+    # Test that updating the current DataContext doesn't affect existing Datasets.
+    context.set_config("foo", 2)
+    assert ds.take_all()[0]["id"] == 1
 
 
 def test_read(
@@ -82,55 +67,55 @@ def test_read(
 ):
     class CustomDatasource(Datasource):
         def prepare_read(self, parallelism: int):
-            value = DataContext.get_current().foo
+            value = DataContext.get_current().get_config("foo")
             meta = BlockMetadata(
                 num_rows=1, size_bytes=8, schema=None, input_files=None, exec_stats=None
             )
             return [ReadTask(lambda: [pd.DataFrame({"id": [value]})], meta)]
 
-    context = DataContext.get_current()
-    context.foo = 12345
-    assert ray.data.read_datasource(CustomDatasource()).take_all()[0]["id"] == 12345
+    _test_updating_context_after_dataset_creation(
+        lambda: ray.data.read_datasource(CustomDatasource()),
+    )
 
 
 def test_map(
     ray_start_regular_shared,
 ):
-    context = DataContext.get_current()
-    context.foo = 70001
-    ds = ray.data.range(1).map(lambda x: {"id": DataContext.get_current().foo})
-    assert ds.take_all()[0]["id"] == 70001
+    _test_updating_context_after_dataset_creation(
+        lambda: ray.data.range(1).map(
+            lambda _: {"id": DataContext.get_current().get_config("foo")}
+        )
+    )
 
 
 def test_flat_map(
     ray_start_regular_shared,
 ):
-    context = DataContext.get_current()
-    context.foo = 70002
-    ds = ray.data.range(1).flat_map(lambda x: [{"id": DataContext.get_current().foo}])
-    assert ds.take_all()[0]["id"] == 70002
+    _test_updating_context_after_dataset_creation(
+        lambda: ray.data.range(1).flat_map(
+            lambda _: [{"id": DataContext.get_current().get_config("foo")}]
+        )
+    )
 
 
 def test_map_batches(
     ray_start_regular_shared,
 ):
-    context = DataContext.get_current()
-    context.foo = 70003
-    ds = ray.data.range(1).map_batches(
-        lambda x: {"id": [DataContext.get_current().foo]}
+    _test_updating_context_after_dataset_creation(
+        lambda: ray.data.range(1).map_batches(
+            lambda x: {"id": [DataContext.get_current().get_config("foo")]}
+        )
     )
-    assert ds.take_all()[0]["id"] == 70003
 
 
 def test_filter(
     ray_start_regular_shared,
 ):
-    context = DataContext.get_current()
-    context.foo = 70004
-    ds = ray.data.from_items([70004]).filter(
-        lambda x: x["item"] == DataContext.get_current().foo
+    _test_updating_context_after_dataset_creation(
+        lambda: ray.data.from_items([1]).filter(
+            lambda x: x["id"] == DataContext.get_current().get_config("foo")
+        )
     )
-    assert ds.take_all()[0]["item"] == 70004
 
 
 def test_streaming_split(

--- a/python/ray/data/tests/test_executor_resource_management.py
+++ b/python/ray/data/tests/test_executor_resource_management.py
@@ -478,7 +478,7 @@ def test_limit_resource_reporting(ray_start_10_cpus_shared):
         DataContext.get_current(),
         make_ref_bundles([[SMALL_STR, SMALL_STR] for i in range(2)]),
     )  # Two two-row bundles
-    op = LimitOperator(3, input_op)
+    op = LimitOperator(3, input_op, DataContext.get_current())
     op.start(ExecutionOptions())
 
     assert op.current_processor_usage() == ExecutionResources(

--- a/python/ray/data/tests/test_executor_resource_management.py
+++ b/python/ray/data/tests/test_executor_resource_management.py
@@ -8,6 +8,7 @@ from ray.data._internal.execution.operators.limit_operator import LimitOperator
 from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.execution.operators.output_splitter import OutputSplitter
 from ray.data._internal.execution.util import make_ref_bundles
+from ray.data.context import DataContext
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.test_operators import _mul2_map_data_prcessor
 from ray.data.tests.util import run_op_tasks_sync
@@ -94,6 +95,7 @@ def test_resource_canonicalization(ray_start_10_cpus_shared):
     op = MapOperator.create(
         _mul2_map_data_prcessor,
         input_op=input_op,
+        data_context=DataContext.get_current(),
         name="TestMapper",
         compute_strategy=TaskPoolStrategy(),
     )
@@ -113,6 +115,7 @@ def test_resource_canonicalization(ray_start_10_cpus_shared):
     op = MapOperator.create(
         _mul2_map_data_prcessor,
         input_op=input_op,
+        data_context=DataContext.get_current(),
         name="TestMapper",
         compute_strategy=TaskPoolStrategy(),
         ray_remote_args={"num_gpus": 2},
@@ -126,6 +129,7 @@ def test_resource_canonicalization(ray_start_10_cpus_shared):
     op = MapOperator.create(
         _mul2_map_data_prcessor,
         input_op=input_op,
+        data_context=DataContext.get_current(),
         name="TestMapper",
         compute_strategy=TaskPoolStrategy(),
         ray_remote_args={"num_gpus": 2, "num_cpus": 1},
@@ -165,6 +169,7 @@ def test_scheduling_strategy_overrides(ray_start_10_cpus_shared, restore_data_co
     op = MapOperator.create(
         _mul2_map_data_prcessor,
         input_op=input_op,
+        data_context=DataContext.get_current(),
         name="TestMapper",
         compute_strategy=TaskPoolStrategy(),
         ray_remote_args={"num_gpus": 2, "scheduling_strategy": "DEFAULT"},
@@ -175,6 +180,7 @@ def test_scheduling_strategy_overrides(ray_start_10_cpus_shared, restore_data_co
     op = MapOperator.create(
         _mul2_map_data_prcessor,
         input_op=input_op,
+        data_context=DataContext.get_current(),
         name="TestMapper",
         compute_strategy=TaskPoolStrategy(),
         ray_remote_args={"num_gpus": 2},
@@ -188,6 +194,7 @@ def test_task_pool_resource_reporting(ray_start_10_cpus_shared):
     input_op = InputDataBuffer(make_ref_bundles([[SMALL_STR] for i in range(100)]))
     op = MapOperator.create(
         _mul2_map_data_prcessor,
+        data_context=DataContext.get_current(),
         input_op=input_op,
         name="TestMapper",
         compute_strategy=TaskPoolStrategy(),
@@ -229,6 +236,7 @@ def test_task_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
     op = MapOperator.create(
         _mul2_map_data_prcessor,
         input_op=input_op,
+        data_context=DataContext.get_current(),
         name="TestMapper",
         compute_strategy=TaskPoolStrategy(),
         min_rows_per_bundle=3,
@@ -278,6 +286,7 @@ def test_actor_pool_resource_reporting(ray_start_10_cpus_shared, restore_data_co
     op = MapOperator.create(
         _mul2_map_data_prcessor,
         input_op=input_op,
+        data_context=DataContext.get_current(),
         name="TestMapper",
         compute_strategy=ActorPoolStrategy(
             min_size=2, max_size=10, max_tasks_in_flight_per_actor=2
@@ -371,6 +380,7 @@ def test_actor_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
     op = MapOperator.create(
         _mul2_map_data_prcessor,
         input_op=input_op,
+        data_context=DataContext.get_current(),
         name="TestMapper",
         compute_strategy=ActorPoolStrategy(min_size=2, max_size=10),
         min_rows_per_bundle=2,

--- a/python/ray/data/tests/test_executor_resource_management.py
+++ b/python/ray/data/tests/test_executor_resource_management.py
@@ -91,7 +91,9 @@ def test_execution_resources(ray_start_10_cpus_shared):
 
 
 def test_resource_canonicalization(ray_start_10_cpus_shared):
-    input_op = InputDataBuffer(make_ref_bundles([[i] for i in range(100)]))
+    input_op = InputDataBuffer(
+        DataContext.get_current(), make_ref_bundles([[i] for i in range(100)])
+    )
     op = MapOperator.create(
         _mul2_map_data_prcessor,
         input_op=input_op,
@@ -165,7 +167,9 @@ def test_execution_options_resource_limit():
 
 
 def test_scheduling_strategy_overrides(ray_start_10_cpus_shared, restore_data_context):
-    input_op = InputDataBuffer(make_ref_bundles([[i] for i in range(100)]))
+    input_op = InputDataBuffer(
+        DataContext.get_current(), make_ref_bundles([[i] for i in range(100)])
+    )
     op = MapOperator.create(
         _mul2_map_data_prcessor,
         input_op=input_op,
@@ -191,7 +195,9 @@ def test_scheduling_strategy_overrides(ray_start_10_cpus_shared, restore_data_co
 def test_task_pool_resource_reporting(ray_start_10_cpus_shared):
     ctx = ray.data.DataContext.get_current()
     ctx._max_num_blocks_in_streaming_gen_buffer = 1
-    input_op = InputDataBuffer(make_ref_bundles([[SMALL_STR] for i in range(100)]))
+    input_op = InputDataBuffer(
+        DataContext.get_current(), make_ref_bundles([[SMALL_STR] for i in range(100)])
+    )
     op = MapOperator.create(
         _mul2_map_data_prcessor,
         data_context=DataContext.get_current(),
@@ -232,7 +238,9 @@ def test_task_pool_resource_reporting(ray_start_10_cpus_shared):
 def test_task_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
     ctx = ray.data.DataContext.get_current()
     ctx._max_num_blocks_in_streaming_gen_buffer = 1
-    input_op = InputDataBuffer(make_ref_bundles([[SMALL_STR] for i in range(100)]))
+    input_op = InputDataBuffer(
+        DataContext.get_current(), make_ref_bundles([[SMALL_STR] for i in range(100)])
+    )
     op = MapOperator.create(
         _mul2_map_data_prcessor,
         input_op=input_op,
@@ -282,7 +290,9 @@ def test_task_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
 def test_actor_pool_resource_reporting(ray_start_10_cpus_shared, restore_data_context):
     ctx = ray.data.DataContext.get_current()
     ctx._max_num_blocks_in_streaming_gen_buffer = 1
-    input_op = InputDataBuffer(make_ref_bundles([[SMALL_STR] for i in range(100)]))
+    input_op = InputDataBuffer(
+        DataContext.get_current(), make_ref_bundles([[SMALL_STR] for i in range(100)])
+    )
     op = MapOperator.create(
         _mul2_map_data_prcessor,
         input_op=input_op,
@@ -376,7 +386,9 @@ def test_actor_pool_resource_reporting(ray_start_10_cpus_shared, restore_data_co
 def test_actor_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
     ctx = ray.data.DataContext.get_current()
     ctx._max_num_blocks_in_streaming_gen_buffer = 1
-    input_op = InputDataBuffer(make_ref_bundles([[SMALL_STR] for i in range(100)]))
+    input_op = InputDataBuffer(
+        DataContext.get_current(), make_ref_bundles([[SMALL_STR] for i in range(100)])
+    )
     op = MapOperator.create(
         _mul2_map_data_prcessor,
         input_op=input_op,
@@ -463,7 +475,8 @@ def test_actor_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
 
 def test_limit_resource_reporting(ray_start_10_cpus_shared):
     input_op = InputDataBuffer(
-        make_ref_bundles([[SMALL_STR, SMALL_STR] for i in range(2)])
+        DataContext.get_current(),
+        make_ref_bundles([[SMALL_STR, SMALL_STR] for i in range(2)]),
     )  # Two two-row bundles
     op = LimitOperator(3, input_op)
     op.start(ExecutionOptions())
@@ -489,8 +502,16 @@ def test_limit_resource_reporting(ray_start_10_cpus_shared):
 
 
 def test_output_splitter_resource_reporting(ray_start_10_cpus_shared):
-    input_op = InputDataBuffer(make_ref_bundles([[SMALL_STR] for i in range(4)]))
-    op = OutputSplitter(input_op, 2, equal=False, locality_hints=["0", "1"])
+    input_op = InputDataBuffer(
+        DataContext.get_current(), make_ref_bundles([[SMALL_STR] for i in range(4)])
+    )
+    op = OutputSplitter(
+        input_op,
+        2,
+        equal=False,
+        data_context=DataContext.get_current(),
+        locality_hints=["0", "1"],
+    )
     op.start(ExecutionOptions(actor_locality_enabled=True))
 
     assert op.current_processor_usage() == ExecutionResources(

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -70,7 +70,7 @@ def _take_outputs(op: PhysicalOperator) -> List[Any]:
 def test_input_data_buffer(ray_start_regular_shared):
     # Create with bundles.
     inputs = make_ref_bundles([[1, 2], [3], [4, 5]])
-    op = InputDataBuffer(inputs)
+    op = InputDataBuffer(DataContext.get_current(), inputs)
 
     # Check we return all bundles in order.
     assert not op.completed()
@@ -84,10 +84,13 @@ def test_all_to_all_operator():
         assert list(ctx.sub_progress_bar_dict.keys()) == ["Test1", "Test2"]
         return make_ref_bundles([[1, 2], [3, 4]]), {"FooStats": []}
 
-    input_op = InputDataBuffer(make_ref_bundles([[i] for i in range(100)]))
+    input_op = InputDataBuffer(
+        DataContext.get_current(), make_ref_bundles([[i] for i in range(100)])
+    )
     op = AllToAllOperator(
         dummy_all_transform,
-        input_op=input_op,
+        input_op,
+        DataContext.get_current(),
         target_max_block_size=DataContext.get_current().target_max_block_size,
         num_outputs=2,
         sub_progress_bar_names=["Test1", "Test2"],
@@ -115,14 +118,17 @@ def test_all_to_all_operator():
 
 def test_num_outputs_total():
     # The number of outputs is always known for InputDataBuffer.
-    input_op = InputDataBuffer(make_ref_bundles([[i] for i in range(100)]))
+    input_op = InputDataBuffer(
+        DataContext.get_current(), make_ref_bundles([[i] for i in range(100)])
+    )
     assert input_op.num_outputs_total() == 100
 
     # Prior to execution, the number of outputs is unknown
     # for Map/AllToAllOperator operators.
     op1 = MapOperator.create(
         _mul2_map_data_prcessor,
-        input_op=input_op,
+        input_op,
+        DataContext.get_current(),
         name="TestMapper",
     )
     assert op1.num_outputs_total() is None
@@ -133,6 +139,7 @@ def test_num_outputs_total():
     op2 = AllToAllOperator(
         dummy_all_transform,
         input_op=op1,
+        data_context=DataContext.get_current(),
         target_max_block_size=DataContext.get_current().target_max_block_size,
         name="TestAll",
     )
@@ -157,12 +164,14 @@ def test_num_outputs_total():
 def test_map_operator_streamed(ray_start_regular_shared, use_actors):
     # Create with inputs.
     input_op = InputDataBuffer(
-        make_ref_bundles([[np.ones(1024) * i] for i in range(100)])
+        DataContext.get_current(),
+        make_ref_bundles([[np.ones(1024) * i] for i in range(100)]),
     )
     compute_strategy = ActorPoolStrategy() if use_actors else TaskPoolStrategy()
     op = MapOperator.create(
         _mul2_map_data_prcessor,
-        input_op=input_op,
+        input_op,
+        DataContext.get_current(),
         name="TestMapper",
         compute_strategy=compute_strategy,
     )
@@ -202,9 +211,15 @@ def test_split_operator(ray_start_regular_shared, equal, chunk_size):
     # so we can test the output order of `OutputSplitter.get_next`.
     num_add_input_blocks = 10
     input_op = InputDataBuffer(
-        make_ref_bundles([[i] * chunk_size for i in range(num_input_blocks)])
+        DataContext.get_current(),
+        make_ref_bundles([[i] * chunk_size for i in range(num_input_blocks)]),
     )
-    op = OutputSplitter(input_op, num_splits, equal=equal)
+    op = OutputSplitter(
+        input_op,
+        num_splits,
+        equal=equal,
+        data_context=DataContext.get_current(),
+    )
 
     # Feed data and implement streaming exec.
     output_splits = [[] for _ in range(num_splits)]
@@ -245,8 +260,10 @@ def test_split_operator_random(ray_start_regular_shared, equal, random_seed):
     random.seed(random_seed)
     inputs = make_ref_bundles([[i] * random.randint(0, 10) for i in range(100)])
     num_inputs = sum(x.num_rows() for x in inputs)
-    input_op = InputDataBuffer(inputs)
-    op = OutputSplitter(input_op, 3, equal=equal)
+    input_op = InputDataBuffer(DataContext.get_current(), inputs)
+    op = OutputSplitter(
+        input_op, 3, equal=equal, data_context=DataContext.get_current()
+    )
 
     # Feed data and implement streaming exec.
     output_splits = collections.defaultdict(list)
@@ -268,8 +285,16 @@ def test_split_operator_random(ray_start_regular_shared, equal, random_seed):
 
 
 def test_split_operator_locality_hints(ray_start_regular_shared):
-    input_op = InputDataBuffer(make_ref_bundles([[i] for i in range(10)]))
-    op = OutputSplitter(input_op, 2, equal=False, locality_hints=["node1", "node2"])
+    input_op = InputDataBuffer(
+        DataContext.get_current(), make_ref_bundles([[i] for i in range(10)])
+    )
+    op = OutputSplitter(
+        input_op,
+        2,
+        equal=False,
+        data_context=DataContext.get_current(),
+        locality_hints=["node1", "node2"],
+    )
 
     def get_fake_loc(item):
         assert isinstance(item, int), item
@@ -315,12 +340,14 @@ def test_split_operator_locality_hints(ray_start_regular_shared):
 def test_map_operator_actor_locality_stats(ray_start_regular_shared):
     # Create with inputs.
     input_op = InputDataBuffer(
-        make_ref_bundles([[np.ones(100) * i] for i in range(100)])
+        DataContext.get_current(),
+        make_ref_bundles([[np.ones(100) * i] for i in range(100)]),
     )
     compute_strategy = ActorPoolStrategy()
     op = MapOperator.create(
         _mul2_map_data_prcessor,
         input_op=input_op,
+        data_context=DataContext.get_current(),
         name="TestMapper",
         compute_strategy=compute_strategy,
     )
@@ -362,11 +389,14 @@ def test_map_operator_min_rows_per_bundle(ray_start_regular_shared, use_actors):
             yield block
 
     # Create with inputs.
-    input_op = InputDataBuffer(make_ref_bundles([[i] for i in range(10)]))
+    input_op = InputDataBuffer(
+        DataContext.get_current(), make_ref_bundles([[i] for i in range(10)])
+    )
     compute_strategy = ActorPoolStrategy() if use_actors else TaskPoolStrategy()
     op = MapOperator.create(
         create_map_transformer_from_block_fn(_check_batch),
         input_op=input_op,
+        data_context=DataContext.get_current(),
         name="TestMapper",
         compute_strategy=compute_strategy,
         min_rows_per_bundle=5,
@@ -395,11 +425,14 @@ def test_map_operator_output_unbundling(
             yield block
 
     # Create with inputs.
-    input_op = InputDataBuffer(make_ref_bundles([[i] for i in range(10)]))
+    input_op = InputDataBuffer(
+        DataContext.get_current(), make_ref_bundles([[i] for i in range(10)])
+    )
     compute_strategy = ActorPoolStrategy() if use_actors else TaskPoolStrategy()
     op = MapOperator.create(
         create_map_transformer_from_block_fn(noop),
         input_op=input_op,
+        data_context=DataContext.get_current(),
         name="TestMapper",
         compute_strategy=compute_strategy,
         # Send the everything in a single bundle of 10 blocks.
@@ -431,11 +464,14 @@ def test_map_operator_ray_args(shutdown_only, use_actors):
     ray.shutdown()
     ray.init(num_cpus=0, num_gpus=1)
     # Create with inputs.
-    input_op = InputDataBuffer(make_ref_bundles([[i] for i in range(10)]))
+    input_op = InputDataBuffer(
+        DataContext.get_current(), make_ref_bundles([[i] for i in range(10)])
+    )
     compute_strategy = ActorPoolStrategy(size=1) if use_actors else TaskPoolStrategy()
     op = MapOperator.create(
         _mul2_map_data_prcessor,
         input_op=input_op,
+        data_context=DataContext.get_current(),
         name="TestMapper",
         compute_strategy=compute_strategy,
         ray_remote_args={"num_cpus": 0, "num_gpus": 1},
@@ -462,11 +498,14 @@ def test_map_operator_shutdown(shutdown_only, use_actors):
         time.sleep(999)
 
     # Create with inputs.
-    input_op = InputDataBuffer(make_ref_bundles([[i] for i in range(10)]))
+    input_op = InputDataBuffer(
+        DataContext.get_current(), make_ref_bundles([[i] for i in range(10)])
+    )
     compute_strategy = ActorPoolStrategy(size=1) if use_actors else TaskPoolStrategy()
     op = MapOperator.create(
         create_map_transformer_from_block_fn(_sleep),
         input_op=input_op,
+        data_context=DataContext.get_current(),
         name="TestMapper",
         compute_strategy=compute_strategy,
         ray_remote_args={"num_cpus": 0, "num_gpus": 1},
@@ -496,12 +535,15 @@ def test_actor_pool_map_operator_init(ray_start_regular_shared):
     def _fail():
         raise ValueError("init_failed")
 
-    input_op = InputDataBuffer(make_ref_bundles([[i] for i in range(10)]))
+    input_op = InputDataBuffer(
+        DataContext.get_current(), make_ref_bundles([[i] for i in range(10)])
+    )
     compute_strategy = ActorPoolStrategy(min_size=1)
 
     op = MapOperator.create(
         create_map_transformer_from_block_fn(_sleep, init_fn=_fail),
         input_op=input_op,
+        data_context=DataContext.get_current(),
         name="TestMapper",
         compute_strategy=compute_strategy,
     )
@@ -516,12 +558,15 @@ def test_actor_pool_map_operator_should_add_input(ray_start_regular_shared):
     def _sleep(block_iter: Iterable[Block]) -> Iterable[Block]:
         time.sleep(999)
 
-    input_op = InputDataBuffer(make_ref_bundles([[i] for i in range(10)]))
+    input_op = InputDataBuffer(
+        DataContext.get_current(), make_ref_bundles([[i] for i in range(10)])
+    )
     compute_strategy = ActorPoolStrategy(size=1)
 
     op = MapOperator.create(
         create_map_transformer_from_block_fn(_sleep),
         input_op=input_op,
+        data_context=DataContext.get_current(),
         name="TestMapper",
         compute_strategy=compute_strategy,
     )
@@ -552,7 +597,9 @@ def test_actor_pool_map_operator_num_active_tasks_and_completed(shutdown_only):
         ray.get(signal_actor.wait.remote())
         yield from block_iter
 
-    input_op = InputDataBuffer(make_ref_bundles([[i] for i in range(num_actors)]))
+    input_op = InputDataBuffer(
+        DataContext.get_current(), make_ref_bundles([[i] for i in range(num_actors)])
+    )
     compute_strategy = ActorPoolStrategy(min_size=num_actors, max_size=2 * num_actors)
 
     # Create an operator with [num_actors, 2 * num_actors] actors.
@@ -560,6 +607,7 @@ def test_actor_pool_map_operator_num_active_tasks_and_completed(shutdown_only):
     op = MapOperator.create(
         create_map_transformer_from_block_fn(_map_transfom_fn),
         input_op=input_op,
+        data_context=DataContext.get_current(),
         name="TestMapper",
         compute_strategy=compute_strategy,
     )
@@ -611,10 +659,13 @@ def test_actor_pool_map_operator_num_active_tasks_and_completed(shutdown_only):
 def test_map_operator_pool_delegation(compute, expected):
     # Test that the MapOperator factory delegates to the appropriate pool
     # implementation.
-    input_op = InputDataBuffer(make_ref_bundles([[i] for i in range(100)]))
+    input_op = InputDataBuffer(
+        DataContext.get_current(), make_ref_bundles([[i] for i in range(100)])
+    )
     op = MapOperator.create(
         _mul2_map_data_prcessor,
         input_op=input_op,
+        data_context=DataContext.get_current(),
         name="TestMapper",
         compute_strategy=compute,
     )
@@ -630,8 +681,8 @@ def test_limit_operator(ray_start_regular_shared):
     limits = list(range(0, total_rows + 2))
     for limit in limits:
         refs = make_ref_bundles([[i] * num_rows_per_block for i in range(num_refs)])
-        input_op = InputDataBuffer(refs)
-        limit_op = LimitOperator(limit, input_op)
+        input_op = InputDataBuffer(DataContext.get_current(), refs)
+        limit_op = LimitOperator(limit, input_op, DataContext.get_current())
         limit_op.mark_execution_completed = MagicMock(
             wraps=limit_op.mark_execution_completed
         )
@@ -687,10 +738,10 @@ def test_union_operator(ray_start_regular_shared, preserve_order):
     data1 = make_ref_bundles([[i] * num_rows_per_block for i in range(2)])
     data2 = make_ref_bundles([[i] * num_rows_per_block for i in range(1)])
 
-    op0 = InputDataBuffer(data0)
-    op1 = InputDataBuffer(data1)
-    op2 = InputDataBuffer(data2)
-    union_op = UnionOperator(op0, op1, op2)
+    op0 = InputDataBuffer(DataContext.get_current(), data0)
+    op1 = InputDataBuffer(DataContext.get_current(), data1)
+    op2 = InputDataBuffer(DataContext.get_current(), data2)
+    union_op = UnionOperator(DataContext.get_current(), op0, op1, op2)
     union_op.start(execution_options)
 
     assert not union_op.has_next()
@@ -844,7 +895,7 @@ def test_operator_metrics():
     MIN_ROWS_PER_BUNDLE = 10
 
     inputs = make_ref_bundles([[i] for i in range(NUM_INPUTS)])
-    input_op = InputDataBuffer(inputs)
+    input_op = InputDataBuffer(DataContext.get_current(), inputs)
 
     def map_fn(block_iter: Iterable[Block], ctx) -> Iterable[Block]:
         for i in range(NUM_BLOCKS_PER_TASK):
@@ -853,6 +904,7 @@ def test_operator_metrics():
     op = MapOperator.create(
         create_map_transformer_from_block_fn(map_fn),
         input_op=input_op,
+        data_context=DataContext.get_current(),
         name="TestEstimatedNumBlocks",
         min_rows_per_bundle=MIN_ROWS_PER_BUNDLE,
     )
@@ -907,7 +959,9 @@ def test_operator_metrics():
 
 def test_map_estimated_num_output_bundles():
     # Test map operator estimation
-    input_op = InputDataBuffer(make_ref_bundles([[i] for i in range(100)]))
+    input_op = InputDataBuffer(
+        DataContext.get_current(), make_ref_bundles([[i] for i in range(100)])
+    )
 
     def yield_five(block_iter: Iterable[Block], ctx) -> Iterable[Block]:
         for i in range(5):
@@ -917,6 +971,7 @@ def test_map_estimated_num_output_bundles():
     op = MapOperator.create(
         create_map_transformer_from_block_fn(yield_five),
         input_op=input_op,
+        data_context=DataContext.get_current(),
         name="TestEstimatedNumBlocks",
         min_rows_per_bundle=min_rows_per_bundle,
     )
@@ -942,10 +997,13 @@ def test_map_estimated_blocks_split():
             yield pd.DataFrame({"id": [i]})
 
     min_rows_per_bundle = 10
-    input_op = InputDataBuffer(make_ref_bundles([[i] for i in range(100)]))
+    input_op = InputDataBuffer(
+        DataContext.get_current(), make_ref_bundles([[i] for i in range(100)])
+    )
     op = MapOperator.create(
         create_map_transformer_from_block_fn(yield_five),
         input_op=input_op,
+        data_context=DataContext.get_current(),
         name="TestEstimatedNumBlocksSplit",
         min_rows_per_bundle=min_rows_per_bundle,
     )
@@ -966,8 +1024,10 @@ def test_map_estimated_blocks_split():
 
 def test_limit_estimated_num_output_bundles():
     # Test limit operator estimation
-    input_op = InputDataBuffer(make_ref_bundles([[i, i] for i in range(100)]))
-    op = LimitOperator(100, input_op)
+    input_op = InputDataBuffer(
+        DataContext.get_current(), make_ref_bundles([[i, i] for i in range(100)])
+    )
+    op = LimitOperator(100, input_op, DataContext.get_current())
 
     while input_op.has_next():
         op.add_input(input_op.get_next(), 0)
@@ -980,8 +1040,10 @@ def test_limit_estimated_num_output_bundles():
     assert op._estimated_num_output_bundles == 50
 
     # Test limit operator estimation where: limit > # of rows
-    input_op = InputDataBuffer(make_ref_bundles([[i, i] for i in range(100)]))
-    op = LimitOperator(300, input_op)
+    input_op = InputDataBuffer(
+        DataContext.get_current(), make_ref_bundles([[i, i] for i in range(100)])
+    )
+    op = LimitOperator(300, input_op, DataContext.get_current())
 
     while input_op.has_next():
         op.add_input(input_op.get_next(), 0)
@@ -996,7 +1058,9 @@ def test_limit_estimated_num_output_bundles():
 
 def test_all_to_all_estimated_num_output_bundles():
     # Test all to all operator
-    input_op = InputDataBuffer(make_ref_bundles([[i] for i in range(100)]))
+    input_op = InputDataBuffer(
+        DataContext.get_current(), make_ref_bundles([[i] for i in range(100)])
+    )
 
     def all_transform(bundles: List[RefBundle], ctx):
         return bundles, {}
@@ -1005,11 +1069,15 @@ def test_all_to_all_estimated_num_output_bundles():
     op1 = AllToAllOperator(
         all_transform,
         input_op,
+        DataContext.get_current(),
         DataContext.get_current().target_max_block_size,
         estimated_output_blocks,
     )
     op2 = AllToAllOperator(
-        all_transform, op1, DataContext.get_current().target_max_block_size
+        all_transform,
+        op1,
+        DataContext.get_current(),
+        DataContext.get_current().target_max_block_size,
     )
 
     while input_op.has_next():
@@ -1033,7 +1101,8 @@ def test_input_data_buffer_does_not_free_inputs():
     block_ref = ray.put(block)
     metadata = BlockAccessor.for_block(block).get_metadata()
     op = InputDataBuffer(
-        input_data=[RefBundle([(block_ref, metadata)], owns_blocks=False)]
+        DataContext.get_current(),
+        input_data=[RefBundle([(block_ref, metadata)], owns_blocks=False)],
     )
 
     op.get_next()

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -120,6 +120,7 @@ class TestResourceManager:
                 MagicMock(),
                 ExecutionOptions(),
                 get_total_resources,
+                DataContext.get_current(),
             )
             expected_resource = ExecutionResources(4, 1, 0)
             # The first call should call ray.cluster_resources().
@@ -136,7 +137,7 @@ class TestResourceManager:
 
     def test_update_usage(self):
         """Test calculating op_usage."""
-        o1 = InputDataBuffer([])
+        o1 = InputDataBuffer(DataContext.get_current(), [])
         o2 = mock_map_op(o1)
         o3 = mock_map_op(o2)
         topo, _ = build_streaming_topology(o3, ExecutionOptions())
@@ -188,7 +189,9 @@ class TestResourceManager:
             )
             topo[op].add_output(ref_bundle)
 
-        resource_manager = ResourceManager(topo, ExecutionOptions(), MagicMock())
+        resource_manager = ResourceManager(
+            topo, ExecutionOptions(), MagicMock(), DataContext.get_current()
+        )
         resource_manager._op_resource_allocator = None
         resource_manager.update_usages()
 
@@ -233,7 +236,7 @@ class TestResourceManager:
         input = make_ref_bundles([[x] for x in range(1)])[0]
         input.size_bytes = MagicMock(return_value=1)
 
-        o1 = InputDataBuffer([input])
+        o1 = InputDataBuffer(DataContext.get_current(), [input])
         o2 = mock_map_op(o1)
         o3 = mock_map_op(o2)
 
@@ -242,6 +245,7 @@ class TestResourceManager:
             topo,
             ExecutionOptions(),
             MagicMock(return_value=ExecutionResources.zero()),
+            DataContext.get_current(),
         )
         ray.data.DataContext.get_current()._max_num_blocks_in_streaming_gen_buffer = 1
         ray.data.DataContext.get_current().target_max_block_size = 2
@@ -321,7 +325,7 @@ class TestReservationOpResourceAllocator:
         DataContext.get_current().op_resource_reservation_enabled = True
         DataContext.get_current().op_resource_reservation_ratio = 0.5
 
-        o1 = InputDataBuffer([])
+        o1 = InputDataBuffer(DataContext.get_current(), [])
         o2 = mock_map_op(o1, incremental_resource_usage=ExecutionResources(1, 0, 15))
         o3 = mock_map_op(o2, incremental_resource_usage=ExecutionResources(1, 0, 10))
         o4 = LimitOperator(1, o3)
@@ -338,7 +342,9 @@ class TestReservationOpResourceAllocator:
             nonlocal global_limits
             return global_limits
 
-        resource_manager = ResourceManager(topo, ExecutionOptions(), MagicMock())
+        resource_manager = ResourceManager(
+            topo, ExecutionOptions(), MagicMock(), DataContext.get_current()
+        )
         resource_manager.get_op_usage = MagicMock(side_effect=lambda op: op_usages[op])
         resource_manager._mem_op_internal = op_internal_usage
         resource_manager._mem_op_outputs = op_outputs_usages
@@ -462,12 +468,14 @@ class TestReservationOpResourceAllocator:
         global_limits = ExecutionResources(cpu=6, gpu=0, object_store_memory=1600)
         incremental_usage = ExecutionResources(cpu=3, gpu=0, object_store_memory=500)
 
-        o1 = InputDataBuffer([])
+        o1 = InputDataBuffer(DataContext.get_current(), [])
         o2 = mock_map_op(o1, incremental_resource_usage=incremental_usage)
         o3 = mock_map_op(o2, incremental_resource_usage=incremental_usage)
         topo, _ = build_streaming_topology(o3, ExecutionOptions())
 
-        resource_manager = ResourceManager(topo, ExecutionOptions(), MagicMock())
+        resource_manager = ResourceManager(
+            topo, ExecutionOptions(), MagicMock(), DataContext.get_current()
+        )
         resource_manager.get_op_usage = MagicMock(
             return_value=ExecutionResources.zero()
         )
@@ -491,7 +499,7 @@ class TestReservationOpResourceAllocator:
         global_limits = ExecutionResources(cpu=6, gpu=0, object_store_memory=1600)
         incremental_usage = ExecutionResources(cpu=0, gpu=0, object_store_memory=100)
 
-        o1 = InputDataBuffer([])
+        o1 = InputDataBuffer(DataContext.get_current(), [])
         o2 = mock_map_op(
             o1,
             ray_remote_args={"num_cpus": 0, "num_gpus": 1},
@@ -500,7 +508,9 @@ class TestReservationOpResourceAllocator:
         )
         topo, _ = build_streaming_topology(o2, ExecutionOptions())
 
-        resource_manager = ResourceManager(topo, ExecutionOptions(), MagicMock())
+        resource_manager = ResourceManager(
+            topo, ExecutionOptions(), MagicMock(), DataContext.get_current()
+        )
         resource_manager.get_op_usage = MagicMock(
             return_value=ExecutionResources.zero()
         )
@@ -516,12 +526,14 @@ class TestReservationOpResourceAllocator:
         """Test that we only handle non-completed map ops."""
         DataContext.get_current().op_resource_reservation_enabled = True
 
-        o1 = InputDataBuffer([])
+        o1 = InputDataBuffer(DataContext.get_current(), [])
         o2 = mock_map_op(o1)
         o3 = LimitOperator(1, o2)
         topo, _ = build_streaming_topology(o3, ExecutionOptions())
 
-        resource_manager = ResourceManager(topo, ExecutionOptions(), MagicMock())
+        resource_manager = ResourceManager(
+            topo, ExecutionOptions(), MagicMock(), DataContext.get_current()
+        )
         resource_manager.get_op_usage = MagicMock(
             return_value=ExecutionResources.zero()
         )
@@ -549,15 +561,17 @@ class TestReservationOpResourceAllocator:
         """
         DataContext.get_current().op_resource_reservation_enabled = True
 
-        o1 = InputDataBuffer([])
+        o1 = InputDataBuffer(DataContext.get_current(), [])
         o2 = mock_map_op(o1)
-        o3 = InputDataBuffer([])
+        o3 = InputDataBuffer(DataContext.get_current(), [])
         o4 = mock_map_op(o3)
         o3 = UnionOperator(o2, o4)
 
         topo, _ = build_streaming_topology(o3, ExecutionOptions())
 
-        resource_manager = ResourceManager(topo, ExecutionOptions(), MagicMock())
+        resource_manager = ResourceManager(
+            topo, ExecutionOptions(), MagicMock(), DataContext.get_current()
+        )
         assert not resource_manager.op_resource_allocator_enabled()
 
 

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -34,6 +34,7 @@ def mock_map_op(
     op = MapOperator.create(
         MagicMock(),
         input_op,
+        DataContext.get_current(),
         ray_remote_args=ray_remote_args or {},
         compute_strategy=compute_strategy,
     )

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -64,7 +64,9 @@ class TestResourceManager:
         # the cluster resources for CPU/GPU, and
         # DEFAULT_OBJECT_STORE_MEMORY_LIMIT_FRACTION of cluster object store memory.
         options = ExecutionOptions()
-        resource_manager = ResourceManager(MagicMock(), options, get_total_resources)
+        resource_manager = ResourceManager(
+            MagicMock(), options, get_total_resources, DataContext.get_current()
+        )
         expected = ExecutionResources(
             cpu=cluster_resources["CPU"],
             gpu=cluster_resources["GPU"],
@@ -77,7 +79,9 @@ class TestResourceManager:
         options.resource_limits = ExecutionResources(
             cpu=1, gpu=2, object_store_memory=100
         )
-        resource_manager = ResourceManager(MagicMock(), options, get_total_resources)
+        resource_manager = ResourceManager(
+            MagicMock(), options, get_total_resources, DataContext.get_current()
+        )
         expected = ExecutionResources(
             cpu=1,
             gpu=2,
@@ -91,7 +95,9 @@ class TestResourceManager:
         options.exclude_resources = ExecutionResources(
             cpu=1, gpu=2, object_store_memory=100
         )
-        resource_manager = ResourceManager(MagicMock(), options, get_total_resources)
+        resource_manager = ResourceManager(
+            MagicMock(), options, get_total_resources, DataContext.get_current()
+        )
         expected = ExecutionResources(
             cpu=cluster_resources["CPU"] - 1,
             gpu=cluster_resources["GPU"] - 2,
@@ -328,7 +334,7 @@ class TestReservationOpResourceAllocator:
         o1 = InputDataBuffer(DataContext.get_current(), [])
         o2 = mock_map_op(o1, incremental_resource_usage=ExecutionResources(1, 0, 15))
         o3 = mock_map_op(o2, incremental_resource_usage=ExecutionResources(1, 0, 10))
-        o4 = LimitOperator(1, o3)
+        o4 = LimitOperator(1, o3, DataContext.get_current())
 
         op_usages = {op: ExecutionResources.zero() for op in [o1, o2, o3, o4]}
         op_internal_usage = {op: 0 for op in [o1, o2, o3, o4]}
@@ -528,7 +534,7 @@ class TestReservationOpResourceAllocator:
 
         o1 = InputDataBuffer(DataContext.get_current(), [])
         o2 = mock_map_op(o1)
-        o3 = LimitOperator(1, o2)
+        o3 = LimitOperator(1, o2, DataContext.get_current())
         topo, _ = build_streaming_topology(o3, ExecutionOptions())
 
         resource_manager = ResourceManager(
@@ -565,7 +571,7 @@ class TestReservationOpResourceAllocator:
         o2 = mock_map_op(o1)
         o3 = InputDataBuffer(DataContext.get_current(), [])
         o4 = mock_map_op(o3)
-        o3 = UnionOperator(o2, o4)
+        o3 = UnionOperator(DataContext.get_current(), o2, o4)
 
         topo, _ = build_streaming_topology(o3, ExecutionOptions())
 

--- a/python/ray/data/tests/test_size_estimation.py
+++ b/python/ray/data/tests/test_size_estimation.py
@@ -195,7 +195,8 @@ def test_split_map(shutdown_only, use_actors):
     nblocks = sum(len(b.block_refs) for b in bundles)
     assert nblocks == 1, nblocks
     ctx.target_max_block_size = 2_000_000
-    bundles: Iterable[RefBundle] = ds2.map(
+    ds3 = ray.data.range(1000, override_num_blocks=1).map(arrow_fn, **kwargs)
+    bundles: Iterable[RefBundle] = ds3.map(
         identity_fn, **kwargs
     ).iter_internal_ref_bundles()
     nblocks = sum(len(b.block_refs) for b in bundles)
@@ -220,7 +221,8 @@ def test_split_flat_map(ray_start_regular_shared):
     nblocks = sum(len(b.block_refs) for b in bundles)
     assert nblocks == 1, nblocks
     ctx.target_max_block_size = 2_000_000
-    bundles = ds2.flat_map(lambda x: [x]).iter_internal_ref_bundles()
+    ds3 = ray.data.range(1000, override_num_blocks=1).map(lambda _: ARROW_LARGE_VALUE)
+    bundles = ds3.flat_map(lambda x: [x]).iter_internal_ref_bundles()
     nblocks = sum(len(b.block_refs) for b in bundles)
     assert 4 < nblocks < 7, nblocks
 
@@ -235,7 +237,8 @@ def test_split_map_batches(ray_start_regular_shared):
     nblocks = sum(len(b.block_refs) for b in bundles)
     assert nblocks == 1, nblocks
     ctx.target_max_block_size = 2_000_000
-    bundles = ds2.map_batches(lambda x: x, batch_size=16).iter_internal_ref_bundles()
+    ds3 = ray.data.range(1000, override_num_blocks=1).map(lambda _: ARROW_LARGE_VALUE)
+    bundles = ds3.map_batches(lambda x: x, batch_size=16).iter_internal_ref_bundles()
     nblocks = sum(len(b.block_refs) for b in bundles)
     assert 4 < nblocks < 7, nblocks
 

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -125,7 +125,12 @@ def test_disallow_non_unique_operators():
         o1,
         DataContext.get_current(),
     )
-    o4 = PhysicalOperator("test_combine", [o2, o3], target_max_block_size=None)
+    o4 = PhysicalOperator(
+        "test_combine",
+        [o2, o3],
+        DataContext.get_current(),
+        target_max_block_size=None,
+    )
     with pytest.raises(ValueError):
         build_streaming_topology(o4, ExecutionOptions(verbose_progress=True))
 

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -85,7 +85,7 @@ def make_ref_bundle(x):
 )
 def test_build_streaming_topology(verbose_progress):
     inputs = make_ref_bundles([[x] for x in range(20)])
-    o1 = InputDataBuffer(inputs)
+    o1 = InputDataBuffer(DataContext.get_current(), inputs)
     o2 = MapOperator.create(
         make_map_transformer(lambda block: [b * -1 for b in block]),
         o1,
@@ -114,7 +114,7 @@ def test_build_streaming_topology(verbose_progress):
 def test_disallow_non_unique_operators():
     inputs = make_ref_bundles([[x] for x in range(20)])
     # An operator [o1] cannot used in the same DAG twice.
-    o1 = InputDataBuffer(inputs)
+    o1 = InputDataBuffer(DataContext.get_current(), inputs)
     o2 = MapOperator.create(
         make_map_transformer(lambda block: [b * -1 for b in block]),
         o1,
@@ -132,7 +132,7 @@ def test_disallow_non_unique_operators():
 
 def test_process_completed_tasks():
     inputs = make_ref_bundles([[x] for x in range(20)])
-    o1 = InputDataBuffer(inputs)
+    o1 = InputDataBuffer(DataContext.get_current(), inputs)
     o2 = MapOperator.create(
         make_map_transformer(lambda block: [b * -1 for b in block]),
         o1,
@@ -175,7 +175,7 @@ def test_process_completed_tasks():
     o1.mark_execution_completed.assert_not_called()
 
     # Test dependents completed.
-    o1 = InputDataBuffer(inputs)
+    o1 = InputDataBuffer(DataContext.get_current(), inputs)
     o2 = MapOperator.create(
         make_map_transformer(lambda block: [b * -1 for b in block]),
         o1,
@@ -198,7 +198,7 @@ def test_process_completed_tasks():
 def test_select_operator_to_run():
     opt = ExecutionOptions()
     inputs = make_ref_bundles([[x] for x in range(20)])
-    o1 = InputDataBuffer(inputs)
+    o1 = InputDataBuffer(DataContext.get_current(), inputs)
     o2 = MapOperator.create(
         make_map_transformer(lambda block: [b * -1 for b in block]),
         o1,
@@ -252,7 +252,7 @@ def test_select_operator_to_run():
 
 def test_dispatch_next_task():
     inputs = make_ref_bundles([[x] for x in range(20)])
-    o1 = InputDataBuffer(inputs)
+    o1 = InputDataBuffer(DataContext.get_current(), inputs)
     o1_state = OpState(o1, [])
     o2 = MapOperator.create(
         make_map_transformer(lambda block: [b * -1 for b in block]),
@@ -279,7 +279,7 @@ def test_dispatch_next_task():
 def test_debug_dump_topology():
     opt = ExecutionOptions()
     inputs = make_ref_bundles([[x] for x in range(20)])
-    o1 = InputDataBuffer(inputs)
+    o1 = InputDataBuffer(DataContext.get_current(), inputs)
     o2 = MapOperator.create(
         make_map_transformer(lambda block: [b * -1 for b in block]),
         o1,
@@ -295,6 +295,7 @@ def test_debug_dump_topology():
         topo,
         ExecutionOptions(),
         MagicMock(return_value=ExecutionResources.zero()),
+        DataContext.get_current(),
     )
     resource_manager.update_usages()
     # Just a sanity check to ensure it doesn't crash.
@@ -303,7 +304,7 @@ def test_debug_dump_topology():
 
 def test_validate_dag():
     inputs = make_ref_bundles([[x] for x in range(20)])
-    o1 = InputDataBuffer(inputs)
+    o1 = InputDataBuffer(DataContext.get_current(), inputs)
     o2 = MapOperator.create(
         make_map_transformer(lambda block: [b * -1 for b in block]),
         o1,
@@ -324,7 +325,7 @@ def test_validate_dag():
 
 
 def test_execution_allowed():
-    op = InputDataBuffer([])
+    op = InputDataBuffer(DataContext.get_current(), [])
 
     # CPU.
     op.incremental_resource_usage = MagicMock(return_value=ExecutionResources(cpu=1))
@@ -425,7 +426,7 @@ def test_execution_allowed():
 def test_select_ops_ensure_at_least_one_live_operator():
     opt = ExecutionOptions()
     inputs = make_ref_bundles([[x] for x in range(20)])
-    o1 = InputDataBuffer(inputs)
+    o1 = InputDataBuffer(DataContext.get_current(), inputs)
     o2 = MapOperator.create(
         make_map_transformer(lambda block: [b * -1 for b in block]),
         o1,
@@ -459,7 +460,7 @@ def test_select_ops_ensure_at_least_one_live_operator():
 
 def test_configure_output_locality():
     inputs = make_ref_bundles([[x] for x in range(20)])
-    o1 = InputDataBuffer(inputs)
+    o1 = InputDataBuffer(DataContext.get_current(), inputs)
     o2 = MapOperator.create(
         make_map_transformer(lambda block: [b * -1 for b in block]),
         o1,
@@ -504,7 +505,7 @@ def test_configure_output_locality():
 
 
 def test_execution_allowed_downstream_aware_memory_throttling():
-    op = InputDataBuffer([])
+    op = InputDataBuffer(DataContext.get_current(), [])
     op.incremental_resource_usage = MagicMock(return_value=ExecutionResources())
     # Below global.
     assert _execution_allowed(
@@ -549,7 +550,7 @@ def test_execution_allowed_downstream_aware_memory_throttling():
 
 
 def test_execution_allowed_nothrottle():
-    op = InputDataBuffer([])
+    op = InputDataBuffer(DataContext.get_current(), [])
     op.incremental_resource_usage = MagicMock(return_value=ExecutionResources())
     # Above global.
     assert not _execution_allowed(

--- a/python/ray/data/tests/test_streaming_integration.py
+++ b/python/ray/data/tests/test_streaming_integration.py
@@ -11,10 +11,7 @@ import pytest
 import ray
 from ray import cloudpickle
 from ray._private.test_utils import wait_for_condition
-from ray.data._internal.execution.interfaces import (
-    ExecutionResources,
-    RefBundle,
-)
+from ray.data._internal.execution.interfaces import ExecutionResources, RefBundle
 from ray.data._internal.execution.operators.base_physical_operator import (
     AllToAllOperator,
 )

--- a/python/ray/data/tests/test_streaming_integration.py
+++ b/python/ray/data/tests/test_streaming_integration.py
@@ -81,7 +81,7 @@ def test_autoshutdown_dangling_executors(ray_start_10_cpus_shared):
     initial = streaming_executor._num_shutdown
     for _ in range(num_runs):
         executor = StreamingExecutor(DataContext.get_current())
-        o = InputDataBuffer([])
+        o = InputDataBuffer(DataContext.get_current(), [])
         # Start the executor. Because non-started executors don't
         # need to be shut down.
         executor.execute(o)
@@ -94,7 +94,7 @@ def test_pipelined_execution(ray_start_10_cpus_shared, restore_data_context):
     ctx.execution_options.preserve_order = True
     executor = StreamingExecutor(ctx)
     inputs = make_ref_bundles([[x] for x in range(20)])
-    o1 = InputDataBuffer(inputs)
+    o1 = InputDataBuffer(DataContext.get_current(), inputs)
     o2 = MapOperator.create(
         make_map_transformer(lambda block: [b * -1 for b in block]),
         o1,
@@ -121,8 +121,8 @@ def test_pipelined_execution(ray_start_10_cpus_shared, restore_data_context):
 def test_output_split_e2e(ray_start_10_cpus_shared):
     executor = StreamingExecutor(DataContext.get_current())
     inputs = make_ref_bundles([[x] for x in range(20)])
-    o1 = InputDataBuffer(inputs)
-    o2 = OutputSplitter(o1, 2, equal=True)
+    o1 = InputDataBuffer(DataContext.get_current(), inputs)
+    o2 = OutputSplitter(o1, 2, equal=True, data_context=DataContext.get_current())
     it = executor.execute(o2)
 
     class Consume(threading.Thread):

--- a/python/ray/data/tests/test_streaming_integration.py
+++ b/python/ray/data/tests/test_streaming_integration.py
@@ -108,7 +108,7 @@ def test_pipelined_execution(ray_start_10_cpus_shared, restore_data_context):
         return reversed_list, {}
 
     ctx = DataContext.get_current()
-    o4 = AllToAllOperator(reverse_sort, o3, ctx.target_max_block_size)
+    o4 = AllToAllOperator(reverse_sort, o3, ctx, ctx.target_max_block_size)
     it = executor.execute(o4)
     output = ref_bundles_to_list(it)
     expected = [[x * -2] for x in range(20)][::-1]

--- a/python/ray/data/tests/test_streaming_integration.py
+++ b/python/ray/data/tests/test_streaming_integration.py
@@ -96,10 +96,14 @@ def test_pipelined_execution(ray_start_10_cpus_shared, restore_data_context):
     inputs = make_ref_bundles([[x] for x in range(20)])
     o1 = InputDataBuffer(inputs)
     o2 = MapOperator.create(
-        make_map_transformer(lambda block: [b * -1 for b in block]), o1
+        make_map_transformer(lambda block: [b * -1 for b in block]),
+        o1,
+        ctx,
     )
     o3 = MapOperator.create(
-        make_map_transformer(lambda block: [b * 2 for b in block]), o2
+        make_map_transformer(lambda block: [b * 2 for b in block]),
+        o2,
+        ctx,
     )
 
     def reverse_sort(inputs: List[RefBundle], ctx):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When users using multiple datasets and want to set different DataContext configurations. 
The recommended way is to set `DataContext.get_current()` before creating a Dataset. The DataContext is supposed to be captured and sealed by a Dataset when it's created. For example:

```python
                import ray

                context = ray.data.DataContext.get_current()

                context.target_max_block_size = 100 * 1024 ** 2
                ds1 = ray.data.range(1)
                context.target_max_block_size = 1 * 1024 ** 2
                ds2 = ray.data.range(1)

                # ds1's target_max_block_size will be 100MB
                ds1.take_all()
                # ds2's target_max_block_size will be 1MB
                ds2.take_all()
```

However in Ray Data internal code, `DataContext.get_current()` has been widely used in an incorrect way. This PR fixes most outstanding issues (but not all), by explicitly passing around the captured DataContext object as an argument to each component. 

## Related issue number
https://github.com/ray-project/ray/issues/41573

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
