### PR TITLE
[doc] [easy] Update `compute` to `concurrency` in the code examples.

### DIFF
--- a/doc/source/_templates/index.html
+++ b/doc/source/_templates/index.html
@@ -84,9 +84,8 @@
 
   # Use 2 parallel actors for inference. Each actor predicts on a
   # different partition of data.
-  scale = ray.data.ActorPoolStrategy(size=2)
   # Step 3: Map the Predictor over the Dataset to get predictions.
-  predictions = ds.map_batches(HuggingFacePredictor, compute=scale)
+  predictions = ds.map_batches(HuggingFacePredictor, concurrency=2)
   # Step 4: Show one prediction output.
   predictions.show(limit=1)
             ''') }}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Update the code samples to the latest format for batch inference as the argument `compute` is deprecated in Ray 2.9

