### PR TITLE
[Fix] Fix ruff rule B020: Loop control variable `conns` overrides iterable it iterates

### DIFF
--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -206,9 +206,9 @@ def find_user_process_by_port_and_status(
         process = psutil.Process(pid)
         try:
             conns = process.connections()
-            for conns in conns:
-                if conns.laddr.port == port:
-                    if statuses_to_check is None or conns.status in statuses_to_check:
+            for conn in conns:
+                if conn.laddr.port == port:
+                    if statuses_to_check is None or conn.status in statuses_to_check:
                         processes.append(process)
         except (psutil.AccessDenied, psutil.ZombieProcess, psutil.NoSuchProcess):
             continue


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Fix new ruff linter error introduced by https://github.com/ray-project/ray/pull/49559

## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
