### PR TITLE
[core][chore] Remove unnecessary inline

### DIFF
--- a/src/ray/util/util.cc
+++ b/src/ray/util/util.cc
@@ -408,4 +408,36 @@ std::string FormatFloat(float value, int32_t precision) {
   return ss.str();
 }
 
+std::string GenerateUUIDV4() {
+  thread_local std::random_device rd;
+  thread_local std::mt19937 gen(rd());
+  std::uniform_int_distribution<> dis(0, 15);
+  std::uniform_int_distribution<> dis2(8, 11);
+
+  std::stringstream ss;
+  int i;
+  ss << std::hex;
+  for (i = 0; i < 8; i++) {
+    ss << dis(gen);
+  }
+  ss << "-";
+  for (i = 0; i < 4; i++) {
+    ss << dis(gen);
+  }
+  ss << "-4";
+  for (i = 0; i < 3; i++) {
+    ss << dis(gen);
+  }
+  ss << "-";
+  ss << dis2(gen);
+  for (i = 0; i < 3; i++) {
+    ss << dis(gen);
+  }
+  ss << "-";
+  for (i = 0; i < 12; i++) {
+    ss << dis(gen);
+  };
+  return ss.str();
+}
 }  // namespace ray
+

--- a/src/ray/util/util.cc
+++ b/src/ray/util/util.cc
@@ -440,4 +440,3 @@ std::string GenerateUUIDV4() {
   return ss.str();
 }
 }  // namespace ray
-

--- a/src/ray/util/util.cc
+++ b/src/ray/util/util.cc
@@ -382,32 +382,6 @@ std::shared_ptr<absl::flat_hash_map<std::string, std::string>> ParseURL(std::str
   return result;
 }
 
-namespace ray {
-
-bool IsRayletFailed(const std::string &raylet_pid) {
-  auto should_shutdown = false;
-  if (!raylet_pid.empty()) {
-    auto pid = static_cast<pid_t>(std::stoi(raylet_pid));
-    if (!IsProcessAlive(pid)) {
-      should_shutdown = true;
-    }
-  } else if (!IsParentProcessAlive()) {
-    should_shutdown = true;
-  }
-  return should_shutdown;
-}
-
-void QuickExit() {
-  ray::RayLog::ShutDownRayLog();
-  _Exit(1);
-}
-
-std::string FormatFloat(float value, int32_t precision) {
-  std::stringstream ss;
-  ss << std::fixed << std::setprecision(precision) << value;
-  return ss.str();
-}
-
 std::string GenerateUUIDV4() {
   thread_local std::random_device rd;
   thread_local std::mt19937 gen(rd());
@@ -439,4 +413,31 @@ std::string GenerateUUIDV4() {
   };
   return ss.str();
 }
+
+namespace ray {
+
+bool IsRayletFailed(const std::string &raylet_pid) {
+  auto should_shutdown = false;
+  if (!raylet_pid.empty()) {
+    auto pid = static_cast<pid_t>(std::stoi(raylet_pid));
+    if (!IsProcessAlive(pid)) {
+      should_shutdown = true;
+    }
+  } else if (!IsParentProcessAlive()) {
+    should_shutdown = true;
+  }
+  return should_shutdown;
+}
+
+void QuickExit() {
+  ray::RayLog::ShutDownRayLog();
+  _Exit(1);
+}
+
+std::string FormatFloat(float value, int32_t precision) {
+  std::stringstream ss;
+  ss << std::fixed << std::setprecision(precision) << value;
+  return ss.str();
+}
+
 }  // namespace ray

--- a/src/ray/util/util.h
+++ b/src/ray/util/util.h
@@ -147,37 +147,8 @@ inline int64_t current_sys_time_us() {
   return mu_since_epoch.count();
 }
 
-inline std::string GenerateUUIDV4() {
-  thread_local std::random_device rd;
-  thread_local std::mt19937 gen(rd());
-  std::uniform_int_distribution<> dis(0, 15);
-  std::uniform_int_distribution<> dis2(8, 11);
-
-  std::stringstream ss;
-  int i;
-  ss << std::hex;
-  for (i = 0; i < 8; i++) {
-    ss << dis(gen);
-  }
-  ss << "-";
-  for (i = 0; i < 4; i++) {
-    ss << dis(gen);
-  }
-  ss << "-4";
-  for (i = 0; i < 3; i++) {
-    ss << dis(gen);
-  }
-  ss << "-";
-  ss << dis2(gen);
-  for (i = 0; i < 3; i++) {
-    ss << dis(gen);
-  }
-  ss << "-";
-  for (i = 0; i < 12; i++) {
-    ss << dis(gen);
-  };
-  return ss.str();
-}
+// Change from inline definition to declaration
+std::string GenerateUUIDV4();
 
 /// A helper function to parse command-line arguments in a platform-compatible manner.
 ///

--- a/src/ray/util/util.h
+++ b/src/ray/util/util.h
@@ -147,7 +147,6 @@ inline int64_t current_sys_time_us() {
   return mu_since_epoch.count();
 }
 
-// Change from inline definition to declaration
 std::string GenerateUUIDV4();
 
 /// A helper function to parse command-line arguments in a platform-compatible manner.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

1. In modern C++, the `inline` specifier is just a request rather than a command, meaning the compiler may treat a function with the `inline` specifier as a normal function and may also inline a function even if it doesn't have the `inline` specifier. Typically, `inline` specifier is used more for avoiding C++ ODR issues rather than for improving performance in modern C++.

2. It's not common to `inline` a long function because the overhead of a function call is not significant compared to the function's execution. In addition, it will increase the size of executable.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

```cpp
#include <iostream>
#include <string>
#include <random>
#include <sstream>

inline std::string GenerateUUIDV4() {
    thread_local std::random_device rd;
    thread_local std::mt19937 gen(rd());
    std::uniform_int_distribution<> dis(0, 15);
    std::uniform_int_distribution<> dis2(8, 11);

    std::stringstream ss;
    int i;
    ss << std::hex;
    for (i = 0; i < 8; i++) {
        ss << dis(gen);
    }
    ss << "-";
    for (i = 0; i < 4; i++) {
        ss << dis(gen);
    }
    ss << "-4";
    for (i = 0; i < 3; i++) {
        ss << dis(gen);
    }
    ss << "-";
    ss << dis2(gen);
    for (i = 0; i < 3; i++) {
        ss << dis(gen);
    }
    ss << "-";
    for (i = 0; i < 12; i++) {
        ss << dis(gen);
    };
    return ss.str();
}

int main() {
    std::cout << GenerateUUIDV4() << std::endl;
}
```
* `g++ -S main.cpp` / `g++ -O2 -S main.cpp` / `g++ -O3 -S main.cpp`
* Check the assembly files.
* Check the screenshots. All of them use `call`, which means the compiler didn't inline the function even though I added the inline specifier.
  * `g++ -S main.cpp`
     <img width="533" alt="Screenshot 2024-12-25 at 11 32 33 AM" src="https://github.com/user-attachments/assets/6b674815-35ac-4839-89f0-891ff6be0fbe" />
  * `g++ -O2 -S main.cpp`
    <img width="554" alt="Screenshot 2024-12-25 at 11 33 56 AM" src="https://github.com/user-attachments/assets/ec9b876d-098c-4d41-9a2c-c75d7effad04" />
  * `g++ -O3 -S main.cpp`
    <img width="452" alt="Screenshot 2024-12-25 at 11 34 13 AM" src="https://github.com/user-attachments/assets/54b15996-8cc6-4d2f-ab32-7ae2eebb577b" />


- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
