### PR TITLE
Fix unpacking zip package treats "../" as the top_level_directory

### DIFF
--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -843,6 +843,7 @@ def get_top_level_dir_from_compressed_package(package_path: str):
     returns None.
 
     Ignores a second top-level directory if it is named __MACOSX.
+    Returns None if the top level directory starts with "..".
     """
 
     package_zip = ZipFile(package_path, "r")
@@ -874,6 +875,11 @@ def get_top_level_dir_from_compressed_package(package_path: str):
                 MAC_OS_ZIP_HIDDEN_DIR_NAME,
             ]:
                 return None
+
+    # If the top level directory starts with "..", it is an invalid base
+    # directory and we should return None
+    if top_level_directory and top_level_directory.startswith(".."):
+        return None
 
     return top_level_directory
 

--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -110,6 +110,18 @@ def random_zip_file_without_top_level_dir(random_dir):
 
 
 @pytest.fixture
+def random_zip_file_with_parent_dir_as_top_level_dir(random_dir):
+    # Create zip file with ".." as top level directory
+    make_archive(
+        random_dir / ARCHIVE_NAME[: ARCHIVE_NAME.rfind(".")],
+        "zip",
+        random_dir,
+        "..",
+    )
+    yield str(random_dir / ARCHIVE_NAME)
+
+
+@pytest.fixture
 def random_zip_file_with_top_level_dir(tmp_path):
     path = tmp_path
     top_level_dir = path / TOP_LEVEL_DIR_NAME
@@ -329,6 +341,12 @@ class TestGetTopLevelDirFromCompressedPackage:
         )
         assert top_level_dir_name is None
 
+
+    def test_get_top_level_parent_dir(self, random_zip_file_with_parent_dir_as_top_level_dir):
+        top_level_dir_name = get_top_level_dir_from_compressed_package(
+            str(random_zip_file_with_parent_dir_as_top_level_dir)
+        )
+        assert top_level_dir_name is None
 
 class TestRemoveDirFromFilepaths:
     def test_valid_removal(self, random_zip_file_with_top_level_dir):

--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -341,12 +341,14 @@ class TestGetTopLevelDirFromCompressedPackage:
         )
         assert top_level_dir_name is None
 
-
-    def test_get_top_level_parent_dir(self, random_zip_file_with_parent_dir_as_top_level_dir):
+    def test_get_top_level_parent_dir(
+        self, random_zip_file_with_parent_dir_as_top_level_dir
+    ):
         top_level_dir_name = get_top_level_dir_from_compressed_package(
             str(random_zip_file_with_parent_dir_as_top_level_dir)
         )
         assert top_level_dir_name is None
+
 
 class TestRemoveDirFromFilepaths:
     def test_valid_removal(self, random_zip_file_with_top_level_dir):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
TL;DR:
Parent path in package shouldn't be treated as top level directory.

The files in zip packages can contain relative paths like "..", and the current implementation of `get_top_level_dir_from_compressed_package()` extract the top_level_directory as "..", which should not be treated as a valid directory. When the top_level_directory is "..", `remove_dir_from_filepaths()` will break because it concatenates the top_level_directory after a temporary folder (see code snippet below, rdir is the top_level_directory), and the resulting path escapes the temporary directory (for example, if the temporary directory is `/tmp/tmp_abc`, the concatenated path becomes `/tmp/tmp_abc/..`).

https://github.com/ray-project/ray/blob/e171ad17082cc937b8c279790bd70cdeb22914a5/python/ray/_private/runtime_env/packaging.py#L901-L904

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
