### PR TITLE
[core] Attempt fix GCS client ASAN

### DIFF
--- a/src/ray/gcs/gcs_client/test/gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/gcs_client_test.cc
@@ -95,11 +95,13 @@ class GcsClientTest : public ::testing::TestWithParam<bool> {
   }
 
   void TearDown() override {
+    client_io_service_->poll();
     client_io_service_->stop();
     client_io_service_thread_->join();
     gcs_client_->Disconnect();
     gcs_client_.reset();
 
+    server_io_service_->poll();
     server_io_service_->stop();
     rpc::DrainServerCallExecutor();
     server_io_service_thread_->join();
@@ -130,9 +132,10 @@ class GcsClientTest : public ::testing::TestWithParam<bool> {
 
   void RestartGcsServer() {
     RAY_LOG(INFO) << "Stopping GCS service, port = " << gcs_server_->GetPort();
-    gcs_server_->Stop();
+    server_io_service_->poll();
     server_io_service_->stop();
     server_io_service_thread_->join();
+    gcs_server_->Stop();
     gcs_server_.reset();
     RAY_LOG(INFO) << "Finished stopping GCS service.";
 

--- a/src/ray/gcs/gcs_server/gcs_redis_failure_detector.cc
+++ b/src/ray/gcs/gcs_server/gcs_redis_failure_detector.cc
@@ -50,7 +50,7 @@ void GcsRedisFailureDetector::DetectRedis() {
       this->io_service_.dispatch(this->callback_, "GcsRedisFailureDetector.DetectRedis");
     }
   };
-  auto cxt = redis_client_->GetPrimaryContext();
+  auto *cxt = redis_client_->GetPrimaryContext();
   cxt->RunArgvAsync({"PING"}, redis_callback);
 }
 

--- a/src/ray/gcs/redis_client.cc
+++ b/src/ray/gcs/redis_client.cc
@@ -33,7 +33,7 @@ Status RedisClient::Connect(instrumented_io_context &io_service) {
     return Status::Invalid("Redis server address is invalid!");
   }
 
-  primary_context_ = std::make_shared<RedisContext>(io_service);
+  primary_context_ = std::make_unique<RedisContext>(io_service);
 
   RAY_CHECK_OK(primary_context_->Connect(options_.server_ip_,
                                          options_.server_port_,

--- a/src/ray/gcs/redis_client.h
+++ b/src/ray/gcs/redis_client.h
@@ -69,7 +69,7 @@ class RedisClient {
   /// Disconnect with Redis. Non-thread safe.
   void Disconnect();
 
-  std::shared_ptr<RedisContext> GetPrimaryContext() { return primary_context_; }
+  RedisContext *GetPrimaryContext() { return primary_context_.get(); }
 
  protected:
   RedisClientOptions options_;
@@ -78,7 +78,7 @@ class RedisClient {
   bool is_connected_{false};
 
   // The following context writes everything to the primary shard
-  std::shared_ptr<RedisContext> primary_context_;
+  std::unique_ptr<RedisContext> primary_context_;
 };
 }  // namespace gcs
 }  // namespace ray

--- a/src/ray/gcs/store_client/redis_store_client.cc
+++ b/src/ray/gcs/store_client/redis_store_client.cc
@@ -285,7 +285,7 @@ void RedisStoreClient::SendRedisCmdWithKeys(std::vector<std::string> keys,
       }
     }
     // Send the actual request
-    auto cxt = redis_client_->GetPrimaryContext();
+    auto *cxt = redis_client_->GetPrimaryContext();
     cxt->RunArgvAsync(command.ToRedisArgs(),
                       [this,
                        concurrency_keys,  // Copied!
@@ -398,7 +398,7 @@ void RedisStoreClient::RedisScanner::Scan() {
   }
   command.args.push_back("COUNT");
   command.args.push_back(std::to_string(batch_count));
-  auto primary_context = redis_client_->GetPrimaryContext();
+  auto *primary_context = redis_client_->GetPrimaryContext();
   primary_context->RunArgvAsync(
       command.ToRedisArgs(),
       // self_ref to keep the scanner alive until the callback is called, even if it
@@ -447,7 +447,7 @@ int RedisStoreClient::GetNextJobID() {
   RedisCommand command = {
       "INCRBY", RedisKey{external_storage_namespace_, "JobCounter"}, {"1"}};
 
-  auto cxt = redis_client_->GetPrimaryContext();
+  auto *cxt = redis_client_->GetPrimaryContext();
   auto reply = cxt->RunArgvSync(command.ToRedisArgs());
   return static_cast<int>(reply->ReadAsInteger());
 }
@@ -511,7 +511,7 @@ bool RedisDelKeyPrefixSync(const std::string &host,
   auto status = cli->Connect(io_service);
   RAY_CHECK_OK(status) << "Failed to connect to redis";
 
-  auto context = cli->GetPrimaryContext();
+  auto *context = cli->GetPrimaryContext();
   // Delete all such keys by using empty table name.
   RedisKey redis_key{external_storage_namespace, /*table_name=*/""};
   std::vector<std::string> cmd{"KEYS",


### PR DESCRIPTION
Attempt to fix issue https://github.com/ray-project/ray/issues/49575

My take on this issue, there're three fixes / improvements in my PR:
- (major) Our current reset logic is to stop io context then reset GCS (all related data members, including the ones suffering use-after-release); the problem is, there could ongoing events being handled or will be handled;
- (minor) Reading io context [doc](https://live.boost.org/doc/libs/1_84_0/doc/html/boost_asio/reference/io_context/stop.html), `stop` only signals stop intention but not block wait all ongoing events stop, so the best practice to sync io context is `poll` then `stop`;
- (minor) We use shared pointer for redis context, which takes a while to justify its lifecycle, use unique pointer for ensured ownership.