### PR TITLE
[runtime envs] For "conda env list --json" strip the prefix before "{".

### DIFF
--- a/python/ray/_private/runtime_env/conda_utils.py
+++ b/python/ray/_private/runtime_env/conda_utils.py
@@ -116,7 +116,7 @@ def create_conda_env_if_needed(
         )
 
     _, stdout, _ = exec_cmd([conda_path, "env", "list", "--json"])
-    envs = json.loads(stdout)["envs"]
+    envs = json.loads(stdout[stdout.index("{") :])["envs"]
 
     if prefix in envs:
         logger.info(f"Conda environment {prefix} already exists.")


### PR DESCRIPTION
## Why are these changes needed?

"conda env list --json" sometimes prints non-json such as deprecation notices before the actual json. This results in parsing errors down the line.

While ideally the conda cli would suppress non-json if --json is supplied, I think this hotfix is small in scope and increases robustness enough to justify the minimal increase in code complexity.

Example:
```
$ (base) ray@raycluster-cpu-kuberay-cpu-cpugroup-worker-wp6nd:~$ conda env list --json
/home/ray/anaconda3/lib/python3.12/site-packages/conda/base/context.py:982: FutureWarning: Adding 'defaults' 
to the channel list implicitly is deprecated and will be removed in 25.3.                                                                                                                                                 
To remove this warning, please choose a default channel explicitly via 'conda config --add channels <name>', 
e.g. 'conda config --add channels defaults'.                                                                 
  deprecated.topic(                                                                                          
{                                                                                                            
  "GID": 100,                                                                                                
  "UID": 1000,                                                                                               
  "active_prefix": "/home/ray/anaconda3",                                                                    
  "active_prefix_name": "base",                                                                              
  "av_data_dir": "/home/ray/anaconda3/etc/conda",                                                            
  "av_metadata_url_base": null,  
```

## Related issue number

N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
