### PR TITLE
[Core] Fix how to calculate the number of hosts in a TPU 

### DIFF
--- a/python/ray/_private/accelerators/tpu.py
+++ b/python/ray/_private/accelerators/tpu.py
@@ -273,10 +273,10 @@ class TPUAcceleratorManager(AcceleratorManager):
     def get_num_workers_in_current_tpu_pod() -> Optional[int]:
         """Return the total number of workers in a TPU pod."""
         tpu_pod_type = TPUAcceleratorManager._get_current_node_tpu_pod_type()
-        chips_per_host = TPUAcceleratorManager.get_current_node_num_accelerators()
-        if tpu_pod_type and chips_per_host > 0:
+        cores_per_host = TPUAcceleratorManager.get_current_node_num_accelerators()
+        if tpu_pod_type and cores_per_host > 0:
             num_chips_or_cores = int(tpu_pod_type.split("-")[1])
-            return num_chips_or_cores // chips_per_host
+            return num_chips_or_cores // cores_per_host
         else:
             logging.debug("Could not get num workers in TPU pod.")
             return None

--- a/python/ray/_private/accelerators/tpu.py
+++ b/python/ray/_private/accelerators/tpu.py
@@ -179,18 +179,18 @@ class TPUAcceleratorManager(AcceleratorManager):
             os.environ.pop(TPU_CHIPS_PER_HOST_BOUNDS_ENV_VAR, None)
             os.environ.pop(TPU_HOST_BOUNDS_ENV_VAR, None)
             return
-        os.environ[TPUAcceleratorManager.get_visible_accelerator_ids_env_var()] = (
-            ",".join([str(i) for i in visible_tpu_chips])
-        )
+        os.environ[
+            TPUAcceleratorManager.get_visible_accelerator_ids_env_var()
+        ] = ",".join([str(i) for i in visible_tpu_chips])
         if num_visible_tpu_chips == 1:
-            os.environ[TPU_CHIPS_PER_HOST_BOUNDS_ENV_VAR] = (
-                TPU_CHIPS_PER_HOST_BOUNDS_1_CHIP_CONFIG
-            )
+            os.environ[
+                TPU_CHIPS_PER_HOST_BOUNDS_ENV_VAR
+            ] = TPU_CHIPS_PER_HOST_BOUNDS_1_CHIP_CONFIG
             os.environ[TPU_HOST_BOUNDS_ENV_VAR] = TPU_SINGLE_HOST_BOUNDS
         elif num_visible_tpu_chips == 2:
-            os.environ[TPU_CHIPS_PER_HOST_BOUNDS_ENV_VAR] = (
-                TPU_CHIPS_PER_HOST_BOUNDS_2_CHIP_CONFIG
-            )
+            os.environ[
+                TPU_CHIPS_PER_HOST_BOUNDS_ENV_VAR
+            ] = TPU_CHIPS_PER_HOST_BOUNDS_2_CHIP_CONFIG
             os.environ[TPU_HOST_BOUNDS_ENV_VAR] = TPU_SINGLE_HOST_BOUNDS
 
     @staticmethod

--- a/python/ray/_private/accelerators/tpu.py
+++ b/python/ray/_private/accelerators/tpu.py
@@ -179,18 +179,18 @@ class TPUAcceleratorManager(AcceleratorManager):
             os.environ.pop(TPU_CHIPS_PER_HOST_BOUNDS_ENV_VAR, None)
             os.environ.pop(TPU_HOST_BOUNDS_ENV_VAR, None)
             return
-        os.environ[
-            TPUAcceleratorManager.get_visible_accelerator_ids_env_var()
-        ] = ",".join([str(i) for i in visible_tpu_chips])
+        os.environ[TPUAcceleratorManager.get_visible_accelerator_ids_env_var()] = (
+            ",".join([str(i) for i in visible_tpu_chips])
+        )
         if num_visible_tpu_chips == 1:
-            os.environ[
-                TPU_CHIPS_PER_HOST_BOUNDS_ENV_VAR
-            ] = TPU_CHIPS_PER_HOST_BOUNDS_1_CHIP_CONFIG
+            os.environ[TPU_CHIPS_PER_HOST_BOUNDS_ENV_VAR] = (
+                TPU_CHIPS_PER_HOST_BOUNDS_1_CHIP_CONFIG
+            )
             os.environ[TPU_HOST_BOUNDS_ENV_VAR] = TPU_SINGLE_HOST_BOUNDS
         elif num_visible_tpu_chips == 2:
