### PR TITLE
[Refactor] fix ruff rule C418: unnecessary-literal-within-dict-call

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ ignore = [
     "B039",
     "B904",
     "C416",
-    "C418",
     "C419",
     # Below are auto-fixable rules
     "I001",

--- a/rllib/utils/tests/test_utils.py
+++ b/rllib/utils/tests/test_utils.py
@@ -49,12 +49,12 @@ class TestUtils(unittest.TestCase):
     }
     # Corresponding space struct.
     spaces = {
-            "a": gym.spaces.Discrete(4),
-            "b": (gym.spaces.Box(-1.0, 10.0, (3,)), gym.spaces.Box(-1.0, 1.0, (3, 1))),
-            "c": {
-                    "ca": gym.spaces.MultiDiscrete([4, 6]),
-                    "cb": gym.spaces.Box(-1.0, 1.0, ()),
-            },
+        "a": gym.spaces.Discrete(4),
+        "b": (gym.spaces.Box(-1.0, 10.0, (3,)), gym.spaces.Box(-1.0, 1.0, (3, 1))),
+        "c": {
+            "ca": gym.spaces.MultiDiscrete([4, 6]),
+            "cb": gym.spaces.Box(-1.0, 1.0, ()),
+        },
     }
 
     @classmethod

--- a/rllib/utils/tests/test_utils.py
+++ b/rllib/utils/tests/test_utils.py
@@ -48,18 +48,14 @@ class TestUtils(unittest.TestCase):
         "c": {"ca": np.array([[[1, 2]], [[3, 5]]]), "cb": np.array([[1.0], [2.0]])},
     }
     # Corresponding space struct.
-    spaces = dict(
-        {
+    spaces = {
             "a": gym.spaces.Discrete(4),
             "b": (gym.spaces.Box(-1.0, 10.0, (3,)), gym.spaces.Box(-1.0, 1.0, (3, 1))),
-            "c": dict(
-                {
+            "c": {
                     "ca": gym.spaces.MultiDiscrete([4, 6]),
                     "cb": gym.spaces.Box(-1.0, 1.0, ()),
-                }
-            ),
-        }
-    )
+            },
+    }
 
     @classmethod
     def setUpClass(cls) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This change removes redundant dict() calls around dictionary literals or comprehensions since they're already creating dictionaries, making the code more concise and eliminating unnecessary function calls.

ref : [https://docs.astral.sh/ruff/rules/unnecessary-literal-within-dict-call/](https://docs.astral.sh/ruff/rules/unnecessary-literal-within-dict-call/
)
## Related issue number

<!-- For example: "Closes #1234" -->
#47991 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
