### PR TITLE
[core]e Enable test for worker log rotation

### DIFF
--- a/python/ray/tests/test_logging.py
+++ b/python/ray/tests/test_logging.py
@@ -205,8 +205,7 @@ def test_log_rotation(shutdown_only, monkeypatch):
         ray_constants.PROCESS_TYPE_PYTHON_CORE_WORKER,
         ray_constants.PROCESS_TYPE_RAYLET,
         ray_constants.PROCESS_TYPE_GCS_SERVER,
-        # Below components are not log rotating now.
-        # ray_constants.PROCESS_TYPE_WORKER,
+        ray_constants.PROCESS_TYPE_WORKER,
     ]
 
     # Run the basic workload.


### PR DESCRIPTION
Followup PR for https://github.com/ray-project/ray/pull/48952 to enable worker log rotation, which I verified to work.