### PR TITLE
[core] Fix GCS health check manager TSAN

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_health_check_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_health_check_manager.cc
@@ -26,6 +26,22 @@ DEFINE_stats(health_check_rpc_latency_ms,
 
 namespace ray::gcs {
 
+/*static*/ std::shared_ptr<GcsHealthCheckManager> GcsHealthCheckManager::Create(
+    instrumented_io_context &io_service,
+    std::function<void(const NodeID &)> on_node_death_callback,
+    int64_t initial_delay_ms,
+    int64_t timeout_ms,
+    int64_t period_ms,
+    int64_t failure_threshold) {
+  return std::shared_ptr<GcsHealthCheckManager>(
+      new GcsHealthCheckManager(io_service,
+                                std::move(on_node_death_callback),
+                                initial_delay_ms,
+                                timeout_ms,
+                                period_ms,
+                                failure_threshold));
+}
+
 GcsHealthCheckManager::GcsHealthCheckManager(
     instrumented_io_context &io_service,
     std::function<void(const NodeID &)> on_node_death_callback,

--- a/src/ray/gcs/gcs_server/gcs_health_check_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_health_check_manager.h
@@ -44,7 +44,7 @@ namespace ray::gcs {
 /// TODO (iycheng): Move the GcsHealthCheckManager to ray/common.
 class GcsHealthCheckManager : public std::enable_shared_from_this<GcsHealthCheckManager> {
  public:
-  /// Constructor of GcsHealthCheckManager.
+  /// Factory constructor of GcsHealthCheckManager.
   ///
   /// \param io_service The thread where all operations in this class should run.
   /// \param on_node_death_callback The callback function when some node is marked as
@@ -53,7 +53,7 @@ class GcsHealthCheckManager : public std::enable_shared_from_this<GcsHealthCheck
   /// \param period_ms The interval between two health checks for the same node.
   /// \param failure_threshold The threshold before a node will be marked as dead due to
   /// health check failure.
-  GcsHealthCheckManager(
+  static std::shared_ptr<GcsHealthCheckManager> Create(
       instrumented_io_context &io_service,
       std::function<void(const NodeID &)> on_node_death_callback,
       int64_t initial_delay_ms = RayConfig::instance().health_check_initial_delay_ms(),
@@ -89,6 +89,13 @@ class GcsHealthCheckManager : public std::enable_shared_from_this<GcsHealthCheck
   void MarkNodeHealthy(const NodeID &node_id);
 
  private:
+  GcsHealthCheckManager(instrumented_io_context &io_service,
+                        std::function<void(const NodeID &)> on_node_death_callback,
+                        int64_t initial_delay_ms,
+                        int64_t timeout_ms,
+                        int64_t period_ms,
+                        int64_t failure_threshold);
+
   /// Fail a node when health check failed. It'll stop the health checking and
   /// call `on_node_death_callback_`.
   ///

--- a/src/ray/gcs/gcs_server/gcs_health_check_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_health_check_manager.h
@@ -111,14 +111,14 @@ class GcsHealthCheckManager : public std::enable_shared_from_this<GcsHealthCheck
     HealthCheckContext(std::shared_ptr<GcsHealthCheckManager> manager,
                        std::shared_ptr<grpc::Channel> channel,
                        NodeID node_id)
-        : manager_(std::move(manager)),
+        : manager_(manager),
           node_id_(node_id),
-          timer_(manager_->io_service_),
-          health_check_remaining_(manager_->failure_threshold_) {
+          timer_(manager->io_service_),
+          health_check_remaining_(manager->failure_threshold_) {
       request_.set_service(node_id.Hex());
       stub_ = grpc::health::v1::Health::NewStub(channel);
       timer_.expires_from_now(
-          boost::posix_time::milliseconds(manager_->initial_delay_ms_));
+          boost::posix_time::milliseconds(manager->initial_delay_ms_));
       timer_.async_wait([this](auto) { StartHealthCheck(); });
     }
 
@@ -131,7 +131,7 @@ class GcsHealthCheckManager : public std::enable_shared_from_this<GcsHealthCheck
    private:
     void StartHealthCheck();
 
-    std::shared_ptr<GcsHealthCheckManager> manager_;
+    std::weak_ptr<GcsHealthCheckManager> manager_;
 
     NodeID node_id_;
 

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -297,7 +297,7 @@ void GcsServer::InitGcsHealthCheckManager(const GcsInitData &gcs_init_data) {
         "GcsServer.NodeDeathCallback");
   };
 
-  gcs_healthcheck_manager_ = std::make_shared<GcsHealthCheckManager>(
+  gcs_healthcheck_manager_ = GcsHealthCheckManager::Create(
       io_context_provider_.GetDefaultIOContext(), node_death_callback);
   for (const auto &item : gcs_init_data.Nodes()) {
     if (item.second.state() == rpc::GcsNodeInfo::ALIVE) {

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -297,7 +297,7 @@ void GcsServer::InitGcsHealthCheckManager(const GcsInitData &gcs_init_data) {
         "GcsServer.NodeDeathCallback");
   };
 
-  gcs_healthcheck_manager_ = std::make_unique<GcsHealthCheckManager>(
+  gcs_healthcheck_manager_ = std::make_shared<GcsHealthCheckManager>(
       io_context_provider_.GetDefaultIOContext(), node_death_callback);
   for (const auto &item : gcs_init_data.Nodes()) {
     if (item.second.state() == rpc::GcsNodeInfo::ALIVE) {

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -244,7 +244,7 @@ class GcsServer {
   /// The gcs node manager.
   std::unique_ptr<GcsNodeManager> gcs_node_manager_;
   /// The health check manager.
-  std::unique_ptr<GcsHealthCheckManager> gcs_healthcheck_manager_;
+  std::shared_ptr<GcsHealthCheckManager> gcs_healthcheck_manager_;
   /// The gcs redis failure detector.
   std::unique_ptr<GcsRedisFailureDetector> gcs_redis_failure_detector_;
   /// The gcs placement group manager.

--- a/src/ray/gcs/gcs_server/test/gcs_health_check_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_health_check_manager_test.cc
@@ -57,7 +57,7 @@ class GcsHealthCheckManagerTest : public ::testing::Test {
   void SetUp() override {
     grpc::EnableDefaultHealthCheckService(true);
 
-    health_check = std::make_shared<gcs::GcsHealthCheckManager>(
+    health_check = gcs::GcsHealthCheckManager::Create(
         io_service,
         [this](const NodeID &id) { dead_nodes.insert(id); },
         initial_delay_ms,

--- a/src/ray/gcs/gcs_server/test/gcs_health_check_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_health_check_manager_test.cc
@@ -52,11 +52,12 @@ using namespace std::literals::chrono_literals;
 
 class GcsHealthCheckManagerTest : public ::testing::Test {
  protected:
-  GcsHealthCheckManagerTest() {}
+  GcsHealthCheckManagerTest() = default;
+  ~GcsHealthCheckManagerTest() = default;
   void SetUp() override {
     grpc::EnableDefaultHealthCheckService(true);
 
-    health_check = std::make_unique<gcs::GcsHealthCheckManager>(
+    health_check = std::make_shared<gcs::GcsHealthCheckManager>(
         io_service,
         [this](const NodeID &id) { dead_nodes.insert(id); },
         initial_delay_ms,
@@ -132,7 +133,7 @@ class GcsHealthCheckManagerTest : public ::testing::Test {
   }
 
   instrumented_io_context io_service;
-  std::unique_ptr<gcs::GcsHealthCheckManager> health_check;
+  std::shared_ptr<gcs::GcsHealthCheckManager> health_check;
   std::unordered_map<NodeID, std::shared_ptr<rpc::GrpcServer>> servers;
   std::unordered_set<NodeID> dead_nodes;
   const int64_t initial_delay_ms = 100;


### PR DESCRIPTION
Fix issue: https://github.com/ray-project/ray/issues/49469

The bug is:
- We have two eventloops in the GCS health check manager, one for asio io context, one for grpc
- In the unit test and production code elsewhere, we only synchronize on io context by `io_context::stop`, but not grpc
- leading to grpc still accessing `GcsHealthCheckManager`, while we **mistakenly think** all async operation have been properly synchronized

In this PR, I use shared pointer to make sure all accesses to gcs health check manager is valid, even if io context has been stopped. Also contain a fix to data member declaration order to respect the usage dependency.