-            os.environ[
-                TPU_CHIPS_PER_HOST_BOUNDS_ENV_VAR
-            ] = TPU_CHIPS_PER_HOST_BOUNDS_2_CHIP_CONFIG
+            os.environ[TPU_CHIPS_PER_HOST_BOUNDS_ENV_VAR] = (
+                TPU_CHIPS_PER_HOST_BOUNDS_2_CHIP_CONFIG
+            )
             os.environ[TPU_HOST_BOUNDS_ENV_VAR] = TPU_SINGLE_HOST_BOUNDS
 
     @staticmethod

--- a/python/ray/tests/accelerators/test_tpu.py
+++ b/python/ray/tests/accelerators/test_tpu.py
@@ -290,6 +290,7 @@ def test_empty_get_current_pod_name_returns_none():
 def test_worker_count(mock_glob, test_case):
     num_devices, accelerator_type, expected_worker_count = test_case
     mock_glob.return_value = ["/dev/accel" + str(x) for x in range(num_devices)]
+    TPUAcceleratorManager.get_current_node_num_accelerators.cache_clear()
 
     with patch(
         "ray._private.accelerators.tpu.TPUAcceleratorManager."
@@ -309,6 +310,7 @@ def test_num_tpu_chips(mock_glob):
         "/dev/accel2",
         "/dev/accel3",
     ]
+    TPUAcceleratorManager.get_current_node_num_accelerators.cache_clear()
     num_tpu_chips = ray.util.accelerators.tpu.get_num_tpu_chips_on_node()
     assert num_tpu_chips == 4
 

--- a/python/ray/tests/accelerators/test_tpu.py
+++ b/python/ray/tests/accelerators/test_tpu.py
@@ -297,7 +297,7 @@ def test_worker_count(mock_glob, test_case):
         "_get_current_node_tpu_pod_type",
         return_value=accelerator_type,
     ):
-       worker_count = ray.util.accelerators.tpu.get_current_pod_worker_count()
+        worker_count = ray.util.accelerators.tpu.get_current_pod_worker_count()
 
     assert worker_count == expected_worker_count
 

--- a/python/ray/tests/accelerators/test_tpu.py
+++ b/python/ray/tests/accelerators/test_tpu.py
@@ -297,7 +297,7 @@ def test_worker_count(mock_glob, test_case):
         "_get_current_node_tpu_pod_type",
         return_value=accelerator_type,
     ):
-        worker_count = ray.util.accelerators.tpu.get_current_pod_worker_count()
+       worker_count = ray.util.accelerators.tpu.get_current_pod_worker_count()
 
     assert worker_count == expected_worker_count
 

--- a/python/ray/tests/accelerators/test_tpu.py
+++ b/python/ray/tests/accelerators/test_tpu.py
@@ -279,13 +279,15 @@ def test_empty_get_current_pod_name_returns_none():
     assert name is None
 
 
-def test_worker_count():
-    with patch(
-        "ray._private.accelerators.tpu.TPUAcceleratorManager."
-        "get_num_workers_in_current_tpu_pod",
-        return_value=4,
-    ):
-        worker_count = ray.util.accelerators.tpu.get_current_pod_worker_count()
+@patch("glob.glob")
+def test_worker_count(mock_glob):
+    mock_glob.return_value = [
+        "/dev/accel0",
+        "/dev/accel1",
+        "/dev/accel2",
+        "/dev/accel3",
+    ]
+    worker_count = ray.util.accelerators.tpu.get_current_pod_worker_count()
     assert worker_count == 4
 
 

--- a/python/ray/tests/accelerators/test_tpu.py
+++ b/python/ray/tests/accelerators/test_tpu.py
@@ -302,7 +302,7 @@ def test_worker_count(mock_glob, test_case):
 
 
 @patch("glob.glob")
-def test_num_tpu_chips():
+def test_num_tpu_chips(mock_glob):
     mock_glob.return_value = [
         "/dev/accel0",
         "/dev/accel1",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Previously the number of worker hosts is calculated by dividing the total number of cores by a constant representing the cores per host. This constant could vary depending on the TPU version, which is error prone.

This change would instead call the predefined API for finding the number of cores on each node.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
