### PR TITLE
[data] Make object store memory fraction configurable 

### DIFF
--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -341,6 +341,8 @@ class DataContext:
         default_factory=lambda: list(DEFAULT_RETRIED_IO_ERRORS)
     )
 
+    override_object_store_memory_limit_fraction: float = None
+
     def __post_init__(self):
         # The additonal ray remote args that should be added to
         # the task-pool-based data tasks.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
When I encounter a situation where memory operators consume a relatively large amount of memory, I want to adjust the proportion of reserved operator memory. However, I find that it is unchangeable. So I submitted this pull request hoping to fix this problem.
<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
