### PR TITLE
[Draft] [spark] Set "HOST_IP" environmental variable for Ray worker nodes

### DIFF
--- a/python/ray/util/spark/cluster_init.py
+++ b/python/ray/util/spark/cluster_init.py
@@ -1572,6 +1572,11 @@ def _start_ray_worker_nodes(
         )
 
         try:
+            tmp_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            tmp_sock.connect((ray_head_ip, spark_job_server_port))
+            host_ip = tmp_sock.getsockname()[0]
+            os.environ["HOST_IP"] = host_ip
+
             is_task_reschedule_failure = False
             # Check node id availability
             response = requests.post(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Set "HOST_IP" environmental variable for Ray worker nodes.

Some library such as vLLM uses `HOST_IP` environmental variables, but for some spark cluster configurations, it is not set correctly in spark worker side. This PR fix the issue.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
