### PR TITLE
[RLlib] Add experimental option to suppress algo config `validate()`; some code cleanups.

### DIFF
--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -567,6 +567,7 @@ class AlgorithmConfig(_Config):
         self._per_module_overrides: Dict[ModuleID, "AlgorithmConfig"] = {}
 
         # `self.experimental()`
+        self._validate_config = True
         self._use_msgpack_checkpoints = False
         self._torch_grad_scaler_class = None
         self._torch_lr_scheduler_classes = None
@@ -906,6 +907,10 @@ class AlgorithmConfig(_Config):
     @OverrideToImplementCustomLogic_CallToSuperRecommended
     def validate(self) -> None:
         """Validates all values in this config."""
+
+        # Validation is blocked.
+        if not self._validate_config:
+            return
 
         self._validate_env_runner_settings()
         self._validate_callbacks_settings()
@@ -3593,6 +3598,7 @@ class AlgorithmConfig(_Config):
     def experimental(
         self,
         *,
+        _validate_config: Optional[bool] = True,
         _use_msgpack_checkpoints: Optional[bool] = NotProvided,
         _torch_grad_scaler_class: Optional[Type] = NotProvided,
         _torch_lr_scheduler_classes: Optional[
@@ -3606,6 +3612,8 @@ class AlgorithmConfig(_Config):
         """Sets the config's experimental settings.
 
         Args:
+            _validate_config: Whether to run `validate()` on this config. True by
+                default. If False, ignores any calls to `self.validate()`.
             _use_msgpack_checkpoints: Create state files in all checkpoints through
                 msgpack rather than pickle.
             _torch_grad_scaler_class: Class to use for torch loss scaling (and gradient
@@ -3647,6 +3655,8 @@ class AlgorithmConfig(_Config):
         Returns:
             This updated AlgorithmConfig object.
         """
+        if _validate_config is not NotProvided:
+            self._validate_config = _validate_config
         if _use_msgpack_checkpoints is not NotProvided:
             self._use_msgpack_checkpoints = _use_msgpack_checkpoints
         if _tf_policy_handles_more_than_one_loss is not NotProvided:
@@ -3891,8 +3901,6 @@ class AlgorithmConfig(_Config):
 
         return eval_config_obj
 
-    # TODO: Move this to those algorithms that really need this, which is currently
-    #  only A2C and PG.
     def validate_train_batch_size_vs_rollout_fragment_length(self) -> None:
         """Detects mismatches for `train_batch_size` vs `rollout_fragment_length`.
 
@@ -3905,18 +3913,11 @@ class AlgorithmConfig(_Config):
         asking the user to set rollout_fragment_length to `auto` or to a matching
         value.
 
-        Also, only checks this if `train_batch_size` > 0 (DDPPO sets this
-        to -1 to auto-calculate the actual batch size later).
-
         Raises:
             ValueError: If there is a mismatch between user provided
                 `rollout_fragment_length` and `total_train_batch_size`.
         """
-        if (
-            self.rollout_fragment_length != "auto"
-            and not self.in_evaluation
-            and self.total_train_batch_size > 0
-        ):
+        if self.rollout_fragment_length != "auto" and not self.in_evaluation:
             min_batch_size = (
                 max(self.num_env_runners, 1)
                 * self.num_envs_per_env_runner
@@ -3933,7 +3934,7 @@ class AlgorithmConfig(_Config):
                 suggested_rollout_fragment_length = self.total_train_batch_size // (
                     self.num_envs_per_env_runner * (self.num_env_runners or 1)
                 )
-                raise ValueError(
+                self._value_error(
                     "Your desired `total_train_batch_size` "
                     f"({self.total_train_batch_size}={self.num_learners} "
                     f"learners x {self.train_batch_size_per_learner}) "
@@ -4402,13 +4403,20 @@ class AlgorithmConfig(_Config):
     # -----------------------------------------------------------
     # Various validation methods for different types of settings.
     # -----------------------------------------------------------
+    def _value_error(self, errmsg) -> None:
+        msg = errmsg + (
+            "\nTo suppress all validation errors, set "
+            "`config.experimental(_validate_config=False)` at your own risk."
+        )
+        raise ValueError(msg)
+
     def _validate_env_runner_settings(self) -> None:
         allowed_vectorize_modes = set(
             list(gym.envs.registration.VectorizeMode.__members__.keys())
             + list(gym.envs.registration.VectorizeMode.__members__.values())
         )
         if self.gym_env_vectorize_mode not in allowed_vectorize_modes:
-            raise ValueError(
+            self._value_error(
                 f"`gym_env_vectorize_mode` ({self.gym_env_vectorize_mode}) must be a "
                 "member of `gym.envs.registration.VectorizeMode`! Allowed values "
                 f"are {allowed_vectorize_modes}."
@@ -4435,7 +4443,7 @@ class AlgorithmConfig(_Config):
                 or self.callbacks_on_checkpoint_loaded is not None
                 or self.callbacks_on_env_runners_recreated is not None
             ):
-                raise ValueError(
+                self._value_error(
                     "Config settings `config.callbacks(on_....=lambda ..)` aren't "
                     "supported on the old API stack! Switch to the new API stack "
                     "through `config.api_stack(enable_env_runner_and_connector_v2=True,"
@@ -4455,7 +4463,7 @@ class AlgorithmConfig(_Config):
 
         # Can not use "tf" with learner API.
         if self.framework_str == "tf" and self.enable_rl_module_and_learner:
-            raise ValueError(
+            self._value_error(
                 "Cannot use `framework=tf` with the new API stack! Either switch to tf2"
                 " via `config.framework('tf2')` OR disable the new API stack via "
                 "`config.api_stack(enable_rl_module_and_learner=False)`."
@@ -4468,7 +4476,7 @@ class AlgorithmConfig(_Config):
             and version.parse(_torch.__version__) < TORCH_COMPILE_REQUIRED_VERSION
             and (self.torch_compile_learner or self.torch_compile_worker)
         ):
-            raise ValueError("torch.compile is only supported from torch 2.0.0")
+            self._value_error("torch.compile is only supported from torch 2.0.0")
 
         # Make sure the Learner's torch-what-to-compile setting is supported.
         if self.torch_compile_learner:
@@ -4480,7 +4488,7 @@ class AlgorithmConfig(_Config):
                 TorchCompileWhatToCompile.FORWARD_TRAIN,
                 TorchCompileWhatToCompile.COMPLETE_UPDATE,
             ]:
-                raise ValueError(
+                self._value_error(
                     f"`config.torch_compile_learner_what_to_compile` must be one of ["
                     f"TorchCompileWhatToCompile.forward_train, "
                     f"TorchCompileWhatToCompile.complete_update] but is"
@@ -4497,7 +4505,7 @@ class AlgorithmConfig(_Config):
         #  https://github.com/ray-project/ray/issues/35409
         #  Remove this once we are able to specify placement group bundle index in RLlib
         if self.num_cpus_per_learner > 1 and self.num_gpus_per_learner > 0:
-            raise ValueError(
+            self._value_error(
                 "Can't set both `num_cpus_per_learner` > 1 and "
                 " `num_gpus_per_learner` > 0! Either set "
                 "`num_cpus_per_learner` > 1 (and `num_gpus_per_learner`"
@@ -4507,13 +4515,6 @@ class AlgorithmConfig(_Config):
                 "https://github.com/ray-project/ray/issues/35409 for more details."
             )
 
-        # Make sure the resource requirements for learner_group is valid.
-        if self.num_learners == 0 and self.num_gpus_per_env_runner > 1:
-            raise ValueError(
-                "num_gpus_per_env_runner must be 0 (cpu) or 1 (gpu) when using local "
-                "mode (i.e., `num_learners=0`)"
-            )
-
     def _validate_multi_agent_settings(self):
         """Checks, whether multi-agent related settings make sense."""
 
@@ -4521,7 +4522,7 @@ class AlgorithmConfig(_Config):
         if isinstance(self.policies_to_train, (list, set, tuple)):
             for pid in self.policies_to_train:
                 if pid not in self.policies:
-                    raise ValueError(
+                    self._value_error(
                         "`config.multi_agent(policies_to_train=..)` contains "
                         f"policy ID ({pid}) that was not defined in "
                         f"`config.multi_agent(policies=..)`!"
@@ -4534,7 +4535,7 @@ class AlgorithmConfig(_Config):
             and self.enable_env_runner_and_connector_v2
             and self.num_envs_per_env_runner > 1
         ):
-            raise ValueError(
+            self._value_error(
                 "For now, using env vectorization "
                 "(`config.num_envs_per_env_runner > 1`) in combination with "
                 "multi-agent AND the new EnvRunners is not supported! Try setting "
@@ -4548,7 +4549,7 @@ class AlgorithmConfig(_Config):
         # (which is also async):
         # `config.evaluation(evaluation_parallel_to_training=True)`.
         if self.enable_async_evaluation is True:
-            raise ValueError(
+            self._value_error(
                 "`enable_async_evaluation` has been deprecated (you should set this to "
                 "False)! Use `config.evaluation(evaluation_parallel_to_training=True)` "
                 "instead."
@@ -4573,7 +4574,7 @@ class AlgorithmConfig(_Config):
             self.evaluation_num_env_runners == 0
             and self.evaluation_parallel_to_training
         ):
-            raise ValueError(
+            self._value_error(
                 "`evaluation_parallel_to_training` can only be done if "
                 "`evaluation_num_env_runners` > 0! Try setting "
                 "`config.evaluation_parallel_to_training` to False."
@@ -4583,7 +4584,7 @@ class AlgorithmConfig(_Config):
         # `evaluation_parallel_to_training=False`.
         if self.evaluation_duration == "auto":
             if not self.evaluation_parallel_to_training:
-                raise ValueError(
+                self._value_error(
                     "`evaluation_duration=auto` not supported for "
                     "`evaluation_parallel_to_training=False`!"
                 )
@@ -4599,7 +4600,7 @@ class AlgorithmConfig(_Config):
             not isinstance(self.evaluation_duration, int)
             or self.evaluation_duration <= 0
         ):
-            raise ValueError(
+            self._value_error(
                 f"`evaluation_duration` ({self.evaluation_duration}) must be an "
                 f"int and >0!"
             )
@@ -4608,7 +4609,7 @@ class AlgorithmConfig(_Config):
         """Checks, whether input related settings make sense."""
 
         if self.input_ == "sampler" and self.off_policy_estimation_methods:
-            raise ValueError(
+            self._value_error(
                 "Off-policy estimation methods can only be used if the input is a "
                 "dataset. We currently do not support applying off_policy_estimation_"
                 "method on a sampler input."
@@ -4656,7 +4657,7 @@ class AlgorithmConfig(_Config):
             # User is using the new EnvRunners, but forgot to switch on
             # `enable_rl_module_and_learner`.
             if self.enable_env_runner_and_connector_v2:
-                raise ValueError(
+                self._value_error(
                     "You are using the new API stack EnvRunners (SingleAgentEnvRunner "
                     "or MultiAgentEnvRunner), but have forgotten to switch on the new "
                     "API stack! Try setting "
@@ -4679,7 +4680,7 @@ class AlgorithmConfig(_Config):
         # Disabled hybrid API stack. Now, both `enable_rl_module_and_learner` and
         # `enable_env_runner_and_connector_v2` must be True or both False.
         if not self.enable_env_runner_and_connector_v2:
-            raise ValueError(
+            self._value_error(
                 "Setting `enable_rl_module_and_learner` to True and "
                 "`enable_env_runner_and_connector_v2` to False ('hybrid API stack'"
                 ") is not longer supported! Set both to True (new API stack) or both "
@@ -4716,7 +4717,7 @@ class AlgorithmConfig(_Config):
         # This is not compatible with RLModules, which all have a method
         # `forward_exploration` to specify custom exploration behavior.
         if self.exploration_config:
-            raise ValueError(
+            self._value_error(
                 "When the RLModule API is enabled, exploration_config can not be "
                 "set. If you want to implement custom exploration behaviour, "
                 "please modify the `forward_exploration` method of the "
@@ -4736,12 +4737,12 @@ class AlgorithmConfig(_Config):
         )
 
         if self.model["custom_model"] is not None:
-            raise ValueError(
+            self._value_error(
                 not_compatible_w_rlm_msg.format("custom_model", "custom_model")
             )
 
         if self.model["custom_model_config"] != {}:
-            raise ValueError(
+            self._value_error(
                 not_compatible_w_rlm_msg.format(
                     "custom_model_config", "custom_model_config"
                 )
@@ -4761,7 +4762,7 @@ class AlgorithmConfig(_Config):
             )
 
         if self.preprocessor_pref not in ["rllib", "deepmind", None]:
-            raise ValueError(
+            self._value_error(
                 "`config.preprocessor_pref` must be either 'rllib', 'deepmind' or None!"
             )
 
@@ -4794,12 +4795,12 @@ class AlgorithmConfig(_Config):
             #  ok for tf2 here.
             #  Remove this hacky check, once we have fully moved to the Learner API.
             if self.framework_str == "tf2" and type(self).__name__ != "AlphaStar":
-                raise ValueError(
+                self._value_error(
                     "`num_gpus` > 1 not supported yet for "
                     f"framework={self.framework_str}!"
                 )
             elif self.simple_optimizer is True:
-                raise ValueError(
+                self._value_error(
                     "Cannot use `simple_optimizer` if `num_gpus` > 1! "
                     "Consider not setting `simple_optimizer` in your config."
                 )
@@ -4848,7 +4849,7 @@ class AlgorithmConfig(_Config):
         # User manually set simple-optimizer to False -> Error if tf-eager.
         elif self.simple_optimizer is False:
             if self.framework_str == "tf2":
-                raise ValueError(
+                self._value_error(
                     "`simple_optimizer=False` not supported for "
                     f"config.framework({self.framework_str})!"
                 )
@@ -4863,7 +4864,7 @@ class AlgorithmConfig(_Config):
             not (self.evaluation_num_env_runners > 0 or self.evaluation_interval)
             and (self.action_space is None or self.observation_space is None)
         ):
-            raise ValueError(
+            self._value_error(
                 "If no evaluation should be run, `action_space` and "
                 "`observation_space` must be provided."
             )
@@ -4874,14 +4875,14 @@ class AlgorithmConfig(_Config):
         if self.offline_data_class and not issubclass(
             self.offline_data_class, OfflineData
         ):
-            raise ValueError(
+            self._value_error(
                 "Unknown `offline_data_class`. OfflineData class needs to inherit "
                 "from `OfflineData` class."
             )
         if self.prelearner_class and not issubclass(
             self.prelearner_class, OfflinePreLearner
         ):
-            raise ValueError(
+            self._value_error(
                 "Unknown `prelearner_class`. PreLearner class needs to inherit "
                 "from `OfflinePreLearner` class."
             )
@@ -4893,7 +4894,7 @@ class AlgorithmConfig(_Config):
         if self.prelearner_buffer_class and not issubclass(
             self.prelearner_buffer_class, EpisodeReplayBuffer
         ):
-            raise ValueError(
+            self._value_error(
                 "Unknown `prelearner_buffer_class`. The buffer class for the "
                 "prelearner needs to inherit from `EpisodeReplayBuffer`. "
                 "Specifically it needs to store and sample lists of "
@@ -4903,7 +4904,7 @@ class AlgorithmConfig(_Config):
         if self.input_read_batch_size and not (
             self.input_read_episodes or self.input_read_sample_batches
         ):
-            raise ValueError(
+            self._value_error(
                 "Setting `input_read_batch_size` is only allowed in case of a "
                 "dataset that holds either `EpisodeType` or `BatchType` data (i.e. "
                 "rows that contains multiple timesteps), but neither "
@@ -4916,7 +4917,7 @@ class AlgorithmConfig(_Config):
             and self.output_write_episodes
             and self.batch_mode != "complete_episodes"
         ):
-            raise ValueError(
+            self._value_error(
                 "When recording episodes only complete episodes should be "
                 "recorded (i.e. `batch_mode=='complete_episodes'`). Otherwise "
                 "recorded episodes cannot be read in for training."

--- a/rllib/algorithms/appo/appo.py
+++ b/rllib/algorithms/appo/appo.py
@@ -277,7 +277,7 @@ class APPOConfig(IMPALAConfig):
         # On new API stack, circular buffer should be used, not `minibatch_buffer_size`.
         if self.enable_rl_module_and_learner:
             if self.minibatch_buffer_size != 1 or self.replay_proportion != 0.0:
-                raise ValueError(
+                self._value_error(
                     "`minibatch_buffer_size/replay_proportion` not valid on new API "
                     "stack with APPO! "
                     "Use `circular_buffer_num_batches` for the number of train batches "
@@ -286,7 +286,7 @@ class APPOConfig(IMPALAConfig):
                     "`circular_buffer_iterations_per_batch`."
                 )
             if self.num_multi_gpu_tower_stacks != 1:
-                raise ValueError(
+                self._value_error(
                     "`num_multi_gpu_tower_stacks` not supported on new API stack with "
                     "APPO! In order to train on multi-GPU, use "
                     "`config.learners(num_learners=[number of GPUs], "
@@ -296,7 +296,7 @@ class APPOConfig(IMPALAConfig):
                     "1-8)."
                 )
             if self.learner_queue_size != 16:
-                raise ValueError(
+                self._value_error(
                     "`learner_queue_size` not supported on new API stack with "
                     "APPO! In order set the size of the circular buffer (which acts as "
                     "a 'learner queue'), use "

--- a/rllib/algorithms/bc/bc.py
+++ b/rllib/algorithms/bc/bc.py
@@ -105,7 +105,7 @@ class BCConfig(MARWILConfig):
         super().validate()
 
         if self.beta != 0.0:
-            raise ValueError("For behavioral cloning, `beta` parameter must be 0.0!")
+            self._value_error("For behavioral cloning, `beta` parameter must be 0.0!")
 
 
 class BC(MARWIL):

--- a/rllib/algorithms/cql/cql.py
+++ b/rllib/algorithms/cql/cql.py
@@ -251,7 +251,7 @@ class CQLConfig(SACConfig):
             and not self.dataset_num_iters_per_learner
             and self.enable_rl_module_and_learner
         ):
-            raise ValueError(
+            self._value_error(
                 "When using a single local learner the number of iterations "
                 "per learner, `dataset_num_iters_per_learner` has to be defined. "
                 "Set this hyperparameter in the `AlgorithmConfig.offline_data`."

--- a/rllib/algorithms/dqn/dqn.py
+++ b/rllib/algorithms/dqn/dqn.py
@@ -410,7 +410,7 @@ class DQNConfig(AlgorithmConfig):
         if self.enable_rl_module_and_learner:
             # `lr_schedule` checking.
             if self.lr_schedule is not None:
-                raise ValueError(
+                self._value_error(
                     "`lr_schedule` is deprecated and must be None! Use the "
                     "`lr` setting to setup a schedule."
                 )
@@ -422,19 +422,19 @@ class DQNConfig(AlgorithmConfig):
             #  when using the new API stack.
             if self.exploration_config["type"] == "ParameterNoise":
                 if self.batch_mode != "complete_episodes":
-                    raise ValueError(
+                    self._value_error(
                         "ParameterNoise Exploration requires `batch_mode` to be "
                         "'complete_episodes'. Try setting `config.env_runners("
                         "batch_mode='complete_episodes')`."
                     )
                 if self.noisy:
-                    raise ValueError(
+                    self._value_error(
                         "ParameterNoise Exploration and `noisy` network cannot be"
                         " used at the same time!"
                     )
 
         if self.td_error_loss_fn not in ["huber", "mse"]:
-            raise ValueError("`td_error_loss_fn` must be 'huber' or 'mse'!")
+            self._value_error("`td_error_loss_fn` must be 'huber' or 'mse'!")
 
         # Check rollout_fragment_length to be compatible with n_step.
         if (
@@ -442,7 +442,7 @@ class DQNConfig(AlgorithmConfig):
             and self.rollout_fragment_length != "auto"
             and self.rollout_fragment_length < self.n_step
         ):
-            raise ValueError(
+            self._value_error(
                 f"Your `rollout_fragment_length` ({self.rollout_fragment_length}) is "
                 f"smaller than `n_step` ({self.n_step})! "
                 "Try setting config.env_runners(rollout_fragment_length="
@@ -461,7 +461,7 @@ class DQNConfig(AlgorithmConfig):
             and not isinstance(self.replay_buffer_config["type"], str)
             and not issubclass(self.replay_buffer_config["type"], EpisodeReplayBuffer)
         ):
-            raise ValueError(
+            self._value_error(
                 "When using the new `EnvRunner API` the replay buffer must be of type "
                 "`EpisodeReplayBuffer`."
             )
@@ -472,7 +472,7 @@ class DQNConfig(AlgorithmConfig):
             )
             or issubclass(self.replay_buffer_config["type"], EpisodeReplayBuffer)
         ):
-            raise ValueError(
+            self._value_error(
                 "When using the old API stack the replay buffer must not be of type "
                 "`EpisodeReplayBuffer`! We suggest you use the following config to run "
                 "DQN on the old API stack: `config.training(replay_buffer_config={"

--- a/rllib/algorithms/dreamerv3/dreamerv3.py
+++ b/rllib/algorithms/dreamerv3/dreamerv3.py
@@ -382,11 +382,11 @@ class DreamerV3Config(AlgorithmConfig):
 
         # Make sure, users are not using DreamerV3 yet for multi-agent:
         if self.is_multi_agent:
-            raise ValueError("DreamerV3 does NOT support multi-agent setups yet!")
+            self._value_error("DreamerV3 does NOT support multi-agent setups yet!")
 
         # Make sure, we are configure for the new API stack.
         if not self.enable_rl_module_and_learner:
-            raise ValueError(
+            self._value_error(
                 "DreamerV3 must be run with `config.api_stack("
                 "enable_rl_module_and_learner=True)`!"
             )
@@ -394,7 +394,7 @@ class DreamerV3Config(AlgorithmConfig):
         # If run on several Learners, the provided batch_size_B must be a multiple
         # of `num_learners`.
         if self.num_learners > 1 and (self.batch_size_B % self.num_learners != 0):
-            raise ValueError(
+            self._value_error(
                 f"Your `batch_size_B` ({self.batch_size_B}) must be a multiple of "
                 f"`num_learners` ({self.num_learners}) in order for "
                 "DreamerV3 to be able to split batches evenly across your Learner "
@@ -403,19 +403,19 @@ class DreamerV3Config(AlgorithmConfig):
 
         # Cannot train actor w/o critic.
         if self.train_actor and not self.train_critic:
-            raise ValueError(
+            self._value_error(
                 "Cannot train actor network (`train_actor=True`) w/o training critic! "
                 "Make sure you either set `train_critic=True` or `train_actor=False`."
             )
         # Use DreamerV3 specific batch size settings.
         if self.train_batch_size is not None:
-            raise ValueError(
+            self._value_error(
                 "`train_batch_size` should NOT be set! Use `batch_size_B` and "
                 "`batch_length_T` instead."
             )
         # Must be run with `EpisodeReplayBuffer` type.
         if self.replay_buffer_config.get("type") != "EpisodeReplayBuffer":
-            raise ValueError(
+            self._value_error(
                 "DreamerV3 must be run with the `EpisodeReplayBuffer` type! None "
                 "other supported."
             )

--- a/rllib/algorithms/marwil/marwil.py
+++ b/rllib/algorithms/marwil/marwil.py
@@ -382,10 +382,10 @@ class MARWILConfig(AlgorithmConfig):
         super().validate()
 
         if self.beta < 0.0 or self.beta > 1.0:
-            raise ValueError("`beta` must be within 0.0 and 1.0!")
+            self._value_error("`beta` must be within 0.0 and 1.0!")
 
         if self.postprocess_inputs is False and self.beta > 0.0:
-            raise ValueError(
+            self._value_error(
                 "`postprocess_inputs` must be True for MARWIL (to "
                 "calculate accum., discounted returns)! Try setting "
                 "`config.offline_data(postprocess_inputs=True)`."
@@ -399,7 +399,7 @@ class MARWILConfig(AlgorithmConfig):
             and not self.dataset_num_iters_per_learner
             and self.enable_rl_module_and_learner
         ):
-            raise ValueError(
+            self._value_error(
                 "When using a local Learner (`config.num_learners=0`), the number of "
                 "iterations per learner (`dataset_num_iters_per_learner`) has to be "
                 "defined! Set this hyperparameter through `config.offline_data("

--- a/rllib/algorithms/ppo/ppo.py
+++ b/rllib/algorithms/ppo/ppo.py
@@ -299,7 +299,7 @@ class PPOConfig(AlgorithmConfig):
             not self.enable_rl_module_and_learner
             and self.minibatch_size > self.train_batch_size
         ):
-            raise ValueError(
+            self._value_error(
                 f"`minibatch_size` ({self.minibatch_size}) must be <= "
                 f"`train_batch_size` ({self.train_batch_size}). In PPO, the train batch"
                 f" will be split into {self.minibatch_size} chunks, each of which "
@@ -310,7 +310,7 @@ class PPOConfig(AlgorithmConfig):
             mbs = self.minibatch_size
             tbs = self.train_batch_size_per_learner or self.train_batch_size
             if isinstance(mbs, int) and isinstance(tbs, int) and mbs > tbs:
-                raise ValueError(
+                self._value_error(
                     f"`minibatch_size` ({mbs}) must be <= "
                     f"`train_batch_size_per_learner` ({tbs}). In PPO, the train batch"
                     f" will be split into {mbs} chunks, each of which is iterated over "
@@ -326,7 +326,7 @@ class PPOConfig(AlgorithmConfig):
             and self.batch_mode == "truncate_episodes"
             and not self.use_gae
         ):
-            raise ValueError(
+            self._value_error(
                 "Episode truncation is not supported without a value "
                 "function (to estimate the return at the end of the truncated"
                 " trajectory). Consider setting "
@@ -337,12 +337,12 @@ class PPOConfig(AlgorithmConfig):
         if self.enable_rl_module_and_learner:
             # `lr_schedule` checking.
             if self.lr_schedule is not None:
-                raise ValueError(
+                self._value_error(
                     "`lr_schedule` is deprecated and must be None! Use the "
                     "`lr` setting to setup a schedule."
                 )
             if self.entropy_coeff_schedule is not None:
-                raise ValueError(
+                self._value_error(
                     "`entropy_coeff_schedule` is deprecated and must be None! Use the "
                     "`entropy_coeff` setting to setup a schedule."
                 )
@@ -352,7 +352,7 @@ class PPOConfig(AlgorithmConfig):
                 description="entropy coefficient",
             )
         if isinstance(self.entropy_coeff, float) and self.entropy_coeff < 0.0:
-            raise ValueError("`entropy_coeff` must be >= 0.0")
+            self._value_error("`entropy_coeff` must be >= 0.0")
 
     @property
     @override(AlgorithmConfig)

--- a/rllib/connectors/learner/learner_connector_pipeline.py
+++ b/rllib/connectors/learner/learner_connector_pipeline.py
@@ -1,5 +1,6 @@
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 from ray.rllib.connectors.connector_pipeline_v2 import ConnectorPipelineV2
+from ray.rllib.core.rl_module.rl_module import RLModule
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.metrics import (
     ALL_MODULES,
@@ -17,7 +18,11 @@ class LearnerConnectorPipeline(ConnectorPipelineV2):
     def __call__(
         self,
         *,
+        rl_module: RLModule,
+        batch: Optional[Dict[str, Any]] = None,
         episodes: List[EpisodeType],
+        explore: bool = False,
+        shared_data: Optional[dict] = None,
         metrics: Optional[MetricsLogger] = None,
         **kwargs,
     ):
@@ -31,7 +36,11 @@ class LearnerConnectorPipeline(ConnectorPipelineV2):
         # Make sure user does not necessarily send initial input into this pipeline.
         # Might just be empty and to be populated from `episodes`.
         ret = super().__call__(
+            rl_module=rl_module,
+            batch=batch if batch is not None else {},
             episodes=episodes,
+            shared_data=shared_data if shared_data is not None else {},
+            explore=explore,
             metrics=metrics,
             metrics_prefix_key=(ALL_MODULES,),
             **kwargs,

--- a/rllib/utils/metrics/metrics_logger.py
+++ b/rllib/utils/metrics/metrics_logger.py
@@ -116,7 +116,7 @@ class MetricsLogger:
         #  MetricsLogger) is serialized and deserialized. We will have to fix this
         #  offline RL logic first, then can remove this hack here and return to always
         #  using the RLock.
-        self._threading_lock = _DummyRLock()  # threading.RLock()
+        self._threading_lock = _DummyRLock()
 
     def __contains__(self, key: Union[str, Tuple[str, ...]]) -> bool:
         """Returns True, if `key` can be found in self.stats.
@@ -467,7 +467,8 @@ class MetricsLogger:
                 clear_on_reduce=clear_on_reduce,
             )
 
-        tree.map_structure_with_path(_map, stats_dict)
+        with self._threading_lock:
+            tree.map_structure_with_path(_map, stats_dict)
 
     def merge_and_log_n_dicts(
         self,

--- a/rllib/utils/minibatch_utils.py
+++ b/rllib/utils/minibatch_utils.py
@@ -60,7 +60,6 @@ class MiniBatchCyclicIterator(MiniBatchIteratorBase):
         minibatch_size: int,
         shuffle_batch_per_epoch: bool = True,
         num_total_minibatches: int = 0,
-        _uses_new_env_runners: bool = False,
     ) -> None:
         """Initializes a MiniBatchCyclicIterator instance."""
         super().__init__(
@@ -79,8 +78,6 @@ class MiniBatchCyclicIterator(MiniBatchIteratorBase):
         self._start = {mid: 0 for mid in batch.policy_batches.keys()}
         # mapping from module_id to the number of epochs covered for each module_id
         self._num_covered_epochs = {mid: 0 for mid in batch.policy_batches.keys()}
-
-        self._uses_new_env_runners = _uses_new_env_runners
 
         self._minibatch_count = 0
         self._num_total_minibatches = num_total_minibatches
@@ -119,8 +116,6 @@ class MiniBatchCyclicIterator(MiniBatchIteratorBase):
                 #  these setups require sequencing, BUT their batches are not yet time-
                 #  ranked (this is done only in their loss functions via the
                 #  `make_time_major` utility).
-                #  Get rid of the _uses_new_env_runners c'tor arg, once this work is
-                #  done.
                 n_steps = self._minibatch_size
 
                 samples_to_concat = []
@@ -139,11 +134,10 @@ class MiniBatchCyclicIterator(MiniBatchIteratorBase):
                     def get_len(b):
                         return len(b[SampleBatch.SEQ_LENS])
 
-                    if self._uses_new_env_runners:
-                        n_steps = int(
-                            get_len(module_batch)
-                            * (self._minibatch_size / len(module_batch))
-                        )
+                    n_steps = int(
+                        get_len(module_batch)
+                        * (self._minibatch_size / len(module_batch))
+                    )
 
                 else:
 

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -312,8 +312,8 @@ def add_rllib_example_script_args(
     parser.add_argument(
         "--num-gpus",
         type=int,
-        default=0,
-        help="The number of GPUs to use (if on the old API stack).",
+        default=None,
+        help="The number of GPUs to use (only on the old API stack).",
     )
 
     return parser
@@ -1097,7 +1097,7 @@ def run_rllib_example_script_experiment(
         # and --num-gpus-per-learner args).
         # New stack.
         if config.enable_rl_module_and_learner:
-            if args.num_gpus > 0:
+            if args.num_gpus is not None and args.num_gpus > 0:
                 raise ValueError(
                     "--num-gpus is not supported on the new API stack! To train on "
                     "GPUs, use the command line options `--num-gpus-per-learner=1` and "
@@ -1148,8 +1148,8 @@ def run_rllib_example_script_experiment(
             else:
                 config.learners(num_gpus_per_learner=args.num_gpus_per_learner)
 
-        # Old stack.
-        else:
+        # Old stack (override only if arg was provided by user).
+        elif args.num_gpus is not None:
             config.resources(num_gpus=args.num_gpus)
 
         # Evaluation setup.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

* Add experimental option to suppress config validation. This will allow us to make users pay attention to raised config validation errors, but at the same time give them an opt-out in case they want to use a (bad) setting no matter what. Example: Running APPO with GPU and 1 remote learner is bad. Or running APPO with CPU and 1 local learner is very slow (but might be useful for debugging).
* Some other code cleanups.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
