### PR TITLE
Repro issue 49234

### DIFF
--- a/experimental/launch_multiple_ray_jobs.sh
+++ b/experimental/launch_multiple_ray_jobs.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+NUM_PROCESSES=400
+for i in $(seq 1 $NUM_PROCESSES); do
+    python3 /home/ubuntu/ray/experimental/start_ray_job.py &
+done
+
+sleep 3600

--- a/experimental/start_ray_job.py
+++ b/experimental/start_ray_job.py
@@ -1,0 +1,31 @@
+"""Script to check ray job status:
+- Start head node:
+ray start --head --port=6379
+- Start worker node:
+ray start --address='172.31.11.87:6379'
+- Check ray cluster status:
+ray status
+- Check job status:
+ray job list
+ray job status <job-id>
+"""
+
+import time
+
+import ray
+
+_NUM_TASKS = 5
+_SLEEP_TIME_SEC = 100
+
+ray.init("172.31.11.87:6379")
+
+
+@ray.remote
+def sleep_task():
+    time.sleep(_SLEEP_TIME_SEC)
+    return "Task Completed!"
+
+
+tasks = [sleep_task.remote() for _ in range(_NUM_TASKS)]
+results = ray.get(tasks)
+print(results)

--- a/src/ray/gcs/gcs_server/gcs_job_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_job_manager.cc
@@ -476,6 +476,14 @@ void GcsJobManager::OnNodeDead(const NodeID &node_id) {
 }
 
 void GcsJobManager::RecordMetrics() {
+  RAY_LOG(ERROR) << "running job number - " << running_job_ids_.size();
+  if (running_job_ids_.size() <= 20) {
+    for (const auto &cur_job_id : running_job_ids_) {
+      RAY_LOG(ERROR) << "cur job id - " << cur_job_id;
+    }
+    RAY_LOG(ERROR) << "----";
+  }
+
   ray::stats::STATS_running_jobs.Record(running_job_ids_.size());
   ray::stats::STATS_finished_jobs.Record(finished_jobs_count_);
 }


### PR DESCRIPTION
https://github.com/ray-project/ray/issues/49234

Steps to reproduce:
1. Start a ray cluster
```
ray start --head --port=6379
ray start --address='172.31.11.87:6379'
```
2. Start multiple jobs with shell script
```
./experimental/launch_multiple_ray_jobs.sh 2>&1 | tee ~/launch-out
```
The script starts 400 jobs on the same ray cluster.

From issue author, there're several things we need to check:
1. On concurrent job creation and completion, during the whole process whether `running_job_ids_` are correctly reported
2. After all jobs completed, whether `running_job_ids_` is correctly reported
3. Whether `running_job_ids_` corresponds with `ray job` interface

To verify all of them, I keep these jobs running for a while, meanwhile I check the stats reported and `ray job` status, all of them work perfectly fine for >10 mintues

![image](https://github.com/user-attachments/assets/663f72a5-71d2-44f8-afb5-3a38a339a978)
![image](https://github.com/user-attachments/assets/52078047-bce5-42dc-97fc-59fa4f4338c2)

Later on, I kill all job processes and verify the stats reported is still correct
```
(myenv) 
[~/ray] (hjiang/gcs-job-with-running) 
ubuntu@hjiang-devbox-pg$ kill -9 `ps aux | grep start_ray_job`

(myenv)
[~/ray] (hjiang/gcs-job-with-running) 
ubuntu@hjiang-devbox-pg$ ray job list | grep RUNNING | wc -l
2025-01-03 09:53:13,924 - INFO - Note: NumExpr detected 32 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 8.
2025-01-03 09:53:13,924 - INFO - NumExpr defaulting to 8 threads.
0
```
Checking the gcs log
```
[2025-01-03 09:52:53,909 E 1621659 1621659] gcs_job_manager.cc:479: running job number - 354
[2025-01-03 09:52:58,909 E 1621659 1621659] gcs_job_manager.cc:479: running job number - 336
[2025-01-03 09:53:03,909 E 1621659 1621659] gcs_job_manager.cc:479: running job number - 0
[2025-01-03 09:53:03,909 E 1621659 1621659] gcs_job_manager.cc:484: ----
```