### PR TITLE
[Dashboard] Added a proper message when Ray jobs submission is used a…

### DIFF
--- a/python/ray/dashboard/modules/job/sdk.py
+++ b/python/ray/dashboard/modules/job/sdk.py
@@ -350,7 +350,13 @@ class JobSubmissionClient(SubmissionClient):
         r = self._do_request("GET", f"/api/jobs/{job_id}")
 
         if r.status_code == 200:
-            return JobDetails(**r.json())
+            if JobDetails is None:
+                raise RuntimeError(
+                    "The Ray jobs CLI & SDK require the ray[default] "
+                    "installation: `pip install 'ray[default]'`"
+                )
+            else:
+                return JobDetails(**r.json())
         else:
             self._raise_error(r)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
I recently used the `ray job submit` CLI and got this confused error message
```sh
TypeError: 'NoneType' object is not callable
```

<!-- Please give a short summary of the change and the problem this solves. -->

As the #41604 mentioned, it need a proper error message instead of raising `NoneType` error.

## Related issue number

<!-- For example: "Closes #1234" -->

Related to #41604

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
