### PR TITLE
[RLlib] Move all new stack Offline RL classes to `PublicAPI(stability='alpha')`.

### DIFF
--- a/rllib/offline/offline_data.py
+++ b/rllib/offline/offline_data.py
@@ -10,15 +10,15 @@ from ray.rllib.core import COMPONENT_RL_MODULE
 from ray.rllib.env import INPUT_ENV_SPACES
 from ray.rllib.offline.offline_prelearner import OfflinePreLearner
 from ray.rllib.utils.annotations import (
-    ExperimentalAPI,
     OverrideToImplementCustomLogic,
     OverrideToImplementCustomLogic_CallToSuperRecommended,
 )
+from ray.util.annotations import PublicAPI
 
 logger = logging.getLogger(__name__)
 
 
-@ExperimentalAPI
+@PublicAPI(stability="alpha")
 class OfflineData:
     @OverrideToImplementCustomLogic_CallToSuperRecommended
     def __init__(self, config: AlgorithmConfig):

--- a/rllib/offline/offline_env_runner.py
+++ b/rllib/offline/offline_env_runner.py
@@ -9,11 +9,16 @@ from ray.rllib.core.columns import Columns
 from ray.rllib.env.env_runner import EnvRunner
 from ray.rllib.env.single_agent_env_runner import SingleAgentEnvRunner
 from ray.rllib.env.single_agent_episode import SingleAgentEpisode
-from ray.rllib.utils.annotations import override
+from ray.rllib.utils.annotations import (
+    override,
+    OverrideToImplementCustomLogic_CallToSuperRecommended,
+    OverrideToImplementCustomLogic,
+)
 from ray.rllib.utils.compression import pack_if_needed
 from ray.rllib.utils.spaces.space_utils import to_jsonable_if_needed
 from ray.rllib.utils.typing import EpisodeType
 from ray.util.debug import log_once
+from ray.util.annotations import PublicAPI
 
 logger = logging.Logger(__file__)
 
@@ -21,10 +26,12 @@ logger = logging.Logger(__file__)
 #  calls only get_state.
 
 
+@PublicAPI(stability="alpha")
 class OfflineSingleAgentEnvRunner(SingleAgentEnvRunner):
     """The environment runner to record the single agent case."""
 
     @override(SingleAgentEnvRunner)
+    @OverrideToImplementCustomLogic_CallToSuperRecommended
     def __init__(self, *, config: AlgorithmConfig, **kwargs):
         # Initialize the parent.
         super().__init__(config=config, **kwargs)
@@ -111,6 +118,7 @@ class OfflineSingleAgentEnvRunner(SingleAgentEnvRunner):
         self._samples = []
 
     @override(SingleAgentEnvRunner)
+    @OverrideToImplementCustomLogic
     def sample(
         self,
         *,
@@ -206,6 +214,7 @@ class OfflineSingleAgentEnvRunner(SingleAgentEnvRunner):
         return samples
 
     @override(EnvRunner)
+    @OverrideToImplementCustomLogic
     def stop(self) -> None:
         """Writes the reamining samples to disk
 
@@ -243,6 +252,7 @@ class OfflineSingleAgentEnvRunner(SingleAgentEnvRunner):
 
         logger.debug(f"Experience buffer length: {len(self._samples)}")
 
+    @OverrideToImplementCustomLogic
     def _map_episodes_to_data(self, samples: List[EpisodeType]) -> None:
         """Converts list of episodes to list of single dict experiences.
 

--- a/rllib/offline/offline_prelearner.py
+++ b/rllib/offline/offline_prelearner.py
@@ -12,7 +12,6 @@ from ray.rllib.core.rl_module.multi_rl_module import MultiRLModuleSpec
 from ray.rllib.env.single_agent_episode import SingleAgentEpisode
 from ray.rllib.policy.sample_batch import MultiAgentBatch, SampleBatch
 from ray.rllib.utils.annotations import (
-    ExperimentalAPI,
     OverrideToImplementCustomLogic,
     OverrideToImplementCustomLogic_CallToSuperRecommended,
 )
@@ -20,6 +19,7 @@ from ray.rllib.utils.compression import unpack_if_needed
 from ray.rllib.utils.replay_buffers.replay_buffer import ReplayBuffer
 from ray.rllib.utils.spaces.space_utils import from_jsonable_if_needed
 from ray.rllib.utils.typing import EpisodeType, ModuleID
+from ray.util.annotations import PublicAPI
 
 if TYPE_CHECKING:
     from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
@@ -51,7 +51,7 @@ SCHEMA = {
 logger = logging.getLogger(__name__)
 
 
-@ExperimentalAPI
+@PublicAPI(stability="alpha")
 class OfflinePreLearner:
     """Class that coordinates data transformation from dataset to learner.
 
@@ -470,6 +470,8 @@ class OfflinePreLearner:
         # Note, `map_batches` expects a `Dict` as return value.
         return {"episodes": episodes}
 
+    @OverrideToImplementCustomLogic
+    @staticmethod
     def _map_sample_batch_to_episode(
         is_multi_agent: bool,
         batch: Dict[str, Union[list, np.ndarray]],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

With the new docs for Offline RL and the new stack enabled by default, we need to move the Offline RL classes in new stack to PublicAPI. As these are still in development we leave them at stability level "alpha".

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
