### PR TITLE
[Refactor] Fix ruff rule F602: Multi-value-repeated-key-variable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ ignore = [
     # The following are rules ignored in ruff
     "E721",
     "E741",
-    "F602",
     "F841",
     "B018",
     "B023",

--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -2226,7 +2226,6 @@ class AutoscalingTest(unittest.TestCase):
                 TAG_RAY_USER_NODE_TYPE: "p2.8xlarge",
                 TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
                 TAG_RAY_NODE_KIND: NODE_KIND_WORKER,
-                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
             },
             2,
         )
@@ -2236,7 +2235,6 @@ class AutoscalingTest(unittest.TestCase):
                 TAG_RAY_USER_NODE_TYPE: "m4.16xlarge",
                 TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
                 TAG_RAY_NODE_KIND: NODE_KIND_WORKER,
-                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
             },
             2,
         )
@@ -2277,7 +2275,6 @@ class AutoscalingTest(unittest.TestCase):
                 TAG_RAY_NODE_KIND: "head",
                 TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
                 TAG_RAY_USER_NODE_TYPE: "p2.xlarge",
-                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
             },
             1,
         )
@@ -2323,7 +2320,6 @@ class AutoscalingTest(unittest.TestCase):
                 TAG_RAY_USER_NODE_TYPE: "p2.8xlarge",
                 TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
                 TAG_RAY_NODE_KIND: "head",
-                TAG_RAY_NODE_STATUS: STATUS_UP_TO_DATE,
             },
             1,
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Dictionary keys should be unique. If a key is repeated with a different value, the first values will be overwritten and the key will correspond to the last value. This is likely a mistake.

Ref: https://docs.astral.sh/ruff/rules/multi-value-repeated-key-variable/

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/47991

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
