### PR TITLE
[core] Post for GetOrGenerateClusterId continuations.

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -18,6 +18,7 @@
 
 #include "ray/common/asio/asio_util.h"
 #include "ray/common/asio/instrumented_io_context.h"
+#include "ray/common/asio/postable.h"
 #include "ray/common/ray_syncer/ray_syncer.h"
 #include "ray/common/runtime_env_manager.h"
 #include "ray/gcs/gcs_server/gcs_function_manager.h"
@@ -204,7 +205,7 @@ class GcsServer {
   /// Get cluster id if persisted, otherwise generate
   /// a new one and persist as necessary.
   /// Expected to be idempotent while server is up.
-  void GetOrGenerateClusterId(std::function<void(ClusterID cluster_id)> &&continuation);
+  void GetOrGenerateClusterId(Postable<void(ClusterID cluster_id)> continuation);
 
   /// Print the asio event loop stats for debugging.
   void PrintAsioStats();


### PR DESCRIPTION
GetOrGenerateClusterId makes InternalKV gets and puts for the cluster ID, then invokes `continuation`. We need to Post the continuation back to the main io context since Start() expects that.
