### PR TITLE
[Refactor] Fix ruff rule E714: Test for object identity should be `is not`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ ignore = [
     "C419",
     # Below are auto-fixable rules
     "I001",
-    "E714",
     "B009",
     "B010",
     "F401",

--- a/python/ray/tests/test_component_failures_2.py
+++ b/python/ray/tests/test_component_failures_2.py
@@ -63,7 +63,7 @@ def _test_component_failed(cluster, component_type):
         time.sleep(1)
         process.kill()
         process.wait()
-        assert not process.poll() is None
+        assert process.poll() is not None
 
         # Make sure that we can still get the objects after the
         # executing tasks died.
@@ -95,7 +95,7 @@ def check_components_alive(cluster, component_type, check_component_alive):
                 + str(process.pid)
                 + "to terminate"
             )
-            assert not process.poll() is None
+            assert process.poll() is not None
 
 
 @pytest.mark.parametrize(

--- a/python/ray/tests/test_multinode_failures.py
+++ b/python/ray/tests/test_multinode_failures.py
@@ -122,7 +122,7 @@ def _test_component_failed(cluster, component_type):
         time.sleep(1)
         process.kill()
         process.wait()
-        assert not process.poll() is None
+        assert process.poll() is not None
 
         # Make sure that we can still get the objects after the
         # executing tasks died.
@@ -154,7 +154,7 @@ def check_components_alive(cluster, component_type, check_component_alive):
                 + str(process.pid)
                 + "to terminate"
             )
-            assert not process.poll() is None
+            assert process.poll() is not None
 
 
 @pytest.mark.parametrize(

--- a/python/ray/tests/test_multinode_failures_2.py
+++ b/python/ray/tests/test_multinode_failures_2.py
@@ -63,7 +63,7 @@ def test_object_reconstruction(ray_start_cluster):
         time.sleep(1)
         process.kill()
         process.wait()
-        assert not process.poll() is None
+        assert process.poll() is not None
 
         # Make sure that we can still get the objects after the
         # executing tasks died.

--- a/release/ray_release/config.py
+++ b/release/ray_release/config.py
@@ -203,7 +203,7 @@ def validate_aws_config(aws_config: Dict[str, Any]) -> Optional[str]:
         if not ebs:
             continue
 
-        if not ebs.get("DeleteOnTermination", False) is True:
+        if ebs.get("DeleteOnTermination", False) is not True:
             return "Ebs volume does not have `DeleteOnTermination: true` set"
     return None
 

--- a/rllib/utils/deprecation.py
+++ b/rllib/utils/deprecation.py
@@ -40,7 +40,7 @@ def deprecation_warning(
     )
 
     if error:
-        if not type(error) is bool and issubclass(error, Exception):
+        if type(error) is not bool and issubclass(error, Exception):
             # error is an Exception
             raise error(msg)
         else:

--- a/rllib/utils/deprecation.py
+++ b/rllib/utils/deprecation.py
@@ -40,7 +40,7 @@ def deprecation_warning(
     )
 
     if error:
-        if type(error) is not bool and issubclass(error, Exception):
+        if not isinstance(error, bool) and issubclass(error, Exception):
             # error is an Exception
             raise error(msg)
         else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
As title.

Note: Auto-fixed by `ruff` using `pre-commit run ruff --all-files`.

## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
