### PR TITLE
[core][compiled graphs] Introduce with_tensor_transport API

### DIFF
--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -20,6 +20,10 @@ import time
 import uuid
 import traceback
 
+from ray.experimental.channel.auto_transport_type import (
+    AutoTransportType,
+    TypeHintResolver,
+)
 import ray.exceptions
 from ray.dag.dag_operation_future import GPUFuture, DAGOperationFuture, ResolvedFuture
 from ray.experimental.channel.cached_channel import CachedChannel
@@ -375,7 +379,9 @@ class CompiledTask:
         # corresponding value from `args` or `kwargs` in the DAG's input.
         self.output_channels: List[ChannelInterface] = []
         self.output_idxs: List[Optional[Union[int, str]]] = []
-        self.arg_type_hints: List["ChannelOutputType"] = []
+        # The DAGNodes that are arguments to this task.
+        # This is used for lazy resolution of the arguments' type hints.
+        self.arg_nodes: List["ray.dag.DAGNode"] = []
         # idxs of possible ClassMethodOutputNodes if they exist, used for visualization
         self.output_node_idxs: List[int] = []
 
@@ -390,6 +396,10 @@ class CompiledTask:
     @property
     def num_readers(self) -> int:
         return len(self.downstream_task_idxs)
+
+    @property
+    def arg_type_hints(self) -> List["ChannelOutputType"]:
+        return [arg_node.type_hint for arg_node in self.arg_nodes]
 
     def __str__(self) -> str:
         return f"""
@@ -890,6 +900,9 @@ class CompiledDAG:
         self.actor_to_tasks: Dict[
             "ray.actor.ActorHandle", List["CompiledTask"]
         ] = defaultdict(list)
+        # Mapping from actor handle to its GPU IDs.
+        # This is used for type hint resolution for with_tensor_transport("auto").
+        self.actor_to_gpu_ids: Dict["ray.actor.ActorHandle", List[str]] = {}
         self.actor_to_executable_tasks: Dict[
             "ray.actor.ActorHandle", List["ExecutableTask"]
         ] = {}
@@ -1043,6 +1056,8 @@ class CompiledDAG:
         # Collect the set of InputNode keys bound to DAG node args.
         input_positional_args: Set[int] = set()
         input_kwargs: Set[str] = set()
+        # Set of tasks with annotation of with_tensor_transport("auto").
+        auto_transport_tasks: Set["CompiledTask"] = set()
 
         # For each task node, set its upstream and downstream task nodes.
         # Also collect the set of tasks that produce torch.tensors.
@@ -1069,6 +1084,14 @@ class CompiledDAG:
                         "Compiled DAGs can only bind methods to an actor "
                         "that is already created with Actor.remote()"
                     )
+
+                if actor_handle not in self.actor_to_gpu_ids:
+                    self.actor_to_gpu_ids[actor_handle] = self._get_gpu_ids(
+                        actor_handle
+                    )
+
+                if isinstance(dag_node.type_hint, AutoTransportType):
+                    auto_transport_tasks.add(task)
 
                 # Collect actors for NCCL P2P methods.
                 if dag_node.type_hint.requires_nccl():
@@ -1140,8 +1163,9 @@ class CompiledDAG:
                 ):
                     downstream_actor_handle = dag_node._get_actor_handle()
 
-                # Add the type hint of the upstream node to the task.
-                task.arg_type_hints.append(upstream_task.dag_node.type_hint)
+                # Add upstream node as the argument nodes of this task, whose
+                # type hints may be updated when resolved lazily.
+                task.arg_nodes.append(upstream_task.dag_node)
 
                 if isinstance(upstream_task.dag_node, InputAttributeNode):
                     # Record all of the keys used to index the InputNode.
@@ -1207,6 +1231,33 @@ class CompiledDAG:
                 f"{[leaf_node.get_method_name() for leaf_node in leaf_nodes]} to the "
                 f"the MultiOutputNode."
             )
+
+        type_hint_resolver = TypeHintResolver(self.actor_to_gpu_ids)
+        # Resolve AutoChannelType type hints and track the actors that use NCCL.
+        # This is needed so that the NCCL group can be initialized for these
+        # actors that use NCCL.
+        for task in auto_transport_tasks:
+            writer = task.dag_node._get_actor_handle()
+            readers = task.downstream_task_idxs.values()
+            if any(reader is None for reader in readers):
+                # None means reader is the driver, currently driver on GPU
+                # is not supported, so we always use shared memory to transfer
+                # tensors.
+                task.dag_node.type_hint = TorchTensorType()
+                continue
+            writer_and_node = (writer, self._get_node_id(writer))
+            reader_and_node_list = [
+                (reader, self._get_node_id(reader)) for reader in readers
+            ]
+            # Update the type hint to the resolved one. This is needed because
+            # the resolved type hint's `register_custom_serializer` will be called
+            # in preparation for channel I/O.
+            task.dag_node.type_hint = type_hint_resolver.resolve(
+                writer_and_node, reader_and_node_list
+            )
+            if task.dag_node.type_hint.requires_nccl():
+                nccl_actors_p2p.add(writer)
+                nccl_actors_p2p.update(readers)
 
         nccl_actors_p2p = list(nccl_actors_p2p)
         if None in nccl_actors_p2p:
@@ -1291,6 +1342,17 @@ class CompiledDAG:
         else:
             self._input_num_positional_args = max(input_positional_args) + 1
         self._input_kwargs = tuple(input_kwargs)
+
+    def _get_gpu_ids(self, actor_handle: "ray.actor.ActorHandle") -> List[str]:
+        """
+        Get the GPU IDs of an actor handle.
+        """
+        accelerator_ids = ray.get(
+            actor_handle.__ray_call__.remote(
+                lambda self: ray.get_runtime_context().get_accelerator_ids()
+            )
+        )
+        return accelerator_ids.get("GPU", [])
 
     def _get_node_id(self, actor_handle: "ray.actor.ActorHandle") -> str:
         """
