### PR TITLE
[Core] fail to download s3 py modules

### DIFF
--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -803,13 +803,19 @@ Currently, three types of remote URIs are supported for hosting ``working_dir`` 
 
 - ``S3``: ``S3`` refers to URIs starting with ``s3://`` that point to compressed packages stored in `AWS S3 <https://aws.amazon.com/s3/>`_.
   To use packages via ``S3`` URIs, you must have the ``smart_open`` and ``boto3`` libraries (you can install them using ``pip install smart_open`` and ``pip install boto3``).
-  Ray does not explicitly pass in any credentials to ``boto3`` for authentication.
+  By default, ray does not explicitly pass in any credentials to ``boto3`` for authentication.
   ``boto3`` will use your environment variables, shared credentials file, and/or AWS config file to authenticate access.
   See the `AWS boto3 documentation <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html>`_ to learn how to configure these.
 
   - Example:
 
     - ``runtime_env = {"working_dir": "s3://example_bucket/example_file.zip"}``
+
+  You can also pass in credentials via ``env_vars``.
+
+  - Example:
+
+    - ``runtime_env = {"working_dir": "s3://example_bucket/example_file.zip", "env_vars": {"AWS_ENDPOINT_URL": "${YOUR_S3_URL}", "AWS_ACCESS_KEY_ID": "${YOUR_ACCESS_KEY_ID}", "AWS_SECRET_ACCESS_KEY": "${YOUR_ACCESS_KEY"}}``
 
 - ``GS``: ``GS`` refers to URIs starting with ``gs://`` that point to compressed packages stored in `Google Cloud Storage <https://cloud.google.com/storage>`_.
   To use packages via ``GS`` URIs, you must have the ``smart_open`` and ``google-cloud-storage`` libraries (you can install them using ``pip install smart_open`` and ``pip install google-cloud-storage``).

--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -657,6 +657,7 @@ async def download_and_unpack_package(
     pkg_uri: str,
     base_directory: str,
     gcs_aio_client: Optional["GcsAioClient"] = None,  # noqa: F821
+    runtime_env: Optional["RuntimeEnv"] = None,  # noqa: F821
     logger: Optional[logging.Logger] = default_logger,
     overwrite: bool = False,
 ) -> str:
@@ -754,7 +755,9 @@ async def download_and_unpack_package(
                 else:
                     return str(pkg_file)
             elif protocol in Protocol.remote_protocols():
-                protocol.download_remote_uri(source_uri=pkg_uri, dest_file=pkg_file)
+                protocol.download_remote_uri(
+                    source_uri=pkg_uri, dest_file=pkg_file, runtime_env=runtime_env
+                )
 
                 if pkg_file.suffix in [".zip", ".jar"]:
                     unzip_package(

--- a/python/ray/_private/runtime_env/protocol.py
+++ b/python/ray/_private/runtime_env/protocol.py
@@ -41,7 +41,7 @@ class ProtocolsProvider:
         protocol: str,
         source_uri: str,
         dest_file: str,
-        runtime_env: Optional["RuntimeEnv"] = None,
+        runtime_env: Optional["RuntimeEnv"] = None,  # noqa: F821
     ):
         """Download file from remote URI to dest file"""
         assert protocol in cls.get_remote_protocols()

--- a/python/ray/_private/runtime_env/py_modules.py
+++ b/python/ray/_private/runtime_env/py_modules.py
@@ -161,7 +161,6 @@ def upload_py_modules_if_needed(
 
 
 class PyModulesPlugin(RuntimeEnvPlugin):
-
     name = "py_modules"
 
     def __init__(
@@ -199,9 +198,12 @@ class PyModulesPlugin(RuntimeEnvPlugin):
         context: RuntimeEnvContext,
         logger: Optional[logging.Logger] = default_logger,
     ) -> int:
-
         module_dir = await download_and_unpack_package(
-            uri, self._resources_dir, self._gcs_aio_client, logger=logger
+            uri,
+            self._resources_dir,
+            self._gcs_aio_client,
+            runtime_env=runtime_env,
+            logger=logger,
         )
 
         if is_whl_uri(uri):

--- a/python/ray/_private/runtime_env/working_dir.py
+++ b/python/ray/_private/runtime_env/working_dir.py
@@ -118,7 +118,6 @@ def set_pythonpath_in_context(python_path: str, context: RuntimeEnvContext):
 
 
 class WorkingDirPlugin(RuntimeEnvPlugin):
-
     name = "working_dir"
 
     # Note working_dir is not following the priority order of other plugins. Instead
@@ -164,6 +163,7 @@ class WorkingDirPlugin(RuntimeEnvPlugin):
             uri,
             self._resources_dir,
             self._gcs_aio_client,
+            runtime_env=runtime_env,
             logger=logger,
             overwrite=True,
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In our scenario, the users would upload working dir or py modules to s3 and submit job with filling security credential in runtime env.
Currently Ray doesn't support fetch security credential information from user runtime env, so the job would fail when download s3 resources.
This PR is to fix this issue.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
None
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
