### PR TITLE
[core] Move task spec

### DIFF
--- a/src/ray/common/task/task.cc
+++ b/src/ray/common/task/task.cc
@@ -18,7 +18,8 @@
 
 namespace ray {
 
-RayTask::RayTask(rpc::Task message) : task_spec_(std::move(*message.mutable_task_spec())) {
+RayTask::RayTask(rpc::Task message)
+    : task_spec_(std::move(*message.mutable_task_spec())) {
   ComputeDependencies();
 }
 

--- a/src/ray/common/task/task.cc
+++ b/src/ray/common/task/task.cc
@@ -18,7 +18,7 @@
 
 namespace ray {
 
-RayTask::RayTask(const rpc::Task &message) : task_spec_(message.task_spec()) {
+RayTask::RayTask(rpc::Task message) : task_spec_(std::move(*message.mutable_task_spec())) {
   ComputeDependencies();
 }
 

--- a/src/ray/common/task/task.h
+++ b/src/ray/common/task/task.h
@@ -36,7 +36,7 @@ class RayTask {
   /// Construct a `RayTask` object from a protobuf message.
   ///
   /// \param message The protobuf message.
-  explicit RayTask(const rpc::Task &message);
+  explicit RayTask(rpc::Task message);
 
   /// Construct a `RayTask` object from a `TaskSpecification`.
   explicit RayTask(TaskSpecification task_spec);

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1881,7 +1881,7 @@ void NodeManager::HandleRequestWorkerLease(rpc::RequestWorkerLeaseRequest reques
                                            rpc::SendReplyCallback send_reply_callback) {
   rpc::Task task_message;
   task_message.mutable_task_spec()->CopyFrom(request.resource_spec());
-  RayTask task(task_message);
+  RayTask task(std::move(task_message));
 
   const auto caller_worker =
       WorkerID::FromBinary(task.GetTaskSpecification().CallerAddress().worker_id());

--- a/src/ray/raylet/scheduling/internal.h
+++ b/src/ray/raylet/scheduling/internal.h
@@ -20,10 +20,7 @@
 #include "ray/common/task/task_common.h"
 #include "src/ray/protobuf/node_manager.pb.h"
 
-namespace ray {
-namespace raylet {
-
-namespace internal {
+namespace ray::raylet::internal {
 
 enum class WorkStatus {
   /// Waiting to be scheduled.
@@ -56,8 +53,8 @@ enum class UnscheduledWorkCause {
 class Work {
  public:
   RayTask task;
-  const bool grant_or_reject;
-  const bool is_selected_based_on_locality;
+  bool grant_or_reject;
+  bool is_selected_based_on_locality;
   rpc::RequestWorkerLeaseReply *reply;
   std::function<void(void)> callback;
   std::shared_ptr<TaskResourceInstances> allocated_instances;
@@ -67,11 +64,11 @@ class Work {
        rpc::RequestWorkerLeaseReply *reply,
        std::function<void(void)> callback,
        WorkStatus status = WorkStatus::WAITING)
-      : task(task),
+      : task(std::move(task)),
         grant_or_reject(grant_or_reject),
         is_selected_based_on_locality(is_selected_based_on_locality),
         reply(reply),
-        callback(callback),
+        callback(std::move(callback)),
         allocated_instances(nullptr),
         status_(status){};
   Work(const Work &Work) = delete;
@@ -104,9 +101,6 @@ class Work {
       UnscheduledWorkCause::WAITING_FOR_RESOURCE_ACQUISITION;
 };
 
-typedef std::function<const rpc::GcsNodeInfo *(const NodeID &node_id)> NodeInfoGetter;
+using NodeInfoGetter = std::function<const rpc::GcsNodeInfo *(const NodeID &node_id)>;
 
-}  // namespace internal
-
-}  // namespace raylet
-}  // namespace ray
+}  // namespace ray::raylet::internal


### PR DESCRIPTION
Still debugging runtime env performance issue, found we copy task spec around when constructing `RayTask`.

How I make sure no other usage:
```
[~/ray] (master) 
ubuntu@hjiang-devbox-pg$ git grep "RayTask>" -- "*.cc" | grep -v test
<no result>

[~/ray] (hjiang/blank-out-runtime-env-override) 
ubuntu@hjiang-devbox-pg$ git grep "RayTask " -- "*.cc" | grep -v test
src/ray/gcs/gcs_server/gcs_actor_scheduler.cc:  RayTask task(actor->GetCreationTaskSpecification(),
src/ray/raylet/local_task_manager.cc:        RAY_LOG(DEBUG) << "RayTask " << task_id
src/ray/raylet/local_task_manager.cc:void LocalTaskManager::RemoveFromRunningTasksIfExists(const RayTask &task) {
src/ray/raylet/local_task_manager.cc:                                    RayTask *task) {
src/ray/raylet/local_task_manager.cc:            << "RayTask " << spec.TaskId() << " argument " << deps[i]
src/ray/raylet/local_task_manager.cc:  RAY_LOG(DEBUG) << "RayTask " << spec.TaskId() << " has args of size " << task_arg_bytes;
src/ray/raylet/local_task_manager.cc:    RayTask *exemplar,
src/ray/raylet/local_task_manager.cc:    const RayTask &task,
src/ray/raylet/node_manager.cc:  auto announce_infeasible_task = [this](const RayTask &task) {
src/ray/raylet/node_manager.cc:  ray::RayTask exemplar;
src/ray/raylet/node_manager.cc:        RayTask task;
src/ray/raylet/node_manager.cc:                      << " RayTask ID: " << task_id
src/ray/raylet/node_manager.cc:  RayTask task(task_message);
src/ray/raylet/node_manager.cc:  RayTask task;
src/ray/raylet/node_manager.cc:                                                  const RayTask &task) {
src/ray/raylet/node_manager.cc:void NodeManager::PublishInfeasibleTaskError(const RayTask &task) const {
src/ray/raylet/scheduling/cluster_task_manager.cc:    std::function<void(const RayTask &)> announce_infeasible_task,
src/ray/raylet/scheduling/cluster_task_manager.cc:    const RayTask &task,
src/ray/raylet/scheduling/cluster_task_manager.cc:      RayTask task = work->task;
src/ray/raylet/scheduling/cluster_task_manager.cc:      const RayTask task = work->task;
src/ray/raylet/scheduling/cluster_task_manager.cc:    RayTask task = work->task;
src/ray/raylet/scheduling/cluster_task_manager.cc:    RayTask *exemplar,
```

I checked all above usage.