### PR TITLE
[Train][release_test] Update release tests for xgboost and lightgbm trainer to V2

### DIFF
--- a/release/train_tests/xgboost_lightgbm/train_batch_inference_benchmark.py
+++ b/release/train_tests/xgboost_lightgbm/train_batch_inference_benchmark.py
@@ -89,6 +89,7 @@ def lightgbm_train_loop_function(config: Dict):
 
     label_column, params = config["label_column"], config["params"]
     train_X, train_y = train_df.drop(label_column, axis=1), train_df[label_column]
+    train_set = lgb.Dataset(train_X, label=train_y)
 
     # 2. Do distributed data-parallel training.
     # Ray Train sets up the necessary coordinator processes and
@@ -96,8 +97,7 @@ def lightgbm_train_loop_function(config: Dict):
     report_callback = config["report_callback_cls"]
     lgb.train(
         params,
-        train_set=train_X,
-        label=train_y,
+        train_set=train_set,
         num_boost_round=10,
         callbacks=[report_callback()],
     )

--- a/release/train_tests/xgboost_lightgbm/train_batch_inference_benchmark.py
+++ b/release/train_tests/xgboost_lightgbm/train_batch_inference_benchmark.py
@@ -6,11 +6,14 @@ import time
 from typing import Dict
 
 import xgboost as xgb
+import lightgbm as lgb
 
 import ray
 from ray import data
-from ray.train.lightgbm import LightGBMTrainer
-from ray.train.xgboost import XGBoostTrainer
+from ray.train.lightgbm.v2 import LightGBMTrainer
+from ray.train.xgboost.v2 import XGBoostTrainer
+from ray.train.xgboost import RayTrainReportCallback as XGBoostReportCallback
+from ray.train.lightgbm import RayTrainReportCallback as LightGBMReportCallback
 from ray.train import RunConfig, ScalingConfig
 
 _TRAINING_TIME_THRESHOLD = 600
@@ -57,22 +60,69 @@ class LightGBMPredictor(BasePredictor):
         return {"predictions": self.model.predict(data)}
 
 
+def xgboost_train_loop_function(config: Dict):
+    # 1. Get the dataset shard for the worker and convert to a `xgboost.DMatrix`
+    train_ds_iter = ray.train.get_dataset_shard("train")
+    train_df = train_ds_iter.materialize().to_pandas()
+
+    label_column, params = config["label_column"], config["params"]
+    train_X, train_y = train_df.drop(label_column, axis=1), train_df[label_column]
+
+    dtrain = xgb.DMatrix(train_X, label=train_y)
+
+    # 2. Do distributed data-parallel training.
+    # Ray Train sets up the necessary coordinator processes and
+    # environment variables for your workers to communicate with each other.
+    xgb.train(
+        params,
+        dtrain=dtrain,
+        num_boost_round=10,
+        callbacks=[XGBoostReportCallback()],
+    )
+
+
+def lightgbm_train_loop_function(config: Dict):
+    # 1. Get the dataset shard for the worker and convert to a `xgboost.DMatrix`
+    train_ds_iter = ray.train.get_dataset_shard("train")
+    train_df = train_ds_iter.materialize().to_pandas()
+
+    label_column, params = config["label_column"], config["params"]
+    train_X, train_y = train_df.drop(label_column, axis=1), train_df[label_column]
+
+    # 2. Do distributed data-parallel training.
+    # Ray Train sets up the necessary coordinator processes and
+    # environment variables for your workers to communicate with each other.
+    lgb.train(
+        params,
+        train_set=train_X,
+        label=train_y,
+        num_boost_round=10,
+        callbacks=[LightGBMReportCallback()],
+    )
+
+
 _FRAMEWORK_PARAMS = {
     "xgboost": {
         "trainer_cls": XGBoostTrainer,
         "predictor_cls": XGBoostPredictor,
-        "params": {
-            "objective": "binary:logistic",
-            "eval_metric": ["logloss", "error"],
+        "train_loop_function": xgboost_train_loop_function,
+        "train_loop_config": {
+            "params": {
+                "objective": "binary:logistic",
+                "eval_metric": ["logloss", "error"],
+            },
+            "label_column": "labels",
         },
     },
     "lightgbm": {
         "trainer_cls": LightGBMTrainer,
         "predictor_cls": LightGBMPredictor,
+        "train_loop_function": lightgbm_train_loop_function,
         "params": {
             "objective": "binary",
             "metric": ["binary_logloss", "binary_error"],
         },
+        "label_column": "labels",
     },
 }
 
@@ -84,15 +134,15 @@ def train(
     framework_params = _FRAMEWORK_PARAMS[framework]
 
     trainer_cls = framework_params["trainer_cls"]
+    framework_train_loop_fn = framework_params["train_loop_function"]
 
     trainer = trainer_cls(
-        params=framework_params["params"],
+        train_loop_function=framework_train_loop_fn,
+        train_loop_config=framework_params["train_loop_config"],
         scaling_config=ScalingConfig(
             num_workers=num_workers,
             resources_per_worker={"CPU": cpus_per_worker},
-            trainer_resources={"CPU": 0},
         ),
-        label_column="labels",
         datasets={"train": ds},
         run_config=RunConfig(
             storage_path="/mnt/cluster_storage", name=f"{framework}_benchmark"

--- a/release/train_tests/xgboost_lightgbm/train_batch_inference_benchmark.py
+++ b/release/train_tests/xgboost_lightgbm/train_batch_inference_benchmark.py
@@ -82,7 +82,7 @@ def xgboost_train_loop_function(config: Dict):
 
 
 def lightgbm_train_loop_function(config: Dict):
-    # 1. Get the dataset shard for the worker and convert to a `xgboost.DMatrix`
+    # 1. Get the dataset shard for the worker and convert to a DataFrame
     train_ds_iter = ray.train.get_dataset_shard("train")
     train_df = train_ds_iter.materialize().to_pandas()
 

--- a/release/train_tests/xgboost_lightgbm/train_batch_inference_benchmark.py
+++ b/release/train_tests/xgboost_lightgbm/train_batch_inference_benchmark.py
@@ -137,7 +137,7 @@ def train(
     framework_train_loop_fn = framework_params["train_loop_function"]
 
     trainer = trainer_cls(
-        train_loop_function=framework_train_loop_fn,
+        train_loop_per_worker=framework_train_loop_fn,
         train_loop_config=framework_params["train_loop_config"],
         scaling_config=ScalingConfig(
             num_workers=num_workers,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR upgrades the release tests for `XGBoostTrainer` and `LightGBMTrainer` from a previous version to a recent version. Both trainers are now subclass of `DataParallelTrainer`, similar to `TorchTrainer`

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
