### PR TITLE
[core] Extract raylet registration into core worker

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -40,6 +40,7 @@
 #include "ray/util/util.h"
 
 using json = nlohmann::json;
+using MessageType = ray::protocol::MessageType;
 
 namespace ray::core {
 
@@ -251,6 +252,53 @@ void TaskCounter::UnsetMetricStatus(const std::string &func_name,
   }
 }
 
+Status CoreWorker::RegisterWorkerToWorkerPool(raylet::RayletConnection &conn,
+                                              const WorkerID &worker_id,
+                                              rpc::WorkerType worker_type,
+                                              const JobID &job_id,
+                                              int runtime_env_hash,
+                                              const Language &language,
+                                              const std::string &ip_address,
+                                              const std::string &serialized_job_config,
+                                              const StartupToken &startup_token,
+                                              NodeID *raylet_id,
+                                              int *port) {
+  flatbuffers::FlatBufferBuilder fbb;
+  // TODO(suquark): Use `WorkerType` in `common.proto` without converting to int.
+  auto message =
+      protocol::CreateRegisterClientRequest(fbb,
+                                            static_cast<int>(worker_type),
+                                            to_flatbuf(fbb, worker_id),
+                                            getpid(),
+                                            startup_token,
+                                            to_flatbuf(fbb, job_id),
+                                            runtime_env_hash,
+                                            language,
+                                            fbb.CreateString(ip_address),
+                                            /*port=*/0,
+                                            fbb.CreateString(serialized_job_config));
+  fbb.Finish(message);
+  // Register the process ID with the raylet.
+  // NOTE(swang): If raylet exits and we are registered as a worker, we will get killed.
+  std::vector<uint8_t> reply;
+  auto request_status = conn.AtomicRequestReply(
+      MessageType::RegisterClientRequest, MessageType::RegisterClientReply, &reply, &fbb);
+  if (!request_status.ok()) {
+    return Status(request_status.code(),
+                  std::string("[RayletClient] Unable to register worker with raylet. ") +
+                      request_status.message());
+  }
+  auto reply_message = flatbuffers::GetRoot<protocol::RegisterClientReply>(reply.data());
+  bool success = reply_message->success();
+  if (!success) {
+    return Status::Invalid(string_from_flatbuf(*reply_message->failure_reason()));
+  }
+
+  *raylet_id = NodeID::FromBinary(reply_message->raylet_id()->str());
+  *port = reply_message->port();
+  return Status::OK();
+}
+
 CoreWorker::CoreWorker(CoreWorkerOptions options, const WorkerID &worker_id)
     : options_(std::move(options)),
       get_call_site_(RayConfig::instance().record_ref_creation_sites()
@@ -349,10 +397,6 @@ CoreWorker::CoreWorker(CoreWorkerOptions options, const WorkerID &worker_id)
 #endif
   io_thread_ = boost::thread(io_thread_attrs, [this]() { RunIOService(); });
 
-  Status raylet_client_status;
-  NodeID local_raylet_id;
-  int assigned_port;
-
   if (options_.worker_type == WorkerType::DRIVER &&
       !options_.serialized_job_config.empty()) {
     // Driver populates the job config via initialization.
@@ -362,32 +406,33 @@ CoreWorker::CoreWorker(CoreWorkerOptions options, const WorkerID &worker_id)
     worker_context_.MaybeInitializeJobInfo(worker_context_.GetCurrentJobID(), job_config);
   }
 
-  local_raylet_client_ =
-      std::make_shared<raylet::RayletClient>(io_service_,
-                                             std::move(grpc_client),
-                                             options_.raylet_socket,
-                                             GetWorkerID(),
-                                             options_.worker_type,
-                                             worker_context_.GetCurrentJobID(),
-                                             options_.runtime_env_hash,
-                                             options_.language,
-                                             options_.node_ip_address,
-                                             &raylet_client_status,
-                                             &local_raylet_id,
-                                             &assigned_port,
-                                             options_.serialized_job_config,
-                                             options_.startup_token);
-
+  auto raylet_conn = std::make_unique<raylet::RayletConnection>(
+      io_service_, options_.raylet_socket, /*num_retries=*/-1, /*timeout=*/-1);
+  NodeID local_raylet_id;
+  int assigned_port = 0;
+  Status raylet_client_status =
+      RegisterWorkerToWorkerPool(*raylet_conn,
+                                 GetWorkerID(),
+                                 options_.worker_type,
+                                 worker_context_.GetCurrentJobID(),
+                                 options_.runtime_env_hash,
+                                 options_.language,
+                                 options_.node_ip_address,
+                                 options_.serialized_job_config,
+                                 options_.startup_token,
+                                 &local_raylet_id,
+                                 &assigned_port);
   if (!raylet_client_status.ok()) {
     // Avoid using FATAL log or RAY_CHECK here because they may create a core dump file.
     RAY_LOG(ERROR).WithField(worker_id)
         << "Failed to register worker to Raylet: " << raylet_client_status;
     QuickExit();
   }
+  RAY_CHECK_GE(assigned_port, 0);
 
+  local_raylet_client_ = std::make_shared<raylet::RayletClient>(
+      std::move(raylet_conn), std::move(grpc_client), GetWorkerID());
   connected_ = true;
-
-  RAY_CHECK(assigned_port >= 0);
 
   // Start RPC server after all the task receivers are properly initialized and we have
   // our assigned port from the raylet.

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -252,17 +252,17 @@ void TaskCounter::UnsetMetricStatus(const std::string &func_name,
   }
 }
 
