### PR TITLE
[core] Use `Status::AlreadyExists` instead of `Status::NotFound` when a named actor already exists

### DIFF
--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -119,6 +119,7 @@ cdef extern from "ray/common/status.h" namespace "ray" nogil:
         c_bool IsUnknownError()
         c_bool IsNotImplemented()
         c_bool IsObjectStoreFull()
+        c_bool IsAlreadyExists()
         c_bool IsOutOfDisk()
         c_bool IsRedisError()
         c_bool IsTimedOut()

--- a/python/ray/includes/common.pxi
+++ b/python/ray/includes/common.pxi
@@ -70,6 +70,8 @@ cdef int check_status(const CRayStatus& status) nogil except -1:
         raise ObjectStoreFullError(message)
     elif status.IsInvalidArgument():
         raise ValueError(message)
+    elif status.IsAlreadyExists():
+        raise ValueError(message)
     elif status.IsOutOfDisk():
         raise OutOfDiskError(message)
     elif status.IsObjectRefEndOfStream():

--- a/src/ray/common/status.cc
+++ b/src/ray/common/status.cc
@@ -53,6 +53,7 @@ namespace ray {
 #define STATUS_CODE_NOT_FOUND "NotFound"
 #define STATUS_CODE_DISCONNECTED "Disconnected"
 #define STATUS_CODE_SCHEDULING_CANCELLED "SchedulingCancelled"
+#define STATUS_CODE_ALREADY_EXISTS "AlreadyExists"
 #define STATUS_CODE_OBJECT_EXISTS "ObjectExists"
 #define STATUS_CODE_OBJECT_NOT_FOUND "ObjectNotFound"
 #define STATUS_CODE_OBJECT_ALREADY_SEALED "ObjectAlreadySealed"
@@ -93,6 +94,7 @@ const absl::flat_hash_map<StatusCode, std::string> kCodeToStr = {
     {StatusCode::NotFound, STATUS_CODE_NOT_FOUND},
     {StatusCode::Disconnected, STATUS_CODE_DISCONNECTED},
     {StatusCode::SchedulingCancelled, STATUS_CODE_SCHEDULING_CANCELLED},
+    {StatusCode::AlreadyExists, STATUS_CODE_ALREADY_EXISTS},
     {StatusCode::ObjectExists, STATUS_CODE_OBJECT_EXISTS},
     {StatusCode::ObjectNotFound, STATUS_CODE_OBJECT_NOT_FOUND},
     {StatusCode::ObjectAlreadySealed, STATUS_CODE_OBJECT_ALREADY_SEALED},

--- a/src/ray/common/status.h
+++ b/src/ray/common/status.h
@@ -84,6 +84,7 @@ enum class StatusCode : char {
   NotFound = 17,
   Disconnected = 18,
   SchedulingCancelled = 19,
+  AlreadyExists = 20,
   // object store status
   ObjectExists = 21,
   ObjectNotFound = 22,
@@ -202,6 +203,10 @@ class RAY_EXPORT Status {
     return Status(StatusCode::SchedulingCancelled, msg);
   }
 
+  static Status AlreadyExists(const std::string &msg) {
+    return Status(StatusCode::AlreadyExists, msg);
+  }
+
   static Status ObjectExists(const std::string &msg) {
     return Status(StatusCode::ObjectExists, msg);
   }
@@ -285,6 +290,7 @@ class RAY_EXPORT Status {
   bool IsNotFound() const { return code() == StatusCode::NotFound; }
   bool IsDisconnected() const { return code() == StatusCode::Disconnected; }
   bool IsSchedulingCancelled() const { return code() == StatusCode::SchedulingCancelled; }
+  bool IsAlreadyExists() const { return code() == StatusCode::AlreadyExists; }
   bool IsObjectExists() const { return code() == StatusCode::ObjectExists; }
   bool IsObjectNotFound() const { return code() == StatusCode::ObjectNotFound; }
   bool IsObjectUnknownOwner() const { return code() == StatusCode::ObjectUnknownOwner; }

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -762,7 +762,7 @@ Status GcsActorManager::RegisterActor(const ray::rpc::RegisterActorRequest &requ
       std::stringstream stream;
       stream << "Actor with name '" << actor->GetName()
              << "' already exists in the namespace " << actor->GetRayNamespace();
-      return Status::NotFound(stream.str());
+      return Status::AlreadyExists(stream.str());
     }
   }
 

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -368,7 +368,7 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   /// \param success_callback Will be invoked after the actor is created successfully or
   /// be invoked immediately if the actor is already registered to `registered_actors_`
   /// and its state is `ALIVE`.
-  /// \return Status::Invalid if this is a named actor and an
+  /// \return Status::AlreadyExists if this is a named actor and an
   /// actor with the specified name already exists. The callback will not be called in
   /// this case.
   Status RegisterActor(const rpc::RegisterActorRequest &request,

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -696,7 +696,7 @@ TEST_F(GcsActorManagerTest, TestNamedActors) {
   ASSERT_EQ(gcs_actor_manager_->GetActorIDByName("actor3", "test_named_actor"),
             ActorID::Nil());
 
-  // Check that naming collisions return Status::Invalid.
+  // Check that naming collisions return Status::AlreadyExists.
   auto request3 = Mocker::GenRegisterActorRequest(job_id_1,
                                                   /*max_restarts=*/0,
                                                   /*detached=*/true,
@@ -704,7 +704,7 @@ TEST_F(GcsActorManagerTest, TestNamedActors) {
                                                   /*ray_namesapce=*/"test_named_actor");
   status = gcs_actor_manager_->RegisterActor(
       request3, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
-  ASSERT_TRUE(status.IsNotFound());
+  ASSERT_TRUE(status.IsAlreadyExists());
   ASSERT_EQ(gcs_actor_manager_->GetActorIDByName("actor2", "test_named_actor").Binary(),
             request2.task_spec().actor_creation_task_spec().actor_id());
 
@@ -716,7 +716,7 @@ TEST_F(GcsActorManagerTest, TestNamedActors) {
                                                   /*ray_namesapce=*/"test_named_actor");
   status = gcs_actor_manager_->RegisterActor(
       request4, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
-  ASSERT_TRUE(status.IsNotFound());
+  ASSERT_TRUE(status.IsAlreadyExists());
   ASSERT_EQ(gcs_actor_manager_->GetActorIDByName("actor2", "test_named_actor").Binary(),
             request2.task_spec().actor_creation_task_spec().actor_id());
 }
@@ -883,7 +883,7 @@ TEST_F(GcsActorManagerTest, TestNamedActorDeletionNotHappendWhenReconstructed) {
                                                   /*name=*/"actor");
   status = gcs_actor_manager_->RegisterActor(
       request2, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
-  ASSERT_TRUE(status.IsNotFound());
+  ASSERT_TRUE(status.IsAlreadyExists());
   ASSERT_EQ(gcs_actor_manager_->GetActorIDByName("actor", "test").Binary(),
             request1.task_spec().actor_creation_task_spec().actor_id());
 }
@@ -1165,7 +1165,7 @@ TEST_F(GcsActorManagerTest, TestRayNamespace) {
   {  // Actors from different jobs, in the same namespace should still collide.
     Status status = gcs_actor_manager_->RegisterActor(
         request3, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
-    ASSERT_TRUE(status.IsNotFound());
+    ASSERT_TRUE(status.IsAlreadyExists());
     ASSERT_EQ(gcs_actor_manager_->GetActorIDByName("actor", "test").Binary(),
               request1.task_spec().actor_creation_task_spec().actor_id());
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It is weird to return `NotFound` when a named actor already exists when creating an actor.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
