### PR TITLE
[core] Remove useless hash function

### DIFF
--- a/src/ray/common/id.h
+++ b/src/ray/common/id.h
@@ -593,10 +593,6 @@ namespace std {
   template <>                                                            \
   struct hash<::ray::type> {                                             \
     size_t operator()(const ::ray::type &id) const { return id.Hash(); } \
-  };                                                                     \
-  template <>                                                            \
-  struct hash<const ::ray::type> {                                       \
-    size_t operator()(const ::ray::type &id) const { return id.Hash(); } \
   };
 
 DEFINE_UNIQUE_ID(UniqueID);

--- a/src/ray/common/test/id_test.cc
+++ b/src/ray/common/test/id_test.cc
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
+
+#include "absl/container/flat_hash_set.h"
 #include "ray/common/common_protocol.h"
 #include "ray/common/task/task_spec.h"
 
@@ -135,6 +137,20 @@ TEST(HashTest, TestNilHash) {
   ObjectID id2 = ObjectID::FromBinary(ObjectID::FromRandom().Binary());
   ASSERT_NE(nil_hash, id2.Hash());
   ASSERT_NE(id1.Hash(), id2.Hash());
+}
+
+TEST(HashTest, TestIdHash) {
+  absl::flat_hash_set<ObjectID> oids;
+  ObjectID cur_oid = ObjectID::FromRandom();
+  oids.emplace(cur_oid);
+
+  // Lookup with the same id shows exists.
+  EXPECT_TRUE(oids.contains(cur_oid));
+  // Lookup with constant reference shows exists.
+  EXPECT_TRUE(oids.contains(static_cast<const ObjectID &>(cur_oid)));
+  // Insert with rvalue reference show exists.
+  auto [_, is_new] = oids.emplace(std::move(cur_oid));
+  EXPECT_FALSE(is_new);
 }
 
 TEST(PlacementGroupIDTest, TestPlacementGroup) {


### PR DESCRIPTION
Don't think const overload is necessary; otherwise you need to implement volatile overload, rvalue reference overload, and so on... If I'm the author, I would use `AbslHashValue`.