### PR TITLE
[KubeRay] support suspending worker groups in KubeRay autoscaler

### DIFF
--- a/python/ray/autoscaler/_private/kuberay/autoscaling_config.py
+++ b/python/ray/autoscaler/_private/kuberay/autoscaling_config.py
@@ -213,16 +213,18 @@ def _node_type_from_group_spec(
     if is_head:
         # The head node type has no workers because the head is not a worker.
         min_workers = max_workers = 0
+        suspend = False
     else:
         # `minReplicas` and `maxReplicas` are required fields for each workerGroupSpec
         min_workers = group_spec["minReplicas"]
         max_workers = group_spec["maxReplicas"]
+        suspend = group_spec.get("suspend", False)
 
     resources = _get_ray_resources_from_group_spec(group_spec, is_head)
 
     node_type = {
-        "min_workers": min_workers,
-        "max_workers": max_workers,
+        "min_workers": min_workers if not suspend else 0,
+        "max_workers": max_workers if not suspend else 0,
         # `node_config` is a legacy field required for compatibility.
         # Pod config data is required by the operator but not by the autoscaler.
         "node_config": {},

--- a/python/ray/tests/kuberay/test_autoscaling_config.py
+++ b/python/ray/tests/kuberay/test_autoscaling_config.py
@@ -140,6 +140,16 @@ def _get_basic_autoscaling_config() -> dict:
     }
 
 
+def _get_autoscaling_config_with_groups_suspended() -> dict:
+    """The expected autoscaling with all groups suspended."""
+    config = _get_basic_autoscaling_config()
+    for _, spec in config["available_node_types"].items():
+        spec["max_workers"] = 0
+        spec["min_workers"] = 0
+    config["max_workers"] = 0
+    return config
+
+
 def _get_ray_cr_no_cpu_error() -> dict:
     """Incorrectly formatted Ray CR without num-cpus rayStartParam and without resource
     limits. Autoscaler should raise an error when reading this.
@@ -236,6 +246,14 @@ def _get_ray_cr_with_only_requests() -> dict:
     return cr
 
 
+def _get_ray_cr_with_groups_suspended() -> dict:
+    """CR with all worker groups suspended"""
+    cr = get_basic_ray_cr()
+    for group in cr["spec"]["workerGroupSpecs"]:
+        group["suspend"] = True
+    return cr
+
+
 def _get_autoscaling_config_with_options() -> dict:
     config = _get_basic_autoscaling_config()
     config["upscaling_speed"] = 1
@@ -311,6 +329,14 @@ TEST_DATA = (
             None,
             None,
             id="autoscaler-options",
+        ),
+        pytest.param(
+            _get_ray_cr_with_groups_suspended(),
+            _get_autoscaling_config_with_groups_suspended(),
+            None,
+            None,
+            None,
+            id="groups-suspended",
         ),
         pytest.param(
             _get_ray_cr_with_tpu_custom_resource(),


### PR DESCRIPTION
Resolves https://github.com/ray-project/kuberay/issues/2666.

https://github.com/ray-project/kuberay/issues/2663 adds a new `suspend` field to the KubeRay worker group spec for suspending worker groups. A suspended worker group should be scaled to 0 and never be scaled up until the group is resumed.

Since the `available_node_types` definition does not provide similar functionality (suspending a node type), the best way to let the auto scaler know a worker group has been suspended is to set its max_workers and min_workers to 0.


1. This PR makes the KubeRay autoscaling config producer produce an autoscaling config with both `max_workers` and `min_workers` of a suspended worker group set to 0 to inform the autoscaler that the suspended group should not have nodes. The autoscaler will periodically take the config and do its work.
2. Autoscaler will then scale down the suspended group. However, this PR filters out the actual k8s patches to the suspended group because we want to keep the original `replicas` values on the RayCluster CR. The suspended group will be scaled down by KubeRay operator instead.


## Related issue number

https://github.com/ray-project/kuberay/issues/2666
https://github.com/ray-project/kuberay/issues/2663

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
