### PR TITLE
[core] Remove extra copies on InternalKVGets and return bool on InternalKVPut

### DIFF
--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -515,7 +515,7 @@ cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
             const c_string &value,
             c_bool overwrite,
             int64_t timeout_ms,
-            const OptionalItemPyCallback[int] &callback)
+            const OptionalItemPyCallback[c_bool] &callback)
 
         CRayStatus AsyncInternalKVExists(
             const c_string &ns,

--- a/python/ray/includes/gcs_client.pxi
+++ b/python/ray/includes/gcs_client.pxi
@@ -210,8 +210,6 @@ cdef class InnerGcsClient:
         self, c_string key, c_string value, c_bool overwrite=False, namespace=None,
         timeout=None
     ) -> Future[bool]:
-        # TODO(ryw): the sync `internal_kv_put` returns bool while this async version
-        # returns int. We should make them consistent.
         cdef:
             c_string ns = namespace or b""
             int64_t timeout_ms = round(1000 * timeout) if timeout else -1

--- a/python/ray/includes/gcs_client.pxi
+++ b/python/ray/includes/gcs_client.pxi
@@ -209,7 +209,7 @@ cdef class InnerGcsClient:
     def async_internal_kv_put(
         self, c_string key, c_string value, c_bool overwrite=False, namespace=None,
         timeout=None
-    ) -> Future[int]:
+    ) -> Future[bool]:
         # TODO(ryw): the sync `internal_kv_put` returns bool while this async version
         # returns int. We should make them consistent.
         cdef:
