### PR TITLE
[core] Only get single node info rather then all when needed

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -471,6 +471,7 @@ ray_cc_library(
         "//src/ray/common:ray_config",
         "//src/ray/common:ray_syncer",
         "//src/ray/common:status",
+        "//src/ray/common:status_or",
         "//src/ray/common:task_common",
         "//src/ray/common:test_util",
         "//src/ray/protobuf:gcs_cc_proto",
@@ -2043,9 +2044,9 @@ ray_cc_test(
         "//:redis-server",
     ],
     tags = [
+        "exclusive",
         "no_tsan",
         "team:core",
-        "exclusive",
     ],
     deps = [
         ":gcs_client_lib",

--- a/python/ray/includes/global_state_accessor.pxd
+++ b/python/ray/includes/global_state_accessor.pxd
@@ -64,7 +64,7 @@ cdef extern from "ray/gcs/gcs_client/global_state_accessor.h" nogil:
             const c_string &node_ip_address,
             c_string *node_to_connect)
         CRayStatus GetNode(
-          const c_string &node_id,
+          const c_string &node_id_str,
           c_string *node_info)
 
 cdef extern from * namespace "ray::gcs" nogil:

--- a/python/ray/includes/global_state_accessor.pxd
+++ b/python/ray/includes/global_state_accessor.pxd
@@ -64,7 +64,7 @@ cdef extern from "ray/gcs/gcs_client/global_state_accessor.h" nogil:
             const c_string &node_ip_address,
             c_string *node_to_connect)
         CRayStatus GetNode(
-          const c_string &node_id_str,
+          const c_string &node_id_hex_str,
           c_string *node_info)
 
 cdef extern from * namespace "ray::gcs" nogil:

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -709,6 +709,16 @@ Status NodeInfoAccessor::GetAllNoCache(int64_t timeout_ms,
   return Status::OK();
 }
 
