### PR TITLE
[data] add dataloader for lance datasource

### DIFF
--- a/python/requirements/ml/data-requirements.txt
+++ b/python/requirements/ml/data-requirements.txt
@@ -13,4 +13,5 @@ pandas==1.5.3; python_version < '3.12'
 modin==0.31.0; python_version >= '3.12'
 pandas==2.2.2; python_version >= '3.12'
 responses==0.13.4
+torch==2.3.0
 pymars>=0.8.3; python_version < "3.12"

--- a/python/requirements/ml/data-test-requirements.txt
+++ b/python/requirements/ml/data-test-requirements.txt
@@ -14,6 +14,7 @@ google-api-core==1.34.0
 webdataset
 raydp==1.7.0b20231020.dev0
 pylance
+torch==2.3.0
 delta-sharing
 pytest-mock
 decord

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -1598,6 +1598,8 @@ pyjwt==2.8.0
     #   snowflake-connector-python
 pylance==0.10.18
     # via -r /ray/ci/../python/requirements/ml/data-test-requirements.txt
+torch==2.3.0
+    # via -r /ray/ci/../python/requirements/ml/data-test-requirements.txt
 pymars==0.10.0 ; python_version < "3.12"
     # via -r /ray/ci/../python/requirements/ml/data-requirements.txt
 pymongo==4.3.2


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The storage format of lance will be used in multimodal preprocessing and training. When used for training, it needs to be loaded by Dataloader. Here are two relatively important characteristics:
1. lance supports point query and can be randomly shuffled.
2. After lance is adapted to dataloader, it can load data in a streaming manner to prevent memory overflow and excessive loading time of training data.

Therefore, this provides how lance can form a Dataset for torch Dataloader implementation, enabling the unification of ray train and ray data.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
