### PR TITLE
[Core] Remove dead StateDataSourceClient.get_task_info method

### DIFF
--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -1805,8 +1805,7 @@ async def test_state_data_source_client_limit_distributed_sources(ray_start_clus
         # 4 refs (driver)
         # 4 pinned in memory for each task
         # 40 for 4 tasks * 10 objects each
-        # 1 from the previous test (refs) is for some reasons not GC'ed. (driver)
-        assert result.total == 53
+        assert result.total == 52
         # Only 1 core worker stat is returned because data is truncated.
         assert len(result.core_workers_stats) == 1
 
@@ -1816,7 +1815,7 @@ async def test_state_data_source_client_limit_distributed_sources(ray_start_clus
             assert (
                 WorkerType.DESCRIPTOR.values_by_number[c.worker_type].name == "DRIVER"
             )
-            assert c.objects_total == 9
+            assert c.objects_total == 8
             assert len(c.object_refs) == 2
         return True
 

--- a/python/ray/util/state/state_manager.py
+++ b/python/ray/util/state/state_manager.py
@@ -33,8 +33,6 @@ from ray.core.generated.gcs_service_pb2 import (
 from ray.core.generated.node_manager_pb2 import (
     GetObjectsInfoReply,
     GetObjectsInfoRequest,
-    GetTasksInfoReply,
-    GetTasksInfoRequest,
 )
 from ray.core.generated.node_manager_pb2_grpc import NodeManagerServiceStub
 from ray.core.generated.reporter_pb2 import (
@@ -445,22 +443,6 @@ class StateDataSourceClient:
         ]
 
         return list(driver_jobs.values()) + submission_jobs
-
-    @handle_grpc_network_errors
-    async def get_task_info(
-        self,
-        node_id: str,
-        timeout: int = None,
-        limit: int = RAY_MAX_LIMIT_FROM_DATA_SOURCE,
-    ) -> Optional[GetTasksInfoReply]:
-        stub = self._raylet_stubs.get(node_id)
-        if not stub:
-            raise ValueError(f"Raylet for a node id, {node_id} doesn't exist.")
-
-        reply = await stub.GetTasksInfo(
-            GetTasksInfoRequest(limit=limit), timeout=timeout
-        )
-        return reply
 
     @handle_grpc_network_errors
     async def get_object_info(

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -288,26 +288,6 @@ message GetSystemConfigReply {
   string system_config = 1;
 }
 
-message GetTasksInfoRequest {
-  // Maximum number of entries to return.
-  // If not specified, return the whole entries without truncation.
-  optional int64 limit = 1;
-}
-
-message GetTasksInfoReply {
-  repeated TaskInfoEntry owned_task_info_entries = 1;
-  // A list of task that's currently running.
-  // All tasks must be treated as TaskStatus::RUNNING
-  // from the caller side.
-  repeated bytes running_task_ids = 2;
-  // Length of the corresponding resource without truncation.
-  int64 total = 3;
-  // NOTE: we don't truncate running_task_ids because it is usually small.
-  // However, there are edge cases it can be very large (e.g., when the
-  // async actor tasks are used, it can have up to 1000 running tasks per
-  // actor). We should handle this better.
-}
-
 message GetObjectsInfoRequest {
   // Maximum number of entries to return.
   // If not specified, return the whole entries without truncation.
@@ -456,8 +436,6 @@ service NodeManagerService {
       returns (ReleaseUnusedBundlesReply);
   // Get the system config.
   rpc GetSystemConfig(GetSystemConfigRequest) returns (GetSystemConfigReply);
-  // [State API] Get the all task information of the node.
-  rpc GetTasksInfo(GetTasksInfoRequest) returns (GetTasksInfoReply);
   // [State API] Get the all object information of the node.
   rpc GetObjectsInfo(GetObjectsInfoRequest) returns (GetObjectsInfoReply);
   // Gets the task execution result. May contain a result if

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -740,42 +740,6 @@ void NodeManager::HandleReleaseUnusedBundles(rpc::ReleaseUnusedBundlesRequest re
   send_reply_callback(Status::OK(), nullptr, nullptr);
 }
 
-void NodeManager::HandleGetTasksInfo(rpc::GetTasksInfoRequest request,
-                                     rpc::GetTasksInfoReply *reply,
-                                     rpc::SendReplyCallback send_reply_callback) {
-  RAY_LOG(DEBUG) << "Received a HandleGetTasksInfo request";
-  auto total = std::make_shared<int>(0);
-  auto count = std::make_shared<int>(0);
-  auto limit = request.has_limit() ? request.limit() : -1;
-  // Each worker query will have limit as well.
-  // At the end there will be limit * num_workers entries returned at max.
-  QueryAllWorkerStates(
-      /*on_replied*/
-      [reply, total, limit, count](const ray::Status &status,
-                                   const rpc::GetCoreWorkerStatsReply &r) {
-        *total += r.tasks_total();
-        if (status.ok()) {
-          for (const auto &task_info : r.owned_task_info_entries()) {
-            if (limit != -1 && *count >= limit) {
-              break;
-            }
-            *count += 1;
-            reply->add_owned_task_info_entries()->CopyFrom(task_info);
-          }
-          for (const auto &running_task_id : r.running_task_ids()) {
-            reply->add_running_task_ids(running_task_id);
-          }
-        } else {
-          RAY_LOG(INFO) << "Failed to query task information from a worker.";
-        }
-      },
-      send_reply_callback,
-      /*include_memory_info*/ false,
-      /*include_task_info*/ true,
-      /*limit*/ limit,
-      /*on_all_replied*/ [total, reply]() { reply->set_total(*total); });
-}
-
 void NodeManager::HandleGetObjectsInfo(rpc::GetObjectsInfoRequest request,
                                        rpc::GetObjectsInfoReply *reply,
                                        rpc::SendReplyCallback send_reply_callback) {

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -624,11 +624,6 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
                              rpc::GetSystemConfigReply *reply,
                              rpc::SendReplyCallback send_reply_callback) override;
 
-  /// Handle a `GetTasksInfo` request.
-  void HandleGetTasksInfo(rpc::GetTasksInfoRequest request,
-                          rpc::GetTasksInfoReply *reply,
-                          rpc::SendReplyCallback send_reply_callback) override;
-
   /// Handle a `GetTaskFailureCause` request.
   void HandleGetTaskFailureCause(rpc::GetTaskFailureCauseRequest request,
                                  rpc::GetTaskFailureCauseReply *reply,

--- a/src/ray/rpc/node_manager/node_manager_client.h
+++ b/src/ray/rpc/node_manager/node_manager_client.h
@@ -187,12 +187,6 @@ class NodeManagerWorkerClient
                          grpc_client_,
                          /*method_timeout_ms*/ -1, )
 
-  /// Get all the task information from the node.
-  VOID_RPC_CLIENT_METHOD(NodeManagerService,
-                         GetTasksInfo,
-                         grpc_client_,
-                         /*method_timeout_ms*/ -1, )
-
   /// Get all the object information from the node.
   VOID_RPC_CLIENT_METHOD(NodeManagerService,
                          GetObjectsInfo,

--- a/src/ray/rpc/node_manager/node_manager_server.h
+++ b/src/ray/rpc/node_manager/node_manager_server.h
@@ -49,7 +49,6 @@ namespace rpc {
   RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(IsLocalWorkerDead)         \
   RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(ShutdownRaylet)            \
   RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(DrainRaylet)               \
-  RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(GetTasksInfo)              \
   RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(GetObjectsInfo)            \
   RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(GetTaskFailureCause)       \
   RAY_NODE_MANAGER_RPC_SERVICE_HANDLER(RegisterMutableObject)     \
@@ -151,10 +150,6 @@ class NodeManagerServiceHandler {
   virtual void HandleGetSystemConfig(GetSystemConfigRequest request,
                                      GetSystemConfigReply *reply,
                                      SendReplyCallback send_reply_callback) = 0;
-
-  virtual void HandleGetTasksInfo(GetTasksInfoRequest request,
-                                  GetTasksInfoReply *reply,
-                                  SendReplyCallback send_reply_callback) = 0;
 
   virtual void HandleGetObjectsInfo(GetObjectsInfoRequest request,
                                     GetObjectsInfoReply *reply,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Dead code
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
