### PR TITLE
[core] change all dynamic_pointer_cast to static_pointer_cast.

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -49,7 +49,7 @@ from libc.stdint cimport (
 )
 from libcpp cimport bool as c_bool, nullptr
 from libcpp.memory cimport (
-    dynamic_pointer_cast,
+    static_pointer_cast,
     make_shared,
     shared_ptr,
     make_unique,
@@ -926,7 +926,7 @@ cdef prepare_args_internal(
             # simple fix for reference counting purposes.
             if <int64_t>size <= put_threshold and \
                     (<int64_t>size + total_inlined <= rpc_inline_threshold):
-                arg_data = dynamic_pointer_cast[CBuffer, LocalMemoryBuffer](
+                arg_data = static_pointer_cast[CBuffer, LocalMemoryBuffer](
                         make_shared[LocalMemoryBuffer](size))
                 if size > 0:
                     (<SerializedObject>serialized_arg).write_to(
@@ -2636,7 +2636,7 @@ cdef shared_ptr[CBuffer] string_to_buffer(c_string& c_str):
     cdef shared_ptr[CBuffer] empty_metadata
     if c_str.size() == 0:
         return empty_metadata
-    return dynamic_pointer_cast[
+    return static_pointer_cast[
         CBuffer, LocalMemoryBuffer](
             make_shared[LocalMemoryBuffer](
                 <uint8_t*>(c_str.data()), c_str.size(), True))

--- a/python/ray/includes/serialization.pxi
+++ b/python/ray/includes/serialization.pxi
@@ -485,7 +485,7 @@ cdef class MessagePackSerializedObject(SerializedObject):
 
     def to_bytes(self) -> bytes:
         cdef shared_ptr[CBuffer] data = \
-          dynamic_pointer_cast[CBuffer, LocalMemoryBuffer](
+          static_pointer_cast[CBuffer, LocalMemoryBuffer](
             make_shared[LocalMemoryBuffer](self._total_bytes))
         buffer = Buffer.make(data)
         self.write_to(buffer)

--- a/src/ray/object_manager/plasma/store.cc
+++ b/src/ray/object_manager/plasma/store.cc
@@ -220,7 +220,7 @@ void PlasmaStore::ReturnFromGet(const std::shared_ptr<GetRequest> &get_request) 
     }
   }
   // Send the get reply to the client.
-  Status s = SendGetReply(std::dynamic_pointer_cast<Client>(get_request->client),
+  Status s = SendGetReply(std::static_pointer_cast<Client>(get_request->client),
                           &get_request->object_ids[0],
                           get_request->objects,
                           get_request->object_ids.size(),

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -359,7 +359,7 @@ NodeManager::NodeManager(
       max_task_args_memory);
   cluster_task_manager_ =
       std::make_shared<ClusterTaskManager>(self_node_id_,
-                                           cluster_resource_scheduler_,
+                                           *cluster_resource_scheduler_,
                                            get_node_info_func,
                                            announce_infeasible_task,
                                            *local_task_manager_);

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -344,7 +344,7 @@ NodeManager::NodeManager(
   }
   local_task_manager_ = std::make_shared<LocalTaskManager>(
       self_node_id_,
-      *std::dynamic_pointer_cast<ClusterResourceScheduler>(cluster_resource_scheduler_),
+      *cluster_resource_scheduler_,
       dependency_manager_,
       [this](const WorkerID &owner_worker_id, const NodeID &owner_node_id) {
         return !this->IsWorkerDead(owner_worker_id, owner_node_id);
@@ -357,14 +357,14 @@ NodeManager::NodeManager(
         return GetObjectsFromPlasma(object_ids, results);
       },
       max_task_args_memory);
-  cluster_task_manager_ = std::make_shared<ClusterTaskManager>(
-      self_node_id_,
-      *std::dynamic_pointer_cast<ClusterResourceScheduler>(cluster_resource_scheduler_),
-      get_node_info_func,
-      announce_infeasible_task,
-      *local_task_manager_);
-  placement_group_resource_manager_ = std::make_shared<NewPlacementGroupResourceManager>(
-      std::dynamic_pointer_cast<ClusterResourceScheduler>(cluster_resource_scheduler_));
+  cluster_task_manager_ =
+      std::make_shared<ClusterTaskManager>(self_node_id_,
+                                           cluster_resource_scheduler_,
+                                           get_node_info_func,
+                                           announce_infeasible_task,
+                                           *local_task_manager_);
+  placement_group_resource_manager_ =
+      std::make_shared<NewPlacementGroupResourceManager>(cluster_resource_scheduler_);
 
   periodical_runner_.RunFnPeriodically(
       [this]() { cluster_task_manager_->ScheduleAndDispatchTasks(); },

--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -676,7 +676,7 @@ TEST_F(ClusterTaskManagerTest, BlockedWorkerDies2Test) {
 TEST_F(ClusterTaskManagerTest, NoFeasibleNodeTest) {
   std::shared_ptr<MockWorker> worker =
       std::make_shared<MockWorker>(WorkerID::FromRandom(), 1234);
-  pool_.PushWorker(std::dynamic_pointer_cast<WorkerInterface>(worker));
+  pool_.PushWorker(std::static_pointer_cast<WorkerInterface>(worker));
 
   RayTask task = CreateTask({{ray::kCPU_ResourceLabel, 999}});
   rpc::RequestWorkerLeaseReply reply;
@@ -838,8 +838,8 @@ TEST_F(ClusterTaskManagerTest, TestIsSelectedBasedOnLocality) {
       std::make_shared<MockWorker>(WorkerID::FromRandom(), 1234);
   std::shared_ptr<MockWorker> worker2 =
       std::make_shared<MockWorker>(WorkerID::FromRandom(), 1235);
-  pool_.PushWorker(std::dynamic_pointer_cast<WorkerInterface>(worker1));
-  pool_.PushWorker(std::dynamic_pointer_cast<WorkerInterface>(worker2));
+  pool_.PushWorker(std::static_pointer_cast<WorkerInterface>(worker1));
+  pool_.PushWorker(std::static_pointer_cast<WorkerInterface>(worker2));
 
   int num_callbacks = 0;
   auto callback = [&](Status, std::function<void()>, std::function<void()>) {
@@ -893,8 +893,8 @@ TEST_F(ClusterTaskManagerTest, TestGrantOrReject) {
       std::make_shared<MockWorker>(WorkerID::FromRandom(), 1234);
   std::shared_ptr<MockWorker> worker2 =
       std::make_shared<MockWorker>(WorkerID::FromRandom(), 1235);
-  pool_.PushWorker(std::dynamic_pointer_cast<WorkerInterface>(worker1));
-  pool_.PushWorker(std::dynamic_pointer_cast<WorkerInterface>(worker2));
+  pool_.PushWorker(std::static_pointer_cast<WorkerInterface>(worker1));
+  pool_.PushWorker(std::static_pointer_cast<WorkerInterface>(worker2));
 
   int num_callbacks = 0;
   auto callback = [&](Status, std::function<void()>, std::function<void()>) {
@@ -1976,7 +1976,7 @@ TEST_F(ClusterTaskManagerTest, TestSpillWaitingTasks) {
   // Dispatch the ready task.
   std::shared_ptr<MockWorker> worker =
       std::make_shared<MockWorker>(WorkerID::FromRandom(), 1234);
-  pool_.PushWorker(std::dynamic_pointer_cast<WorkerInterface>(worker));
+  pool_.PushWorker(std::static_pointer_cast<WorkerInterface>(worker));
   task_manager_.ScheduleAndDispatchTasks();
   pool_.TriggerCallbacks();
   ASSERT_EQ(num_callbacks, 4);
@@ -2320,7 +2320,7 @@ TEST_F(ClusterTaskManagerTestWithoutCPUsAtHead, ZeroCPUNode) {
 TEST_F(ClusterTaskManagerTest, SchedulingClassCapSpillback) {
   std::shared_ptr<MockWorker> worker =
       std::make_shared<MockWorker>(WorkerID::FromRandom(), 1234);
-  pool_.PushWorker(std::dynamic_pointer_cast<WorkerInterface>(worker));
+  pool_.PushWorker(std::static_pointer_cast<WorkerInterface>(worker));
 
   std::vector<RayTask> tasks;
   std::vector<std::unique_ptr<rpc::RequestWorkerLeaseReply>> replies;

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -278,7 +278,7 @@ class WorkerPoolMock : public WorkerPool {
                                                                client_call_manager_,
                                                                worker_startup_token);
     std::shared_ptr<WorkerInterface> worker =
-        std::dynamic_pointer_cast<WorkerInterface>(worker_);
+        std::static_pointer_cast<WorkerInterface>(worker_);
     auto rpc_client = std::make_shared<MockWorkerClient>();
     worker->Connect(rpc_client);
     mock_worker_rpc_clients_.emplace(worker->WorkerId(), rpc_client);


### PR DESCRIPTION
We use dynamic_cast and dynamic_pointer_cast to do a bunch of downcasts (base -> derived casts). I found that all dynamic_pointer_casts are unused: they are either upcasts, or casting to itself. So I changed them to static_pointer_cast for upcasts, and no-op to no-casts.

We do have a bunch of dynamic_casts which are real downcasts. I believe we can remove them all, but I did not have time to take a look.