### PR TITLE
[core][compiled graphs] Support reduce scatter and all gather collective in compiled graph

### DIFF
--- a/python/ray/dag/collective_node.py
+++ b/python/ray/dag/collective_node.py
@@ -63,10 +63,12 @@ class _CollectiveOperation:
                 "but found duplicate actor handles from input nodes: "
                 f"{invalid_input_nodes}"
             )
-        
+
         self.comm_op = comm_op
         if self.comm_op not in [self.ALLREDUCE, self.REDUCESCATTER]:
-            raise NotImplementedError("Only all-reduce and reduce-scatter are implemented")
+            raise NotImplementedError(
+                "Only all-reduce and reduce-scatter are implemented"
+            )
 
         self._op = op
         if not isinstance(self._op, ReduceOp):
@@ -137,11 +139,14 @@ class _CollectiveOperation:
             communicator.allreduce(send_buf, recv_buf, self._op)
         elif self.comm_op == self.REDUCESCATTER:
             world_size = len(self._actor_handles)
-            assert send_buf.shape[0] % world_size == 0, "Input tensor's first dimension should be divisible by the number of ators participated"
+            assert (
+                send_buf.shape[0] % world_size == 0
+            ), "Input tensor's first dimension should be divisible by "
+            "the number of ators participated"
             recv_buf = torch.empty(
                 (send_buf.shape[0] // world_size, *send_buf.shape[1:]),
                 dtype=send_buf.dtype,
-                device=send_buf.device
+                device=send_buf.device,
             )
             communicator.reducescatter(send_buf, recv_buf, self._op)
         return recv_buf

--- a/python/ray/dag/collective_node.py
+++ b/python/ray/dag/collective_node.py
@@ -136,7 +136,13 @@ class _CollectiveOperation:
             recv_buf = torch.empty_like(send_buf)
             communicator.allreduce(send_buf, recv_buf, self._op)
         elif self.comm_op == self.REDUCESCATTER:
-            # TODO: check input size of 
+            world_size = len(self._actor_handles)
+            assert send_buf.shape[0] % world_size == 0, "Input tensor's first dimension should be divisible by the number of ators participated"
+            recv_buf = torch.empty(
+                (send_buf.shape[0] // world_size, *send_buf.shape[1:]),
+                dtype=send_buf.dtype,
+                device=send_buf.device
+            )
             communicator.reducescatter(send_buf, recv_buf, self._op)
         return recv_buf
 

--- a/python/ray/dag/collective_node.py
+++ b/python/ray/dag/collective_node.py
@@ -15,8 +15,8 @@ from ray.experimental.channel.torch_tensor_type import Communicator, TorchTensor
 from ray.experimental.util.types import (
     _CollectiveOp,
     ReduceOp,
-    AllReduceReduceOp,
-    ReduceScatterReduceOp,
+    AllReduceOp,
+    ReduceScatterOp,
 )
 from ray.util.annotations import DeveloperAPI
 
@@ -129,10 +129,10 @@ class _CollectiveOperation:
         if not isinstance(send_buf, torch.Tensor):
             raise ValueError("Expected a torch tensor")
         communicator = self.get_communicator()
-        if isinstance(self._op, AllReduceReduceOp):
+        if isinstance(self._op, AllReduceOp):
             recv_buf = torch.empty_like(send_buf)
             communicator.allreduce(send_buf, recv_buf, self._op)
-        elif isinstance(self._op, ReduceScatterReduceOp):
+        elif isinstance(self._op, ReduceScatterOp):
             world_size = len(self._actor_handles)
             if not send_buf.shape[0] % world_size == 0:
                 raise ValueError(

--- a/python/ray/dag/tests/experimental/test_cpu_communicator_dag.py
+++ b/python/ray/dag/tests/experimental/test_cpu_communicator_dag.py
@@ -490,7 +490,9 @@ def test_reducescatter_different_shapes_among_participants(ray_start_cluster):
 
     compiled_dag = dag.experimental_compile()
 
-    ref = compiled_dag.execute([((20, 10), dtype, 1 + idx) for idx in range(num_workers)])
+    ref = compiled_dag.execute(
+        [((20, 10), dtype, 1 + idx) for idx in range(num_workers)]
+    )
     result = ray.get(ref)
     reduced_val = sum(1 + idx for idx in range(num_workers))
     for tensor in result:
@@ -526,7 +528,7 @@ def test_reducescatter_different_shapes_among_participants(ray_start_cluster):
 )
 def test_reducescatter_scheduling(ray_start_cluster):
     """
-    Test scheduling avoids potential deadlocks that arise from reduce-scatter operations.
+    Test scheduling avoids potential deadlocks arised from reduce-scatter operations.
 
     inp --> x(0) --> +----------------+
         |            | reduce-scatter |

--- a/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
@@ -436,7 +436,7 @@ def test_torch_tensor_custom_comm(ray_start_regular):
         ) -> None:
             self._inner.allreduce(send_buf, recv_buf, op)
             recv_buf += 1
-        
+
         def reducescatter(
             self,
             send_buf: "torch.Tensor",
@@ -554,7 +554,7 @@ def test_torch_tensor_custom_comm_invalid(ray_start_regular):
             op: ReduceOp,
         ) -> None:
             raise NotImplementedError
-        
+
         def reducescatter(
             self,
             send_buf: "torch.Tensor",
@@ -716,7 +716,7 @@ def test_torch_tensor_custom_comm_inited(ray_start_regular):
             op: ReduceOp,
         ) -> None:
             raise NotImplementedError
-        
+
         def reducescatter(
             self,
             send_buf: "torch.Tensor",
@@ -1189,7 +1189,7 @@ def test_torch_tensor_nccl_all_reduce_custom_comm(ray_start_regular):
         ) -> None:
             self._inner.allreduce(send_buf, recv_buf, op)
             recv_buf += 1
-        
+
         def reducescatter(
             self,
             send_buf: "torch.Tensor",
@@ -1427,7 +1427,9 @@ def test_torch_tensor_nccl_reduce_scatter_get_partial(ray_start_regular):
 
 
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
-def test_torch_tensor_nccl_reduce_scatter_different_shapes_among_participants(ray_start_regular):
+def test_torch_tensor_nccl_reduce_scatter_different_shapes_among_participants(
+    ray_start_regular,
+):
     """
     Test an error is thrown when participants of reduce-scatter have tensors
     of different shapes.
@@ -1460,7 +1462,9 @@ def test_torch_tensor_nccl_reduce_scatter_different_shapes_among_participants(ra
 
     compiled_dag = dag.experimental_compile()
 
-    ref = compiled_dag.execute([((20, 10), dtype, 1 + idx) for idx in range(num_workers)])
+    ref = compiled_dag.execute(
+        [((20, 10), dtype, 1 + idx) for idx in range(num_workers)]
+    )
     result = ray.get(ref)
     reduced_val = sum(1 + idx for idx in range(num_workers))
     for tensor in result:
@@ -1558,7 +1562,7 @@ def test_torch_tensor_nccl_reduce_scatter_custom_comm(ray_start_regular):
             allocator: Optional[TorchTensorAllocator] = None,
         ) -> "torch.Tensor":
             return self._inner.recv(shape, dtype, peer_rank, allocator=allocator)
-        
+
         def allreduce(
             self,
             send_buf: "torch.Tensor",
@@ -1627,7 +1631,7 @@ def test_torch_tensor_nccl_reduce_scatter_custom_comm(ray_start_regular):
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
 def test_torch_tensor_nccl_reduce_scatter_scheduling(ray_start_regular):
     """
-    Test scheduling avoids potential deadlocks that arise from reduce-scatter operations.
+    Test scheduling avoids potential deadlocks raised from reduce-scatter operations.
 
     inp --> x(0) --> +----------------+
         |            | reduce-scatter |
@@ -1717,7 +1721,7 @@ def test_nccl_reduce_scatter_with_class_method_output_node(ray_start_regular):
             torch.tensor([5], device="cuda"),
             torch.tensor([55], device="cuda"),
             t2,
-            t3
+            t3,
         ]
         assert all(torch.equal(r, e) for r, e in zip(result, expected_result))
 

--- a/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
@@ -28,8 +28,8 @@ from ray._private.test_utils import (
 from ray.experimental.channel.torch_tensor_type import TorchTensorType
 from ray.tests.conftest import *  # noqa
 from ray.experimental.util.types import (
-    AllReduceReduceOp,
-    ReduceScatterReduceOp,
+    AllReduceOp,
+    ReduceScatterOp,
 )
 
 logger = logging.getLogger(__name__)
@@ -435,7 +435,7 @@ def test_torch_tensor_custom_comm(ray_start_regular):
             self,
             send_buf: "torch.Tensor",
             recv_buf: "torch.Tensor",
-            op: AllReduceReduceOp = AllReduceReduceOp.SUM,
+            op: AllReduceOp = AllReduceOp.SUM,
         ) -> None:
             self._inner.allreduce(send_buf, recv_buf, op)
             recv_buf += 1
@@ -444,7 +444,7 @@ def test_torch_tensor_custom_comm(ray_start_regular):
             self,
             send_buf: "torch.Tensor",
             recv_buf: "torch.Tensor",
-            op: ReduceScatterReduceOp = ReduceScatterReduceOp.SUM,
+            op: ReduceScatterOp = ReduceScatterOp.SUM,
         ) -> None:
             self._inner.reducescatter(send_buf, recv_buf, op)
             recv_buf += 1
@@ -554,7 +554,7 @@ def test_torch_tensor_custom_comm_invalid(ray_start_regular):
             self,
             send_buf: "torch.Tensor",
             recv_buf: "torch.Tensor",
-            op: AllReduceReduceOp = AllReduceReduceOp.SUM,
+            op: AllReduceOp = AllReduceOp.SUM,
         ) -> None:
             raise NotImplementedError
 
@@ -562,7 +562,7 @@ def test_torch_tensor_custom_comm_invalid(ray_start_regular):
             self,
             send_buf: "torch.Tensor",
             recv_buf: "torch.Tensor",
-            op: ReduceScatterReduceOp = ReduceScatterReduceOp.SUM,
+            op: ReduceScatterOp = ReduceScatterOp.SUM,
         ) -> None:
             raise NotImplementedError
 
@@ -716,7 +716,7 @@ def test_torch_tensor_custom_comm_inited(ray_start_regular):
             self,
             send_buf: "torch.Tensor",
             recv_buf: "torch.Tensor",
-            op: AllReduceReduceOp = AllReduceReduceOp.SUM,
+            op: AllReduceOp = AllReduceOp.SUM,
         ) -> None:
             raise NotImplementedError
 
@@ -724,7 +724,7 @@ def test_torch_tensor_custom_comm_inited(ray_start_regular):
             self,
             send_buf: "torch.Tensor",
             recv_buf: "torch.Tensor",
-            op: ReduceScatterReduceOp = ReduceScatterReduceOp.SUM,
+            op: ReduceScatterOp = ReduceScatterOp.SUM,
         ) -> None:
             raise NotImplementedError
 
@@ -990,7 +990,7 @@ def test_torch_tensor_nccl_all_reduce(ray_start_regular):
             worker.compute_with_tuple_args.bind(inp, i)
             for i, worker in enumerate(workers)
         ]
-        collectives = collective.allreduce.bind(computes, AllReduceReduceOp.SUM)
+        collectives = collective.allreduce.bind(computes, AllReduceOp.SUM)
         recvs = [
             worker.recv.bind(collective)
             for worker, collective in zip(workers, collectives)
@@ -1036,7 +1036,7 @@ def test_torch_tensor_nccl_all_reduce_get_partial(ray_start_regular):
             worker.compute_with_tuple_args.bind(inp, i)
             for i, worker in enumerate(workers)
         ]
-        collectives = collective.allreduce.bind(computes, AllReduceReduceOp.SUM)
+        collectives = collective.allreduce.bind(computes, AllReduceOp.SUM)
         recv = workers[0].recv.bind(collectives[0])
         tensor = workers[1].recv_tensor.bind(collectives[0])
         dag = MultiOutputNode([recv, tensor, collectives[1]])
@@ -1080,7 +1080,7 @@ def test_torch_tensor_nccl_all_reduce_wrong_shape(ray_start_regular):
             worker.compute_with_tuple_args.bind(inp, i)
             for i, worker in enumerate(workers)
         ]
-        collectives = collective.allreduce.bind(computes, AllReduceReduceOp.SUM)
+        collectives = collective.allreduce.bind(computes, AllReduceOp.SUM)
         recvs = [
             worker.recv.bind(collective)
             for worker, collective in zip(workers, collectives)
@@ -1188,7 +1188,7 @@ def test_torch_tensor_nccl_all_reduce_custom_comm(ray_start_regular):
             self,
             send_buf: "torch.Tensor",
             recv_buf: "torch.Tensor",
-            op: AllReduceReduceOp = AllReduceReduceOp.SUM,
+            op: AllReduceOp = AllReduceOp.SUM,
         ) -> None:
             self._inner.allreduce(send_buf, recv_buf, op)
             recv_buf += 1
@@ -1197,7 +1197,7 @@ def test_torch_tensor_nccl_all_reduce_custom_comm(ray_start_regular):
             self,
             send_buf: "torch.Tensor",
             recv_buf: "torch.Tensor",
-            op: ReduceScatterReduceOp = ReduceScatterReduceOp.SUM,
+            op: ReduceScatterOp = ReduceScatterOp.SUM,
         ) -> None:
             self._inner.reducescatter(send_buf, recv_buf, op)
             recv_buf += 1
@@ -1320,7 +1320,7 @@ def test_nccl_all_reduce_with_class_method_output_node(ray_start_regular):
     with InputNode() as inp:
         t1, t2 = workers[0].return_two_tensors.bind(inp[0], inp[1])
         t3, t4 = workers[1].return_two_tensors.bind(inp[2], inp[3])
-        tensors = collective.allreduce.bind([t1, t4], AllReduceReduceOp.SUM)
+        tensors = collective.allreduce.bind([t1, t4], AllReduceOp.SUM)
         dag = MultiOutputNode(tensors + [t2, t3])
 
     compiled_dag = dag.experimental_compile()
@@ -1359,7 +1359,7 @@ def test_torch_tensor_nccl_reduce_scatter(ray_start_regular):
             worker.compute_with_tuple_args.bind(inp, i)
             for i, worker in enumerate(workers)
         ]
-        collectives = collective.reducescatter.bind(computes, ReduceScatterReduceOp.SUM)
+        collectives = collective.reducescatter.bind(computes, ReduceScatterOp.SUM)
         recvs = [
             worker.recv_tensor.bind(collective)
             for worker, collective in zip(workers, collectives)
@@ -1405,7 +1405,7 @@ def test_torch_tensor_nccl_reduce_scatter_get_partial(ray_start_regular):
             worker.compute_with_tuple_args.bind(inp, i)
             for i, worker in enumerate(workers)
         ]
-        collectives = collective.reducescatter.bind(computes, ReduceScatterReduceOp.SUM)
+        collectives = collective.reducescatter.bind(computes, ReduceScatterOp.SUM)
         tensor1 = workers[0].recv_tensor.bind(collectives[0])
         tensor2 = workers[1].recv_tensor.bind(collectives[0])
         dag = MultiOutputNode([tensor1, tensor2, collectives[1]])
@@ -1456,7 +1456,7 @@ def test_torch_tensor_nccl_reduce_scatter_wrong_shape(
             worker.compute_with_tuple_args.bind(inp, i)
             for i, worker in enumerate(workers)
         ]
-        collectives = collective.reducescatter.bind(computes, ReduceScatterReduceOp.SUM)
+        collectives = collective.reducescatter.bind(computes, ReduceScatterOp.SUM)
         recvs = [
             worker.recv_tensor.bind(collective)
             for worker, collective in zip(workers, collectives)
@@ -1495,7 +1495,7 @@ def test_torch_tensor_nccl_reduce_scatter_tensor_wrong_first_dimension(
     ray_start_regular,
 ):
     """
-    Test an error is thrown when input tensors' shape's firt dimension
+    Test an error is thrown when input tensors' shape's first dimension
     is not divisible by the number of participants.
     """
     if not USE_GPU:
@@ -1517,7 +1517,7 @@ def test_torch_tensor_nccl_reduce_scatter_tensor_wrong_first_dimension(
             worker.compute_with_tuple_args.bind(inp, i)
             for i, worker in enumerate(workers)
         ]
-        collectives = collective.reducescatter.bind(computes, ReduceScatterReduceOp.SUM)
+        collectives = collective.reducescatter.bind(computes, ReduceScatterOp.SUM)
         recvs = [
             worker.recv_tensor.bind(collective)
             for worker, collective in zip(workers, collectives)
@@ -1623,7 +1623,7 @@ def test_torch_tensor_nccl_reduce_scatter_custom_comm(ray_start_regular):
             self,
             send_buf: "torch.Tensor",
             recv_buf: "torch.Tensor",
-            op: AllReduceReduceOp = AllReduceReduceOp.SUM,
+            op: AllReduceOp = AllReduceOp.SUM,
         ) -> None:
             self._inner.allreduce(send_buf, recv_buf, op)
             recv_buf += 1
@@ -1632,7 +1632,7 @@ def test_torch_tensor_nccl_reduce_scatter_custom_comm(ray_start_regular):
             self,
             send_buf: "torch.Tensor",
             recv_buf: "torch.Tensor",
-            op: ReduceScatterReduceOp = ReduceScatterReduceOp.SUM,
+            op: ReduceScatterOp = ReduceScatterOp.SUM,
         ) -> None:
             self._inner.reducescatter(send_buf, recv_buf, op)
             recv_buf += 1
@@ -1759,7 +1759,7 @@ def test_nccl_reduce_scatter_with_class_method_output_node(ray_start_regular):
     with InputNode() as inp:
         t1, t2 = workers[0].return_two_tensors.bind(inp[0], inp[1])
         t3, t4 = workers[1].return_two_tensors.bind(inp[2], inp[3])
-        tensors = collective.reducescatter.bind([t1, t4], ReduceScatterReduceOp.SUM)
+        tensors = collective.reducescatter.bind([t1, t4], ReduceScatterOp.SUM)
         dag = MultiOutputNode(tensors + [t2, t3])
 
     compiled_dag = dag.experimental_compile()

--- a/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
@@ -984,51 +984,6 @@ def test_torch_tensor_nccl_all_reduce(ray_start_regular):
 
 
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
-def test_torch_tensor_nccl_reduce_scatter(ray_start_regular):
-    """
-    Test basic reduce-scatter.
-    """
-    if not USE_GPU:
-        pytest.skip("NCCL tests require GPUs")
-
-    assert (
-        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
-    ), "This test requires at least 2 GPUs"
-
-    actor_cls = TorchTensorWorker.options(num_cpus=0, num_gpus=1)
-
-    num_workers = 2
-    workers = [actor_cls.remote() for _ in range(num_workers)]
-
-    with InputNode() as inp:
-        computes = [
-            worker.compute_with_tuple_args.bind(inp, i)
-            for i, worker in enumerate(workers)
-        ]
-        collectives = collective.reducescatter.bind(computes, ReduceOp.SUM)
-        recvs = [
-            worker.recv.bind(collective)
-            for worker, collective in zip(workers, collectives)
-        ]
-        dag = MultiOutputNode(recvs)
-
-    compiled_dag = dag.experimental_compile()
-
-    for i in range(3):
-        i += 1
-        shape = (num_workers,)
-        dtype = torch.float16
-        ref = compiled_dag.execute(
-            [(shape, dtype, i + idx) for idx in range(num_workers)]
-        )
-        result = ray.get(ref)
-        reduced_val = sum(i + idx for idx in range(num_workers))
-        print(f'\n@@@@@@@@@@@@@@@@@@@@@@@@@@@\n{[(shape, dtype, i + idx) for idx in range(num_workers)]}\n')
-        print(f'\n!!!!!!!!!!!!!!!!!!!!!!!!!!!\n{result}\n')
-        assert result == [(reduced_val, shape, dtype) for _ in workers]
-
-
-@pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
 def test_torch_tensor_nccl_all_reduce_get_partial(ray_start_regular):
     """
     Test getting partial results from an all-reduce does not hang.
@@ -1343,6 +1298,52 @@ def test_nccl_all_reduce_with_class_method_output_node(ray_start_regular):
         ref = compiled_dag.execute(t1, t2, t3, t4)
         result = ray.get(ref)
         assert result == [t1 + t4, t1 + t4, t2, t3]
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
+def test_torch_tensor_nccl_reduce_scatter(ray_start_regular):
+    """
+    Test basic reduce-scatter.
+    """
+    if not USE_GPU:
+        pytest.skip("NCCL tests require GPUs")
+
+    assert (
+        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
+    ), "This test requires at least 2 GPUs"
+
+    actor_cls = TorchTensorWorker.options(num_cpus=0, num_gpus=1)
+
+    num_workers = 2
+    workers = [actor_cls.remote() for _ in range(num_workers)]
+
+    with InputNode() as inp:
+        computes = [
+            worker.compute_with_tuple_args.bind(inp, i)
+            for i, worker in enumerate(workers)
+        ]
+        collectives = collective.reducescatter.bind(computes, ReduceOp.SUM)
+        recvs = [
+            worker.recv_tensor.bind(collective)
+            for worker, collective in zip(workers, collectives)
+        ]
+        dag = MultiOutputNode(recvs)
+
+    compiled_dag = dag.experimental_compile()
+
+    for i in range(3):
+        i += 1
+        shape = (num_workers * i, i)
+        dtype = torch.float16
+        ref = compiled_dag.execute(
+            [(shape, dtype, i + idx) for idx in range(num_workers)]
+        )
+        result = ray.get(ref)
+        reduced_val = sum(i + idx for idx in range(num_workers))
+        for tensor in result:
+            tensor = tensor.to("cpu")
+            expected_tensor_val = torch.ones((i, i), dtype=dtype) * reduced_val
+            assert torch.equal(tensor, expected_tensor_val)
 
 
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 2}], indirect=True)

