### PR TITLE
[core] Add a precommit hook to check incorrect C++ file inclusion

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -143,3 +143,11 @@ repos:
         types: [python]
         pass_filenames: false
         args: [".", "-s", "ci", "-s", "python/ray/thirdparty_files", "-s", "python/build", "-s", "lib"]
+
+  - repo: local
+    hooks:
+      - id: check_cpp_files_inclusion
+        name: Check ray core C++ files inclusion violations
+        entry: python ci/lint/check_cpp_files_inclusion.py
+        language: python
+        types: [python]

--- a/ci/lint/check_cpp_files_inclusion.py
+++ b/ci/lint/check_cpp_files_inclusion.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""This script checks whether header file inclusion for ray core C++ code is correct.
+"""
+
+import subprocess
+
+# All ray core C++ code is under certain folder.
+_RAY_CORE_CPP_DIR = "src/ray"
+
+
+def get_merge_base_develop() -> str:
+    """Return merge-base develop commit of current HEAD"""
+    current_branch = subprocess.check_output(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"]
+    ).strip()
+    return subprocess.check_output(
+        ["git", "merge-base", current_branch, "origin/master"]
+    ).strip()
+
+
+def diff_files_with_develop() -> str:
+    """Return files that are changed between merge-base develop and HEAD."""
+    return (
+        subprocess.check_output(
+            ["git", "diff", "--name-only", "HEAD", get_merge_base_develop()]
+        )
+        .strip()
+        .decode()
+        .split("\n")
+    )
+
+
+def check_ray_core_inclusion(fname: str):
+    """Check whether ray core file has incorrect inclusion `src/ray/...`, which doesn't
+    build on windows env.
+
+    raise:
+        ImportError: if incorrect inclusion is detected.
+    """
+    # Exclude protobuf, which requires absolution path for compilation.
+    cmd = f"grep 'src/ray' {fname} | grep -v 'pb'"
+    grep_res = subprocess.check_output(cmd, shell=True, text=True)
+    if grep_res:
+        raise ImportError(f"{fname} has invalid header file inclusion: {grep_res}")
+
+
+def main():
+    changed_files = diff_files_with_develop()
+    for cur_file in changed_files:
+        if not cur_file.startswith(_RAY_CORE_CPP_DIR):
+            continue
+        check_ray_core_inclusion(cur_file)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
In the past several weeks, ray core team suffered several times production issue (aka. failed compilation on windows);
In this PR, I wrote a simple script to check against certain cases and add it to the pre-commit hook.
TODO: Add to CI as well.

How I tested:
- I intentionally violate our inclusion rule
- Precommit hook does detect invalid usage

Effect:
```
Check ray core C++ files inclusion violations............................Failed
- hook id: check_cpp_files_inclusion
- exit code: 1

Traceback (most recent call last):
  File "/home/ubuntu/ray/ci/lint/check_cpp_files_inclusion.py", line 56, in <module>
    main()
  File "/home/ubuntu/ray/ci/lint/check_cpp_files_inclusion.py", line 52, in main
    check_ray_core_inclusion(cur_file)
  File "/home/ubuntu/ray/ci/lint/check_cpp_files_inclusion.py", line 44, in check_ray_core_inclusion
    raise ImportError(f"{fname} has invalid header file inclusion: {grep_res}")
ImportError: src/ray/raylet/agent_manager.h has invalid header file inclusion: #include "src/ray/util/process.h"
```