### PR TITLE
[core] [easy] [no-op] Apply thread annotation to pipe streamer

### DIFF
--- a/src/ray/util/pipe_logger.cc
+++ b/src/ray/util/pipe_logger.cc
@@ -48,12 +48,10 @@ size_t GetPipeLogReadSizeOrDefault() {
   return kDefaultPipeLogReadBufSize;
 }
 
-// TODO(hjiang): Make thread annotation for std::mutex.
 struct StreamDumper {
-  std::mutex mu;
-  bool stopped = false;
-  std::condition_variable cv;
-  std::deque<std::string> content;
+  absl::Mutex mu;
+  bool stopped ABSL_GUARDED_BY(mu) = false;
+  std::deque<std::string> content ABSL_GUARDED_BY(mu);
 };
 
 // Read bytes from handle into [data], return number of bytes read.
@@ -119,9 +117,8 @@ std::shared_ptr<StreamDumper> CreateStreamDumper(ReadFunc read_func,
         // Reached the end of stream.
         if (cur_new_line == kEofIndicator) {
           {
-            std::lock_guard lck(stream_dumper->mu);
+            absl::MutexLock lock(&stream_dumper->mu);
             stream_dumper->stopped = true;
-            stream_dumper->cv.notify_one();
           }
 
           // Place IO operation out of critical section.
@@ -134,9 +131,8 @@ std::shared_ptr<StreamDumper> CreateStreamDumper(ReadFunc read_func,
 
         // We only log non-empty lines.
         if (!cur_new_line.empty()) {
-          std::lock_guard lck(stream_dumper->mu);
+          absl::MutexLock lock(&stream_dumper->mu);
           stream_dumper->content.emplace_back(std::move(cur_new_line));
-          stream_dumper->cv.notify_one();
         }
       }
 
@@ -158,10 +154,13 @@ std::shared_ptr<StreamDumper> CreateStreamDumper(ReadFunc read_func,
     while (true) {
       std::string curline;
       {
-        std::unique_lock lck(stream_dumper->mu);
-        stream_dumper->cv.wait(lck, [stream_dumper]() {
-          return !stream_dumper->content.empty() || stream_dumper->stopped;
-        });
+        auto has_new_content_or_stopped =
+            [stream_dumper]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(stream_dumper->mu) {
+              return !stream_dumper->content.empty() || stream_dumper->stopped;
+            };
+
+        absl::MutexLock lock(&stream_dumper->mu);
+        stream_dumper->mu.Await(absl::Condition(&has_new_content_or_stopped));
 
         // Keep logging until all content flushed.
         if (!stream_dumper->content.empty()) {


### PR DESCRIPTION
This PR addresses a TODO item, to add thread annotation to stream dumper.