### PR TITLE
[core][chore] Fix the incorrect wording "bitset"

### DIFF
--- a/java/runtime/src/main/java/io/ray/runtime/object/ObjectStore.java
+++ b/java/runtime/src/main/java/io/ray/runtime/object/ObjectStore.java
@@ -167,7 +167,7 @@ public abstract class ObjectStore {
    *     returning it as ready. If false, ray.wait() will not trigger fetching of objects to the
    *     local node and will return immediately once the object is available anywhere in the
    *     cluster.
-   * @return A bitset that indicates each object has appeared or not.
+   * @return A list of booleans that indicates each object has appeared or not.
    */
   public abstract List<Boolean> wait(
       List<ObjectId> objectIds, int numObjects, long timeoutMs, boolean fetchLocal);

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -684,8 +684,8 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[in] IDs of the objects to wait for.
   /// \param[in] num_objects Number of objects that should appear.
   /// \param[in] timeout_ms Timeout in milliseconds, wait infinitely if it's negative.
-  /// \param[out] results A vector of booleans that indicates each object has appeared or not.
-  /// \return Status.
+  /// \param[out] results A vector of booleans that indicates each object has appeared or
+  /// not. \return Status.
   Status Wait(const std::vector<ObjectID> &object_ids,
               const int num_objects,
               const int64_t timeout_ms,

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -684,7 +684,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// \param[in] IDs of the objects to wait for.
   /// \param[in] num_objects Number of objects that should appear.
   /// \param[in] timeout_ms Timeout in milliseconds, wait infinitely if it's negative.
-  /// \param[out] results A bitset that indicates each object has appeared or not.
+  /// \param[out] results A vector of booleans that indicates each object has appeared or not.
   /// \return Status.
   Status Wait(const std::vector<ObjectID> &object_ids,
               const int num_objects,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Both Java and C++ have `BitSet`. In C++, `wait` uses `vector<bool>`, while in Java, it uses `List[Boolean]`. Although, broadly speaking, a bitset can be considered as representing `vector<bool>` since `vector<bool>` uses a single bit to store a boolean, in Java, `List[Boolean]` still uses a byte to store a boolean as far as I know. Therefore, a bitset is not an accurate equivalent in any case.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
