### PR TITLE
[core] Don't build cpp with default dev build command

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -697,7 +697,7 @@ def api_main(program, *args):
     parser.add_argument(
         "-l",
         "--language",
-        default="python,cpp",
+        default="python",
         type=str,
         help="A list of languages to build native libraries. "
         'Supported languages include "python" and "java". '

--- a/python/setup.py
+++ b/python/setup.py
@@ -700,7 +700,7 @@ def api_main(program, *args):
         default="python",
         type=str,
         help="A list of languages to build native libraries. "
-        'Supported languages include "python" and "java". '
+        'Supported languages include "python", "cpp", and "java". '
         "If not specified, only the Python library will be built.",
     )
     parsed_args = parser.parse_args(args)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Right now we recompile the files for the C++ api with the default `pip install -e . --verbose` build command we always use. This turns it off to speed up incremental build times a bit when using that to build.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
