### PR TITLE
[core] Stabilize many_nodes release test

### DIFF
--- a/release/benchmarks/many_nodes.yaml
+++ b/release/benchmarks/many_nodes.yaml
@@ -5,7 +5,7 @@ max_workers: 999
 
 head_node_type:
     name: head_node
-    instance_type: ridn.16xlarge # Network optimized.
+    instance_type: r6idn.16xlarge # Network optimized.
     resources:
       cpu: 0
       custom_resources:

--- a/release/benchmarks/many_nodes.yaml
+++ b/release/benchmarks/many_nodes.yaml
@@ -5,7 +5,7 @@ max_workers: 999
 
 head_node_type:
     name: head_node
-    instance_type: r5dn.16xlarge # Network optimized.
+    instance_type: ridn.16xlarge # Network optimized.
     resources:
       cpu: 0
       custom_resources:
@@ -14,7 +14,7 @@ head_node_type:
 
 worker_node_types:
     - name: small_worker
-      instance_type: m5.2xlarge
+      instance_type: m6i.2xlarge
       min_workers: 249
       max_workers: 249
       use_spot: false
@@ -22,3 +22,6 @@ worker_node_types:
         custom_resources:
           node: 1
 
+flags:
+  disable_nfs_mount: true
+  allow-cross-zone-autoscaling: true

--- a/release/benchmarks/many_nodes.yaml
+++ b/release/benchmarks/many_nodes.yaml
@@ -21,6 +21,3 @@ worker_node_types:
       resources:
         custom_resources:
           node: 1
-
-flags:
-  allow-cross-zone-autoscaling: true

--- a/release/benchmarks/many_nodes.yaml
+++ b/release/benchmarks/many_nodes.yaml
@@ -23,5 +23,4 @@ worker_node_types:
           node: 1
 
 flags:
-  disable_nfs_mount: true
   allow-cross-zone-autoscaling: true


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
many_nodes release test is flaky because it failed to acquire the 249 nodes necessary to start the task. We were getting the message ```Launching instances failed: NewInstances[m5.2xlarge;num:112;all:false]: could not launch any instances...error InsufficientInstanceCapacity: We currently do not have sufficient m5.2xlarge capacity in the Availability Zone you requested (us-west-2a).``` We're fixing it by upgrading the instance types to r6 and m6 as they seem to have more availability.
- Upgrading instances to ridn6 and m6i
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#49097
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
