### PR TITLE
[core][compiled-graphs] CachedChannel's inner channel must be provided

### DIFF
--- a/python/ray/experimental/channel/cached_channel.py
+++ b/python/ray/experimental/channel/cached_channel.py
@@ -87,6 +87,7 @@ class CachedChannel(ChannelInterface):
 
     def close(self) -> None:
         from ray.experimental.channel import ChannelContext
+
         self._inner_channel.close()
         ctx = ChannelContext.get_current().serialization_context
         ctx.reset_data(self._channel_id)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In the Ray codebase, the `inner_channel` of `CachedChannel` is always provided in both the code and tests.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
