### PR TITLE
[core] Remove grpc client thread number

### DIFF
--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -109,22 +109,6 @@ class GrpcClient {
     stub_ = GrpcService::NewStub(channel_);
   }
 
-  GrpcClient(const std::string &address,
-             const int port,
-             ClientCallManager &call_manager,
-             int num_threads,
-             bool use_tls = false)
-      : client_call_manager_(call_manager), use_tls_(use_tls) {
-    grpc::ChannelArguments argument = CreateDefaultChannelArguments();
-    argument.SetInt(GRPC_ARG_ENABLE_HTTP_PROXY,
-                    ::RayConfig::instance().grpc_enable_http_proxy() ? 1 : 0);
-    argument.SetMaxSendMessageSize(::RayConfig::instance().max_grpc_message_size());
-    argument.SetMaxReceiveMessageSize(::RayConfig::instance().max_grpc_message_size());
-
-    channel_ = BuildChannel(address, port, argument);
-    stub_ = GrpcService::NewStub(channel_);
-  }
-
   /// Create a new `ClientCall` and send request.
   ///
   /// \tparam Request Type of the request message.

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -116,9 +116,6 @@ class GrpcClient {
              bool use_tls = false)
       : client_call_manager_(call_manager), use_tls_(use_tls) {
     grpc::ChannelArguments argument = CreateDefaultChannelArguments();
-    grpc::ResourceQuota quota;
-    quota.SetMaxThreads(num_threads);
-    argument.SetResourceQuota(quota);
     argument.SetInt(GRPC_ARG_ENABLE_HTTP_PROXY,
                     ::RayConfig::instance().grpc_enable_http_proxy() ? 1 : 0);
     argument.SetMaxSendMessageSize(::RayConfig::instance().max_grpc_message_size());

--- a/src/ray/rpc/object_manager/object_manager_client.h
+++ b/src/ray/rpc/object_manager/object_manager_client.h
@@ -48,8 +48,8 @@ class ObjectManagerClient {
     freeobjects_rr_index_ = rand() % num_connections_;
     grpc_clients_.reserve(num_connections_);
     for (int i = 0; i < num_connections_; i++) {
-      grpc_clients_.emplace_back(new GrpcClient<ObjectManagerService>(
-          address, port, client_call_manager, num_connections_));
+      grpc_clients_.emplace_back(
+          new GrpcClient<ObjectManagerService>(address, port, client_call_manager));
     }
   };
 


### PR DESCRIPTION
This PR resolves https://github.com/ray-project/ray/issues/49240

From my understanding:
- Threads are allocated at server side, by default each grpc request is handled by a different thread, coming out of a threadpool; the quota used in the grpc client constructor caps the max num
- On client side, apart from the polling thread (all sync grpc calls are built upon async one, which bakes an eventloop in a polling thread), I'm not aware of any conditions which require extra threads inside of client library, since it leverages http2 and io multiplex underlying

Performance test commit: d631f40085f663489fe686f5edcacf6e0b3c86e9
Performance dashboard: https://b534fd88.us1a.app.preset.io/superset/dashboard/19/?native_filters_key=LosP6LvuIiFtoQC_7slPcR-99euapUl2IU9rKLMjMntJgZz6LtYnyGly9fhI5oJ1
Average perf metrics value for latency: 16.832991340999996

Release test for this branch: https://buildkite.com/ray-project/release/builds/27984#0193bd0f-098b-4df9-9504-e23263a6b30f
Perf latency metrics for this PR: 14.782282467999991