### PR TITLE
[core] Use redis error as callback arg

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -593,7 +593,7 @@ void GcsPlacementGroupManager::HandleGetPlacementGroup(
     }
     RAY_LOG(DEBUG) << "Finished getting placement group info, placement group id = "
                    << placement_group_id;
-    GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
+    GCS_RPC_SEND_REPLY(send_reply_callback, reply, status);
   };
 
   auto it = registered_placement_groups_.find(placement_group_id);

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -715,6 +715,10 @@ void GcsPlacementGroupManager::WaitPlacementGroup(
     auto on_done = [this, placement_group_id, callback](
                        const Status &status,
                        const std::optional<PlacementGroupTableData> &result) {
+      if (!status.ok()) {
+        callback(status);
+        return;
+      }
       if (result) {
         RAY_LOG(DEBUG) << "Placement group is removed, placement group id = "
                        << placement_group_id;

--- a/src/ray/gcs/gcs_server/store_client_kv.cc
+++ b/src/ray/gcs/gcs_server/store_client_kv.cc
@@ -62,6 +62,7 @@ void StoreClientInternalKV::Get(
       table_name_,
       MakeKey(ns, key),
       [callback = std::move(callback)](auto status, auto result) {
+        RAY_CHECK_OK(status) << "Fails to get key from storage " << status;
         callback(result.has_value() ? std::optional<std::string>(result.value())
                                     : std::optional<std::string>());
       }));

--- a/src/ray/gcs/gcs_server/store_client_kv.cc
+++ b/src/ray/gcs/gcs_server/store_client_kv.cc
@@ -62,7 +62,7 @@ void StoreClientInternalKV::Get(
       table_name_,
       MakeKey(ns, key),
       [callback = std::move(callback)](auto status, auto result) {
-        RAY_CHECK_OK(status) << "Fails to get key from storage " << status;
+        RAY_CHECK(status.ok()) << "Fails to get key from storage " << status;
         callback(result.has_value() ? std::optional<std::string>(result.value())
                                     : std::optional<std::string>());
       }));

--- a/src/ray/gcs/store_client/redis_store_client.cc
+++ b/src/ray/gcs/store_client/redis_store_client.cc
@@ -148,7 +148,7 @@ Status RedisStoreClient::AsyncGet(const std::string &table_name,
     if (reply->IsError()) {
       status = reply->ReadAsStatus();
     }
-    callback(Status::OK(), std::move(result));
+    callback(status, std::move(result));
   };
 
   RedisCommand command{/*command=*/"HGET",

--- a/src/ray/gcs/store_client/redis_store_client.cc
+++ b/src/ray/gcs/store_client/redis_store_client.cc
@@ -144,8 +144,10 @@ Status RedisStoreClient::AsyncGet(const std::string &table_name,
     if (!reply->IsNil()) {
       result = reply->ReadAsString();
     }
-    RAY_CHECK(!reply->IsError())
-        << "Failed to get from Redis with status: " << reply->ReadAsStatus();
+    Status status = Status::OK();
+    if (reply->IsError()) {
+      status = reply->ReadAsStatus();
+    }
     callback(Status::OK(), std::move(result));
   };
 


### PR DESCRIPTION
As of now, the callback for getting job status from storage takes two arguments, 
- one for `status`, which means the status of getting entry from storage
- another for optional result, which indicates the extracted value

For all storage client implementations as of now, I'm not sure why `status` argument is not used;
IMO either we propagate the status to caller; or we check failure and remove the `status` argument.
This PR does (1).