### PR TITLE
[core] Task submitter shared pointer cleanup

### DIFF
--- a/src/ray/core_worker/actor_manager.h
+++ b/src/ray/core_worker/actor_manager.h
@@ -33,7 +33,7 @@ namespace core {
 class ActorManager {
  public:
   explicit ActorManager(std::shared_ptr<gcs::GcsClient> gcs_client,
-                        std::shared_ptr<ActorTaskSubmitterInterface> actor_task_submitter,
+                        ActorTaskSubmitterInterface &actor_task_submitter,
                         std::shared_ptr<ReferenceCounterInterface> reference_counter)
       : gcs_client_(gcs_client),
         actor_task_submitter_(actor_task_submitter),
@@ -191,7 +191,7 @@ class ActorManager {
   std::shared_ptr<gcs::GcsClient> gcs_client_;
 
   /// Interface to submit tasks directly to other actors.
-  std::shared_ptr<ActorTaskSubmitterInterface> actor_task_submitter_;
+  ActorTaskSubmitterInterface &actor_task_submitter_;
 
   /// Used to keep track of actor handle reference counts.
   /// All actor handle related ref counting logic should be included here.

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -670,7 +670,7 @@ CoreWorker::CoreWorker(CoreWorkerOptions options, const WorkerID &worker_id)
 
   actor_creator_ = std::make_shared<DefaultActorCreator>(gcs_client_);
 
-  actor_task_submitter_ = std::make_shared<ActorTaskSubmitter>(*core_worker_client_pool_,
+  actor_task_submitter_ = std::make_unique<ActorTaskSubmitter>(*core_worker_client_pool_,
                                                                *memory_store_,
                                                                *task_manager_,
                                                                *actor_creator_,
@@ -731,7 +731,7 @@ CoreWorker::CoreWorker(CoreWorkerOptions options, const WorkerID &worker_id)
   }
 
   actor_manager_ = std::make_unique<ActorManager>(
-      gcs_client_, actor_task_submitter_, reference_counter_);
+      gcs_client_, *actor_task_submitter_, reference_counter_);
 
   std::function<Status(const ObjectID &object_id, const ObjectLookupCallback &callback)>
       object_lookup_fn;

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1743,7 +1743,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   std::shared_ptr<ActorCreatorInterface> actor_creator_;
 
   // Interface to submit tasks directly to other actors.
-  std::shared_ptr<ActorTaskSubmitter> actor_task_submitter_;
+  std::unique_ptr<ActorTaskSubmitter> actor_task_submitter_;
 
   // A class to publish object status from other raylets/workers.
   std::unique_ptr<pubsub::Publisher> object_info_publisher_;

--- a/src/ray/core_worker/test/actor_manager_test.cc
+++ b/src/ray/core_worker/test/actor_manager_test.cc
@@ -140,7 +140,7 @@ class ActorManagerTest : public ::testing::Test {
 
   void SetUp() {
     actor_manager_ = std::make_shared<ActorManager>(
-        gcs_client_mock_, actor_task_submitter_, reference_counter_);
+        gcs_client_mock_, *actor_task_submitter_, reference_counter_);
   }
 
   void TearDown() { actor_manager_.reset(); }


### PR DESCRIPTION
Cleanup shared pointer and use unique pointer for clear memory ownership and less error prune.