--- a/python/ray/experimental/channel/communicator.py
+++ b/python/ray/experimental/channel/communicator.py
@@ -157,6 +157,23 @@ class Communicator(ABC):
             op: The reduce operation.
         """
         raise NotImplementedError
+    
+    @abstractmethod
+    def allgather(
+        self,
+        send_buf: "torch.Tensor",
+        recv_buf: "torch.Tensor",
+    ) -> None:
+        """
+        Collectively allgather the tensor across the group.
+
+        Args:
+            send_buf: The input torch.tensor to allgather. It should already be
+                on this actor's default device.
+            recv_buf: The output torch.tensor to store the allgather result.
+            op: The reduce operation.
+        """
+        raise NotImplementedError
 
     @abstractmethod
     def destroy() -> None:

--- a/python/ray/experimental/channel/communicator.py
+++ b/python/ray/experimental/channel/communicator.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Callable, List, Optional, Tuple
 
 import ray
-from ray.experimental.util.types import AllReduceReduceOp, ReduceScatterReduceOp
+from ray.experimental.util.types import AllReduceOp, ReduceScatterOp
 from ray.util.annotations import DeveloperAPI
 
 if TYPE_CHECKING:
@@ -127,7 +127,7 @@ class Communicator(ABC):
         self,
         send_buf: "torch.Tensor",
         recv_buf: "torch.Tensor",
-        op: AllReduceReduceOp,
+        op: AllReduceOp,
     ) -> None:
         """
         Collectively allreduce the tensor across the group.
