### PR TITLE
[Autoscaler][Schema] Cleaned up `ClusterResourceConstraint` definition

### DIFF
--- a/python/ray/autoscaler/v2/event_logger.py
+++ b/python/ray/autoscaler/v2/event_logger.py
@@ -142,13 +142,13 @@ class AutoscalerEventLogger:
             for infeasible_constraint in infeasible_cluster_resource_constraints:
                 log_str = "No available node types can fulfill cluster constraint: "
                 for i, requests_by_count in enumerate(
-                    infeasible_constraint.min_bundles
+                    infeasible_constraint.resource_requests
                 ):
                     resource_map = ResourceRequestUtil.to_resource_map(
                         requests_by_count.request
                     )
                     log_str += f"{resource_map}*{requests_by_count.count}"
-                    if i < len(infeasible_constraint.min_bundles) - 1:
+                    if i < len(infeasible_constraint.resource_requests) - 1:
                         log_str += ", "
 
                 log_str += (

--- a/python/ray/autoscaler/v2/scheduler.py
+++ b/python/ray/autoscaler/v2/scheduler.py
@@ -1194,9 +1194,8 @@ class ResourceDemandScheduler(IResourceScheduler):
             return []
 
         constraint = constraints[0]
-        min_bundles = constraint.min_bundles
         # Flatten the requests for iterating through.
-        requests = ResourceRequestUtil.ungroup_by_count(min_bundles)
+        requests = ResourceRequestUtil.ungroup_by_count(constraint.resource_requests)
 
         # Pass the empty nodes to schedule.
         scheduled_nodes, infeasible = ResourceDemandScheduler._try_schedule(

--- a/python/ray/autoscaler/v2/tests/test_event_logger.py
+++ b/python/ray/autoscaler/v2/tests/test_event_logger.py
@@ -78,7 +78,7 @@ def test_log_scheduling_updates():
         ],
         infeasible_cluster_resource_constraints=[
             ClusterResourceConstraint(
-                min_bundles=ResourceRequestUtil.group_by_count(
+                resource_requests=ResourceRequestUtil.group_by_count(
                     cluster_resource_constraints
                 )
             )

--- a/python/ray/autoscaler/v2/tests/test_scheduler.py
+++ b/python/ray/autoscaler/v2/tests/test_scheduler.py
@@ -70,7 +70,7 @@ def sched_request(
         cluster_resource_constraints=(
             [
                 ClusterResourceConstraint(
-                    min_bundles=ResourceRequestUtil.group_by_count(
+                    resource_requests=ResourceRequestUtil.group_by_count(
                         cluster_resource_constraints
                     )
                 )

--- a/python/ray/autoscaler/v2/tests/test_sdk.py
+++ b/python/ray/autoscaler/v2/tests/test_sdk.py
@@ -61,12 +61,12 @@ def assert_cluster_resource_constraints(
     # We only have 1 constraint for now.
     assert len(state.cluster_resource_constraints) == 1
 
-    min_bundles = state.cluster_resource_constraints[0].min_bundles
-    assert len(min_bundles) == len(expected_bundles) == len(expected_count)
+    resource_requests = state.cluster_resource_constraints[0].resource_requests
+    assert len(resource_requests) == len(expected_bundles) == len(expected_count)
 
     # Sort all the bundles by bundle's resource names
-    min_bundles = sorted(
-        min_bundles,
+    resource_requests = sorted(
+        resource_requests,
         key=lambda bundle_by_count: "".join(
             bundle_by_count.request.resources_bundle.keys()
         ),
@@ -76,7 +76,7 @@ def assert_cluster_resource_constraints(
         expected, key=lambda bundle_count: "".join(bundle_count[0].keys())
     )
 
-    for actual_bundle_count, expected_bundle_count in zip(min_bundles, expected):
+    for actual_bundle_count, expected_bundle_count in zip(resource_requests, expected):
         assert (
             dict(actual_bundle_count.request.resources_bundle)
             == expected_bundle_count[0]

--- a/python/ray/autoscaler/v2/tests/test_utils.py
+++ b/python/ray/autoscaler/v2/tests/test_utils.py
@@ -189,7 +189,7 @@ def test_cluster_status_parser_cluster_resource_state():
             ],
             "cluster_resource_constraints": [
                 {
-                    "min_bundles": [
+                    "resource_requests": [
                         {
                             "request": {
                                 "resources_bundle": {"GPU": 2, "CPU": 100},

--- a/python/ray/autoscaler/v2/utils.py
+++ b/python/ray/autoscaler/v2/utils.py
@@ -559,7 +559,7 @@ class ClusterStatusParser:
                     ResourceRequestByCount(
                         bundle=dict(r.request.resources_bundle.items()), count=r.count
                     )
-                    for r in constraint_request.min_bundles
+                    for r in constraint_request.resource_requests
                 ]
             )
             constraint_demand.append(demand)

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -1440,7 +1440,7 @@ Status AutoscalerStateAccessor::RequestClusterResourceConstraint(
     auto count = count_array[i];
 
     auto new_resource_requests_by_count =
-        request.mutable_cluster_resource_constraint()->add_min_bundles();
+        request.mutable_cluster_resource_constraint()->add_resource_requests();
 
     new_resource_requests_by_count->mutable_request()->mutable_resources_bundle()->insert(
         bundle.begin(), bundle.end());

--- a/src/ray/gcs/gcs_server/test/gcs_autoscaler_state_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_autoscaler_state_manager_test.cc
@@ -636,9 +636,10 @@ TEST_F(GcsAutoscalerStateManagerTest, TestClusterResourcesConstraint) {
         Mocker::GenClusterResourcesConstraint({{{"CPU", 2}, {"GPU", 1}}}, {1}));
     const auto &state = GetClusterResourceStateSync();
     ASSERT_EQ(state.cluster_resource_constraints_size(), 1);
-    ASSERT_EQ(state.cluster_resource_constraints(0).min_bundles_size(), 1);
-    CheckResourceRequest(state.cluster_resource_constraints(0).min_bundles(0).request(),
-                         {{"CPU", 2}, {"GPU", 1}});
+    ASSERT_EQ(state.cluster_resource_constraints(0).resource_requests_size(), 1);
+    CheckResourceRequest(
+        state.cluster_resource_constraints(0).resource_requests(0).request(),
+        {{"CPU", 2}, {"GPU", 1}});
   }
 
   // Override it
@@ -647,9 +648,10 @@ TEST_F(GcsAutoscalerStateManagerTest, TestClusterResourcesConstraint) {
         {{{"CPU", 4}, {"GPU", 5}, {"TPU", 1}}}, {1}));
     const auto &state = GetClusterResourceStateSync();
     ASSERT_EQ(state.cluster_resource_constraints_size(), 1);
-    ASSERT_EQ(state.cluster_resource_constraints(0).min_bundles_size(), 1);
-    CheckResourceRequest(state.cluster_resource_constraints(0).min_bundles(0).request(),
-                         {{"CPU", 4}, {"GPU", 5}, {"TPU", 1}});
+    ASSERT_EQ(state.cluster_resource_constraints(0).resource_requests_size(), 1);
+    CheckResourceRequest(
+        state.cluster_resource_constraints(0).resource_requests(0).request(),
+        {{"CPU", 4}, {"GPU", 5}, {"TPU", 1}});
   }
 }
 

--- a/src/ray/gcs/test/gcs_test_util.h
+++ b/src/ray/gcs/test/gcs_test_util.h
@@ -421,7 +421,7 @@ struct Mocker {
     for (size_t i = 0; i < request_resources.size(); i++) {
       auto &resource = request_resources[i];
       auto count = count_array[i];
-      auto bundle = constraint.add_min_bundles();
+      auto bundle = constraint.add_resource_requests();
       bundle->set_count(count);
       bundle->mutable_request()->mutable_resources_bundle()->insert(resource.begin(),
                                                                     resource.end());

--- a/src/ray/protobuf/autoscaler.proto
+++ b/src/ray/protobuf/autoscaler.proto
@@ -79,7 +79,8 @@ message GangResourceRequest {
 message ClusterResourceConstraint {
   // Commands the autoscaler to accommodate the specified requests.
   //
-  // For more context, please check out py-doc for `ray.autoscaler.sdk.request_resources` method
+  // For more context, please check out py-doc for `ray.autoscaler.sdk.request_resources`
+  // method
   //
   // NOTE: This call is only a hint to the autoscaler. The actual resulting cluster
   //       size may be slightly larger or smaller than expected depending on the

--- a/src/ray/protobuf/autoscaler.proto
+++ b/src/ray/protobuf/autoscaler.proto
@@ -77,9 +77,14 @@ message GangResourceRequest {
 // Cluster resource constraint represents minimal cluster size requirement,
 // this is issued through ray.autoscaler.sdk.request_resources.
 message ClusterResourceConstraint {
-  // If not emtpy, the cluster should have the capacity (total resource) to fit
-  // the min_bundles.
-  repeated ResourceRequestByCount min_bundles = 1;
+  // Commands the autoscaler to accommodate the specified requests.
+  //
+  // For more context, please check out py-doc for `ray.autoscaler.sdk.request_resources` method
+  //
+  // NOTE: This call is only a hint to the autoscaler. The actual resulting cluster
+  //       size may be slightly larger or smaller than expected depending on the
+  //       internal bin packing algorithm and max worker count restrictions.
+  repeated ResourceRequestByCount resource_requests = 1;
 }
 
 // Node status for a ray node.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Updating the `ClusterResourceConstraint` definition to make its implemented semantic align with `ray.autoscaler.sdk.request_resources`

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
