### PR TITLE
[core][compiled graphs] Support nsight.nvtx profiling

### DIFF
--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -25,7 +25,6 @@ from ray.dag.dag_operation_future import GPUFuture, DAGOperationFuture, Resolved
 from ray.experimental.channel.cached_channel import CachedChannel
 from ray.experimental.channel.communicator import Communicator
 from ray.dag.constants import (
-    RAY_CGRAPH_ENABLE_PROFILING,
     RAY_CGRAPH_ENABLE_NVTX_PROFILING,
     RAY_CGRAPH_VISUALIZE_SCHEDULE,
 )
@@ -1594,6 +1593,8 @@ class CompiledDAG:
             # so that they will be executed in that order.
             executable_tasks.sort(key=lambda task: task.bind_index)
             self.actor_to_executable_tasks[actor_handle] = executable_tasks
+
+        from ray.dag.constants import RAY_CGRAPH_ENABLE_PROFILING
 
         if RAY_CGRAPH_ENABLE_PROFILING:
             exec_task_func = do_profile_tasks

--- a/python/ray/dag/constants.py
+++ b/python/ray/dag/constants.py
@@ -20,6 +20,13 @@ RAY_CGRAPH_ENABLE_DETECT_DEADLOCK = (
 # Feature flag to turn on profiling.
 RAY_CGRAPH_ENABLE_PROFILING = os.environ.get("RAY_CGRAPH_ENABLE_PROFILING", "0") == "1"
 
+# Feature flag to turn on NVTX (NVIDIA Tools Extension Library) profiling.
+# With this flag, Compiled Graph uses nvtx to automatically annotate and profile
+# function calls during each actor's execution loop.
+RAY_CGRAPH_ENABLE_NVTX_PROFILING = (
+    os.environ.get("RAY_CGRAPH_ENABLE_NVTX_PROFILING", "0") == "1"
+)
+
 # Feature flag to turn on visualization of the execution schedule.
 RAY_CGRAPH_VISUALIZE_SCHEDULE = (
     os.environ.get("RAY_CGRAPH_VISUALIZE_SCHEDULE", "0") == "1"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

With the feature flag turned on, Compiled Graph uses nvtx to automatically annotate and profile function calls during each actor's execution loop.
NVTX documentation: https://nvtx.readthedocs.io/en/latest/install.html

Before (no CPU profiling info):
<img width="853" alt="Screenshot 2024-12-23 at 3 47 56 PM" src="https://github.com/user-attachments/assets/6135879e-8ac9-46e7-98f8-f88ced91f842" />


After (with CPU profiling info):
<img width="820" alt="Screenshot 2024-12-23 at 3 48 42 PM" src="https://github.com/user-attachments/assets/d4e99530-c4b0-49fa-a739-7be764e99097" />



Will add Ray docs in a separate PR.

## Related issue number

<!-- For example: "Closes #1234" -->
Part of https://github.com/ray-project/ray/issues/49390

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Manually tested the profile is generated and looks good
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