@@ -1492,10 +1554,16 @@ class CompiledDAG:
                     reader_and_node_list = list(
                         input_node_to_reader_and_node_set[input_dag_node]
                     )
+
+                    if isinstance(input_dag_node.type_hint, AutoTransportType):
+                        # Currently driver on GPU is not supported, so we always
+                        # use shared memory to transfer tensors.
+                        input_dag_node.type_hint = TorchTensorType()
+
                     output_channel = do_allocate_channel(
                         self,
                         reader_and_node_list,
-                        type_hint,
+                        input_dag_node.type_hint,
                         None,
                     )
                     task.output_channels.append(output_channel)

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -1142,7 +1142,7 @@ class CompiledDAG:
             if type(dag_node.type_hint) is ChannelOutputType:
                 # No type hint specified by the user. Replace
                 # with the default type hint for this DAG.
-                dag_node.with_type_hint(self._default_type_hint)
+                dag_node.type_hint(self._default_type_hint)
 
             for _, val in task.kwargs.items():
                 if isinstance(val, DAGNode):

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -912,6 +912,7 @@ class CompiledDAG:
             "ray.actor.ActorHandle", List[_DAGNodeOperation]
         ] = defaultdict(list)
         # Mapping from the actor handle to the node ID that the actor is on.
+        # A None actor handle means the actor is the driver.
         self.actor_to_node_id: Dict[Optional["ray.actor.ActorHandle"], str] = {}
 
         # This is set to true when type hint of `transport="nccl"` is used.
@@ -1057,6 +1058,8 @@ class CompiledDAG:
         input_positional_args: Set[int] = set()
         input_kwargs: Set[str] = set()
         # Set of tasks with annotation of with_tensor_transport("auto").
+        # These only correspond to ClassMethodNodes, but not InputNodes
+        # or InputAttributeNodes.
         auto_transport_tasks: Set["CompiledTask"] = set()
 
         # For each task node, set its upstream and downstream task nodes.

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -1253,7 +1253,9 @@ class CompiledDAG:
             # the resolved type hint's `register_custom_serializer` will be called
             # in preparation for channel I/O.
             task.dag_node.type_hint = type_hint_resolver.resolve(
-                writer_and_node, reader_and_node_list
+                task.dag_node.type_hint,
+                writer_and_node,
+                reader_and_node_list,
             )
             if task.dag_node.type_hint.requires_nccl():
                 nccl_actors_p2p.add(writer)
