### PR TITLE
[data] Fixes `ray.data._internal.utils:iterate_with_retry`

### DIFF
--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -1064,11 +1064,11 @@ def iterate_with_retry(
     assert max_attempts >= 1, f"`max_attempts` must be positive. Got {max_attempts}."
 
     num_items_yielded = 0
-    for i in range(max_attempts):
+    for attempt in range(max_attempts):
         try:
             iterable = iterable_factory()
-            for i, item in enumerate(iterable):
-                if i < num_items_yielded:
+            for item_index, item in enumerate(iterable):
+                if item_index < num_items_yielded:
                     # Skip items that have already been yielded.
                     continue
 
@@ -1079,11 +1079,11 @@ def iterate_with_retry(
             is_retryable = match is None or any(
                 [pattern in str(e) for pattern in match]
             )
-            if is_retryable and i + 1 < max_attempts:
+            if is_retryable and attempt + 1 < max_attempts:
                 # Retry with binary expoential backoff with random jitter.
-                backoff = min((2 ** (i + 1)), max_backoff_s) * random.random()
+                backoff = min((2 ** (attempt + 1)), max_backoff_s) * random.random()
                 logger.debug(
-                    f"Retrying {i+1} attempts to {description} after {backoff} seconds."
+                    f"Retrying {attempt+1} attempts to {description} after {backoff} seconds."
                 )
                 time.sleep(backoff)
             else:

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -1083,7 +1083,8 @@ def iterate_with_retry(
                 # Retry with binary expoential backoff with random jitter.
                 backoff = min((2 ** (attempt + 1)), max_backoff_s) * random.random()
                 logger.debug(
-                    f"Retrying {attempt+1} attempts to {description} after {backoff} seconds."
+                    f"Retrying {attempt+1} attempts to {description} "
+                    f"after {backoff} seconds."
                 )
                 time.sleep(backoff)
             else:


### PR DESCRIPTION
## Why are these changes needed?

There is a variable name reuse bug in `ray.data._internal.utils:iterate_with_retry`, I fixed it and added a unit test which fails (as a result of the bug) in the master branch but succeeds after applying this PR.

## Related issue number
N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [X] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
