### PR TITLE
[core][compiled-graphs][1/N] Polish APIs: execution_timeout, retrieval_timeout, buffer_size_bytes

### DIFF
--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -734,9 +734,10 @@ class CompiledDAG:
                 None means using default timeout (DAGContext.submit_timeout),
                 0 means immediate timeout (immediate success or timeout without
                 blocking), -1 means infinite timeout (block indefinitely).
-            buffer_size_bytes: The number of bytes to allocate for object data and
-                metadata. Each argument passed to a task in the DAG must be
-                less than or equal to this value when serialized.
+            buffer_size_bytes: The initial buffer size in bytes for messages
+                that can be passed between tasks in the DAG. The buffers will
+                be automatically resized if larger messages are written to the
+                channel.
             enable_asyncio: Whether to enable asyncio. If enabled, caller must
                 be running in an event loop and must use `execute_async` to
                 invoke the DAG. Otherwise, the caller should use `execute` to

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -720,7 +720,7 @@ class CompiledDAG:
 
     def __init__(
         self,
-        execution_timeout: Optional[float] = None,
+        submit_timeout: Optional[float] = None,
         buffer_size_bytes: Optional[int] = None,
         enable_asyncio: bool = False,
         asyncio_max_queue_size: Optional[int] = None,
@@ -730,8 +730,8 @@ class CompiledDAG:
     ):
         """
         Args:
-            execution_timeout: The maximum time in seconds to wait for execute() calls.
-                None means using default timeout (DAGContext.execution_timeout),
+            submit_timeout: The maximum time in seconds to wait for execute() calls.
+                None means using default timeout (DAGContext.submit_timeout),
                 0 means immediate timeout (immediate success or timeout without
                 blocking), -1 means infinite timeout (block indefinitely).
             buffer_size_bytes: The number of bytes to allocate for object data and
@@ -783,9 +783,9 @@ class CompiledDAG:
         if self._max_inflight_executions is None:
             self._max_inflight_executions = ctx.max_inflight_executions
         self._dag_id = uuid.uuid4().hex
-        self._execution_timeout: Optional[float] = execution_timeout
-        if self._execution_timeout is None:
-            self._execution_timeout = ctx.execution_timeout
+        self._submit_timeout: Optional[float] = submit_timeout
+        if self._submit_timeout is None:
+            self._submit_timeout = ctx.submit_timeout
         self._buffer_size_bytes: Optional[int] = buffer_size_bytes
         if self._buffer_size_bytes is None:
             self._buffer_size_bytes = ctx.buffer_size_bytes
@@ -2102,7 +2102,7 @@ class CompiledDAG:
 
         Raises:
             RayChannelTimeoutError: If the execution does not complete within
-                self._execution_timeout seconds.
+                self._submit_timeout seconds.
 
         NOTE: Not thread-safe due to _execution_index etc.
         """
@@ -2123,7 +2123,7 @@ class CompiledDAG:
             inp = RayDAGArgs(args=args, kwargs=kwargs)
 
         self.raise_if_too_many_inflight_requests()