+StatusOr<std::vector<rpc::GcsNodeInfo>> NodeInfoAccessor::GetAllNoCacheWithFilter(
+    int64_t timeout_ms, rpc::GetAllNodeInfoRequest_Filters filter) {
+  rpc::GetAllNodeInfoRequest request;
+  *request.mutable_filters() = std::move(filter);
+  rpc::GetAllNodeInfoReply reply;
+  RAY_RETURN_NOT_OK(
+      client_impl_->GetGcsRpcClient().SyncGetAllNodeInfo(request, &reply, timeout_ms));
+  return VectorFromProtobuf(std::move(*reply.mutable_node_info_list()));
+}
+
 Status NodeInfoAccessor::CheckAlive(const std::vector<std::string> &raylet_addresses,
                                     int64_t timeout_ms,
                                     std::vector<bool> &nodes_alive) {

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -709,7 +709,7 @@ Status NodeInfoAccessor::GetAllNoCache(int64_t timeout_ms,
   return Status::OK();
 }
 
-StatusOr<std::vector<rpc::GcsNodeInfo>> NodeInfoAccessor::GetAllNoCacheWithFilter(
+StatusOr<std::vector<rpc::GcsNodeInfo>> NodeInfoAccessor::GetAllNoCacheWithFilters(
     int64_t timeout_ms, rpc::GetAllNodeInfoRequest_Filters filters) {
   rpc::GetAllNodeInfoRequest request;
   *request.mutable_filters() = std::move(filters);

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -710,9 +710,9 @@ Status NodeInfoAccessor::GetAllNoCache(int64_t timeout_ms,
 }
 
 StatusOr<std::vector<rpc::GcsNodeInfo>> NodeInfoAccessor::GetAllNoCacheWithFilter(
-    int64_t timeout_ms, rpc::GetAllNodeInfoRequest_Filters filter) {
+    int64_t timeout_ms, rpc::GetAllNodeInfoRequest_Filters filters) {
   rpc::GetAllNodeInfoRequest request;
-  *request.mutable_filters() = std::move(filter);
+  *request.mutable_filters() = std::move(filters);
   rpc::GetAllNodeInfoReply reply;
   RAY_RETURN_NOT_OK(
       client_impl_->GetGcsRpcClient().SyncGetAllNodeInfo(request, &reply, timeout_ms));

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -422,7 +422,7 @@ class NodeInfoAccessor {
   ///
   /// \return All nodes that match the given filter from the gcs without the cache.
   virtual StatusOr<std::vector<rpc::GcsNodeInfo>> GetAllNoCacheWithFilter(
-      int64_t timeout_ms, rpc::GetAllNodeInfoRequest_Filters filter);
+      int64_t timeout_ms, rpc::GetAllNodeInfoRequest_Filters filters);
 
   /// Send a check alive request to GCS for the liveness of some nodes.
   ///

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -17,6 +17,7 @@
 #include "absl/types/optional.h"
 #include "ray/common/id.h"
 #include "ray/common/placement_group.h"
+#include "ray/common/status_or.h"
 #include "ray/common/task/task_spec.h"
 #include "ray/gcs/callback.h"
 #include "ray/rpc/client_call.h"
@@ -414,8 +415,14 @@ class NodeInfoAccessor {
 
   /// Get information of all nodes from an RPC to GCS synchronously.
   ///
-  /// \return All nodes in cache.
+  /// \return All nodes from gcs without cache.
   virtual Status GetAllNoCache(int64_t timeout_ms, std::vector<rpc::GcsNodeInfo> &nodes);
+
+  /// Get information of all nodes from an RPC to GCS synchronously with filter.
+  ///
+  /// \return All nodes that match the given filter from the gcs without the cache.
+  virtual StatusOr<std::vector<rpc::GcsNodeInfo>> GetAllNoCacheWithFilter(
+      int64_t timeout_ms, rpc::GetAllNodeInfoRequest_Filters filter);
 
   /// Send a check alive request to GCS for the liveness of some nodes.
   ///

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -418,10 +418,10 @@ class NodeInfoAccessor {
   /// \return All nodes from gcs without cache.
   virtual Status GetAllNoCache(int64_t timeout_ms, std::vector<rpc::GcsNodeInfo> &nodes);
 
-  /// Get information of all nodes from an RPC to GCS synchronously with filter.
+  /// Get information of all nodes from an RPC to GCS synchronously with filters.
   ///
-  /// \return All nodes that match the given filter from the gcs without the cache.
-  virtual StatusOr<std::vector<rpc::GcsNodeInfo>> GetAllNoCacheWithFilter(
+  /// \return All nodes that match the given filters from the gcs without the cache.
+  virtual StatusOr<std::vector<rpc::GcsNodeInfo>> GetAllNoCacheWithFilters(
       int64_t timeout_ms, rpc::GetAllNodeInfoRequest_Filters filters);
 
   /// Send a check alive request to GCS for the liveness of some nodes.

--- a/src/ray/gcs/gcs_client/global_state_accessor.cc
+++ b/src/ray/gcs/gcs_client/global_state_accessor.cc
@@ -413,7 +413,7 @@ ray::Status GlobalStateAccessor::GetNode(const std::string &node_id_hex_str,
           std::max(end_time_point - current_time_ms(), static_cast<int64_t>(0));
       RAY_ASSIGN_OR_RETURN(
           node_infos,
-          gcs_client_->Nodes().GetAllNoCacheWithFilter(timeout_ms, std::move(filters)));
+          gcs_client_->Nodes().GetAllNoCacheWithFilters(timeout_ms, std::move(filters)));
     }
     if (!node_infos.empty()) {
       *node_info = node_infos[0].SerializeAsString();
@@ -447,7 +447,7 @@ ray::Status GlobalStateAccessor::GetNodeToConnectForDriver(
       auto timeout_ms =
           std::max(end_time_point - current_time_ms(), static_cast<int64_t>(0));
       RAY_ASSIGN_OR_RETURN(
-          node_infos, gcs_client_->Nodes().GetAllNoCacheWithFilter(timeout_ms, filters));
+          node_infos, gcs_client_->Nodes().GetAllNoCacheWithFilters(timeout_ms, filters));
     }
     if (!node_infos.empty()) {
       *node_to_connect = node_infos[0].SerializeAsString();
@@ -465,7 +465,7 @@ ray::Status GlobalStateAccessor::GetNodeToConnectForDriver(
       absl::ReaderMutexLock lock(&mutex_);
       auto timeout_ms = end_time_point - current_time_ms();
       RAY_ASSIGN_OR_RETURN(
-          node_infos, gcs_client_->Nodes().GetAllNoCacheWithFilter(timeout_ms, filters));
+          node_infos, gcs_client_->Nodes().GetAllNoCacheWithFilters(timeout_ms, filters));
     }
     if (node_infos.empty() && node_ip_address == gcs_address) {
       filters.set_node_ip_address("127.0.0.1");
@@ -475,7 +475,7 @@ ray::Status GlobalStateAccessor::GetNodeToConnectForDriver(
             std::max(end_time_point - current_time_ms(), static_cast<int64_t>(0));
         RAY_ASSIGN_OR_RETURN(
             node_infos,
-            gcs_client_->Nodes().GetAllNoCacheWithFilter(timeout_ms, filters));
+            gcs_client_->Nodes().GetAllNoCacheWithFilters(timeout_ms, filters));
       }
     }
     if (!node_infos.empty()) {

--- a/src/ray/gcs/gcs_client/global_state_accessor.cc
+++ b/src/ray/gcs/gcs_client/global_state_accessor.cc
@@ -409,7 +409,8 @@ ray::Status GlobalStateAccessor::GetNode(const std::string &node_id_str,
     filter.set_node_id(node_id.Binary());
     {
       absl::ReaderMutexLock lock(&mutex_);
-      auto timeout_ms = std::max(end_time_point - current_time_ms(), 0LL);
+      auto timeout_ms =
+          std::max(end_time_point - current_time_ms(), static_cast<int64_t>(0));
       node_infos_status =
           gcs_client_->Nodes().GetAllNoCacheWithFilter(timeout_ms, std::move(filter));
     }
@@ -447,7 +448,8 @@ ray::Status GlobalStateAccessor::GetNodeToConnectForDriver(
   while (true) {
     {
       absl::ReaderMutexLock lock(&mutex_);
-      auto timeout_ms = std::max(end_time_point - current_time_ms(), 0LL);
+      auto timeout_ms =
+          std::max(end_time_point - current_time_ms(), static_cast<int64_t>(0));
       node_infos_status =
           gcs_client_->Nodes().GetAllNoCacheWithFilter(timeout_ms, filter);
       RAY_RETURN_NOT_OK(node_infos_status.status());
@@ -475,7 +477,8 @@ ray::Status GlobalStateAccessor::GetNodeToConnectForDriver(
       filter.set_node_ip_address("127.0.0.1");
       {
         absl::ReaderMutexLock lock(&mutex_);
-        auto timeout_ms = std::max(end_time_point - current_time_ms(), 0LL);
+        auto timeout_ms =
+            std::max(end_time_point - current_time_ms(), static_cast<int64_t>(0));
         node_infos_status =
             gcs_client_->Nodes().GetAllNoCacheWithFilter(timeout_ms, filter);
         RAY_RETURN_NOT_OK(node_infos_status.status());

--- a/src/ray/gcs/gcs_client/global_state_accessor.cc
+++ b/src/ray/gcs/gcs_client/global_state_accessor.cc
@@ -396,41 +396,37 @@ std::string GlobalStateAccessor::GetSystemConfig() {
   return future.get();
 }
 
-ray::Status GlobalStateAccessor::GetNode(const std::string &node_id_str,
+ray::Status GlobalStateAccessor::GetNode(const std::string &node_id_hex_str,
                                          std::string *node_info) {
-  auto end_time_point =
+  const auto end_time_point =
       current_time_ms() + RayConfig::instance().raylet_start_wait_time_s() * 1000;
-  auto node_id = NodeID::FromHex(node_id_str);
+  const auto node_id_binary = NodeID::FromHex(node_id_hex_str).Binary();
 
-  StatusOr<std::vector<rpc::GcsNodeInfo>> node_infos_status{Status::NotFound("")};
+  std::vector<rpc::GcsNodeInfo> node_infos;
   while (true) {
-    rpc::GetAllNodeInfoRequest_Filters filter;
-    filter.set_state(rpc::GcsNodeInfo_GcsNodeState::GcsNodeInfo_GcsNodeState_ALIVE);
-    filter.set_node_id(node_id.Binary());
+    rpc::GetAllNodeInfoRequest_Filters filters;
+    filters.set_state(rpc::GcsNodeInfo_GcsNodeState::GcsNodeInfo_GcsNodeState_ALIVE);
+    filters.set_node_id(node_id_binary);
     {
       absl::ReaderMutexLock lock(&mutex_);
       auto timeout_ms =
           std::max(end_time_point - current_time_ms(), static_cast<int64_t>(0));
-      node_infos_status =
-          gcs_client_->Nodes().GetAllNoCacheWithFilter(timeout_ms, std::move(filter));
+      RAY_ASSIGN_OR_RETURN(
+          node_infos,
+          gcs_client_->Nodes().GetAllNoCacheWithFilter(timeout_ms, std::move(filters)));
     }
-    if (!node_infos_status.ok()) {
-      return node_infos_status.status();
-    }
-    if (node_infos_status->empty()) {
-      node_infos_status = Status::NotFound(
-          "GCS cannot find the node with node ID " + node_id_str +
-          ". The node registration may not be complete yet before the timeout." +
-          " Try increase the RAY_raylet_start_wait_time_s config.");
-
-    } else {
-      *node_info = (*node_infos_status)[0].SerializeAsString();
+    if (!node_infos.empty()) {
+      *node_info = node_infos[0].SerializeAsString();
       return Status::OK();
     }
+
     if (current_time_ms() >= end_time_point) {
-      return node_infos_status.status();
+      return Status::NotFound(
+          "GCS cannot find the node with node ID " + node_id_hex_str +
+          ". The node registration may not be complete yet before the timeout." +
+          " Try increase the RAY_raylet_start_wait_time_s config.");
     }
-    RAY_LOG(WARNING) << "Retrying to get node with node ID " << node_id;
+    RAY_LOG(WARNING) << "Retrying to get node with node ID " << node_id_hex_str;
     // Some of the information may not be in GCS yet, so wait a little bit.
     std::this_thread::sleep_for(std::chrono::seconds(1));
   }
@@ -438,24 +434,23 @@ ray::Status GlobalStateAccessor::GetNode(const std::string &node_id_str,
 
 ray::Status GlobalStateAccessor::GetNodeToConnectForDriver(
     const std::string &node_ip_address, std::string *node_to_connect) {
-  auto end_time_point =
+  const auto end_time_point =
       current_time_ms() + RayConfig::instance().raylet_start_wait_time_s() * 1000;
 
-  StatusOr<std::vector<rpc::GcsNodeInfo>> node_infos_status{Status::NotFound("")};
-  rpc::GetAllNodeInfoRequest_Filters filter;
-  filter.set_state(rpc::GcsNodeInfo_GcsNodeState::GcsNodeInfo_GcsNodeState_ALIVE);
-  filter.set_node_ip_address(node_ip_address);
+  std::vector<rpc::GcsNodeInfo> node_infos;
+  rpc::GetAllNodeInfoRequest_Filters filters;
+  filters.set_state(rpc::GcsNodeInfo_GcsNodeState::GcsNodeInfo_GcsNodeState_ALIVE);
+  filters.set_node_ip_address(node_ip_address);
   while (true) {
     {
       absl::ReaderMutexLock lock(&mutex_);
       auto timeout_ms =
           std::max(end_time_point - current_time_ms(), static_cast<int64_t>(0));
-      node_infos_status =
-          gcs_client_->Nodes().GetAllNoCacheWithFilter(timeout_ms, filter);
-      RAY_RETURN_NOT_OK(node_infos_status.status());
+      RAY_ASSIGN_OR_RETURN(
+          node_infos, gcs_client_->Nodes().GetAllNoCacheWithFilter(timeout_ms, filters));
     }
-    if (!node_infos_status->empty()) {
-      *node_to_connect = (*node_infos_status)[0].SerializeAsString();
+    if (!node_infos.empty()) {
+      *node_to_connect = node_infos[0].SerializeAsString();
       return Status::OK();
     }
 
@@ -465,45 +460,42 @@ ray::Status GlobalStateAccessor::GetNodeToConnectForDriver(
       auto [address, _] = gcs_client_->GetGcsServerAddress();
       gcs_address = std::move(address);
     }
-    filter.set_node_ip_address(gcs_address);
+    filters.set_node_ip_address(gcs_address);
     {
       absl::ReaderMutexLock lock(&mutex_);
       auto timeout_ms = end_time_point - current_time_ms();
-      node_infos_status =
-          gcs_client_->Nodes().GetAllNoCacheWithFilter(timeout_ms, filter);
-      RAY_RETURN_NOT_OK(node_infos_status.status());
+      RAY_ASSIGN_OR_RETURN(
+          node_infos, gcs_client_->Nodes().GetAllNoCacheWithFilter(timeout_ms, filters));
     }
-    if (node_infos_status->empty() && node_ip_address == gcs_address) {
-      filter.set_node_ip_address("127.0.0.1");
+    if (node_infos.empty() && node_ip_address == gcs_address) {
+      filters.set_node_ip_address("127.0.0.1");
       {
         absl::ReaderMutexLock lock(&mutex_);
         auto timeout_ms =
             std::max(end_time_point - current_time_ms(), static_cast<int64_t>(0));
-        node_infos_status =
-            gcs_client_->Nodes().GetAllNoCacheWithFilter(timeout_ms, filter);
-        RAY_RETURN_NOT_OK(node_infos_status.status());
+        RAY_ASSIGN_OR_RETURN(
+            node_infos,
+            gcs_client_->Nodes().GetAllNoCacheWithFilter(timeout_ms, filters));
       }
     }
-    if (!node_infos_status->empty()) {
+    if (!node_infos.empty()) {
       RAY_LOG(INFO) << "This node has an IP address of " << node_ip_address
                     << ", but we cannot find a local Raylet with the same address. "
                     << "This can happen when you connect to the Ray cluster "
                     << "with a different IP address or when connecting to a container.";
-      *node_to_connect = (*node_infos_status)[0].SerializeAsString();
+      *node_to_connect = node_infos[0].SerializeAsString();
       return Status::OK();
     }
 
-    std::ostringstream oss;
-    oss << "This node has an IP address of " << node_ip_address << ", and Ray "
-        << "expects this IP address to be either the GCS address or one of"
-        << " the Raylet addresses. Connected to GCS at " << gcs_address
-        << ", and found no Raylet with this IP address. "
-        << "You might need to provide --node-ip-address to specify the IP "
-        << "address that the head should use when sending to this node.";
-    node_infos_status = Status::NotFound(oss.str());
-
     if (current_time_ms() >= end_time_point) {
-      return node_infos_status.status();
+      std::ostringstream oss;
+      oss << "This node has an IP address of " << node_ip_address << ", and Ray "
+          << "expects this IP address to be either the GCS address or one of"
+          << " the Raylet addresses. Connected to GCS at " << gcs_address
+          << ", and found no Raylet with this IP address. "
+          << "You might need to provide --node-ip-address to specify the IP "
+          << "address that the head should use when sending to this node.";
+      return Status::NotFound(oss.str());
     }
     RAY_LOG(WARNING) << "Some processes that the driver needs to connect to have "
                         "not registered with GCS, so retrying. Have you run "

--- a/src/ray/gcs/gcs_client/global_state_accessor.cc
+++ b/src/ray/gcs/gcs_client/global_state_accessor.cc
@@ -396,69 +396,38 @@ std::string GlobalStateAccessor::GetSystemConfig() {
   return future.get();
 }
 
-ray::Status GlobalStateAccessor::GetAliveNodes(std::vector<rpc::GcsNodeInfo> &nodes) {
-  std::promise<std::pair<Status, std::vector<rpc::GcsNodeInfo>>> promise;
-  {
-    absl::ReaderMutexLock lock(&mutex_);
-    RAY_CHECK_OK(gcs_client_->Nodes().AsyncGetAll(
-        [&promise](Status status, std::vector<rpc::GcsNodeInfo> &&nodes) {
-          promise.set_value(
-              std::pair<Status, std::vector<rpc::GcsNodeInfo>>(status, std::move(nodes)));
-        },
-        /*timeout_ms=*/-1));
-  }
-  auto result = promise.get_future().get();
-  auto status = result.first;
-  if (!status.ok()) {
-    return status;
-  }
-
-  std::copy_if(result.second.begin(),
-               result.second.end(),
-               std::back_inserter(nodes),
-               [](const rpc::GcsNodeInfo &node) {
-                 return node.state() == rpc::GcsNodeInfo::ALIVE;
-               });
-  return status;
-}
-
-ray::Status GlobalStateAccessor::GetNode(const std::string &node_id,
+ray::Status GlobalStateAccessor::GetNode(const std::string &node_id_str,
                                          std::string *node_info) {
-  auto start_ms = current_time_ms();
-  auto node_id_binary = NodeID::FromHex(node_id).Binary();
+  auto end_time_point =
+      current_time_ms() + RayConfig::instance().raylet_start_wait_time_s() * 1000;
+  auto node_id = NodeID::FromHex(node_id_str);
+
+  StatusOr<std::vector<rpc::GcsNodeInfo>> node_infos_status{Status::NotFound("")};
   while (true) {
-    std::vector<rpc::GcsNodeInfo> nodes;
-    auto status = GetAliveNodes(nodes);
-    if (!status.ok()) {
-      return status;
+    rpc::GetAllNodeInfoRequest_Filters filter;
+    filter.set_state(rpc::GcsNodeInfo_GcsNodeState::GcsNodeInfo_GcsNodeState_ALIVE);
+    filter.set_node_id(node_id.Binary());
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      auto timeout_ms = std::max(end_time_point - current_time_ms(), 0LL);
+      node_infos_status =
+          gcs_client_->Nodes().GetAllNoCacheWithFilter(timeout_ms, std::move(filter));
     }
+    if (!node_infos_status.ok()) {
+      return node_infos_status.status();
+    }
+    if (node_infos_status->empty()) {
+      node_infos_status = Status::NotFound(
+          "GCS cannot find the node with node ID " + node_id_str +
+          ". The node registration may not be complete yet before the timeout." +
+          " Try increase the RAY_raylet_start_wait_time_s config.");
 
-    if (nodes.empty()) {
-      status = Status::NotFound("GCS has started but no raylets have registered yet.");
     } else {
-      int relevant_client_index = -1;
-      for (int i = 0; i < static_cast<int>(nodes.size()); i++) {
-        const auto &node = nodes[i];
-        if (node_id_binary == node.node_id()) {
-          relevant_client_index = i;
-          break;
-        }
-      }
-
-      if (relevant_client_index < 0) {
-        status = Status::NotFound(
-            "GCS cannot find the node with node ID " + node_id +
-            ". The node registration may not be complete yet before the timeout." +
-            " Try increase the RAY_raylet_start_wait_time_s config.");
-      } else {
-        *node_info = nodes[relevant_client_index].SerializeAsString();
-        return Status::OK();
-      }
+      *node_info = (*node_infos_status)[0].SerializeAsString();
+      return Status::OK();
     }
-
-    if (current_time_ms() - start_ms >=
-        RayConfig::instance().raylet_start_wait_time_s() * 1000) {
-      return status;
+    if (current_time_ms() >= end_time_point) {
+      return node_infos_status.status();
     }
     RAY_LOG(WARNING) << "Retrying to get node with node ID " << node_id;
     // Some of the information may not be in GCS yet, so wait a little bit.
@@ -468,73 +437,70 @@ ray::Status GlobalStateAccessor::GetNode(const std::string &node_id,
 
 ray::Status GlobalStateAccessor::GetNodeToConnectForDriver(
     const std::string &node_ip_address, std::string *node_to_connect) {
-  auto start_ms = current_time_ms();
+  auto end_time_point =
+      current_time_ms() + RayConfig::instance().raylet_start_wait_time_s() * 1000;
+
+  StatusOr<std::vector<rpc::GcsNodeInfo>> node_infos_status{Status::NotFound("")};
+  rpc::GetAllNodeInfoRequest_Filters filter;
+  filter.set_state(rpc::GcsNodeInfo_GcsNodeState::GcsNodeInfo_GcsNodeState_ALIVE);
+  filter.set_node_ip_address(node_ip_address);
   while (true) {
-    std::vector<rpc::GcsNodeInfo> nodes;
-    auto status = GetAliveNodes(nodes);
-    if (!status.ok()) {
-      return status;
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      auto timeout_ms = std::max(end_time_point - current_time_ms(), 0LL);
+      node_infos_status =
+          gcs_client_->Nodes().GetAllNoCacheWithFilter(timeout_ms, filter);
+      RAY_RETURN_NOT_OK(node_infos_status.status());
+    }
+    if (!node_infos_status->empty()) {
+      *node_to_connect = (*node_infos_status)[0].SerializeAsString();
+      return Status::OK();
     }
 
-    if (nodes.empty()) {
-      status = Status::NotFound("GCS has started but no raylets have registered yet.");
-    } else {
-      int relevant_client_index = -1;
-      int head_node_client_index = -1;
-      std::pair<std::string, int> gcs_address;
+    std::string gcs_address;
+    {
+      absl::WriterMutexLock lock(&mutex_);
+      auto [address, _] = gcs_client_->GetGcsServerAddress();
+      gcs_address = std::move(address);
+    }
+    filter.set_node_ip_address(gcs_address);
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      auto timeout_ms = end_time_point - current_time_ms();
+      node_infos_status =
+          gcs_client_->Nodes().GetAllNoCacheWithFilter(timeout_ms, filter);
+      RAY_RETURN_NOT_OK(node_infos_status.status());
+    }
+    if (node_infos_status->empty() && node_ip_address == gcs_address) {
+      filter.set_node_ip_address("127.0.0.1");
       {
-        absl::WriterMutexLock lock(&mutex_);
-        gcs_address = gcs_client_->GetGcsServerAddress();
-      }
-
-      for (int i = 0; i < static_cast<int>(nodes.size()); i++) {
-        const auto &node = nodes[i];
-        std::string ip_address = node.node_manager_address();
-        if (ip_address == node_ip_address) {
-          relevant_client_index = i;
-          break;
-        }
-        // TODO(kfstorm): Do we need to replace `node_ip_address` with
-        // `get_node_ip_address()`?
-        if ((ip_address == "127.0.0.1" && gcs_address.first == node_ip_address) ||
-            ip_address == gcs_address.first) {
-          head_node_client_index = i;
-        }
-      }
-
-      if (relevant_client_index < 0 && head_node_client_index >= 0) {
-        RAY_LOG(INFO) << "This node has an IP address of " << node_ip_address
-                      << ", but we cannot find a local Raylet with the same address. "
-                      << "This can happen when you connect to the Ray cluster "
-                      << "with a different IP address or when connecting to a container.";
-        relevant_client_index = head_node_client_index;
-      }
-      if (relevant_client_index < 0) {
-        std::ostringstream oss;
-        oss << "This node has an IP address of " << node_ip_address << ", and Ray "
-            << "expects this IP address to be either the GCS address or one of"
-            << " the Raylet addresses. Connected to GCS at " << gcs_address.first
-            << " and found raylets at ";
-        for (size_t i = 0; i < nodes.size(); i++) {
-          if (i > 0) {
-            oss << ", ";
-          }
-          oss << nodes[i].node_manager_address();
-        }
-        oss << " but none of these match this node's IP " << node_ip_address
-            << ". Are any of these actually a different IP address for the same node?"
-            << "You might need to provide --node-ip-address to specify the IP "
-            << "address that the head should use when sending to this node.";
-        status = Status::NotFound(oss.str());
-      } else {
-        *node_to_connect = nodes[relevant_client_index].SerializeAsString();
-        return Status::OK();
+        absl::ReaderMutexLock lock(&mutex_);
+        auto timeout_ms = std::max(end_time_point - current_time_ms(), 0LL);
+        node_infos_status =
+            gcs_client_->Nodes().GetAllNoCacheWithFilter(timeout_ms, filter);
+        RAY_RETURN_NOT_OK(node_infos_status.status());
       }
     }
+    if (!node_infos_status->empty()) {
+      RAY_LOG(INFO) << "This node has an IP address of " << node_ip_address
+                    << ", but we cannot find a local Raylet with the same address. "
+                    << "This can happen when you connect to the Ray cluster "
+                    << "with a different IP address or when connecting to a container.";
+      *node_to_connect = (*node_infos_status)[0].SerializeAsString();
+      return Status::OK();
+    }
 
-    if (current_time_ms() - start_ms >=
-        RayConfig::instance().raylet_start_wait_time_s() * 1000) {
-      return status;
+    std::ostringstream oss;
+    oss << "This node has an IP address of " << node_ip_address << ", and Ray "
+        << "expects this IP address to be either the GCS address or one of"
+        << " the Raylet addresses. Connected to GCS at " << gcs_address
+        << ", and found no Raylet with this IP address. "
+        << "You might need to provide --node-ip-address to specify the IP "
+        << "address that the head should use when sending to this node.";
+    node_infos_status = Status::NotFound(oss.str());
+
+    if (current_time_ms() >= end_time_point) {
+      return node_infos_status.status();
     }
     RAY_LOG(WARNING) << "Some processes that the driver needs to connect to have "
                         "not registered with GCS, so retrying. Have you run "

--- a/src/ray/gcs/gcs_client/global_state_accessor.h
+++ b/src/ray/gcs/gcs_client/global_state_accessor.h
@@ -209,7 +209,7 @@ class GlobalStateAccessor {
   /// \param[out] node_info The output parameter to store the node info. To support
   /// multi-language, we serialize each GcsNodeInfo and return the serialized string.
   /// Where used, it needs to be deserialized with protobuf function.
-  ray::Status GetNode(const std::string &node_id_str, std::string *node_info)
+  ray::Status GetNode(const std::string &node_id_hex_str, std::string *node_info)
       ABSL_LOCKS_EXCLUDED(mutex_);
 
   /// Get the node to connect for a Ray driver.

--- a/src/ray/gcs/gcs_client/global_state_accessor.h
+++ b/src/ray/gcs/gcs_client/global_state_accessor.h
@@ -209,7 +209,7 @@ class GlobalStateAccessor {
   /// \param[out] node_info The output parameter to store the node info. To support
   /// multi-language, we serialize each GcsNodeInfo and return the serialized string.
   /// Where used, it needs to be deserialized with protobuf function.
-  ray::Status GetNode(const std::string &node_id, std::string *node_info)
+  ray::Status GetNode(const std::string &node_id_str, std::string *node_info)
       ABSL_LOCKS_EXCLUDED(mutex_);
 
   /// Get the node to connect for a Ray driver.
@@ -223,12 +223,6 @@ class GlobalStateAccessor {
       ABSL_LOCKS_EXCLUDED(mutex_);
 
  private:
-  /// Synchronously get the current alive nodes from GCS Service.
-  ///
-  /// \param[out] nodes The output parameter to store the alive nodes.
-  ray::Status GetAliveNodes(std::vector<rpc::GcsNodeInfo> &nodes)
-      ABSL_LOCKS_EXCLUDED(mutex_);
-
   /// MultiItem transformation helper in template style.
   ///
   /// \return MultiItemCallback within in rpc type DATA.

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -233,7 +233,6 @@ void GcsNodeManager::HandleGetAllNodeInfo(rpc::GetAllNodeInfoRequest request,
       request.filters().has_node_ip_address()
           ? std::make_optional(request.filters().node_ip_address())
           : std::nullopt;
-  std::optional<std::string> filter_node_;
   auto filter_fn = [&filter_node_id, &filter_node_name, &filter_node_ip_address](
                        const rpc::GcsNodeInfo &node) {
     if (filter_node_id.has_value() &&

--- a/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
@@ -379,6 +379,18 @@ TEST_F(GcsServerTest, TestNodeInfoFilters) {
     ASSERT_EQ(reply.num_filtered(), 2);
     ASSERT_EQ(reply.total(), 3);
   }
+
+  {
+    // Get by node_ip_address
+    rpc::GetAllNodeInfoRequest request;
+    request.mutable_filters()->set_node_ip_address("127.0.0.1");
+    rpc::GetAllNodeInfoReply reply;
+    RAY_CHECK_OK(client_->SyncGetAllNodeInfo(request, &reply));
+
+    ASSERT_EQ(reply.node_info_list_size(), 1);
+    ASSERT_EQ(reply.num_filtered(), 2);
+    ASSERT_EQ(reply.total(), 3);
+  }
 }
 
 TEST_F(GcsServerTest, TestWorkerInfo) {

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -229,6 +229,7 @@ message GetAllNodeInfoRequest {
     optional bytes node_id = 1;
     optional GcsNodeInfo.GcsNodeState state = 2;
     optional string node_name = 3;
+    optional string node_ip_address = 4;
   }
 
   // Maximum number to return.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
GetAllNodeInfo is a heavily hit request on large clusters that starts to take a long time as clusters get large since it has to copy and send back info for all nodes. However, on some of these requests we're only looking for a single node with its id or ip address, and GetAllNodeInfo already has the option for a filter, so we should use that to only get info for the node we need it for. Here I'm utilizing the node_id filter and adding a node_ip_address filter, and using it in the global_state_accessor.

### GetNodeToConnectForDriver Old Logic:
- Get all the alive nodes
- Get the gcs_server_address
- If we find the node which matches the ip_address we wanted, return that node_info.

**Else**
- If we find a node with an ip_address that matches the gcs_server_address, return that node_info.
- If we wanted an ip_address that matched the gcs_server_address and we find an ip_address that matches the 127.0.0.1

### GcsNodeToConnectForDriver New Logic
- Try to get the info for the address we requested
- If we get it return that info

**Else**
- Get the gcs_server_address
- Try to get the node info for the gcs_server_address.
- If the ip_address we wanted matches the gcs_server_addresss, try to get the node info for 127.0.0.1

The 127.0.0.1 is the last prioritized requst because the assumption is that the cluster is running locally and rpc performance shouldn't really matter.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
