### PR TITLE
[serve] Refactor replica wrapper

### DIFF
--- a/python/ray/serve/_private/default_impl.py
+++ b/python/ray/serve/_private/default_impl.py
@@ -26,10 +26,8 @@ from ray.serve._private.deployment_scheduler import (
 )
 from ray.serve._private.grpc_util import gRPCServer
 from ray.serve._private.handle_options import DynamicHandleOptions, InitHandleOptions
-from ray.serve._private.replica_scheduler import (
-    ActorReplicaWrapper,
-    PowerOfTwoChoicesReplicaScheduler,
-)
+from ray.serve._private.replica_scheduler import PowerOfTwoChoicesReplicaScheduler
+from ray.serve._private.replica_scheduler.replica_wrapper import RunningReplica
 from ray.serve._private.router import Router, SingletonThreadRouter
 from ray.serve._private.utils import (
     generate_request_id,
@@ -168,7 +166,7 @@ def create_router(
         use_replica_queue_len_cache=(
             not is_inside_ray_client_context and RAY_SERVE_ENABLE_QUEUE_LENGTH_CACHE
         ),
-        create_replica_wrapper_func=lambda r: ActorReplicaWrapper(r),
+        create_replica_wrapper_func=lambda r: RunningReplica(r),
     )
 
     return SingletonThreadRouter(

--- a/python/ray/serve/_private/handle_options.py
+++ b/python/ray/serve/_private/handle_options.py
@@ -53,7 +53,14 @@ class DynamicHandleOptionsBase(ABC):
     multiplexed_model_id: str = ""
     stream: bool = False
 
+    @abstractmethod
     def copy_and_update(self, **kwargs) -> "DynamicHandleOptionsBase":
+        pass
+
+
+@dataclass(frozen=True)
+class DynamicHandleOptions(DynamicHandleOptionsBase):
+    def copy_and_update(self, **kwargs) -> "DynamicHandleOptions":
         new_kwargs = {}
 
         for f in fields(self):
@@ -63,8 +70,3 @@ class DynamicHandleOptionsBase(ABC):
                 new_kwargs[f.name] = kwargs[f.name]
 
         return DynamicHandleOptions(**new_kwargs)
-
-
-@dataclass(frozen=True)
-class DynamicHandleOptions(DynamicHandleOptionsBase):
-    pass

--- a/python/ray/serve/_private/replica_result.py
+++ b/python/ray/serve/_private/replica_result.py
@@ -6,6 +6,7 @@ from functools import wraps
 from typing import Callable, Coroutine, Optional, Union
 
 import ray
+from ray.serve._private.common import RequestMetadata
 from ray.serve._private.utils import calculate_remaining_timeout
 from ray.serve.exceptions import RequestCancelledError
 
@@ -54,13 +55,12 @@ class ActorReplicaResult(ReplicaResult):
     def __init__(
         self,
         obj_ref_or_gen: Union[ray.ObjectRef, ray.ObjectRefGenerator],
-        is_streaming: bool,
-        request_id: str,
+        metadata: RequestMetadata,
     ):
         self._obj_ref: Optional[ray.ObjectRef] = None
         self._obj_ref_gen: Optional[ray.ObjectRefGenerator] = None
-        self._is_streaming: bool = is_streaming
-        self._request_id: str = request_id
+        self._is_streaming: bool = metadata.is_streaming
+        self._request_id: str = metadata.request_id
         self._object_ref_or_gen_sync_lock = threading.Lock()
 
         if isinstance(obj_ref_or_gen, ray.ObjectRefGenerator):

--- a/python/ray/serve/_private/replica_scheduler/__init__.py
+++ b/python/ray/serve/_private/replica_scheduler/__init__.py
@@ -6,6 +6,5 @@ from ray.serve._private.replica_scheduler.replica_scheduler import (  # noqa: F4
     ReplicaScheduler,
 )
 from ray.serve._private.replica_scheduler.replica_wrapper import (  # noqa: F401
-    ActorReplicaWrapper,
     RunningReplica,
 )

--- a/python/ray/serve/_private/replica_scheduler/__init__.py
+++ b/python/ray/serve/_private/replica_scheduler/__init__.py
@@ -7,5 +7,5 @@ from ray.serve._private.replica_scheduler.replica_scheduler import (  # noqa: F4
 )
 from ray.serve._private.replica_scheduler.replica_wrapper import (  # noqa: F401
     ActorReplicaWrapper,
-    ReplicaWrapper,
+    RunningReplica,
 )

--- a/python/ray/serve/_private/replica_scheduler/replica_scheduler.py
+++ b/python/ray/serve/_private/replica_scheduler/replica_scheduler.py
@@ -6,7 +6,7 @@ from ray.serve._private.replica_scheduler.common import (
     PendingRequest,
     ReplicaQueueLengthCache,
 )
-from ray.serve._private.replica_scheduler.replica_wrapper import ReplicaWrapper
+from ray.serve._private.replica_scheduler.replica_wrapper import RunningReplica
 
 
 class ReplicaScheduler(ABC):
@@ -15,17 +15,17 @@ class ReplicaScheduler(ABC):
     @abstractmethod
     async def choose_replica_for_request(
         self, pending_request: PendingRequest, *, is_retry: bool = False
-    ) -> ReplicaWrapper:
+    ) -> RunningReplica:
         pass
 
     @abstractmethod
     def create_replica_wrapper(
         self, replica_info: RunningReplicaInfo
-    ) -> ReplicaWrapper:
+    ) -> RunningReplica:
         pass
 
     @abstractmethod
