### PR TITLE
[core] [compiled graphs] Join monitor thread before creating a new one

### DIFF
--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -1957,7 +1957,12 @@ class CompiledDAG:
 
             def run(self):
                 try:
-                    ray.get(list(outer.worker_task_refs.values()))
+                    waiting_refs = list(outer.worker_task_refs.values())
+                    while waiting_refs:
+                        ready_refs, waiting_refs = ray.wait(
+                            waiting_refs, num_returns=10
+                        )
+                        ray.get(ready_refs)
                 except Exception as e:
                     logger.debug(f"Handling exception from worker tasks: {e}")
                     self.teardown()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently some of the fault_tolerance tests are flaky and fail with OOM on 
```
[2024-12-10T06:56:44Z] Traceback (most recent call last):
--
  | [2024-12-10T06:56:44Z]   File "/rayci/python/ray/dag/compiled_dag_node.py", line 1963, in run
  | [2024-12-10T06:56:44Z]     ray.get(list(outer.worker_task_refs.values()))
```
which happens on the monitor thread. Currently we're not joining the monitor thread before creating a new one. So we could have dangling monitor threads when executing many times. This can cause oom when executing graphs a lot in quick succession and lots of these gets on the monitor threads are going.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#45922
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
