### PR TITLE
[serve] log new deployment handle only when router is initialized

### DIFF
--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -147,7 +147,7 @@ class _DeploymentHandleBase:
         self.init_options = init_options
 
         logger.info(
-            f"Initialized DeploymentHandle '{self.handle_id}' for {self.deployment_id}.",
+            f"Initialized DeploymentHandle {self.handle_id} for {self.deployment_id}.",
             extra={"log_to_stderr": False},
         )
 

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -53,6 +53,7 @@ class _DeploymentHandleBase:
         _router: Optional[Router] = None,
         _create_router: Optional[CreateRouterCallable] = None,
         _request_counter: Optional[metrics.Counter] = None,
+        _handle_id: Optional[str] = None,
     ):
         self.deployment_id = DeploymentID(name=deployment_name, app_name=app_name)
         self.init_options: Optional[InitHandleOptionsBase] = init_options
@@ -60,7 +61,9 @@ class _DeploymentHandleBase:
             handle_options or create_dynamic_handle_options()
         )
 
-        self.handle_id = get_random_string()
+        # Handle ID is shared among handles that are returned by
+        # `handle.options` or `handle.method`
+        self.handle_id = _handle_id or get_random_string()
         self.request_counter = _request_counter or self._create_request_counter(
             app_name, deployment_name, self.handle_id
         )
@@ -179,6 +182,7 @@ class _DeploymentHandleBase:
             _router=self._router,
             _create_router=self._create_router,
             _request_counter=self.request_counter,
+            _handle_id=self.handle_id,
         )
 
     def _remote(

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -71,11 +71,6 @@ class _DeploymentHandleBase:
         else:
             self._create_router = _create_router
 
-        logger.info(
-            f"Created DeploymentHandle '{self.handle_id}' for {self.deployment_id}.",
-            extra={"log_to_stderr": False},
-        )
-
     @staticmethod
     def _gen_handle_tag(app_name: str, deployment_name: str, handle_id: str):
         if app_name:
@@ -147,6 +142,11 @@ class _DeploymentHandleBase:
             handle_options=init_options,
         )
         self.init_options = init_options
+
+        logger.info(
+            f"Initialized DeploymentHandle '{self.handle_id}' for {self.deployment_id}.",
+            extra={"log_to_stderr": False},
+        )
 
         # Record handle api telemetry when not in the proxy
         if (


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Only log a new deployment handle on `._init()`, which is when the router is initialized. This avoids spamming `Created DeploymentHandle` logs that get printed every time you modify dynamic handle options like `handle.options(streaming=True).remote()` or using different methods like `handle.method.remote()`.

Test manually.
Before:
```
(ServeReplica:default:Model pid=39104) INFO 2024-12-23 10:48:21,756 default_Model pjfcqgoi 89de356f-21cb-4b8f-99e7-dbba31f7b8ba -- Created DeploymentHandle '33m08fpj' for Deployment(name='TextEncoder', app='default').
(ServeReplica:default:Model pid=39104) INFO 2024-12-23 10:48:21,764 default_Model pjfcqgoi 89de356f-21cb-4b8f-99e7-dbba31f7b8ba -- POST /v1 200 16.7ms
(ServeReplica:default:Model pid=39104) INFO 2024-12-23 10:48:22,388 default_Model pjfcqgoi 810570e4-ca58-41a5-874e-7b95ff26141b -- Created DeploymentHandle '76c8chbm' for Deployment(name='TextEncoder', app='default').
(ServeReplica:default:Model pid=39104) INFO 2024-12-23 10:48:22,390 default_Model pjfcqgoi 810570e4-ca58-41a5-874e-7b95ff26141b -- POST /v1 200 3.6ms
(ServeReplica:default:Model pid=39104) INFO 2024-12-23 10:48:22,997 default_Model pjfcqgoi 137c4185-2703-435e-9737-4aa3aadadaad -- Created DeploymentHandle 'mq0hrx6o' for Deployment(name='TextEncoder', app='default').
(ServeReplica:default:Model pid=39104) INFO 2024-12-23 10:48:23,000 default_Model pjfcqgoi 137c4185-2703-435e-9737-4aa3aadadaad -- POST /v1 200 4.3ms
(ServeReplica:default:Model pid=39104) INFO 2024-12-23 10:48:30,634 default_Model pjfcqgoi 40d51fe5-784a-4a71-b661-b03d54adb09c -- Created DeploymentHandle 'rsgulc18' for Deployment(name='TextEncoder', app='default').
(ServeReplica:default:Model pid=39104) INFO 2024-12-23 10:48:30,637 default_Model pjfcqgoi 40d51fe5-784a-4a71-b661-b03d54adb09c -- POST /v1 200 4.9ms
```

After:
```
(ServeReplica:default:Model pid=39294) INFO 2024-12-23 10:49:29,164 default_Model etdvo35p adde49a9-3b12-4812-93e2-41dc0a0dec33 -- POST /v1 200 14.3ms
(ServeReplica:default:Model pid=39294) INFO 2024-12-23 10:49:29,973 default_Model etdvo35p 4a942c1b-888a-44f7-a9c7-50e100d41d59 -- POST /v1 200 3.6ms
(ServeReplica:default:Model pid=39294) INFO 2024-12-23 10:49:30,308 default_Model etdvo35p 7d8f4f96-c3dd-4980-ad3e-22ee1fc08184 -- POST /v1 200 3.5ms
(ServeReplica:default:Model pid=39294) INFO 2024-12-23 10:49:30,675 default_Model etdvo35p fa61825d-33d3-4bda-b408-27f593888070 -- POST /v1 200 3.7ms
(ServeReplica:default:Model pid=39294) INFO 2024-12-23 10:49:31,007 default_Model etdvo35p 3e3ad439-c375-40e4-84bb-f74b1b0c32a2 -- POST /v1 200 3.5ms
```

## Related issue number

Closes https://github.com/ray-project/ray/issues/49314

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