-    def update_replicas(self, replicas: List[ReplicaWrapper]):
+    def update_replicas(self, replicas: List[RunningReplica]):
         pass
 
     def update_running_replicas(self, running_replicas: List[RunningReplicaInfo]):
@@ -49,5 +49,5 @@ class ReplicaScheduler(ABC):
 
     @property
     @abstractmethod
-    def curr_replicas(self) -> Dict[ReplicaID, ReplicaWrapper]:
+    def curr_replicas(self) -> Dict[ReplicaID, RunningReplica]:
         pass

--- a/python/ray/serve/_private/replica_scheduler/replica_wrapper.py
+++ b/python/ray/serve/_private/replica_scheduler/replica_wrapper.py
@@ -18,14 +18,98 @@ from ray.serve.generated.serve_pb2 import RequestMetadata as RequestMetadataProt
 
 
 class ReplicaWrapper(ABC):
-    """Defines the interface for a scheduler to talk to a replica.
+    """This is used to abstract away details of the transport layer
+    when communicating with the replica.
+    """
 
-    This is used to abstract away details of Ray actor calls for testing.
+    @abstractmethod
+    def send_request_java(self, pr: PendingRequest):
+        pass
+
+    @abstractmethod
+    def send_request_python(self, pr: PendingRequest, *, with_rejection: bool):
+        pass
+
+
+class ActorReplicaWrapper(ReplicaWrapper):
+    def __init__(self, actor_handle):
+        self._actor_handle = actor_handle
+
+    def send_request_java(self, pr: PendingRequest) -> ActorReplicaResult:
+        """Send the request to a Java replica.
+        Does not currently support streaming.
+        """
+        if pr.metadata.is_streaming:
+            raise RuntimeError("Streaming not supported for Java.")
+
+        if len(pr.args) != 1:
+            raise ValueError("Java handle calls only support a single argument.")
+
+        return ActorReplicaResult(
+            self._actor_handle.handle_request.remote(
+                RequestMetadataProto(
+                    request_id=pr.metadata.request_id,
+                    # Default call method in java is "call," not "__call__" like Python.
+                    call_method="call"
+                    if pr.metadata.call_method == "__call__"
+                    else pr.metadata.call_method,
+                ).SerializeToString(),
+                pr.args,
+            ),
+            pr.metadata,
+        )
+
+    def _send_request_python(
+        self, pr: PendingRequest, *, with_rejection: bool
+    ) -> Union[ObjectRef, ObjectRefGenerator]:
+        """Send the request to a Python replica."""
+        if with_rejection:
+            # Call a separate handler that may reject the request.
+            # This handler is *always* a streaming call and the first message will
+            # be a system message that accepts or rejects.
+            method = self._actor_handle.handle_request_with_rejection.options(
+                num_returns="streaming"
+            )
+        elif pr.metadata.is_streaming:
+            method = self._actor_handle.handle_request_streaming.options(
+                num_returns="streaming"
+            )
+        else:
+            method = self._actor_handle.handle_request
+
+        return method.remote(pickle.dumps(pr.metadata), *pr.args, **pr.kwargs)
+
+    async def send_request_python(
+        self, pr: PendingRequest, with_rejection: bool
+    ) -> Tuple[ActorReplicaResult, Optional[ReplicaQueueLengthInfo]]:
+        obj_ref_gen = self._send_request_python(pr, with_rejection=with_rejection)
+
+        if not with_rejection:
+            return ActorReplicaResult(obj_ref_gen, pr.metadata), None
+
+        try:
+            first_ref = await obj_ref_gen.__anext__()
+            queue_len_info: ReplicaQueueLengthInfo = pickle.loads(await first_ref)
+            return ActorReplicaResult(obj_ref_gen, pr.metadata), queue_len_info
+        except asyncio.CancelledError as e:
+            # HTTP client disconnected or request was explicitly canceled.
+            ray.cancel(obj_ref_gen)
+            raise e from None
+
+
+class RunningReplica:
+    """Contains info on a running replica.
+    Also defines the interface for a scheduler to talk to a replica.
     """
 
     def __init__(self, replica_info: RunningReplicaInfo):
         self._replica_info = replica_info
         self._multiplexed_model_ids = set(replica_info.multiplexed_model_ids)
+        self._loop = asyncio.get_running_loop()
+
+        # Lazily created
+        self._channel = None
+        self._stub = None
 
         if replica_info.is_cross_language:
             self._actor_handle = JavaActorHandleProxy(replica_info.actor_handle)
@@ -36,6 +120,11 @@ class ReplicaWrapper(ABC):
     def replica_id(self) -> ReplicaID:
         """ID of this replica."""
         return self._replica_info.replica_id
+
+    @property
+    def actor_id(self) -> ray.ActorID:
+        """Actor ID of this replica."""
+        return self._actor_handle._actor_id
 
     @property
     def node_id(self) -> str:
@@ -59,26 +148,29 @@ class ReplicaWrapper(ABC):
     def is_cross_language(self) -> bool:
         return self._replica_info.is_cross_language
 
+    def _get_replica_wrapper(self, pr: PendingRequest) -> ReplicaWrapper:
+        return ActorReplicaWrapper(self._actor_handle)
+
     def push_proxy_handle(self, handle: ActorHandle):
         """When on proxy, push proxy's self handle to replica"""
         self._actor_handle.push_proxy_handle.remote(handle)
 
