### PR TITLE
Adding input validation to ScalingConfig resources_per_worker

### DIFF
--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -177,6 +177,19 @@ class ScalingConfig:
                     "`resources_per_worker."
                 )
 
+            # Validate inputs for resources_per_worker
+            accepted_resource_arguments: List[str] = ["GPU", "CPU", "memory", "custom"]
+            invalid_resources = []
+            for key in self.resources_per_worker.keys():
+                if key not in accepted_resource_arguments:
+                    invalid_resources.append(key)
+            if len(invalid_resources) >= 1:
+                raise ValueError(
+                    f"The resources_per_worker argument expects keys from the list"
+                    f"in {accepted_resource_arguments}. You have provided invalid"
+                    f"resource names {invalid_resources}"
+                )
+
     def __repr__(self):
         return _repr_dataclass(self)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

Adding error handler to help users identify when they have input an invalid resource type (e.g. misspelling a resource as "cpu" or "Memory", adding a parameter that does not exist, etc.)

Currently if you provide something like "memory" misspelt as "Memory" Ray will complain that your cluster lacks resources (even if you are requesting less than the available amount of resources).

This change adds a simple error check that will tell users if they have provided a misspelt or invalid resource name type, 

(See slack thread for issue inspiration: https://ray.slack.com/archives/C053M5UBEVD/p1734471893141579)

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

[RayTrain] ScalingConfig resources_per_worker input validation/error handling #49372

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