@@ -145,7 +145,7 @@ class Communicator(ABC):
         self,
         send_buf: "torch.Tensor",
         recv_buf: "torch.Tensor",
-        op: ReduceScatterReduceOp,
+        op: ReduceScatterOp,
     ) -> None:
         """
         Collectively reducescatter the tensor across the group.

--- a/python/ray/experimental/channel/communicator.py
+++ b/python/ray/experimental/channel/communicator.py
@@ -139,6 +139,24 @@ class Communicator(ABC):
             op: The reduce operation.
         """
         raise NotImplementedError
+    
+    @abstractmethod
+    def reducescatter(
+        self,
+        send_buf: "torch.Tensor",
+        recv_buf: "torch.Tensor",
+        op: ReduceOp,
+    ) -> None:
+        """
+        Collectively reducescatter the tensor across the group.
+
+        Args:
+            send_buf: The input torch.tensor to reducescatter. It should already be
+                on this actor's default device.
+            recv_buf: The output torch.tensor to store the reducescatter result.
+            op: The reduce operation.
+        """
+        raise NotImplementedError
 
     @abstractmethod
     def destroy() -> None:

--- a/python/ray/experimental/channel/communicator.py
+++ b/python/ray/experimental/channel/communicator.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Callable, List, Optional, Tuple
 
 import ray
