### PR TITLE
[core] [1/N] New interface to combine client registerat and announce at NodeManager

### DIFF
--- a/src/ray/raylet/format/node_manager.fbs
+++ b/src/ray/raylet/format/node_manager.fbs
@@ -74,10 +74,8 @@ enum MessageType:int {
   //
   // Send an initial connection message to the raylet with port assigned. This is sent
   // from a worker or driver to a raylet.
+  // The corresponding response type is [AnnounceWorkerPortReply].
   RegisterClientWithPortRequest,
-  // Send a reply confirming the successful registration of a worker or driver.
-  // This is sent from the raylet to a worker or driver.
-  RegisterClientWithPortReply,
 }
 
 table Task {

--- a/src/ray/raylet/format/node_manager.fbs
+++ b/src/ray/raylet/format/node_manager.fbs
@@ -70,6 +70,14 @@ enum MessageType:int {
   ConnectClient,
   // Subscribe to Plasma updates.
   SubscribePlasmaReady,
+  // [RegisterClientWithPort] series is the combination for [RegisterClient] and [AnnounceWorkerPort].
+  //
+  // Send an initial connection message to the raylet with port assigned. This is sent
+  // from a worker or driver to a raylet.
+  RegisterClientWithPortRequest,
+  // Send a reply confirming the successful registration of a worker or driver.
+  // This is sent from the raylet to a worker or driver.
+  RegisterClientWithPortReply,
 }
 
 table Task {
@@ -142,6 +150,20 @@ table RegisterClientReply {
   raylet_id: string;
   // Port that this worker should listen on.
   port: int;
+}
+
+table RegisterClientWithPortRequest {
+  // Request to register client.
+  request_client_request: RegisterClientRequest;
+  // Request to assign port.
+  announcement_port_request: AnnounceWorkerPort;
+}
+
+table RegisterClientWithPortResponse {
+  // Response to register client.
+  request_client_request: [RegisterClientReply];
+  // Response to assign port.
+  announcement_port_request: [AnnounceWorkerPortReply];
 }
 
 table AnnounceWorkerPort {

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -432,6 +432,9 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   /// \return Void.
   void ProcessRegisterClientRequestMessage(
       const std::shared_ptr<ClientConnection> &client, const uint8_t *message_data);
+  void ProcessRegisterClientRequestMessageImpl(
+      const std::shared_ptr<ClientConnection> &client,
+      const ray::protocol::RegisterClientRequest *message);
 
   /// Process client message of AnnounceWorkerPort
   ///
@@ -440,6 +443,13 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   /// \return Void.
   void ProcessAnnounceWorkerPortMessage(const std::shared_ptr<ClientConnection> &client,
                                         const uint8_t *message_data);
+  void ProcessAnnounceWorkerPortMessageImpl(
+      const std::shared_ptr<ClientConnection> &client,
+      const ray::protocol::AnnounceWorkerPort *message);
+
+  /// Process client registration and port announcement.
+  void ProcessRegisterClientAndAnnouncePortMessage(
+      const std::shared_ptr<ClientConnection> &client, const uint8_t *message_data);
 
   /// Handle the case that a worker is available.
   ///

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -432,9 +432,22 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   /// \return Void.
   void ProcessRegisterClientRequestMessage(
       const std::shared_ptr<ClientConnection> &client, const uint8_t *message_data);
-  void ProcessRegisterClientRequestMessageImpl(
+  Status ProcessRegisterClientRequestMessageImpl(
       const std::shared_ptr<ClientConnection> &client,
-      const ray::protocol::RegisterClientRequest *message);
+      const ray::protocol::RegisterClientRequest *message,
+      std::optional<int> port);
+
+  // Register a new worker into worker pool.
+  Status RegisterForNewWorker(std::shared_ptr<WorkerInterface> worker,
+                              pid_t pid,
+                              const StartupToken &worker_startup_token,
+                              std::function<void(Status, int)> send_reply_callback = {});
+  // Register a new driver into worker pool.
+  Status RegisterForNewDriver(std::shared_ptr<WorkerInterface> worker,
+                              pid_t pid,
+                              const JobID &job_id,
+                              const ray::protocol::RegisterClientRequest *message,
+                              std::function<void(Status, int)> send_reply_callback = {});
 
   /// Process client message of AnnounceWorkerPort
   ///
@@ -446,6 +459,10 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   void ProcessAnnounceWorkerPortMessageImpl(
       const std::shared_ptr<ClientConnection> &client,
       const ray::protocol::AnnounceWorkerPort *message);
+
+  // Send status of port announcement to client side.
+  void SendPortAnnouncementResponse(const std::shared_ptr<ClientConnection> &client,
+                                    Status status);
 
   /// Process client registration and port announcement.
   void ProcessRegisterClientAndAnnouncePortMessage(

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -796,6 +796,37 @@ Status WorkerPool::RegisterWorker(const std::shared_ptr<WorkerInterface> &worker
   return Status::OK();
 }
 
+Status WorkerPool::RegisterWorker(const std::shared_ptr<WorkerInterface> &worker,
+                                  pid_t pid,
+                                  StartupToken worker_startup_token) {
+  RAY_CHECK(worker);
+  auto &state = GetStateForLanguage(worker->GetLanguage());
+  auto it = state.worker_processes.find(worker_startup_token);
+  if (it == state.worker_processes.end()) {
+    RAY_LOG(WARNING) << "Received a register request from an unknown token: "
+                     << worker_startup_token;
+    return Status::Invalid("Unknown worker");
+  }
+
+  auto process = Process::FromPid(pid);
+  worker->SetProcess(process);
+
+  auto &starting_process_info = it->second;
+  auto end = std::chrono::high_resolution_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+      end - starting_process_info.start_time);
+
+  // TODO(hjiang): Add tag to indicate whether port has been assigned beforehand.
+  STATS_worker_register_time_ms.Record(duration.count());
+  RAY_LOG(DEBUG) << "Registering worker " << worker->WorkerId() << " with pid " << pid
+                 << ", register cost: " << duration.count()
+                 << ", worker_type: " << rpc::WorkerType_Name(worker->GetWorkerType())
+                 << ", startup token: " << worker_startup_token;
+
+  state.registered_workers.insert(worker);
+  return Status::OK();
+}
+
 void WorkerPool::OnWorkerStarted(const std::shared_ptr<WorkerInterface> &worker) {
   auto &state = GetStateForLanguage(worker->GetLanguage());
   const StartupToken worker_startup_token = worker->GetStartupToken();
@@ -876,6 +907,26 @@ Status WorkerPool::RegisterDriver(const std::shared_ptr<WorkerInterface> &driver
           send_reply_callback(Status::OK(), port);
         });
   }
+  return Status::OK();
+}
+
+Status WorkerPool::RegisterDriver(const std::shared_ptr<WorkerInterface> &driver,
+                                  const rpc::JobConfig &job_config) {
+  auto &state = GetStateForLanguage(driver->GetLanguage());
+  state.registered_drivers.insert(std::move(driver));
+  const auto job_id = driver->GetAssignedJobId();
+  HandleJobStarted(job_id, job_config);
+
+  if (driver->GetLanguage() == Language::JAVA) {
+    return Status::OK();
+  }
+
+  if (!first_job_registered_ && RayConfig::instance().prestart_worker_first_driver() &&
+      !RayConfig::instance().enable_worker_prestart()) {
+    RAY_LOG(DEBUG) << "PrestartDefaultCpuWorkers " << num_prestart_python_workers;
+    PrestartDefaultCpuWorkers(Language::PYTHON, num_prestart_python_workers);
+  }
+  first_job_registered_ = true;
   return Status::OK();
 }
 

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -310,6 +310,12 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
                         StartupToken worker_startup_token,
                         std::function<void(Status, int)> send_reply_callback);
 
