### PR TITLE
[data/preprocessors] allow scalers to be used in append mode

### DIFF
--- a/python/ray/data/preprocessors/scaler.py
+++ b/python/ray/data/preprocessors/scaler.py
@@ -433,7 +433,7 @@ class RobustScaler(Preprocessor):
         return (
             f"{self.__class__.__name__}(columns={self.columns!r}, "
             f"quantile_range={self.quantile_range!r}), "
-            f"output_columns={self.output_columns!r}"
+            f"output_columns={self.output_columns!r})"
         )
 
 
@@ -447,5 +447,8 @@ def _derive_and_validate_output_columns(
     """
 
     if output_columns and len(columns) != len(output_columns):
-        raise ValueError("The length of columns and output_columns must match.")
+        raise ValueError(
+            "Invalid output_columns: Got len(columns) != len(output_columns)."
+            "The length of columns and output_columns must match."
+        )
     return output_columns or columns

--- a/python/ray/data/preprocessors/scaler.py
+++ b/python/ray/data/preprocessors/scaler.py
@@ -62,8 +62,7 @@ class StandardScaler(Preprocessor):
 
         >>> preprocessor = StandardScaler(
         ...     columns=["X1", "X2"],
-        ...     inplace=False,
-        ...     suffix="scaled"
+        ...     output_columns=["X1_scaled", "X2_scaled"]
         ... )
         >>> preprocessor.fit_transform(ds).to_pandas()  # doctest: +SKIP
            X1  X2  X3  X1_scaled  X2_scaled
@@ -73,23 +72,17 @@ class StandardScaler(Preprocessor):
 
     Args:
         columns: The columns to separately scale.
-        inplace: Whether to modify the input dataset in place. If False, the
-            transformed columns will be appended with a suffix.
-        suffix: The suffix to append to the transformed columns. Required if
-            ``inplace`` is False.
+        output_columns: The names of the transformed columns. If None, the transformed
+            columns will be the same as the input columns. If not None, the length of
+            ``output_columns`` must match the length of ``columns``, othwerwise an error
+            will be raised.
     """
 
-    def __init__(
-        self, columns: List[str], *, inplace: bool = True, suffix: Optional[str] = None
-    ):
+    def __init__(self, columns: List[str], output_columns: Optional[List[str]] = None):
         self.columns = columns
-        self.output_columns = columns
-
-        if not inplace and suffix is None:
-            raise ValueError("If inplace is False, suffix must be provided.")
-
-        if not inplace:
-            self.output_columns = [f"{col}_{suffix}" for col in columns]
+        self.output_columns = _derive_and_validate_output_columns(
+            columns, output_columns
+        )
 
     def _fit(self, dataset: Dataset) -> Preprocessor:
         mean_aggregates = [Mean(col) for col in self.columns]
@@ -113,7 +106,7 @@ class StandardScaler(Preprocessor):
         return df
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(columns={self.columns!r})"
+        return f"{self.__class__.__name__}(columns={self.columns!r}, output_columns={self.output_columns!r})"
 
 
 @PublicAPI(stability="alpha")
@@ -166,7 +159,7 @@ class MinMaxScaler(Preprocessor):
         1   0  -3  0.0
         2   2   3  0.0
 
-        >>> preprocessor = MinMaxScaler(columns=["X1", "X2"], inplace=False, suffix="scaled")
+        >>> preprocessor = MinMaxScaler(columns=["X1", "X2"], output_columns=["X1_scaled", "X2_scaled"])
         >>> preprocessor.fit_transform(ds).to_pandas()  # doctest: +SKIP
            X1  X2  X3  X1_scaled  X2_scaled
         0  -2  -3   1        0.0        0.0
@@ -175,25 +168,17 @@ class MinMaxScaler(Preprocessor):
 
     Args:
         columns: The columns to separately scale.
-        inplace: Whether to modify the input dataset in place. If False, the
-            transformed columns will be appended with a suffix.
-        suffix: The suffix to append to the transformed columns. Required if
-            ``inplace`` is False.
+        output_columns: The names of the transformed columns. If None, the transformed
+            columns will be the same as the input columns. If not None, the length of
+            ``output_columns`` must match the length of ``columns``, othwerwise an error
+            will be raised.
     """
 
-    def __init__(
-        self, columns: List[str], *, inplace: bool = True, suffix: Optional[str] = None
-    ):
+    def __init__(self, columns: List[str], output_columns: Optional[List[str]] = None):
         self.columns = columns
-        self.suffix = suffix
-        self.inplace = inplace
-        self.output_columns = columns
-
-        if not inplace and suffix is None:
-            raise ValueError("If inplace is False, suffix must be provided.")
-
-        if not inplace:
-            self.output_columns = [f"{col}_{suffix}" for col in columns]
+        self.output_columns = self.output_columns = _derive_and_validate_output_columns(
+            columns, output_columns
+        )
 
     def _fit(self, dataset: Dataset) -> Preprocessor:
         aggregates = [Agg(col) for Agg in [Min, Max] for col in self.columns]
@@ -217,7 +202,7 @@ class MinMaxScaler(Preprocessor):
         return df
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(columns={self.columns!r})"
+        return f"{self.__class__.__name__}(columns={self.columns!r}, output_columns={self.output_columns!r})"
 
 
 @PublicAPI(stability="alpha")
@@ -266,7 +251,7 @@ class MaxAbsScaler(Preprocessor):
         0  -6   2  0.0
         1   3  -4  0.0
 
-        >>> preprocessor = MaxAbsScaler(columns=["X1", "X2"], inplace=False, suffix="scaled")
+        >>> preprocessor = MaxAbsScaler(columns=["X1", "X2"], output_columns=["X1_scaled", "X2_scaled"])
         >>> preprocessor.fit_transform(ds).to_pandas()  # doctest: +SKIP
            X1  X2  X3  X1_scaled  X2_scaled
         0  -2  -3   1       -1.0       -1.0
@@ -275,23 +260,17 @@ class MaxAbsScaler(Preprocessor):
 
     Args:
         columns: The columns to separately scale.
-        inplace: Whether to modify the input dataset in place. If False, the
-            transformed columns will be appended with a suffix.
-        suffix: The suffix to append to the transformed columns. Required if
-            ``inplace`` is False.
+        output_columns: The names of the transformed columns. If None, the transformed
+            columns will be the same as the input columns. If not None, the length of
+            ``output_columns`` must match the length of ``columns``, othwerwise an error
+            will be raised.
     """
 
-    def __init__(
-        self, columns: List[str], *, inplace: bool = True, suffix: Optional[str] = None
-    ):
+    def __init__(self, columns: List[str], output_columns: Optional[List[str]] = None):
         self.columns = columns
-        self.output_columns = columns
-
-        if not inplace and suffix is None:
-            raise ValueError("If inplace is False, suffix must be provided.")
-
-        if not inplace:
-            self.output_columns = [f"{col}_{suffix}" for col in columns]
+        self.output_columns = _derive_and_validate_output_columns(
+            columns, output_columns
+        )
 
     def _fit(self, dataset: Dataset) -> Preprocessor:
         aggregates = [AbsMax(col) for col in self.columns]
@@ -313,7 +292,7 @@ class MaxAbsScaler(Preprocessor):
         return df
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(columns={self.columns!r})"
+        return f"{self.__class__.__name__}(columns={self.columns!r}, output_columns={self.output_columns!r})"
 
 
 @PublicAPI(stability="alpha")
@@ -365,8 +344,7 @@ class RobustScaler(Preprocessor):
 
         >>> preprocessor = RobustScaler(
         ...    columns=["X1", "X2"],
-        ...    inplace=False,
-        ...    suffix="scaled"
+        ...    output_columns=["X1_scaled", "X2_scaled"]
         ... )
         >>> preprocessor.fit_transform(ds).to_pandas()  # doctest: +SKIP
            X1  X2  X3  X1_scaled  X2_scaled
@@ -381,30 +359,24 @@ class RobustScaler(Preprocessor):
         quantile_range: A tuple that defines the lower and upper quantiles. Values
             must be between 0 and 1. Defaults to the 1st and 3rd quartiles:
             ``(0.25, 0.75)``.
-        inplace: Whether to modify the input dataset in place. If False, the
-            transformed columns will be appended with a suffix.
-        suffix: The suffix to append to the transformed columns. Required if
-            ``inplace`` is False.
+        output_columns: The names of the transformed columns. If None, the transformed
+            columns will be the same as the input columns. If not None, the length of
+            ``output_columns`` must match the length of ``columns``, othwerwise an error
+            will be raised.
     """
 
     def __init__(
         self,
         columns: List[str],
         quantile_range: Tuple[float, float] = (0.25, 0.75),
-        *,
-        inplace: bool = True,
-        suffix: Optional[str] = None,
+        output_columns: Optional[List[str]] = None,
     ):
         self.columns = columns
         self.quantile_range = quantile_range
 
-        self.output_columns = columns
-
-        if not inplace and suffix is None:
-            raise ValueError("If inplace is False, suffix must be provided.")
-
-        if not inplace:
-            self.output_columns = [f"{col}_{suffix}" for col in columns]
+        self.output_columns = _derive_and_validate_output_columns(
+            columns, output_columns
+        )
 
     def _fit(self, dataset: Dataset) -> Preprocessor:
         low = self.quantile_range[0]
@@ -460,5 +432,20 @@ class RobustScaler(Preprocessor):
     def __repr__(self):
         return (
             f"{self.__class__.__name__}(columns={self.columns!r}, "
-            f"quantile_range={self.quantile_range!r})"
+            f"quantile_range={self.quantile_range!r}), "
+            f"output_columns={self.output_columns!r}"
         )
+
+
+def _derive_and_validate_output_columns(
+    columns: List[str], output_columns: Optional[List[str]]
+) -> List[str]:
+    """
+    Returns the output columns, checking if they are explicitely set, otherwise defaulting to
+    the input columns. Throws an error when the length of the output columns does not match the
+    length of the input columns.
+    """
+
+    if output_columns and len(columns) != len(output_columns):
+        raise ValueError("The length of columns and output_columns must match.")
+    return output_columns or columns

--- a/python/ray/data/tests/preprocessors/test_scaler.py
+++ b/python/ray/data/tests/preprocessors/test_scaler.py
@@ -66,9 +66,11 @@ def test_min_max_scaler():
 
     # append mode
     with pytest.raises(ValueError):
-        MinMaxScaler(columns=["B", "C"], inplace=False)
+        MinMaxScaler(columns=["B", "C"], output_columns=["B_mm_scaled"])
 
-    scaler = MinMaxScaler(columns=["B", "C"], inplace=False, suffix="mm_scaled")
+    scaler = MinMaxScaler(
+        columns=["B", "C"], output_columns=["B_mm_scaled", "C_mm_scaled"]
+    )
     scaler.fit(ds)
 
     pred_in_df = pd.DataFrame.from_dict(
@@ -144,9 +146,11 @@ def test_max_abs_scaler():
 
     # append mode
     with pytest.raises(ValueError):
-        MaxAbsScaler(columns=["B", "C"], inplace=False)
+        MaxAbsScaler(columns=["B", "C"], output_columns=["B_ma_scaled"])
 
-    scaler = MaxAbsScaler(columns=["B", "C"], inplace=False, suffix="ma_scaled")
+    scaler = MaxAbsScaler(
+        columns=["B", "C"], output_columns=["B_ma_scaled", "C_ma_scaled"]
+    )
     scaler.fit(ds)
 
     pred_in_df = pd.DataFrame.from_dict(
@@ -229,9 +233,11 @@ def test_robust_scaler():
 
     # append mode
     with pytest.raises(ValueError):
-        RobustScaler(columns=["B", "C"], inplace=False)
+        RobustScaler(columns=["B", "C"], output_columns=["B_r_scaled"])
 
-    scaler = RobustScaler(columns=["B", "C"], inplace=False, suffix="r_scaled")
+    scaler = RobustScaler(
+        columns=["B", "C"], output_columns=["B_r_scaled", "C_r_scaled"]
+    )
     scaler.fit(ds)
 
     pred_in_df = pd.DataFrame.from_dict(
@@ -313,9 +319,11 @@ def test_standard_scaler():
 
     # append mode
     with pytest.raises(ValueError):
-        StandardScaler(columns=["B", "C"], inplace=False)
+        StandardScaler(columns=["B", "C"], output_columns=["B_s_scaled"])
 
-    scaler = StandardScaler(columns=["B", "C"], inplace=False, suffix="r_scaled")
+    scaler = StandardScaler(
+        columns=["B", "C"], output_columns=["B_s_scaled", "C_s_scaled"]
+    )
     scaler.fit(ds)
 
     pred_in_df = pd.DataFrame.from_dict(
@@ -328,8 +336,8 @@ def test_standard_scaler():
             "A": pred_col_a,
             "B": pred_col_b,
             "C": pred_col_c,
-            "B_r_scaled": pred_processed_col_b,
-            "C_r_scaled": pred_processed_col_c,
+            "B_s_scaled": pred_processed_col_b,
+            "C_s_scaled": pred_processed_col_c,
         }
     )
 

--- a/python/ray/data/tests/preprocessors/test_scaler.py
+++ b/python/ray/data/tests/preprocessors/test_scaler.py
@@ -39,7 +39,7 @@ def test_min_max_scaler():
         {"A": processed_col_a, "B": processed_col_b, "C": processed_col_c}
     )
 
-    assert out_df.equals(expected_df)
+    pd.testing.assert_frame_equal(out_df, expected_df)
 
     # Transform batch.
     pred_col_a = [1, 2, 3]
@@ -62,7 +62,31 @@ def test_min_max_scaler():
         }
     )
 
-    assert pred_out_df.equals(pred_expected_df)
+    pd.testing.assert_frame_equal(pred_out_df, pred_expected_df)
+
+    # append mode
+    with pytest.raises(ValueError):
+        MinMaxScaler(columns=["B", "C"], inplace=False)
+
+    scaler = MinMaxScaler(columns=["B", "C"], inplace=False, suffix="mm_scaled")
+    scaler.fit(ds)
+
+    pred_in_df = pd.DataFrame.from_dict(
+        {"A": pred_col_a, "B": pred_col_b, "C": pred_col_c}
+    )
+    pred_out_df = scaler.transform_batch(pred_in_df)
+
+    pred_expected_df = pd.DataFrame.from_dict(
+        {
+            "A": pred_col_a,
+            "B": pred_col_b,
+            "C": pred_col_c,
+            "B_mm_scaled": pred_processed_col_b,
+            "C_mm_scaled": pred_processed_col_c,
+        }
+    )
+
+    pd.testing.assert_frame_equal(pred_out_df, pred_expected_df)
 
 
 def test_max_abs_scaler():
@@ -93,7 +117,7 @@ def test_max_abs_scaler():
         {"A": processed_col_a, "B": processed_col_b, "C": processed_col_c}
     )
 
-    assert out_df.equals(expected_df)
+    pd.testing.assert_frame_equal(out_df, expected_df)
 
     # Transform batch.
     pred_col_a = [1, 2, 3]
@@ -116,7 +140,31 @@ def test_max_abs_scaler():
         }
     )
 
-    assert pred_out_df.equals(pred_expected_df)
+    pd.testing.assert_frame_equal(pred_out_df, pred_expected_df)
+
+    # append mode
+    with pytest.raises(ValueError):
+        MaxAbsScaler(columns=["B", "C"], inplace=False)
+
+    scaler = MaxAbsScaler(columns=["B", "C"], inplace=False, suffix="ma_scaled")
+    scaler.fit(ds)
+
+    pred_in_df = pd.DataFrame.from_dict(
+        {"A": pred_col_a, "B": pred_col_b, "C": pred_col_c}
+    )
+    pred_out_df = scaler.transform_batch(pred_in_df)
+
+    pred_expected_df = pd.DataFrame.from_dict(
+        {
+            "A": pred_col_a,
+            "B": pred_col_b,
+            "C": pred_col_c,
+            "B_ma_scaled": pred_processed_col_b,
+            "C_ma_scaled": pred_processed_col_c,
+        }
+    )
+
+    pd.testing.assert_frame_equal(pred_out_df, pred_expected_df)
 
 
 def test_robust_scaler():
@@ -154,7 +202,7 @@ def test_robust_scaler():
         {"A": processed_col_a, "B": processed_col_b, "C": processed_col_c}
     )
 
-    assert out_df.equals(expected_df)
+    pd.testing.assert_frame_equal(out_df, expected_df)
 
     # Transform batch.
     pred_col_a = [1, 2, 3]
@@ -177,7 +225,31 @@ def test_robust_scaler():
         }
     )
 
-    assert pred_out_df.equals(pred_expected_df)
+    pd.testing.assert_frame_equal(pred_out_df, pred_expected_df)
+
+    # append mode
+    with pytest.raises(ValueError):
+        RobustScaler(columns=["B", "C"], inplace=False)
+
+    scaler = RobustScaler(columns=["B", "C"], inplace=False, suffix="r_scaled")
+    scaler.fit(ds)
+
+    pred_in_df = pd.DataFrame.from_dict(
+        {"A": pred_col_a, "B": pred_col_b, "C": pred_col_c}
+    )
+    pred_out_df = scaler.transform_batch(pred_in_df)
+
+    pred_expected_df = pd.DataFrame.from_dict(
+        {
+            "A": pred_col_a,
+            "B": pred_col_b,
+            "C": pred_col_c,
+            "B_r_scaled": pred_processed_col_b,
+            "C_r_scaled": pred_processed_col_c,
+        }
+    )
+
+    pd.testing.assert_frame_equal(pred_out_df, pred_expected_df)
 
 
 def test_standard_scaler():
@@ -214,7 +286,7 @@ def test_standard_scaler():
         {"A": processed_col_a, "B": processed_col_b, "C": processed_col_c}
     )
 
-    assert out_df.equals(expected_df)
+    pd.testing.assert_frame_equal(out_df, expected_df)
 
     # Transform batch.
     pred_col_a = [1, 2, 3]
@@ -237,7 +309,31 @@ def test_standard_scaler():
         }
     )
 
-    assert pred_out_df.equals(pred_expected_df)
+    pd.testing.assert_frame_equal(pred_out_df, pred_expected_df)
+
+    # append mode
+    with pytest.raises(ValueError):
+        StandardScaler(columns=["B", "C"], inplace=False)
+
+    scaler = StandardScaler(columns=["B", "C"], inplace=False, suffix="r_scaled")
+    scaler.fit(ds)
+
+    pred_in_df = pd.DataFrame.from_dict(
+        {"A": pred_col_a, "B": pred_col_b, "C": pred_col_c}
+    )
+    pred_out_df = scaler.transform_batch(pred_in_df)
+
+    pred_expected_df = pd.DataFrame.from_dict(
+        {
+            "A": pred_col_a,
+            "B": pred_col_b,
+            "C": pred_col_c,
+            "B_r_scaled": pred_processed_col_b,
+            "C_r_scaled": pred_processed_col_c,
+        }
+    )
+
+    pd.testing.assert_frame_equal(pred_out_df, pred_expected_df)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is the first part of https://github.com/ray-project/ray/issues/48133. In this PR I extended the scalers to allow for appending the transformed results instead of overriding the columns. 

Opening this one to make sure we are all aligned on the approach. If all looks good I can go ahead and update docs and make the changes on the other preprocessors.

## Related issue number

https://github.com/ray-project/ray/issues/48133

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
