### PR TITLE
[Dashboard] add RAY_PROMETHEUS_HEADERS env for carrying additional headers to Prometheus

### DIFF
--- a/python/ray/dashboard/modules/data/data_head.py
+++ b/python/ray/dashboard/modules/data/data_head.py
@@ -15,6 +15,7 @@ from ray.dashboard.modules.metrics.metrics_head import (
     PROMETHEUS_HEADERS_ENV_VAR,
     PROMETHEUS_HOST_ENV_VAR,
     PrometheusQueryError,
+    parse_prom_headers,
 )
 
 logger = logging.getLogger(__name__)
@@ -54,9 +55,11 @@ class DataHead(dashboard_utils.DashboardHeadModule):
         self.prometheus_host = os.environ.get(
             PROMETHEUS_HOST_ENV_VAR, DEFAULT_PROMETHEUS_HOST
         )
-        self.prometheus_headers = os.environ.get(
-            PROMETHEUS_HEADERS_ENV_VAR,
-            DEFAULT_PROMETHEUS_HEADERS,
+        self.prometheus_headers = parse_prom_headers(
+            os.environ.get(
+                PROMETHEUS_HEADERS_ENV_VAR,
+                DEFAULT_PROMETHEUS_HEADERS,
+            )
         )
 
     @optional_utils.DashboardHeadRouteTable.get("/api/data/datasets/{job_id}")
@@ -155,7 +158,7 @@ class DataHead(dashboard_utils.DashboardHeadModule):
     async def _query_prometheus(self, query):
         async with self.http_session.get(
             f"{self.prometheus_host}/api/v1/query?query={quote(query)}",
-            headers=json.loads(self.prometheus_headers),
+            headers=self.prometheus_headers,
         ) as resp:
             if resp.status == 200:
                 prom_data = await resp.json()

--- a/python/ray/dashboard/modules/metrics/metrics_head.py
+++ b/python/ray/dashboard/modules/metrics/metrics_head.py
@@ -74,7 +74,9 @@ def parse_prom_headers(prometheus_headers):
     raise ValueError(
         f"{PROMETHEUS_HEADERS_ENV_VAR} should be a JSON string in one of the formats:\n"
         + "1) An object with string keys and string values.\n"
-        + "2) an array of string arrays with 2 string elements each."
+        + "2) an array of string arrays with 2 string elements each.\n"
+        + 'For example, {"H1": "V1", "H2": "V2"} and\n'
+        + '[["H1", "V1"], ["H2", "V2"], ["H2", "V3"]] are valid.'
     )
 
 

--- a/python/ray/dashboard/modules/metrics/metrics_head.py
+++ b/python/ray/dashboard/modules/metrics/metrics_head.py
@@ -60,6 +60,24 @@ GRAFANA_DASHBOARD_OUTPUT_DIR_ENV_VAR = "RAY_METRICS_GRAFANA_DASHBOARD_OUTPUT_DIR
 GRAFANA_HEALTHCHECK_PATH = "api/health"
 
 
+# parse_prom_headers will make sure the input is in one of the following formats:
+# 1. {"H1": "V1", "H2": "V2"}
+# 2. [["H1", "V1"], ["H2", "V2"], ["H2", "V3"]]
+def parse_prom_headers(prometheus_headers):
+    parsed = json.loads(prometheus_headers)
+    if isinstance(parsed, dict):
+        if all(isinstance(k, str) and isinstance(v, str) for k, v in parsed.items()):
+            return parsed
+    if isinstance(parsed, list):
+        if all(len(e) == 2 and all(isinstance(v, str) for v in e) for e in parsed):
+            return parsed
+    raise ValueError(
+        f"{PROMETHEUS_HEADERS_ENV_VAR} should be a JSON string in one of the formats:\n"
+        + "1) An object with string keys and string values.\n"
+        + "2) an array of string arrays with 2 string elements each."
+    )
+
+
 class PrometheusQueryError(Exception):
     def __init__(self, status, message):
         self.message = (
@@ -76,9 +94,11 @@ class MetricsHead(dashboard_utils.DashboardHeadModule):
         self.prometheus_host = os.environ.get(
             PROMETHEUS_HOST_ENV_VAR, DEFAULT_PROMETHEUS_HOST
         )
-        self.prometheus_headers = os.environ.get(
-            PROMETHEUS_HEADERS_ENV_VAR,
-            DEFAULT_PROMETHEUS_HEADERS,
+        self.prometheus_headers = parse_prom_headers(
+            os.environ.get(
+                PROMETHEUS_HEADERS_ENV_VAR,
+                DEFAULT_PROMETHEUS_HEADERS,
+            )
         )
         default_metrics_root = os.path.join(self._dashboard_head.session_dir, "metrics")
         session_latest_metrics_root = os.path.join(
@@ -174,7 +194,7 @@ class MetricsHead(dashboard_utils.DashboardHeadModule):
             path = f"{self.prometheus_host}/{PROMETHEUS_HEALTHCHECK_PATH}"
 
             async with self.http_session.get(
-                path, headers=json.loads(self.prometheus_headers)
+                path, headers=self.prometheus_headers
             ) as resp:
                 if resp.status != 200:
                     return dashboard_optional_utils.rest_response(
@@ -253,25 +273,17 @@ class MetricsHead(dashboard_utils.DashboardHeadModule):
         prometheus_host = os.environ.get(
             PROMETHEUS_HOST_ENV_VAR, DEFAULT_PROMETHEUS_HOST
         )
-        prometheus_headers = json.loads(
+        prometheus_headers = parse_prom_headers(
             os.environ.get(PROMETHEUS_HEADERS_ENV_VAR, DEFAULT_PROMETHEUS_HEADERS)
         )
-        # prometheus_headers should be in one of the following formats:
-        # 1. {"H1": "V1", "H2": "V2"}
+        # parse_prom_headers will make sure the prometheus_headers is either format of:
+        # 1. {"H1": "V1", "H2": "V2"} or
         # 2. [["H1", "V1"], ["H2", "V2"], ["H2", "V3"]]
-        # Note that the format of {"H2": ["V2", "V3"]} is not supported.
         prometheus_header_pairs = []
         if isinstance(prometheus_headers, list):
-            prometheus_header_pairs = [
-                (str(pair[0]), str(pair[1]))
-                for pair in prometheus_headers
-                if isinstance(pair, list) and len(pair) > 1
-            ]
+            prometheus_header_pairs = prometheus_headers
         elif isinstance(prometheus_headers, dict):
-            prometheus_header_pairs = [
-                (str(header), str(value))
-                for header, value in prometheus_headers.items()
-            ]
+            prometheus_header_pairs = [(k, v) for k, v in prometheus_headers.items()]
 
         data_sources_path = os.path.join(grafana_provisioning_folder, "datasources")
         os.makedirs(
@@ -429,7 +441,7 @@ class MetricsHead(dashboard_utils.DashboardHeadModule):
     async def _query_prometheus(self, query):
         async with self.http_session.get(
             f"{self.prometheus_host}/api/v1/query?query={quote(query)}",
-            headers=json.loads(self.prometheus_headers),
+            headers=self.prometheus_headers,
         ) as resp:
             if resp.status == 200:
                 prom_data = await resp.json()

--- a/python/ray/dashboard/modules/metrics/templates.py
+++ b/python/ray/dashboard/modules/metrics/templates.py
@@ -1,3 +1,5 @@
+import yaml
+
 GRAFANA_INI_TEMPLATE = """
 [security]
 allow_embedding = true
@@ -22,15 +24,27 @@ providers:
       path: {dashboard_output_folder}
 """
 
-GRAFANA_DATASOURCE_TEMPLATE = """apiVersion: 1
 
-datasources:
-  - name: {prometheus_name}
-    url: {prometheus_host}
-    type: prometheus
-    isDefault: true
-    access: proxy
-"""
+def GRAFANA_DATASOURCE_TEMPLATE(
+    prometheus_name, prometheus_host, jsonData, secureJsonData
+):
+    return yaml.safe_dump(
+        {
+            "apiVersion": 1,
+            "datasources": [
+                {
+                    "name": prometheus_name,
+                    "url": prometheus_host,
+                    "type": "prometheus",
+                    "isDefault": True,
+                    "access": "proxy",
+                    "jsonData": jsonData,
+                    "secureJsonData": secureJsonData,
+                }
+            ],
+        }
+    )
+
 
 PROMETHEUS_YML_TEMPLATE = """# my global config
 global:

--- a/python/ray/dashboard/tests/test_dashboard.py
+++ b/python/ray/dashboard/tests/test_dashboard.py
@@ -42,7 +42,6 @@ from ray._private.utils import get_or_create_event_loop
 from ray.core.generated import common_pb2
 from ray.dashboard import dashboard
 from ray.dashboard.head import DashboardHead
-from ray.dashboard.modules.metrics.metrics_head import PROMETHEUS_HEADERS_ENV_VAR
 from ray.dashboard.utils import DashboardHeadModule
 from ray.experimental.internal_kv import _initialize_internal_kv
 from ray.util.state import StateApiClient
@@ -1193,6 +1192,8 @@ def test_dashboard_module_load(tmpdir):
     reason="This test is not supposed to work for minimal installation.",
 )
 def test_extra_prom_headers_validation(tmpdir, monkeypatch):
+    from ray.dashboard.modules.metrics.metrics_head import PROMETHEUS_HEADERS_ENV_VAR
+
     """Test the extra Prometheus headers validation in DashboardHead."""
     head = DashboardHead(
         http_host="127.0.0.1",

--- a/release/ray_release/command_runner/_prometheus_metrics.py
+++ b/release/ray_release/command_runner/_prometheus_metrics.py
@@ -18,6 +18,24 @@ PROMETHEUS_HEADERS_ENV_VAR = "RAY_PROMETHEUS_HEADERS"
 RETRIES = 3
 
 
+# parse_prom_headers will make sure the input is in one of the following formats:
+# 1. {"H1": "V1", "H2": "V2"}
+# 2. [["H1", "V1"], ["H2", "V2"], ["H2", "V3"]]
+def parse_prom_headers(prometheus_headers):
+    parsed = json.loads(prometheus_headers)
+    if isinstance(parsed, dict):
+        if all(isinstance(k, str) and isinstance(v, str) for k, v in parsed.items()):
+            return parsed
+    if isinstance(parsed, list):
+        if all(len(e) == 2 and all(isinstance(v, str) for v in e) for e in parsed):
+            return parsed
+    raise ValueError(
+        f"{PROMETHEUS_HEADERS_ENV_VAR} should be a JSON string in one of the formats:\n"
+        + "1) An object with string keys and string values.\n"
+        + "2) an array of string arrays with 2 string elements each."
+    )
+
+
 class PrometheusQueryError(Exception):
     def __init__(self, status, message):
         self.message = (
@@ -33,9 +51,11 @@ class PrometheusClient:
         self.prometheus_host = os.environ.get(
             PROMETHEUS_HOST_ENV_VAR, DEFAULT_PROMETHEUS_HOST
         )
-        self.prometheus_headers = os.environ.get(
-            PROMETHEUS_HEADERS_ENV_VAR,
-            DEFAULT_PROMETHEUS_HEADERS,
+        self.prometheus_headers = parse_prom_headers(
+            os.environ.get(
+                PROMETHEUS_HEADERS_ENV_VAR,
+                DEFAULT_PROMETHEUS_HEADERS,
+            )
         )
 
     async def query_prometheus(self, query_type, **kwargs):
@@ -43,9 +63,7 @@ class PrometheusClient:
             [f"{k}={quote(str(v), safe='')}" for k, v in kwargs.items()]
         )
         logger.debug(f"Running Prometheus query {url}")
-        async with self.http_session.get(
-            url, json.loads(self.prometheus_headers)
-        ) as resp:
+        async with self.http_session.get(url, self.prometheus_headers) as resp:
             for _ in range(RETRIES):
                 if resp.status == 200:
                     prom_data = await resp.json()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Some users from Slack channels have an authentication proxy in front of their Prometheus server and that proxy requires requests to have specific HTTP headers to pass. Currently, we don't have a way for them to customize headers for those requests.

This PR introduces a new `RAY_PROMETHEUS_HEADERS` environment variable, next to the existing `RAY_PROMETHEUS_HOST`, to allow users to add custom headers for requests to Prometheus from Ray Dashboard and Grafana [(ref)](https://grafana.com/docs/grafana/latest/administration/provisioning/#custom-http-headers-for-data-sources)

The format of `RAY_PROMETHEUS_HEADERS` should be a JSON string in one of the following:
1. `{"H1": "V1", "H2": "V2"}`
2. `[["H1", "V1"], ["H2", "V2"], ["H2", "V3"]]`

The second format supports multiple headers with the same name (which is valid by HTTP spec) while the first format doesn't due to the aiohttp limitation. i.e. the format like`{"H2": ["V2", "V3"]}` is not supported.

## A Grafana datasource.yml example of the first format
<img width="616" alt="Screenshot 2024-12-21 at 08 20 18" src="https://github.com/user-attachments/assets/c4e0f9ce-102a-4c1b-962e-740197003ad8" />

## A Grafana datasource.yml example of the second format
<img width="635" alt="Screenshot 2024-12-21 at 08 18 44" src="https://github.com/user-attachments/assets/4d16f5a2-04b2-4712-ac96-783235ec5281" />


## A request dump example from Ray Dashboard to Prometheus
<img width="1330" alt="Screenshot 2024-12-21 at 10 19 12" src="https://github.com/user-attachments/assets/d345bc71-2bf6-4a6f-8d9f-6a9a4f46e9b1" />


## A request dump example from Grafana to Prometheus
<img width="1329" alt="Screenshot 2024-12-21 at 10 58 17" src="https://github.com/user-attachments/assets/80a149b8-e601-4b35-9ccf-084dbdb3f18c" />



<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
