### PR TITLE
[Tune] Update `BayesOptSearch` docs

### DIFF
--- a/python/ray/tune/search/bayesopt/bayesopt_search.py
+++ b/python/ray/tune/search/bayesopt/bayesopt_search.py
@@ -39,27 +39,27 @@ def _dict_hash(config, precision):
 
 
 class BayesOptSearch(Searcher):
-    """Uses fmfn/BayesianOptimization to optimize hyperparameters.
+    """Uses bayesian-optimization/BayesianOptimization to optimize hyperparameters.
 
-    fmfn/BayesianOptimization is a library for Bayesian Optimization. More
-    info can be found here: https://github.com/fmfn/BayesianOptimization.
+    bayesian-optimization/BayesianOptimization is a library for Bayesian Optimization. More
+    info can be found here: https://github.com/bayesian-optimization/BayesianOptimization.
 
     This searcher will automatically filter out any NaN, inf or -inf
     results.
 
-    You will need to install fmfn/BayesianOptimization via the following:
+    You will need to install bayesian-optimization/BayesianOptimization via the following:
 
     .. code-block:: bash
 
-        pip install bayesian-optimization
+        pip install bayesian-optimization==1.4.3
 
     Initializing this search algorithm with a ``space`` requires that it's
     in the ``BayesianOptimization`` search space format. Otherwise, you
     should instead pass in a Tune search space into ``Tuner(param_space=...)``,
     and the search space will be automatically converted for you.
 
-    See this `BayesianOptimization example notebook
-    <https://github.com/fmfn/BayesianOptimization/blob/master/examples/advanced-tour.ipynb>`_
+    See this ``BayesianOptimization`` example notebook
+    <https://github.com/bayesian-optimization/BayesianOptimization/blob/33b99ec0a4fc51239e1a2fca3eaa37ad6debac5d/examples/advanced-tour.ipynb>`_
     for an example.
 
     Args:
@@ -154,7 +154,7 @@ class BayesOptSearch(Searcher):
     ):
         assert byo is not None, (
             "BayesOpt must be installed!. You can install BayesOpt with"
-            " the command: `pip install bayesian-optimization`."
+            " the command: `pip install bayesian-optimization==1.4.3`."
         )
         if mode:
             assert mode in ["min", "max"], "`mode` must be 'min' or 'max'."


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The current documentation of the `BayesOptSearch` is incomplete/wrong.
- It doesn't specify the version of the package which should be installed (`1.4.3` as far as I can tell: link)
- There is a link to an example notebook, but it is not version pinned, instead pointing to `master`.
- References to the repo are still going to @fmfn's personal repository and not the the organization repository.

<!-- Please give a short summary of the change and the problem this solves. -->
I've updated the docstrings. The PR is untested, as I assume the docstring change should not affect tests passing.
NB: I am a member of [bayesian-optimization](https://github.com/bayesian-optimization).

## Related issue number

see also #49845

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
