### PR TITLE
[Refactor][Core] Migrate to RunArgvAsync for GetNextJobID

### DIFF
--- a/src/mock/ray/gcs/store_client/in_memory_store_client.h
+++ b/src/mock/ray/gcs/store_client/in_memory_store_client.h
@@ -74,7 +74,7 @@ class MockInMemoryStoreClient : public InMemoryStoreClient {
                Postable<void(bool)> callback),
               (override));
 
-  MOCK_METHOD(int, GetNextJobID, (), (override));
+  MOCK_METHOD(Status, AsyncGetNextJobID, (Postable<void(int)> callback), (override));
 };
 
 }  // namespace gcs

--- a/src/mock/ray/gcs/store_client/redis_store_client.h
+++ b/src/mock/ray/gcs/store_client/redis_store_client.h
@@ -54,7 +54,7 @@ class MockStoreClient : public StoreClient {
                const std::vector<std::string> &keys,
                Postable<void(int64_t)> callback),
               (override));
-  MOCK_METHOD(int, GetNextJobID, (), (override));
+  MOCK_METHOD(Status, AsyncGetNextJobID, (Postable<void(int)> callback), (override));
   MOCK_METHOD(Status,
               AsyncGetKeys,
               (const std::string &table_name,

--- a/src/mock/ray/gcs/store_client/store_client.h
+++ b/src/mock/ray/gcs/store_client/store_client.h
@@ -54,7 +54,7 @@ class MockStoreClient : public StoreClient {
                const std::vector<std::string> &keys,
                Postable<void(int64_t)> callback),
               (override));
-  MOCK_METHOD(int, GetNextJobID, (), (override));
+  MOCK_METHOD(Status, AsyncGetNextJobID, (Postable<void(int)> callback), (override));
   MOCK_METHOD(Status,
               AsyncGetKeys,
               (const std::string &table_name,

--- a/src/ray/gcs/gcs_server/gcs_job_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_job_manager.cc
@@ -449,7 +449,8 @@ void GcsJobManager::HandleReportJobError(rpc::ReportJobErrorRequest request,
 void GcsJobManager::HandleGetNextJobID(rpc::GetNextJobIDRequest request,
                                        rpc::GetNextJobIDReply *reply,
                                        rpc::SendReplyCallback send_reply_callback) {
-  auto callback = [reply, send_reply_callback](int job_id) {
+  auto callback = [reply,
+                   send_reply_callback = std::move(send_reply_callback)](int job_id) {
     reply->set_job_id(job_id);
     GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
   };

--- a/src/ray/gcs/gcs_server/gcs_job_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_job_manager.cc
@@ -449,8 +449,11 @@ void GcsJobManager::HandleReportJobError(rpc::ReportJobErrorRequest request,
 void GcsJobManager::HandleGetNextJobID(rpc::GetNextJobIDRequest request,
                                        rpc::GetNextJobIDReply *reply,
                                        rpc::SendReplyCallback send_reply_callback) {
-  reply->set_job_id(gcs_table_storage_.GetNextJobID());
-  GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
+  auto callback = [reply, send_reply_callback](int job_id) {
+    reply->set_job_id(job_id);
+    GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
+  };
+  RAY_CHECK_OK(gcs_table_storage_.AsyncGetNextJobID({std::move(callback), io_context_}));
 }
 
 std::shared_ptr<rpc::JobConfig> GcsJobManager::GetJobConfig(const JobID &job_id) const {

--- a/src/ray/gcs/gcs_server/gcs_table_storage.h
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.h
@@ -261,9 +261,9 @@ class GcsTableStorage {
     return *worker_table_;
   }
 
-  int GetNextJobID() {
+  Status AsyncGetNextJobID(Postable<void(int)> callback) {
     RAY_CHECK(store_client_);
-    return store_client_->GetNextJobID();
+    return store_client_->AsyncGetNextJobID(callback);
   }
 
  protected:

--- a/src/ray/gcs/gcs_server/gcs_table_storage.h
+++ b/src/ray/gcs/gcs_server/gcs_table_storage.h
@@ -263,7 +263,7 @@ class GcsTableStorage {
 
   Status AsyncGetNextJobID(Postable<void(int)> callback) {
     RAY_CHECK(store_client_);
-    return store_client_->AsyncGetNextJobID(callback);
+    return store_client_->AsyncGetNextJobID(std::move(callback));
   }
 
  protected:

--- a/src/ray/gcs/store_client/in_memory_store_client.cc
+++ b/src/ray/gcs/store_client/in_memory_store_client.cc
@@ -110,8 +110,10 @@ Status InMemoryStoreClient::AsyncBatchDelete(const std::string &table_name,
   return Status::OK();
 }
 
-int InMemoryStoreClient::GetNextJobID() {
-  return job_id_.fetch_add(1, std::memory_order_acq_rel);
+Status InMemoryStoreClient::AsyncGetNextJobID(Postable<void(int)> callback) {
+  auto job_id = job_id_.fetch_add(1, std::memory_order_acq_rel);
+  std::move(callback).Post("GcsInMemoryStore.GetNextJobID", job_id);
+  return Status::OK();
 }
 
 InMemoryStoreClient::InMemoryTable &InMemoryStoreClient::GetOrCreateMutableTable(

--- a/src/ray/gcs/store_client/in_memory_store_client.h
+++ b/src/ray/gcs/store_client/in_memory_store_client.h
@@ -62,7 +62,7 @@ class InMemoryStoreClient : public StoreClient {
                           const std::vector<std::string> &keys,
                           Postable<void(int64_t)> callback) override;
 
-  int GetNextJobID() override;
+  Status AsyncGetNextJobID(Postable<void(int)> callback) override;
 
   Status AsyncGetKeys(const std::string &table_name,
                       const std::string &prefix,

--- a/src/ray/gcs/store_client/observable_store_client.cc
+++ b/src/ray/gcs/store_client/observable_store_client.cc
@@ -103,7 +103,7 @@ Status ObservableStoreClient::AsyncBatchDelete(const std::string &table_name,
 }
 
 Status ObservableStoreClient::AsyncGetNextJobID(Postable<void(int)> callback) {
-  return delegate_->AsyncGetNextJobID(callback);
+  return delegate_->AsyncGetNextJobID(std::move(callback));
 }
 
 Status ObservableStoreClient::AsyncGetKeys(

--- a/src/ray/gcs/store_client/observable_store_client.cc
+++ b/src/ray/gcs/store_client/observable_store_client.cc
@@ -102,7 +102,9 @@ Status ObservableStoreClient::AsyncBatchDelete(const std::string &table_name,
       }));
 }
 
-int ObservableStoreClient::GetNextJobID() { return delegate_->GetNextJobID(); }
+Status ObservableStoreClient::AsyncGetNextJobID(Postable<void(int)> callback) {
+  return delegate_->AsyncGetNextJobID(callback);
+}
 
 Status ObservableStoreClient::AsyncGetKeys(
     const std::string &table_name,

--- a/src/ray/gcs/store_client/observable_store_client.h
+++ b/src/ray/gcs/store_client/observable_store_client.h
@@ -53,7 +53,7 @@ class ObservableStoreClient : public StoreClient {
                           const std::vector<std::string> &keys,
                           Postable<void(int64_t)> callback) override;
 
-  int GetNextJobID() override;
+  Status AsyncGetNextJobID(Postable<void(int)> callback) override;
 
   Status AsyncGetKeys(const std::string &table_name,
                       const std::string &prefix,

--- a/src/ray/gcs/store_client/redis_store_client.cc
+++ b/src/ray/gcs/store_client/redis_store_client.cc
@@ -452,7 +452,7 @@ Status RedisStoreClient::AsyncGetNextJobID(Postable<void(int)> callback) {
   cxt->RunArgvAsync(command.ToRedisArgs(),
                     [callback = std::move(callback)](
                         const std::shared_ptr<CallbackReply> &reply) mutable {
-                      auto job_id = reply->ReadAsInteger();
+                      auto job_id = static_cast<int>(reply->ReadAsInteger());
                       std::move(callback).Post("GcsStore.GetNextJobID", job_id);
                     });
 

--- a/src/ray/gcs/store_client/redis_store_client.h
+++ b/src/ray/gcs/store_client/redis_store_client.h
@@ -135,7 +135,7 @@ class RedisStoreClient : public StoreClient {
                           const std::vector<std::string> &keys,
                           Postable<void(int64_t)> callback) override;
 
-  int GetNextJobID() override;
+  Status AsyncGetNextJobID(Postable<void(int)> callback) override;
 
   Status AsyncGetKeys(const std::string &table_name,
                       const std::string &prefix,

--- a/src/ray/gcs/store_client/store_client.h
+++ b/src/ray/gcs/store_client/store_client.h
@@ -101,9 +101,10 @@ class StoreClient {
                                   const std::vector<std::string> &keys,
                                   Postable<void(int64_t)> callback) = 0;
 
-  /// Get next job id by `INCR` "JobCounter" key synchronously.
+  /// Get next job id by `INCR` "JobCounter" key asynchronously.
   ///
-  /// \return Next job id in integer representation.
+  /// \param callback returns the next job id in integer representation.
+  /// \return Status
   virtual Status AsyncGetNextJobID(Postable<void(int)> callback) = 0;
 
   /// Get all the keys match the prefix from the given table asynchronously.

--- a/src/ray/gcs/store_client/store_client.h
+++ b/src/ray/gcs/store_client/store_client.h
@@ -104,7 +104,7 @@ class StoreClient {
   /// Get next job id by `INCR` "JobCounter" key synchronously.
   ///
   /// \return Next job id in integer representation.
-  virtual int GetNextJobID() = 0;
+  virtual Status AsyncGetNextJobID(Postable<void(int)> callback) = 0;
 
   /// Get all the keys match the prefix from the given table asynchronously.
   ///


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR converts `GetNextJobID` to `AsyncNextJobID` and uses `RunArgvAsync` instead of `RunArgvSync`.

## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
