### PR TITLE
[core][cgraph] Use cv instead of busy wait for next version

### DIFF
--- a/src/ray/object_manager/common.h
+++ b/src/ray/object_manager/common.h
@@ -151,7 +151,8 @@ struct PlasmaObjectHeader {
   /// \param sem The semaphores for this channel.
   Status WriteRelease(Semaphores &sem);
 
-  bool WaitForNewVersionSealed(int64_t version_to_wait_for);
+  bool WaitForNewVersionSealed(int64_t version_to_wait_for,
+                               std::chrono::milliseconds time_to_wait_for);
 
   /// Blocks until the given version is ready to read. Returns false if the
   /// maximum number of readers have already read the requested version.

--- a/src/ray/object_manager/common.h
+++ b/src/ray/object_manager/common.h
@@ -94,8 +94,8 @@ struct PlasmaObjectHeader {
   // has been WriteRelease'd. A reader may read the actual object value if
   // is_sealed=true and num_read_acquires_remaining != 0.
   bool is_sealed = false;
-  std::mutex version_sealed_mutex;
-  std::condition_variable version_sealed_cv;
+  std::optional<std::mutex> version_sealed_mutex;
+  std::optional<std::condition_variable> version_sealed_cv;
   // Set to indicate an error was encountered computing the next version of
   // the mutable object. Lockless access allowed.
   std::atomic<bool> has_error = false;

--- a/src/ray/object_manager/plasma/client.cc
+++ b/src/ray/object_manager/plasma/client.cc
@@ -206,12 +206,6 @@ class PlasmaClient::Impl : public std::enable_shared_from_this<PlasmaClient::Imp
 
   uint8_t *LookupMmappedFile(MEMFD_TYPE store_fd_val) const;
 
-  ray::PlasmaObjectHeader *GetPlasmaObjectHeader(const PlasmaObject &object) const {
-    auto base_ptr = LookupMmappedFile(object.store_fd);
-    auto header_ptr = base_ptr + object.header_offset;
-    return reinterpret_cast<ray::PlasmaObjectHeader *>(header_ptr);
-  }
-
   void InsertObjectInUse(const ObjectID &object_id,
                          std::unique_ptr<PlasmaObject> object,
                          bool is_sealed);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We shouldn't busy wait and use all those cycles just to wait for the next version. Instead we can use a condition variable and just check every second, and when notified of a change. This will also allow us to take a threadpool approach effectively afterwards instead of the current un-scaleable approach of creating a new thread for every channel.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
