### PR TITLE
[core] [easy] [no-op] Fix comment for scheduling id and apply thread annotation

### DIFF
--- a/src/ray/common/scheduling/scheduling_ids.cc
+++ b/src/ray/common/scheduling/scheduling_ids.cc
@@ -21,9 +21,8 @@ int64_t StringIdMap::Get(const std::string &string_id) const {
   auto it = string_to_int_.find(string_id);
   if (it == string_to_int_.end()) {
     return -1;
-  } else {
-    return it->second;
   }
+  return it->second;
 };
 
 std::string StringIdMap::Get(uint64_t id) const {
@@ -44,7 +43,7 @@ int64_t StringIdMap::Insert(const std::string &string_id, uint8_t max_id) {
   if (sit == string_to_int_.end()) {
     int64_t id = hasher_(string_id);
     if (max_id != 0) {
-      id = id % MAX_ID_TEST;
+      id = id % kMaxIdForTest;
     }
     for (size_t i = 0; true; i++) {
       auto it = int_to_string_.find(id);
@@ -60,9 +59,8 @@ int64_t StringIdMap::Insert(const std::string &string_id, uint8_t max_id) {
       }
     }
     return id;
-  } else {
-    return sit->second;
   }
+  return sit->second;
 };
 
 StringIdMap &StringIdMap::InsertOrDie(const std::string &string_id, int64_t value) {

--- a/src/ray/common/scheduling/scheduling_ids.cc
+++ b/src/ray/common/scheduling/scheduling_ids.cc
@@ -43,7 +43,7 @@ int64_t StringIdMap::Insert(const std::string &string_id, uint8_t max_id) {
   if (sit == string_to_int_.end()) {
     int64_t id = hasher_(string_id);
     if (max_id != 0) {
-      id = id % kMaxIdForTest;
+      id = id % max_id;
     }
     for (size_t i = 0; true; i++) {
       auto it = int_to_string_.find(id);

--- a/src/ray/common/scheduling/scheduling_ids.h
+++ b/src/ray/common/scheduling/scheduling_ids.h
@@ -27,7 +27,7 @@
 #include "ray/util/util.h"
 
 /// Limit the ID range to test for collisions.
-#define MAX_ID_TEST 8
+inline constexpr int kMaxIdForTest = 8;
 
 namespace ray {
 
@@ -48,14 +48,9 @@ const std::string kBundle_ResourceLabel = "bundle";
 
 /// Class to map string IDs to unique integer IDs and back.
 class StringIdMap {
-  absl::flat_hash_map<std::string, int64_t> string_to_int_;
-  absl::flat_hash_map<int64_t, std::string> int_to_string_;
-  std::hash<std::string> hasher_;
-  mutable absl::Mutex mutex_;
-
  public:
-  StringIdMap(){};
-  ~StringIdMap(){};
+  StringIdMap() {}
+  ~StringIdMap() = default;
 
   /// Get integer ID associated with an existing string ID.
   ///
@@ -73,7 +68,7 @@ class StringIdMap {
   ///
   /// \param String ID to be inserted.
   /// \param max_id The number of unique possible ids. This is used
-  ///               to force collisions for testing. If -1, it is not used.
+  ///               to force collisions for testing. If 0, it is not used.
   /// \return The integer ID associated with string ID string_id.
   int64_t Insert(const std::string &string_id, uint8_t num_ids = 0);
 
@@ -86,6 +81,12 @@ class StringIdMap {
 
   /// Get number of identifiers.
   int64_t Count();
+
+ private:
+  absl::flat_hash_map<std::string, int64_t> string_to_int_ ABSL_GUARDED_BY(mutex_);
+  absl::flat_hash_map<int64_t, std::string> int_to_string_ ABSL_GUARDED_BY(mutex_);
+  const std::hash<std::string> hasher_{};
+  mutable absl::Mutex mutex_;
 };
 
 enum class SchedulingIDTag { Node, Resource };

--- a/src/ray/common/scheduling/scheduling_ids.h
+++ b/src/ray/common/scheduling/scheduling_ids.h
@@ -26,9 +26,6 @@
 #include "ray/util/logging.h"
 #include "ray/util/util.h"
 
-/// Limit the ID range to test for collisions.
-inline constexpr int kMaxIdForTest = 8;
-
 namespace ray {
 
 /// List of predefined resources.


### PR DESCRIPTION
Changes behavior of StringIdMap::Insert to recognize max_id. This param is only used by unit tests.