### PR TITLE
[dashboard] Move StateHead's methods into free functions.

### DIFF
--- a/python/ray/dashboard/modules/state/state_head.py
+++ b/python/ray/dashboard/modules/state/state_head.py
@@ -1,11 +1,9 @@
 import asyncio
-import functools
 import logging
-from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict
 from datetime import datetime
-from typing import AsyncIterable, Callable, List, Optional, Tuple
+from typing import AsyncIterable
 
 import aiohttp.web
 from aiohttp.web import Response
@@ -23,22 +21,15 @@ from ray.dashboard.datacenter import DataSource
 from ray.dashboard.modules.log.log_manager import LogsManager
 from ray.dashboard.optional_utils import rest_response
 from ray.dashboard.state_aggregator import StateAPIManager
-from ray.dashboard.utils import Change
-from ray.util.state.common import (
-    DEFAULT_LIMIT,
-    DEFAULT_LOG_LIMIT,
-    DEFAULT_RPC_TIMEOUT,
-    RAY_MAX_LIMIT_FROM_API_SERVER,
-    GetLogOptions,
-    ListApiOptions,
-    PredicateType,
-    SummaryApiOptions,
-    SummaryApiResponse,
-    SupportedFilterType,
+from ray.dashboard.state_api_utils import (
+    handle_list_api,
+    handle_summary_api,
+    options_from_req,
 )
+from ray.dashboard.utils import Change, RateLimitedModule
+from ray.util.state.common import DEFAULT_LOG_LIMIT, DEFAULT_RPC_TIMEOUT, GetLogOptions
 from ray.util.state.exception import DataSourceUnavailable
 from ray.util.state.state_manager import StateDataSourceClient
-from ray.util.state.util import convert_string_to_type
 
 logger = logging.getLogger(__name__)
 routes = dashboard_optional_utils.DashboardHeadRouteTable
@@ -49,90 +40,6 @@ routes = dashboard_optional_utils.DashboardHeadRouteTable
 RAY_DASHBOARD_STATE_HEAD_TPE_MAX_WORKERS = env_integer(
     "RAY_DASHBOARD_STATE_HEAD_TPE_MAX_WORKERS", 1
 )
-
-
-class RateLimitedModule(ABC):
-    """Simple rate limiter
-
-    Inheriting from this class and decorate any class methods will
-    apply simple rate limit.
-    It will limit the maximal number of concurrent invocations of **all** the
-    methods decorated.
-
-    The below Example class will only allow 10 concurrent calls to A() and B()
-
-    E.g.:
-
-        class Example(RateLimitedModule):
-            def __init__(self):
-                super().__init__(max_num_call=10)
-
-            @RateLimitedModule.enforce_max_concurrent_calls
-            async def A():
-                ...
-
-            @RateLimitedModule.enforce_max_concurrent_calls
-            async def B():
-                ...
-
-            async def limit_handler_(self):
-                raise RuntimeError("rate limited reached!")
-
-    """
-
-    def __init__(self, max_num_call: int, logger: Optional[logging.Logger] = None):
-        """
-        Args:
-            max_num_call: Maximal number of concurrent invocations of all decorated
-                functions in the instance.
-                Setting to -1 will disable rate limiting.
-
-            logger: Logger
-        """
-        self.max_num_call_ = max_num_call
-        self.num_call_ = 0
-        self.logger_ = logger
-
-    @staticmethod
-    def enforce_max_concurrent_calls(func):
-        """Decorator to enforce max number of invocations of the decorated func
-
-        NOTE: This should be used as the innermost decorator if there are multiple
-        ones.
-
-        E.g., when decorating functions already with @routes.get(...), this must be
-        added below then the routes decorators:
-            ```
-            @routes.get('/')
-            @RateLimitedModule.enforce_max_concurrent_calls
-            async def fn(self):
-                ...
-
-            ```
-        """
-
-        @functools.wraps(func)
-        async def async_wrapper(self, *args, **kwargs):
-            if self.max_num_call_ >= 0 and self.num_call_ >= self.max_num_call_:
-                if self.logger_:
-                    self.logger_.warning(
-                        f"Max concurrent requests reached={self.max_num_call_}"
-                    )
-                return await self.limit_handler_()
-            self.num_call_ += 1
-            try:
-                ret = await func(self, *args, **kwargs)
-            finally:
-                self.num_call_ -= 1
-            return ret
-
-        # Returning closure here to avoid passing 'self' to the
-        # 'enforce_max_concurrent_calls' decorator.
-        return async_wrapper
-
-    @abstractmethod
-    async def limit_handler_(self):
-        """Handler that is invoked when max number of concurrent calls reached"""
 
 
 class StateHead(dashboard_utils.DashboardHeadModule, RateLimitedModule):
@@ -169,7 +76,7 @@ class StateHead(dashboard_utils.DashboardHeadModule, RateLimitedModule):
         DataSource.agents.signal.append(self._update_agent_stubs)
 
     async def limit_handler_(self):
-        return self._reply(
+        return rest_response(
             success=False,
             error_message=(
                 "Max number of in-progress requests="
@@ -179,65 +86,6 @@ class StateHead(dashboard_utils.DashboardHeadModule, RateLimitedModule):
                 f"Max allowed = {RAY_STATE_SERVER_MAX_HTTP_REQUEST_ALLOWED}"
             ),
             result=None,
-        )
-
-    def _get_filters_from_req(
-        self, req: aiohttp.web.Request
-    ) -> List[Tuple[str, PredicateType, SupportedFilterType]]:
-        filter_keys = req.query.getall("filter_keys", [])
-        filter_predicates = req.query.getall("filter_predicates", [])
-        filter_values = req.query.getall("filter_values", [])
-        assert len(filter_keys) == len(filter_values)
-        filters = []
-        for key, predicate, val in zip(filter_keys, filter_predicates, filter_values):
-            filters.append((key, predicate, val))
-        return filters
-
-    def _options_from_req(self, req: aiohttp.web.Request) -> ListApiOptions:
-        """Obtain `ListApiOptions` from the aiohttp request."""
-        limit = int(
-            req.query.get("limit")
-            if req.query.get("limit") is not None
-            else DEFAULT_LIMIT
-        )
-
-        if limit > RAY_MAX_LIMIT_FROM_API_SERVER:
-            raise ValueError(
-                f"Given limit {limit} exceeds the supported "
-                f"limit {RAY_MAX_LIMIT_FROM_API_SERVER}. Use a lower limit."
-            )
-
-        timeout = int(req.query.get("timeout", 30))
-        filters = self._get_filters_from_req(req)
-        detail = convert_string_to_type(req.query.get("detail", False), bool)
-        exclude_driver = convert_string_to_type(
-            req.query.get("exclude_driver", True), bool
-        )
-
-        return ListApiOptions(
-            limit=limit,
-            timeout=timeout,
-            filters=filters,
-            detail=detail,
-            exclude_driver=exclude_driver,
-        )
-
-    def _summary_options_from_req(self, req: aiohttp.web.Request) -> SummaryApiOptions:
-        timeout = int(req.query.get("timeout", DEFAULT_RPC_TIMEOUT))
-        filters = self._get_filters_from_req(req)
-        summary_by = req.query.get("summary_by", None)
-        return SummaryApiOptions(
-            timeout=timeout, filters=filters, summary_by=summary_by
-        )
-
-    def _reply(self, success: bool, error_message: str, result: dict, **kwargs):
-        """Reply to the client."""
-        return rest_response(
-            success=success,
-            message=error_message,
-            result=result,
-            convert_google_style=False,
-            **kwargs,
         )
 
     async def _update_raylet_stubs(self, change: Change):
@@ -284,44 +132,31 @@ class StateHead(dashboard_utils.DashboardHeadModule, RateLimitedModule):
                 int(ports[1]),
             )
 
-    async def _handle_list_api(
-        self, list_api_fn: Callable[[ListApiOptions], dict], req: aiohttp.web.Request
-    ):
-        try:
-            result = await list_api_fn(option=self._options_from_req(req))
-            return self._reply(
-                success=True,
-                error_message="",
-                result=asdict(result),
-            )
-        except DataSourceUnavailable as e:
-            return self._reply(success=False, error_message=str(e), result=None)
-
     @routes.get("/api/v0/actors")
     @RateLimitedModule.enforce_max_concurrent_calls
     async def list_actors(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
         record_extra_usage_tag(TagKey.CORE_STATE_API_LIST_ACTORS, "1")
-        return await self._handle_list_api(self._state_api.list_actors, req)
+        return await handle_list_api(self._state_api.list_actors, req)
 
     @routes.get("/api/v0/jobs")
     @RateLimitedModule.enforce_max_concurrent_calls
     async def list_jobs(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
         record_extra_usage_tag(TagKey.CORE_STATE_API_LIST_JOBS, "1")
         try:
-            result = await self._state_api.list_jobs(option=self._options_from_req(req))
-            return self._reply(
+            result = await self._state_api.list_jobs(option=options_from_req(req))
+            return rest_response(
                 success=True,
                 error_message="",
                 result=asdict(result),
             )
         except DataSourceUnavailable as e:
-            return self._reply(success=False, error_message=str(e), result=None)
+            return rest_response(success=False, error_message=str(e), result=None)
 
     @routes.get("/api/v0/nodes")
     @RateLimitedModule.enforce_max_concurrent_calls
     async def list_nodes(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
         record_extra_usage_tag(TagKey.CORE_STATE_API_LIST_NODES, "1")
-        return await self._handle_list_api(self._state_api.list_nodes, req)
+        return await handle_list_api(self._state_api.list_nodes, req)
 
     @routes.get("/api/v0/placement_groups")
     @RateLimitedModule.enforce_max_concurrent_calls
@@ -329,25 +164,25 @@ class StateHead(dashboard_utils.DashboardHeadModule, RateLimitedModule):
         self, req: aiohttp.web.Request
     ) -> aiohttp.web.Response:
         record_extra_usage_tag(TagKey.CORE_STATE_API_LIST_PLACEMENT_GROUPS, "1")
-        return await self._handle_list_api(self._state_api.list_placement_groups, req)
+        return await handle_list_api(self._state_api.list_placement_groups, req)
 
     @routes.get("/api/v0/workers")
     @RateLimitedModule.enforce_max_concurrent_calls
     async def list_workers(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
         record_extra_usage_tag(TagKey.CORE_STATE_API_LIST_WORKERS, "1")
-        return await self._handle_list_api(self._state_api.list_workers, req)
+        return await handle_list_api(self._state_api.list_workers, req)
 
     @routes.get("/api/v0/tasks")
     @RateLimitedModule.enforce_max_concurrent_calls
     async def list_tasks(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
         record_extra_usage_tag(TagKey.CORE_STATE_API_LIST_TASKS, "1")
-        return await self._handle_list_api(self._state_api.list_tasks, req)
+        return await handle_list_api(self._state_api.list_tasks, req)
 
     @routes.get("/api/v0/objects")
     @RateLimitedModule.enforce_max_concurrent_calls
     async def list_objects(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
         record_extra_usage_tag(TagKey.CORE_STATE_API_LIST_OBJECTS, "1")
-        return await self._handle_list_api(self._state_api.list_objects, req)
+        return await handle_list_api(self._state_api.list_objects, req)
 
     @routes.get("/api/v0/runtime_envs")
     @RateLimitedModule.enforce_max_concurrent_calls
@@ -361,7 +196,7 @@ class StateHead(dashboard_utils.DashboardHeadModule, RateLimitedModule):
         self, req: aiohttp.web.Request
     ) -> aiohttp.web.Response:
         record_extra_usage_tag(TagKey.CORE_STATE_API_LIST_CLUSTER_EVENTS, "1")
-        return await self._handle_list_api(self._state_api.list_cluster_events, req)
+        return await handle_list_api(self._state_api.list_cluster_events, req)
 
     @routes.get("/api/v0/logs")
     @RateLimitedModule.enforce_max_concurrent_calls
@@ -378,7 +213,7 @@ class StateHead(dashboard_utils.DashboardHeadModule, RateLimitedModule):
         timeout = int(req.query.get("timeout", DEFAULT_RPC_TIMEOUT))
 
         if not node_id and not node_ip:
-            return self._reply(
+            return rest_response(
                 success=False,
                 error_message=(
                     "Both node id and node ip are not provided. "
@@ -389,7 +224,7 @@ class StateHead(dashboard_utils.DashboardHeadModule, RateLimitedModule):
 
         node_id = node_id or self._log_api.ip_to_node_id(node_ip)
         if not node_id:
-            return self._reply(
+            return rest_response(
                 success=False,
                 error_message=(
                     f"Cannot find matching node_id for a given node ip {node_ip}"
@@ -402,13 +237,13 @@ class StateHead(dashboard_utils.DashboardHeadModule, RateLimitedModule):
                 node_id, timeout, glob_filter=glob_filter
             )
         except DataSourceUnavailable as e:
-            return self._reply(
+            return rest_response(
                 success=False,
                 error_message=str(e),
                 result=None,
             )
 
-        return self._reply(success=True, error_message="", result=result)
+        return rest_response(success=True, error_message="", result=result)
 
     @routes.get("/api/v0/logs/{media_type}")
     @RateLimitedModule.enforce_max_concurrent_calls
@@ -497,35 +332,23 @@ class StateHead(dashboard_utils.DashboardHeadModule, RateLimitedModule):
         await response.write_eof()
         return response
 
-    async def _handle_summary_api(
-        self,
-        summary_fn: Callable[[SummaryApiOptions], SummaryApiResponse],
-        req: aiohttp.web.Request,
-    ):
-        result = await summary_fn(option=self._summary_options_from_req(req))
-        return self._reply(
-            success=True,
-            error_message="",
-            result=asdict(result),
-        )
-
     @routes.get("/api/v0/tasks/summarize")
     @RateLimitedModule.enforce_max_concurrent_calls
     async def summarize_tasks(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
         record_extra_usage_tag(TagKey.CORE_STATE_API_SUMMARIZE_TASKS, "1")
-        return await self._handle_summary_api(self._state_api.summarize_tasks, req)
+        return await handle_summary_api(self._state_api.summarize_tasks, req)
 
     @routes.get("/api/v0/actors/summarize")
     @RateLimitedModule.enforce_max_concurrent_calls
     async def summarize_actors(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
         record_extra_usage_tag(TagKey.CORE_STATE_API_SUMMARIZE_ACTORS, "1")
-        return await self._handle_summary_api(self._state_api.summarize_actors, req)
+        return await handle_summary_api(self._state_api.summarize_actors, req)
 
     @routes.get("/api/v0/objects/summarize")
     @RateLimitedModule.enforce_max_concurrent_calls
     async def summarize_objects(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
         record_extra_usage_tag(TagKey.CORE_STATE_API_SUMMARIZE_OBJECTS, "1")
-        return await self._handle_summary_api(self._state_api.summarize_objects, req)
+        return await handle_summary_api(self._state_api.summarize_objects, req)
 
     @routes.get("/api/v0/tasks/timeline")
     @RateLimitedModule.enforce_max_concurrent_calls
@@ -549,7 +372,7 @@ class StateHead(dashboard_utils.DashboardHeadModule, RateLimitedModule):
         """Testing only. Response after a specified delay."""
         delay = int(req.match_info.get("delay_s", 10))
         await asyncio.sleep(delay)
-        return self._reply(
+        return rest_response(
             success=True,
             error_message="",
             result={},

--- a/python/ray/dashboard/modules/state/state_head.py
+++ b/python/ray/dashboard/modules/state/state_head.py
@@ -188,7 +188,7 @@ class StateHead(dashboard_utils.DashboardHeadModule, RateLimitedModule):
     @RateLimitedModule.enforce_max_concurrent_calls
     async def list_runtime_envs(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
         record_extra_usage_tag(TagKey.CORE_STATE_API_LIST_RUNTIME_ENVS, "1")
-        return await self._handle_list_api(self._state_api.list_runtime_envs, req)
+        return await handle_list_api(self._state_api.list_runtime_envs, req)
 
     @routes.get("/api/v0/cluster_events")
     @RateLimitedModule.enforce_max_concurrent_calls

--- a/python/ray/dashboard/state_api_utils.py
+++ b/python/ray/dashboard/state_api_utils.py
@@ -1,0 +1,240 @@
+import dataclasses
+from dataclasses import asdict, fields
+from typing import Callable, List, Tuple
+
+import aiohttp.web
+
+from ray.dashboard.optional_utils import rest_response
+from ray.util.state.common import (
+    DEFAULT_LIMIT,
+    DEFAULT_RPC_TIMEOUT,
+    RAY_MAX_LIMIT_FROM_API_SERVER,
+    ListApiOptions,
+    PredicateType,
+    StateSchema,
+    SummaryApiOptions,
+    SummaryApiResponse,
+    SupportedFilterType,
+    filter_fields,
+)
+from ray.util.state.exception import DataSourceUnavailable
+from ray.util.state.util import convert_string_to_type
+
+
+async def handle_list_api(
+    list_api_fn: Callable[[ListApiOptions], dict], req: aiohttp.web.Request
+):
+    try:
+        result = await list_api_fn(option=options_from_req(req))
+        return rest_response(
+            success=True,
+            error_message="",
+            result=asdict(result),
+        )
+    except DataSourceUnavailable as e:
+        return rest_response(success=False, error_message=str(e), result=None)
+
+
+def _get_filters_from_req(
+    req: aiohttp.web.Request,
+) -> List[Tuple[str, PredicateType, SupportedFilterType]]:
+    filter_keys = req.query.getall("filter_keys", [])
+    filter_predicates = req.query.getall("filter_predicates", [])
+    filter_values = req.query.getall("filter_values", [])
+    assert len(filter_keys) == len(filter_values)
+    filters = []
+    for key, predicate, val in zip(filter_keys, filter_predicates, filter_values):
+        filters.append((key, predicate, val))
+    return filters
+
+
+def options_from_req(req: aiohttp.web.Request) -> ListApiOptions:
+    """Obtain `ListApiOptions` from the aiohttp request."""
+    limit = int(
+        req.query.get("limit") if req.query.get("limit") is not None else DEFAULT_LIMIT
+    )
+
+    if limit > RAY_MAX_LIMIT_FROM_API_SERVER:
+        raise ValueError(
+            f"Given limit {limit} exceeds the supported "
+            f"limit {RAY_MAX_LIMIT_FROM_API_SERVER}. Use a lower limit."
+        )
+
+    timeout = int(req.query.get("timeout", 30))
+    filters = _get_filters_from_req(req)
+    detail = convert_string_to_type(req.query.get("detail", False), bool)
+    exclude_driver = convert_string_to_type(req.query.get("exclude_driver", True), bool)
+
+    return ListApiOptions(
+        limit=limit,
+        timeout=timeout,
+        filters=filters,
+        detail=detail,
+        exclude_driver=exclude_driver,
+    )
+
+
+def summary_options_from_req(req: aiohttp.web.Request) -> SummaryApiOptions:
+    timeout = int(req.query.get("timeout", DEFAULT_RPC_TIMEOUT))
+    filters = _get_filters_from_req(req)
+    summary_by = req.query.get("summary_by", None)
+    return SummaryApiOptions(timeout=timeout, filters=filters, summary_by=summary_by)
+
+
+async def handle_summary_api(
+    self,
+    summary_fn: Callable[[SummaryApiOptions], SummaryApiResponse],
+    req: aiohttp.web.Request,
+):
+    result = await summary_fn(option=summary_options_from_req(req))
+    return rest_response(
+        success=True,
+        error_message="",
+        result=asdict(result),
+    )
+
+
+def convert_filters_type(
+    filter: List[Tuple[str, PredicateType, SupportedFilterType]],
+    schema: StateSchema,
+) -> List[Tuple[str, PredicateType, SupportedFilterType]]:
+    """Convert the given filter's type to SupportedFilterType.
+
+    This method is necessary because click can only accept a single type
+    for its tuple (which is string in this case).
+
+    Args:
+        filter: A list of filter which is a tuple of (key, val).
+        schema: The state schema. It is used to infer the type of the column for filter.
+
+    Returns:
+        A new list of filters with correct types that match the schema.
+    """
+    new_filter = []
+    if dataclasses.is_dataclass(schema):
+        schema = {field.name: field.type for field in fields(schema)}
+    else:
+        schema = schema.schema_dict()
+
+    for col, predicate, val in filter:
+        if col in schema:
+            column_type = schema[col]
+            try:
+                isinstance(val, column_type)
+            except TypeError:
+                # Calling `isinstance` to the Literal type raises a TypeError.
+                # Ignore this case.
+                pass
+            else:
+                if isinstance(val, column_type):
+                    # Do nothing.
+                    pass
+                elif column_type is int or column_type == "integer":
+                    try:
+                        val = convert_string_to_type(val, int)
+                    except ValueError:
+                        raise ValueError(
+                            f"Invalid filter `--filter {col} {val}` for a int type "
+                            "column. Please provide an integer filter "
+                            f"`--filter {col} [int]`"
+                        )
+                elif column_type is float or column_type == "number":
+                    try:
+                        val = convert_string_to_type(
+                            val,
+                            float,
+                        )
+                    except ValueError:
+                        raise ValueError(
+                            f"Invalid filter `--filter {col} {val}` for a float "
+                            "type column. Please provide an integer filter "
+                            f"`--filter {col} [float]`"
+                        )
+                elif column_type is bool or column_type == "boolean":
+                    try:
+                        val = convert_string_to_type(val, bool)
+                    except ValueError:
+                        raise ValueError(
+                            f"Invalid filter `--filter {col} {val}` for a boolean "
+                            "type column. Please provide "
+                            f"`--filter {col} [True|true|1]` for True or "
+                            f"`--filter {col} [False|false|0]` for False."
+                        )
+        new_filter.append((col, predicate, val))
+    return new_filter
+
+
+def do_filter(
+    data: List[dict],
+    filters: List[Tuple[str, PredicateType, SupportedFilterType]],
+    state_dataclass: StateSchema,
+    detail: bool,
+) -> List[dict]:
+    """Return the filtered data given filters.
+
+    Args:
+        data: A list of state data.
+        filters: A list of KV tuple to filter data (key, val). The data is filtered
+            if data[key] != val.
+        state_dataclass: The state schema.
+
+    Returns:
+        A list of filtered state data in dictionary. Each state data's
+        unnecessary columns are filtered by the given state_dataclass schema.
+    """
+    filters = convert_filters_type(filters, state_dataclass)
+    result = []
+    for datum in data:
+        match = True
+        for filter_column, filter_predicate, filter_value in filters:
+            filterable_columns = state_dataclass.filterable_columns()
+            filter_column = filter_column.lower()
+            if filter_column not in filterable_columns:
+                raise ValueError(
+                    f"The given filter column {filter_column} is not supported. "
+                    "Enter filters with –-filter key=value "
+                    "or –-filter key!=value "
+                    f"Supported filter columns: {filterable_columns}"
+                )
+
+            if filter_column not in datum:
+                match = False
+            elif filter_predicate == "=":
+                if isinstance(filter_value, str) and isinstance(
+                    datum[filter_column], str
+                ):
+                    # Case insensitive match for string filter values.
+                    match = datum[filter_column].lower() == filter_value.lower()
+                elif isinstance(filter_value, str) and isinstance(
+                    datum[filter_column], bool
+                ):
+                    match = datum[filter_column] == convert_string_to_type(
+                        filter_value, bool
+                    )
+                elif isinstance(filter_value, str) and isinstance(
+                    datum[filter_column], int
+                ):
+                    match = datum[filter_column] == convert_string_to_type(
+                        filter_value, int
+                    )
+                else:
+                    match = datum[filter_column] == filter_value
+            elif filter_predicate == "!=":
+                if isinstance(filter_value, str) and isinstance(
+                    datum[filter_column], str
+                ):
+                    match = datum[filter_column].lower() != filter_value.lower()
+                else:
+                    match = datum[filter_column] != filter_value
+            else:
+                raise ValueError(
+                    f"Unsupported filter predicate {filter_predicate} is given. "
+                    "Available predicates: =, !=."
+                )
+
+            if not match:
+                break
+
+        if match:
+            result.append(filter_fields(datum, state_dataclass, detail))
+    return result

--- a/python/ray/dashboard/state_api_utils.py
+++ b/python/ray/dashboard/state_api_utils.py
@@ -21,7 +21,7 @@ from ray.util.state.exception import DataSourceUnavailable
 from ray.util.state.util import convert_string_to_type
 
 
-def do_reply(self, success: bool, error_message: str, result: dict, **kwargs):
+def do_reply(success: bool, error_message: str, result: dict, **kwargs):
     return rest_response(
         success=success,
         message=error_message,

--- a/python/ray/dashboard/state_api_utils.py
+++ b/python/ray/dashboard/state_api_utils.py
@@ -92,7 +92,6 @@ def summary_options_from_req(req: aiohttp.web.Request) -> SummaryApiOptions:
 
 
 async def handle_summary_api(
-    self,
     summary_fn: Callable[[SummaryApiOptions], SummaryApiResponse],
     req: aiohttp.web.Request,
 ):

--- a/python/ray/dashboard/state_api_utils.py
+++ b/python/ray/dashboard/state_api_utils.py
@@ -21,18 +21,28 @@ from ray.util.state.exception import DataSourceUnavailable
 from ray.util.state.util import convert_string_to_type
 
 
+def do_reply(self, success: bool, error_message: str, result: dict, **kwargs):
+    return rest_response(
+        success=success,
+        message=error_message,
+        result=result,
+        convert_google_style=False,
+        **kwargs,
+    )
+
+
 async def handle_list_api(
     list_api_fn: Callable[[ListApiOptions], dict], req: aiohttp.web.Request
 ):
     try:
         result = await list_api_fn(option=options_from_req(req))
-        return rest_response(
+        return do_reply(
             success=True,
             error_message="",
             result=asdict(result),
         )
     except DataSourceUnavailable as e:
-        return rest_response(success=False, error_message=str(e), result=None)
+        return do_reply(success=False, error_message=str(e), result=None)
 
 
 def _get_filters_from_req(
@@ -87,7 +97,7 @@ async def handle_summary_api(
     req: aiohttp.web.Request,
 ):
     result = await summary_fn(option=summary_options_from_req(req))
-    return rest_response(
+    return do_reply(
         success=True,
         error_message="",
         result=asdict(result),

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -70,8 +70,8 @@ from ray.dashboard.state_aggregator import (
     GCS_QUERY_FAILURE_WARNING,
     NODE_QUERY_FAILURE_WARNING,
     StateAPIManager,
-    _convert_filters_type,
 )
+from ray.dashboard.state_api_utils import convert_filters_type
 from ray.util.state import (
     get_actor,
     get_node,
@@ -1616,39 +1616,39 @@ async def test_filter_non_existent_column(state_api_manager):
 
 def test_type_conversion():
     # Test string
-    r = _convert_filters_type([("actor_id", "=", "123")], ActorState)
+    r = convert_filters_type([("actor_id", "=", "123")], ActorState)
     assert r[0][2] == "123"
-    r = _convert_filters_type([("actor_id", "=", "abcd")], ActorState)
+    r = convert_filters_type([("actor_id", "=", "abcd")], ActorState)
     assert r[0][2] == "abcd"
-    r = _convert_filters_type([("actor_id", "=", "True")], ActorState)
+    r = convert_filters_type([("actor_id", "=", "True")], ActorState)
     assert r[0][2] == "True"
 
     # Test boolean
-    r = _convert_filters_type([("success", "=", "1")], RuntimeEnvState)
+    r = convert_filters_type([("success", "=", "1")], RuntimeEnvState)
     assert r[0][2]
-    r = _convert_filters_type([("success", "=", "True")], RuntimeEnvState)
+    r = convert_filters_type([("success", "=", "True")], RuntimeEnvState)
     assert r[0][2]
-    r = _convert_filters_type([("success", "=", "true")], RuntimeEnvState)
+    r = convert_filters_type([("success", "=", "true")], RuntimeEnvState)
     assert r[0][2]
     with pytest.raises(ValueError):
-        r = _convert_filters_type([("success", "=", "random_string")], RuntimeEnvState)
-    r = _convert_filters_type([("success", "=", "false")], RuntimeEnvState)
+        r = convert_filters_type([("success", "=", "random_string")], RuntimeEnvState)
+    r = convert_filters_type([("success", "=", "false")], RuntimeEnvState)
     assert r[0][2] is False
-    r = _convert_filters_type([("success", "=", "False")], RuntimeEnvState)
+    r = convert_filters_type([("success", "=", "False")], RuntimeEnvState)
     assert r[0][2] is False
-    r = _convert_filters_type([("success", "=", "0")], RuntimeEnvState)
+    r = convert_filters_type([("success", "=", "0")], RuntimeEnvState)
     assert r[0][2] is False
 
     # Test int
-    r = _convert_filters_type([("pid", "=", "0")], ObjectState)
+    r = convert_filters_type([("pid", "=", "0")], ObjectState)
     assert r[0][2] == 0
-    r = _convert_filters_type([("pid", "=", "123")], ObjectState)
+    r = convert_filters_type([("pid", "=", "123")], ObjectState)
     assert r[0][2] == 123
     # Only integer can be provided.
     with pytest.raises(ValueError):
-        r = _convert_filters_type([("pid", "=", "123.3")], ObjectState)
+        r = convert_filters_type([("pid", "=", "123.3")], ObjectState)
     with pytest.raises(ValueError):
-        r = _convert_filters_type([("pid", "=", "abc")], ObjectState)
+        r = convert_filters_type([("pid", "=", "abc")], ObjectState)
 
     # currently, there's no schema that has float column.
 


### PR DESCRIPTION
StateHead and its StateAPIManager has a pretty big footprint. It serves all `api/v0/*` APIs, and hence reads from all data sources: GcsClient, Raylets, Agents. It keeps a bunch of methods for transformation of data.

To break it down and split out dependencies, we first refactor by moving these transformation methods into free functions, so that other Heads can make use of them.

This PR is no-op in runtime, but serves as a foundation for moving some APIs to other heads.