### PR TITLE
[core] Fix gcs member dependency order

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -458,17 +458,18 @@ void GcsNodeManager::Initialize(const GcsInitData &gcs_init_data) {
       sorted_dead_node_list_.emplace_back(node_id, node_info.end_time_ms());
     }
   }
-  sorted_dead_node_list_.sort(
-      [](const std::pair<NodeID, int64_t> &left,
-         const std::pair<NodeID, int64_t> &right) { return left.second < right.second; });
+  std::sort(
+      sorted_dead_node_list_.begin(),
+      sorted_dead_node_list_.end(),
+      [](const auto &left, const auto &right) { return left.second < right.second; });
 }
 
 void GcsNodeManager::AddDeadNodeToCache(std::shared_ptr<rpc::GcsNodeInfo> node) {
   if (dead_nodes_.size() >= RayConfig::instance().maximum_gcs_dead_node_cached_count()) {
-    const auto &node_id = sorted_dead_node_list_.begin()->first;
+    const auto &node_id = sorted_dead_node_list_.front().first;
     RAY_CHECK_OK(gcs_table_storage_->NodeTable().Delete(node_id, nullptr));
-    dead_nodes_.erase(sorted_dead_node_list_.begin()->first);
-    sorted_dead_node_list_.erase(sorted_dead_node_list_.begin());
+    dead_nodes_.erase(sorted_dead_node_list_.front().first);
+    sorted_dead_node_list_.pop_front();
   }
   auto node_id = NodeID::FromBinary(node->node_id());
   dead_nodes_.emplace(node_id, node);

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -19,6 +19,7 @@
 #include <boost/bimap.hpp>
 #include <boost/bimap/unordered_multiset_of.hpp>
 #include <boost/bimap/unordered_set_of.hpp>
+#include <deque>
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
@@ -34,8 +35,7 @@
 #include "ray/util/event.h"
 #include "src/ray/protobuf/gcs.pb.h"
 
-namespace ray {
-namespace gcs {
+namespace ray::gcs {
 
 class GcsAutoscalerStateManagerTest;
 class GcsStateTest;
@@ -235,8 +235,8 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   /// Dead nodes.
   absl::flat_hash_map<NodeID, std::shared_ptr<rpc::GcsNodeInfo>> dead_nodes_;
   /// The nodes are sorted according to the timestamp, and the oldest is at the head of
-  /// the list.
-  std::list<std::pair<NodeID, int64_t>> sorted_dead_node_list_;
+  /// the deque.
+  std::deque<std::pair<NodeID, int64_t>> sorted_dead_node_list_;
   /// Listeners which monitors the addition of nodes.
   std::vector<std::function<void(std::shared_ptr<rpc::GcsNodeInfo>)>>
       node_added_listeners_;
@@ -271,5 +271,4 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   friend GcsStateTest;
 };
 
-}  // namespace gcs
-}  // namespace ray
+}  // namespace ray::gcs

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -284,8 +284,8 @@ void GcsServer::InitGcsNodeManager(const GcsInitData &gcs_init_data) {
   // Initialize by gcs tables data.
   gcs_node_manager_->Initialize(gcs_init_data);
   // Register service.
-  node_info_service_.reset(new rpc::NodeInfoGrpcService(
-      io_context_provider_.GetDefaultIOContext(), *gcs_node_manager_));
+  node_info_service_ = std::make_unique<rpc::NodeInfoGrpcService>(
+      io_context_provider_.GetDefaultIOContext(), *gcs_node_manager_);
   rpc_server_.RegisterService(*node_info_service_);
 }
 

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -241,6 +241,8 @@ class GcsServer {
   std::unique_ptr<GcsResourceManager> gcs_resource_manager_;
   /// The autoscaler state manager.
   std::unique_ptr<GcsAutoscalerStateManager> gcs_autoscaler_state_manager_;
+  /// A publisher for publishing gcs messages.
+  std::unique_ptr<GcsPublisher> gcs_publisher_;
   /// The gcs node manager.
   std::unique_ptr<GcsNodeManager> gcs_node_manager_;
   /// The health check manager.
@@ -254,8 +256,6 @@ class GcsServer {
   /// The gcs placement group scheduler.
   /// [gcs_placement_group_scheduler_] depends on [raylet_client_pool_].
   std::unique_ptr<GcsPlacementGroupScheduler> gcs_placement_group_scheduler_;
-  /// A publisher for publishing gcs messages.
-  std::unique_ptr<GcsPublisher> gcs_publisher_;
   /// Function table manager.
   std::unique_ptr<GcsFunctionManager> function_manager_;
   /// Stores references to URIs stored by the GCS for runtime envs.


### PR DESCRIPTION
Two changes in this PR:
- Fix GCS data member declaration order based on their dependency (node manager depends on publisher)
- Use `std::deque` instead of `std::list` to manage dead node list