### PR TITLE
[core] Introduces MutexProtected for reader and writer locks.

### DIFF
--- a/src/ray/core_worker/core_worker_process.h
+++ b/src/ray/core_worker/core_worker_process.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include "ray/util/mutex_protected.h"
+
 namespace ray {
 namespace core {
 
@@ -141,13 +143,10 @@ class CoreWorkerProcessImpl {
   const CoreWorkerOptions options_;
 
   /// The core worker instance of this worker process.
-  std::shared_ptr<CoreWorker> core_worker_ ABSL_GUARDED_BY(mutex_);
+  MutexProtected<std::shared_ptr<CoreWorker>> core_worker_;
 
   /// The worker ID of this worker.
   const WorkerID worker_id_;
-
-  /// To protect access to core_worker_
-  mutable absl::Mutex mutex_;
 };
 }  // namespace core
 }  // namespace ray

--- a/src/ray/util/counter_map.h
+++ b/src/ray/util/counter_map.h
@@ -21,6 +21,7 @@
 #include "absl/container/flat_hash_set.h"
 #include "absl/synchronization/mutex.h"
 #include "ray/util/logging.h"
+#include "ray/util/mutex_protected.h"
 
 /// \class CounterMap
 ///
@@ -151,64 +152,61 @@ class CounterMapThreadSafe {
  public:
   CounterMapThreadSafe() = default;
 
-  void SetOnChangeCallback(std::function<void(const K &)> on_change)
-      ABSL_LOCKS_EXCLUDED(mutex_) {
-    absl::WriterMutexLock lock(&mutex_);
-    counter_map_.SetOnChangeCallback(std::move(on_change));
+  void SetOnChangeCallback(std::function<void(const K &)> on_change) {
+    auto write_locked = counter_map_.LockForWrite();
+    write_locked.Get().SetOnChangeCallback(std::move(on_change));
   }
 
-  void FlushOnChangeCallbacks() ABSL_LOCKS_EXCLUDED(mutex_) {
-    absl::WriterMutexLock lock(&mutex_);
-    counter_map_.FlushOnChangeCallbacks();
+  void FlushOnChangeCallbacks() {
+    auto write_locked = counter_map_.LockForWrite();
+    write_locked.Get().FlushOnChangeCallbacks();
   }
 
-  void Increment(const K &key, int64_t val = 1) ABSL_LOCKS_EXCLUDED(mutex_) {
-    absl::WriterMutexLock lock(&mutex_);
-    counter_map_.Increment(key, val);
+  void Increment(const K &key, int64_t val = 1) {
+    auto write_locked = counter_map_.LockForWrite();
+    write_locked.Get().Increment(key, val);
   }
 
-  void Decrement(const K &key, int64_t val = 1) ABSL_LOCKS_EXCLUDED(mutex_) {
-    absl::WriterMutexLock lock(&mutex_);
-    counter_map_.Decrement(key, val);
+  void Decrement(const K &key, int64_t val = 1) {
+    auto write_locked = counter_map_.LockForWrite();
+    write_locked.Get().Decrement(key, val);
   }
 
-  int64_t Get(const K &key) {
-    absl::ReaderMutexLock lock(&mutex_);
-    return counter_map_.Get(key);
+  int64_t Get(const K &key) const {
+    const auto read_locked = counter_map_.LockForRead();
+    return read_locked.Get().Get(key);
   }
 
-  void Swap(const K &old_key, const K &new_key, int64_t val = 1)
-      ABSL_LOCKS_EXCLUDED(mutex_) {
-    absl::WriterMutexLock lock(&mutex_);
-    counter_map_.Swap(old_key, new_key, val);
+  void Swap(const K &old_key, const K &new_key, int64_t val = 1) {
+    auto write_locked = counter_map_.LockForWrite();
+    write_locked.Get().Swap(old_key, new_key, val);
   }
 
-  size_t Size() {
-    absl::ReaderMutexLock lock(&mutex_);
-    return counter_map_.Size();
+  size_t Size() const {
+    const auto read_locked = counter_map_.LockForRead();
+    return read_locked.Get().Size();
   }
 
-  size_t Total() {
-    absl::ReaderMutexLock lock(&mutex_);
-    return counter_map_.Total();
+  size_t Total() const {
+    const auto read_locked = counter_map_.LockForRead();
+    return read_locked.Get().Total();
   }
 
-  size_t NumPendingCallbacks() {
-    absl::ReaderMutexLock lock(&mutex_);
-    return counter_map_.NumPendingCallbacks();
+  size_t NumPendingCallbacks() const {
+    const auto read_locked = counter_map_.LockForRead();
+    return read_locked.Get().NumPendingCallbacks();
   }
 
-  void ForEachEntry(std::function<void(const K &, int64_t)> callback) {
-    absl::ReaderMutexLock lock(&mutex_);
-    counter_map_.ForEachEntry(std::move(callback));
+  void ForEachEntry(std::function<void(const K &, int64_t)> callback) const {
+    const auto read_locked = counter_map_.LockForRead();
+    read_locked.Get().ForEachEntry(std::move(callback));
   }
 
-  absl::flat_hash_map<K, int64_t> GetAll() {
-    absl::ReaderMutexLock lock(&mutex_);
-    return counter_map_.GetAll();
+  absl::flat_hash_map<K, int64_t> GetAll() const {
+    const auto read_locked = counter_map_.LockForRead();
+    return read_locked.Get().GetAll();
   }
 
  private:
-  absl::Mutex mutex_;
-  CounterMap<K> counter_map_;
+  ray::MutexProtected<CounterMap<K>> counter_map_;
 };

--- a/src/ray/util/mutex_protected.h
+++ b/src/ray/util/mutex_protected.h
@@ -1,0 +1,70 @@
+// Copyright 2024 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <type_traits>
+#include <utility>
+
+#include "absl/synchronization/mutex.h"
+
+namespace ray {
+
+// A wrapper class that protects a value with a mutex. One can get a const& with a reader
+// lock and a mutable & with a writer lock.
+//
+// Limitation: we only protect a single value. For the classes where a mutex protects
+// multiple values, or with methods that requires/excludes locks, we have to write an
+// impl class to be protected.
+template <typename T>
+class MutexProtected {
+ public:
+  explicit MutexProtected(T initialValue) : value_(std::move(initialValue)) {}
+
+  // Default constructor enabled only if T is default-constructible
+  template <typename = typename std::enable_if_t<std::is_default_constructible_v<T>>>
+  explicit MutexProtected() {}
+
+  class ReadLocked {
+   public:
+    ReadLocked(absl::Mutex *mutex, const T &value) : lock_(mutex), value_(value) {}
+
+    const T &Get() const { return value_; }
+
+   private:
+    absl::ReaderMutexLock lock_;
+    const T &value_;
+  };
+
+  class WriteLocked {
+   public:
+    WriteLocked(absl::Mutex *mutex, T &value) : lock_(mutex), value_(value) {}
+
+    T &Get() { return value_; }
+
+   private:
+    absl::WriterMutexLock lock_;
+    T &value_;
+  };
+
+  ReadLocked LockForRead() const { return ReadLocked(&mutex_, value_); }
+
+  WriteLocked LockForWrite() { return WriteLocked(&mutex_, value_); }
+
+ private:
+  T value_;
+  mutable absl::Mutex mutex_;
+};
+
+}  // namespace ray


### PR DESCRIPTION
This PR is a no-op refactor to encourage better usage of reader writer locks.