-    @abstractmethod
     async def get_queue_len(self, *, deadline_s: float) -> int:
         """Returns current queue len for the replica.
-
         `deadline_s` is passed to verify backoff for testing.
         """
-        raise NotImplementedError
+        # NOTE(edoakes): the `get_num_ongoing_requests` method name is shared by
+        # the Python and Java replica implementations. If you change it, you need to
+        # change both (or introduce a branch here).
+        obj_ref = self._actor_handle.get_num_ongoing_requests.remote()
+        try:
+            return await obj_ref
+        except asyncio.CancelledError:
+            ray.cancel(obj_ref)
+            raise
 
-    @abstractmethod
-    def send_request(self, pr: PendingRequest) -> ReplicaResult:
-        """Send request to this replica."""
-        raise NotImplementedError
-
-    @abstractmethod
-    async def send_request_with_rejection(
-        self, pr: PendingRequest
+    async def send_request(
+        self, pr: PendingRequest, with_rejection: bool
     ) -> Tuple[Optional[ReplicaResult], ReplicaQueueLengthInfo]:
         """Send request to this replica.
 
@@ -90,101 +182,14 @@ class ReplicaWrapper(ABC):
 
         Only supported for Python replicas.
         """
-        raise NotImplementedError
 
-
-class ActorReplicaWrapper(ReplicaWrapper):
-    async def get_queue_len(self, *, deadline_s: float) -> int:
-        # NOTE(edoakes): the `get_num_ongoing_requests` method name is shared by
-        # the Python and Java replica implementations. If you change it, you need to
-        # change both (or introduce a branch here).
-        obj_ref = self._actor_handle.get_num_ongoing_requests.remote()
-        try:
-            return await obj_ref
-        except asyncio.CancelledError:
-            ray.cancel(obj_ref)
-            raise
-
-    def _send_request_java(self, pr: PendingRequest) -> ObjectRef:
-        """Send the request to a Java replica.
-
-        Does not currently support streaming.
-        """
-        if pr.metadata.is_streaming:
-            raise RuntimeError("Streaming not supported for Java.")
-
-        if len(pr.args) != 1:
-            raise ValueError("Java handle calls only support a single argument.")
-
-        return self._actor_handle.handle_request.remote(
-            RequestMetadataProto(
-                request_id=pr.metadata.request_id,
-                # Default call method in java is "call," not "__call__" like Python.
-                call_method="call"
-                if pr.metadata.call_method == "__call__"
-                else pr.metadata.call_method,
-            ).SerializeToString(),
-            pr.args,
-        )
-
-    def _send_request_python(
-        self, pr: PendingRequest, *, with_rejection: bool
-    ) -> Union[ray.ObjectRef, ObjectRefGenerator]:
-        """Send the request to a Python replica."""
-        if with_rejection:
-            # Call a separate handler that may reject the request.
-            # This handler is *always* a streaming call and the first message will
-            # be a system message that accepts or rejects.
-            method = self._actor_handle.handle_request_with_rejection.options(
-                num_returns="streaming"
-            )
-        elif pr.metadata.is_streaming:
-            method = self._actor_handle.handle_request_streaming.options(
-                num_returns="streaming"
-            )
-        else:
-            method = self._actor_handle.handle_request
-
-        return method.remote(pickle.dumps(pr.metadata), *pr.args, **pr.kwargs)
-
-    def send_request(self, pr: PendingRequest) -> ReplicaResult:
+        wrapper = self._get_replica_wrapper(pr)
         if self._replica_info.is_cross_language:
-            return ActorReplicaResult(
-                self._send_request_java(pr),
-                is_streaming=pr.metadata.is_streaming,
-                request_id=pr.metadata.request_id,
-            )
-        else:
-            return ActorReplicaResult(
-                self._send_request_python(pr, with_rejection=False),
-                is_streaming=pr.metadata.is_streaming,
-                request_id=pr.metadata.request_id,
-            )
+            assert not with_rejection, "Request rejection not supported for Java."
+            return wrapper.send_request_java(pr), None
 
-    async def send_request_with_rejection(
-        self, pr: PendingRequest
-    ) -> Tuple[Optional[ReplicaResult], ReplicaQueueLengthInfo]:
-        assert (
-            not self._replica_info.is_cross_language
-        ), "Request rejection not supported for Java."
+        result, queue_len_info = await wrapper.send_request_python(pr, with_rejection)
+        if queue_len_info and not queue_len_info.accepted:
+            return None, queue_len_info
 
-        obj_ref_gen = self._send_request_python(pr, with_rejection=True)
-        try:
-            first_ref = await obj_ref_gen.__anext__()
-            queue_len_info: ReplicaQueueLengthInfo = pickle.loads(await first_ref)
-
-            if not queue_len_info.accepted:
-                return None, queue_len_info
-            else:
-                return (
-                    ActorReplicaResult(
-                        obj_ref_gen,
-                        is_streaming=pr.metadata.is_streaming,
-                        request_id=pr.metadata.request_id,
-                    ),
-                    queue_len_info,
-                )
-        except asyncio.CancelledError as e:
-            # HTTP client disconnected or request was explicitly canceled.
-            ray.cancel(obj_ref_gen)
-            raise e from None
+        return result, queue_len_info

--- a/python/ray/serve/_private/replica_scheduler/replica_wrapper.py
+++ b/python/ray/serve/_private/replica_scheduler/replica_wrapper.py
@@ -105,11 +105,6 @@ class RunningReplica:
     def __init__(self, replica_info: RunningReplicaInfo):
         self._replica_info = replica_info
         self._multiplexed_model_ids = set(replica_info.multiplexed_model_ids)
-        self._loop = asyncio.get_running_loop()
-
-        # Lazily created
-        self._channel = None
-        self._stub = None
 
         if replica_info.is_cross_language:
             self._actor_handle = JavaActorHandleProxy(replica_info.actor_handle)

--- a/python/ray/serve/_private/utils.py
+++ b/python/ray/serve/_private/utils.py
@@ -23,7 +23,7 @@ from ray._private.utils import import_attr
 from ray._private.worker import LOCAL_MODE, SCRIPT_MODE
 from ray._raylet import MessagePackSerializer
 from ray.actor import ActorHandle
-from ray.serve._private.common import ServeComponentType
+from ray.serve._private.common import RequestMetadata, ServeComponentType
 from ray.serve._private.constants import HTTP_PROXY_TIMEOUT, SERVE_LOGGER_NAME
 from ray.types import ObjectRef
 from ray.util.serialization import StandaloneSerializationContext
@@ -598,7 +598,7 @@ def validate_route_prefix(route_prefix: Union[DEFAULT, None, str]):
         )
 
 
