### PR TITLE
[core] Add spdlog for rotation filename format

### DIFF
--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -131,6 +131,11 @@ def ray_deps_setup():
         build_file = "@com_github_ray_project_ray//bazel:BUILD.spdlog",
         urls = ["https://github.com/gabime/spdlog/archive/v1.12.0.zip"],
         sha256 = "6174bf8885287422a6c6a0312eb8a30e8d22bcfcee7c48a6d02d1835d7769232",
+        # spdlog rotation filename format conflict with ray, update the format.
+        patches = [
+            "@com_github_ray_project_ray//thirdparty/patches:spdlog-rotation-file-format.patch",
+        ],
+        patch_args = ["-p1"],
     )
 
     auto_http_archive(

--- a/thirdparty/patches/spdlog-rotation-file-format.patch
+++ b/thirdparty/patches/spdlog-rotation-file-format.patch
@@ -1,0 +1,30 @@
+commit b19217a482b28c008793940ca154a2f99c5b3fd7
+Author: dentiny <dentinyhao@gmail.com>
+Date:   Thu Dec 19 17:17:56 2024 +0000
+
+    patch spdlog rotation filename
+
+    Signed-off-by: dentiny <dentinyhao@gmail.com>
+
+diff --git a/include/spdlog/sinks/rotating_file_sink-inl.h b/include/spdlog/sinks/rotating_file_sink-inl.h
+index cf8b9d5c..4504b866 100644
+--- a/include/spdlog/sinks/rotating_file_sink-inl.h
++++ b/include/spdlog/sinks/rotating_file_sink-inl.h
+@@ -50,7 +50,7 @@ SPDLOG_INLINE rotating_file_sink<Mutex>::rotating_file_sink(
+ }
+
+ // calc filename according to index and file extension if exists.
+-// e.g. calc_filename("logs/mylog.txt, 3) => "logs/mylog.3.txt".
++// e.g. calc_filename("logs/mylog.txt, 3) => "logs/mylog-3.txt".
+ template<typename Mutex>
+ SPDLOG_INLINE filename_t rotating_file_sink<Mutex>::calc_filename(const filename_t &filename, std::size_t index)
+ {
+@@ -61,7 +61,7 @@ SPDLOG_INLINE filename_t rotating_file_sink<Mutex>::calc_filename(const filename
+
+     filename_t basename, ext;
+     std::tie(basename, ext) = details::file_helper::split_by_extension(filename);
+-    return fmt_lib::format(SPDLOG_FILENAME_T("{}.{}{}"), basename, index, ext);
++    return fmt_lib::format(SPDLOG_FILENAME_T("{}-{}{}"), basename, index, ext);
+ }
+
+ template<typename Mutex>

--- a/thirdparty/patches/spdlog-rotation-file-format.patch
+++ b/thirdparty/patches/spdlog-rotation-file-format.patch
@@ -1,4 +1,4 @@
-commit b19217a482b28c008793940ca154a2f99c5b3fd7
+commit cce4e59224c22e80ba86e2882355b3718e51a75e
 Author: dentiny <dentinyhao@gmail.com>
 Date:   Thu Dec 19 17:17:56 2024 +0000
 
@@ -7,7 +7,7 @@ Date:   Thu Dec 19 17:17:56 2024 +0000
     Signed-off-by: dentiny <dentinyhao@gmail.com>
 
 diff --git a/include/spdlog/sinks/rotating_file_sink-inl.h b/include/spdlog/sinks/rotating_file_sink-inl.h
-index cf8b9d5c..4504b866 100644
+index cf8b9d5c..0efcc258 100644
 --- a/include/spdlog/sinks/rotating_file_sink-inl.h
 +++ b/include/spdlog/sinks/rotating_file_sink-inl.h
 @@ -50,7 +50,7 @@ SPDLOG_INLINE rotating_file_sink<Mutex>::rotating_file_sink(
@@ -15,16 +15,19 @@ index cf8b9d5c..4504b866 100644
 
  // calc filename according to index and file extension if exists.
 -// e.g. calc_filename("logs/mylog.txt, 3) => "logs/mylog.3.txt".
-+// e.g. calc_filename("logs/mylog.txt, 3) => "logs/mylog-3.txt".
++// e.g. calc_filename("logs/mylog.txt, 3) => "logs/mylog.txt.1".
  template<typename Mutex>
  SPDLOG_INLINE filename_t rotating_file_sink<Mutex>::calc_filename(const filename_t &filename, std::size_t index)
  {
-@@ -61,7 +61,7 @@ SPDLOG_INLINE filename_t rotating_file_sink<Mutex>::calc_filename(const filename
-
-     filename_t basename, ext;
-     std::tie(basename, ext) = details::file_helper::split_by_extension(filename);
+@@ -58,10 +58,7 @@ SPDLOG_INLINE filename_t rotating_file_sink<Mutex>::calc_filename(const filename
+     {
+         return filename;
+     }
+-
+-    filename_t basename, ext;
+-    std::tie(basename, ext) = details::file_helper::split_by_extension(filename);
 -    return fmt_lib::format(SPDLOG_FILENAME_T("{}.{}{}"), basename, index, ext);
-+    return fmt_lib::format(SPDLOG_FILENAME_T("{}-{}{}"), basename, index, ext);
++    return fmt_lib::format(SPDLOG_FILENAME_T("{}.{}"), filename, index);
  }
 
  template<typename Mutex>

--- a/thirdparty/patches/spdlog-rotation-file-format.patch
+++ b/thirdparty/patches/spdlog-rotation-file-format.patch
@@ -1,4 +1,4 @@
-commit cce4e59224c22e80ba86e2882355b3718e51a75e
+commit 2d6bc609769eaa4a70a6dd384351f54c6633f3a9
 Author: dentiny <dentinyhao@gmail.com>
 Date:   Thu Dec 19 17:17:56 2024 +0000
 
@@ -7,7 +7,7 @@ Date:   Thu Dec 19 17:17:56 2024 +0000
     Signed-off-by: dentiny <dentinyhao@gmail.com>
 
 diff --git a/include/spdlog/sinks/rotating_file_sink-inl.h b/include/spdlog/sinks/rotating_file_sink-inl.h
-index cf8b9d5c..0efcc258 100644
+index cf8b9d5c..7580c06f 100644
 --- a/include/spdlog/sinks/rotating_file_sink-inl.h
 +++ b/include/spdlog/sinks/rotating_file_sink-inl.h
 @@ -50,7 +50,7 @@ SPDLOG_INLINE rotating_file_sink<Mutex>::rotating_file_sink(
@@ -15,7 +15,7 @@ index cf8b9d5c..0efcc258 100644
 
  // calc filename according to index and file extension if exists.
 -// e.g. calc_filename("logs/mylog.txt, 3) => "logs/mylog.3.txt".
-+// e.g. calc_filename("logs/mylog.txt, 3) => "logs/mylog.txt.1".
++// e.g. calc_filename("logs/mylog.txt, 3) => "logs/mylog.txt.3".
  template<typename Mutex>
  SPDLOG_INLINE filename_t rotating_file_sink<Mutex>::calc_filename(const filename_t &filename, std::size_t index)
  {


### PR DESCRIPTION
Ray's filename formatting conflict with spdlog's, making it possible to have to have files interleaved.

https://github.com/ray-project/ray/blob/9a03760fc812e7737cd60d96526b104c1497fecb/python/ray/_private/node.py#L828-L830

A detailed example, it's possible to have
- /tmp/ray/session_latest/gcs_server.1.out created by ray's unique filename rule
- /tmp/ray/session_latest/gcs_server.2.out created by spdlog for the rotation naming rule

I tried to upstream a customized naming function to spdlog, but gets rejected.
Ref: https://github.com/gabime/spdlog/pull/3296