### PR TITLE
[data] Fix NameError by ensuring DataFileContent is imported at runtime in IcebergDatasource class

### DIFF
--- a/python/ray/data/_internal/datasource/iceberg_datasource.py
+++ b/python/ray/data/_internal/datasource/iceberg_datasource.py
@@ -181,6 +181,7 @@ class IcebergDatasource(Datasource):
 
     def get_read_tasks(self, parallelism: int) -> List[ReadTask]:
         from pyiceberg.io import pyarrow as pyi_pa_io
+        from pyiceberg.manifest import DataFileContent
 
         # Get the PyIceberg scan
         data_scan = self._get_data_scan()

--- a/python/ray/data/_internal/datasource/iceberg_datasource.py
+++ b/python/ray/data/_internal/datasource/iceberg_datasource.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from pyiceberg.catalog import Catalog
     from pyiceberg.expressions import BooleanExpression
     from pyiceberg.io import FileIO
-    from pyiceberg.manifest import DataFile, DataFileContent
+    from pyiceberg.manifest import DataFile
     from pyiceberg.schema import Schema
     from pyiceberg.table import DataScan, FileScanTask, Table
     from pyiceberg.table.metadata import TableMetadata


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The changes address a NameError encountered when using the IcebergDatasource in Ray’s data module. The error occurred because DataFileContent was imported only under a type-checking block (if TYPE_CHECKING:), making it unavailable at runtime. This caused a NameError when the code attempted to access DataFileContent.POSITION_DELETES.

By add the import of DataFileContent outside the type-checking block, the identifier becomes available during execution, resolving the NameError.

This fix ensures that the IcebergDatasource functions correctly at runtime, preventing the NameError and allowing for proper data processing.

```
Status message: Job entrypoint command failed with exit code 1, last available logs (truncated to 20,000 chars):
  File "/home/ray/anaconda3/lib/python3.12/site-packages/ray/data/read_api.py", line 397, in read_datasource
    read_tasks = datasource_or_legacy_reader.get_read_tasks(requested_parallelism)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.12/site-packages/ray/data/_internal/datasource/iceberg_datasource.py", line 206, in get_read_tasks
    position_delete_count = sum(
                            ^^^^
  File "/home/ray/anaconda3/lib/python3.12/site-packages/ray/data/_internal/datasource/iceberg_datasource.py", line 209, in <genexpr>
    if delete.content == DataFileContent.POSITION_DELETES
                         ^^^^^^^^^^^^^^^
NameError: name 'DataFileContent' is not defined
```

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
