### PR TITLE
[data] feat: Implement `ray.data.Dataset.offset`

### DIFF
--- a/python/ray/data/_internal/execution/operators/offset_operator.py
+++ b/python/ray/data/_internal/execution/operators/offset_operator.py
@@ -39,7 +39,8 @@ class OffsetOperator(OneToOneOperator):
         assert not self.completed()
         assert input_index == 0, input_index
         if self._offset_reached():
-            # The offset has been reached, so we can pass through all incoming input blocks.
+            # The offset has been reached,
+            # so we can pass through all incoming input blocks.
             out_blocks: List[ObjectRef[Block]] = []
             out_metadata: List[BlockMetadata] = []
             for block, metadata in refs.blocks:

--- a/python/ray/data/_internal/execution/operators/offset_operator.py
+++ b/python/ray/data/_internal/execution/operators/offset_operator.py
@@ -1,0 +1,153 @@
+import copy
+from collections import deque
+from typing import Deque, List, Optional, Tuple
+
+import ray
+from ray.data._internal.execution.interfaces import PhysicalOperator, RefBundle
+from ray.data._internal.execution.operators.base_physical_operator import (
+    OneToOneOperator,
+)
+from ray.data._internal.remote_fn import cached_remote_fn
+from ray.data._internal.stats import StatsDict
+from ray.data.block import Block, BlockAccessor, BlockMetadata
+from ray.data.context import DataContext
+from ray.types import ObjectRef
+
+
+class OffsetOperator(OneToOneOperator):
+    """Physical operator for offset."""
+
+    def __init__(
+        self,
+        offset: int,
+        input_op: PhysicalOperator,
+        data_context: DataContext,
+    ):
+        self._offset = offset
+        self._consumed_rows = 0  # includes both skipped and outputted rows
+        self._buffer: Deque[RefBundle] = deque()
+        self._name = f"offset={offset}"
+        self._output_metadata: List[BlockMetadata] = []
+        self._cur_output_bundles = 0
+        self._total_output_rows = 0
+        super().__init__(self._name, input_op, data_context, target_max_block_size=None)
+
+    def _offset_reached(self) -> bool:
+        return self._consumed_rows >= self._offset
+
+    def _add_input_inner(self, refs: RefBundle, input_index: int) -> None:
+        assert not self.completed()
+        assert input_index == 0, input_index
+        if self._offset_reached():
+            # The offset has been reached, so we can pass through all incoming input blocks.
+            out_blocks: List[ObjectRef[Block]] = []
+            out_metadata: List[BlockMetadata] = []
+            for block, metadata in refs.blocks:
+                num_rows = metadata.num_rows
+                assert num_rows is not None
+                out_blocks.append(block)
+                out_metadata.append(metadata)
+                self._output_metadata.append(metadata)
+                self._consumed_rows += num_rows
+            self._cur_output_bundles += 1
+            out_refs = RefBundle(
+                list(zip(out_blocks, out_metadata)),
+                owns_blocks=refs.owns_blocks,
+            )
+            self._buffer.append(out_refs)
+            self._metrics.on_output_queued(out_refs)
+        else:
+            # The offset has not been reached, so we need to skip some rows.
+            out_blocks: List[ObjectRef[Block]] = []
+            out_metadata: List[BlockMetadata] = []
+            for block, metadata in refs.blocks:
+                num_rows = metadata.num_rows
+                assert num_rows is not None
+                if self._consumed_rows + num_rows <= self._offset:
+                    # Skip the entire block.
+                    self._consumed_rows += num_rows
+                else:
+                    # Slice the last block.
+                    def slice_fn(
+                        block, metadata, num_rows_to_skip
+                    ) -> Tuple[Block, BlockMetadata]:
+                        assert num_rows_to_skip < metadata.num_rows
+                        block = BlockAccessor.for_block(block).slice(
+                            num_rows_to_skip, metadata.num_rows, copy=True
+                        )
+                        metadata = copy.deepcopy(metadata)
+                        metadata.num_rows -= num_rows_to_skip
+                        metadata.size_bytes = BlockAccessor.for_block(
+                            block
+                        ).size_bytes()
+                        return block, metadata
+
+                    block, metadata_ref = cached_remote_fn(
+                        slice_fn, num_cpus=0, num_returns=2
+                    ).remote(
+                        block,
+                        metadata,
+                        self._offset - self._consumed_rows,
+                    )
+                    out_blocks.append(block)
+                    metadata = ray.get(metadata_ref)
+                    out_metadata.append(metadata)
+                    self._output_metadata.append(metadata)
+                    self._consumed_rows += num_rows
+                    break
+            self._cur_output_bundles += 1
+            out_refs = RefBundle(
+                list(zip(out_blocks, out_metadata)),
+                owns_blocks=refs.owns_blocks,
+            )
+            self._buffer.append(out_refs)
+            self._metrics.on_output_queued(out_refs)
+
+        # We cannot estimate if we have only consumed empty blocks,
+        # and if the input dependency's total number of output bundles is unknown.
+        num_inputs = self.input_dependency.num_outputs_total()
+        if self._consumed_rows > 0 and num_inputs is not None:
+            # Estimate number of output bundles
+            # Check the case where _offset > # of input rows
+            estimated_total_output_rows = max(
+                0,
+                self._consumed_rows / self._cur_output_bundles * num_inputs
+                - self._offset,
+            )
+            self._estimated_num_output_bundles = round(
+                estimated_total_output_rows
+                / self._consumed_rows
+                * self._cur_output_bundles
+            )
+
+    def has_next(self) -> bool:
+        return len(self._buffer) > 0
+
+    def _get_next_inner(self) -> RefBundle:
+        output = self._buffer.popleft()
+        self._metrics.on_output_dequeued(output)
+        return output
+
+    def get_stats(self) -> StatsDict:
+        return {self._name: self._output_metadata}
+
+    def num_outputs_total(self) -> Optional[int]:
+        # Before execution is completed, we don't know how many output
+        # bundles we will have. We estimate based off the consumption so far.
+        if self._execution_completed:
+            return self._cur_output_bundles
+        return self._estimated_num_output_bundles
+
+    def num_output_rows_total(self) -> Optional[int]:
+        # The total number of rows is simply the the number
+        # of input rows minus the offset, capped at 0.
+        input_num_rows = self.input_dependency.num_output_rows_total()
+        if input_num_rows is None:
+            return None
+        return max(0, input_num_rows - self._offset)
+
+    def throttling_disabled(self) -> bool:
+        return True
+
+    def implements_accurate_memory_accounting(self) -> bool:
+        return True

