### PR TITLE
[Refactor][Core] Make RedisCallback take unique_ptr as argument

### DIFF
--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -191,11 +191,10 @@ void RedisRequestContext::RedisResponseFn(redisAsyncContext *async_context,
         [request_cxt]() { request_cxt->Run(); },
         std::chrono::milliseconds(delay));
   } else {
-    auto reply = std::make_shared<CallbackReply>(*redis_reply);
     request_cxt->io_service_.post(
-        [reply, callback = std::move(request_cxt->callback_)]() {
+        [redis_reply, callback = std::move(request_cxt->callback_)]() {
           if (callback) {
-            callback(std::move(reply));
+            callback(std::make_unique<CallbackReply>(*redis_reply));
           }
         },
         "RedisRequestContext.Callback");

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -104,7 +104,7 @@ class CallbackReply {
 
 /// Every callback should take in a vector of the results from the Redis
 /// operation.
-using RedisCallback = std::function<void(std::shared_ptr<CallbackReply>)>;
+using RedisCallback = std::function<void(std::unique_ptr<CallbackReply>)>;
 
 class RedisContext;
 struct RedisRequestContext {

--- a/src/ray/gcs/store_client/redis_store_client.cc
+++ b/src/ray/gcs/store_client/redis_store_client.cc
@@ -299,7 +299,7 @@ void RedisStoreClient::SendRedisCmdWithKeys(std::vector<std::string> keys,
                           request();
                         }
                         if (redis_callback) {
-                          redis_callback(reply);
+                          redis_callback(std::move(reply));
                         }
                       });
   };


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR makes `RedisCallback` to accept `unique_ptr` instead of `shared_ptr` as input argument.

## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
