### PR TITLE
[core] Add thread checker for GcsAutoscalerStateManager.

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.h
@@ -17,6 +17,7 @@
 #include "ray/gcs/gcs_server/gcs_init_data.h"
 #include "ray/rpc/gcs_server/gcs_rpc_server.h"
 #include "ray/rpc/node_manager/node_manager_client_pool.h"
+#include "ray/util/thread_checker.h"
 #include "src/ray/protobuf/gcs.pb.h"
 
 namespace ray {
@@ -183,6 +184,8 @@ class GcsAutoscalerStateManager : public rpc::autoscaler::AutoscalerStateHandler
   /// The absl::Time in the pair is the last time the item was updated.
   absl::flat_hash_map<ray::NodeID, std::pair<absl::Time, rpc::ResourcesData>>
       node_resource_info_;
+
+  ThreadChecker thread_checker_;
 
   FRIEND_TEST(GcsAutoscalerStateManagerTest, TestReportAutoscalingState);
 };


### PR DESCRIPTION
GcsAutoscalerStateManager is supposed to be accessed only on a single thread, because its underlying maps are not mutex protected.