### PR TITLE
[core] Fix PlasmaObjectHeader timeout_point types for windows

### DIFF
--- a/src/ray/object_manager/common.cc
+++ b/src/ray/object_manager/common.cc
@@ -280,7 +280,7 @@ Status PlasmaObjectHeader::ReadAcquire(
     int64_t version_to_read,
     int64_t &version_read,
     const std::function<Status()> &check_signals,
-    const std::unique_ptr<std::chrono::steady_clock::time_point> &timeout_point) {
+    const std::optional<std::chrono::steady_clock::time_point> &timeout_point) {
   return Status::NotImplemented("Not supported on Windows.");
 }
 

--- a/src/ray/object_manager/common.cc
+++ b/src/ray/object_manager/common.cc
@@ -254,7 +254,7 @@ Status PlasmaObjectHeader::ReadRelease(Semaphores &sem, int64_t read_version) {
 
 Status PlasmaObjectHeader::TryToAcquireSemaphore(
     sem_t *sem,
-    const std::unique_ptr<std::chrono::steady_clock::time_point> &timeout_point,
+    const std::optional<std::chrono::steady_clock::time_point> &timeout_point,
     const std::function<Status()> &check_signals) const {
   return Status::NotImplemented("Not supported on Windows.");
 }
@@ -266,7 +266,7 @@ Status PlasmaObjectHeader::WriteAcquire(
     uint64_t write_data_size,
     uint64_t write_metadata_size,
     int64_t write_num_readers,
-    const std::unique_ptr<std::chrono::steady_clock::time_point> &timeout_point) {
+    const std::optional<std::chrono::steady_clock::time_point> &timeout_point) {
   return Status::NotImplemented("Not supported on Windows.");
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Windows definitions weren't updated along with others.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
