### PR TITLE
[core][compiled graphs] Fix dag test_signature_mismatch test

### DIFF
--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -2591,9 +2591,9 @@ def test_signature_mismatch(shutdown_only):
     with pytest.raises(
         TypeError,
         match=(
-            r"missing a required argument: 'y'\. The function `f` has a signature "
-            r"`\(x, \*, y\)`, but the given arguments to `bind` doesn't match\. "
-            r"args:.*kwargs:.*"
+            r"missing a required (keyword-only )?argument: 'y'\. The function `f` "
+            r"has a signature `\(x, \*, y\)`, but the given arguments to "
+            r"`bind` doesn't match\. args:.*kwargs:.*"
         ),
     ):
         with InputNode() as inp:
@@ -2602,9 +2602,9 @@ def test_signature_mismatch(shutdown_only):
     with pytest.raises(
         TypeError,
         match=(
-            r"missing a required argument: 'y'\. The function `g` has a signature "
-            r"`\(x, y, z=1\)`, but the given arguments to `bind` doesn't match\. "
-            r"args:.*kwargs:.*"
+            r"missing a required (keyword-only )?argument: 'y'\. The function `g` "
+            r"has a signature `\(x, y, z=1\)`, but the given arguments to "
+            r"`bind` doesn't match\. args:.*kwargs:.*"
         ),
     ):
         with InputNode() as inp:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The test_signature_mismatch test fails on python 3.12. In the buildkite postmerge it doesn't always run all the tests in the python 3.12 section so test_accelerated_dag.py comes off as flaky even though it's been consistently failing on 3.12 since this was added last week.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#45922
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
