### PR TITLE
[core][chore] Use make_shared to create shared ptr if possible

### DIFF
--- a/src/mock/ray/core_worker/memory_store.h
+++ b/src/mock/ray/core_worker/memory_store.h
@@ -25,14 +25,16 @@ class DefaultCoreWorkerMemoryStoreWithThread : public CoreWorkerMemoryStore {
     std::unique_ptr<InstrumentedIOContextWithThread> io_context =
         std::make_unique<InstrumentedIOContextWithThread>(
             "DefaultCoreWorkerMemoryStoreWithThread");
-    return std::make_unique<DefaultCoreWorkerMemoryStoreWithThread>(std::move(io_context));
+    return std::make_unique<DefaultCoreWorkerMemoryStoreWithThread>(
+        std::move(io_context));
   }
 
   static std::shared_ptr<DefaultCoreWorkerMemoryStoreWithThread> CreateShared() {
     std::unique_ptr<InstrumentedIOContextWithThread> io_context =
         std::make_unique<InstrumentedIOContextWithThread>(
             "DefaultCoreWorkerMemoryStoreWithThread");
-    return std::make_shared<DefaultCoreWorkerMemoryStoreWithThread>(std::move(io_context));
+    return std::make_shared<DefaultCoreWorkerMemoryStoreWithThread>(
+        std::move(io_context));
   }
 
   ~DefaultCoreWorkerMemoryStoreWithThread() { io_context_->Stop(); }

--- a/src/mock/ray/core_worker/memory_store.h
+++ b/src/mock/ray/core_worker/memory_store.h
@@ -25,16 +25,20 @@ class DefaultCoreWorkerMemoryStoreWithThread : public CoreWorkerMemoryStore {
     std::unique_ptr<InstrumentedIOContextWithThread> io_context =
         std::make_unique<InstrumentedIOContextWithThread>(
             "DefaultCoreWorkerMemoryStoreWithThread");
-    return std::make_unique<DefaultCoreWorkerMemoryStoreWithThread>(
-        std::move(io_context));
+    // C++ limitation: std::make_unique cannot be used because std::unique_ptr cannot
+    // invoke private constructors.
+    return std::unique_ptr<DefaultCoreWorkerMemoryStoreWithThread>(
+        new DefaultCoreWorkerMemoryStoreWithThread(std::move(io_context)));
   }
 
   static std::shared_ptr<DefaultCoreWorkerMemoryStoreWithThread> CreateShared() {
     std::unique_ptr<InstrumentedIOContextWithThread> io_context =
         std::make_unique<InstrumentedIOContextWithThread>(
             "DefaultCoreWorkerMemoryStoreWithThread");
-    return std::make_shared<DefaultCoreWorkerMemoryStoreWithThread>(
-        std::move(io_context));
+    // C++ limitation: std::make_shared cannot be used because std::shared_ptr cannot
+    // invoke private constructors.
+    return std::shared_ptr<DefaultCoreWorkerMemoryStoreWithThread>(
+        new DefaultCoreWorkerMemoryStoreWithThread(std::move(io_context)));
   }
 
   ~DefaultCoreWorkerMemoryStoreWithThread() { io_context_->Stop(); }

--- a/src/mock/ray/core_worker/memory_store.h
+++ b/src/mock/ray/core_worker/memory_store.h
@@ -25,16 +25,14 @@ class DefaultCoreWorkerMemoryStoreWithThread : public CoreWorkerMemoryStore {
     std::unique_ptr<InstrumentedIOContextWithThread> io_context =
         std::make_unique<InstrumentedIOContextWithThread>(
             "DefaultCoreWorkerMemoryStoreWithThread");
-    return std::unique_ptr<DefaultCoreWorkerMemoryStoreWithThread>(
-        new DefaultCoreWorkerMemoryStoreWithThread(std::move(io_context)));
+    return std::make_unique<DefaultCoreWorkerMemoryStoreWithThread>(std::move(io_context));
   }
 
   static std::shared_ptr<DefaultCoreWorkerMemoryStoreWithThread> CreateShared() {
     std::unique_ptr<InstrumentedIOContextWithThread> io_context =
         std::make_unique<InstrumentedIOContextWithThread>(
             "DefaultCoreWorkerMemoryStoreWithThread");
-    return std::shared_ptr<DefaultCoreWorkerMemoryStoreWithThread>(
-        new DefaultCoreWorkerMemoryStoreWithThread(std::move(io_context)));
+    return std::make_shared<DefaultCoreWorkerMemoryStoreWithThread>(std::move(io_context));
   }
 
   ~DefaultCoreWorkerMemoryStoreWithThread() { io_context_->Stop(); }

--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -115,6 +115,8 @@ Status ConnectSocketRetry(local_stream_socket &socket,
 }
 
 std::shared_ptr<ServerConnection> ServerConnection::Create(local_stream_socket &&socket) {
+  // C++ limitation: std::make_shared cannot be used because std::shared_ptr cannot invoke
+  // protected constructors.
   std::shared_ptr<ServerConnection> self(new ServerConnection(std::move(socket)));
   return self;
 }
