### PR TITLE
[core] Remove gcs InternalConfigTable

### DIFF
--- a/python/ray/tests/test_gcs_utils.py
+++ b/python/ray/tests/test_gcs_utils.py
@@ -309,7 +309,7 @@ def test_redis_cleanup(redis_replicas, shutdown_only):
     else:
         cli = redis.Redis(host, int(port))
 
-    table_names = ["KV", "INTERNAL_CONFIG", "WORKERS", "JobCounter", "NODE", "JOB"]
+    table_names = ["KV", "WORKERS", "JobCounter", "NODE", "JOB"]
     c1_keys = [f"RAYc1@{name}".encode() for name in table_names]
     c2_keys = [f"RAYc2@{name}".encode() for name in table_names]
     assert set(cli.keys()) == set(c1_keys + c2_keys)

--- a/src/mock/ray/gcs/gcs_server/gcs_table_storage.h
+++ b/src/mock/ray/gcs/gcs_server/gcs_table_storage.h
@@ -97,7 +97,7 @@ namespace gcs {
 
 class MockGcsNodeTable : public GcsNodeTable {
  public:
-  MockGcsNodeTable() : GcsNodeTable(nullptr){};
+  MockGcsNodeTable() : GcsNodeTable(nullptr) {};
 
   MOCK_METHOD(Status,
               Put,
@@ -114,16 +114,6 @@ namespace ray {
 namespace gcs {
 
 class MockGcsWorkerTable : public GcsWorkerTable {
- public:
-};
-
-}  // namespace gcs
-}  // namespace ray
-
-namespace ray {
-namespace gcs {
-
-class MockGcsInternalConfigTable : public GcsInternalConfigTable {
  public:
 };
 

--- a/src/mock/ray/gcs/gcs_server/gcs_table_storage.h
+++ b/src/mock/ray/gcs/gcs_server/gcs_table_storage.h
@@ -97,7 +97,7 @@ namespace gcs {
 
 class MockGcsNodeTable : public GcsNodeTable {
  public:
-  MockGcsNodeTable() : GcsNodeTable(nullptr) {};
+  MockGcsNodeTable() : GcsNodeTable(nullptr){};
 
   MOCK_METHOD(Status,
               Put,

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -18,18 +18,10 @@
 
 #include "ray/common/asio/asio_util.h"
 #include "ray/common/asio/instrumented_io_context.h"
-#include "ray/common/network_util.h"
 #include "ray/common/ray_config.h"
 #include "ray/gcs/gcs_server/gcs_actor_manager.h"
-#include "ray/gcs/gcs_server/gcs_autoscaler_state_manager.h"
-#include "ray/gcs/gcs_server/gcs_job_manager.h"
-#include "ray/gcs/gcs_server/gcs_node_manager.h"
-#include "ray/gcs/gcs_server/gcs_placement_group_manager.h"
 #include "ray/gcs/gcs_server/gcs_resource_manager.h"
-#include "ray/gcs/gcs_server/gcs_worker_manager.h"
-#include "ray/gcs/gcs_server/runtime_env_handler.h"
 #include "ray/gcs/gcs_server/store_client_kv.h"
-#include "ray/gcs/store_client/observable_store_client.h"
 #include "ray/pubsub/publisher.h"
 #include "ray/util/util.h"
 
@@ -82,25 +74,6 @@ GcsServer::GcsServer(const ray::gcs::GcsServerConfig &config,
   default:
     RAY_LOG(FATAL) << "Unexpected storage type: " << storage_type_;
   }
-
-  auto on_done = [this](const ray::Status &status) {
-    RAY_CHECK(status.ok()) << "Failed to put internal config";
-    this->io_context_provider_.GetDefaultIOContext().stop();
-  };
-
-  ray::rpc::StoredConfig stored_config;
-  stored_config.set_config(config_.raylet_config_list);
-  RAY_CHECK_OK(gcs_table_storage_->InternalConfigTable().Put(
-      ray::UniqueID::Nil(), stored_config, on_done));
-  // Here we need to make sure the Put of internal config is happening in sync
-  // way. But since the storage API is async, we need to run the default io context
-  // to block current thread.
-  // This will run async operations from InternalConfigTable().Put() above
-  // inline.
-  io_context_provider_.GetDefaultIOContext().run();
-  // Reset the main service to the initial status otherwise, the signal handler
-  // will be called.
-  io_context_provider_.GetDefaultIOContext().restart();
 
   // Init GCS publisher instance.
   std::unique_ptr<pubsub::Publisher> inner_publisher;
@@ -652,7 +625,8 @@ void GcsServer::InitGcsWorkerManager() {
 
 void GcsServer::InitGcsAutoscalerStateManager(const GcsInitData &gcs_init_data) {
   RAY_CHECK(kv_manager_) << "kv_manager_ is not initialized.";
-  auto v2_enabled = std::to_string(RayConfig::instance().enable_autoscaler_v2());
+  auto v2_enabled =
+      std::to_string(static_cast<int>(RayConfig::instance().enable_autoscaler_v2()));
   RAY_LOG(INFO) << "Autoscaler V2 enabled: " << v2_enabled;
 
   kv_manager_->GetInstance().Put(

--- a/src/ray/gcs/gcs_server/gcs_table_storage.cc
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.cc
@@ -210,7 +210,6 @@ template class GcsTable<JobID, ErrorTableData>;
 template class GcsTable<WorkerID, WorkerTableData>;
 template class GcsTable<ActorID, ActorTableData>;
 template class GcsTable<ActorID, TaskSpec>;
-template class GcsTable<UniqueID, StoredConfig>;
 template class GcsTableWithJobId<ActorID, ActorTableData>;
 template class GcsTableWithJobId<ActorID, TaskSpec>;
 template class GcsTable<PlacementGroupID, PlacementGroupTableData>;

--- a/src/ray/gcs/gcs_server/gcs_table_storage.h
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.h
@@ -32,7 +32,6 @@ using rpc::GcsNodeInfo;
 using rpc::JobTableData;
 using rpc::PlacementGroupTableData;
 using rpc::ResourceUsageBatchData;
-using rpc::StoredConfig;
 using rpc::TaskSpec;
 using rpc::WorkerTableData;
 
@@ -209,14 +208,6 @@ class GcsWorkerTable : public GcsTable<WorkerID, WorkerTableData> {
   }
 };
 
-class GcsInternalConfigTable : public GcsTable<UniqueID, StoredConfig> {
- public:
-  explicit GcsInternalConfigTable(std::shared_ptr<StoreClient> store_client)
-      : GcsTable(std::move(store_client)) {
-    table_name_ = TablePrefix_Name(TablePrefix::INTERNAL_CONFIG);
-  }
-};
-
 /// \class GcsTableStorage
 ///
 /// This class is not meant to be used directly. All gcs table storage classes should
@@ -231,7 +222,6 @@ class GcsTableStorage {
     placement_group_table_ = std::make_unique<GcsPlacementGroupTable>(store_client_);
     node_table_ = std::make_unique<GcsNodeTable>(store_client_);
     worker_table_ = std::make_unique<GcsWorkerTable>(store_client_);
-    system_config_table_ = std::make_unique<GcsInternalConfigTable>(store_client_);
   }
 
   virtual ~GcsTableStorage() = default;
@@ -266,11 +256,6 @@ class GcsTableStorage {
     return *worker_table_;
   }
 
-  GcsInternalConfigTable &InternalConfigTable() {
-    RAY_CHECK(system_config_table_ != nullptr);
-    return *system_config_table_;
-  }
-
   int GetNextJobID() {
     RAY_CHECK(store_client_);
     return store_client_->GetNextJobID();
@@ -284,7 +269,6 @@ class GcsTableStorage {
   std::unique_ptr<GcsPlacementGroupTable> placement_group_table_;
   std::unique_ptr<GcsNodeTable> node_table_;
   std::unique_ptr<GcsWorkerTable> worker_table_;
-  std::unique_ptr<GcsInternalConfigTable> system_config_table_;
 };
 
 /// \class RedisGcsTableStorage

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -39,11 +39,10 @@ enum TablePrefix {
   DIRECT_ACTOR = 14;
   // WORKER is already used in WorkerType, so use WORKERS here.
   WORKERS = 15;
-  INTERNAL_CONFIG = 16;
-  PLACEMENT_GROUP_SCHEDULE = 17;
-  PLACEMENT_GROUP = 18;
-  KV = 19;
-  ACTOR_TASK_SPEC = 20;
+  PLACEMENT_GROUP_SCHEDULE = 16;
+  PLACEMENT_GROUP = 17;
+  KV = 18;
+  ACTOR_TASK_SPEC = 19;
 }
 
 // The channel that Add operations to the Table should be published on, if any.
@@ -467,10 +466,6 @@ message WorkerTableData {
 message WorkerDeltaData {
   bytes raylet_id = 1;
   bytes worker_id = 2;
-}
-
-message StoredConfig {
-  string config = 1;
 }
 
 message PubSubMessage {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
GCS InternalConfigTable is actually unused now. It was only used for the raylet_config_list before and now that's stored directly as a member of GcsInternalKVManager and HandleGetInternalConfig directly returns the raylet_config_list that was stored as a member variable.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
