### PR TITLE
[core] Application cgroup setup

### DIFF
--- a/src/ray/common/cgroup/cgroup_setup.cc
+++ b/src/ray/common/cgroup/cgroup_setup.cc
@@ -59,7 +59,7 @@ void MoveProcsInSystemCgroup() {
   }
 }
 
-void EnableControllersInCgroup() {
+void EnableCgroupSubtreeControl() {
   std::ofstream out_file(kRootCgroupSubtreeControl.data());
   // Able to add new PIDs and memory constraint to the system cgroup.
   out_file << "+memory +pids";
@@ -81,7 +81,10 @@ bool SetupCgroupsPreparation() {
   }
 
   MoveProcsInSystemCgroup();
-  EnableControllersInCgroup();
+  EnableCgroupSubtreeControl();
+
+  // Setup application cgroup.  
+  
 
   return true;
 }

--- a/src/ray/common/cgroup/cgroup_setup.cc
+++ b/src/ray/common/cgroup/cgroup_setup.cc
@@ -14,6 +14,12 @@
 
 #include "ray/common/cgroup/cgroup_setup.h"
 
+#ifndef __linux__
+namespace ray {
+bool SetupCgroupsPreparation() { return false; }
+}  // namespace ray
+#else  // __linux__
+
 #include <sys/stat.h>
 
 #include <cerrno>
@@ -108,3 +114,5 @@ bool SetupCgroupsPreparation() {
 }
 
 }  // namespace ray
+
+#endif  // __linux__

--- a/src/ray/common/cgroup/cgroup_setup.cc
+++ b/src/ray/common/cgroup/cgroup_setup.cc
@@ -16,7 +16,7 @@
 
 #ifndef __linux__
 namespace ray {
-bool SetupCgroupsPreparation() { return false; }
+bool SetupCgroupsPreparation(const std::string &node_id /*unused*/) { return false; }
 }  // namespace ray
 #else  // __linux__
 
