### PR TITLE
[kuberay][conformance][jobs] Add tests for `ray job status` to ensure the contract between KubeRay / Ray

### DIFF
--- a/python/ray/dashboard/modules/job/tests/test_cli.py
+++ b/python/ray/dashboard/modules/job/tests/test_cli.py
@@ -530,6 +530,20 @@ class TestDelete:
             mock_client_instance.delete_job.assert_called_with("job_id")
 
 
+class TestStatus:
+    def test_address(self, mock_sdk_client):
+        _job_cli_group_test_address(mock_sdk_client, "status", "fake_job_id")
+
+    def test_status(self, mock_sdk_client):
+        runner = CliRunner()
+        mock_client_instance = mock_sdk_client.return_value
+
+        with set_env_var("RAY_ADDRESS", "env_addr"):
+            result = runner.invoke(job_cli_group, ["status", "job_id"])
+            check_exit_code(result, 0)
+            mock_client_instance.get_job_info.assert_called_with("job_id")
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/dashboard/modules/job/tests/test_cli_integration.py
+++ b/python/ray/dashboard/modules/job/tests/test_cli_integration.py
@@ -270,6 +270,23 @@ class TestJobDelete:
         assert f"Job '{job_id}' deleted successfully" in stdout
 
 
+class TestJobStatus:
+    # `ray job status` should exit with 0 if the job exists and non-zero if it doesn't.
+    # This is the contract between Ray and KubRay v1.3.0.
+    def test_status_job_exists(self, ray_start_stop):
+        cmd = "echo hello"
+        job_id = "test_job_id"
+        _run_cmd(
+            f"ray job submit --submission-id={job_id} -- bash -c '{cmd}'",
+            should_fail=False,
+        )
+        _run_cmd(f"ray job status {job_id}", should_fail=False)
+
+    def test_status_job_does_not_exist(self, ray_start_stop):
+        job_id = "test_job_id"
+        _run_cmd(f"ray job status {job_id}", should_fail=True)
+
+
 def test_quote_escaping(ray_start_stop):
     cmd = "echo \"hello 'world'\""
     job_id = "test_quote_escaping"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In KubeRay v1.3, the RayJob controller relies on the `ray job status` command. This PR adds tests to ensure the contract between Ray and KubeRay. See https://github.com/ray-project/kuberay/pull/2579 for more details.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
