### PR TITLE
[Serve] makes resource request log in one line

### DIFF
--- a/python/ray/dashboard/client/src/common/CodeDialogButton/CodeDialogButton.tsx
+++ b/python/ray/dashboard/client/src/common/CodeDialogButton/CodeDialogButton.tsx
@@ -61,6 +61,7 @@ export const CodeDialogButton = ({
                 padding: 2,
                 overflow: "scroll",
                 maxHeight: 600,
+                textWrap: "wrap",
               }}
             >
               {typeof code === "string" ? code : yaml.dump(code, { indent: 2 })}

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -2164,10 +2164,8 @@ class DeploymentState:
                     f"have taken more than {SLOW_STARTUP_WARNING_S}s to be scheduled. "
                     "This may be due to waiting for the cluster to auto-scale or for a "
                     "runtime environment to be installed. "
-                    "Resources required for each replica: "
-                    f"{required} "
-                    "Total resources available: "
-                    f"{available} "
+                    f"Resources required for each replica: {required}, "
+                    f"total resources available: {available}. "
                     "Use `ray status` for more details."
                 )
                 logger.warning(message)

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -2161,13 +2161,13 @@ class DeploymentState:
                 message = (
                     f"Deployment '{self.deployment_name}' in application "
                     f"'{self.app_name}' has {len(pending_allocation)} replicas that "
-                    f"have taken more than {SLOW_STARTUP_WARNING_S}s to be scheduled.\n"
+                    f"have taken more than {SLOW_STARTUP_WARNING_S}s to be scheduled. "
                     "This may be due to waiting for the cluster to auto-scale or for a "
-                    "runtime environment to be installed.\n"
-                    "Resources required for each replica:\n"
-                    f"{required}\n"
-                    "Total resources available:\n"
-                    f"{available}\n"
+                    "runtime environment to be installed. "
+                    "Resources required for each replica: "
+                    f"{required} "
+                    "Total resources available: "
+                    f"{available} "
                     "Use `ray status` for more details."
                 )
                 logger.warning(message)

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -3286,7 +3286,7 @@ class TestAutoscaling:
                 "a runtime environment to be installed. "
                 "Resources required for each replica: "
                 '{"CPU": 0.1}, '
-                "Total resources available: "
+                "total resources available: "
                 "{}. "
                 "Use `ray status` for more details."
             )

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -3285,9 +3285,9 @@ class TestAutoscaling:
                 "This may be due to waiting for the cluster to auto-scale or for "
                 "a runtime environment to be installed. "
                 "Resources required for each replica: "
-                '{"CPU": 0.1} '
+                '{"CPU": 0.1}, '
                 "Total resources available: "
-                "{} "
+                "{}. "
                 "Use `ray status` for more details."
             )
         else:

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -3281,13 +3281,13 @@ class TestAutoscaling:
         elif target_startup_status == ReplicaStartupStatus.PENDING_ALLOCATION:
             expected_message = (
                 "Deployment 'test_deployment' in application 'test_app' "
-                "has 3 replicas that have taken more than 30s to be scheduled.\n"
+                "has 3 replicas that have taken more than 30s to be scheduled. "
                 "This may be due to waiting for the cluster to auto-scale or for "
-                "a runtime environment to be installed.\n"
-                "Resources required for each replica:\n"
-                '{"CPU": 0.1}\n'
-                "Total resources available:\n"
-                "{}\n"
+                "a runtime environment to be installed. "
+                "Resources required for each replica: "
+                '{"CPU": 0.1} '
+                "Total resources available: "
+                "{} "
                 "Use `ray status` for more details."
             )
         else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

There are complains around this log being hard to read in the console being multi-lined. Updated the log to log in one single line. 

## Related issue number

Closes https://anyscale1.atlassian.net/browse/SERVE-268?atlOrigin=eyJpIjoiOWU2YjFhMmQwYWVhNGIyNzkwMzU4YjBhZjdhYWEyYWMiLCJwIjoiaiJ9

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