@@ -1350,7 +1352,7 @@ class CompiledDAG:
         """
         accelerator_ids = ray.get(
             actor_handle.__ray_call__.remote(
-                lambda: ray.get_runtime_context().get_accelerator_ids()
+                lambda self: ray.get_runtime_context().get_accelerator_ids()
             )
         )
         return accelerator_ids.get("GPU", [])

--- a/python/ray/dag/dag_node.py
+++ b/python/ray/dag/dag_node.py
@@ -145,7 +145,10 @@ class DAGNode(DAGNodeBase):
         _direct_return: bool = False,
     ):
         if transport == "auto":
-            self._type_hint = AutoTransportType()
+            self._type_hint = AutoTransportType(
+                _static_shape=_static_shape,
+                _direct_return=_direct_return,
+            )
         elif transport == "nccl":
             self._type_hint = TorchTensorType(
                 transport=transport,
@@ -596,6 +599,7 @@ class DAGNode(DAGNodeBase):
         )
         instance._stable_uuid = self._stable_uuid
         instance._type_hint = copy.deepcopy(self._type_hint)
+        instance._original_type_hint = copy.deepcopy(self._original_type_hint)
         return instance
 
     def __getstate__(self):

--- a/python/ray/dag/dag_node.py
+++ b/python/ray/dag/dag_node.py
@@ -1,8 +1,10 @@
+import copy
+from ray.experimental.channel.auto_transport_type import AutoTransportType
+from ray.experimental.channel.torch_tensor_type import TorchTensorType
 import ray
 from ray.dag.base import DAGNodeBase
 from ray.dag.py_obj_scanner import _PyObjScanner
 from ray.util.annotations import DeveloperAPI
-import copy
 
 from itertools import chain
 
@@ -21,6 +23,7 @@ import asyncio
 
 from ray.dag.compiled_dag_node import build_compiled_dag_from_ray_dag
 from ray.experimental.channel import ChannelOutputType
+from ray.experimental.channel.communicator import Communicator
 
 T = TypeVar("T")
 
@@ -79,6 +82,12 @@ class DAGNode(DAGNodeBase):
         self.cache_from_last_execute = {}
 
         self._type_hint: ChannelOutputType = ChannelOutputType()
+
+        # If the original type hint is an AutoTransportType, we make a copy
+        # here when it is resolved to the actual type, as additional debugging
+        # information. Otherwise, it is None.
+        self._original_type_hint: Optional[ChannelOutputType] = None
+
         # Whether this node calls `experimental_compile`.
         self.is_cgraph_output_node = False
 
@@ -129,13 +138,41 @@ class DAGNode(DAGNodeBase):
             upstream_node._downstream_nodes.append(self)
         return upstream_nodes
 
-    def with_type_hint(self, typ: ChannelOutputType):
-        self._type_hint = copy.deepcopy(typ)
+    def with_tensor_transport(
+        self,
+        transport: Optional[Union[str, Communicator]] = "auto",
+        _static_shape: bool = False,
+        _direct_return: bool = False,
+    ):
+        if transport == "auto":
+            self._type_hint = AutoTransportType()
+        elif transport == "nccl":
+            self._type_hint = TorchTensorType(
+                transport=transport,
+                _static_shape=_static_shape,
+                _direct_return=_direct_return,
+            )
+        else:
+            if not isinstance(transport, Communicator):
+                raise ValueError(
+                    "transport must be 'auto', 'nccl' or a Communicator type"
+                )
+            self._type_hint = TorchTensorType(
+                transport=transport,
+                _static_shape=_static_shape,
+                _direct_return=_direct_return,
+            )
         return self
 
     @property
     def type_hint(self) -> ChannelOutputType:
         return self._type_hint
+
+    @type_hint.setter
+    def type_hint(self, type_hint: ChannelOutputType) -> None:
+        if isinstance(self._type_hint, AutoTransportType):
+            self._original_type_hint = self._type_hint
+        self._type_hint = type_hint
 
     def get_args(self) -> Tuple[Any]:
         """Return the tuple of arguments for this node."""
@@ -558,7 +595,7 @@ class DAGNode(DAGNodeBase):
             new_args, new_kwargs, new_options, new_other_args_to_resolve
         )
         instance._stable_uuid = self._stable_uuid
-        instance = instance.with_type_hint(self.type_hint)
+        instance._type_hint = copy.deepcopy(self._type_hint)
         return instance
 
     def __getstate__(self):

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -25,7 +25,6 @@ from ray._private.utils import (
     get_or_create_event_loop,
 )
 from ray.dag import DAGContext
-from ray.experimental.channel.torch_tensor_type import TorchTensorType
 from ray._private.test_utils import (
     run_string_as_driver_nonblocking,
     wait_for_pid_to_exit,
@@ -891,13 +890,13 @@ class TestMultiArgs:
         a2 = Actor.remote(0)
         c = Collector.remote()
         with InputNode() as i:
-            i.with_type_hint(TorchTensorType())
+            i.with_tensor_transport()
             branch1 = a1.echo.bind(i[0])
-            branch1.with_type_hint(TorchTensorType())
+            branch1.with_tensor_transport()
             branch2 = a2.echo.bind(i[1])
-            branch2.with_type_hint(TorchTensorType())
+            branch2.with_tensor_transport()
             dag = c.collect_two.bind(branch2, branch1)
-            dag.with_type_hint(TorchTensorType())
+            dag.with_tensor_transport()
 
         compiled_dag = dag.experimental_compile()
 
@@ -2850,7 +2849,7 @@ def test_torch_tensor_type(shutdown_only):
                     inp,
                     self._base.generate_torch_tensor.bind(
                         inp,
-                    ).with_type_hint(TorchTensorType()),
+                    ).with_tensor_transport(),
                 )
             self._cdag = dag.experimental_compile()
 

--- a/python/ray/dag/tests/experimental/test_cpu_communicator_dag.py
+++ b/python/ray/dag/tests/experimental/test_cpu_communicator_dag.py
@@ -7,7 +7,6 @@ import pytest
 import ray
 import ray.cluster_utils
 from ray.exceptions import RayChannelError
-from ray.experimental.channel.torch_tensor_type import TorchTensorType
 from ray.experimental.channel.cpu_communicator import CPUCommunicator
 from ray.dag import InputNode
 import ray.experimental.collective as collective
@@ -83,7 +82,7 @@ def test_p2p_basic(ray_start_cluster):
 
     with InputNode() as inp:
         dag = sender.send.bind(inp.shape, inp.dtype, inp[0])
-        dag = dag.with_type_hint(TorchTensorType(transport=cpu_group))
+        dag = dag.with_tensor_transport(transport=cpu_group)
         dag = receiver.recv.bind(dag)
 
     compiled_dag = dag.experimental_compile()
@@ -273,9 +272,9 @@ def test_allreduce_scheduling(ray_start_cluster):
         x = workers[0].send.bind(shape, dtype, inp)
         y = workers[1].send.bind(shape, dtype, inp)
 
-        # Tensor to be sent from workes[0] to workers[1].
+        # Tensor to be sent from workers[0] to workers[1].
         t = workers[0].send.bind(shape, dtype, inp)
-        t.with_type_hint(TorchTensorType(transport=cpu_group))
+        t = t.with_tensor_transport(transport=cpu_group)
 
         collectives = collective.allreduce.bind([x, y], transport=cpu_group)
         recv = workers[1].recv.bind(t)

--- a/python/ray/dag/tests/experimental/test_mocked_nccl_dag.py
+++ b/python/ray/dag/tests/experimental/test_mocked_nccl_dag.py
@@ -8,7 +8,6 @@ import pytest
 import ray
 import ray.cluster_utils
 from ray.exceptions import RayChannelError, RayTaskError
-from ray.experimental.channel.torch_tensor_type import TorchTensorType
 from ray.experimental.channel.conftest import (
     Barrier,
     start_nccl_mock,
@@ -94,7 +93,7 @@ def test_p2p(ray_start_cluster):
     # Test torch.Tensor sent between actors.
     with InputNode() as inp:
         dag = sender.send.bind(inp.shape, inp.dtype, inp[0], inp.send_as_dict)
-        dag = dag.with_type_hint(TorchTensorType(transport="nccl"))
+        dag = dag.with_tensor_transport(transport="nccl")
         dag = receiver.recv.bind(dag)
 
     compiled_dag = dag.experimental_compile()
@@ -147,7 +146,7 @@ def test_p2p_static_shape(ray_start_cluster, send_as_dict):
     # Test torch.Tensor sent between actors.
     with InputNode() as inp:
         dag = sender.send.bind(inp.shape, inp.dtype, inp[0], send_as_dict=send_as_dict)
-        dag = dag.with_type_hint(TorchTensorType(transport="nccl", _static_shape=True))
+        dag = dag.with_tensor_transport(transport="nccl", _static_shape=True)
         dag = receiver.recv.bind(dag)
 
     compiled_dag = dag.experimental_compile()
@@ -187,7 +186,7 @@ def test_p2p_static_shape_error(capsys, ray_start_cluster, send_as_dict):
     # Test torch.Tensor sent between actors.
     with InputNode() as inp:
         dag = sender.send.bind(inp.shape, inp.dtype, inp[0], send_as_dict=send_as_dict)
-        dag = dag.with_type_hint(TorchTensorType(transport="nccl", _static_shape=True))
+        dag = dag.with_tensor_transport(transport="nccl", _static_shape=True)
         dag = receiver.recv.bind(dag)
 
     compiled_dag = dag.experimental_compile()
@@ -241,7 +240,7 @@ def test_p2p_direct_return(ray_start_cluster):
     # Test torch.Tensor sent between actors.
     with InputNode() as inp:
         dag = sender.send.bind(inp.shape, inp.dtype, inp.value, inp.send_as_dict)
-        dag = dag.with_type_hint(TorchTensorType(transport="nccl", _direct_return=True))
+        dag = dag.with_tensor_transport(transport="nccl", _direct_return=True)
         dag = receiver.recv.bind(dag)
 
     compiled_dag = dag.experimental_compile()
@@ -283,7 +282,7 @@ def test_p2p_direct_return_error(capsys, ray_start_cluster):
     # Test torch.Tensor sent between actors.
     with InputNode() as inp:
         dag = sender.send.bind(inp.shape, inp.dtype, inp.value, inp.send_as_dict)
-        dag = dag.with_type_hint(TorchTensorType(transport="nccl", _direct_return=True))
+        dag = dag.with_tensor_transport(transport="nccl", _direct_return=True)
         dag = receiver.recv.bind(dag)
 
     compiled_dag = dag.experimental_compile()
@@ -349,8 +348,8 @@ def test_p2p_static_shape_and_direct_return(
     # Test torch.Tensor sent between actors.
     with InputNode() as inp:
         dag = sender.send.bind(inp.shape, inp.dtype, inp.value, inp.send_as_dict)
-        dag = dag.with_type_hint(
-            TorchTensorType(transport="nccl", _static_shape=True, _direct_return=True)
+        dag = dag.with_tensor_transport(
+            transport="nccl", _static_shape=True, _direct_return=True
         )
         dag = receiver.recv.bind(dag)
 

--- a/python/ray/dag/tests/experimental/test_multi_args_gpu.py
+++ b/python/ray/dag/tests/experimental/test_multi_args_gpu.py
@@ -7,7 +7,6 @@ import pytest
 import ray
 from ray.dag import InputNode, MultiOutputNode
 import ray.cluster_utils
-from ray.experimental.channel.torch_tensor_type import TorchTensorType
 from ray.tests.conftest import *  # noqa
 import torch
 
@@ -41,14 +40,14 @@ def test_multi_args_simulate_pp(ray_start_regular):
         for microbatch_idx in range(NUM_MICROBATCHES):
             microbatch = dag_input[microbatch_idx]
             stage_fwd_out = w0.forward.bind(microbatch)
-            stage_fwd_out.with_type_hint(TorchTensorType(transport="nccl"))
+            stage_fwd_out.with_tensor_transport(transport="nccl")
             stage_fwd_out = w1.forward.bind(stage_fwd_out)
             dag_outs.append(stage_fwd_out)
 
         grad_out = dag_input[NUM_MICROBATCHES]
         for _ in range(NUM_MICROBATCHES):
             stage_bwd_out = w1.backward.bind(grad_out)
-            stage_bwd_out.with_type_hint(TorchTensorType(transport="nccl"))
+            stage_bwd_out.with_tensor_transport(transport="nccl")
             stage_bwd_out = w0.backward.bind(stage_bwd_out)
             dag_outs.append(stage_bwd_out)
 

--- a/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
@@ -19,13 +19,13 @@ from ray.experimental.channel.communicator import (
     Communicator,
     TorchTensorAllocator,
 )
+from ray.experimental.channel.torch_tensor_type import TorchTensorType
 from ray.experimental.channel.nccl_group import _NcclGroup
 from ray._private.test_utils import (
     get_log_message,
     init_log_pubsub,
 )
 
-from ray.experimental.channel.torch_tensor_type import TorchTensorType
 from ray.tests.conftest import *  # noqa
 from ray.experimental.util.types import ReduceOp
 
@@ -159,7 +159,7 @@ def test_torch_tensor_p2p(ray_start_regular):
     # Test torch.Tensor sent between actors.
     with InputNode() as inp:
         dag = sender.send.bind(inp.shape, inp.dtype, inp[0])
-        dag = dag.with_type_hint(TorchTensorType())
+        dag = dag.with_tensor_transport()
         dag = receiver.recv.bind(dag)
 
     compiled_dag = dag.experimental_compile()
@@ -191,7 +191,7 @@ def test_torch_tensor_as_dag_input(ray_start_regular):
 
     # Test torch.Tensor as input.
     with InputNode() as inp:
-        torch_inp = inp.with_type_hint(TorchTensorType())
+        torch_inp = inp.with_tensor_transport()
         dag = receiver.recv.bind(torch_inp)
 
     compiled_dag = dag.experimental_compile()
@@ -236,7 +236,7 @@ def test_torch_tensor_nccl(
     # Test normal execution.
     with InputNode() as inp:
         dag = sender.send.bind(inp.shape, inp.dtype, inp[0])
-        dag = dag.with_type_hint(TorchTensorType(transport="nccl"))
+        dag = dag.with_tensor_transport(transport="nccl")
         dag = receiver.recv.bind(dag)
 
     compiled_dag = dag.experimental_compile(
@@ -252,10 +252,63 @@ def test_torch_tensor_nccl(
     # Test that actors can be reused for a new DAG.
     with InputNode() as inp:
         dag = sender.send.bind(inp.shape, inp.dtype, inp[0])
-        dag = dag.with_type_hint(TorchTensorType(transport="nccl"))
+        dag = dag.with_tensor_transport(transport="nccl")
         dag = receiver.recv.bind(dag)
 
     compiled_dag = dag.experimental_compile()
+
+    # Test that we can pass different shapes and data.
+    for i in range(3):
+        shape = (10 * (i + 1),)
+        ref = compiled_dag.execute(i, shape=shape, dtype=dtype)
+        assert ray.get(ref) == (i, shape, dtype)
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
+@pytest.mark.parametrize("num_gpus", [[0, 0], [1, 0], [0, 1], [1, 1], [0.5, 0.5]])
+def test_torch_tensor_auto(ray_start_regular, num_gpus):
+    if not USE_GPU:
+        pytest.skip("NCCL tests require GPUs")
+
+    assert (
+        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
+    ), "This test requires at least 2 GPUs"
+
+    sender = TorchTensorWorker.options(num_cpus=0, num_gpus=num_gpus[0]).remote()
+    receiver = TorchTensorWorker.options(num_cpus=0, num_gpus=num_gpus[1]).remote()
+    # Use NCCL only when sender and receiver are on different GPUs.
+    # When each actor has 0.5 GPU, sender and receiver are allocated
+    # on the same GPU, so we use auto.
+    expected_transport = "nccl" if num_gpus == [1, 1] else "auto"
+
+    shape = (10,)
+    dtype = torch.float16
+
+    # Test normal execution.
+    with InputNode() as inp:
+        data = sender.send.bind(inp.shape, inp.dtype, inp[0])
+        data_annotated = data.with_tensor_transport(transport="auto")
+        dag = receiver.recv.bind(data_annotated)
+
+    compiled_dag = dag.experimental_compile()
+    assert isinstance(data_annotated.type_hint, TorchTensorType)
+    assert data_annotated.type_hint.transport == expected_transport
+
+    # Test that we can pass different shapes and data.
+    for i in range(3):
+        shape = (10 * (i + 1),)
+        ref = compiled_dag.execute(i, shape=shape, dtype=dtype)
+        assert ray.get(ref) == (i, shape, dtype)
+
+    # Test that actors can be reused for a new DAG.
+    with InputNode() as inp:
+        dag = sender.send.bind(inp.shape, inp.dtype, inp[0])
+        dag = dag.with_tensor_transport(transport="auto")
+        dag = receiver.recv.bind(dag)
+
+    compiled_dag = dag.experimental_compile()
+    assert isinstance(data_annotated.type_hint, TorchTensorType)
+    assert data_annotated.type_hint.transport == expected_transport
 
     # Test that we can pass different shapes and data.
     for i in range(3):
@@ -288,10 +341,8 @@ def test_torch_tensor_nccl_overlap_timed(ray_start_regular, overlap_gpu_communic
     with InputNode() as inp:
         branches = [sender.send.bind(shape, dtype, inp) for sender in senders]
         branches = [
-            branch.with_type_hint(
-                TorchTensorType(
-                    transport="nccl", _static_shape=True, _direct_return=True
-                )
+            branch.with_tensor_transport(
+                transport="nccl", _static_shape=True, _direct_return=True
             )
             for branch in branches
         ]
@@ -337,7 +388,7 @@ def test_torch_tensor_nccl_disallows_driver(ray_start_regular):
 
     # Test that InputNode cannot cannot participate in the NCCL group.
     with InputNode() as inp:
-        torch_inp = inp.with_type_hint(TorchTensorType(transport="nccl"))
+        torch_inp = inp.with_tensor_transport(transport="nccl")
         dag = receiver.recv.bind(torch_inp)
     with pytest.raises(
         ValueError,
@@ -351,7 +402,7 @@ def test_torch_tensor_nccl_disallows_driver(ray_start_regular):
     # Test that OutputNode cannot cannot participate in the NCCL group.
     with InputNode() as inp:
         dag = sender.send.bind(shape, dtype, inp)
-        dag = dag.with_type_hint(TorchTensorType(transport="nccl"))
+        dag = dag.with_tensor_transport(transport="nccl")
 
     with pytest.raises(
         ValueError,
@@ -460,7 +511,7 @@ def test_torch_tensor_custom_comm(ray_start_regular):
     nccl_group = TestNcclGroup(2, comm_id, [sender, receiver])
     with InputNode() as inp:
         dag = sender.send.bind(inp.shape, inp.dtype, inp.value)
-        dag = dag.with_type_hint(TorchTensorType(transport=nccl_group))
+        dag = dag.with_tensor_transport(transport=nccl_group)
         dag = receiver.recv.bind(dag)
 
     compiled_dag = dag.experimental_compile()
@@ -569,10 +620,10 @@ def test_torch_tensor_custom_comm_invalid(ray_start_regular):
     # Case 1: custom NCCL group first, then default NCCL group
     with InputNode() as inp:
         dag = actor1.send.bind(inp.shape, inp.dtype, inp.value)
-        dag = dag.with_type_hint(TorchTensorType(transport=nccl_group))
+        dag = dag.with_tensor_transport(transport=nccl_group)
         dag = actor2.recv.options(num_returns=3).bind(dag)
         dag = actor2.send.bind(*dag)
-        dag = dag.with_type_hint(TorchTensorType(transport="nccl"))
+        dag = dag.with_tensor_transport(transport="nccl")
         dag = actor1.recv.bind(dag)
     with pytest.raises(
         ValueError,
@@ -583,10 +634,10 @@ def test_torch_tensor_custom_comm_invalid(ray_start_regular):
     # Case 2: default NCCL group first, then custom NCCL group
     with InputNode() as inp:
         dag = actor1.send.bind(inp.shape, inp.dtype, inp.value)
-        dag = dag.with_type_hint(TorchTensorType(transport="nccl"))
+        dag = dag.with_tensor_transport(transport="nccl")
         dag = actor2.recv.options(num_returns=3).bind(dag)
         dag = actor2.send.bind(*dag)
-        dag = dag.with_type_hint(TorchTensorType(transport=nccl_group))
+        dag = dag.with_tensor_transport(transport=nccl_group)
         dag = actor1.recv.bind(dag)
     with pytest.raises(
         ValueError,
@@ -599,10 +650,10 @@ def test_torch_tensor_custom_comm_invalid(ray_start_regular):
     # Using two different custom NCCL groups are currently not supported
     with InputNode() as inp:
         dag = actor1.send.bind(inp.shape, inp.dtype, inp.value)
-        dag = dag.with_type_hint(TorchTensorType(transport=nccl_group))
+        dag = dag.with_tensor_transport(transport=nccl_group)
         dag = actor2.recv.options(num_returns=3).bind(dag)
         dag = actor2.send.bind(*dag)
-        dag = dag.with_type_hint(TorchTensorType(transport=nccl_group2))
+        dag = dag.with_tensor_transport(transport=nccl_group2)
         dag = actor1.recv.bind(dag)
     with pytest.raises(
         ValueError,
@@ -725,7 +776,7 @@ def test_torch_tensor_custom_comm_inited(ray_start_regular):
 
     with InputNode() as inp:
         dag = sender.send.bind(inp.shape, inp.dtype, inp.value)
-        dag = dag.with_type_hint(TorchTensorType(transport=nccl_group))
+        dag = dag.with_tensor_transport(transport=nccl_group)
         dag = receiver.recv.bind(dag)
 
     compiled_dag = dag.experimental_compile()
@@ -759,7 +810,7 @@ def test_torch_tensor_nccl_static_shape(ray_start_regular):
 
     with InputNode() as inp:
         dag = sender.send.bind(inp.shape, inp.dtype, inp[0])
-        dag = dag.with_type_hint(TorchTensorType(transport="nccl", _static_shape=True))
+        dag = dag.with_tensor_transport(transport="nccl", _static_shape=True)
         dag = receiver.recv.bind(dag)
 
     compiled_dag = dag.experimental_compile()
@@ -797,7 +848,7 @@ def test_torch_tensor_nccl_direct_return(ray_start_regular):
 
     with InputNode() as inp:
         dag = sender.send.bind(inp.shape, inp.dtype, inp.value, inp.send_tensor)
-        dag = dag.with_type_hint(TorchTensorType(transport="nccl", _direct_return=True))
+        dag = dag.with_tensor_transport(transport="nccl", _direct_return=True)
         dag = receiver.recv.bind(dag)
 
     compiled_dag = dag.experimental_compile()
@@ -838,7 +889,7 @@ def test_torch_tensor_nccl_nested_dynamic(ray_start_regular):
 
     with InputNode() as inp:
         dag = sender.send_dict.bind(inp)
-        dag = dag.with_type_hint(TorchTensorType(transport="nccl"))
+        dag = dag.with_tensor_transport(transport="nccl")
         dag = receiver.recv_dict.bind(dag)
 
     compiled_dag = dag.experimental_compile()
@@ -878,12 +929,10 @@ def test_torch_tensor_exceptions(
         dag = sender.send_or_raise.bind(
             inp.shape, inp.dtype, inp.value, inp.raise_exception
         )
-        dag = dag.with_type_hint(
-            TorchTensorType(
-                _static_shape=static_shape,
-                _direct_return=direct_return,
-                transport="nccl",
-            )
+        dag = dag.with_tensor_transport(
+            transport="nccl",
+            _static_shape=static_shape,
+            _direct_return=direct_return,
         )
         dag = receiver.recv.bind(dag)
 
@@ -962,12 +1011,10 @@ def test_torch_tensor_exceptions2(
 
     with InputNode() as inp:
         dag = sender.send_int.bind(inp)
-        dag = dag.with_type_hint(
-            TorchTensorType(
-                transport="nccl",
-                _direct_return=True,
-                _static_shape=True,
-            )
+        dag = dag.with_tensor_transport(
+            transport="nccl",
+            _direct_return=True,
+            _static_shape=True,
         )
         dag = receiver.recv.bind(dag)
 
@@ -1292,9 +1339,9 @@ def test_torch_tensor_nccl_all_reduce_scheduling(ray_start_regular):
         x = workers[0].send.bind(shape, dtype, inp)
         y = workers[1].send.bind(shape, dtype, inp)
 
-        # Tensor to be sent from workes[0] to workers[1].
+        # Tensor to be sent from workers[0] to workers[1].
         t = workers[0].send.bind(shape, dtype, inp)
-        t.with_type_hint(TorchTensorType(transport="nccl"))
+        t.with_tensor_transport(transport="nccl")
 
         collectives = collective.allreduce.bind([x, y])
         recv = workers[1].recv.bind(t)
@@ -1373,7 +1420,7 @@ def test_tensor_writable_warning_suppressed(ray_start_regular):
     with InputNode() as inp:
         # TODO(swang): Test that we are using the minimum number of
         # channels/messages when _direct_return=True.
-        torch_inp = inp.with_type_hint(TorchTensorType())
+        torch_inp = inp.with_tensor_transport()
         dag = receiver.recv.bind(torch_inp)
 
     compiled_dag = dag.experimental_compile()
@@ -1427,7 +1474,7 @@ class TestTorchTensorTypeHintCustomSerializer:
 
     @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
     @pytest.mark.parametrize("tensor_device", ["cpu", "cuda"])
-    def test_input_node_with_type_hint(self, ray_start_regular, tensor_device):
+    def test_input_node_with_tensor_transport(self, ray_start_regular, tensor_device):
         """
         Since `inp` has a TorchTensorType hint, both the driver and `worker` will
         use the custom serializer.