+  // Similar to the above function overload, but the port has been assigned, but directly
+  // returns registration status without taking a callback.
+  Status RegisterWorker(const std::shared_ptr<WorkerInterface> &worker,
+                        pid_t pid,
+                        StartupToken worker_startup_token);
+
   /// To be invoked when a worker is started. This method should be called when the worker
   /// announces its port.
   ///
@@ -327,6 +333,11 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   Status RegisterDriver(const std::shared_ptr<WorkerInterface> &worker,
                         const rpc::JobConfig &job_config,
                         std::function<void(Status, int)> send_reply_callback);
+
+  // Similar to the above function overload, but the port has been assigned, but directly
+  // returns registration status without taking a callback.
+  Status RegisterDriver(const std::shared_ptr<WorkerInterface> &worker,
+                        const rpc::JobConfig &job_config);
 
   /// Get the client connection's registered worker.
   ///


### PR DESCRIPTION
Issue reference: https://github.com/ray-project/ray/issues/48837
This PR simply combines two existing API call: client registration and port announcement into one, with no functionality change.

The plan is to
- Add new APIs at callee side, so we don't have production effect;
- Do no-op code refactor at caller side, so it's easier to refactor and merge API calls
- Connect caller and callee with the new API calls, after (1) and (2) the code structure should be at a clean state which is friendly and easy for API merge.