-async def resolve_deployment_response(obj: Any):
+async def resolve_deployment_response(obj: Any, request_metadata: RequestMetadata):
     """Resolve `DeploymentResponse` objects to underlying object references.
 
     This enables composition without explicitly calling `_to_object_ref`.

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -186,21 +186,24 @@ class _DeploymentHandleBase:
 
     def _remote(
         self,
-        request_metadata: RequestMetadata,
         args: Tuple[Any],
         kwargs: Dict[str, Any],
-    ) -> concurrent.futures.Future:
-        self.request_counter.inc(
-            tags={
-                "route": request_metadata.route,
-                "application": request_metadata.app_name,
-            }
-        )
-
+    ) -> Tuple[concurrent.futures.Future, RequestMetadata]:
         if not self.is_initialized:
             self._init()
 
-        return self._router.assign_request(request_metadata, *args, **kwargs)
+        metadata = serve._private.default_impl.get_request_metadata(
+            self.init_options, self.handle_options
+        )
+
+        self.request_counter.inc(
+            tags={
+                "route": metadata.route,
+                "application": metadata.app_name,
+            }
+        )
+
+        return self._router.assign_request(metadata, *args, **kwargs), metadata
 
     def __getattr__(self, name):
         return self.options(method_name=name)
@@ -725,11 +728,8 @@ class DeploymentHandle(_DeploymentHandleBase):
             **kwargs: Keyword arguments to be serialized and passed to the
                 remote method call.
         """
