### PR TITLE
[core][compiled-graphs] Always call `ensure_registered_as_[reader|writer]` in `read` / `write` function

### DIFF
--- a/python/ray/experimental/channel/cached_channel.py
+++ b/python/ray/experimental/channel/cached_channel.py
@@ -58,6 +58,7 @@ class CachedChannel(ChannelInterface):
         )
 
     def write(self, value: Any, timeout: Optional[float] = None):
+        self.ensure_registered_as_writer()
         # TODO: better organize the imports
         from ray.experimental.channel import ChannelContext
 
@@ -74,6 +75,7 @@ class CachedChannel(ChannelInterface):
         ctx.set_data(self._channel_id, value, self._num_reads)
 
     def read(self, timeout: Optional[float] = None) -> Any:
+        self.ensure_registered_as_reader()
         # TODO: better organize the imports
         from ray.experimental.channel import ChannelContext
 

--- a/python/ray/experimental/channel/intra_process_channel.py
+++ b/python/ray/experimental/channel/intra_process_channel.py
@@ -49,6 +49,7 @@ class IntraProcessChannel(ChannelInterface):
         return f"IntraProcessChannel(channel_id={self._channel_id})"
 
     def write(self, value: Any, timeout: Optional[float] = None):
+        self.ensure_registered_as_writer()
         # No need to check timeout as the operation is non-blocking.
 
         # Because both the reader and writer are in the same worker process,
@@ -58,6 +59,7 @@ class IntraProcessChannel(ChannelInterface):
         ctx.set_data(self._channel_id, value, self._num_readers)
 
     def read(self, timeout: Optional[float] = None, deserialize: bool = True) -> Any:
+        self.ensure_registered_as_reader()
         assert deserialize, "Data passed from the actor to itself is never serialized"
         # No need to check timeout as the operation is non-blocking.
         ctx = ChannelContext.get_current().serialization_context

--- a/python/ray/experimental/channel/shared_memory_channel.py
+++ b/python/ray/experimental/channel/shared_memory_channel.py
@@ -588,6 +588,7 @@ class BufferedSharedMemoryChannel(ChannelInterface):
         available to write. If a buffer is not available within timeout, it raises
         RayChannelTimeoutError.
         """
+        self.ensure_registered_as_writer()
         # A single channel is not supposed to read and write at the same time.
         assert self._next_read_index == 0
         self._buffers[self._next_write_index].write(value, timeout)
@@ -602,6 +603,7 @@ class BufferedSharedMemoryChannel(ChannelInterface):
         available to read. If a buffer is not available within timeout, it raises
         RayChannelTimeoutError.
         """
+        self.ensure_registered_as_reader()
         # A single channel is not supposed to read and write at the same time.
         assert self._next_write_index == 0
         output = self._buffers[self._next_read_index].read(timeout)

--- a/python/ray/experimental/channel/torch_tensor_nccl_channel.py
+++ b/python/ray/experimental/channel/torch_tensor_nccl_channel.py
@@ -158,11 +158,17 @@ class TorchTensorNcclChannel(ChannelInterface):
         )
 
     def ensure_registered_as_writer(self):
+        if self._local_channel is not None:
+            self._local_channel.ensure_registered_as_writer()
         self._gpu_data_channel.ensure_registered_as_writer()
         if self._cpu_data_channel is not None:
             self._cpu_data_channel.ensure_registered_as_writer()
 
     def ensure_registered_as_reader(self):
+        reader = utils.get_self_actor()
+        if reader == self._writer:
+            self._local_channel.ensure_registered_as_reader()
+            return
         self._gpu_data_channel.ensure_registered_as_reader()
         if self._cpu_data_channel is not None:
             self._cpu_data_channel.ensure_registered_as_reader()

--- a/python/ray/experimental/channel/torch_tensor_nccl_channel.py
+++ b/python/ray/experimental/channel/torch_tensor_nccl_channel.py
@@ -221,6 +221,8 @@ class TorchTensorNcclChannel(ChannelInterface):
         (3) on the first `write` call. The reader is expected to reuse the sent
         data for subsequent messages.
         """
+        self.ensure_registered_as_writer()
+
         if self._local_channel is not None:
             self._local_channel.write(value)
 
@@ -307,6 +309,8 @@ class TorchTensorNcclChannel(ChannelInterface):
         If _direct_return=True was specified, then we skip step (2) and (3) and
         directly return the data received in (1).
         """
+        self.ensure_registered_as_reader()
+
         # If the reader is the same actor as the writer, then we can use the
         # local channel to read the data.
         reader = utils.get_self_actor()
@@ -535,6 +539,8 @@ class _TorchTensorNcclChannel(ChannelInterface):
         first message. The reader is expected to reuse the sent metadata for
         subsequent messages.
         """
+        self.ensure_registered_as_writer()
+
         import torch
 
         for tensor in tensors:
@@ -597,6 +603,8 @@ class _TorchTensorNcclChannel(ChannelInterface):
         tensor metadata. The GPU recv may exceed the timeout without throwing
         an error.
         """
+        self.ensure_registered_as_reader()
+
         meta_list: List[_TorchTensorMetadata] = self._get_recv_tensors_metadata(timeout)
 
         bufs: List["torch.Tensor"] = []


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

1. Most channel read/write functions don't call `ensure_registered_as_[reader|writer]`. This PR ensures that `ensure_registered_as_[reader|writer]` is called if it hasn't already been called.

2. Fixed a bug in `ensure_registered_as_reader` for `TorchTensorNcclChannel`. It is unnecessary to call `ensure_registered_as_reader` for the internal GPU channel if the reader reads from the local channel."

After #49711 is merged, we can have a central place to verify whether `ensure_registered_as_reader` is called.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
