### PR TITLE
[WIP] [core] Avoid linux direct syscall

### DIFF
--- a/src/ray/util/util.h
+++ b/src/ray/util/util.h
@@ -20,6 +20,7 @@
 
 #ifdef __linux__
 #include <sys/syscall.h>
+#include <unistd.h>
 #endif
 
 #ifdef _WIN32
@@ -108,7 +109,7 @@ inline uint64_t GetTid() {
 #elif defined(_WIN32)
 inline DWORD GetTid() { return GetCurrentThreadId(); }
 #else
-inline pid_t GetTid() { return syscall(__NR_gettid); }
+inline pid_t GetTid() { return gettid(); }
 #endif
 
 inline int64_t current_sys_time_s() {


### PR DESCRIPTION
I feel really confused why do we use syscall, when there's already library support.
Checking the manpage: https://man7.org/linux/man-pages/man2/gettid.2.html, it's been supported from 2.4.11, which is pretty old days.

I **suspect** it could be related to our segfault issue in https://github.com/ray-project/ray/issues/49222#issuecomment-2566363132
It's just a suspicion, no real concrete clue due to missing symbol in released version. Let me know if you have better ideas.