### PR TITLE
[train] bump v2/test_scheduling from small to medium

### DIFF
--- a/python/ray/train/v2/BUILD
+++ b/python/ray/train/v2/BUILD
@@ -121,7 +121,7 @@ py_test(
 
 py_test(
     name = "test_scheduling",
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_scheduling.py"],
     tags = ["exclusive", "team:ml", "train_v2"],
     deps = ["//:ray_lib", ":conftest"],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Fix timeout. Glancing over the test failures it seems like the time is spent on actually adding the nodes, rather than the Train scheduling code.

```
[2025-01-03T06:45:15Z] //python/ray/train/v2:test_scheduling                                   TIMEOUT in 3 out of 3 in 70.4s
[2025-01-03T06:45:15Z]   Stats over 3 runs: max = 70.4s, min = 60.0s, avg = 66.3s, dev = 4.5s
```

## Related issue number
Closes https://github.com/ray-project/ray/issues/49593

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
