### PR TITLE
[RLlib; docs] Adjust the documentation of the default API stack and replace 'rollouts' with 'env_runners'.

### DIFF
--- a/doc/source/rllib/new-api-stack-migration-guide.rst
+++ b/doc/source/rllib/new-api-stack-migration-guide.rst
@@ -25,7 +25,7 @@ RLlib classes and code to RLlib's new API stack.
 Change your AlgorithmConfig
 ---------------------------
 
-RLlib turns off the new API stack by default for all RLlib algorithms. To activate it, use the `api_stack()` method
+RLlib turns on the new API stack by default for all RLlib algorithms. To deactivate it, use the `api_stack()` method
 in your `AlgorithmConfig` object like so:
 
 .. testcode::
@@ -34,14 +34,14 @@ in your `AlgorithmConfig` object like so:
 
     config = (
         PPOConfig()
-        # Switch both the new API stack flags to True (both False by default).
-        # This action enables the use of
+        # Switch both the new API stack flags to False (both True by default).
+        # This action disables the use of
         # a) RLModule (replaces ModelV2) and Learner (replaces Policy).
         # b) the correct EnvRunner, which replaces RolloutWorker, and
         #    ConnectorV2 pipelines, which replaces the old stack Connectors.
         .api_stack(
-            enable_rl_module_and_learner=True,
-            enable_env_runner_and_connector_v2=True,
+            enable_rl_module_and_learner=False,
+            enable_env_runner_and_connector_v2=False,
         )
     )
 

--- a/doc/source/rllib/rllib-training.rst
+++ b/doc/source/rllib/rllib-training.rst
@@ -269,7 +269,7 @@ Specifying Framework Options
 Specifying Rollout Workers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: ray.rllib.algorithms.algorithm_config.AlgorithmConfig.rollouts
+.. automethod:: ray.rllib.algorithms.algorithm_config.AlgorithmConfig.env_runners
     :noindex:
 
 


### PR DESCRIPTION
…llouts' with 'env_runners' in 'Getting Started'.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

RLlib's default API stack is now the new API stack, however, the documentation still tells the other way around. This PR makes some primer adjustments. For the long run we need to rewrite the pages fully and replace references therein.

## Related issue number

Closes #49076 #49073

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
