### PR TITLE
[core] Remove shared pointer for dependency waiter

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -730,7 +730,8 @@ CoreWorker::CoreWorker(CoreWorkerOptions options, const WorkerID &worker_id)
   // Unfortunately the raylet client has to be constructed after the receivers.
   if (task_receiver_ != nullptr) {
     task_argument_waiter_ = std::make_unique<DependencyWaiterImpl>(*local_raylet_client_);
-    task_receiver_->Init(core_worker_client_pool_, rpc_address_, task_argument_waiter_);
+    task_receiver_->Init(
+        core_worker_client_pool_, rpc_address_, task_argument_waiter_.get());
   }
 
   actor_manager_ = std::make_unique<ActorManager>(

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1818,7 +1818,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
 
   /// Used to notify the task receiver when the arguments of a queued
   /// actor task are ready.
-  std::shared_ptr<DependencyWaiterImpl> task_argument_waiter_;
+  std::unique_ptr<DependencyWaiterImpl> task_argument_waiter_;
 
   // Interface that receives tasks from direct actor calls.
   std::unique_ptr<TaskReceiver> task_receiver_;

--- a/src/ray/core_worker/test/direct_actor_transport_test.cc
+++ b/src/ray/core_worker/test/direct_actor_transport_test.cc
@@ -831,7 +831,7 @@ class TaskReceiverTest : public ::testing::Test {
   TaskReceiverTest()
       : worker_context_(WorkerType::WORKER, JobID::FromInt(0)),
         worker_client_(std::shared_ptr<MockWorkerClient>(new MockWorkerClient())),
-        dependency_waiter_(std::make_shared<MockDependencyWaiter>()) {
+        dependency_waiter_(std::make_unique<MockDependencyWaiter>()) {
     auto execute_task = std::bind(&TaskReceiverTest::MockExecuteTask,
                                   this,
                                   std::placeholders::_1,
@@ -847,7 +847,7 @@ class TaskReceiverTest : public ::testing::Test {
     receiver_->Init(std::make_shared<rpc::CoreWorkerClientPool>(
                         [&](const rpc::Address &addr) { return worker_client_; }),
                     rpc_address_,
-                    dependency_waiter_);
+                    dependency_waiter_.get());
   }
 
   Status MockExecuteTask(
@@ -878,7 +878,7 @@ class TaskReceiverTest : public ::testing::Test {
   instrumented_io_context main_io_service_;
   MockTaskEventBuffer task_event_buffer_;
   std::shared_ptr<MockWorkerClient> worker_client_;
-  std::shared_ptr<DependencyWaiter> dependency_waiter_;
+  std::unique_ptr<DependencyWaiter> dependency_waiter_;
 };
 
 TEST_F(TaskReceiverTest, TestNewTaskFromDifferentWorker) {

--- a/src/ray/core_worker/transport/task_receiver.cc
+++ b/src/ray/core_worker/transport/task_receiver.cc
@@ -27,8 +27,8 @@ namespace core {
 
 void TaskReceiver::Init(std::shared_ptr<rpc::CoreWorkerClientPool> client_pool,
                         rpc::Address rpc_address,
-                        std::shared_ptr<DependencyWaiter> dependency_waiter) {
-  waiter_ = std::move(dependency_waiter);
+                        DependencyWaiter *dependency_waiter) {
+  waiter_ = dependency_waiter;
   rpc_address_ = rpc_address;
   client_pool_ = client_pool;
 }

--- a/src/ray/core_worker/transport/task_receiver.h
+++ b/src/ray/core_worker/transport/task_receiver.h
@@ -79,7 +79,7 @@ class TaskReceiver {
   /// Initialize this receiver. This must be called prior to use.
   void Init(std::shared_ptr<rpc::CoreWorkerClientPool>,
             rpc::Address rpc_address,
-            std::shared_ptr<DependencyWaiter> dependency_waiter);
+            DependencyWaiter *dependency_waiter);
 
   /// Handle a `PushTask` request. If it's an actor request, this function will enqueue
   /// the task and then start scheduling the requests to begin the execution. If it's a
@@ -136,7 +136,7 @@ class TaskReceiver {
   /// Address of our RPC server.
   rpc::Address rpc_address_;
   /// Shared waiter for dependencies required by incoming tasks.
-  std::shared_ptr<DependencyWaiter> waiter_;
+  DependencyWaiter *waiter_ = nullptr;
   /// Queue of pending requests per actor handle.
   /// TODO(ekl) GC these queues once the handle is no longer active.
   absl::flat_hash_map<WorkerID, std::unique_ptr<SchedulingQueue>>


### PR DESCRIPTION
As usual, cleanup shared pointer usage for dependency waiter to avoid abusing shared pointer.