@@ -1448,7 +1495,7 @@ class TestTorchTensorTypeHintCustomSerializer:
         worker = Worker.options(num_gpus=1).remote()
 
         with InputNode() as inp:
-            dag = worker.echo.bind(inp.with_type_hint(TorchTensorType()))
+            dag = worker.echo.bind(inp.with_tensor_transport())
         compiled_dag = dag.experimental_compile()
         cpu_tensor = torch.tensor([1])
         input_tensor = cpu_tensor
@@ -1494,9 +1541,9 @@ class TestTorchTensorTypeHintCustomSerializer:
         worker1 = Worker.options(num_gpus=1).remote()
         worker2 = Worker.options(num_gpus=1).remote()
         with InputNode() as inp:
-            dag = inp[0].with_type_hint(TorchTensorType())
+            dag = inp[0].with_tensor_transport()
             branch1 = worker1.echo.bind(dag)
-            dag = inp[1].with_type_hint(TorchTensorType())
+            dag = inp[1].with_tensor_transport()
             branch2 = worker2.echo.bind(dag)
             dag = MultiOutputNode([branch1, branch2])
 
@@ -1556,7 +1603,7 @@ class TestTorchTensorTypeHintCustomSerializer:
         worker2 = Worker.options(num_gpus=1).remote()
 
         with InputNode() as inp:
