### PR TITLE
[Data] Fix the OOM issue caused by pyarrow.Dataset.to_batches

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -444,6 +444,7 @@ def read_fragments(
     assert len(fragments) > 0
 
     import pyarrow as pa
+    import pyarrow.parquet as pq
 
     logger.debug(f"Reading {len(fragments)} parquet fragments")
     use_threads = to_batches_kwargs.pop("use_threads", False)
@@ -463,12 +464,12 @@ def read_fragments(
             }
 
         def get_batch_iterable():
-            return fragment.to_batches(
+            pq_file = pq.ParquetFile(fragment.path,filesystem=fragment.filesystem)
+            return pq_file.iter_batches(
                 use_threads=use_threads,
                 columns=columns,
-                schema=schema,
                 batch_size=batch_size,
-                **to_batches_kwargs,
+                **to_batches_kwargs
             )
 
         # S3 can raise transient errors during iteration, and PyArrow doesn't expose a


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
<!-- Please give a short summary of the change and the problem this solves. -->

When reading Parquet files, Ray Data uses the `pyarrow.dataset.ParquetFileFragment.to_batches` method. However, when reading large Parquet files (like 2GB), it accumulates memory usage and leaks, which will lead to out-of-memory (OOM) issues. For details, please refer to the link: https://github.com/apache/arrow/issues/39808.

Replacing it with the `ParquetFile.iter_batches` method can solve this problem.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks
- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
