### PR TITLE
[Doc] Fix incorrect URL in `persist-kuberay-custom-resource-logs.md`

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides/persist-kuberay-custom-resource-logs.md
+++ b/doc/source/cluster/kubernetes/user-guides/persist-kuberay-custom-resource-logs.md
@@ -95,7 +95,7 @@ A few notes on the above config:
   in the Fluent Bit container's stdout sooner.
 - The [Kubernetes downward API][KubernetesDownwardAPI] populates the `POD_LABELS` variable used in the `FILTER` section. It pulls the label from the pod's metadata label `ray.io/cluster`, which is defined in the Fluent Bit sidecar container's environment.
 - The `tenant_id` field allows you to assign logs to different tenants. In this example, Fluent Bit sidecar sends the logs to the `test` tenant. You can adjust this configuration to match the tenant ID set up in your Grafana Loki instance, enabling multi-tenancy support in Grafana.
-- The `Host` field specifies the endpoint of the Loki gateway. If Loki and the RayCluster are in different namespaces, you need to append `.namespace` to the host name, for example, `loki-gateway.monitoring` (replace `monitoring` with the namespace where Loki resides).
+- The `Host` field specifies the endpoint of the Loki gateway. If Loki and the RayCluster are in different namespaces, you need to append `.namespace` to the hostname, for example, `loki-gateway.monitoring` (replacing `monitoring` with the namespace where Loki resides).
 
 ### Adding logging sidecars to RayCluster Custom Resource (CR)
 

--- a/doc/source/cluster/kubernetes/user-guides/persist-kuberay-custom-resource-logs.md
+++ b/doc/source/cluster/kubernetes/user-guides/persist-kuberay-custom-resource-logs.md
@@ -95,7 +95,7 @@ A few notes on the above config:
   in the Fluent Bit container's stdout sooner.
 - The [Kubernetes downward API][KubernetesDownwardAPI] populates the `POD_LABELS` variable used in the `FILTER` section. It pulls the label from the pod's metadata label `ray.io/cluster`, which is defined in the Fluent Bit sidecar container's environment.
 - The `tenant_id` field allows you to assign logs to different tenants. In this example, Fluent Bit sidecar sends the logs to the `test` tenant. You can adjust this configuration to match the tenant ID set up in your Grafana Loki instance, enabling multi-tenancy support in Grafana.
-
+- The `Host` field specifies the endpoint of the Loki gateway. If Loki and the RayCluster are in different namespaces, you need to append `.namespace` to the host name, for example, `loki-gateway.monitoring` (replace `monitoring` with the namespace where Loki resides).
 
 ### Adding logging sidecars to RayCluster Custom Resource (CR)
 
@@ -254,7 +254,7 @@ for instructions on this step.
 Now, run the following commands to deploy the Fluent Bit ConfigMap and a single-pod RayCluster with
 a Fluent Bit sidecar.
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/refs/heads/master/ray-operator/config/samples/ray-cluster-fluentbit-sidecar.yaml
+kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/refs/heads/master/ray-operator/config/samples/ray-cluster.fluentbit.yaml
 ```
 
 To access Grafana from your local machine, set up port forwarding by running:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
- The link used in `Deploying a RayCluster with a logging sidecar` is currently unavailable because the name needs to be changed to `ray-cluster.fluentbit.yaml`.
- Add `Host` field to explain  how to handle the Loki and Raycluster cross-namespace issue.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