-            dag = inp[0].with_type_hint(TorchTensorType())
+            dag = inp[0].with_tensor_transport()
             branch1 = worker1.echo.bind(dag)
             dag = inp[1]
             branch2 = worker2.echo.bind(dag)
@@ -1600,7 +1647,7 @@ def test_torch_nccl_channel_with_local_reader(ray_start_regular):
     # Test torch.Tensor sent between actors.
     with InputNode() as inp:
         dag = w1.send.bind(inp.shape, inp.dtype, inp[0])
-        dag = dag.with_type_hint(TorchTensorType(transport="nccl"))
+        dag = dag.with_tensor_transport(transport="nccl")
         branch1 = w1.recv.bind(dag)
         branch2 = w2.recv.bind(dag)
         dag = MultiOutputNode([branch1, branch2])
@@ -1635,7 +1682,7 @@ def test_torch_nccl_channel_with_two_local_readers(ray_start_regular):
     # Test torch.Tensor sent between actors.
     with InputNode() as inp:
         dag = w1.send.bind(inp.shape, inp.dtype, inp[0])
-        dag = dag.with_type_hint(TorchTensorType(transport="nccl"))
+        dag = dag.with_tensor_transport(transport="nccl")
         branch1 = w1.recv.bind(dag)
         branch2 = w1.recv.bind(dag)
         branch3 = w2.recv.bind(dag)
