### PR TITLE
[data] add column relaxation

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -5,7 +5,6 @@ import itertools
 import logging
 import time
 import warnings
-from collections.abc import Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -768,8 +767,6 @@ class Dataset:
         def add_column(batch: DataBatch) -> DataBatch:
             column = fn(batch)
             if batch_format == "pandas":
-                import pandas as pd
-
                 batch.loc[:, col] = column
                 return batch
             elif batch_format == "pyarrow":

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -765,20 +765,11 @@ class Dataset:
                 f"got: {batch_format}"
             )
 
-        def _raise_duplicate_column_error(col: str):
-            raise ValueError(f"Trying to add an existing column with name {col!r}")
-
         def add_column(batch: DataBatch) -> DataBatch:
             column = fn(batch)
             if batch_format == "pandas":
                 import pandas as pd
 
-                assert isinstance(column, (pd.Series, Sequence)), (
-                    f"For pandas batch format, the function must return a pandas "
-                    f"Series or sequence, got: {type(column)}"
-                )
-                if col in batch:
-                    _raise_duplicate_column_error(col)
                 batch.loc[:, col] = column
                 return batch
             elif batch_format == "pyarrow":
@@ -797,10 +788,9 @@ class Dataset:
                 # which case we'll want to append it
                 column_idx = batch.schema.get_field_index(col)
                 if column_idx == -1:
-                    # Append the column to the table
                     return batch.append_column(col, column)
                 else:
-                    _raise_duplicate_column_error(col)
+                    return batch.set_column(column_idx, col, column)
 
             else:
                 # batch format is assumed to be numpy since we checked at the
@@ -809,8 +799,6 @@ class Dataset:
                     f"For numpy batch format, the function must return a "
                     f"numpy.ndarray, got: {type(column)}"
                 )
-                if col in batch:
-                    _raise_duplicate_column_error(col)
                 batch[col] = column
                 return batch
 

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -399,17 +399,13 @@ def test_add_column(ray_start_regular_shared):
     assert ds.take(2) == [{"id": 1}, {"id": 2}]
 
     # Adding a column in the wrong format may result in an error
-    with pytest.raises(
-        ray.exceptions.UserCodeException
-    ):
+    with pytest.raises(ray.exceptions.UserCodeException):
         ds = ray.data.range(5).add_column(
             "id", lambda x: range(7), batch_format="pandas"
         )
         assert ds.take(2) == [{"id": 1}, {"id": 2}]
-    
-    ds = ray.data.range(5).add_column(
-        "const", lambda _: 3, batch_format="pandas"
-    )
+
+    ds = ray.data.range(5).add_column("const", lambda _: 3, batch_format="pandas")
     assert ds.take(2) == [{"id": 0, "const": 3}, {"id": 1, "const": 3}]
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Why are these changes needed?

Aligns `ray.data.Dataset.add_column` to it's docstring and allows more flexibility for adding columns to pandas dataframes.

## Related issue number

Closes #49114

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit test
   - [ ] Release tests
   - [ ] This PR is not tested :(
`python -m pytest -v -s python\ray\data\tests\test_map.py::test_add_column`