-from ray.experimental.util.types import ReduceOp
+from ray.experimental.util.types import AllReduceReduceOp, ReduceScatterReduceOp
 from ray.util.annotations import DeveloperAPI
 
 if TYPE_CHECKING:
@@ -127,7 +127,7 @@ class Communicator(ABC):
         self,
         send_buf: "torch.Tensor",
         recv_buf: "torch.Tensor",
-        op: ReduceOp,
+        op: AllReduceReduceOp,
     ) -> None:
         """
         Collectively allreduce the tensor across the group.
@@ -145,7 +145,7 @@ class Communicator(ABC):
         self,
         send_buf: "torch.Tensor",
         recv_buf: "torch.Tensor",
-        op: ReduceOp,
+        op: ReduceScatterReduceOp,
     ) -> None:
         """
         Collectively reducescatter the tensor across the group.

--- a/python/ray/experimental/channel/communicator.py
+++ b/python/ray/experimental/channel/communicator.py
@@ -139,7 +139,7 @@ class Communicator(ABC):
             op: The reduce operation.
         """
         raise NotImplementedError
-    
+
     @abstractmethod
     def reducescatter(
         self,

--- a/python/ray/experimental/channel/cpu_communicator.py
+++ b/python/ray/experimental/channel/cpu_communicator.py
@@ -4,9 +4,9 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 import ray
 from ray.experimental.channel.communicator import (
-    AllReduceReduceOp,
+    AllReduceOp,
     Communicator,
-    ReduceScatterReduceOp,
+    ReduceScatterOp,
     TorchTensorAllocator,
 )
 from ray.experimental.util.types import ReduceOp
@@ -133,7 +133,7 @@ class CPUCommunicator(Communicator):
         self,
         send_buf: "torch.Tensor",
         recv_buf: "torch.Tensor",
-        op: AllReduceReduceOp = AllReduceReduceOp.SUM,
+        op: AllReduceOp = AllReduceOp.SUM,
     ):
         all_ranks = [
             self.get_rank(actor_handle) for actor_handle in self.get_actor_handles()
@@ -155,7 +155,7 @@ class CPUCommunicator(Communicator):
         self,
         send_buf: "torch.Tensor",
         recv_buf: "torch.Tensor",
-        op: ReduceScatterReduceOp = ReduceScatterReduceOp.SUM,
+        op: ReduceScatterOp = ReduceScatterOp.SUM,
     ):
         all_ranks = [
             self.get_rank(actor_handle) for actor_handle in self.get_actor_handles()

--- a/python/ray/experimental/channel/cpu_communicator.py
+++ b/python/ray/experimental/channel/cpu_communicator.py
@@ -162,7 +162,13 @@ class CPUCommunicator(Communicator):
             barrier.wait_collective.remote(self.num_ops[barrier_key], send_buf, op)
         )
         assert recv_buf is not None, "Receiving buffer required for CPUCommunicator"
-        recv_buf[:] = result[send_buf.shape[0] // len(all_ranks) * self.get_self_rank():send_buf.shape[0] // len(all_ranks) * (self.get_self_rank()+1)]
+        recv_buf[:] = result[
+            send_buf.shape[0]
+            // len(all_ranks)
+            * self.get_self_rank() : send_buf.shape[0]
+            // len(all_ranks)
+            * (self.get_self_rank() + 1)
+        ]
         self.num_ops[barrier_key] += 1
 
     def destroy(self) -> None:

--- a/python/ray/experimental/channel/nccl_group.py
+++ b/python/ray/experimental/channel/nccl_group.py
@@ -285,7 +285,7 @@ class _NcclGroup(Communicator):
                 "There may be a dtype mismatch between input tensors from "
                 "different ranks."
             )
-        
+
     def reducescatter(
         self,
         send_buf: "torch.Tensor",

--- a/python/ray/experimental/channel/nccl_group.py
+++ b/python/ray/experimental/channel/nccl_group.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, List, Optional, Tuple
 import ray
 from ray.exceptions import RayChannelError
 from ray.experimental.channel.communicator import Communicator, TorchTensorAllocator
-from ray.experimental.util.types import AllReduceReduceOp, ReduceScatterReduceOp
+from ray.experimental.util.types import AllReduceOp, ReduceScatterOp
 
 if TYPE_CHECKING:
     import cupy as cp
@@ -254,7 +254,7 @@ class _NcclGroup(Communicator):
         self,
         send_buf: "torch.Tensor",
         recv_buf: "torch.Tensor",
-        op: AllReduceReduceOp = AllReduceReduceOp.SUM,
+        op: AllReduceOp = AllReduceOp.SUM,
     ):
         if self._closed:
             raise RayChannelError("NCCL group has been destroyed.")
@@ -290,7 +290,7 @@ class _NcclGroup(Communicator):
         self,
         send_buf: "torch.Tensor",
         recv_buf: "torch.Tensor",
-        op: ReduceScatterReduceOp = ReduceScatterReduceOp.SUM,
+        op: ReduceScatterOp = ReduceScatterOp.SUM,
     ):
         if self._closed:
             raise RayChannelError("NCCL group has been destroyed.")

--- a/python/ray/experimental/channel/nccl_group.py
+++ b/python/ray/experimental/channel/nccl_group.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, List, Optional, Tuple
 import ray
 from ray.exceptions import RayChannelError
 from ray.experimental.channel.communicator import Communicator, TorchTensorAllocator
-from ray.experimental.util.types import ReduceOp
+from ray.experimental.util.types import AllReduceReduceOp, ReduceScatterReduceOp
 
 if TYPE_CHECKING:
     import cupy as cp
@@ -254,7 +254,7 @@ class _NcclGroup(Communicator):
         self,
         send_buf: "torch.Tensor",
         recv_buf: "torch.Tensor",
-        op: ReduceOp = ReduceOp.SUM,
+        op: AllReduceReduceOp = AllReduceReduceOp.SUM,
     ):
         if self._closed:
             raise RayChannelError("NCCL group has been destroyed.")
@@ -290,7 +290,7 @@ class _NcclGroup(Communicator):
         self,
         send_buf: "torch.Tensor",
         recv_buf: "torch.Tensor",
-        op: ReduceOp = ReduceOp.SUM,
+        op: ReduceScatterReduceOp = ReduceScatterReduceOp.SUM,
     ):
         if self._closed:
             raise RayChannelError("NCCL group has been destroyed.")

--- a/python/ray/experimental/channel/nccl_group.py
+++ b/python/ray/experimental/channel/nccl_group.py
@@ -285,6 +285,42 @@ class _NcclGroup(Communicator):
                 "There may be a dtype mismatch between input tensors from "
                 "different ranks."
             )
+        
+    def reducescatter(
+        self,
+        send_buf: "torch.Tensor",
+        recv_buf: "torch.Tensor",
+        op: ReduceOp = ReduceOp.SUM,
+    ):
+        if self._closed:
+            raise RayChannelError("NCCL group has been destroyed.")
+
+        assert send_buf.dtype == recv_buf.dtype, (
+            "Ray Compiled Graph derived the dtype of recv_buf from send_buf, "
+            "so send_buf and recv_buf must have the same dtype. "
+            "If you see this error, please file an issue at Ray repository."
+        )
+        self._comm.reduceScatter(
+            self.nccl_util.get_tensor_ptr(send_buf),
+            self.nccl_util.get_tensor_ptr(recv_buf),
+            recv_buf.numel(),
+            self.nccl_util.get_nccl_tensor_dtype(send_buf),
+            op.value,
+            self._cuda_stream.ptr,
+        )
+
+        # Buffer values are undefined if NCCL ops are aborted. Therefore, we
+        # need to synchronize here and check that the channel is still open to
+        # ensure that the receive buffer is valid.
+        # TODO(swang): Avoid CUDA synchronization.
+        # TODO(wxdeng): Use check_async_error.
+        self._cuda_stream.synchronize()
+        if self._closed:
+            raise RayChannelError(
+                "NCCL group has been destroyed during allreduce operation. "
+                "There may be a dtype mismatch between input tensors from "
+                "different ranks."
+            )
 
     @property
     def recv_stream(self) -> Optional["cp.cuda.ExternalStream"]:

--- a/python/ray/experimental/collective/__init__.py
+++ b/python/ray/experimental/collective/__init__.py
@@ -1,4 +1,5 @@
 from ray.experimental.collective.allreduce import allreduce
 from ray.experimental.collective.reducescatter import reducescatter
+from ray.experimental.collective.allgather import allgather
 
-__all__ = ["allreduce", "reducescatter"]
+__all__ = ["allreduce", "reducescatter", "allgather"]

--- a/python/ray/experimental/collective/__init__.py
+++ b/python/ray/experimental/collective/__init__.py
@@ -1,3 +1,4 @@
 from ray.experimental.collective.allreduce import allreduce
+from ray.experimental.collective.reducescatter import reducescatter
 
-__all__ = ["allreduce"]
+__all__ = ["allreduce", "reducescatter"]

--- a/python/ray/experimental/collective/allgather.py
+++ b/python/ray/experimental/collective/allgather.py
@@ -9,22 +9,16 @@ from ray.dag.constants import (
     PARENT_CLASS_NODE_KEY,
 )
 from ray.experimental.channel.torch_tensor_type import Communicator, TorchTensorType
-from ray.experimental.util.types import ReduceScatterOp
-from ray.util.collective.types import ReduceOp as RayReduceOp
-
-# TODO(wxdeng): Unify `ReduceOp` and `RayReduceOp`. Directly importing `RayReduceOp`
-# has dependency issues for some tests.
 
 logger = logging.getLogger(__name__)
 
 
-class ReduceScatterWrapper:
-    """Wrapper for NCCL reduce-scatter."""
+class AllGatherWrapper:
+    """Wrapper for NCCL all-gather."""
 
     def bind(
         self,
         input_nodes: List["ray.dag.DAGNode"],
-        op: ReduceScatterOp = ReduceScatterOp.SUM,
         transport: Optional[Union[str, Communicator]] = None,
     ) -> List[CollectiveOutputNode]:
         """
