### PR TITLE
[core][observability] Improve observability when the core worker fails to read data from the Raylet socket

### DIFF
--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -201,9 +201,11 @@ Status ServerConnection::ReadBuffer(
       bytes_remaining -= bytes_read;
       if (error.value() == EINTR) {
         continue;
-      } else if (error.value() == ENOENT) {
+      }
+      if (error.value() == ENOENT) {
         return Status::IOError("Failed to read data from the socket: " + error.message());
-      } else if (error.value() != boost::system::errc::errc_t::success) {
+      }
+      if (error.value() != boost::system::errc::errc_t::success) {
         return boost_to_ray_status(error);
       }
     }

--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -201,6 +201,8 @@ Status ServerConnection::ReadBuffer(
       bytes_remaining -= bytes_read;
       if (error.value() == EINTR) {
         continue;
+      } else if (error.value() == ENOENT) {
+        return Status::IOError("Failed to read data from the socket: " + error.message());
       } else if (error.value() != boost::system::errc::errc_t::success) {
         return boost_to_ray_status(error);
       }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If a core worker process has already established a connection with the Raylet but the Raylet process subsequently exits, the core worker process will fail to read data from the socket. However, the error code returned is ENOENT, and users will see the message "No such file or directory" which is very confusing.

This PR improves observability, allowing users to identify that the I/O error is related to the socket.

For example, comment out [import logging.handlers](https://github.com/ray-project/ray/blob/7b476ea4fd3f7addc4b87099f94d2d46a379b427/python/ray/_private/ray_logging/__init__.py#L4) and run a random Ray program. The runtime environment agent process will fail to import logging.handlers, causing the Raylet process to exit because it shares fate with the runtime environment agent process. See https://github.com/ray-project/ray/pull/48958#discussion_r1861208079 for more details.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

1. Comment out [import logging.handlers](https://github.com/ray-project/ray/blob/7b476ea4fd3f7addc4b87099f94d2d46a379b427/python/ray/_private/ray_logging/__init__.py#L4)
2. Run `python3 -c "import ray; ray.init();"`

* Without this PR
  <img width="1440" alt="Screenshot 2024-12-09 at 12 44 36 AM" src="https://github.com/user-attachments/assets/4d9747e4-2545-4dcf-9192-dfe537780043">

* With this PR
  <img width="1440" alt="Screenshot 2024-12-09 at 12 44 54 AM" src="https://github.com/user-attachments/assets/e380acc2-f273-4627-9546-5c1a06b59786">


- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
