### PR TITLE
[RLlib] APPO accelerate vol 02: Bug fix for > 1 Learner actor.

### DIFF
--- a/rllib/algorithms/impala/impala.py
+++ b/rllib/algorithms/impala/impala.py
@@ -855,7 +855,7 @@ class IMPALA(Algorithm):
     def _pre_queue_batch_refs(
         self, batch_refs: List[Tuple[int, ObjectRef]]
     ) -> List[List[ObjectRef]]:
-        # `batch_refs` is a list of tuple(actor_id, ObjRef[MABatch]).
+        # `batch_refs` is a list of tuple(aggregator_actor_id, ObjRef[MABatch]).
 
         # Each ObjRef[MABatch] was returned by one AggregatorActor from a single
         # `get_batch()` call and the underlying MABatch is already located on a

--- a/rllib/algorithms/impala/impala.py
+++ b/rllib/algorithms/impala/impala.py
@@ -286,7 +286,7 @@ class IMPALAConfig(AlgorithmConfig):
                 help="Aggregator workers are no longer supported on the old API "
                 "stack! To use aggregation (and GPU pre-loading) on the new API "
                 "stack, activate the new API stack, then set "
-                "`config.training(num_aggregator_actors_per_learner=..)`. Good "
+                "`config.learners(num_aggregator_actors_per_learner=..)`. Good "
                 "choices are normally 1 or 2, but this depends on your overall "
                 "setup, especially your `EnvRunner` throughput.",
                 error=True,
@@ -297,7 +297,7 @@ class IMPALAConfig(AlgorithmConfig):
                 help="Aggregator workers are no longer supported on the old API "
                 "stack! To use aggregation (and GPU pre-loading) on the new API "
                 "stack, activate the new API stack and THEN set "
-                "`config.training(max_requests_in_flight_per_aggregator_actor=..)"
+                "`config.learners(max_requests_in_flight_per_aggregator_actor=..)"
                 "`.",
                 error=True,
             )

--- a/rllib/algorithms/utils.py
+++ b/rllib/algorithms/utils.py
@@ -48,12 +48,11 @@ class AggregatorActor(FaultAwareApply):
 
         # Set device and node.
         self._node = platform.node()
-        self._device = (
-            torch.device(f"cuda:{ray.get_gpu_ids()[0]}")
+        self._device = torch.device(
+            f"cuda:{ray.get_gpu_ids()[0]}"
             if self.config.num_gpus_per_learner > 0
-            else torch.device("cpu")
+            else "cpu"
         )
-
         self.metrics = MetricsLogger()
 
         # Create the RLModule.

--- a/rllib/tuned_examples/appo/pong_appo.py
+++ b/rllib/tuned_examples/appo/pong_appo.py
@@ -55,11 +55,13 @@ config = (
         num_envs_per_env_runner=5,
         max_requests_in_flight_per_env_runner=1,
     )
+    .learners(
+        num_aggregator_actors_per_learner=2,
+    )
     .training(
         learner_connector=_make_learner_connector,
         train_batch_size_per_learner=500,
         target_network_update_freq=4,
-        num_aggregator_actors_per_learner=2,
         lr=0.0005 * ((args.num_learners or 1) ** 0.5),
         vf_loss_coeff=1.0,
         entropy_coeff=[[0, 0.01], [3000000, 0.0]],  # <- crucial parameter to finetune

--- a/rllib/tuned_examples/appo/pong_appo.py
+++ b/rllib/tuned_examples/appo/pong_appo.py
@@ -52,7 +52,7 @@ config = (
     )
     .env_runners(
         env_to_module_connector=_make_env_to_module_connector,
-        num_envs_per_env_runner=5,
+        num_envs_per_env_runner=2,
         max_requests_in_flight_per_env_runner=1,
     )
     .learners(

--- a/rllib/tuned_examples/impala/heavy_cartpole_impala.py
+++ b/rllib/tuned_examples/impala/heavy_cartpole_impala.py
@@ -50,8 +50,8 @@ config = (
     IMPALAConfig()
     .environment("heavy-cart")
     # .env_runners(compress_observations=True)
+    .learners(num_aggregator_actors_per_learner=2)
     .training(
-        num_aggregator_actors_per_learner=2,
         train_batch_size_per_learner=500,
         # train_batch_size=500,
     )

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -289,15 +289,23 @@ def add_rllib_example_script_args(
         "--num-learners",
         type=int,
         default=None,
-        help="The number of Learners to use. If none, use the algorithm's default "
+        help="The number of Learners to use. If `None`, use the algorithm's default "
         "value.",
     )
     parser.add_argument(
         "--num-gpus-per-learner",
         type=float,
         default=None,
-        help="The number of GPUs per Learner to use. If none and there are enough GPUs "
-        "for all required Learners (--num-learners), use a value of 1, otherwise 0.",
+        help="The number of GPUs per Learner to use. If `None` and there are enough "
+        "GPUs for all required Learners (--num-learners), use a value of 1, "
+        "otherwise 0.",
+    )
+    parser.add_argument(
+        "--num-aggregator-actors-per-learner",
+        type=int,
+        default=None,
+        help="The number of Aggregator actors to use per Learner. If `None`, use the "
+        "algorithm's default value.",
     )
 
     # Ray init options.
@@ -1133,6 +1141,14 @@ def run_rllib_example_script_experiment(
                     config.learners(num_gpus_per_learner=1)
                 else:
                     config.learners(num_gpus_per_learner=0, num_cpus_per_learner=1)
+
+            # User wants to use aggregator actors per Learner.
+            if args.num_aggregator_actors_per_learner is not None:
+                config.learners(
+                    num_aggregator_actors_per_learner=(
+                        args.num_aggregator_actors_per_learner
+                    )
+                )
 
             # User hard-requires n GPUs, but they are not available -> Error.
             elif num_gpus_available < num_gpus_requested:

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -1135,13 +1135,6 @@ def run_rllib_example_script_experiment(
             if args.num_learners is not None:
                 config.learners(num_learners=args.num_learners)
 
-            # User wants to use GPUs if available, but doesn't hard-require them.
-            if args.num_gpus_per_learner is None:
-                if num_gpus_available >= num_gpus_needed_if_available:
-                    config.learners(num_gpus_per_learner=1)
-                else:
-                    config.learners(num_gpus_per_learner=0, num_cpus_per_learner=1)
-
             # User wants to use aggregator actors per Learner.
             if args.num_aggregator_actors_per_learner is not None:
                 config.learners(
@@ -1149,6 +1142,13 @@ def run_rllib_example_script_experiment(
                         args.num_aggregator_actors_per_learner
                     )
                 )
+
+            # User wants to use GPUs if available, but doesn't hard-require them.
+            if args.num_gpus_per_learner is None:
+                if num_gpus_available >= num_gpus_needed_if_available:
+                    config.learners(num_gpus_per_learner=1)
+                else:
+                    config.learners(num_gpus_per_learner=0, num_cpus_per_learner=1)
 
             # User hard-requires n GPUs, but they are not available -> Error.
             elif num_gpus_available < num_gpus_requested:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

APPO accelerate vol 02: Bug fix for > 1 Learner actor.

The device detection on the Aggregation actors was faulty, leading to all aggregation actors to be placed on `cuda:0`.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
