### PR TITLE
[core] Implement move semantics for status

### DIFF
--- a/src/ray/common/status.h
+++ b/src/ray/common/status.h
@@ -125,7 +125,11 @@ class RAY_EXPORT Status {
 
   // Copy the specified status.
   Status(const Status &s);
-  void operator=(const Status &s);
+  Status &operator=(const Status &s);
+
+  // Move the specified status.
+  Status(Status &&s);
+  Status &operator=(Status &&s);
 
   // Return a success status.
   static Status OK() { return Status(); }
@@ -332,6 +336,8 @@ class RAY_EXPORT Status {
     // If code is RpcError, this contains the RPC error code
     int rpc_code;
   };
+  // Use raw pointer instead of unique pointer to achieve copiable `Status`.
+  //
   // OK status has a `nullptr` state_.  Otherwise, `state_` points to
   // a `State` structure containing the error code and message(s)
   State *state_;
@@ -347,12 +353,27 @@ static inline std::ostream &operator<<(std::ostream &os, const Status &x) {
 inline Status::Status(const Status &s)
     : state_((s.state_ == nullptr) ? nullptr : new State(*s.state_)) {}
 
-inline void Status::operator=(const Status &s) {
+inline Status &Status::operator=(const Status &s) {
   // The following condition catches both aliasing (when this == &s),
   // and the common case where both s and *this are ok.
   if (state_ != s.state_) {
     CopyFrom(s.state_);
   }
+  return *this;
+}
+
+inline Status::Status(Status &&rhs) {
+  state_ = rhs.state_;
+  rhs.state_ = nullptr;
+}
+
+inline Status &Status::operator=(Status &&rhs) {
+  if (this == &rhs) {
+    return *this;
+  }
+  state_ = rhs.state_;
+  rhs.state_ = nullptr;
+  return *this;
 }
 
 Status boost_to_ray_status(const boost::system::error_code &error);

--- a/src/ray/common/test/status_test.cc
+++ b/src/ray/common/test/status_test.cc
@@ -20,6 +20,66 @@
 namespace ray {
 class StatusTest : public ::testing::Test {};
 
+TEST_F(StatusTest, CopyAndMoveForOkStatus) {
+  // OK status.
+  Status ok_status = Status::OK();
+
+  // Copy constructor.
+  {
+    Status new_status = ok_status;
+    EXPECT_TRUE(new_status.ok());
+  }
+  // Copy assignment.
+  {
+    Status new_status = Status::Invalid("invalid");
+    new_status = ok_status;
+    EXPECT_TRUE(new_status.ok());
+  }
+
+  // Move constructor.
+  Status copied_ok_status = ok_status;
+  {
+    Status new_status = std::move(ok_status);
+    EXPECT_TRUE(new_status.ok());
+  }
+  // Move assignment.
+  {
+    Status new_status = Status::Invalid("invalid");
+    new_status = std::move(copied_ok_status);
+    EXPECT_TRUE(new_status.ok());
+  }
+}
+
+TEST_F(StatusTest, CopyAndMoveErrorStatus) {
+  // Invalid status.
+  Status invalid_status = Status::Invalid("invalid");
+
+  // Copy constructor.
+  {
+    Status new_status = invalid_status;
+    EXPECT_EQ(new_status.code(), StatusCode::Invalid);
+  }
+  // Copy assignment.
+  {
+    Status new_status = Status::OK();
+    new_status = invalid_status;
+    EXPECT_EQ(new_status.code(), StatusCode::Invalid);
+  }
+
+  // Move constructor.
+  Status copied_invalid_status = invalid_status;
+  {
+    Status new_status = std::move(invalid_status);
+    EXPECT_EQ(new_status.code(), StatusCode::Invalid);
+  }
+  // Move assignment.
+  {
+    Status new_status = Status::OK();
+    new_status = std::move(copied_invalid_status);
+    EXPECT_EQ(new_status.code(), StatusCode::Invalid);
+  }
+}
+
 TEST_F(StatusTest, StringToCode) {
   auto ok = Status::OK();
   StatusCode status = Status::StringToCode(ok.CodeAsString());


### PR DESCRIPTION
I'm really surprised we don't have move semantics for `Status`, which is a core data structure in ray.