### PR TITLE
[dashboard] Bugfix: add back DashboardHead.gcs_aio_client.

### DIFF
--- a/python/ray/dashboard/head.py
+++ b/python/ray/dashboard/head.py
@@ -260,16 +260,16 @@ class DashboardHead:
         gcs_address = self.gcs_address
 
         # Dashboard will handle connection failure automatically
-        gcs_client = GcsClient(
+        self.gcs_client = GcsClient(
             address=gcs_address, nums_reconnect_retry=0, cluster_id=self.cluster_id_hex
         )
-        gcs_aio_client = GcsAioClient(
+        self.gcs_aio_client = GcsAioClient(
             address=gcs_address, nums_reconnect_retry=0, cluster_id=self.cluster_id_hex
         )
-        internal_kv._initialize_internal_kv(gcs_client)
+        internal_kv._initialize_internal_kv(self.gcs_client)
 
         if not self.minimal:
-            self.metrics = await self._setup_metrics(gcs_aio_client)
+            self.metrics = await self._setup_metrics(self.gcs_aio_client)
 
         try:
             assert internal_kv._internal_kv_initialized()
@@ -320,13 +320,13 @@ class DashboardHead:
         # This could be done better in the future, including
         # removing the polling on the Ray side, by communicating the
         # server address to Ray via stdin / stdout or a pipe.
-        gcs_client.internal_kv_put(
+        self.gcs_client.internal_kv_put(
             ray_constants.DASHBOARD_ADDRESS.encode(),
             f"{dashboard_http_host}:{http_port}".encode(),
             True,
             namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
         )
-        gcs_client.internal_kv_put(
+        self.gcs_client.internal_kv_put(
             dashboard_consts.DASHBOARD_RPC_ADDRESS.encode(),
             f"{self.ip}:{self.grpc_port}".encode(),
             True,


### PR DESCRIPTION
Previously we removed DashboardHead.gcs_aio_client because now every Head creates their own so this field is no longer used. However DashboardHead itself uses it in _gcs_check_alive. Add it back.