### PR TITLE
[core] Optimize health check destruction

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_health_check_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_health_check_manager.cc
@@ -85,6 +85,12 @@ std::vector<NodeID> GcsHealthCheckManager::GetAllNodes() const {
 void GcsHealthCheckManager::HealthCheckContext::StartHealthCheck() {
   using ::grpc::health::v1::HealthCheckResponse;
 
+  // If current context is requested to stop, directly destruct itself and exit.
+  if (stopped_) {
+    delete this;
+    return;
+  }
+
   // Reset the context/request/response for the next request.
   context_.~ClientContext();
   new (&context_) grpc::ClientContext();


### PR DESCRIPTION
Current implementation is not good enough IMO: even if the node context has been requested to stop, we still send extra rpc request, and check whether stopped after rpc completed.