### PR TITLE
[data] Adding in `iter_rows` to public api, remove beta tags for DataIterator

### DIFF
--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -187,6 +187,7 @@ class DataIterator(abc.ABC):
     def _get_dataset_tag(self) -> str:
         return "unknown_dataset"
 
+    @PublicAPI(stability="beta")
     def iter_rows(self) -> Iterable[Dict[str, Any]]:
         """Return a local row iterable over the dataset.
 

--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -55,7 +55,7 @@ class _IterableFromIterator(Iterable[T]):
         return self.iterator_gen()
 
 
-@PublicAPI(stability="beta")
+@PublicAPI
 class DataIterator(abc.ABC):
     """An iterator for reading records from a :class:`~Dataset`.
 
@@ -90,7 +90,7 @@ class DataIterator(abc.ABC):
         """
         raise NotImplementedError
 
-    @PublicAPI(stability="beta")
+    @PublicAPI
     def iter_batches(
         self,
         *,
@@ -187,7 +187,7 @@ class DataIterator(abc.ABC):
     def _get_dataset_tag(self) -> str:
         return "unknown_dataset"
 
-    @PublicAPI(stability="beta")
+    @PublicAPI
     def iter_rows(self) -> Iterable[Dict[str, Any]]:
         """Return a local row iterable over the dataset.
 
@@ -219,7 +219,7 @@ class DataIterator(abc.ABC):
         return _IterableFromIterator(_wrapped_iterator)
 
     @abc.abstractmethod
-    @PublicAPI(stability="beta")
+    @PublicAPI
     def stats(self) -> str:
         """Returns a string containing execution timing information."""
         raise NotImplementedError
@@ -229,7 +229,7 @@ class DataIterator(abc.ABC):
         """Return the schema of the dataset iterated over."""
         raise NotImplementedError
 
-    @PublicAPI(stability="beta")
+    @PublicAPI
     def iter_torch_batches(
         self,
         *,
@@ -646,7 +646,7 @@ class DataIterator(abc.ABC):
 
         return TorchIterableDataset(make_generator)
 
-    @PublicAPI(stability="beta")
+    @PublicAPI
     def to_tf(
         self,
         feature_columns: Union[str, List[str]],
@@ -897,7 +897,7 @@ class DataIterator(abc.ABC):
         )
         return dataset.with_options(options)
 
-    @PublicAPI(stability="beta")
+    @PublicAPI
     def materialize(self) -> "MaterializedDataset":
         """Execute and materialize this data iterator into object store memory.
 


### PR DESCRIPTION
## Why are these changes needed?
Adds the `DataIterator.iter_rows` method to the public api, removes the beta tag from the DataIterator API.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