-        request_metadata = serve._private.default_impl.get_request_metadata(
-            self.init_options, self.handle_options
-        )
 
-        future = self._remote(request_metadata, args, kwargs)
+        future, request_metadata = self._remote(args, kwargs)
         if self.handle_options.stream:
             response_cls = DeploymentResponseGenerator
         else:

--- a/python/ray/serve/tests/test_actor_replica_wrapper.py
+++ b/python/ray/serve/tests/test_actor_replica_wrapper.py
@@ -1,7 +1,7 @@
 import asyncio
 import pickle
 import sys
-from typing import Tuple, Union
+from typing import Union
 
 import pytest
 
@@ -9,7 +9,6 @@ import ray
 from ray import ObjectRef, ObjectRefGenerator
 from ray._private.test_utils import SignalActor
 from ray._private.utils import get_or_create_event_loop
-from ray.actor import ActorHandle
 from ray.serve._private.common import (
     DeploymentID,
     ReplicaID,
@@ -18,7 +17,7 @@ from ray.serve._private.common import (
     RunningReplicaInfo,
 )
 from ray.serve._private.replica_scheduler.common import PendingRequest
-from ray.serve._private.replica_scheduler.replica_wrapper import ActorReplicaWrapper
+from ray.serve._private.replica_scheduler.replica_wrapper import RunningReplica
 from ray.serve._private.test_utils import send_signal_on_cancellation
 
 
@@ -84,30 +83,23 @@ class FakeReplicaActor:
 
 
 @pytest.fixture
-def setup_fake_replica(ray_instance) -> Tuple[ActorReplicaWrapper, ActorHandle]:
+def setup_fake_replica(ray_instance) -> RunningReplica:
     actor_handle = FakeReplicaActor.remote()
-    return (
-        ActorReplicaWrapper(
-            RunningReplicaInfo(
-                ReplicaID(
-                    "fake_replica", deployment_id=DeploymentID(name="fake_deployment")
-                ),
-                node_id=None,
-                node_ip=None,
-                availability_zone=None,
-                actor_handle=actor_handle,
-                max_ongoing_requests=10,
-                is_cross_language=False,
-            )
-        ),
-        actor_handle,
+    return RunningReplicaInfo(
+        ReplicaID("fake_replica", deployment_id=DeploymentID(name="fake_deployment")),
+        node_id=None,
+        node_ip=None,
+        availability_zone=None,
+        actor_handle=actor_handle,
+        max_ongoing_requests=10,
+        is_cross_language=False,
     )
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("is_streaming", [False, True])
-async def test_send_request(setup_fake_replica, is_streaming: bool):
-    replica, _ = setup_fake_replica
+async def test_send_request_without_rejection(setup_fake_replica, is_streaming: bool):
+    replica = RunningReplica(setup_fake_replica)
 
     pr = PendingRequest(
         args=["Hello"],
@@ -118,7 +110,7 @@ async def test_send_request(setup_fake_replica, is_streaming: bool):
             is_streaming=is_streaming,
         ),
     )
-    replica_result = replica.send_request(pr)
+    replica_result, _ = await replica.send_request(pr, with_rejection=False)
     if is_streaming:
         assert isinstance(replica_result.to_object_ref_gen(), ObjectRefGenerator)
         for i in range(5):
@@ -135,7 +127,8 @@ async def test_send_request(setup_fake_replica, is_streaming: bool):
 async def test_send_request_with_rejection(
     setup_fake_replica, accepted: bool, is_streaming: bool
 ):
-    replica, actor_handle = setup_fake_replica
+    actor_handle = setup_fake_replica.actor_handle
+    replica = RunningReplica(setup_fake_replica)
     ray.get(
         actor_handle.set_replica_queue_length_info.remote(
             ReplicaQueueLengthInfo(accepted=accepted, num_ongoing_requests=10),
@@ -151,7 +144,7 @@ async def test_send_request_with_rejection(
             is_streaming=is_streaming,
         ),
     )
-    replica_result, info = await replica.send_request_with_rejection(pr)
+    replica_result, info = await replica.send_request(pr, with_rejection=True)
     assert info.accepted == accepted
     assert info.num_ongoing_requests == 10
     if not accepted:
@@ -172,7 +165,7 @@ async def test_send_request_with_rejection_cancellation(setup_fake_replica):
     Verify that the downstream actor method call is cancelled if the call to send the
     request to the replica is cancelled.
     """
-    replica, actor_handle = setup_fake_replica
+    replica = RunningReplica(setup_fake_replica)
 
     executing_signal_actor = SignalActor.remote()
     cancelled_signal_actor = SignalActor.remote()
@@ -192,7 +185,7 @@ async def test_send_request_with_rejection_cancellation(setup_fake_replica):
     # Send request should hang because the downstream actor method call blocks
     # before sending the system message.
     send_request_task = get_or_create_event_loop().create_task(
-        replica.send_request_with_rejection(pr)
+        replica.send_request(pr, with_rejection=True)
     )
 
     # Check that the downstream actor method call has started.

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -25,7 +25,7 @@ from ray.serve._private.replica_result import ReplicaResult
 from ray.serve._private.replica_scheduler import (
     PendingRequest,
     ReplicaScheduler,
-    ReplicaWrapper,
+    RunningReplica,
 )
 from ray.serve._private.replica_scheduler.pow_2_scheduler import ReplicaQueueLengthCache
 from ray.serve._private.router import (
@@ -72,7 +72,7 @@ class FakeReplicaResult(ReplicaResult):
         raise NotImplementedError
 
 
-class FakeReplica(ReplicaWrapper):
+class FakeReplica(RunningReplica):
     def __init__(
         self,
         replica_id: ReplicaID,
@@ -97,27 +97,35 @@ class FakeReplica(ReplicaWrapper):
     def get_queue_len(self, *, deadline_s: float) -> int:
         raise NotImplementedError
 
-    def send_request(self, pr: PendingRequest) -> FakeReplicaResult:
-        if pr.metadata.is_streaming:
-            return FakeReplicaResult(self._replica_id, is_generator_object=True)
+    async def send_request(
+        self, pr: PendingRequest, with_rejection: bool
+    ) -> Tuple[Optional[FakeReplicaResult], Optional[ReplicaQueueLengthInfo]]:
+        if with_rejection:
+            if self._error:
+                raise self._error
+
+            assert (
+                not self.is_cross_language
+            ), "Rejection not supported for cross language."
+            assert (
+                self._queue_len_info is not None
+            ), "Must set queue_len_info to use `send_request_with_rejection`."
+
+            return (
+                FakeReplicaResult(self._replica_id, is_generator_object=True),
+                self._queue_len_info,
+            )
         else:
-            return FakeReplicaResult(self._replica_id, is_generator_object=False)
-
-    async def send_request_with_rejection(
-        self, pr: PendingRequest
-    ) -> Tuple[Optional[FakeReplicaResult], ReplicaQueueLengthInfo]:
-        if self._error:
-            raise self._error
-
-        assert not self.is_cross_language, "Rejection not supported for cross language."
-        assert (
-            self._queue_len_info is not None
-        ), "Must set queue_len_info to use `send_request_with_rejection`."
-
-        return (
-            FakeReplicaResult(self._replica_id, is_generator_object=True),
-            self._queue_len_info,
-        )
+            if pr.metadata.is_streaming:
+                return (
+                    FakeReplicaResult(self._replica_id, is_generator_object=True),
+                    None,
+                )
+            else:
+                return (
+                    FakeReplicaResult(self._replica_id, is_generator_object=False),
+                    None,
+                )
 
 
 class FakeReplicaScheduler(ReplicaScheduler):
@@ -142,7 +150,7 @@ class FakeReplicaScheduler(ReplicaScheduler):
         return self._dropped_replicas
 
     @property
-    def curr_replicas(self) -> Dict[ReplicaID, ReplicaWrapper]:
+    def curr_replicas(self) -> Dict[ReplicaID, RunningReplica]:
         replicas = {}
         if self._replica_to_return is not None:
             replicas[self._replica_to_return.replica_id] = self._replica_to_return
@@ -153,7 +161,7 @@ class FakeReplicaScheduler(ReplicaScheduler):
 
         return replicas
 
-    def update_replicas(self, replicas: List[ReplicaWrapper]):
+    def update_replicas(self, replicas: List[RunningReplica]):
         pass
 
     def on_replica_actor_died(self, replica_id: ReplicaID):


### PR DESCRIPTION
## Why are these changes needed?

Refactor replica wrapper in replica scheduler such that:
- The class that replica scheduler interacts with is `RunningReplica`.
- `RunningReplica` holds references to wrapper classes (e.g. `ActorReplicaWrapper`) that handle sending the actual request over the wire to the replicas.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
