### PR TITLE
[Arrow] Allow Python Objects fallback to override logging warning 

### DIFF
--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -122,45 +122,53 @@ def convert_to_pyarrow_array(column_values: np.ndarray, column_name: str) -> pa.
             ArrowPythonObjectArray,
             _object_extension_type_allowed,
         )
+        from ray.data import DataContext
+
+        enable_fallback_config: Optional[bool] = (
+            DataContext.get_current().enable_fallback_to_arrow_object_ext_type
+        )
 
         if not _object_extension_type_allowed():
-            should_serialize_as_object_ext_type = False
+            object_ext_type_fallback_allowed = False
             object_ext_type_detail = (
                 "skipping fallback to serialize as pickled python"
                 f" objects (due to unsupported Arrow version {PYARROW_VERSION}, "
                 f"min required version is {MIN_PYARROW_VERSION_SCALAR_SUBCLASS})"
             )
         else:
-            from ray.data import DataContext
+            # NOTE: By default setting is unset which (for compatibility reasons)
+            #       is allowing the fallback
+            object_ext_type_fallback_allowed = (
+                enable_fallback_config is None or enable_fallback_config
+            )
 
-            if not DataContext.get_current().enable_fallback_to_arrow_object_ext_type:
-                should_serialize_as_object_ext_type = False
+            if object_ext_type_fallback_allowed:
+                object_ext_type_detail = (
+                    "falling back to serialize as pickled python objects"
+                )
+            else:
                 object_ext_type_detail = (
                     "skipping fallback to serialize as pickled python objects "
                     "(due to DataContext.enable_fallback_to_arrow_object_ext_type "
                     "= False)"
                 )
-            else:
-                should_serialize_as_object_ext_type = True
-                object_ext_type_detail = (
-                    "falling back to serialize as pickled python objects"
+
+        if not object_ext_type_fallback_allowed:
+            # NOTE: To avoid logging following warning for every block it's
+            #       only going to be logged in following cases
+            #           - When fallback is disallowed, and
+            #           - Configuration enabling fallback is not set, and
+            #           - It's being logged for the first time
+            if enable_fallback_config is None and log_once(
+                "_fallback_to_arrow_object_extension_type_warning"
+            ):
+                logger.warning(
+                    f"Failed to convert column '{column_name}' into pyarrow "
+                    f"array due to: {ace}; {object_ext_type_detail}",
+                    exc_info=ace,
                 )
 
-        # NOTE: To avoid logging following warning for every block it's
-        #       only going to be logged in following cases
-        #           - When fallback is disabled, or
-        #           - It's being logged for the first time
-        if not should_serialize_as_object_ext_type or log_once(
-            "_fallback_to_arrow_object_extension_type_warning"
-        ):
-            logger.warning(
-                f"Failed to convert column '{column_name}' into pyarrow "
-                f"array due to: {ace}; {object_ext_type_detail}",
-                exc_info=ace,
-            )
-
-        # If `ArrowPythonObjectType` is not supported raise original exception
-        if not should_serialize_as_object_ext_type:
+            # If `ArrowPythonObjectType` is not supported raise original exception
             raise
 
         # Otherwise, attempt to fall back to serialize as python objects

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -154,12 +154,12 @@ def convert_to_pyarrow_array(column_values: np.ndarray, column_name: str) -> pa.
                 )
 
         if not object_ext_type_fallback_allowed:
-            # NOTE: To avoid logging following warning for every block it's
-            #       only going to be logged in following cases
-            #           - When fallback is disallowed, and
-            #           - Configuration enabling fallback is not set, and
-            #           - It's being logged for the first time
-            if enable_fallback_config is None and log_once(
+            # To avoid logging following warning for every block it's
+            # only going to be logged in following cases
+            #   - When fallback is disallowed, and
+            #   - Fallback configuration is not set or set to false, and
+            #   - It's being logged for the first time
+            if not enable_fallback_config and log_once(
                 "_fallback_to_arrow_object_extension_type_warning"
             ):
                 logger.warning(

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -118,15 +118,15 @@ def convert_to_pyarrow_array(column_values: np.ndarray, column_name: str) -> pa.
             return _convert_to_pyarrow_native_array(column_values, column_name)
 
     except ArrowConversionError as ace:
+        from ray.data import DataContext
         from ray.data.extensions.object_extension import (
             ArrowPythonObjectArray,
             _object_extension_type_allowed,
         )
-        from ray.data import DataContext
 
-        enable_fallback_config: Optional[bool] = (
-            DataContext.get_current().enable_fallback_to_arrow_object_ext_type
-        )
+        enable_fallback_config: Optional[
+            bool
+        ] = DataContext.get_current().enable_fallback_to_arrow_object_ext_type
 
         if not _object_extension_type_allowed():
             object_ext_type_fallback_allowed = False

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -80,8 +80,6 @@ DEFAULT_ENABLE_TENSOR_EXTENSION_CASTING = True
 #       V2 in turn relies on int64 offsets, therefore having a limit of ~9Eb (exabytes)
 DEFAULT_USE_ARROW_TENSOR_V2 = env_bool("RAY_DATA_USE_ARROW_TENSOR_V2", True)
 
-DEFAULT_ENABLE_FALLBACK_TO_ARROW_OBJECT_EXT_TYPE = True
-
 DEFAULT_AUTO_LOG_STATS = False
 
 DEFAULT_VERBOSE_STATS_LOG = False
@@ -301,9 +299,7 @@ class DataContext:
     read_op_min_num_blocks: int = DEFAULT_READ_OP_MIN_NUM_BLOCKS
     enable_tensor_extension_casting: bool = DEFAULT_ENABLE_TENSOR_EXTENSION_CASTING
     use_arrow_tensor_v2: bool = DEFAULT_USE_ARROW_TENSOR_V2
-    enable_fallback_to_arrow_object_ext_type = (
-        DEFAULT_ENABLE_FALLBACK_TO_ARROW_OBJECT_EXT_TYPE
-    )
+    enable_fallback_to_arrow_object_ext_type: Optional[bool] = None
     enable_auto_log_stats: bool = DEFAULT_AUTO_LOG_STATS
     verbose_stats_logs: bool = DEFAULT_VERBOSE_STATS_LOG
     trace_allocations: bool = DEFAULT_TRACE_ALLOCATIONS


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This change enables setting `DataContext.enable_fallback_to_arrow_object_ext_type` to override logging a warning.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
