### PR TITLE
[core] Fix profile_events use after move

### DIFF
--- a/src/ray/core_worker/task_event_buffer.cc
+++ b/src/ray/core_worker/task_event_buffer.cc
@@ -529,6 +529,7 @@ void TaskEventBufferImpl::FlushEvents(bool forced) {
                     std::vector{profile_events_to_send});
   }
 
+  // Aggregate and prepare the data to send.
   std::unique_ptr<rpc::TaskEventData> data =
       CreateDataToSend(std::move(status_events_to_send),
                        std::move(profile_events_to_send),

--- a/src/ray/core_worker/task_event_buffer.cc
+++ b/src/ray/core_worker/task_event_buffer.cc
@@ -406,7 +406,7 @@ std::unique_ptr<rpc::TaskEventData> TaskEventBufferImpl::CreateDataToSend(
   // Aggregate the task events by TaskAttempt.
   absl::flat_hash_map<TaskAttempt, rpc::TaskEvents> agg_task_events;
   auto to_rpc_event_fn = [this, &agg_task_events, &dropped_task_attempts_to_send](
-                             std::shared_ptr<TaskEvent> &event) {
+                             const std::shared_ptr<TaskEvent> &event) {
     if (dropped_task_attempts_to_send.contains(event->GetTaskAttempt())) {
       // We are marking this as data loss due to some missing task status updates.
       // We will not send this event to GCS.
@@ -462,7 +462,7 @@ void TaskEventBufferImpl::WriteExportData(
   // in the same order as the buffer.
   std::vector<TaskAttempt> agg_task_event_insertion_order;
   auto to_rpc_event_fn = [&agg_task_events, &agg_task_event_insertion_order](
-                             std::shared_ptr<TaskEvent> &event) {
+                             const std::shared_ptr<TaskEvent> &event) {
     // Aggregate events by task attempt before converting to proto
     auto itr = agg_task_events.find(event->GetTaskAttempt());
     if (itr == agg_task_events.end()) {

--- a/src/ray/core_worker/task_event_buffer.cc
+++ b/src/ray/core_worker/task_event_buffer.cc
@@ -524,16 +524,15 @@ void TaskEventBufferImpl::FlushEvents(bool forced) {
   profile_events_to_send.reserve(RayConfig::instance().task_events_send_batch_size());
   GetTaskProfileEventsToSend(&profile_events_to_send);
 
-  // Aggregate and prepare the data to send.
+  if (export_event_write_enabled_) {
+    WriteExportData(std::move(status_events_to_write_for_export),
+                    std::vector{profile_events_to_send});
+  }
+
   std::unique_ptr<rpc::TaskEventData> data =
       CreateDataToSend(std::move(status_events_to_send),
                        std::move(profile_events_to_send),
                        std::move(dropped_task_attempts_to_send));
-  if (export_event_write_enabled_) {
-    // TODO (dayshah): use after move of profile_events_to_send
-    WriteExportData(std::move(status_events_to_write_for_export),
-                    std::move(profile_events_to_send));
-  }
 
   gcs::TaskInfoAccessor *task_accessor = nullptr;
   {

--- a/src/ray/core_worker/task_event_buffer.h
+++ b/src/ray/core_worker/task_event_buffer.h
@@ -363,9 +363,9 @@ class TaskEventBufferImpl : public TaskEventBuffer {
   ///        status events being dropped.
   /// \return A unique_ptr to rpc::TaskEvents to be sent to GCS.
   std::unique_ptr<rpc::TaskEventData> CreateDataToSend(
-      std::vector<std::shared_ptr<TaskEvent>> &&status_events_to_send,
-      std::vector<std::shared_ptr<TaskEvent>> &&profile_events_to_send,
-      absl::flat_hash_set<TaskAttempt> &&dropped_task_attempts_to_send);
+      const std::vector<std::shared_ptr<TaskEvent>> &status_events_to_send,
+      const std::vector<std::shared_ptr<TaskEvent>> &profile_events_to_send,
+      const absl::flat_hash_set<TaskAttempt> &dropped_task_attempts_to_send);
 
   /// Write task events for the Export API.
   ///
@@ -375,8 +375,8 @@ class TaskEventBufferImpl : public TaskEventBuffer {
   ///              fit in the buffer.
   /// \param profile_events_to_send Task profile events to be written.
   void WriteExportData(
-      std::vector<std::shared_ptr<TaskEvent>> &&status_events_to_write_for_export,
-      std::vector<std::shared_ptr<TaskEvent>> &&profile_events_to_send);
+      const std::vector<std::shared_ptr<TaskEvent>> &status_events_to_write_for_export,
+      const std::vector<std::shared_ptr<TaskEvent>> &profile_events_to_send);
 
   /// Reset the counters during flushing data to GCS.
   void ResetCountersForFlush();


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Fix use after move
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