@@ -1666,7 +1713,7 @@ def test_torch_nccl_channel_with_all_local_readers(ray_start_regular):
 
     with InputNode() as inp:
         dag = worker.send.bind(inp.shape, inp.dtype, inp[0])
-        dag = dag.with_type_hint(TorchTensorType(transport="nccl"))
+        dag = dag.with_tensor_transport(transport="nccl")
         dag = MultiOutputNode([worker.recv.bind(dag)])
     with pytest.raises(
         AssertionError,

--- a/python/ray/experimental/channel/auto_transport_type.py
+++ b/python/ray/experimental/channel/auto_transport_type.py
@@ -101,6 +101,12 @@ class TypeHintResolver:
         writer = writer_and_node[0]
         readers = [reader for reader, _ in reader_and_node_list]
 
+        if any(reader is None for reader in readers):
+            # None means reader is the driver, currently driver on GPU
+            # is not supported, so we always use shared memory to transfer
+            # tensors.
+            return TorchTensorType()
+
         # Case 1: writer and readers don't both use GPU, use shared memory
         # to transport the tensors
         if not (self._use_gpu(writer) and self._use_gpu(readers)):

--- a/python/ray/experimental/channel/auto_transport_type.py
+++ b/python/ray/experimental/channel/auto_transport_type.py
@@ -54,7 +54,8 @@ class TypeHintResolver:
         Get the GPU IDs of the actor.
 
         Returns:
-            The GPU IDs of the actor. If the actor is not found, return an empty list.
+            The GPU IDs of the actor. If the actor is not found,
+            return an empty list.
         """
         gpu_ids = self._actor_to_gpu_ids.get(actor, [])
         assert len(gpu_ids) <= 1, (

--- a/python/ray/experimental/channel/auto_transport_type.py
+++ b/python/ray/experimental/channel/auto_transport_type.py
@@ -1,0 +1,142 @@
+from typing import Dict, List, Optional, Tuple, Union
+
+import ray
+from ray.experimental.channel import ChannelOutputType
+from ray.experimental.channel.torch_tensor_type import TorchTensorType
+
+
+class TypeHintResolver:
+    """
+    This class is used to resolve `AutoChannelType` into an actual channel type
+    (e.g., `TorchTensorType` with proper transport) based on node locations and
+    GPU IDs of the readers and writers.
+    """
+
+    def __init__(self, actor_to_gpu_ids: Dict["ray.actor.ActorHandle", List[str]]):
+        """
+        Args:
+            actor_to_gpu_ids: Mapping from actor handle to its GPU IDs.
+        """
+        self.actor_to_gpu_ids = actor_to_gpu_ids
+
+    def _use_same_gpu(
+        self,
+        writer_and_node: Tuple["ray.actor.ActorHandle", str],
+        reader_and_node: Union[
+            Tuple["ray.actor.ActorHandle", str],
+            List[Tuple["ray.actor.ActorHandle", str]],
+        ],
+    ) -> bool:
+        """
+        Check if the writer and readers use the same GPU.
+
+        Args:
+            writer_and_node: A tuple of writer actor handle and its node ID.
+            reader_and_node: A tuple of reader actor handle and its node ID, or
+                a list of such tuples.
+
+        Returns:
+            True if the writer and all the readers use the same GPU, False otherwise.
+        """
+        if isinstance(reader_and_node, list):
+            return all(
+                self._use_same_gpu(writer_and_node, entry) for entry in reader_and_node
+            )
+        if writer_and_node[1] != reader_and_node[1]:
+            return False
+        writer_gpu_ids = self._check_single_gpu(
+            self.actor_to_gpu_ids.get(writer_and_node[0], [])
+        )
+        reader_gpu_ids = self._check_single_gpu(
+            self.actor_to_gpu_ids.get(reader_and_node[0], [])
+        )
+        return writer_gpu_ids == reader_gpu_ids
+
+    def _use_gpu(
+        self, actors: Union["ray.actor.ActorHandle", List["ray.actor.ActorHandle"]]
+    ) -> bool:
+        """
+        Check if the actors use GPUs.
+
+        Args:
+            actors: An actor handle or a list of actor handles.
+
+        Returns:
+            True if the actors use GPUs, False otherwise.
+        """
+        if isinstance(actors, list):
+            return all(self._use_gpu(actor) for actor in actors)
+        gpu_ids = self.actor_to_gpu_ids.get(actors, [])
+        return len(self._check_single_gpu(gpu_ids)) > 0
+
+    def _check_single_gpu(self, gpu_ids: List[str]) -> List[str]:
+        """
+        Check and assert gpu_ids has only one GPU ID.
+
+        Returns:
+            The same list of GPU IDs as passed in.
+        """
+        assert len(gpu_ids) <= 1, (
+            "Compiled Graphs currently don't support allocating multiple GPUs "
+            "to a single actor"
+        )
+        return gpu_ids
+
+    def resolve(
+        self,
+        writer_and_node: Tuple["ray.actor.ActorHandle", str],
+        reader_and_node_list: List[Tuple["ray.actor.ActorHandle", str]],
+    ) -> "ChannelOutputType":
+        """
+        Resolve to the actual channel type based on the node locations and GPU IDs.
+
+        Args:
+            writer_and_node: A tuple of writer actor handle and its node ID.
+            reader_and_node_list: A list of tuples of reader actor handle and its
+                node ID.
+
+        Returns:
+            The actual channel type.
+        """
+        writer = writer_and_node[0]
+        readers = [reader for reader, _ in reader_and_node_list]
+
+        # Case 1: writer and readers don't both use GPU, use shared memory
+        # to transport the tensors
+        if not (self._use_gpu(writer) and self._use_gpu(readers)):
+            return TorchTensorType()
+
+        # Case 2: writer and readers use the same GPU are are on the same node,
+        # use shared memory to transport the tensors
+        if self._use_same_gpu(writer_and_node, reader_and_node_list):
+            return TorchTensorType()
+
+        # Case 3: writer and readers use different GPUs, use NCCL to transport
+        # the tensors
+        return TorchTensorType(transport="nccl")
+
+
+class AutoTransportType(ChannelOutputType):
+    """
+    Type hint for automatic transport selection for tensors.
+
+    With this type hint Compiled Graphs automatically decide the best transport
+    to use (e.g., NCCL or shared memory) based on the node locations and GPU IDs
+    of the readers and writers.
+    """
+
+    def create_channel(
+        self,
+        writer: Optional["ray.actor.ActorHandle"],
+        reader_and_node_list: List[Tuple["ray.actor.ActorHandle", str]],
+        driver_actor_id: Optional[str] = None,
+    ) -> "ChannelOutputType":
+        """
+        Directly calling create_channel() on AutoTransportType should not happen,
+        just raise an exception with informative message.
+        """
+        raise ValueError(
+            "This should not happen: AutoTransportType should "
+            "have been resolved before creating a channel. "
+            "Please file a Ray GitHub issue for bug report."
+        )

--- a/release/microbenchmark/experimental/accelerated_dag_gpu_microbenchmark.py
+++ b/release/microbenchmark/experimental/accelerated_dag_gpu_microbenchmark.py
@@ -16,7 +16,6 @@ import ray.cluster_utils
 from ray.dag import InputNode, DAGContext
 from ray.util.collective.collective_group import nccl_util
 
-from ray.experimental.channel.torch_tensor_type import TorchTensorType
 from ray._private.ray_microbenchmark_helpers import timeit
 
 
@@ -128,12 +127,10 @@ def exec_ray_dag(
         dag = sender.send.bind(SHAPE, DTYPE, inp)
 
         if use_cgraph:
-            dag = dag.with_type_hint(
-                TorchTensorType(
-                    _static_shape=static_shape,
-                    _direct_return=direct_return,
-                    transport="nccl" if use_nccl else "auto",
-                )
+            dag = dag.with_tensor_transport(
+                transport="nccl" if use_nccl else "auto",
+                _static_shape=static_shape,
+                _direct_return=direct_return,
             )
 
         dag = receiver.recv.bind(dag)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Currently to specify a torch tensor transport, we use `with_type_hint(TorchTensorType(transport="nccl"|"auto"|Communicator))` API, which is a bit verbose and non-intuitive.
This PR introduces a new `with_tensor_transport()` API to replace the old `with_type_hint()` API.

It also supports an "auto" option for the "transport" arg to automatically decide whether to use shared memory, intra-process channel or NCCL as the transport, based on the node location and GPU assignments of the reader and writer actors. 

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #47258

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
