### PR TITLE
[Refactor][Core] Replace redis function arguments with reference and remove redundant struct statement

### DIFF
--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -34,23 +34,22 @@ namespace ray {
 
 namespace gcs {
 
-CallbackReply::CallbackReply(redisReply *redis_reply) : reply_type_(redis_reply->type) {
-  RAY_CHECK(nullptr != redis_reply);
-
+CallbackReply::CallbackReply(const redisReply &redis_reply)
+    : reply_type_(redis_reply.type) {
   switch (reply_type_) {
   case REDIS_REPLY_NIL: {
     break;
   }
   case REDIS_REPLY_ERROR: {
-    RAY_LOG(FATAL) << "Got an error in redis reply: " << redis_reply->str;
+    RAY_LOG(FATAL) << "Got an error in redis reply: " << redis_reply.str;
     break;
   }
   case REDIS_REPLY_INTEGER: {
-    int_reply_ = static_cast<int64_t>(redis_reply->integer);
+    int_reply_ = static_cast<int64_t>(redis_reply.integer);
     break;
   }
   case REDIS_REPLY_STATUS: {
-    const std::string status_str(redis_reply->str, redis_reply->len);
+    const std::string status_str(redis_reply.str, redis_reply.len);
     if (status_str == "OK") {
       status_reply_ = Status::OK();
     } else {
@@ -59,11 +58,11 @@ CallbackReply::CallbackReply(redisReply *redis_reply) : reply_type_(redis_reply-
     break;
   }
   case REDIS_REPLY_STRING: {
-    string_reply_ = std::string(redis_reply->str, redis_reply->len);
+    string_reply_ = std::string(redis_reply.str, redis_reply.len);
     break;
   }
   case REDIS_REPLY_ARRAY: {
-    if (redis_reply->elements == 0) {
+    if (redis_reply.elements == 0) {
       break;
     }
     // Array replies are used for scan or get.
@@ -78,12 +77,12 @@ CallbackReply::CallbackReply(redisReply *redis_reply) : reply_type_(redis_reply-
 
 bool CallbackReply::IsError() const { return reply_type_ == REDIS_REPLY_ERROR; }
 
-void CallbackReply::ParseAsStringArrayOrScanArray(redisReply *redis_reply) {
-  RAY_CHECK(REDIS_REPLY_ARRAY == redis_reply->type);
-  const auto array_size = static_cast<size_t>(redis_reply->elements);
+void CallbackReply::ParseAsStringArrayOrScanArray(const redisReply &redis_reply) {
+  RAY_CHECK(REDIS_REPLY_ARRAY == redis_reply.type);
+  const auto array_size = static_cast<size_t>(redis_reply.elements);
   if (array_size == 2) {
-    auto *cursor_entry = redis_reply->element[0];
-    auto *array_entry = redis_reply->element[1];
+    auto *cursor_entry = redis_reply.element[0];
+    auto *array_entry = redis_reply.element[1];
     if (REDIS_REPLY_ARRAY == array_entry->type) {
       // Parse as a scan array
       RAY_CHECK(REDIS_REPLY_STRING == cursor_entry->type);
@@ -103,12 +102,12 @@ void CallbackReply::ParseAsStringArrayOrScanArray(redisReply *redis_reply) {
   ParseAsStringArray(redis_reply);
 }
 
-void CallbackReply::ParseAsStringArray(redisReply *redis_reply) {
-  RAY_CHECK(REDIS_REPLY_ARRAY == redis_reply->type);
-  const auto array_size = static_cast<size_t>(redis_reply->elements);
+void CallbackReply::ParseAsStringArray(const redisReply &redis_reply) {
+  RAY_CHECK(REDIS_REPLY_ARRAY == redis_reply.type);
+  const auto array_size = static_cast<size_t>(redis_reply.elements);
   string_array_reply_.reserve(array_size);
   for (size_t i = 0; i < array_size; ++i) {
-    auto *entry = redis_reply->element[i];
+    auto *entry = redis_reply.element[i];
     if (entry->type == REDIS_REPLY_STRING) {
       string_array_reply_.emplace_back(std::string(entry->str, entry->len));
     } else {
@@ -172,7 +171,7 @@ RedisRequestContext::RedisRequestContext(instrumented_io_context &io_service,
   }
 }
 
-void RedisRequestContext::RedisResponseFn(struct redisAsyncContext *async_context,
+void RedisRequestContext::RedisResponseFn(redisAsyncContext *async_context,
                                           void *raw_reply,
                                           void *privdata) {
   auto *request_cxt = static_cast<RedisRequestContext *>(privdata);
@@ -192,7 +191,7 @@ void RedisRequestContext::RedisResponseFn(struct redisAsyncContext *async_contex
         [request_cxt]() { request_cxt->Run(); },
         std::chrono::milliseconds(delay));
   } else {
-    auto reply = std::make_shared<CallbackReply>(redis_reply);
+    auto reply = std::make_shared<CallbackReply>(*redis_reply);
     request_cxt->io_service_.post(
         [reply, callback = std::move(request_cxt->callback_)]() {
           if (callback) {
@@ -665,7 +664,7 @@ std::unique_ptr<CallbackReply> RedisContext::RunArgvSync(
     RAY_LOG(ERROR) << "Failed to send redis command (sync): " << context_->errstr;
     return nullptr;
   }
-  std::unique_ptr<CallbackReply> callback_reply(new CallbackReply(redis_reply));
+  std::unique_ptr<CallbackReply> callback_reply(new CallbackReply(*redis_reply));
   freeReplyObject(redis_reply);
   return callback_reply;
 }

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -43,7 +43,7 @@ using rpc::TablePrefix;
 /// A simple reply wrapper for redis reply.
 class CallbackReply {
  public:
-  explicit CallbackReply(redisReply *redis_reply);
+  explicit CallbackReply(const redisReply &redis_reply);
 
   /// Whether this reply is `nil` type reply.
   bool IsNil() const;
@@ -74,10 +74,10 @@ class CallbackReply {
 
  private:
   /// Parse redis reply as string array or scan array.
-  void ParseAsStringArrayOrScanArray(redisReply *redis_reply);
+  void ParseAsStringArrayOrScanArray(const redisReply &redis_reply);
 
   /// Parse redis reply as string array.
-  void ParseAsStringArray(redisReply *redis_reply);
+  void ParseAsStringArray(const redisReply &redis_reply);
 
   /// Flag indicating the type of reply this represents.
   int reply_type_;
@@ -113,7 +113,7 @@ struct RedisRequestContext {
                       RedisAsyncContext *context,
                       std::vector<std::string> args);
 
-  static void RedisResponseFn(struct redisAsyncContext *async_context,
+  static void RedisResponseFn(redisAsyncContext *async_context,
                               void *raw_reply,
                               void *privdata);
 

--- a/src/ray/gcs/test/callback_reply_test.cc
+++ b/src/ray/gcs/test/callback_reply_test.cc
@@ -41,7 +41,7 @@ TEST(TestCallbackReply, TestParseAsStringArray) {
     redis_reply_array_elements[0] = &redis_reply_string1;
     redis_reply_array_elements[1] = &redis_reply_string2;
     redis_reply_array.element = redis_reply_array_elements;
-    CallbackReply callback_reply(&redis_reply_array);
+    CallbackReply callback_reply(redis_reply_array);
     ASSERT_EQ(
         callback_reply.ReadAsStringArray(),
         (std::vector<std::optional<std::string>>{std::optional<std::string>(string1),
@@ -68,7 +68,7 @@ TEST(TestCallbackReply, TestParseAsStringArray) {
     redis_reply_array_elements[1] = &redis_reply_string1;
     redis_reply_array_elements[2] = &redis_reply_nil2;
     redis_reply_array.element = redis_reply_array_elements;
-    CallbackReply callback_reply(&redis_reply_array);
+    CallbackReply callback_reply(redis_reply_array);
     ASSERT_EQ(
         callback_reply.ReadAsStringArray(),
         (std::vector<std::optional<std::string>>{std::optional<std::string>(),
@@ -95,7 +95,7 @@ TEST(TestCallbackReply, TestParseAsStringArray) {
     redis_reply_test_elements[0] = &redis_reply_cursor;
     redis_reply_test_elements[1] = &redis_reply_array;
     redis_reply_test.element = redis_reply_test_elements;
-    CallbackReply callback_reply(&redis_reply_test);
+    CallbackReply callback_reply(redis_reply_test);
     std::vector<std::string> scan_array;
     ASSERT_EQ(callback_reply.ReadAsScanArray(&scan_array), 18446744073709551614u);
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR includes the following refactoring:  
- Updated the function signatures of the `CallbackReply` constructor, `ParseAsStringArrayOrScanArray`, and `ParseAsStringArray` to accept const references instead of pointers as input.  
- Removed the redundant `struct` statement in `RedisResponseFn`.

## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
