### PR TITLE
[Core] Make sure draining node is not selected for scheduling

### DIFF
--- a/src/ray/gcs/gcs_server/test/gcs_resource_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_resource_manager_test.cc
@@ -84,13 +84,13 @@ TEST_F(GcsResourceManagerTest, TestBasic) {
       ResourceMapToResourceRequest(resource_map, /*requires_object_store_memory=*/false);
 
   // Test `AcquireResources`.
-  ASSERT_TRUE(cluster_resource_manager_.HasSufficientResource(
+  ASSERT_TRUE(cluster_resource_manager_.HasAvailableResources(
       scheduling_node_id,
       resource_request,
       /*ignore_object_store_memory_requirement=*/true));
   ASSERT_TRUE(cluster_resource_manager_.SubtractNodeAvailableResources(scheduling_node_id,
                                                                        resource_request));
-  ASSERT_FALSE(cluster_resource_manager_.HasSufficientResource(
+  ASSERT_FALSE(cluster_resource_manager_.HasAvailableResources(
       scheduling_node_id,
       resource_request,
       /*ignore_object_store_memory_requirement=*/true));

--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -198,7 +198,17 @@ bool ClusterResourceManager::SubtractNodeAvailableResources(
   return true;
 }
 
-bool ClusterResourceManager::HasSufficientResource(
+bool ClusterResourceManager::HasFeasibleResources(
+    scheduling::NodeID node_id, const ResourceRequest &resource_request) const {
+  auto it = nodes_.find(node_id);
+  if (it == nodes_.end()) {
+    return false;
+  }
+
+  return it->second.GetLocalView().IsFeasible(resource_request);
+}
+
+bool ClusterResourceManager::HasAvailableResources(
     scheduling::NodeID node_id,
     const ResourceRequest &resource_request,
     bool ignore_object_store_memory_requirement) const {
@@ -207,14 +217,8 @@ bool ClusterResourceManager::HasSufficientResource(
     return false;
   }
 
-  const NodeResources &resources = it->second.GetLocalView();
-
-  if (!ignore_object_store_memory_requirement && resources.object_pulls_queued &&
-      resource_request.RequiresObjectStoreMemory()) {
-    return false;
-  }
-
-  return resources.available >= resource_request.GetResourceSet();
+  return it->second.GetLocalView().IsAvailable(resource_request,
+                                               ignore_object_store_memory_requirement);
 }
 
 bool ClusterResourceManager::AddNodeAvailableResources(scheduling::NodeID node_id,

--- a/src/ray/raylet/scheduling/cluster_resource_manager.h
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.h
@@ -94,15 +94,18 @@ class ClusterResourceManager {
   bool SubtractNodeAvailableResources(scheduling::NodeID node_id,
                                       const ResourceRequest &resource_request);
 
-  /// Check if we have sufficient resource to fullfill resource request for an given node.
+  /// Check if we have available resources to fullfill resource request for an given node.
   ///
   /// \param node_id: the id of the node.
   /// \param resource_request: the request we want to check.
   /// \param ignore_object_store_memory_requirement: if true, we will ignore the
   ///  require_object_store_memory in the resource_request.
-  bool HasSufficientResource(scheduling::NodeID node_id,
+  bool HasAvailableResources(scheduling::NodeID node_id,
                              const ResourceRequest &resource_request,
                              bool ignore_object_store_memory_requirement) const;
+
+  bool HasFeasibleResources(scheduling::NodeID node_id,
+                            const ResourceRequest &resource_request) const;
 
   /// Add available resource to a given node.
   /// Return false if such node doesn't exist.

--- a/src/ray/raylet/scheduling/cluster_resource_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager_test.cc
@@ -58,35 +58,56 @@ struct ClusterResourceManagerTest : public ::testing::Test {
   std::unique_ptr<ClusterResourceManager> manager;
 };
 
-TEST_F(ClusterResourceManagerTest, HasSufficientResourceTest) {
-  ASSERT_FALSE(manager->HasSufficientResource(
+TEST_F(ClusterResourceManagerTest, HasFeasibleResourcesTest) {
+  ASSERT_FALSE(manager->HasFeasibleResources(node3, {}));
+  ASSERT_FALSE(manager->HasFeasibleResources(
+      node0,
+      ResourceMapToResourceRequest({{"GPU", 1}},
+                                   /*requires_object_store_memory=*/false)));
+  ASSERT_TRUE(manager->HasFeasibleResources(
+      node0,
+      ResourceMapToResourceRequest({{"CPU", 1}},
+                                   /*requires_object_store_memory=*/false)));
+  manager->SubtractNodeAvailableResources(
+      node0,
+      ResourceMapToResourceRequest({{"CPU", 1}},
+                                   /*requires_object_store_memory=*/false));
+  // node0 has no available CPU resource but it's still feasible.
+  ASSERT_TRUE(manager->HasFeasibleResources(
+      node0,
+      ResourceMapToResourceRequest({{"CPU", 1}},
+                                   /*requires_object_store_memory=*/false)));
+}
+
+TEST_F(ClusterResourceManagerTest, HasAvailableResourcesTest) {
+  ASSERT_FALSE(manager->HasAvailableResources(
       node3, {}, /*ignore_object_store_memory_requirement*/ false));
-  ASSERT_TRUE(manager->HasSufficientResource(
+  ASSERT_TRUE(manager->HasAvailableResources(
       node0,
       ResourceMapToResourceRequest({{"CPU", 1}},
                                    /*requires_object_store_memory=*/true),
       /*ignore_object_store_memory_requirement*/ false));
-  ASSERT_FALSE(manager->HasSufficientResource(
+  ASSERT_FALSE(manager->HasAvailableResources(
       node0,
       ResourceMapToResourceRequest({{"CUSTOM", 1}},
                                    /*requires_object_store_memory=*/true),
       /*ignore_object_store_memory_requirement*/ false));
-  ASSERT_TRUE(manager->HasSufficientResource(
+  ASSERT_TRUE(manager->HasAvailableResources(
       node1,
       ResourceMapToResourceRequest({{"CUSTOM", 1}},
                                    /*requires_object_store_memory=*/true),
       /*ignore_object_store_memory_requirement*/ false));
-  ASSERT_TRUE(manager->HasSufficientResource(
+  ASSERT_TRUE(manager->HasAvailableResources(
       node2,
       ResourceMapToResourceRequest({{"CPU", 1}},
                                    /*requires_object_store_memory=*/false),
       /*ignore_object_store_memory_requirement*/ false));
-  ASSERT_FALSE(manager->HasSufficientResource(
+  ASSERT_FALSE(manager->HasAvailableResources(
       node2,
       ResourceMapToResourceRequest({{"CPU", 1}},
                                    /*requires_object_store_memory=*/true),
       /*ignore_object_store_memory_requirement*/ false));
-  ASSERT_TRUE(manager->HasSufficientResource(
+  ASSERT_TRUE(manager->HasAvailableResources(
       node2,
       ResourceMapToResourceRequest({{"CPU", 1}},
                                    /*requires_object_store_memory=*/true),

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -311,9 +311,9 @@ scheduling::NodeID ClusterResourceScheduler::GetBestSchedulableNode(
       !IsSchedulableOnNode(best_node,
                            task_spec.GetRequiredPlacementResources().GetResourceMap(),
                            requires_object_store_memory)) {
-    // Prefer waiting on the local node since the local node is chosen for a reason (e.g.
-    // spread).
-    if (preferred_node_id == local_node_id_.Binary()) {
+    // Prefer waiting on the local node if possible
+    // since the local node is chosen for a reason (e.g. spread).
+    if ((preferred_node_id == local_node_id_.Binary()) && NodeAvailable(local_node_id_)) {
       *is_infeasible = false;
       return local_node_id_;
     }

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
@@ -435,15 +435,15 @@ TEST_F(ClusterResourceSchedulerTest, SpreadSchedulingStrategyTest) {
 }
 
 TEST_F(ClusterResourceSchedulerTest, SchedulingWithPreferredNodeTest) {
-  absl::flat_hash_map<std::string, double> resource_total({{"CPU", 10}});
   auto local_node_id = scheduling::NodeID(NodeID::FromRandom().Binary());
   instrumented_io_context io_context;
   ClusterResourceScheduler resource_scheduler(
-      io_context, local_node_id, resource_total, is_node_available_fn_);
+      io_context, local_node_id, {{"CPU", 8}}, is_node_available_fn_);
   AssertPredefinedNodeResources();
   auto remote_node_id = scheduling::NodeID(NodeID::FromRandom().Binary());
+  absl::flat_hash_map<std::string, double> remote_resource_total({{"CPU", 10}});
   resource_scheduler.GetClusterResourceManager().AddOrUpdateNode(
-      remote_node_id, resource_total, resource_total);
+      remote_node_id, remote_resource_total, remote_resource_total);
 
   absl::flat_hash_map<std::string, double> resource_request({{"CPU", 5}});
   int64_t violations;
@@ -472,6 +472,42 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingWithPreferredNodeTest) {
                                                              &is_infeasible);
   ASSERT_EQ(node_id_2, local_node_id);
 
+  // Never prefer the infeasible node.
+  TaskSpecBuilder spec_builder_1;
+  spec_builder_1.SetCommonTaskSpec(RandomTaskId(),
+                                   "dummy_task",
+                                   Language::PYTHON,
+                                   FunctionDescriptorBuilder::BuildPython("", "", "", ""),
+                                   RandomJobId(),
+                                   rpc::JobConfig(),
+                                   TaskID::Nil(),
+                                   0,
+                                   TaskID::Nil(),
+                                   rpc::Address(),
+                                   0,
+                                   /*returns_dynamic=*/false,
+                                   /*is_streaming_generator*/ false,
+                                   /*generator_backpressure_num_objects*/ -1,
+                                   {{"CPU", 9}},
+                                   {},
+                                   "",
+                                   0,
+                                   TaskID::Nil(),
+                                   "",
+                                   nullptr);
+  spec_builder_1.SetNormalTaskSpec(0, false, "", scheduling_strategy, ActorID::Nil());
+  // Remote node is feasible but has no available resource.
+  resource_scheduler.GetClusterResourceManager().AddOrUpdateNode(
+      remote_node_id, remote_resource_total, {{"CPU", 0}});
+  auto node_id_3 = resource_scheduler.GetBestSchedulableNode(
+      spec_builder_1.Build(),
+      /*preferred_node_id=*/local_node_id.Binary(),
+      false,
+      false,
+      &is_infeasible);
+  ASSERT_EQ(node_id_3, remote_node_id);
+  ASSERT_FALSE(is_infeasible);
+
   // Never prefer the draining node even if it has available resources
   // and other nodes don't.
   // Allocate some local resources so the local node is not idle and won't be drained
@@ -482,39 +518,36 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingWithPreferredNodeTest) {
   rpc::DrainRayletRequest drain_request;
   drain_request.set_deadline_timestamp_ms(std::numeric_limits<int64_t>::max());
   resource_scheduler.GetLocalResourceManager().SetLocalNodeDraining(drain_request);
-  // Remote node is feasible but has no available resource.
-  resource_scheduler.GetClusterResourceManager().AddOrUpdateNode(
-      remote_node_id, resource_total, {{"CPU", 0}});
-  TaskSpecBuilder spec_builder;
-  spec_builder.SetCommonTaskSpec(RandomTaskId(),
-                                 "dummy_task",
-                                 Language::PYTHON,
-                                 FunctionDescriptorBuilder::BuildPython("", "", "", ""),
-                                 RandomJobId(),
-                                 rpc::JobConfig(),
-                                 TaskID::Nil(),
-                                 0,
-                                 TaskID::Nil(),
-                                 rpc::Address(),
-                                 0,
-                                 /*returns_dynamic=*/false,
-                                 /*is_streaming_generator*/ false,
-                                 /*generator_backpressure_num_objects*/ -1,
-                                 {{"CPU", 1}},
-                                 {},
-                                 "",
-                                 0,
-                                 TaskID::Nil(),
-                                 "",
-                                 nullptr);
-  spec_builder.SetNormalTaskSpec(0, false, "", scheduling_strategy, ActorID::Nil());
-  auto node_id_3 = resource_scheduler.GetBestSchedulableNode(
-      spec_builder.Build(),
+  TaskSpecBuilder spec_builder_2;
+  spec_builder_2.SetCommonTaskSpec(RandomTaskId(),
+                                   "dummy_task",
+                                   Language::PYTHON,
+                                   FunctionDescriptorBuilder::BuildPython("", "", "", ""),
+                                   RandomJobId(),
+                                   rpc::JobConfig(),
+                                   TaskID::Nil(),
+                                   0,
+                                   TaskID::Nil(),
+                                   rpc::Address(),
+                                   0,
+                                   /*returns_dynamic=*/false,
+                                   /*is_streaming_generator*/ false,
+                                   /*generator_backpressure_num_objects*/ -1,
+                                   {{"CPU", 1}},
+                                   {},
+                                   "",
+                                   0,
+                                   TaskID::Nil(),
+                                   "",
+                                   nullptr);
+  spec_builder_2.SetNormalTaskSpec(0, false, "", scheduling_strategy, ActorID::Nil());
+  auto node_id_4 = resource_scheduler.GetBestSchedulableNode(
+      spec_builder_2.Build(),
       /*preferred_node_id=*/local_node_id.Binary(),
       false,
       false,
       &is_infeasible);
-  ASSERT_EQ(node_id_3, remote_node_id);
+  ASSERT_EQ(node_id_4, remote_node_id);
 }
 
 TEST_F(ClusterResourceSchedulerTest, SchedulingUpdateAvailableResourcesTest) {

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
@@ -20,6 +20,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "ray/common/ray_config.h"
+#include "ray/common/task/task_util.h"
+#include "ray/common/test_util.h"
 #include "ray/common/scheduling/resource_set.h"
 #include "ray/common/scheduling/scheduling_ids.h"
 #include "mock/ray/gcs/gcs_client/gcs_client.h"
@@ -457,6 +459,7 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingWithPreferredNodeTest) {
                                                              remote_node_id.Binary(),
                                                              &violations,
                                                              &is_infeasible);
+  ASSERT_EQ(node_id_1, remote_node_id);
 
   // If no preferred node specified, then still prefer the local one.
   auto node_id_2 = resource_scheduler.GetBestSchedulableNode(resource_request,
@@ -467,9 +470,51 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingWithPreferredNodeTest) {
                                                              std::string(),
                                                              &violations,
                                                              &is_infeasible);
+  ASSERT_EQ(node_id_2, local_node_id);
 
-  ASSERT_EQ((std::set<scheduling::NodeID>{node_id_1, node_id_2}),
-            (std::set<scheduling::NodeID>{remote_node_id, local_node_id}));
+  // Never prefer the draining node even if it has available resources
+  // and other nodes don't.
+  // Allocate some local resources so the local node is not idle and won't be drained
+  // immediately.
+  auto task_allocation = std::make_shared<TaskResourceInstances>();
+  ASSERT_TRUE(resource_scheduler.GetLocalResourceManager().AllocateLocalTaskResources(
+      resource_request, task_allocation));
+  rpc::DrainRayletRequest drain_request;
+  drain_request.set_deadline_timestamp_ms(std::numeric_limits<int64_t>::max());
+  resource_scheduler.GetLocalResourceManager().SetLocalNodeDraining(drain_request);
+  // Remote node is feasible but has no available resource.
+  resource_scheduler.GetClusterResourceManager().AddOrUpdateNode(
+      remote_node_id, resource_total, {{"CPU", 0}});
+  TaskSpecBuilder spec_builder;
+  spec_builder.SetCommonTaskSpec(RandomTaskId(),
+                                 "dummy_task",
+                                 Language::PYTHON,
+                                 FunctionDescriptorBuilder::BuildPython("", "", "", ""),
+                                 RandomJobId(),
+                                 rpc::JobConfig(),
+                                 TaskID::Nil(),
+                                 0,
+                                 TaskID::Nil(),
+                                 rpc::Address(),
+                                 0,
+                                 /*returns_dynamic=*/false,
+                                 /*is_streaming_generator*/ false,
+                                 /*generator_backpressure_num_objects*/ -1,
+                                 {{"CPU", 1}},
+                                 {},
+                                 "",
+                                 0,
+                                 TaskID::Nil(),
+                                 "",
+                                 nullptr);
+  spec_builder.SetNormalTaskSpec(0, false, "", scheduling_strategy, ActorID::Nil());
+  auto node_id_3 = resource_scheduler.GetBestSchedulableNode(
+      spec_builder.Build(),
+      /*preferred_node_id=*/local_node_id.Binary(),
+      false,
+      false,
+      &is_infeasible);
+  ASSERT_EQ(node_id_3, remote_node_id);
 }
 
 TEST_F(ClusterResourceSchedulerTest, SchedulingUpdateAvailableResourcesTest) {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We shouldn't schedule new tasks to a draining node and the code covers all cases except for one and this PR fixes it.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
