### PR TITLE
[core] Fix windows include

### DIFF
--- a/src/ray/common/cgroup/cgroup_setup.cc
+++ b/src/ray/common/cgroup/cgroup_setup.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "src/ray/common/cgroup/cgroup_setup.h"
+#include "ray/common/cgroup/cgroup_setup.h"
 
 #include <sys/stat.h>
 
@@ -23,9 +23,9 @@
 #include <vector>
 
 #include "absl/strings/str_format.h"
-#include "src/ray/util/filesystem.h"
-#include "src/ray/util/logging.h"
-#include "src/ray/util/util.h"
+#include "ray/util/filesystem.h"
+#include "ray/util/logging.h"
+#include "ray/util/util.h"
 
 namespace ray {
 

--- a/src/ray/common/ray_syncer/ray_syncer_bidi_reactor.h
+++ b/src/ray/common/ray_syncer/ray_syncer_bidi_reactor.h
@@ -19,7 +19,7 @@
 #include <memory>
 #include <string>
 
-#include "src/ray/common/ray_syncer/common.h"
+#include "ray/common/ray_syncer/common.h"
 #include "src/ray/protobuf/ray_syncer.grpc.pb.h"
 
 namespace ray::syncer {


### PR DESCRIPTION
As titled, we cannot have `src/` prefix for inclusion, which breaks windows build.

Command to search:
```
[~/ray] (hjiang/fix-windows-include) 
ubuntu@hjiang-devbox-pg$ git grep "src/ray" -- "*.h" | grep "include" | grep -v "pb"
(myenv) 
[~/ray] (hjiang/fix-windows-include) 
ubuntu@hjiang-devbox-pg$ git grep "src/ray" -- "*.cc" | grep "include" | grep -v "pb"
cpp/src/ray/test/ray_remote_test.cc:#include "cpp/src/ray/runtime/task/task_executor.h"
cpp/src/ray/test/ray_remote_test.cc:#include "cpp/src/ray/util/function_helper.h"
```