-Status CoreWorker::RegisterWorkerToWorkerPool(raylet::RayletConnection &conn,
-                                              const WorkerID &worker_id,
-                                              rpc::WorkerType worker_type,
-                                              const JobID &job_id,
-                                              int runtime_env_hash,
-                                              const Language &language,
-                                              const std::string &ip_address,
-                                              const std::string &serialized_job_config,
-                                              const StartupToken &startup_token,
-                                              NodeID *raylet_id,
-                                              int *port) {
+Status CoreWorker::RegisterWorkerToRaylet(raylet::RayletConnection &conn,
+                                          const WorkerID &worker_id,
+                                          rpc::WorkerType worker_type,
+                                          const JobID &job_id,
+                                          int runtime_env_hash,
+                                          const Language &language,
+                                          const std::string &ip_address,
+                                          const std::string &serialized_job_config,
+                                          const StartupToken &startup_token,
+                                          NodeID *raylet_id,
+                                          int *port) {
   flatbuffers::FlatBufferBuilder fbb;
   // TODO(suquark): Use `WorkerType` in `common.proto` without converting to int.
   auto message =
@@ -410,18 +410,17 @@ CoreWorker::CoreWorker(CoreWorkerOptions options, const WorkerID &worker_id)
       io_service_, options_.raylet_socket, /*num_retries=*/-1, /*timeout=*/-1);
   NodeID local_raylet_id;
   int assigned_port = 0;
-  Status raylet_client_status =
-      RegisterWorkerToWorkerPool(*raylet_conn,
-                                 GetWorkerID(),
-                                 options_.worker_type,
-                                 worker_context_.GetCurrentJobID(),
-                                 options_.runtime_env_hash,
-                                 options_.language,
-                                 options_.node_ip_address,
-                                 options_.serialized_job_config,
-                                 options_.startup_token,
-                                 &local_raylet_id,
-                                 &assigned_port);
+  Status raylet_client_status = RegisterWorkerToRaylet(*raylet_conn,
+                                                       GetWorkerID(),
+                                                       options_.worker_type,
+                                                       worker_context_.GetCurrentJobID(),
+                                                       options_.runtime_env_hash,
+                                                       options_.language,
+                                                       options_.node_ip_address,
+                                                       options_.serialized_job_config,
+                                                       options_.startup_token,
+                                                       &local_raylet_id,
+                                                       &assigned_port);
   if (!raylet_client_status.ok()) {
     // Avoid using FATAL log or RAY_CHECK here because they may create a core dump file.
     RAY_LOG(ERROR).WithField(worker_id)

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1355,6 +1355,19 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   FRIEND_TEST(TestOverrideRuntimeEnv, TestCondaInherit);
   FRIEND_TEST(TestOverrideRuntimeEnv, TestCondaOverride);
 
+  /// Register core worker to worker pool.
+  Status RegisterWorkerToWorkerPool(raylet::RayletConnection &conn,
+                                    const WorkerID &worker_id,
+                                    rpc::WorkerType worker_type,
+                                    const JobID &job_id,
+                                    int runtime_env_hash,
+                                    const Language &language,
+                                    const std::string &ip_address,
+                                    const std::string &serialized_job_config,
+                                    const StartupToken &startup_token,
+                                    NodeID *raylet_id,
+                                    int *port);
+
   std::shared_ptr<rpc::RuntimeEnvInfo> OverrideTaskOrActorRuntimeEnvInfo(
       const std::string &serialized_runtime_env_info) const;
 

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1356,17 +1356,17 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   FRIEND_TEST(TestOverrideRuntimeEnv, TestCondaOverride);
 
   /// Register core worker to worker pool.
-  Status RegisterWorkerToWorkerPool(raylet::RayletConnection &conn,
-                                    const WorkerID &worker_id,
-                                    rpc::WorkerType worker_type,
-                                    const JobID &job_id,
-                                    int runtime_env_hash,
-                                    const Language &language,
-                                    const std::string &ip_address,
-                                    const std::string &serialized_job_config,
-                                    const StartupToken &startup_token,
-                                    NodeID *raylet_id,
-                                    int *port);
+  Status RegisterWorkerToRaylet(raylet::RayletConnection &conn,
+                                const WorkerID &worker_id,
+                                rpc::WorkerType worker_type,
+                                const JobID &job_id,
+                                int runtime_env_hash,
+                                const Language &language,
+                                const std::string &ip_address,
+                                const std::string &serialized_job_config,
+                                const StartupToken &startup_token,
+                                NodeID *raylet_id,
+                                int *port);
 
   std::shared_ptr<rpc::RuntimeEnvInfo> OverrideTaskOrActorRuntimeEnvInfo(
       const std::string &serialized_runtime_env_info) const;

--- a/src/ray/raylet_client/raylet_client.h
+++ b/src/ray/raylet_client/raylet_client.h
@@ -256,6 +256,8 @@ class RayletClientInterface : public PinObjectsInterface,
 
 namespace raylet {
 
+/// Raylet client is responsible for communication with raylet. It implements
+/// [RayletClientInterface] and works on worker registration, lease management, etc.
 class RayletClient : public RayletClientInterface {
  public:
   /// Connect to the raylet.

--- a/src/ray/raylet_client/raylet_client.h
+++ b/src/ray/raylet_client/raylet_client.h
@@ -24,6 +24,7 @@
 #include "ray/common/client_connection.h"
 #include "ray/common/status.h"
 #include "ray/common/task/task_spec.h"
+#include "ray/raylet_client/raylet_connection.h"
 #include "ray/rpc/node_manager/node_manager_client.h"
 #include "ray/util/process.h"
 #include "src/ray/protobuf/common.pb.h"
@@ -38,7 +39,6 @@ using ray::WorkerID;
 
 using ray::Language;
 
-using MessageType = ray::protocol::MessageType;
 // Maps from resource name to its allocation.
 using ResourceMappingType =
     std::unordered_map<std::string, std::vector<std::pair<int64_t, double>>>;
@@ -56,7 +56,7 @@ class PinObjectsInterface {
       const ObjectID &generator_id,
       const ray::rpc::ClientCallback<ray::rpc::PinObjectIDsReply> &callback) = 0;
 
-  virtual ~PinObjectsInterface(){};
+  virtual ~PinObjectsInterface() = default;
 };
 
 /// Interface for leasing workers. Abstract for testing.
@@ -256,45 +256,11 @@ class RayletClientInterface : public PinObjectsInterface,
 
 namespace raylet {
 
-class RayletConnection {
- public:
-  /// Connect to the raylet.
-  ///
-  /// \param raylet_socket The name of the socket to use to connect to the raylet.
-  /// \param worker_id A unique ID to represent the worker.
-  /// \param is_worker Whether this client is a worker. If it is a worker, an
-  ///        additional message will be sent to register as one.
-  /// \param job_id The ID of the driver. This is non-nil if the client is a
-  ///        driver.
-  /// \return The connection information.
-  RayletConnection(instrumented_io_context &io_service,
-                   const std::string &raylet_socket,
-                   int num_retries,
-                   int64_t timeout);
-
-  ray::Status WriteMessage(MessageType type,
-                           flatbuffers::FlatBufferBuilder *fbb = nullptr);
-
-  ray::Status AtomicRequestReply(MessageType request_type,
-                                 MessageType reply_type,
-                                 std::vector<uint8_t> *reply_message,
-                                 flatbuffers::FlatBufferBuilder *fbb = nullptr);
-
- private:
-  /// Shutdown the raylet if the local connection is disconnected.
-  void ShutdownIfLocalRayletDisconnected(const Status &status);
-  /// The connection to raylet.
-  std::shared_ptr<ServerConnection> conn_;
-  /// A mutex to protect stateful operations of the raylet client.
-  std::mutex mutex_;
-  /// A mutex to protect write operations of the raylet client.
-  std::mutex write_mutex_;
-};
-
 class RayletClient : public RayletClientInterface {
  public:
   /// Connect to the raylet.
   ///
+  /// \param raylet_conn connection to raylet.
   /// \param grpc_client gRPC client to the raylet.
   /// \param raylet_socket The name of the socket to use to connect to the raylet.
   /// \param worker_id A unique ID to represent the worker.
@@ -314,20 +280,9 @@ class RayletClient : public RayletClientInterface {
   /// provided by driver will be passed to Raylet.
   /// \param startup_token The startup token of the process assigned to
   /// it during startup as a command line argument.
-  RayletClient(instrumented_io_context &io_service,
+  RayletClient(std::unique_ptr<RayletConnection> raylet_conn,
                std::shared_ptr<ray::rpc::NodeManagerWorkerClient> grpc_client,
-               const std::string &raylet_socket,
-               const WorkerID &worker_id,
-               rpc::WorkerType worker_type,
-               const JobID &job_id,
-               const int &runtime_env_hash,
-               const Language &language,
-               const std::string &ip_address,
-               Status *status,
-               NodeID *raylet_id,
-               int *port,
-               const std::string &serialized_job_config,
-               StartupToken startup_token);
+               const WorkerID &worker_id);
 
   /// Connect to the raylet via grpc only.
   ///

--- a/src/ray/raylet_client/raylet_connection.cc
+++ b/src/ray/raylet_client/raylet_connection.cc
@@ -1,0 +1,65 @@
+// Copyright 2024 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/raylet_client/raylet_connection.h"
+
+using MessageType = ray::protocol::MessageType;
+
+namespace ray::raylet {
+
+RayletConnection::RayletConnection(instrumented_io_context &io_service,
+                                   const std::string &raylet_socket,
+                                   int num_retries,
+                                   int64_t timeout) {
+  local_stream_socket socket(io_service);
+  Status s = ConnectSocketRetry(socket, raylet_socket, num_retries, timeout);
+  // If we could not connect to the socket, exit.
+  if (!s.ok()) {
+    RAY_LOG(FATAL) << "Could not connect to socket " << raylet_socket;
+  }
+  conn_ = ServerConnection::Create(std::move(socket));
+}
+
+Status RayletConnection::WriteMessage(MessageType type,
+                                      flatbuffers::FlatBufferBuilder *fbb) {
+  std::unique_lock<std::mutex> guard(write_mutex_);
+  int64_t length = fbb ? fbb->GetSize() : 0;
+  uint8_t *bytes = fbb ? fbb->GetBufferPointer() : nullptr;
+  auto status = conn_->WriteMessage(static_cast<int64_t>(type), length, bytes);
+  ShutdownIfLocalRayletDisconnected(status);
+  return status;
+}
+
+Status RayletConnection::AtomicRequestReply(MessageType request_type,
+                                            MessageType reply_type,
+                                            std::vector<uint8_t> *reply_message,
+                                            flatbuffers::FlatBufferBuilder *fbb) {
+  std::unique_lock<std::mutex> guard(mutex_);
+  RAY_RETURN_NOT_OK(WriteMessage(request_type, fbb));
+  auto status = conn_->ReadMessage(static_cast<int64_t>(reply_type), reply_message);
+  ShutdownIfLocalRayletDisconnected(status);
+  return status;
+}
+
+void RayletConnection::ShutdownIfLocalRayletDisconnected(const Status &status) {
+  if (!status.ok() && IsRayletFailed(RayConfig::instance().RAYLET_PID())) {
+    RAY_LOG(WARNING) << "The connection is failed because the local raylet has been "
+                        "dead. Terminate the process. Status: "
+                     << status;
+    QuickExit();
+    RAY_LOG(FATAL) << "Unreachable.";
+  }
+}
+
+}  // namespace ray::raylet

--- a/src/ray/raylet_client/raylet_connection.h
+++ b/src/ray/raylet_client/raylet_connection.h
@@ -25,6 +25,8 @@
 
 namespace ray::raylet {
 
+/// `RayletConnection` is a wrapper around a connection with raylet, which is responsible
+/// for sending request to raylet.
 class RayletConnection {
  public:
   /// Connect to the raylet.
@@ -41,9 +43,11 @@ class RayletConnection {
                    int num_retries,
                    int64_t timeout);
 
+  /// Send request to raylet without waiting for response.
   ray::Status WriteMessage(ray::protocol::MessageType type,
                            flatbuffers::FlatBufferBuilder *fbb = nullptr);
 
+  /// Send request to raylet and blockingly wait for response.
   ray::Status AtomicRequestReply(ray::protocol::MessageType request_type,
                                  ray::protocol::MessageType reply_type,
                                  std::vector<uint8_t> *reply_message,

--- a/src/ray/raylet_client/raylet_connection.h
+++ b/src/ray/raylet_client/raylet_connection.h
@@ -1,0 +1,63 @@
+// Copyright 2024 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "ray/common/asio/instrumented_io_context.h"
+#include "ray/common/client_connection.h"
+
+namespace ray::raylet {
+
+class RayletConnection {
+ public:
+  /// Connect to the raylet.
+  ///
+  /// \param raylet_socket The name of the socket to use to connect to the raylet.
+  /// \param worker_id A unique ID to represent the worker.
+  /// \param is_worker Whether this client is a worker. If it is a worker, an
+  ///        additional message will be sent to register as one.
+  /// \param job_id The ID of the driver. This is non-nil if the client is a
+  ///        driver.
+  /// \return The connection information.
+  RayletConnection(instrumented_io_context &io_service,
+                   const std::string &raylet_socket,
+                   int num_retries,
+                   int64_t timeout);
+
+  ray::Status WriteMessage(ray::protocol::MessageType type,
+                           flatbuffers::FlatBufferBuilder *fbb = nullptr);
+
+  ray::Status AtomicRequestReply(ray::protocol::MessageType request_type,
+                                 ray::protocol::MessageType reply_type,
+                                 std::vector<uint8_t> *reply_message,
+                                 flatbuffers::FlatBufferBuilder *fbb = nullptr);
+
+ private:
+  /// Shutdown the raylet if the local connection is disconnected.
+  void ShutdownIfLocalRayletDisconnected(const Status &status);
+  /// The connection to raylet.
+  std::shared_ptr<ServerConnection> conn_;
+  /// A mutex to protect stateful operations of the raylet client.
+  std::mutex mutex_;
+  /// A mutex to protect write operations of the raylet client.
+  std::mutex write_mutex_;
+};
+
+}  // namespace ray::raylet


### PR DESCRIPTION
Necessary for issue: https://github.com/ray-project/ray/issues/47994

Since we will combine (1) worker registration and (2) port announcement, before that we need to extract (1) into core worker.

Update: the code is expected to be a no-op refactor, so the code structure is at a cleaner state before we merge APIs.