### PR TITLE
Fix lint

### DIFF
--- a/doc/source/rllib/rllib-advanced-api.rst
+++ b/doc/source/rllib/rllib-advanced-api.rst
@@ -110,7 +110,7 @@ Customizing exploration behavior
 RLlib offers a unified top-level API to configure and customize an agent’s
 exploration behavior, including the decisions, like how and whether, to sample
 actions from distributions, stochastically or deterministically.
-Set up the behavior using built-in Exploration classes. 
+Set up the behavior using built-in Exploration classes.
 See `this package <https://github.com/ray-project/ray/blob/master/rllib/utils/exploration/>`__),
 which you specify and further configure inside
 ``AlgorithmConfig().env_runners(..)``.

--- a/doc/source/rllib/rllib-callback.rst
+++ b/doc/source/rllib/rllib-callback.rst
@@ -93,7 +93,7 @@ a subclass of :py:class:`~ray.rllib.callbacks.callbacks.RLlibCallback`.
 Callback events
 ---------------
 
-During a training iteration, the Algorithm normally walks through the following event tree, 
+During a training iteration, the Algorithm normally walks through the following event tree,
 a high-level overview of all supported events in RLlib's callbacks system:
 
 .. code-block:: text
@@ -354,4 +354,3 @@ See this more complex example that `generates and logs a PacMan heatmap (image) 
 
 See :ref:`Callbacks invoked in Algorithm <rllib-callback-reference-algorithm-bound>`
 for the exact call signatures of all available callbacks and the argument types they expect.
-

--- a/doc/source/rllib/rllib-fault-tolerance.rst
+++ b/doc/source/rllib/rllib-fault-tolerance.rst
@@ -42,7 +42,7 @@ In addition to worker fault tolerance, RLlib offers fault tolerance at the envir
 
 Rollout or evaluation workers often run multiple environments in parallel to take
 advantage of, for example, the parallel computing power that GPU offers. You can control this parallelism with
-the ``num_envs_per_env_runner`` config. It may then be wasteful if RLlib needs to reconstruct 
+the ``num_envs_per_env_runner`` config. It may then be wasteful if RLlib needs to reconstruct
 the entire worker needs because of errors from a single environment.
 
 In that case, RLlib offers the capability to restart individual environments without bubbling the


### PR DESCRIPTION
Changes made by my linter:
```
[~/ray] (hjiang/pipe-logging) 
ubuntu@hjiang-devbox-pg$ git push 
trim trailing whitespace.................................................Failed
- hook id: trailing-whitespace
- exit code: 1
- files were modified by this hook

Fixing doc/source/rllib/rllib-advanced-api.rst
Fixing doc/source/rllib/rllib-callback.rst
Fixing doc/source/rllib/rllib-fault-tolerance.rst

fix end of files.........................................................Failed
- hook id: end-of-file-fixer
- exit code: 1
- files were modified by this hook

Fixing doc/source/rllib/rllib-callback.rst
```