@@ -53,7 +47,7 @@ class ReduceScatterWrapper:
         """
         if transport is None:
             transport = TorchTensorType.NCCL
-        collective_op = _CollectiveOperation(input_nodes, transport, op)
+        collective_op = _CollectiveOperation(input_nodes, transport)
         collective_output_nodes: List[CollectiveOutputNode] = []
 
         for input_node in input_nodes:
@@ -63,7 +57,7 @@ class ReduceScatterWrapper:
             if actor_handle is None:
                 raise ValueError("Expected an actor handle from the input node")
             collective_output_node = CollectiveOutputNode(
-                method_name=f"reducescatter.{op}",
+                method_name=f"allgather",
                 method_args=(input_node,),
                 method_kwargs=dict(),
                 method_options=dict(),
@@ -80,13 +74,13 @@ class ReduceScatterWrapper:
 
     def __call__(
         self,
+        tensor_list,
         tensor,
         group_name: str = "default",
-        op: RayReduceOp = RayReduceOp.SUM,
     ):
-        from ray.util.collective.collective import reducescatter
+        from ray.util.collective.collective import allgather
 
-        return reducescatter(tensor, group_name, op)
+        return allgather(tensor_list, tensor, group_name)
 
 
-reducescatter = ReduceScatterWrapper()
+allgather = AllGatherWrapper()

--- a/python/ray/experimental/collective/allreduce.py
+++ b/python/ray/experimental/collective/allreduce.py
@@ -53,7 +53,7 @@ class AllReduceWrapper:
         """
         if transport is None:
             transport = TorchTensorType.NCCL