@@ -220,8 +220,8 @@ cdef class InnerGcsClient:
             check_status_timeout_as_rpc_error(
                 self.inner.get().InternalKV().AsyncInternalKVPut(
                     ns, key, value, overwrite, timeout_ms,
-                    OptionalItemPyCallback[int](
-                        &convert_optional_int,
+                    OptionalItemPyCallback[c_bool](
+                        &convert_optional_bool,
                         assign_and_decrement_fut,
                         fut)))
         return asyncio.wrap_future(fut)

--- a/src/mock/ray/gcs/gcs_client/accessor.h
+++ b/src/mock/ray/gcs/gcs_client/accessor.h
@@ -327,7 +327,7 @@ class MockInternalKVAccessor : public InternalKVAccessor {
                const std::string &value,
                bool overwrite,
                const int64_t timeout_ms,
-               const OptionalItemCallback<int> &callback),
+               const OptionalItemCallback<bool> &callback),
               (override));
   MOCK_METHOD(Status,
               AsyncInternalKVExists,

--- a/src/mock/ray/gcs/gcs_server/gcs_kv_manager.h
+++ b/src/mock/ray/gcs/gcs_server/gcs_kv_manager.h
@@ -33,7 +33,7 @@ class MockInternalKVInterface : public ray::gcs::InternalKVInterface {
       MultiGet,
       (const std::string &ns,
        const std::vector<std::string> &keys,
-       std::function<void(std::unordered_map<std::string, std::string>)> callback),
+       std::function<void(absl::flat_hash_map<std::string, std::string>)> callback),
       (override));
   MOCK_METHOD(void,
               Put,
@@ -90,9 +90,9 @@ class FakeInternalKVInterface : public ray::gcs::InternalKVInterface {
 
   void MultiGet(const std::string &ns,
                 const std::vector<std::string> &keys,
-                std::function<void(std::unordered_map<std::string, std::string>)>
+                std::function<void(absl::flat_hash_map<std::string, std::string>)>
                     callback) override {
-    std::unordered_map<std::string, std::string> result;
+    absl::flat_hash_map<std::string, std::string> result;
     for (const auto &key : keys) {
       std::string full_key = ns + key;
       auto it = kv_store_.find(full_key);

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -1202,12 +1202,13 @@ Status InternalKVAccessor::AsyncInternalKVMultiGet(
   return Status::OK();
 }
 
-Status InternalKVAccessor::AsyncInternalKVPut(const std::string &ns,
-                                              const std::string &key,
-                                              const std::string &value,
-                                              bool overwrite,
-                                              const int64_t timeout_ms,
-                                              const OptionalItemCallback<int> &callback) {
+Status InternalKVAccessor::AsyncInternalKVPut(
+    const std::string &ns,
+    const std::string &key,
+    const std::string &value,
+    bool overwrite,
+    const int64_t timeout_ms,
+    const OptionalItemCallback<bool> &callback) {
   rpc::InternalKVPutRequest req;
   req.set_namespace_(ns);
   req.set_key(key);
@@ -1216,7 +1217,7 @@ Status InternalKVAccessor::AsyncInternalKVPut(const std::string &ns,
   client_impl_->GetGcsRpcClient().InternalKVPut(
       req,
       [callback](const Status &status, rpc::InternalKVPutReply &&reply) {
-        callback(status, reply.added_num());
+        callback(status, reply.added());
       },
       timeout_ms);
   return Status::OK();
@@ -1291,8 +1292,8 @@ Status InternalKVAccessor::Put(const std::string &ns,
       value,
       overwrite,
       timeout_ms,
-      [&ret_promise, &added](Status status, std::optional<int> added_num) {
-        added = static_cast<bool>(added_num.value_or(0));
+      [&ret_promise, &added](Status status, std::optional<bool> was_added) {
+        added = was_added.value_or(false);
         ret_promise.set_value(status);
       }));
   return ret_promise.get_future().get();

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -809,7 +809,7 @@ class InternalKVAccessor {
                                     const std::string &value,
                                     bool overwrite,
                                     const int64_t timeout_ms,
-                                    const OptionalItemCallback<int> &callback);
+                                    const OptionalItemCallback<bool> &callback);
 
   /// Asynchronously check the existence of a given key
   ///

--- a/src/ray/gcs/gcs_server/gcs_job_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_job_manager.cc
@@ -395,7 +395,7 @@ void GcsJobManager::HandleGetAllJobInfo(rpc::GetAllJobInfoRequest request,
            send_reply_callback,
            job_data_key_to_indices,
            num_finished_tasks,
-           try_send_reply](std::unordered_map<std::string, std::string> &&result) {
+           try_send_reply](auto result) {
             for (const auto &data : result) {
               const std::string &job_data_key = data.first;
               // The JobInfo stored by the Ray Job API.

--- a/src/ray/gcs/gcs_server/gcs_kv_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_kv_manager.h
@@ -47,7 +47,7 @@ class InternalKVInterface {
   virtual void MultiGet(
       const std::string &ns,
       const std::vector<std::string> &keys,
-      std::function<void(std::unordered_map<std::string, std::string>)> callback) = 0;
+      std::function<void(absl::flat_hash_map<std::string, std::string>)> callback) = 0;
 
   /// Associate a key with the specified value.
   ///

--- a/src/ray/gcs/gcs_server/store_client_kv.cc
+++ b/src/ray/gcs/gcs_server/store_client_kv.cc
@@ -35,11 +35,11 @@ std::string MakeKey(const std::string &ns, const std::string &key) {
 
 std::string ExtractKey(const std::string &key) {
   if (absl::StartsWith(key, kNamespacePrefix)) {
-    std::vector<std::string> parts =
+    std::vector<std::string_view> parts =
         absl::StrSplit(key, absl::MaxSplits(kNamespaceSep, 1));
     RAY_CHECK(parts.size() == 2) << "Invalid key: " << key;
 
-    return parts[1];
+    return std::string{parts[1]};
   }
   return key;
 }

--- a/src/ray/gcs/gcs_server/store_client_kv.cc
+++ b/src/ray/gcs/gcs_server/store_client_kv.cc
@@ -34,15 +34,14 @@ std::string MakeKey(const std::string &ns, const std::string &key) {
 }
 
 std::string ExtractKey(const std::string &key) {
-  auto view = std::string_view(key);
-  if (absl::StartsWith(view, kNamespacePrefix)) {
+  if (absl::StartsWith(key, kNamespacePrefix)) {
     std::vector<std::string> parts =
         absl::StrSplit(key, absl::MaxSplits(kNamespaceSep, 1));
     RAY_CHECK(parts.size() == 2) << "Invalid key: " << key;
 
     return parts[1];
   }
-  return std::string(view.begin(), view.end());
+  return key;
 }
 
 }  // namespace
@@ -65,8 +64,7 @@ void StoreClientInternalKV::Get(
       MakeKey(ns, key),
       {[callback = std::move(callback)](auto status, auto result) {
          RAY_CHECK(status.ok()) << "Fails to get key from storage " << status;
-         callback(result.has_value() ? std::optional<std::string>(result.value())
-                                     : std::optional<std::string>());
+         callback(std::move(result));
        },
        io_context_}));
 }
@@ -74,7 +72,7 @@ void StoreClientInternalKV::Get(
 void StoreClientInternalKV::MultiGet(
     const std::string &ns,
     const std::vector<std::string> &keys,
-    std::function<void(std::unordered_map<std::string, std::string>)> callback) {
+    std::function<void(absl::flat_hash_map<std::string, std::string>)> callback) {
   if (!callback) {
     callback = [](auto) {};
   }
@@ -83,17 +81,18 @@ void StoreClientInternalKV::MultiGet(
   for (const auto &key : keys) {
     prefixed_keys.emplace_back(MakeKey(ns, key));
   }
-  RAY_CHECK_OK(
-      delegate_->AsyncMultiGet(table_name_,
-                               prefixed_keys,
-                               {[callback = std::move(callback)](auto result) {
-                                  std::unordered_map<std::string, std::string> ret;
-                                  for (const auto &item : result) {
-                                    ret.emplace(ExtractKey(item.first), item.second);
-                                  }
-                                  callback(std::move(ret));
-                                },
-                                io_context_}));
+  RAY_CHECK_OK(delegate_->AsyncMultiGet(
+      table_name_,
+      prefixed_keys,
+      {[callback = std::move(callback)](auto result) {
+         absl::flat_hash_map<std::string, std::string> ret;
+         ret.reserve(result.size());
+         for (auto &&item : std::move(result)) {
+           ret.emplace(ExtractKey(item.first), std::move(item.second));
+         }
+         callback(std::move(ret));
+       },
+       io_context_}));
 }
 
 void StoreClientInternalKV::Put(const std::string &ns,

--- a/src/ray/gcs/gcs_server/store_client_kv.h
+++ b/src/ray/gcs/gcs_server/store_client_kv.h
@@ -36,7 +36,7 @@ class StoreClientInternalKV : public InternalKVInterface {
 
   void MultiGet(const std::string &ns,
                 const std::vector<std::string> &keys,
-                std::function<void(std::unordered_map<std::string, std::string>)>
+                std::function<void(absl::flat_hash_map<std::string, std::string>)>
                     callback) override;
 
   void Put(const std::string &ns,

--- a/src/ray/gcs/gcs_server/test/gcs_job_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_job_manager_test.cc
@@ -89,7 +89,7 @@ TEST_F(GcsJobManagerTest, TestFakeInternalKV) {
 
   fake_kv_->MultiGet("ns",
                      {"key", "key2"},
-                     [](const std::unordered_map<std::string, std::string> &result) {
+                     [](const absl::flat_hash_map<std::string, std::string> &result) {
                        ASSERT_EQ(result.size(), 2);
                        ASSERT_EQ(result.at("key"), "value");
                        ASSERT_EQ(result.at("key2"), "value2");

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -565,6 +565,7 @@ message InternalKVPutRequest {
 
 message InternalKVPutReply {
   GcsStatus status = 1;
+  // Refers to whether the key / value was actually added.
   bool added = 2;
 }
 

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -565,7 +565,7 @@ message InternalKVPutRequest {
 
 message InternalKVPutReply {
   GcsStatus status = 1;
-  int32 added_num = 2;
+  bool added = 2;
 }
 
 message InternalKVDelRequest {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Two things 
<!-- Please give a short summary of the change and the problem this solves. -->
- Moves the value on an InternalKVGet. This is a frequently hit path. It also adds moves for InternalKVMultiGet, and switches it to flat_hash_map. 
- There was an old todo to make internal_kv_put have a bool callback to make it consistent all the way through, so did that too.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