@@ -39,25 +39,10 @@ namespace {
 // TODO(hjiang): Use `absl::NoDestructor` to avoid non-trivially destructible global
 // objects. Cgroup path for ray system components.
 //
-// System cgroup related constants.
-const std::string kSystemCgroupFolder = []() {
-  // Append UUID to system cgroup path to avoid conflict.
-  // Chances are that multiple ray cluster runs on the same filesystem.
-  return absl::StrFormat("/sys/fs/cgroup/ray_system_%s", GenerateUUIDV4());
-}();
-// Cgroup PID path for ray system components.
-const std::string kSystemCgroupProcs =
-    ray::JoinPaths(kSystemCgroupFolder, "cgroup.procs");
-
-// Application cgroup related constants.
-const std::string kApplicationCgroupFolder = []() {
-  // Append UUID to application cgroup path to avoid conflict.
-  // Chances are that multiple ray cluster runs on the same filesystem.
-  return absl::StrFormat("/sys/fs/cgroup/ray_application_%s", GenerateUUIDV4());
-}();
-const std::string kApplicationCgroupSubtreeControl = []() {
-  return absl::StrFormat("%s/cgroup.subtree_control", kApplicationCgroupFolder);
-}();
+// Root folder for cgroup v2 for the current raylet instance.
+// See README under the current folder for details.
+std::string cgroup_v2_app_folder;
+std::string cgroup_v2_system_folder;
 
 // Parent cgroup path.
 constexpr std::string_view kRtootCgroupProcs = "/sys/fs/cgroup/cgroup.procs";
@@ -71,7 +56,7 @@ constexpr int kCgroupFilePerm = 0600;
 // root cgroup. This function will move all PIDs under root cgroup into system cgroup.
 void MoveProcsInSystemCgroup() {
   std::ifstream in_file(kRtootCgroupProcs.data());
-  std::ofstream out_file(kSystemCgroupProcs.data());
+  std::ofstream out_file(cgroup_v2_system_folder.data());
   int pid = 0;
   while (in_file >> pid) {
     out_file << pid << std::endl;
@@ -86,14 +71,26 @@ void EnableCgroupSubtreeControl(const char *subtree_control_path) {
 
 }  // namespace
 
-bool SetupCgroupsPreparation() {
+bool SetupCgroupsPreparation(const std::string &node_id) {
 #ifndef __linux__
   RAY_LOG(ERROR) << "Cgroup is not supported on non-Linux platforms.";
   return true;
 #endif
 
+  RAY_CHECK(cgroup_v2_app_folder.empty())
+      << "Cgroup v2 for raylet should be only initialized once.";
+
+  cgroup_v2_app_folder = absl::StrFormat("/sys/fs/cgroup/ray_application_%s", node_id);
+  cgroup_v2_system_folder = absl::StrFormat("/sys/fs/cgroup/ray_system_%s", node_id);
+  const std::string cgroup_v2_app_procs =
+      ray::JoinPaths(cgroup_v2_app_folder, "cgroup.procs");
+  const std::string cgroup_v2_app_subtree_control =
+      ray::JoinPaths(cgroup_v2_app_folder, "cgroup.subtree_control");
+  const std::string cgroup_v2_system_procs =
+      ray::JoinPaths(cgroup_v2_system_folder, "cgroup.procs");
+
   // Create the system cgroup.
-  int ret_code = mkdir(kSystemCgroupFolder.data(), kCgroupFilePerm);
+  int ret_code = mkdir(cgroup_v2_system_folder.data(), kCgroupFilePerm);
   if (ret_code != 0) {
     RAY_LOG(ERROR) << "Failed to create system cgroup: " << strerror(errno);
     return false;
@@ -103,15 +100,20 @@ bool SetupCgroupsPreparation() {
   EnableCgroupSubtreeControl(kRootCgroupSubtreeControl.data());
 
   // Setup application cgroup.
-  ret_code = mkdir(kApplicationCgroupFolder.data(), kCgroupFilePerm);
+  ret_code = mkdir(cgroup_v2_app_folder.data(), kCgroupFilePerm);
   if (ret_code != 0) {
     RAY_LOG(ERROR) << "Failed to create application cgroup: " << strerror(errno);
     return false;
   }
-  EnableCgroupSubtreeControl(kApplicationCgroupSubtreeControl.data());
+  EnableCgroupSubtreeControl(cgroup_v2_app_subtree_control.data());
 
   return true;
 }
+
+const std::string &GetCgroupV2AppFolder() { return cgroup_v2_app_folder; }
+
+// Get folder name for system cgroup v2 for current raylet instance.
+const std::string &GetCgroupV2SystemFolder() { return cgroup_v2_system_folder; }
 
 }  // namespace ray
 

--- a/src/ray/common/cgroup/cgroup_setup.h
+++ b/src/ray/common/cgroup/cgroup_setup.h
@@ -14,11 +14,11 @@
 
 #pragma once
 
-#include <fstream>
-
 namespace ray {
 
 // Util function to setup cgroups preparation for resource constraints.
+// It's expected to call from raylet to setup node level cgroup configurations.
+//
 // If error happens, error will be logged and return false.
 // Cgroup is not supported on non-linux platforms.
 bool SetupCgroupsPreparation();

--- a/src/ray/common/cgroup/cgroup_setup.h
+++ b/src/ray/common/cgroup/cgroup_setup.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <string>
+
 namespace ray {
 
 // Util function to setup cgroups preparation for resource constraints.
@@ -21,6 +23,14 @@ namespace ray {
 //
 // If error happens, error will be logged and return false.
 // Cgroup is not supported on non-linux platforms.
-bool SetupCgroupsPreparation();
+//
+// NOTICE: This function is expected to be called once for eacy raylet instance.
+bool SetupCgroupsPreparation(const std::string &node_id);
+
+// Get folder name for application cgroup v2 for current raylet instance.
+const std::string &GetCgroupV2AppFolder();
+
+// Get folder name for system cgroup v2 for current raylet instance.
+const std::string &GetCgroupV2SystemFolder();
 
 }  // namespace ray


### PR DESCRIPTION
There're two categories of cgroup we need to support, 
- One for system cgroup, which is used to place system components like raylet, GCS, etc
- Another for application, which is used to place all application like tasks/actors

Application cgroup is organized in tree structure, with
- A subtree node of `/sys/fs/cgroup/ray_application`, which applies a global resource control over all leaf nodes
- All sub-cgroup for tasks/actors will be placed under the above node as leaf cgroup node

This PR implements application cgroup setup.