-        collective_op = _CollectiveOperation(input_nodes, "ar", op, transport)
+        collective_op = _CollectiveOperation(input_nodes, op, transport)
         collective_output_nodes: List[CollectiveOutputNode] = []
 
         for input_node in input_nodes:

--- a/python/ray/experimental/collective/allreduce.py
+++ b/python/ray/experimental/collective/allreduce.py
@@ -9,7 +9,7 @@ from ray.dag.constants import (
     PARENT_CLASS_NODE_KEY,
 )
 from ray.experimental.channel.torch_tensor_type import Communicator, TorchTensorType
-from ray.experimental.util.types import AllReduceReduceOp
+from ray.experimental.util.types import AllReduceOp
 from ray.util.collective.types import ReduceOp as RayReduceOp
 
 # TODO(wxdeng): Unify `ReduceOp` and `RayReduceOp`. Directly importing `RayReduceOp`
@@ -24,7 +24,7 @@ class AllReduceWrapper:
     def bind(
         self,
         input_nodes: List["ray.dag.DAGNode"],
-        op: AllReduceReduceOp = AllReduceReduceOp.SUM,
+        op: AllReduceOp = AllReduceOp.SUM,
         transport: Optional[Union[str, Communicator]] = None,
     ) -> List[CollectiveOutputNode]:
         """

--- a/python/ray/experimental/collective/allreduce.py
+++ b/python/ray/experimental/collective/allreduce.py
@@ -53,7 +53,7 @@ class AllReduceWrapper:
         """
         if transport is None:
             transport = TorchTensorType.NCCL
-        collective_op = _CollectiveOperation(input_nodes, op, transport)
+        collective_op = _CollectiveOperation(input_nodes, transport, op)
         collective_output_nodes: List[CollectiveOutputNode] = []
 
         for input_node in input_nodes:

--- a/python/ray/experimental/collective/allreduce.py
+++ b/python/ray/experimental/collective/allreduce.py
@@ -53,7 +53,7 @@ class AllReduceWrapper:
         """
         if transport is None:
             transport = TorchTensorType.NCCL
-        collective_op = _CollectiveOperation(input_nodes, op, transport)
+        collective_op = _CollectiveOperation(input_nodes, "ar", op, transport)
         collective_output_nodes: List[CollectiveOutputNode] = []
 
         for input_node in input_nodes:

--- a/python/ray/experimental/collective/allreduce.py
+++ b/python/ray/experimental/collective/allreduce.py
@@ -9,7 +9,7 @@ from ray.dag.constants import (
     PARENT_CLASS_NODE_KEY,
 )
 from ray.experimental.channel.torch_tensor_type import Communicator, TorchTensorType
-from ray.experimental.util.types import ReduceOp
+from ray.experimental.util.types import AllReduceReduceOp
 from ray.util.collective.types import ReduceOp as RayReduceOp
 
 # TODO(wxdeng): Unify `ReduceOp` and `RayReduceOp`. Directly importing `RayReduceOp`
@@ -24,7 +24,7 @@ class AllReduceWrapper:
     def bind(
         self,
         input_nodes: List["ray.dag.DAGNode"],
-        op: ReduceOp = ReduceOp.SUM,
+        op: AllReduceReduceOp = AllReduceReduceOp.SUM,
         transport: Optional[Union[str, Communicator]] = None,
     ) -> List[CollectiveOutputNode]:
         """

