### PR TITLE
[Refactor] Fix ruff rule B009: Do not call `getattr` with a constant attribute value. It is not any safer than normal property access.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ ignore = [
     # Below are auto-fixable rules
     "I001",
     "E714",
-    "B009",
     "F401",
     "Q000",
     "Q001",

--- a/python/ray/dashboard/modules/snapshot/tests/test_component_activities.py
+++ b/python/ray/dashboard/modules/snapshot/tests/test_component_activities.py
@@ -25,7 +25,7 @@ def set_ray_cluster_activity_hook(request):
     Fixture that sets RAY_CLUSTER_ACTIVITY_HOOK environment variable
     for test_e2e_component_activities_hook.
     """
-    external_hook = getattr(request, "param")
+    external_hook = request.param
     assert (
         external_hook
     ), "Please pass value of RAY_CLUSTER_ACTIVITY_HOOK env var to this fixture"

--- a/python/ray/dashboard/optional_utils.py
+++ b/python/ray/dashboard/optional_utils.py
@@ -62,8 +62,8 @@ def method_route_table_factory():
             bound_items = []
             for r in cls._routes._items:
                 if isinstance(r, RouteDef):
-                    route_method = getattr(r.handler, "__route_method__")
-                    route_path = getattr(r.handler, "__route_path__")
+                    route_method = r.handler.__route_method__
+                    route_path = r.handler.__route_path__
                     instance = cls._bind_map[route_method][route_path].instance
                     if instance is not None:
                         bound_items.append(r)

--- a/python/ray/tests/modin/modin_test_utils.py
+++ b/python/ray/tests/modin/modin_test_utils.py
@@ -37,8 +37,8 @@ def df_categories_equals(df1, df2):
     if not hasattr(df1, "select_dtypes"):
         if isinstance(df1, pandas.CategoricalDtype):
             return categories_equals(df1, df2)
-        elif isinstance(getattr(df1, "dtype"), pandas.CategoricalDtype) and isinstance(
-            getattr(df1, "dtype"), pandas.CategoricalDtype
+        elif isinstance(df1.dtype, pandas.CategoricalDtype) and isinstance(
+            df1.dtype, pandas.CategoricalDtype
         ):
             return categories_equals(df1.dtype, df2.dtype)
         else:

--- a/python/ray/tune/utils/util.py
+++ b/python/ray/tune/utils/util.py
@@ -81,7 +81,7 @@ class UtilMonitor(Thread):
                     float(psutil.cpu_percent(interval=None))
                 )
                 self.values["ram_util_percent"].append(
-                    float(getattr(psutil.virtual_memory(), "percent"))
+                    float(psutil.virtual_memory().percent)
                 )
             if self.GPUtil is not None:
                 gpu_list = []

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -631,11 +631,11 @@ class AlgorithmConfig(_Config):
         # Worst naming convention ever: NEVER EVER use reserved key-words...
         if "lambda_" in config:
             assert hasattr(self, "lambda_")
-            config["lambda"] = getattr(self, "lambda_")
+            config["lambda"] = self.lambda_
             config.pop("lambda_")
         if "input_" in config:
             assert hasattr(self, "input_")
-            config["input"] = getattr(self, "input_")
+            config["input"] = self.input_
             config.pop("input_")
 
         # Convert `policies` (PolicySpecs?) into dict.

--- a/rllib/tests/run_regression_tests.py
+++ b/rllib/tests/run_regression_tests.py
@@ -135,7 +135,7 @@ def _load_experiments_from_file(
                 "Your Python file must contain a 'config' variable "
                 "that is an AlgorithmConfig object."
             )
-        algo_config = getattr(module, "config")
+        algo_config = module.config
         if stop is None:
             stop = getattr(module, "stop", {})
         else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
As title.

Note: Auto-fixed by `ruff` using `pre-commit run ruff --all-files`.

## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
