### PR TITLE
[core][cgraph] Use threadpool and one io_context for mutable object provider

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -929,3 +929,8 @@ RAY_CONFIG(int, object_manager_rpc_threads_num, 0)
 
 // Write export API events to file if enabled
 RAY_CONFIG(bool, enable_export_api_write, false)
+
+// Number of threads used for io context in mutable object provider for compiled graphs.
+RAY_CONFIG(uint32_t,
+           mutable_object_provider_num_threads,
+           std::max(1U, std::thread::hardware_concurrency() / 4U))

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -612,7 +612,8 @@ CoreWorker::CoreWorker(CoreWorkerOptions options, const WorkerID &worker_id)
       };
   experimental_mutable_object_provider_ =
       std::make_shared<experimental::MutableObjectProvider>(
-          *plasma_store_provider_->store_client(), raylet_channel_client_factory);
+          *plasma_store_provider_->store_client(),
+          std::move(raylet_channel_client_factory));
 #endif
 
   auto push_error_callback = [this](const JobID &job_id,

--- a/src/ray/core_worker/experimental_mutable_object_provider.cc
+++ b/src/ray/core_worker/experimental_mutable_object_provider.cc
@@ -27,7 +27,8 @@ MutableObjectProvider::MutableObjectProvider(plasma::PlasmaClientInterface &plas
       io_context_(),
       io_work_guard_(io_context_.get_executor()),
       io_thread_pool_(RayConfig::instance().mutable_object_provider_num_threads()) {
-  for (int i = 0; i < RayConfig::instance().mutable_object_provider_num_threads(); ++i) {
+  for (uint32_t i = 0; i < RayConfig::instance().mutable_object_provider_num_threads();
+       ++i) {
     boost::asio::post(io_thread_pool_, [this]() {  // TODO(jhumphri): Decompose this.
 #ifndef _WIN32
       // Block SIGINT and SIGTERM so they will be handled by the main thread.

--- a/src/ray/core_worker/experimental_mutable_object_provider.cc
+++ b/src/ray/core_worker/experimental_mutable_object_provider.cc
@@ -22,19 +22,31 @@ MutableObjectProvider::MutableObjectProvider(plasma::PlasmaClientInterface &plas
                                              RayletFactory factory)
     : plasma_(plasma),
       object_manager_(std::make_shared<ray::experimental::MutableObjectManager>()),
-      raylet_client_factory_(std::move(factory)) {}
+      raylet_client_factory_(std::move(factory)),
+      // NOLINTNEXTLINE
+      io_context_(),
+      io_work_guard_(io_context_.get_executor()),
+      io_thread_pool_(RayConfig::instance().mutable_object_provider_num_threads()) {
+  for (int i = 0; i < RayConfig::instance().mutable_object_provider_num_threads(); ++i) {
+    boost::asio::post(io_thread_pool_, [this]() {  // TODO(jhumphri): Decompose this.
+#ifndef _WIN32
+      // Block SIGINT and SIGTERM so they will be handled by the main thread.
+      sigset_t mask;
+      sigemptyset(&mask);
+      sigaddset(&mask, SIGINT);
+      sigaddset(&mask, SIGTERM);
+      pthread_sigmask(SIG_BLOCK, &mask, nullptr);
+#endif
+      SetThreadName("worker.channel_io");
+      io_context_.run();
+      RAY_LOG(INFO) << "Core worker channel io service stopped.";
+    });
+  }
+}
 
 MutableObjectProvider::~MutableObjectProvider() {
-  for (std::unique_ptr<boost::asio::executor_work_guard<
-           boost::asio::io_context::executor_type>> &io_work : io_works_) {
-    io_work->reset();
-  }
-  RAY_CHECK(object_manager_->SetErrorAll().code() == StatusCode::OK);
-
-  for (std::unique_ptr<std::thread> &io_thread : io_threads_) {
-    RAY_CHECK(io_thread->joinable());
-    io_thread->join();
-  }
+  io_work_guard_.reset();
+  io_thread_pool_.join();
 }
 
 void MutableObjectProvider::RegisterWriterChannel(
@@ -51,42 +63,30 @@ void MutableObjectProvider::RegisterWriterChannel(
     return;
   }
 
-  std::shared_ptr<std::vector<std::shared_ptr<MutableObjectReaderInterface>>>
-      remote_readers =
-          std::make_shared<std::vector<std::shared_ptr<MutableObjectReaderInterface>>>();
+  auto remote_readers =
+      std::make_shared<std::vector<std::shared_ptr<MutableObjectReaderInterface>>>();
   // TODO(sang): Currently, these attributes are not cleaned up.
   // Start a thread that repeatedly listens for values on this object and then sends
   // them via RPC to the remote reader.
-  io_contexts_.push_back(std::make_unique<instrumented_io_context>());
-  instrumented_io_context &io_context = *io_contexts_.back();
-  io_works_.push_back(
-      std::make_unique<
-          boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>(
-          io_context.get_executor()));
-
+  remote_readers->reserve(remote_reader_node_ids.size());
   // Find remote readers.
   for (const auto &node_id : remote_reader_node_ids) {
-    client_call_managers_.push_back(std::make_unique<rpc::ClientCallManager>(io_context));
-    std::shared_ptr<MutableObjectReaderInterface> reader =
-        raylet_client_factory_(node_id, *client_call_managers_.back());
+    client_call_managers_.push_back(
+        std::make_unique<rpc::ClientCallManager>(io_context_));
+    auto reader = raylet_client_factory_(node_id, *client_call_managers_.back());
     RAY_CHECK(reader);
-    remote_readers->push_back(reader);
+    remote_readers->push_back(std::move(reader));
   }
 
   // TODO(jhumphri): Extend this to support multiple channels. Currently, we must have
   // one thread per channel because the thread blocks on the channel semaphore.
   // TODO(sang): We currently create a thread per object id. It is not scalable.
   // We should instead just use a pool of threads.
-  io_context.post(
-      [this,
-       &io_context,
-       writer_object_id,
-       remote_readers = std::move(remote_readers)]() {
-        PollWriterClosure(io_context, writer_object_id, remote_readers);
+  io_context_.post(
+      [this, writer_object_id, remote_readers = std::move(remote_readers)]() {
+        PollWriterClosure(io_context_, writer_object_id, remote_readers);
       },
       "experimental::MutableObjectProvider.PollWriter");
-  io_threads_.push_back(std::make_unique<std::thread>(
-      &MutableObjectProvider::RunIOContext, this, std::ref(io_context)));
 }
 
 void MutableObjectProvider::RegisterReaderChannel(const ObjectID &object_id) {
@@ -257,22 +257,6 @@ void MutableObjectProvider::PollWriterClosure(
           }
         });
   }
-}
-
-void MutableObjectProvider::RunIOContext(instrumented_io_context &io_context) {
-  // TODO(jhumphri): Decompose this.
-#ifndef _WIN32
-  // Block SIGINT and SIGTERM so they will be handled by the main thread.
-  sigset_t mask;
-  sigemptyset(&mask);
-  sigaddset(&mask, SIGINT);
-  sigaddset(&mask, SIGTERM);
-  pthread_sigmask(SIG_BLOCK, &mask, nullptr);
-#endif
-
-  SetThreadName("worker.channel_io");
-  io_context.run();
-  RAY_LOG(INFO) << "Core worker channel io service stopped.";
 }
 
 }  // namespace experimental

--- a/src/ray/core_worker/experimental_mutable_object_provider.h
+++ b/src/ray/core_worker/experimental_mutable_object_provider.h
@@ -179,25 +179,14 @@ class MutableObjectProvider {
   // Creates a Raylet client for each mutable object. When the polling thread detects a
   // write to the mutable object, this client sends the updated mutable object via RPC to
   // the Raylet on the remote node.
-  std::function<std::shared_ptr<MutableObjectReaderInterface>(
-      const NodeID &node_id, rpc::ClientCallManager &client_call_manager)>
-      raylet_client_factory_;
+  RayletFactory raylet_client_factory_;
 
-  // Each mutable object that requires inter-node communication has its own thread and
-  // event loop. Thus, all of the objects below are vectors, with each vector index
-  // corresponding to a different mutable object.
-  // Keeps alive the event loops for RPCs for inter-node communication of mutable objects.
-  std::vector<std::unique_ptr<
-      boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>>
-      io_works_;
-  // Contexts in which the application looks for local changes to mutable objects and
-  // sends the changes to remote nodes via the network.
-  std::vector<std::unique_ptr<instrumented_io_context>> io_contexts_;
+  instrumented_io_context io_context_;
+  boost::asio::executor_work_guard<boost::asio::io_context::executor_type> io_work_guard_;
+  boost::asio::thread_pool io_thread_pool_;
+
   // Manage outgoing RPCs that send mutable object changes to remote nodes.
   std::vector<std::unique_ptr<rpc::ClientCallManager>> client_call_managers_;
-  // Threads that wait for local mutable object changes (one thread per mutable object)
-  // and then send the changes to remote nodes via the network.
-  std::vector<std::unique_ptr<std::thread>> io_threads_;
 
   // Protects the `written_so_far_` map.
   absl::Mutex written_so_far_lock_;

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -741,11 +741,6 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   /// Otherwise returns false.
   bool IsWorkerDead(const WorkerID &worker_id, const NodeID &node_id) const;
 
-  /// Creates a Raylet client. Used by `mutable_object_provider_` when a new writer
-  /// channel is registered.
-  std::shared_ptr<raylet::RayletClient> CreateRayletClient(
-      const NodeID &node_id, rpc::ClientCallManager &client_call_manager);
-
   /// ID of this node.
   NodeID self_node_id_;
   /// The user-given identifier or name of this node.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
