### PR TITLE
[core] [easy] Fix cpp example

### DIFF
--- a/cpp/example/BUILD.bazel
+++ b/cpp/example/BUILD.bazel
@@ -1,39 +1,11 @@
 cc_binary(
     name = "example",
-    srcs = glob([
-        "*.cc",
-    ]),
+    srcs = ["example.cc"],
     data = [
-        "example.so",
+        "//cpp:libray_api.so",
+    ],
+    deps = [
+        "//cpp:ray_api_lib",
     ],
     linkstatic = True,
-    deps = [
-        ":ray_api",
-    ],
-)
-
-cc_binary(
-    name = "example.so",
-    srcs = glob([
-        "*.cc",
-    ]),
-    linkopts = ["-shared"],
-    linkstatic = True,
-    deps = [
-        ":ray_api",
-    ],
-)
-
-cc_library(
-    name = "ray_api",
-    srcs = [
-        "thirdparty/lib/libray_api.so",
-    ],
-    hdrs = glob([
-        "thirdparty/include/**/*.h",
-        "thirdparty/include/**/*.hpp",
-    ]),
-    linkopts = ["-Wl,-rpath,./"],
-    strip_include_prefix = "thirdparty/include",
-    visibility = ["//visibility:public"],
 )

--- a/cpp/example/run.sh
+++ b/cpp/example/run.sh
@@ -1,13 +1,11 @@
 #!/usr/bin/env bash
 
-#Cause the script to exit if a single command fails.
+# Cause the script to exit if a single command fails.
 set -e
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" || exit; pwd)"
-
-bazel --nosystem_rc --nohome_rc build //:example
+bazel --nosystem_rc --nohome_rc build //cpp/example:example
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    DYLD_LIBRARY_PATH="$ROOT_DIR/thirdparty/lib" "${ROOT_DIR}"/bazel-bin/example
+    bazel-bin/cpp/example/example
 else
-    LD_LIBRARY_PATH="$ROOT_DIR/thirdparty/lib" "${ROOT_DIR}"/bazel-bin/example
+    bazel-bin/cpp/example/example
 fi


### PR DESCRIPTION
A few fixes to C++ example file:
- Change`run.sh` access mode to allow execute via `chmod +x run.sh`
- Update `run.sh`, I feel confused what `third_party` folder is, IMO it's not needed
- Minor update for `cc_binary`: cc executable no need for another shared library and such complicated link path specification; even if we want to "load" it in another executable, data dependency is good enough.

How I tested: I verified my change works via executing the script, both compilation/link and execution seem normal.

Redo for https://github.com/ray-project/ray/pull/47557. which is broken due to too many linter and clang format complaints due to lagging from main branch.