### PR TITLE
[core][compiled graphs] `allreduce` errors with num returns > 1

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -302,7 +302,7 @@ class ActorMethod:
                     (node, i),
                     dict(),
                     dict(),
-                    {IS_CLASS_METHOD_OUTPUT_KEY: True},
+                    {IS_CLASS_METHOD_OUTPUT_KEY: True, PARENT_CLASS_NODE_KEY: actor},
                 )
                 output_nodes.append(output_node)
             return tuple(output_nodes)

--- a/python/ray/experimental/channel/nccl_group.py
+++ b/python/ray/experimental/channel/nccl_group.py
@@ -262,9 +262,11 @@ class _NcclGroup(GPUCommunicator):
         if self._closed:
             raise RayChannelError("NCCL group has been destroyed.")
 
-        assert (
-            send_buf.dtype == recv_buf.dtype
-        ), "send_buf and recv_buf must have the same dtype"
+        assert send_buf.dtype == recv_buf.dtype, (
+            "Ray Compiled Graph derived the dtype of recv_buf from send_buf, "
+            "so send_buf and recv_buf must have the same dtype. "
+            "If you see this error, please file an issue at Ray repository."
+        )
         self._comm.allReduce(
             self.nccl_util.get_tensor_ptr(send_buf),
             self.nccl_util.get_tensor_ptr(recv_buf),
@@ -282,8 +284,9 @@ class _NcclGroup(GPUCommunicator):
         self._cuda_stream.synchronize()
         if self._closed:
             raise RayChannelError(
-                "NCCL group has been destroyed. There may be a dtype mismatch "
-                "between different ranks."
+                "NCCL group has been destroyed during allreduce operation. "
+                "There may be a dtype mismatch between input tensors from "
+                "different ranks."
             )
 
     @property


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

#48522 has two questions:

* Q1: `allreduce` doesn't support `ClassMethodNode (is_class_method_output)`. The failure happens in the constructor of `_CollectiveOperation`.

https://github.com/ray-project/ray/blob/835cb112d4bd978a9cbcee60ec31aa5e7f691ce0/python/ray/dag/collective_node.py#L45-L49

Solution: pass the actor information to `ClassMethodNode (is_class_method_output)`. See the change in `actor.py` for more details.

* Q2: deadlock

The issue is that rank_0 sends `torch.ones(size, device=self.device)` with `dtype` as `torch.float32`, while rank_1 sends `torch.arange(size, device=self.device)` with `dtype` as `torch.int64`. This `dtype` mismatch causes rank_0's `allReduce` result to remain the same as `torch.ones(size, device=self.device)`, while rank_1 gets stuck at `self._cuda_stream.synchronize()` until times out.

## Related issue number

Closes #48522

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
