### PR TITLE
[core] Use `ActorState_Name` to print `ActorState`

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -1036,7 +1036,8 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id,
   const auto actor = it->second;
 
   RAY_LOG(DEBUG) << "Try to kill actor " << actor->GetActorID() << ", with status "
-                 << actor->GetState() << ", name " << actor->GetName();
+                 << rpc::ActorTableData::ActorState_Name(actor->GetState()) << ", name "
+                 << actor->GetName();
   if (actor->GetState() == rpc::ActorTableData::DEPENDENCIES_UNREADY) {
     // The actor creation task still has unresolved dependencies. Remove from the
     // unresolved actors map.
@@ -1647,7 +1648,8 @@ void GcsActorManager::Initialize(const GcsInitData &gcs_init_data) {
       // We could not reschedule actors in state of `DEPENDENCIES_UNREADY` because the
       // dependencies of them may not have been resolved yet.
       RAY_LOG(INFO).WithField(actor->GetActorID().JobId()).WithField(actor->GetActorID())
-          << "Rescheduling a non-alive actor, state = " << actor->GetState();
+          << "Rescheduling a non-alive actor, state = "
+          << rpc::ActorTableData::ActorState_Name(actor->GetState());
       gcs_actor_scheduler_->Reschedule(actor);
     }
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

https://github.com/ray-project/ray/blob/8c2d9450a312072b245fd82946131c16437f9eda/src/ray/protobuf/gcs.proto#L78-L90

`ActorState` is an enum defined in Protobuf. If `ActorState_Name` is not called, an integer will be printed instead. For example, `rpc::ActorTableData::DEAD` would print as 4.

* Without this PR: "with status 4"
  <img width="1562" alt="Screenshot 2024-12-28 at 8 16 07 PM" src="https://github.com/user-attachments/assets/10a19e37-ebaa-4c24-90e1-b0360cdb6d7f" />

* With this PR: "with status DEAD"
  <img width="1694" alt="Screenshot 2024-12-28 at 10 40 01 PM" src="https://github.com/user-attachments/assets/f185e744-f003-4d96-820e-8f0668f5ac28" />

I also considered implementing `std::ostream &operator<<(std::ostream &out, ...)`. However, there are several issues:

* `ActorState` can be printed directly without causing compilation errors, making it difficult to determine whether the overloaded operator is being called.
* A file that references `ActorState` does not necessarily `#include` the utility function `operator<<`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
