### PR TITLE
[core] Add test for application log rotation

### DIFF
--- a/python/ray/tests/test_logging.py
+++ b/python/ray/tests/test_logging.py
@@ -195,6 +195,8 @@ def test_log_rotation(shutdown_only, monkeypatch):
     session_path = Path(session_dir)
     log_dir_path = session_path / "logs"
 
+    # NOTICE: There's no ray_constants.PROCESS_TYPE_WORKER because "worker" is a
+    # substring of "python-core-worker".
     log_rotating_component = [
         ray_constants.PROCESS_TYPE_DASHBOARD,
         ray_constants.PROCESS_TYPE_DASHBOARD_AGENT,


### PR DESCRIPTION
My investigation result on application logging:
- Currently application log is not correctly rotated, but our unit tests somehow pass
- The reason is, it only checks whether file exists; but application log is named as "worker-..." which is a substring of "python-core-worker-..."

This PR adds a unit test which breaks for the currently broken logging implementation;
Also fix a bug in regex matching.