### PR TITLE
[core] Ray check macro allow type conversion

### DIFF
--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -158,10 +158,11 @@ enum class RayLogLevel {
 
 #endif  // NDEBUG
 
-#define RAY_CHECK_OP(left, op, right)        \
-  if (const auto &_left_ = (left); true)     \
-    if (const auto &_right_ = (right); true) \
-  RAY_CHECK(RAY_PREDICT_TRUE(_left_ op _right_)) << " " << _left_ << " vs " << _right_
+#define RAY_CHECK_OP(left, op, right)                                           \
+  if (const auto &_left_ = (left); true)                                        \
+    if (const auto &_right_ = (right); true)                                    \
+  RAY_CHECK(RAY_PREDICT_TRUE(_left_ op static_cast<decltype(_left_)>(_right_))) \
+      << " " << _left_ << " vs " << _right_
 
 #define RAY_CHECK_EQ(left, right) RAY_CHECK_OP(left, ==, right)
 #define RAY_CHECK_NE(left, right) RAY_CHECK_OP(left, !=, right)

--- a/src/ray/util/tests/logging_test.cc
+++ b/src/ray/util/tests/logging_test.cc
@@ -289,6 +289,7 @@ TEST(LogPerfTest, PerfTest) {
 }
 
 TEST(PrintLogTest, TestCheckOp) {
+  // Check comparison with the same type.
   int i = 1;
   RAY_CHECK_EQ(i, 1);
   ASSERT_DEATH(RAY_CHECK_EQ(i, 2), "1 vs 2");
@@ -311,6 +312,10 @@ TEST(PrintLogTest, TestCheckOp) {
   int j = 0;
   RAY_CHECK_NE(i, j);
   ASSERT_DEATH(RAY_CHECK_EQ(i, j), "1 vs 0");
+
+  // Check comparison with type conversion.
+  std::vector<int> vec;
+  RAY_CHECK_EQ(vec.size(), 0);
 }
 
 TEST(PrintLogTest, RayCheckOk) {


### PR DESCRIPTION
For the current implementation, `RAY_CHECK_EQ(container.size(), 1)` will fail since they're not of the same type;
I feel like this is is a reasonable request, and developers themselves should decide whether it's a valid check.

This PR casts two operands to the same type, and adds a unit test which fails previously.