### PR TITLE
[serve] Add replica pid to replica startup logs

### DIFF
--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -972,6 +972,11 @@ class DeploymentReplica:
         return self._actor.node_id
 
     @property
+    def actor_pid(self) -> Optional[int]:
+        """Returns the node id of the actor, None if not placed."""
+        return self._actor.pid
+
+    @property
     def initialization_latency_s(self) -> Optional[float]:
         """Returns how long the replica took to initialize."""
 
@@ -2000,7 +2005,7 @@ class DeploymentState:
                 replica_startup_message = (
                     f"{replica.replica_id} started successfully "
                     f"on node '{replica.actor_node_id}' after "
-                    f"{e2e_replica_start_latency:.1f}s."
+                    f"{e2e_replica_start_latency:.1f}s (PID: {replica.actor_pid})."
                 )
                 if replica.initialization_latency_s is not None:
                     # This condition should always be True. The initialization


### PR DESCRIPTION
## Why are these changes needed?

Log the replica PID when it starts. This will help with debugging. Sometimes we might want to check Ray core logs, and PID can be used to cross reference replica ID with actor logs.

Example:
```
INFO 2024-12-11 20:57:19,397 controller 62696 -- Replica(id='a1mjqmdq', deployment='api', app='default') started successfully on node '7acc041e50ba72d78dbf376298ddd1f1975e0f7b7e9e712cd9ac99f7' after 0.6s (PID: 62691). Replica constructor, reconfigure method, and initial health check took 0.0s.
```
