### PR TITLE
[Core] Improve the find_available_port Logic to Reduce the Port Conflict during Testing

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -2220,15 +2220,11 @@ def has_no_words(string, words):
 def find_available_port(start, end, port_num=1):
     ports = []
     for _ in range(port_num):
-        random_port = 0
-        with socket.socket() as s:
-            s.bind(("", 0))
-            random_port = s.getsockname()[1]
-        if random_port >= start and random_port <= end and random_port not in ports:
-            ports.append(random_port)
-            continue
-
-        for port in range(start, end + 1):
+        # start from a random point in the range to avoid port conflict
+        random_offset = random.randint(start, end + 1)
+        for port in list(range(random_offset, end + 1)) + list(
+            range(start, random_offset)
+        ):
             if port in ports:
                 continue
             try:

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -240,10 +240,6 @@ def start_redis(db_dir):
     while True:
         is_need_restart = False
         # Setup external Redis and env var for initialization.
-        redis_ports = find_available_port(49159, 55535, redis_replicas() * 2)
-        redis_ports = list(
-            zip(redis_ports[0 : redis_replicas()], redis_ports[redis_replicas() :])
-        )
         processes = []
         enable_tls = "RAY_REDIS_CA_CERT" in os.environ
         leader_port = None


### PR DESCRIPTION


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR contains a short term remediation of the flaky test `test_gcs_fault_tolerance`.

The cause of the flakiness:
1. When a test is trying to start a redis server, it will:
  (1) First find the available ports by checking whether a socket can be bind to the ports
  (2) Then pass the port to the command to start the redis server
2. With this logic, a corner case can happen when a port is claimed by another application after the port passed the check and before it is used by the redis server
3. So if there are multiple tests trying to acquire a port at the same time, the start of the redis server could fail due to `Address already in use` issue.

Instead of always search from the beginning of the range, this PR update the `find_available_port` function logic to add a random offset when looking for the port in the range. This can be short term remediation to reduce port conflict when multiple tests calling the function at the same time. 

The PR also remove the unnecessary logic in the `start_redis` function.

For the long term, we might need to look at how we can improve the port acquiring mechanism to make it exclusive across tests. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #43777 
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