--- a/python/ray/experimental/collective/conftest.py
+++ b/python/ray/experimental/collective/conftest.py
@@ -58,6 +58,14 @@ class AbstractNcclGroup(Communicator):
         op: ReduceOp = ReduceOp.SUM,
     ) -> None:
         raise NotImplementedError
+    
+    def reducescatter(
+        self,
+        send_buf: "torch.Tensor",
+        recv_buf: "torch.Tensor",
+        op: ReduceOp = ReduceOp.SUM,
+    ) -> None:
+        raise NotImplementedError
 
     @property
     def recv_stream(self) -> Optional["cp.cuda.ExternalStream"]:

--- a/python/ray/experimental/collective/conftest.py
+++ b/python/ray/experimental/collective/conftest.py
@@ -7,9 +7,9 @@ import torch
 import ray
 from ray.experimental.channel.common import ChannelContext
 from ray.experimental.channel.communicator import (
-    AllReduceReduceOp,
+    AllReduceOp,
     Communicator,
-    ReduceScatterReduceOp,
+    ReduceScatterOp,
     TorchTensorAllocator,
 )
 
@@ -56,7 +56,7 @@ class AbstractNcclGroup(Communicator):
         self,
         send_buf: "torch.Tensor",
         recv_buf: "torch.Tensor",
-        op: AllReduceReduceOp = AllReduceReduceOp.SUM,
+        op: AllReduceOp = AllReduceOp.SUM,
     ) -> None:
         raise NotImplementedError
 
@@ -64,7 +64,7 @@ class AbstractNcclGroup(Communicator):
         self,
         send_buf: "torch.Tensor",
         recv_buf: "torch.Tensor",
-        op: ReduceScatterReduceOp = ReduceScatterReduceOp.SUM,
+        op: ReduceScatterOp = ReduceScatterOp.SUM,
     ) -> None:
         raise NotImplementedError
 

--- a/python/ray/experimental/collective/conftest.py
+++ b/python/ray/experimental/collective/conftest.py
@@ -58,7 +58,7 @@ class AbstractNcclGroup(Communicator):
         op: ReduceOp = ReduceOp.SUM,
     ) -> None:
         raise NotImplementedError
-    
+
     def reducescatter(
         self,
         send_buf: "torch.Tensor",

--- a/python/ray/experimental/collective/conftest.py
+++ b/python/ray/experimental/collective/conftest.py
@@ -7,8 +7,9 @@ import torch
 import ray
 from ray.experimental.channel.common import ChannelContext
 from ray.experimental.channel.communicator import (
+    AllReduceReduceOp,
     Communicator,
-    ReduceOp,
+    ReduceScatterReduceOp,
     TorchTensorAllocator,
 )
 
@@ -55,7 +56,7 @@ class AbstractNcclGroup(Communicator):
         self,
         send_buf: "torch.Tensor",
         recv_buf: "torch.Tensor",
-        op: ReduceOp = ReduceOp.SUM,
+        op: AllReduceReduceOp = AllReduceReduceOp.SUM,
     ) -> None:
         raise NotImplementedError
 
@@ -63,7 +64,7 @@ class AbstractNcclGroup(Communicator):
         self,
         send_buf: "torch.Tensor",
         recv_buf: "torch.Tensor",
-        op: ReduceOp = ReduceOp.SUM,
+        op: ReduceScatterReduceOp = ReduceScatterReduceOp.SUM,
     ) -> None:
         raise NotImplementedError
 

--- a/python/ray/experimental/collective/reducescatter.py
+++ b/python/ray/experimental/collective/reducescatter.py
@@ -53,7 +53,7 @@ class ReduceScatterWrapper:
         """
         if transport is None:
             transport = TorchTensorType.NCCL
-        collective_op = _CollectiveOperation(input_nodes, "rs", op, transport)
+        collective_op = _CollectiveOperation(input_nodes, op, transport)
         collective_output_nodes: List[CollectiveOutputNode] = []
 
         for input_node in input_nodes:

--- a/python/ray/experimental/collective/reducescatter.py
+++ b/python/ray/experimental/collective/reducescatter.py
@@ -8,7 +8,7 @@ from ray.dag.constants import (
     COLLECTIVE_OPERATION_KEY,
     PARENT_CLASS_NODE_KEY,
 )
-from ray.experimental.channel.torch_tensor_type import GPUCommunicator, TorchTensorType
+from ray.experimental.channel.torch_tensor_type import Communicator, TorchTensorType
 from ray.experimental.util.types import ReduceOp
 from ray.util.collective.types import ReduceOp as RayReduceOp
 
@@ -25,7 +25,7 @@ class ReduceScatterWrapper:
         self,
         input_nodes: List["ray.dag.DAGNode"],
         op: ReduceOp = ReduceOp.SUM,
-        transport: Optional[Union[str, GPUCommunicator]] = None,
+        transport: Optional[Union[str, Communicator]] = None,
     ) -> List[CollectiveOutputNode]:
         """
         Bind input nodes with a collective operation. The collective operation is

--- a/python/ray/experimental/collective/reducescatter.py
+++ b/python/ray/experimental/collective/reducescatter.py
@@ -9,7 +9,7 @@ from ray.dag.constants import (
     PARENT_CLASS_NODE_KEY,
 )
 from ray.experimental.channel.torch_tensor_type import Communicator, TorchTensorType
-from ray.experimental.util.types import ReduceScatterReduceOp
+from ray.experimental.util.types import ReduceScatterOp
 from ray.util.collective.types import ReduceOp as RayReduceOp
 
 # TODO(wxdeng): Unify `ReduceOp` and `RayReduceOp`. Directly importing `RayReduceOp`
