### PR TITLE
[core] Cleanup resource id shared pointer usage in core worker

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -3102,7 +3102,7 @@ Status CoreWorker::AllocateReturnObject(const ObjectID &object_id,
 
 Status CoreWorker::ExecuteTask(
     const TaskSpecification &task_spec,
-    std::shared_ptr<ResourceMappingType> resource_ids,
+    std::optional<ResourceMappingType> resource_ids,
     std::vector<std::pair<ObjectID, std::shared_ptr<RayObject>>> *return_objects,
     std::vector<std::pair<ObjectID, std::shared_ptr<RayObject>>> *dynamic_return_objects,
     std::vector<std::pair<ObjectID, bool>> *streaming_generator_returns,
@@ -3151,7 +3151,7 @@ Status CoreWorker::ExecuteTask(
   {
     absl::MutexLock lock(&mutex_);
     current_tasks_.emplace(task_spec.TaskId(), task_spec);
-    if (resource_ids != nullptr) {
+    if (resource_ids.has_value()) {
       resource_ids_ = std::move(*resource_ids);
     }
   }
@@ -3568,7 +3568,7 @@ std::vector<rpc::ObjectReference> CoreWorker::ExecuteTaskLocalMode(
   std::vector<std::pair<ObjectID, std::shared_ptr<RayObject>>> dynamic_return_objects;
   std::vector<std::pair<ObjectID, bool>> streaming_generator_returns;
   RAY_UNUSED(ExecuteTask(task_spec,
-                         /*resource_ids=*/std::make_shared<ResourceMappingType>(),
+                         /*resource_ids=*/ResourceMappingType{},
                          &return_objects,
                          &dynamic_return_objects,
                          &streaming_generator_returns,

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -262,7 +262,7 @@ CoreWorker::CoreWorker(CoreWorkerOptions options, const WorkerID &worker_id)
       periodical_runner_(PeriodicalRunner::Create(io_service_)),
       task_queue_length_(0),
       num_executed_tasks_(0),
-      resource_ids_(new ResourceMappingType()),
+      resource_ids_(),
       grpc_service_(io_service_, *this),
       task_execution_service_work_(task_execution_service_),
       exiting_detail_(std::nullopt),
@@ -3014,9 +3014,9 @@ const std::string CoreWorker::GetActorName() const {
   return actor_manager_->GetActorHandle(actor_id_)->GetName();
 }
 
-const ResourceMappingType CoreWorker::GetResourceIDs() const {
+ResourceMappingType CoreWorker::GetResourceIDs() const {
   absl::MutexLock lock(&mutex_);
-  return *resource_ids_;
+  return resource_ids_;
 }
 
 std::unique_ptr<worker::ProfileEvent> CoreWorker::CreateProfileEvent(
@@ -3102,7 +3102,7 @@ Status CoreWorker::AllocateReturnObject(const ObjectID &object_id,
 
 Status CoreWorker::ExecuteTask(
     const TaskSpecification &task_spec,
-    const std::shared_ptr<ResourceMappingType> &resource_ids,
+    std::shared_ptr<ResourceMappingType> resource_ids,
     std::vector<std::pair<ObjectID, std::shared_ptr<RayObject>>> *return_objects,
     std::vector<std::pair<ObjectID, std::shared_ptr<RayObject>>> *dynamic_return_objects,
     std::vector<std::pair<ObjectID, bool>> *streaming_generator_returns,
@@ -3151,8 +3151,8 @@ Status CoreWorker::ExecuteTask(
   {
     absl::MutexLock lock(&mutex_);
     current_tasks_.emplace(task_spec.TaskId(), task_spec);
-    if (resource_ids) {
-      resource_ids_ = resource_ids;
+    if (resource_ids != nullptr) {
+      resource_ids_ = std::move(*resource_ids);
     }
   }
 
@@ -3285,7 +3285,7 @@ Status CoreWorker::ExecuteTask(
     RAY_CHECK(it != current_tasks_.end());
     current_tasks_.erase(it);
     if (task_spec.IsNormalTask()) {
-      resource_ids_.reset(new ResourceMappingType());
+      resource_ids_.clear();
     }
   }
 
@@ -3540,7 +3540,6 @@ void CoreWorker::HandleReportGeneratorItemReturns(
 
 std::vector<rpc::ObjectReference> CoreWorker::ExecuteTaskLocalMode(
     const TaskSpecification &task_spec, const ActorID &actor_id) {
-  auto resource_ids = std::make_shared<ResourceMappingType>();
   auto return_objects = std::vector<std::pair<ObjectID, std::shared_ptr<RayObject>>>();
   auto borrowed_refs = ReferenceCounter::ReferenceTableProto();
 
@@ -3569,7 +3568,7 @@ std::vector<rpc::ObjectReference> CoreWorker::ExecuteTaskLocalMode(
   std::vector<std::pair<ObjectID, std::shared_ptr<RayObject>>> dynamic_return_objects;
   std::vector<std::pair<ObjectID, bool>> streaming_generator_returns;
   RAY_UNUSED(ExecuteTask(task_spec,
-                         resource_ids,
+                         /*resource_ids=*/std::make_shared<ResourceMappingType>(),
                          &return_objects,
                          &dynamic_return_objects,
                          &streaming_generator_returns,
@@ -4424,15 +4423,15 @@ void CoreWorker::HandleGetCoreWorkerStats(rpc::GetCoreWorkerStatsRequest request
   stats->set_actor_id(actor_id_.Binary());
   stats->set_worker_type(worker_context_.GetWorkerType());
   stats->set_num_running_tasks(current_tasks_.size());
-  auto used_resources_map = stats->mutable_used_resources();
-  for (auto const &it : *resource_ids_) {
+  auto *used_resources_map = stats->mutable_used_resources();
+  for (auto const &[resource_name, resource_allocations] : resource_ids_) {
     rpc::ResourceAllocations allocations;
-    for (auto const &pair : it.second) {
+    for (auto const &[cur_resource_slot, cur_resource_alloc] : resource_allocations) {
       auto resource_slot = allocations.add_resource_slots();
-      resource_slot->set_slot(pair.first);
-      resource_slot->set_allocation(pair.second);
+      resource_slot->set_slot(cur_resource_slot);
+      resource_slot->set_allocation(cur_resource_alloc);
     }
-    (*used_resources_map)[it.first] = allocations;
+    (*used_resources_map)[resource_name] = allocations;
   }
   stats->set_actor_title(actor_title_);
   google::protobuf::Map<std::string, std::string> webui_map(webui_display_.begin(),

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1011,7 +1011,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   const std::string GetActorName() const;
 
   // Get the resource IDs available to this worker (as assigned by the raylet).
-  const ResourceMappingType GetResourceIDs() const;
+  ResourceMappingType GetResourceIDs() const;
 
   /// Create a profile event and push it the TaskEventBuffer when the event is destructed.
   std::unique_ptr<worker::ProfileEvent> CreateProfileEvent(const std::string &event_name);
@@ -1470,7 +1470,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \return Status.
   Status ExecuteTask(
       const TaskSpecification &task_spec,
-      const std::shared_ptr<ResourceMappingType> &resource_ids,
+      std::shared_ptr<ResourceMappingType> resource_ids,
       std::vector<std::pair<ObjectID, std::shared_ptr<RayObject>>> *return_objects,
       std::vector<std::pair<ObjectID, std::shared_ptr<RayObject>>>
           *dynamic_return_objects,
@@ -1811,7 +1811,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// A map from resource name to the resource IDs that are currently reserved
   /// for this worker. Each pair consists of the resource ID and the fraction
   /// of that resource allocated for this worker. This is set on task assignment.
-  std::shared_ptr<ResourceMappingType> resource_ids_ ABSL_GUARDED_BY(mutex_);
+  ResourceMappingType resource_ids_ ABSL_GUARDED_BY(mutex_);
 
   /// Common rpc service for all worker modules.
   rpc::CoreWorkerGrpcService grpc_service_;

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1450,7 +1450,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   ///
   /// \param spec[in] task_spec Task specification.
   /// \param spec[in] resource_ids Resource IDs of resources assigned to this
-  ///                 worker. If nullptr, reuse the previously assigned
+  ///                 worker. If nullopt, reuse the previously assigned
   ///                 resources.
   /// \param results[out] return_objects Result objects that should be returned
   /// to the caller.
@@ -1470,7 +1470,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \return Status.
   Status ExecuteTask(
       const TaskSpecification &task_spec,
-      std::shared_ptr<ResourceMappingType> resource_ids,
+      std::optional<ResourceMappingType> resource_ids,
       std::vector<std::pair<ObjectID, std::shared_ptr<RayObject>>> *return_objects,
       std::vector<std::pair<ObjectID, std::shared_ptr<RayObject>>>
           *dynamic_return_objects,

--- a/src/ray/core_worker/test/direct_actor_transport_test.cc
+++ b/src/ray/core_worker/test/direct_actor_transport_test.cc
@@ -852,7 +852,7 @@ class TaskReceiverTest : public ::testing::Test {
 
   Status MockExecuteTask(
       const TaskSpecification &task_spec,
-      const std::shared_ptr<ResourceMappingType> &resource_ids,
+      std::optional<ResourceMappingType> resource_ids,
       std::vector<std::pair<ObjectID, std::shared_ptr<RayObject>>> *return_objects,
       std::vector<std::pair<ObjectID, std::shared_ptr<RayObject>>>
           *dynamic_return_objects,

--- a/src/ray/core_worker/transport/task_receiver.cc
+++ b/src/ray/core_worker/transport/task_receiver.cc
@@ -63,9 +63,9 @@ void TaskReceiver::HandleTask(const rpc::PushTaskRequest &request,
 
   // Only assign resources for non-actor tasks. Actor tasks inherit the resources
   // assigned at initial actor creation time.
-  std::shared_ptr<ResourceMappingType> resource_ids;
+  std::optional<ResourceMappingType> resource_ids;
   if (!task_spec.IsActorTask()) {
-    resource_ids = std::make_shared<ResourceMappingType>();
+    resource_ids = ResourceMappingType{};
     for (const auto &mapping : request.resource_mapping()) {
       std::vector<std::pair<int64_t, double>> rids;
       rids.reserve(mapping.resource_ids().size());

--- a/src/ray/core_worker/transport/task_receiver.h
+++ b/src/ray/core_worker/transport/task_receiver.h
@@ -66,10 +66,10 @@ class TaskReceiver {
   TaskReceiver(WorkerContext &worker_context,
                instrumented_io_context &main_io_service,
                worker::TaskEventBuffer &task_event_buffer,
-               const TaskHandler &task_handler,
+               TaskHandler task_handler,
                const OnActorCreationTaskDone &actor_creation_task_done_)
       : worker_context_(worker_context),
-        task_handler_(task_handler),
+        task_handler_(std::move(task_handler)),
         task_main_io_service_(main_io_service),
         task_event_buffer_(task_event_buffer),
         actor_creation_task_done_(actor_creation_task_done_),

--- a/src/ray/core_worker/transport/task_receiver.h
+++ b/src/ray/core_worker/transport/task_receiver.h
@@ -52,7 +52,7 @@ class TaskReceiver {
  public:
   using TaskHandler = std::function<Status(
       const TaskSpecification &task_spec,
-      const std::shared_ptr<ResourceMappingType> resource_ids,
+      std::optional<ResourceMappingType> resource_ids,
       std::vector<std::pair<ObjectID, std::shared_ptr<RayObject>>> *return_objects,
       std::vector<std::pair<ObjectID, std::shared_ptr<RayObject>>>
           *dynamic_return_objects,

--- a/src/ray/raylet_client/raylet_client.h
+++ b/src/ray/raylet_client/raylet_client.h
@@ -39,6 +39,7 @@ using ray::WorkerID;
 using ray::Language;
 
 using MessageType = ray::protocol::MessageType;
+// Maps from resource name to its allocation.
 using ResourceMappingType =
     std::unordered_map<std::string, std::vector<std::pair<int64_t, double>>>;
 using WaitResultPair = std::pair<std::vector<ObjectID>, std::vector<ObjectID>>;


### PR DESCRIPTION
As usual, cleanup unnecessaery shared pointer usage to achieve better performance and prevent potential memory leak.