--- a/python/ray/data/_internal/planner/planner.py
+++ b/python/ray/data/_internal/planner/planner.py
@@ -34,6 +34,7 @@ def _register_default_plan_logical_op_fns():
     )
     from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
     from ray.data._internal.execution.operators.limit_operator import LimitOperator
+    from ray.data._internal.execution.operators.offset_operator import OffsetOperator
     from ray.data._internal.execution.operators.union_operator import UnionOperator
     from ray.data._internal.execution.operators.zip_operator import ZipOperator
     from ray.data._internal.logical.operators.all_to_all_operator import (
@@ -48,7 +49,7 @@ def _register_default_plan_logical_op_fns():
         Project,
     )
     from ray.data._internal.logical.operators.n_ary_operator import Union, Zip
-    from ray.data._internal.logical.operators.one_to_one_operator import Limit
+    from ray.data._internal.logical.operators.one_to_one_operator import Limit, Offset
     from ray.data._internal.logical.operators.read_operator import Read
     from ray.data._internal.logical.operators.write_operator import Write
     from ray.data._internal.planner.plan_all_to_all_op import plan_all_to_all_op
@@ -112,6 +113,12 @@ def _register_default_plan_logical_op_fns():
         return LimitOperator(logical_op._limit, physical_children[0], data_context)
 
     register_plan_logical_op_fn(Limit, plan_limit_op)
+
+    def plan_offset_op(logical_op, physical_children, data_context):
+        assert len(physical_children) == 1
+        return OffsetOperator(logical_op._offset, physical_children[0], data_context)
+
+    register_plan_logical_op_fn(Offset, plan_offset_op)
 
     def plan_count_op(logical_op, physical_children, data_context):
         assert len(physical_children) == 1

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -71,7 +71,7 @@ from ray.data._internal.logical.operators.n_ary_operator import (
     Union as UnionLogicalOperator,
 )
 from ray.data._internal.logical.operators.n_ary_operator import Zip
-from ray.data._internal.logical.operators.one_to_one_operator import Limit
+from ray.data._internal.logical.operators.one_to_one_operator import Limit, Offset
 from ray.data._internal.logical.operators.write_operator import Write
 from ray.data._internal.logical.optimizers import LogicalPlan
 from ray.data._internal.pandas_block import PandasBlockBuilder, PandasBlockSchema
@@ -2549,6 +2549,27 @@ class Dataset:
         """
         plan = self._plan.copy()
         op = Limit(self._logical_plan.dag, limit=limit)
+        logical_plan = LogicalPlan(op, self.context)
+        return Dataset(plan, logical_plan)
+
+    @PublicAPI(api_group=BT_API_GROUP)
+    def offset(self, offset: int) -> "Dataset":
+        """Skip the first ``offset`` rows of the dataset.
+
+        Examples:
+            >>> import ray
+            >>> ds = ray.data.range(1000)
+            >>> ds.offset(5).count()
+            995
+
+        Args:
+            offset: The size of the dataset to skip.
+
+        Returns:
+            The dataset, with ``offset`` elements skipped.
+        """
+        plan = self._plan.copy()
+        op = Offset(self._logical_plan.dag, offset=offset)
         logical_plan = LogicalPlan(op, self.context)
         return Dataset(plan, logical_plan)
 

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -737,11 +737,6 @@ def test_offset_operator(ray_start_regular_shared):
         )
         output = []
         offset_op.start(ExecutionOptions())
-        if offset == 0:
-            assert not offset_op.has_next()
-            assert offset_op.completed()
-            continue
-
         while input_op.has_next():
             assert not offset_op.completed(), offset
             offset_op.add_input(input_op.get_next(), 0)


### PR DESCRIPTION
CC @neilshah12 and @richardliaw 

## Why are these changes needed?

This allows Ray Data users to call `ds.offset` on their datasets. This feature corresponds to SQL's `OFFSET` feature. ~This feature is useful, e.g., for implementing pagination on a dataset (in conjunction with `ds.limit`).~

## Notes
- should we detect `offset < 0` and raise `ValueError`? 
- should we detect `offset is None` and raise `ValueError`? 
   - another option: detect `None` and treat this as `offset == 0`. This more closely aligns with SQL syntax. 
- are we missing any test coverage? 

## Related issue number

n/a

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
