### PR TITLE
[core] Exclusively run redis test

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2045,6 +2045,7 @@ ray_cc_test(
     tags = [
         "no_tsan",
         "team:core",
+        "exclusive",
     ],
     deps = [
         ":gcs_client_lib",


### PR DESCRIPTION
The test case is not a real unit test, which is supposed to be self-contained and not access external resource.
To tolerant the access to a fixed port number, mark it as exclusive, otherwise flaky test.