### PR TITLE
[core] Use rotation log file for application logging

### DIFF
--- a/python/ray/_private/workers/default_worker.py
+++ b/python/ray/_private/workers/default_worker.py
@@ -9,9 +9,10 @@ import ray._private.node
 import ray._private.ray_constants as ray_constants
 import ray._private.utils
 import ray.actor
+import sys
 from ray._private.async_compat import try_install_uvloop
 from ray._private.parameter import RayParams
-from ray._private.ray_logging import configure_log_file, get_worker_log_file_name
+from ray._private.ray_logging import get_worker_log_file_name
 from ray._private.runtime_env.setup_hook import load_and_execute_setup_hook
 
 parser = argparse.ArgumentParser(
@@ -273,10 +274,13 @@ if __name__ == "__main__":
     worker = ray._private.worker.global_worker
 
     # Setup log file.
-    out_file, err_file = node.get_log_file_handles(
-        get_worker_log_file_name(args.worker_type)
+    out_file, err_file = node.get_log_file_handles_with_rotation(
+        get_worker_log_file_name(args.worker_type),
+        rotation_max_size=args.logging_rotate_bytes,
+        rotation_file_num=args.logging_rotate_backup_count,
     )
-    configure_log_file(out_file, err_file)
+    sys.stdout = out_file
+    sys.stderr = err_file
     worker.set_out_file(out_file)
     worker.set_err_file(err_file)
 

--- a/python/ray/tests/test_logging.py
+++ b/python/ray/tests/test_logging.py
@@ -273,25 +273,26 @@ def test_log_rotation(shutdown_only, monkeypatch):
             f"backup count {backup_count}, file count: {file_cnt}"
         )
 
-    # TODO(hjiang): Enable after log rotation implemented for user application.
+    # Test application log, which starts with `worker-`.
+    # Should be tested separately with other components since "worker" is a substring
+    # of "python-core-worker".
     #
-    # # Test application log, which starts with `worker-`.
-    # # Should be tested separately with other components since "worker" is a substring
-    # # of "python-core-worker".
-    # #
-    # # Check file count.
-    # application_stdout_paths = []
-    # for path in paths:
-    #    if path.stem.startswith("worker-") and re.search(r".*\.out(\.\d+)?", str(path))
-    # # and path.stat().st_size > 0:
-    #         application_stdout_paths.append(path)
-    # assert len(application_stdout_paths) == 4, application_stdout_paths
+    # Check file count.
+    application_stdout_paths = []
+    for path in paths:
+        if (
+            path.stem.startswith("worker-")
+            and re.search(r".*\.out(\.\d+)?", str(path))
+            and path.stat().st_size > 0
+        ):
+            application_stdout_paths.append(path)
+    assert len(application_stdout_paths) == 4, application_stdout_paths
 
-    # # Check file content, each file should have one line.
-    # for cur_path in application_stdout_paths:
-    #     with cur_path.open() as f:
-    #         lines = f.readlines()
-    #         assert len(lines) == 1, lines
+    # Check file content, each file should have one line.
+    for cur_path in application_stdout_paths:
+        with cur_path.open() as f:
+            lines = f.readlines()
+            assert len(lines) == 1, lines
 
 
 def test_periodic_event_stats(shutdown_only):


### PR DESCRIPTION
A followup for oversized logging file. It supports rotated logging file via overriding stdout and stderr with logging module.

I already tried the existing `StreamToLogger` module here: https://github.com/ray-project/ray/blob/c18686a39dbffd31868336c59d7274de08ef440b/python/ray/serve/_private/logging_utils.py#L357, which doesn't work (gets blocked forever)