### PR TITLE
[serve] Mark deployment handle API as stable

### DIFF
--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -498,7 +498,7 @@ class DeploymentResponse(_DeploymentResponseBase):
         return replica_result.to_object_ref(timeout_s=remaining_timeout_s)
 
 
-@PublicAPI(stability="beta")
+@PublicAPI(stability="stable")
 class DeploymentResponseGenerator(_DeploymentResponseBase):
     """A future-like object wrapping the result of a streaming deployment handle call.
 

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -328,7 +328,7 @@ class _DeploymentResponseBase:
         return self._cancelled
 
 
-@PublicAPI(stability="beta")
+@PublicAPI(stability="stable")
 class DeploymentResponse(_DeploymentResponseBase):
     """A future-like object wrapping the result of a unary deployment handle call.
 
@@ -621,7 +621,7 @@ class DeploymentResponseGenerator(_DeploymentResponseBase):
         return replica_result.to_object_ref_gen()
 
 
-@PublicAPI(stability="beta")
+@PublicAPI(stability="stable")
 class DeploymentHandle(_DeploymentHandleBase):
     """A handle used to make requests to a deployment at runtime.
 


### PR DESCRIPTION
## Why are these changes needed?

Mark `DeploymentHandle` and `DeploymentResponse` APIs as stable since they have been out for many releases and the API is unlikely to change.
