### PR TITLE
[Core] Streaming generator supports num_returns

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -3687,6 +3687,7 @@ cdef class CoreWorker:
                     args,
                     c_string name,
                     int num_returns,
+                    c_bool is_streaming_generator,
                     resources,
                     int max_retries,
                     c_bool retry_exceptions,
@@ -3733,7 +3734,8 @@ cdef class CoreWorker:
                 &incremented_put_arg_ids)
 
             task_options = CTaskOptions(
-                name, num_returns, c_resources,
+                name, num_returns, is_streaming_generator,
+                c_resources,
                 b"",
                 generator_backpressure_num_objects,
                 serialized_runtime_env_info,
@@ -3936,6 +3938,7 @@ cdef class CoreWorker:
                           args,
                           c_string name,
                           int num_returns,
+                          c_bool is_streaming_generator,
                           int max_retries,
                           c_bool retry_exceptions,
                           retry_exception_allowlist,
@@ -3984,6 +3987,7 @@ cdef class CoreWorker:
                     CTaskOptions(
                         name,
                         num_returns,
+                        is_streaming_generator,
                         c_resources,
                         concurrency_group_name,
                         generator_backpressure_num_objects,

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -318,15 +318,18 @@ cdef extern from "ray/core_worker/common.h" nogil:
     cdef cppclass CTaskOptions "ray::core::TaskOptions":
         CTaskOptions()
         CTaskOptions(c_string name, int num_returns,
+                     c_bool is_streaming_generator,
                      unordered_map[c_string, double] &resources,
                      c_string concurrency_group_name,
                      int64_t generator_backpressure_num_objects)
         CTaskOptions(c_string name, int num_returns,
+                     c_bool is_streaming_generator,
                      unordered_map[c_string, double] &resources,
                      c_string concurrency_group_name,
                      int64_t generator_backpressure_num_objects,
                      c_string serialized_runtime_env)
         CTaskOptions(c_string name, int num_returns,
+                     c_bool is_streaming_generator,
                      unordered_map[c_string, double] &resources,
                      c_string concurrency_group_name,
                      int64_t generator_backpressure_num_objects,
@@ -737,4 +740,3 @@ cdef extern from "ray/common/constants.h" nogil:
     cdef const char[] kWorkerSetupHookKeyName
     cdef int kResourceUnitScaling
     cdef const char[] kImplicitResourcePrefix
-    cdef int kStreamingGeneratorReturn

--- a/python/ray/includes/common.pxi
+++ b/python/ray/includes/common.pxi
@@ -10,7 +10,6 @@ from ray.includes.common cimport (
     kWorkerSetupHookKeyName,
     kResourceUnitScaling,
     kImplicitResourcePrefix,
-    kStreamingGeneratorReturn,
 )
 
 from ray.exceptions import (
@@ -120,4 +119,3 @@ cdef int check_status_timeout_as_rpc_error(const CRayStatus& status) nogil excep
 WORKER_PROCESS_SETUP_HOOK_KEY_NAME_GCS = str(kWorkerSetupHookKeyName)
 RESOURCE_UNIT_SCALING = kResourceUnitScaling
 IMPLICIT_RESOURCE_PREFIX = kImplicitResourcePrefix.decode()
-STREAMING_GENERATOR_RETURN = kStreamingGeneratorReturn

--- a/src/ray/common/constants.h
+++ b/src/ray/common/constants.h
@@ -25,8 +25,6 @@ constexpr int kResourceUnitScaling = 10000;
 
 constexpr char kWorkerSetupHookKeyName[] = "FunctionsToRun";
 
-constexpr int kStreamingGeneratorReturn = -2;
-
 /// Length of Ray full-length IDs in bytes.
 constexpr size_t kUniqueIDSize = 28;
 

--- a/src/ray/core_worker/common.h
+++ b/src/ray/core_worker/common.h
@@ -63,6 +63,7 @@ struct TaskOptions {
   TaskOptions() {}
   TaskOptions(std::string name,
               int num_returns,
+              bool is_streaming_generator,
               std::unordered_map<std::string, double> &resources,
               const std::string &concurrency_group_name = "",
               int64_t generator_backpressure_num_objects = -1,
@@ -71,6 +72,7 @@ struct TaskOptions {
               const std::unordered_map<std::string, std::string> &labels = {})
       : name(name),
         num_returns(num_returns),
+        is_streaming_generator(is_streaming_generator),
         resources(resources),
         concurrency_group_name(concurrency_group_name),
         serialized_runtime_env_info(serialized_runtime_env_info),
@@ -82,6 +84,7 @@ struct TaskOptions {
   std::string name;
   /// Number of returns of this task.
   int num_returns = 1;
+  bool is_streaming_generator;
   /// Resources required by this task.
   std::unordered_map<std::string, double> resources;
   /// The name of the concurrency group in which this task will be executed.

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1385,6 +1385,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
       const RayFunction &function,
       const std::vector<std::unique_ptr<TaskArg>> &args,
       int64_t num_returns,
+      bool is_streaming_generator,
       const std::unordered_map<std::string, double> &required_resources,
       const std::unordered_map<std::string, double> &required_placement_resources,
       const std::string &debugger_breakpoint,

--- a/src/ray/internal/internal.cc
+++ b/src/ray/internal/internal.cc
@@ -35,7 +35,7 @@ std::vector<rpc::ObjectReference> SendInternal(
     std::string serialized_retry_exception_allowlist) {
   std::unordered_map<std::string, double> resources;
   std::string name = function.GetFunctionDescriptor()->DefaultTaskName();
-  TaskOptions options{name, return_num, resources};
+  TaskOptions options{name, return_num, false, resources};
 
   char meta_data[3] = {'R', 'A', 'W'};
   std::shared_ptr<LocalMemoryBuffer> meta =


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Replace static generator with streaming generator implementation. This is a pure implementation change so it's backward compatible.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #46934
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
