### PR TITLE
[RLlib; release tests] Fix `config.rollouts` -> `config.env_runners` deprecation errors.

### DIFF
--- a/python/ray/air/tests/test_integration_wandb.py
+++ b/python/ray/air/tests/test_integration_wandb.py
@@ -335,7 +335,7 @@ class TestWandbLogger:
             "framework": "torch",
             "num_gpus": 1,
             "num_workers": 20,
-            "num_envs_per_worker": 1,
+            "num_envs_per_env_runner": 1,
             "compress_observations": True,
             "lambda": 0.99,
             "train_batch_size": 512,

--- a/python/ray/tests/test_client_library_integration.py
+++ b/python/ray/tests/test_client_library_integration.py
@@ -24,7 +24,7 @@ def test_rllib_integration(ray_start_regular):
                 dqn.DQNConfig().environment("CartPole-v1")
                 # Run locally.
                 # Test with compression.
-                .rollouts(num_rollout_workers=0, compress_observations=True)
+                .env_runners(num_env_runners=0, compress_observations=True)
             )
             num_iterations = 2
             trainer = config.build()

--- a/release/long_running_tests/workloads/impala.py
+++ b/release/long_running_tests/workloads/impala.py
@@ -48,9 +48,9 @@ run_experiments(
             "run": "IMPALA",
             "env": "CartPole-v1",
             "config": {
-                "num_workers": 8,
+                "num_env_runners": 8,
                 "num_gpus": 0,
-                "num_envs_per_worker": 5,
+                "num_envs_per_env_runner": 5,
                 "remote_worker_envs": True,
                 "remote_env_batch_wait_ms": 99999999,
                 "rollout_fragment_length": 50,

--- a/release/ml_user_tests/tune_rllib/run_connect_tests.py
+++ b/release/ml_user_tests/tune_rllib/run_connect_tests.py
@@ -32,7 +32,7 @@ def run(smoke_test=False, storage_path: str = None):
         )
         .environment("ale_py:ALE/Pong-v5", clip_rewards=True)
         .framework(tune.grid_search(["tf", "torch"]))
-        .rollouts(
+        .env_runners(
             rollout_fragment_length=50,
             num_env_runners=num_workers,
             num_envs_per_env_runner=1,

--- a/release/rllib_contrib/learning_tests/yaml_files/a2c/a2c-breakout-v5.yaml
+++ b/release/rllib_contrib/learning_tests/yaml_files/a2c/a2c-breakout-v5.yaml
@@ -14,7 +14,7 @@ a2c-breakoutnoframeskip-v5:
         rollout_fragment_length: auto
         clip_rewards: True
         num_workers: 5
-        num_envs_per_worker: 5
+        num_envs_per_env_runner: 5
         num_gpus: 1
         lr_schedule: [
             [0, 0.0007],

--- a/release/rllib_contrib/learning_tests/yaml_files/apex/apex-breakoutnoframeskip-v5.yaml
+++ b/release/rllib_contrib/learning_tests/yaml_files/apex/apex-breakoutnoframeskip-v5.yaml
@@ -30,7 +30,7 @@ apex-breakoutnoframeskip-v5:
             final_epsilon: 0.01
         num_gpus: 1
         num_workers: 16
-        num_envs_per_worker: 8
+        num_envs_per_env_runner: 8
         rollout_fragment_length: 20
         train_batch_size: 512
         target_network_update_freq: 50000

--- a/release/rllib_tests/checkpointing_tests/test_e2e_rl_module_restore.py
+++ b/release/rllib_tests/checkpointing_tests/test_e2e_rl_module_restore.py
@@ -51,7 +51,7 @@ class TestE2ERLModuleLoad(unittest.TestCase):
         config = (
             PPOConfig()
             .experimental(_enable_new_api_stack=True)
-            .rollouts(rollout_fragment_length=4)
+            .env_runners(rollout_fragment_length=4)
             .environment(MultiAgentCartPole, env_config={"num_agents": num_agents})
             .training(num_sgd_iter=1, train_batch_size=8, sgd_minibatch_size=8)
             .multi_agent(policies=policies, policy_mapping_fn=policy_mapping_fn)
@@ -179,7 +179,7 @@ class TestE2ERLModuleLoad(unittest.TestCase):
         config = (
             PPOConfig()
             .experimental(_enable_new_api_stack=True)
-            .rollouts(rollout_fragment_length=4)
+            .env_runners(rollout_fragment_length=4)
             .environment("CartPole-v1")
             .training(num_sgd_iter=1, train_batch_size=8, sgd_minibatch_size=8)
             .resources(**scaling_config)

--- a/release/rllib_tests/learning_tests/yaml_files/appo/hybrid_stack/appo-pongnoframeskip-v5.yaml
+++ b/release/rllib_tests/learning_tests/yaml_files/appo/hybrid_stack/appo-pongnoframeskip-v5.yaml
@@ -23,7 +23,7 @@ appo-pongnoframeskip-v5:
         num_workers: 31
         broadcast_interval: 1
         max_sample_requests_in_flight_per_worker: 1
-        num_envs_per_worker: 8
+        num_envs_per_env_runner: 8
         num_sgd_iter: 2
         vf_loss_coeff: 1.0
         clip_param: 0.3

--- a/release/rllib_tests/learning_tests/yaml_files/appo/old_stack/appo-pongnoframeskip-v5.yaml
+++ b/release/rllib_tests/learning_tests/yaml_files/appo/old_stack/appo-pongnoframeskip-v5.yaml
@@ -21,7 +21,7 @@ appo-pongnoframeskip-v5:
         broadcast_interval: 1
         max_sample_requests_in_flight_per_worker: 1
         num_multi_gpu_tower_stacks: 1
-        num_envs_per_worker: 8
+        num_envs_per_env_runner: 8
         num_sgd_iter: 2
         vf_loss_coeff: 1.0
         clip_param: 0.3

--- a/release/rllib_tests/learning_tests/yaml_files/impala/impala-breakoutnoframeskip-v5.yaml
+++ b/release/rllib_tests/learning_tests/yaml_files/impala/impala-breakoutnoframeskip-v5.yaml
@@ -16,7 +16,7 @@ impala-breakoutnoframeskip-v5:
         rollout_fragment_length: 50
         train_batch_size: 500
         num_workers: 10
-        num_envs_per_worker: 5
+        num_envs_per_env_runner: 5
         clip_rewards: True
         lr: 0.0005
         num_gpus: 1

--- a/release/rllib_tests/learning_tests/yaml_files/ppo/new_stack/ppo_breakout.py
+++ b/release/rllib_tests/learning_tests/yaml_files/ppo/new_stack/ppo_breakout.py
@@ -44,7 +44,7 @@ config = (
         },
         clip_rewards=True,
     )
-    .rollouts(env_to_module_connector=_make_env_to_module_connector)
+    .env_runners(env_to_module_connector=_make_env_to_module_connector)
     .training(
         learner_connector=_make_learner_connector,
         lambda_=0.95,

--- a/release/rllib_tests/learning_tests/yaml_files/ppo/old_stack/ppo-breakoutnoframeskip-v5.yaml
+++ b/release/rllib_tests/learning_tests/yaml_files/ppo/old_stack/ppo-breakoutnoframeskip-v5.yaml
@@ -26,7 +26,7 @@ ppo-breakoutnoframeskip-v5:
         num_workers: 30
         # Run without Learner- and RLModule API (new stack).
         _enable_new_api_stack: false
-        num_envs_per_worker: 1
+        num_envs_per_env_runner: 1
         batch_mode: truncate_episodes
         observation_filter: NoFilter
         model:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Fix `config.rollouts` -> `config.env_runners` deprecation errors.

* Replace deprecated calls to `AlgorithmConfig.rollouts` with `AlgorithmConfig.env_runners`.
* Replace deprecated `AlgorithmConfig.num_env_per_worker` with `AlgorithmConfig.num_envs_per_env_runner`.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #49397
Closes #49396

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