@@ -24,7 +24,7 @@ class ReduceScatterWrapper:
     def bind(
         self,
         input_nodes: List["ray.dag.DAGNode"],
-        op: ReduceScatterReduceOp = ReduceScatterReduceOp.SUM,
+        op: ReduceScatterOp = ReduceScatterOp.SUM,
         transport: Optional[Union[str, Communicator]] = None,
     ) -> List[CollectiveOutputNode]:
         """

--- a/python/ray/experimental/collective/reducescatter.py
+++ b/python/ray/experimental/collective/reducescatter.py
@@ -1,0 +1,92 @@
+import logging
+from typing import List, Optional, Union
+
+import ray
+from ray.dag.collective_node import CollectiveOutputNode, _CollectiveOperation
+from ray.dag.constants import (
+    BIND_INDEX_KEY,
+    COLLECTIVE_OPERATION_KEY,
+    PARENT_CLASS_NODE_KEY,
+)
+from ray.experimental.channel.torch_tensor_type import GPUCommunicator, TorchTensorType
+from ray.experimental.util.types import ReduceOp
+from ray.util.collective.types import ReduceOp as RayReduceOp
+
+# TODO(wxdeng): Unify `ReduceOp` and `RayReduceOp`. Directly importing `RayReduceOp`
+# has dependency issues for some tests.
+
+logger = logging.getLogger(__name__)
+
+
+class ReduceScatterWrapper:
+    """Wrapper for NCCL reduce-scatter."""
+
+    def bind(
+        self,
+        input_nodes: List["ray.dag.DAGNode"],
+        op: ReduceOp = ReduceOp.SUM,
+        transport: Optional[Union[str, GPUCommunicator]] = None,
+    ) -> List[CollectiveOutputNode]:
+        """
+        Bind input nodes with a collective operation. The collective operation is
+        directly applied to the torch tensors from the input nodes. The output nodes
+        are the results of the collective operation in the same torch tensors.
+
+        Requirements:
+        1. Each input node returns a torch tensor.
+        2. Each input node is from a different actor.
+        3. If a custom transport is specified, its actor set matches the actor set
+           of the input nodes.
+        4. All tensors have the same shape.
+
+        Requirements 1-3 are checked in the `CollectiveGroup` constructor.
+        Requirement 4 is not checked yet.
+
+        Args:
+            input_nodes: A list of DAG nodes.
+            op: The collective operation.
+            transport: GPU communicator for the collective operation. If not
+                specified, the default NCCL is used.
+
+        Returns:
+            A list of collective output nodes.
+        """
+        if transport is None:
+            transport = TorchTensorType.NCCL
+        collective_op = _CollectiveOperation(input_nodes, "rs", op, transport)
+        collective_output_nodes: List[CollectiveOutputNode] = []
+
+        for input_node in input_nodes:
+            actor_handle: Optional[
+                "ray.actor.ActorHandle"
+            ] = input_node._get_actor_handle()
+            if actor_handle is None:
+                raise ValueError("Expected an actor handle from the input node")
+            collective_output_node = CollectiveOutputNode(
+                method_name=f"reducescatter.{op}",
+                method_args=(input_node,),
+                method_kwargs=dict(),
+                method_options=dict(),
+                other_args_to_resolve={
+                    PARENT_CLASS_NODE_KEY: actor_handle,
+                    BIND_INDEX_KEY: actor_handle._ray_dag_bind_index,
+                    COLLECTIVE_OPERATION_KEY: collective_op,
+                },
+            )
+            actor_handle._ray_dag_bind_index += 1
+            collective_output_nodes.append(collective_output_node)
+
+        return collective_output_nodes
+
+    def __call__(
+        self,
+        tensor,
+        group_name: str = "default",
+        op: RayReduceOp = RayReduceOp.SUM,
+    ):
+        from ray.util.collective.collective import reducescatter
+
+        return reducescatter(tensor, group_name, op)
+
+
+reducescatter = ReduceScatterWrapper()

--- a/python/ray/experimental/collective/reducescatter.py
+++ b/python/ray/experimental/collective/reducescatter.py
@@ -9,7 +9,7 @@ from ray.dag.constants import (
     PARENT_CLASS_NODE_KEY,
 )
 from ray.experimental.channel.torch_tensor_type import Communicator, TorchTensorType
-from ray.experimental.util.types import ReduceOp
+from ray.experimental.util.types import ReduceScatterReduceOp
 from ray.util.collective.types import ReduceOp as RayReduceOp
 
 # TODO(wxdeng): Unify `ReduceOp` and `RayReduceOp`. Directly importing `RayReduceOp`
@@ -24,7 +24,7 @@ class ReduceScatterWrapper:
     def bind(
         self,
         input_nodes: List["ray.dag.DAGNode"],
-        op: ReduceOp = ReduceOp.SUM,
+        op: ReduceScatterReduceOp = ReduceScatterReduceOp.SUM,
         transport: Optional[Union[str, Communicator]] = None,
     ) -> List[CollectiveOutputNode]:
         """

--- a/python/ray/experimental/util/types.py
+++ b/python/ray/experimental/util/types.py
@@ -9,6 +9,23 @@ class _CollectiveOp(Enum):
 
 @PublicAPI
 class ReduceOp(_CollectiveOp):
+    pass
+
+
+@PublicAPI
+class AllReduceReduceOp(ReduceOp):
+    SUM = 0
+    PRODUCT = 1
+    MAX = 2
+    MIN = 3
+    AVG = 4
+
+    def __str__(self):
+        return f"{self.name.lower()}"
+
+
+@PublicAPI
+class ReduceScatterReduceOp(ReduceOp):
     SUM = 0
     PRODUCT = 1
     MAX = 2

--- a/python/ray/experimental/util/types.py
+++ b/python/ray/experimental/util/types.py
@@ -13,7 +13,7 @@ class ReduceOp(_CollectiveOp):
 
 
 @PublicAPI
-class AllReduceReduceOp(ReduceOp):
+class AllReduceOp(ReduceOp):
     SUM = 0
     PRODUCT = 1
     MAX = 2
@@ -25,7 +25,7 @@ class AllReduceReduceOp(ReduceOp):
 
 
 @PublicAPI
-class ReduceScatterReduceOp(ReduceOp):
+class ReduceScatterOp(ReduceOp):
     SUM = 0
     PRODUCT = 1
     MAX = 2


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently we do not have other collective operations except allreduce in Ray Compiled Graphs, we plan to add the other collective operations required in FSDP in the future.

Proposed API:
For reduce scatter:
```python
import ray.experimental.collective as collective

with InputNode() as inp:
    dag = [worker.return_tensor.bind(inp) for worker in workers]
    dag = collective.reducescatter.bind(dag, ReduceOp.SUM)
    dag = MultiOutputNode(dag)
```
For all agther:
```python
import ray.experimental.collective as collective

with InputNode() as inp:
    dag = [worker.return_tensor.bind(inp) for worker in workers]
    dag = collective.allgather.bind(dag)
    dag = MultiOutputNode(dag)
```

## Related issue number

Meta-issue: [#47983](https://github.com/ray-project/ray/issues/47983)

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
