### PR TITLE
[core] Construct statusor data with union

### DIFF
--- a/src/ray/common/status_or.h
+++ b/src/ray/common/status_or.h
@@ -70,6 +70,9 @@ class StatusOr {
     status_ = rhs.status();
   }
   StatusOr &operator=(const StatusOr &rhs) {
+    if (this == &rhs) {
+      return *this;
+    }
     if (rhs.ok()) {
       status_ = Status::OK();
       AssignValue(rhs.value());
@@ -78,9 +81,25 @@ class StatusOr {
     AssignStatus(rhs.status());
   }
 
-  StatusOr(StatusOr &&) noexcept(std::is_nothrow_move_constructible_v<T>) = default;
-  StatusOr &operator=(StatusOr &&) noexcept(std::is_nothrow_move_assignable_v<T>) =
-      default;
+  StatusOr(StatusOr &&rhs) noexcept(std::is_nothrow_move_constructible_v<T>) {
+    if (rhs.ok()) {
+      status_ = Status::OK();
+      MakeValue(std::move(rhs).value());
+      return;
+    }
+    status_ = std::move(rhs).status();
+  }
+  StatusOr &operator=(StatusOr &&rhs) noexcept(std::is_nothrow_move_assignable_v<T>) {
+    if (this == &rhs) {
+      return *this;
+    }
+    if (rhs.ok()) {
+      status_ = Status::OK();
+      AssignValue(std::move(rhs).value());
+      return;
+    }
+    AssignStatus(std::move(rhs).status());
+  }
 
   ~StatusOr() noexcept(std::is_nothrow_destructible_v<T>) {
     if (ok()) {

--- a/src/ray/common/status_or.h
+++ b/src/ray/common/status_or.h
@@ -37,7 +37,7 @@ class StatusOr {
   StatusOr(T &&data) : status_(Status::OK()) { MakeValue(std::move(data)); }
 
   template <typename... Args>
-  explicit StatusOr(std::in_place_t ip, Args &&...args) {
+  explicit StatusOr(std::in_place_t ip, Args &&...args) : status_(Status::OK()) {
     MakeValue(std::forward<Args>(args)...);
   }
 
@@ -57,7 +57,7 @@ class StatusOr {
       MakeValue(std::move(status_or).value());
       status_ = Status::OK();
     } else {
-      status_ = std::move(status_or).status();
+      status_ = status_or.status();
     }
   }
 
@@ -76,9 +76,10 @@ class StatusOr {
     if (rhs.ok()) {
       status_ = Status::OK();
       AssignValue(rhs.value());
-      return;
+      return *this;
     }
     AssignStatus(rhs.status());
+    return *this;
   }
 
   StatusOr(StatusOr &&rhs) noexcept(std::is_nothrow_move_constructible_v<T>) {
@@ -87,7 +88,7 @@ class StatusOr {
       MakeValue(std::move(rhs).value());
       return;
     }
-    status_ = std::move(rhs).status();
+    status_ = rhs.status();
   }
   StatusOr &operator=(StatusOr &&rhs) noexcept(std::is_nothrow_move_assignable_v<T>) {
     if (this == &rhs) {
@@ -96,9 +97,10 @@ class StatusOr {
     if (rhs.ok()) {
       status_ = Status::OK();
       AssignValue(std::move(rhs).value());
-      return;
+      return *this;
     }
-    AssignStatus(std::move(rhs).status());
+    AssignStatus(rhs.status());
+    return *this;
   }
 
   ~StatusOr() noexcept(std::is_nothrow_destructible_v<T>) {

--- a/src/ray/common/test/status_or_test.cc
+++ b/src/ray/common/test/status_or_test.cc
@@ -120,13 +120,7 @@ TEST(StatusOrTest, OperatorTest) {
 
 TEST(StatusOrTest, EqualityTest) {
   {
-    StatusOr<int> val1 = Status{};
-    StatusOr<int> val2 = Status{StatusCode::OK, "msg"};
-    EXPECT_NE(val1, val2);
-  }
-
-  {
-    StatusOr<int> val1 = Status{};
+    StatusOr<int> val1 = Status::InvalidArgument("msg");
     StatusOr<int> val2 = 20;
     EXPECT_NE(val1, val2);
   }

--- a/src/ray/common/test/status_or_test.cc
+++ b/src/ray/common/test/status_or_test.cc
@@ -237,4 +237,20 @@ TEST(StatusOrTest, CopyAssignment) {
   }
 }
 
+TEST(StatusOrTest, MoveAssignment) {
+  // Move value.
+  {
+    StatusOr<int> val = 10;
+    StatusOr<int> moved = std::move(val);
+    EXPECT_EQ(moved.value(), 10);
+  }
+
+  // Move status.
+  {
+    StatusOr<int> val = Status::InvalidArgument("error");
+    StatusOr<int> moved = std::move(val);
+    EXPECT_EQ(moved.code(), StatusCode::InvalidArgument);
+  }
+}
+
 }  // namespace ray

--- a/src/ray/common/test/status_or_test.cc
+++ b/src/ray/common/test/status_or_test.cc
@@ -219,4 +219,22 @@ TEST(StatusOrTest, OrElse) {
   }
 }
 
+TEST(StatusOrTest, CopyAssignment) {
+  // Copy value.
+  {
+    StatusOr<int> val = 10;
+    StatusOr<int> copy = val;
+    EXPECT_EQ(val.value(), 10);
+    EXPECT_EQ(copy.value(), 10);
+  }
+
+  // Error status.
+  {
+    StatusOr<int> val = Status::InvalidArgument("error");
+    StatusOr<int> copy = val;
+    EXPECT_EQ(val.code(), StatusCode::InvalidArgument);
+    EXPECT_EQ(copy.code(), StatusCode::InvalidArgument);
+  }
+}
+
 }  // namespace ray


### PR DESCRIPTION
For the code simplicity and review ease, I choose the easy and in-performant implementation at the first place, plan to do some optimizations for `ray::StatusOr`; the effect is reasonable since the data structure is core in error propagation.

In this PR, I follow the abseil statusor's implementation to use union and placement new to manage data, so it's not initialized for every status or usage.