@@ -417,6 +419,8 @@ std::shared_ptr<ClientConnection> ClientConnection::Create(
     const std::string &debug_label,
     const std::vector<std::string> &message_type_enum_names,
     int64_t error_message_type) {
+  // C++ limitation: std::make_shared cannot be used because std::shared_ptr cannot invoke
+  // protected constructors.
   std::shared_ptr<ClientConnection> self(new ClientConnection(message_handler,
                                                               std::move(socket),
                                                               debug_label,

--- a/src/ray/common/test_util.cc
+++ b/src/ray/common/test_util.cc
@@ -261,7 +261,7 @@ std::shared_ptr<RayObject> GenerateRandomObject(
     ref.set_object_id(inlined_id.Binary());
     refs.push_back(ref);
   }
-  return std::shared_ptr<RayObject>(new RayObject(GenerateRandomBuffer(), nullptr, refs));
+  return std::make_shared<RayObject>(GenerateRandomBuffer(), nullptr, refs);
 }
 
 /// Path to redis server executable binary.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -413,8 +413,7 @@ std::shared_ptr<raylet::RayletClient> NodeManager::CreateRayletClient(
       rpc::NodeManagerWorkerClient::make(node_info->node_manager_address(),
                                          node_info->node_manager_port(),
                                          client_call_manager);
-  return std::shared_ptr<raylet::RayletClient>(
-      new raylet::RayletClient(std::move(grpc_client)));
+  return std::make_shared<raylet::RayletClient>(std::move(grpc_client));
 };
 
 bool NodeManager::IsWorkerDead(const WorkerID &worker_id, const NodeID &node_id) const {

--- a/src/ray/rpc/node_manager/node_manager_client.h
+++ b/src/ray/rpc/node_manager/node_manager_client.h
@@ -73,8 +73,8 @@ class NodeManagerWorkerClient
       const std::string &address,
       const int port,
       ClientCallManager &client_call_manager) {
-    // C++ limitation: std::make_shared cannot be used because std::shared_ptr cannot invoke
-    // private constructors.
+    // C++ limitation: std::make_shared cannot be used because std::shared_ptr cannot
+    // invoke private constructors.
     auto instance = new NodeManagerWorkerClient(address, port, client_call_manager);
     return std::shared_ptr<NodeManagerWorkerClient>(instance);
   }

--- a/src/ray/rpc/node_manager/node_manager_client.h
+++ b/src/ray/rpc/node_manager/node_manager_client.h
@@ -73,6 +73,8 @@ class NodeManagerWorkerClient
       const std::string &address,
       const int port,
       ClientCallManager &client_call_manager) {
+    // C++ limitation: std::make_shared cannot be used because std::shared_ptr cannot invoke
+    // private constructors.
     auto instance = new NodeManagerWorkerClient(address, port, client_call_manager);
     return std::shared_ptr<NodeManagerWorkerClient>(instance);
   }

--- a/src/ray/rpc/retryable_grpc_client.h
+++ b/src/ray/rpc/retryable_grpc_client.h
@@ -120,6 +120,8 @@ class RetryableGrpcClient : public std::enable_shared_from_this<RetryableGrpcCli
       uint64_t server_unavailable_timeout_seconds,
       std::function<void()> server_unavailable_timeout_callback,
       std::string server_name) {
+    // C++ limitation: std::make_shared cannot be used because std::shared_ptr cannot invoke
+    // private constructors.
     return std::shared_ptr<RetryableGrpcClient>(
         new RetryableGrpcClient(std::move(channel),
                                 io_context,
@@ -267,6 +269,8 @@ RetryableGrpcClient::RetryableGrpcRequest::Create(
   };
 
   return std::shared_ptr<RetryableGrpcClient::RetryableGrpcRequest>(
+      // C++ limitation: std::make_shared cannot be used because std::shared_ptr cannot invoke
+      // private constructors.
       new RetryableGrpcClient::RetryableGrpcRequest(
           std::move(executor), std::move(failure_callback), request_bytes, timeout_ms));
 }

--- a/src/ray/rpc/retryable_grpc_client.h
+++ b/src/ray/rpc/retryable_grpc_client.h
@@ -120,8 +120,8 @@ class RetryableGrpcClient : public std::enable_shared_from_this<RetryableGrpcCli
       uint64_t server_unavailable_timeout_seconds,
       std::function<void()> server_unavailable_timeout_callback,
       std::string server_name) {
-    // C++ limitation: std::make_shared cannot be used because std::shared_ptr cannot invoke
-    // private constructors.
+    // C++ limitation: std::make_shared cannot be used because std::shared_ptr cannot
+    // invoke private constructors.
     return std::shared_ptr<RetryableGrpcClient>(
         new RetryableGrpcClient(std::move(channel),
                                 io_context,
@@ -269,8 +269,8 @@ RetryableGrpcClient::RetryableGrpcRequest::Create(
   };
 
   return std::shared_ptr<RetryableGrpcClient::RetryableGrpcRequest>(
-      // C++ limitation: std::make_shared cannot be used because std::shared_ptr cannot invoke
-      // private constructors.
+      // C++ limitation: std::make_shared cannot be used because std::shared_ptr cannot
+      // invoke private constructors.
       new RetryableGrpcClient::RetryableGrpcRequest(
           std::move(executor), std::move(failure_callback), request_bytes, timeout_ms));
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This [YouTube video](https://www.youtube.com/watch?v=UOB7-B2MfwA) mentions that `make_shared` is better than `std::shared_ptr<MyClass>(new MyClass(...))` in two aspects:

* `make_shared` requires only one memory allocation.
* `make_shared` is exception-safe.

I quickly went through all lines of code matching `std::shared_ptr<` in the repo.

* Use `make_shared` if the constructor is accessible.
* Add comments similar to [this](https://github.com/ray-project/ray/blob/f186d61cd4c2bbb4b2dcd48fe486d03db09c017a/src/ray/raylet/runtime_env_agent_client.cc#L76) if the constructor is private or protected.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