-        self._dag_submitter.write(inp, self._execution_timeout)
+        self._dag_submitter.write(inp, self._submit_timeout)
 
         if self._returns_list:
             ref = [
@@ -2797,7 +2797,7 @@ class CompiledDAG:
 @DeveloperAPI
 def build_compiled_dag_from_ray_dag(
     dag: "ray.dag.DAGNode",
-    execution_timeout: Optional[float] = None,
+    submit_timeout: Optional[float] = None,
     buffer_size_bytes: Optional[int] = None,
     enable_asyncio: bool = False,
     asyncio_max_queue_size: Optional[int] = None,
@@ -2806,7 +2806,7 @@ def build_compiled_dag_from_ray_dag(
     overlap_gpu_communication: Optional[bool] = None,
 ) -> "CompiledDAG":
     compiled_dag = CompiledDAG(
-        execution_timeout,
+        submit_timeout,
         buffer_size_bytes,
         enable_asyncio,
         asyncio_max_queue_size,

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -2016,7 +2016,7 @@ class CompiledDAG:
         from ray.dag import DAGContext
 
         ctx = DAGContext.get_current()
-        timeout = ctx.retrieval_timeout
+        timeout = ctx.get_timeout
 
         while self._max_finished_execution_index < execution_index:
             self.increment_max_finished_execution_index()
@@ -2045,7 +2045,7 @@ class CompiledDAG:
                 self.dag_output_channels. None means wrapping results from all output
                 channels into a single list.
             timeout: The maximum time in seconds to wait for the result.
-                None means using default timeout (DAGContext.retrieval_timeout),
+                None means using default timeout (DAGContext.get_timeout),
                 0 means immediate timeout (immediate success or timeout without
                 blocking), -1 means infinite timeout (block indefinitely).
 
@@ -2060,7 +2060,7 @@ class CompiledDAG:
 
             ctx = DAGContext.get_current()
             if timeout is None:
-                timeout = ctx.retrieval_timeout
+                timeout = ctx.get_timeout
 
         while self._max_finished_execution_index < execution_index:
             if len(self._result_buffer) >= self._max_buffered_results:

--- a/python/ray/dag/context.py
+++ b/python/ray/dag/context.py
@@ -9,7 +9,7 @@ _default_context: "Optional[DAGContext]" = None
 _context_lock = threading.Lock()
 
 DEFAULT_SUBMIT_TIMEOUT_S = int(os.environ.get("RAY_DAG_submit_timeout", 10))
-DEFAULT_RETRIEVAL_TIMEOUT_S = int(os.environ.get("RAY_DAG_retrieval_timeout", 10))
+DEFAULT_GET_TIMEOUT_S = int(os.environ.get("RAY_DAG_get_timeout", 10))
 DEFAULT_TEARDOWN_TIMEOUT_S = int(os.environ.get("RAY_DAG_teardown_timeout", 30))
 # Default buffer size is 1MB.
 DEFAULT_BUFFER_SIZE_BYTES = int(os.environ.get("RAY_DAG_buffer_size_bytes", 1e6))
@@ -50,8 +50,9 @@ class DAGContext:
     Args:
         submit_timeout: The maximum time in seconds to wait for execute()
             calls.
-        retrieval_timeout: The maximum time in seconds to wait to retrieve
-            a result from the DAG.
+        get_timeout: The maximum time in seconds to wait when retrieving
+            a result from the DAG during `ray.get`. This should be set to a
+            value higher than the expected time to execute the entire DAG.
         teardown_timeout: The maximum time in seconds to wait for the DAG to
             cleanly shut down.
         buffer_size_bytes: The maximum size of messages that can be passed
@@ -74,7 +75,7 @@ class DAGContext:
     """
 
     submit_timeout: int = DEFAULT_SUBMIT_TIMEOUT_S
-    retrieval_timeout: int = DEFAULT_RETRIEVAL_TIMEOUT_S
+    get_timeout: int = DEFAULT_GET_TIMEOUT_S
     teardown_timeout: int = DEFAULT_TEARDOWN_TIMEOUT_S
     buffer_size_bytes: int = DEFAULT_BUFFER_SIZE_BYTES
     asyncio_max_queue_size: int = DEFAULT_ASYNCIO_MAX_QUEUE_SIZE

--- a/python/ray/dag/context.py
+++ b/python/ray/dag/context.py
@@ -8,26 +8,28 @@ from ray.util.annotations import DeveloperAPI
 _default_context: "Optional[DAGContext]" = None
 _context_lock = threading.Lock()
 
-DEFAULT_SUBMIT_TIMEOUT_S = int(os.environ.get("RAY_DAG_submit_timeout", 10))
-DEFAULT_GET_TIMEOUT_S = int(os.environ.get("RAY_DAG_get_timeout", 10))
-DEFAULT_TEARDOWN_TIMEOUT_S = int(os.environ.get("RAY_DAG_teardown_timeout", 30))
+DEFAULT_SUBMIT_TIMEOUT_S = int(os.environ.get("RAY_CGRAPH_submit_timeout", 10))
+DEFAULT_GET_TIMEOUT_S = int(os.environ.get("RAY_CGRAPH_get_timeout", 10))
+DEFAULT_TEARDOWN_TIMEOUT_S = int(os.environ.get("RAY_CGRAPH_teardown_timeout", 30))
 # Default buffer size is 1MB.
-DEFAULT_BUFFER_SIZE_BYTES = int(os.environ.get("RAY_DAG_buffer_size_bytes", 1e6))
+DEFAULT_BUFFER_SIZE_BYTES = int(os.environ.get("RAY_CGRAPH_buffer_size_bytes", 1e6))
 # Default asyncio_max_queue_size is 0, which means no limit.
 DEFAULT_ASYNCIO_MAX_QUEUE_SIZE = int(
-    os.environ.get("RAY_DAG_asyncio_max_queue_size", 0)
+    os.environ.get("RAY_CGRAPH_asyncio_max_queue_size", 0)
 )
 # The default max_buffered_results is 1000, and the default buffer size is 1 MB.
 # The maximum memory usage for buffered results is 1 GB.
-DEFAULT_MAX_BUFFERED_RESULTS = int(os.environ.get("RAY_DAG_max_buffered_results", 1000))
+DEFAULT_MAX_BUFFERED_RESULTS = int(
+    os.environ.get("RAY_CGRAPH_max_buffered_results", 1000)
+)
 # The default number of in-flight executions that can be submitted before consuming the
 # output.
 DEFAULT_MAX_INFLIGHT_EXECUTIONS = int(
-    os.environ.get("RAY_DAG_max_inflight_executions", 10)
+    os.environ.get("RAY_CGRAPH_max_inflight_executions", 10)
 )
 
 DEFAULT_OVERLAP_GPU_COMMUNICATION = bool(
-    os.environ.get("RAY_DAG_overlap_gpu_communication", 0)
+    os.environ.get("RAY_CGRAPH_overlap_gpu_communication", 0)
 )
 
 
@@ -37,7 +39,7 @@ class DAGContext:
     """Global settings for Ray DAG.
 
     You can configure parameters in the DAGContext by setting the environment
-    variables, `RAY_DAG_<param>` (e.g., `RAY_DAG_buffer_size_bytes`) or Python.
+    variables, `RAY_CGRAPH_<param>` (e.g., `RAY_CGRAPH_buffer_size_bytes`) or Python.
 
     Examples:
         >>> from ray.dag import DAGContext

--- a/python/ray/dag/context.py
+++ b/python/ray/dag/context.py
@@ -8,7 +8,7 @@ from ray.util.annotations import DeveloperAPI
 _default_context: "Optional[DAGContext]" = None
 _context_lock = threading.Lock()
 
-DEFAULT_EXECUTION_TIMEOUT_S = int(os.environ.get("RAY_DAG_execution_timeout", 10))
+DEFAULT_SUBMIT_TIMEOUT_S = int(os.environ.get("RAY_DAG_submit_timeout", 10))
 DEFAULT_RETRIEVAL_TIMEOUT_S = int(os.environ.get("RAY_DAG_retrieval_timeout", 10))
 DEFAULT_TEARDOWN_TIMEOUT_S = int(os.environ.get("RAY_DAG_teardown_timeout", 30))
 # Default buffer size is 1MB.
@@ -48,7 +48,7 @@ class DAGContext:
         500
 
     Args:
-        execution_timeout: The maximum time in seconds to wait for execute()
+        submit_timeout: The maximum time in seconds to wait for execute()
             calls.
         retrieval_timeout: The maximum time in seconds to wait to retrieve
             a result from the DAG.
@@ -73,7 +73,7 @@ class DAGContext:
             performance of the DAG execution.
     """
 
-    execution_timeout: int = DEFAULT_EXECUTION_TIMEOUT_S
+    submit_timeout: int = DEFAULT_SUBMIT_TIMEOUT_S
     retrieval_timeout: int = DEFAULT_RETRIEVAL_TIMEOUT_S
     teardown_timeout: int = DEFAULT_TEARDOWN_TIMEOUT_S
     buffer_size_bytes: int = DEFAULT_BUFFER_SIZE_BYTES

--- a/python/ray/dag/context.py
+++ b/python/ray/dag/context.py
@@ -55,8 +55,10 @@ class DAGContext:
             value higher than the expected time to execute the entire DAG.
         teardown_timeout: The maximum time in seconds to wait for the DAG to
             cleanly shut down.
-        buffer_size_bytes: The maximum size of messages that can be passed
-            between tasks in the DAG.
+        buffer_size_bytes: The initial buffer size in bytes for messages
+            that can be passed between tasks in the DAG. The buffers will
+            be automatically resized if larger messages are written to the
+            channel.
         asyncio_max_queue_size: The max queue size for the async execution.
             It is only used when enable_asyncio=True.
         max_buffered_results: The maximum number of execution results that

--- a/python/ray/dag/dag_node.py
+++ b/python/ray/dag/dag_node.py
@@ -183,7 +183,7 @@ class DAGNode(DAGNodeBase):
 
     def experimental_compile(
         self,
-        _execution_timeout: Optional[float] = None,
+        _submit_timeout: Optional[float] = None,
         _buffer_size_bytes: Optional[int] = None,
         enable_asyncio: bool = False,
         _asyncio_max_queue_size: Optional[int] = None,
@@ -194,7 +194,7 @@ class DAGNode(DAGNodeBase):
         """Compile an accelerated execution path for this DAG.
 
         Args:
-            _execution_timeout: The maximum time in seconds to wait for execute() calls.
+            _submit_timeout: The maximum time in seconds to wait for execute() calls.
                 None means using default timeout, 0 means immediate timeout
                 (immediate success or timeout without blocking), -1 means
                 infinite timeout (block indefinitely).
@@ -246,7 +246,7 @@ class DAGNode(DAGNodeBase):
         self.is_adag_output_node = True
         return build_compiled_dag_from_ray_dag(
             self,
-            _execution_timeout,
+            _submit_timeout,
             _buffer_size_bytes,
             enable_asyncio,
             _asyncio_max_queue_size,

--- a/python/ray/dag/dag_node.py
+++ b/python/ray/dag/dag_node.py
@@ -198,8 +198,10 @@ class DAGNode(DAGNodeBase):
                 None means using default timeout, 0 means immediate timeout
                 (immediate success or timeout without blocking), -1 means
                 infinite timeout (block indefinitely).
-            _buffer_size_bytes: The maximum size of messages that can be passed
-                between tasks in the DAG.
+            _buffer_size_bytes: The initial buffer size in bytes for messages
+                that can be passed between tasks in the DAG. The buffers will
+                be automatically resized if larger messages are written to the
+                channel.
             enable_asyncio: Whether to enable asyncio for this DAG.
             _asyncio_max_queue_size: The max queue size for the async execution.
                 It is only used when enable_asyncio=True.

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -43,10 +43,10 @@ pytestmark = [
 @pytest.fixture
 def temporary_change_timeout(request):
     ctx = DAGContext.get_current()
-    original = ctx.execution_timeout
-    ctx.execution_timeout = request.param
-    yield ctx.execution_timeout
-    ctx.execution_timeout = original
+    original = ctx.submit_timeout
+    ctx.submit_timeout = request.param
+    yield ctx.submit_timeout
+    ctx.submit_timeout = original
 
 
 @ray.remote

--- a/python/ray/dag/tests/experimental/test_multi_node_dag.py
+++ b/python/ray/dag/tests/experimental/test_multi_node_dag.py
@@ -323,7 +323,7 @@ def test_multi_node_dag_from_actor(ray_start_cluster):
                 )
 
             self._adag = dag.experimental_compile(
-                _execution_timeout=120,
+                _submit_timeout=120,
             )
 
         def call(self, prompt: str) -> bytes:

--- a/python/ray/experimental/channel/shared_memory_channel.py
+++ b/python/ray/experimental/channel/shared_memory_channel.py
@@ -43,9 +43,10 @@ def _create_channel_ref(
     readers' buffers.
 
     Args:
-        buffer_size_bytes: The number of bytes to allocate for the object data and
-            metadata. Writes to the channel must produce serialized data and
-            metadata less than or equal to this value.
+        buffer_size_bytes: The initial buffer size in bytes for messages
+            that can be passed between tasks in the DAG. The buffers will
+            be automatically resized if larger messages are written to the
+            channel.
     Returns:
         Channel: A wrapper around ray.ObjectRef.
     """
@@ -104,9 +105,10 @@ class SharedMemoryType(ChannelOutputType):
     ):
         """
         Args:
-            buffer_size_bytes: The number of bytes to allocate for the object data and
-                metadata. Writes to the channel must produce serialized data and
-                metadata less than or equal to this value.
+            buffer_size_bytes: The initial buffer size in bytes for messages
+                that can be passed between tasks in the DAG. The buffers will
+                be automatically resized if larger messages are written to the
+                channel.
             num_shm_buffers: The number of shared memory buffer per channel.
         """
         super().__init__()

--- a/release/microbenchmark/experimental/accelerated_dag_gpu_microbenchmark.py
+++ b/release/microbenchmark/experimental/accelerated_dag_gpu_microbenchmark.py
@@ -375,7 +375,7 @@ def main(distributed):
     # NCCL takes a while to warm up on multi node so increase the default
     # timeout.
     ctx = DAGContext.get_current()
-    ctx.retrieval_timeout = 120
+    ctx.get_timeout = 120
 
     sender_hint, receiver_hint = None, None
     if distributed:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* Rename `execution_timeout` to `submit_timeout`.
* Rename `retrieval_timeout` to `get_timeout` and update comments.
* Update comments of `buffer_size_bytes`

## Related issue number

https://github.com/ray-project/ray/issues/49051

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
