### PR TITLE
[core][autoscaler] Remove worker_rpc_drain from Autoscaler V2

### DIFF
--- a/python/ray/autoscaler/v2/instance_manager/config.py
+++ b/python/ray/autoscaler/v2/instance_manager/config.py
@@ -16,7 +16,6 @@ from ray.autoscaler._private.constants import (
     DEFAULT_UPSCALING_SPEED,
     DISABLE_LAUNCH_CONFIG_CHECK_KEY,
     DISABLE_NODE_UPDATERS_KEY,
-    WORKER_RPC_DRAIN_KEY,
 )
 from ray.autoscaler._private.kuberay.autoscaling_config import AutoscalingConfigProducer
 from ray.autoscaler._private.monitor import BASE_READONLY_CONFIG
@@ -401,10 +400,6 @@ class AutoscalingConfig:
     def disable_launch_config_check(self) -> bool:
         provider_config = self.get_provider_config()
         return provider_config.get(DISABLE_LAUNCH_CONFIG_CHECK_KEY, True)
-
-    def worker_rpc_drain(self) -> bool:
-        provider_config = self._configs.get("provider", {})
-        return provider_config.get(WORKER_RPC_DRAIN_KEY, True)
 
     def get_instance_reconcile_config(self) -> InstanceReconcileConfig:
         # TODO(rickyx): we need a way to customize these configs,

--- a/python/ray/autoscaler/v2/instance_manager/reconciler.py
+++ b/python/ray/autoscaler/v2/instance_manager/reconciler.py
@@ -1140,34 +1140,15 @@ class Reconciler:
         to_launch = reply.to_launch
         to_terminate = reply.to_terminate
         updates = {}
-        instances_by_id = {i.instance_id: i for i in im_instances}
         # Add terminating instances.
         for terminate_request in to_terminate:
             instance_id = terminate_request.instance_id
-            instance = instances_by_id[instance_id]
-
-            if autoscaling_config.worker_rpc_drain():
-                # If we would need to stop/drain ray.
-                updates[terminate_request.instance_id] = IMInstanceUpdateEvent(
-                    instance_id=instance_id,
-                    new_instance_status=IMInstance.RAY_STOP_REQUESTED,
-                    termination_request=terminate_request,
-                    details=f"draining ray: {terminate_request.details}",
-                )
-            else:
-                # If we would just terminate the cloud instance.
-                assert (
-                    instance.cloud_instance_id
-                ), f"Cloud instance id is not set on {instance.instance_id}."
-                updates[terminate_request.instance_id] = IMInstanceUpdateEvent(
-                    instance_id=instance_id,
-                    new_instance_status=IMInstance.TERMINATING,
-                    cloud_instance_id=instance.cloud_instance_id,
-                    details=(
-                        "terminating cloud instance without draining ray -"
-                        f"{terminate_request.details}"
-                    ),
-                )
+            updates[terminate_request.instance_id] = IMInstanceUpdateEvent(
+                instance_id=instance_id,
+                new_instance_status=IMInstance.RAY_STOP_REQUESTED,
+                termination_request=terminate_request,
+                details=f"draining ray: {terminate_request.details}",
+            )
 
         # Add new instances.
         for launch_request in to_launch:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The flag `worker_rpc_drain` is always true. 

The autoscaler shouldn't shut down a Raylet or instruct the NodeProvider to terminate a Ray node (or Ray Pod) without draining it first. 

* Shut down a Raylet before draining it.
  * Raylet dies -> K8s restarts the Ray container -> Ray scheduler schedules tasks or actors to the node -> KubeRay deletes the Ray Pod
* Terminate a Ray node before draining it.
  * Update the KubeRay CR -> Ray scheduler schedules tasks or actors to the node -> KubeRay deletes the Ray Pod -> Running tasks or actors were unexpectedly deleted

The next step is to remove it from Autoscaler V1.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
