### PR TITLE
Fix bazel installation for github codespace

### DIFF
--- a/ci/env/install-bazel.sh
+++ b/ci/env/install-bazel.sh
@@ -121,7 +121,3 @@ if [[ "${CI-}" == "true" ]]; then
     fi
   fi
 fi
-
-# Append bazel executable directory to system `PATH`.
-BAZEL_EXEC_BIN=$(dirname "$(which bazel)")
-echo "export PATH=${BAZEL_EXEC_BIN}:\$PATH" >> ~/.bashrc

--- a/ci/env/install-bazel.sh
+++ b/ci/env/install-bazel.sh
@@ -109,7 +109,7 @@ if [[ "${CI-}" == "true" ]]; then
   if [[ "${OSTYPE}" == msys ]]; then
     echo "startup --output_user_root=c:/tmp" >> ~/.bazelrc
   fi
-  
+
   if [[ "${platform}" == darwin ]]; then
     echo "Using local disk cache on mac"
     echo "build --disk_cache=/tmp/bazel-cache" >> ~/.bazelrc
@@ -121,3 +121,7 @@ if [[ "${CI-}" == "true" ]]; then
     fi
   fi
 fi
+
+# Append bazel executable directory to system `PATH`.
+BAZEL_EXEC_BIN=$(dirname "$(which bazel)")
+echo "export PATH=${BAZEL_EXEC_BIN}:\$PATH" >> ~/.bashrc

--- a/doc/source/ray-contribute/development.rst
+++ b/doc/source/ray-contribute/development.rst
@@ -140,6 +140,7 @@ To build Ray on Ubuntu, run the following commands:
 
 .. note::
   The `install-bazel.sh` script installs `bazelisk` for building Ray.
+  It's worth noticing `bazel` is installed at `$HOME/bin/bazel`, please make sure it's on the executable `PATH`.
   If you prefer to use `bazel`, only version `6.5.0` is currently supported.
 
 For RHELv8 (Redhat EL 8.0-64 Minimal), run the following commands:


### PR DESCRIPTION
Fix issue: https://github.com/ray-project/ray/issues/49470

The problem is: not all the platform defaults binary installation to default system executable path, so we have to append them manually to the `PATH`.