### PR TITLE
[Fix][Core] Periodically check log message queue cleared before shutdown

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1909,20 +1909,21 @@ def shutdown(_exiting_interpreter: bool = False):
         # by the `ray_print_logs` thread. If not, waits for 0.5 seconds and retries
         # the check up to 10 times, ensuring that excessive logs have time to be
         # printed before shutting down.
-        wait_times = 10
-        wait_interval = 0.5
-        total_wait_time = wait_times * wait_interval
-        for _ in range(wait_times):
-            time.sleep(wait_interval)
-            if global_worker.gcs_log_subscriber.is_empty:
-                break
-        if not global_worker.gcs_log_subscriber.is_empty:
-            logger.warning(
-                "Some logs were truncated before the driver exited "
-                f"because we printed for {total_wait_time} seconds "
-                "but still couldn't process all the logs. This might "
-                " be due to long-running tasks or actors."
-            )
+        if hasattr(global_worker, "gcs_log_subscriber"):
+            wait_times = 10
+            wait_interval = 0.5
+            total_wait_time = wait_times * wait_interval
+            for _ in range(wait_times):
+                time.sleep(wait_interval)
+                if global_worker.gcs_log_subscriber.is_empty:
+                    break
+            if not global_worker.gcs_log_subscriber.is_empty:
+                logger.warning(
+                    "Some logs were truncated before the driver exited "
+                    f"because we printed for {total_wait_time} seconds "
+                    "but still couldn't process all the logs. This might "
+                    " be due to long-running tasks or actors."
+                )
     disconnect(_exiting_interpreter)
 
     # disconnect internal kv

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2808,6 +2808,11 @@ cdef class _GcsSubscriber:
         """
         return self.inner.get().last_batch_size()
 
+    @property
+    def is_empty(self):
+        """Whether the subscriber has no messages in the queue."""
+        return self.inner.get().IsEmpty()
+
     def close(self):
         """Closes the subscriber and its active subscription."""
         with nogil:

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -631,6 +631,8 @@ cdef extern from "ray/gcs/pubsub/gcs_pub_sub.h" nogil:
 
         int64_t last_batch_size()
 
+        c_bool IsEmpty() const
+
         CRayStatus PollError(
             c_string* key_id, int64_t timeout_ms, CErrorTableData* data)
 

--- a/src/ray/gcs/pubsub/gcs_pub_sub.cc
+++ b/src/ray/gcs/pubsub/gcs_pub_sub.cc
@@ -455,5 +455,10 @@ int64_t PythonGcsSubscriber::last_batch_size() {
   return last_batch_size_;
 }
 
+bool PythonGcsSubscriber::IsEmpty() const {
+  absl::ReaderMutexLock lock(&mu_);
+  return queue_.empty();
+}
+
 }  // namespace gcs
 }  // namespace ray

--- a/src/ray/gcs/pubsub/gcs_pub_sub.h
+++ b/src/ray/gcs/pubsub/gcs_pub_sub.h
@@ -193,6 +193,9 @@ class RAY_EXPORT PythonGcsSubscriber {
 
   int64_t last_batch_size();
 
+  // Whether there are no messages in the queue.
+  bool IsEmpty() const;
+
  private:
   Status DoPoll(int64_t timeout_ms, rpc::PubMessage *message);
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

There is a dedicated daemon thread for printing logs. If the main thread ends while there are still log messages in the queue, some pending logs may not be printed. Originally, our approach was to wait only 0.5 seconds before shutting down, regardless of whether the queue was empty. This PR introduces periodic checks to determine whether the log message queue has been cleared. If it hasn't, the process sleeps for a short while but sets a maximum number of checks to prevent a forever-running task that continuously prints logs without stopping.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes: ray-project/ray#48701

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
