### PR TITLE
[core] [no-op] [easy] Rename function and add comments for check port free

### DIFF
--- a/src/ray/common/network_util.cc
+++ b/src/ray/common/network_util.cc
@@ -19,7 +19,7 @@
 
 using boost::asio::ip::tcp;
 
-bool CheckFree(int port) {
+bool CheckPortFree(int port) {
   instrumented_io_context io_service;
   tcp::socket socket(io_service);
   socket.open(boost::asio::ip::tcp::v4());

--- a/src/ray/common/network_util.h
+++ b/src/ray/common/network_util.h
@@ -14,4 +14,6 @@
 
 #pragma once
 
-bool CheckFree(int port);
+// Check whether the given [port] is available, via attempt to bind a socket to the port.
+// Notice, the check could be non-authentic if there're concurrent port assignments.
+bool CheckPortFree(int port);

--- a/src/ray/common/test_util.cc
+++ b/src/ray/common/test_util.cc
@@ -52,7 +52,7 @@ int TestSetupUtil::StartUpRedisServer(int port, bool save) {
     // Use random port (in range [2000, 7000) to avoid port conflicts between UTs.
     do {
       actual_port = rand() % 5000 + 2000;
-    } while (!CheckFree(actual_port));
+    } while (!CheckPortFree(actual_port));
   }
 
   std::string program = TEST_REDIS_SERVER_EXEC_PATH;

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -670,7 +670,7 @@ Status WorkerPool::GetNextFreePort(int *port) {
   for (int i = 0; i < current_size; i++) {
     *port = free_ports_->front();
     free_ports_->pop();
-    if (CheckFree(*port)) {
+    if (CheckPortFree(*port)) {
       return Status::OK();
     }
     // Return to pool to check later.


### PR DESCRIPTION
As titled, rename the function to avoid confusion, also add a documentation to clarify the caveat.