### PR TITLE
[tune] Remove `ray.train.report` usage within Tune internal code

### DIFF
--- a/python/ray/tune/trainable/function_trainable.py
+++ b/python/ray/tune/trainable/function_trainable.py
@@ -6,7 +6,6 @@ from functools import partial
 from numbers import Number
 from typing import Any, Callable, Dict, Optional, Type
 
-import ray.train
 from ray.air._internal.util import RunnerThread, StartTraceback
 from ray.air.constants import _ERROR_FETCH_TIMEOUT
 from ray.train._internal.checkpoint_manager import _TrainingResult
@@ -232,9 +231,9 @@ def wrap_function(
                 if not output:
                     return
                 elif isinstance(output, dict):
-                    ray.train.report(output)
+                    get_session().report(output)
                 elif isinstance(output, Number):
-                    ray.train.report({DEFAULT_METRIC: output})
+                    get_session().report({DEFAULT_METRIC: output})
                 else:
                     raise ValueError(
                         "Invalid return or yield value. Either return/yield "
@@ -253,7 +252,7 @@ def wrap_function(
             # If train_func returns, we need to notify the main event loop
             # of the last result while avoiding double logging. This is done
             # with the keyword RESULT_DUPLICATE -- see tune/tune_controller.py.
-            ray.train.report({RESULT_DUPLICATE: True})
+            get_session().report({RESULT_DUPLICATE: True})
             return output
 
         @classmethod


### PR DESCRIPTION
## Summary

This is a preparation PR for splitting up the `ray.train.*` APIs between `ray.tune.*` and `ray.train.*`. Ray Tune currently uses the public `ray.train.report` API within its internals (the `FunctionTrainable` implementation). This PR removes this internal usage, which is needed because Tune would not work with a new patched implementation of `ray.train`.

See: https://github.com/ray-project/enhancements/pull/57