### PR TITLE
Update performance metrics for 2.41.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 429.38368,
+    "_dashboard_memory_usage_mb": 390.30784,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.73,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1250\t7.77GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4016\t1.85GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5453\t0.92GiB\tpython distributed/test_many_actors.py\n2144\t0.3GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4132\t0.24GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1033\t0.15GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3713\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4299\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n4301\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4383\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
-    "actors_per_second": 573.9193627849573,
+    "_peak_memory": 3.71,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1121\t7.35GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3589\t1.74GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4619\t0.89GiB\tpython distributed/test_many_actors.py\n2720\t0.38GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3705\t0.32GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n584\t0.15GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3075\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3898\t0.08GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n3900\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4795\t0.07GiB\tray::DashboardTester.run",
+    "actors_per_second": 621.1720124265681,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 573.9193627849573
+            "perf_metric_value": 621.1720124265681
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 61.359
+            "perf_metric_value": 76.527
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2647.381
+            "perf_metric_value": 2133.868
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4086.815
+            "perf_metric_value": 3426.907
         }
     ],
     "success": "1",
-    "time": 17.4240505695343
+    "time": 16.098600387573242
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 210.870272,
+    "_dashboard_memory_usage_mb": 209.874944,
     "_dashboard_test_success": true,
-    "_peak_memory": 1.67,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3497\t0.53GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1252\t0.24GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2647\t0.22GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3613\t0.19GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4584\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1047\t0.14GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3780\t0.1GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n2558\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4826\t0.08GiB\tray::StateAPIGeneratorActor.start\n3782\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
+    "_peak_memory": 1.63,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3363\t0.49GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2842\t0.25GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1103\t0.23GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3479\t0.19GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4450\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3672\t0.1GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n2751\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4726\t0.08GiB\tray::StateAPIGeneratorActor.start\n3674\t0.08GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4224\t0.07GiB\tray::JobSupervisor",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 357.7562004234592
+            "perf_metric_value": 254.54948431672497
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4.011
+            "perf_metric_value": 4.244
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.241
+            "perf_metric_value": 10.247
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 85.322
+            "perf_metric_value": 69.5
         }
     ],
     "success": "1",
-    "tasks_per_second": 357.7562004234592,
-    "time": 302.79519963264465,
+    "tasks_per_second": 254.54948431672497,
+    "time": 303.9285092353821,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 179.154944,
+    "_dashboard_memory_usage_mb": 207.286272,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.14,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1227\t6.99GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3385\t0.91GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4360\t0.43GiB\tpython distributed/test_many_pgs.py\n2443\t0.42GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1033\t0.15GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3501\t0.11GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2367\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3670\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n3672\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3696\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
+    "_peak_memory": 2.19,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1124\t7.71GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3572\t0.97GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2761\t0.42GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4597\t0.36GiB\tpython distributed/test_many_pgs.py\n582\t0.16GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3688\t0.15GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2685\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3881\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n2426\t0.09GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l\n3883\t0.08GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22.55708308512839
+            "perf_metric_value": 14.517908227524005
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.755
+            "perf_metric_value": 3.548
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 30.541
+            "perf_metric_value": 6.624
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 351.637
+            "perf_metric_value": 198.916
         }
     ],
-    "pgs_per_second": 22.55708308512839,
+    "pgs_per_second": 14.517908227524005,
     "success": "1",
-    "time": 44.3319730758667
+    "time": 68.880446434021
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 785.780736,
+    "_dashboard_memory_usage_mb": 554.65984,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.46,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1250\t7.37GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3426\t1.12GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3542\t0.78GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4331\t0.73GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n2099\t0.19GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1035\t0.15GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n2315\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3709\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n4604\t0.08GiB\tray::StateAPIGeneratorActor.start\n3711\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
+    "_peak_memory": 3.35,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3558\t1.03GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4598\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3674\t0.71GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2961\t0.24GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1103\t0.23GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n583\t0.14GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3867\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n2877\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4764\t0.09GiB\tray::DashboardTester.run\n4826\t0.08GiB\tray::StateAPIGeneratorActor.start",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 563.3604483841477
+            "perf_metric_value": 82.12632410337037
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 112.338
+            "perf_metric_value": 73.353
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 506.419
+            "perf_metric_value": 343.068
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 759.07
+            "perf_metric_value": 528.581
         }
     ],
     "success": "1",
-    "tasks_per_second": 563.3604483841477,
-    "time": 317.7506248950958,
+    "tasks_per_second": 82.12632410337037,
+    "time": 421.76363801956177,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.40.0"}
+{"release_version": "2.41.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8670.630812242769,
-        106.83987787916737
+        8502.185649124818,
+        59.39579734958622
     ],
     "1_1_actor_calls_concurrent": [
-        5349.871656557709,
-        262.76145872329056
+        5685.557541355921,
+        99.73222945207537
     ],
     "1_1_actor_calls_sync": [
-        2100.531675221624,
-        45.884459150638435
+        2008.2251736389535,
+        20.33277638732348
     ],
     "1_1_async_actor_calls_async": [
-        4641.857377193749,
-        229.84033542194967
+        4944.531859420242,
+        293.794843634801
     ],
     "1_1_async_actor_calls_sync": [
-        1470.5838167142256,
-        61.994313956259205
+        1485.8803339848037,
+        20.550046952451634
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2994.804100896146,
-        72.1671038495112
+        3010.0192503432813,
+        112.5187905869462
     ],
     "1_n_actor_calls_async": [
-        8118.8880400901135,
-        51.66079706586818
+        8488.963904822358,
+        291.21698385238375
     ],
     "1_n_async_actor_calls_async": [
-        7265.632549025338,
-        100.08002254309318
+        7423.794674477096,
+        74.75548088782585
     ],
     "client__1_1_actor_calls_async": [
-        927.7378599556337,
-        32.80234721559512
+        1098.439590807965,
+        6.592486113693813
     ],
     "client__1_1_actor_calls_concurrent": [
-        968.0008238131173,
-        29.311573682343898
+        1101.532038654861,
+        12.722832487818907
     ],
     "client__1_1_actor_calls_sync": [
-        528.8636206448897,
-        6.436001638898678
+        540.0068247341576,
+        6.0576821391632825
     ],
     "client__get_calls": [
-        1004.2954376391058,
-        76.06541415192476
+        1131.9334072179877,
+        20.4210935531117
     ],
     "client__put_calls": [
-        796.6672485266845,
-        42.64509793165841
+        828.2633586422576,
+        31.538607699579494
     ],
     "client__put_gigabytes": [
-        0.1523218281420353,
-        0.0017062706720517254
+        0.15630094720805565,
+        0.0007378049516346425
     ],
     "client__tasks_and_get_batch": [
-        0.9840492186511862,
-        0.010660110600558213
+        0.9952310409487755,
+        0.03335427710052468
     ],
     "client__tasks_and_put_batch": [
-        13963.575440510822,
-        302.4709584876189
+        14392.617635730732,
+        409.08882397913544
     ],
     "multi_client_put_calls_Plasma_Store": [
-        16018.142349512491,
-        110.30685859732601
+        15812.670260851048,
+        465.78308516717277
     ],
     "multi_client_put_gigabytes": [
-        47.90805309960038,
-        3.9883369373484028
+        38.924152937872186,
+        3.092161674668955
     ],
     "multi_client_tasks_async": [
-        21860.338179655857,
-        3613.2906958577523
+        22288.616282558643,
+        1657.7936475517824
     ],
     "n_n_actor_calls_async": [
-        26065.409129685446,
-        842.8691955339091
+        27468.738598402517,
+        495.8063418438702
     ],
     "n_n_actor_calls_with_arg_async": [
-        2674.014821048363,
-        20.95074522247394
+        2767.6430830862673,
+        27.252446576921344
     ],
     "n_n_async_actor_calls_async": [
-        22620.58710137489,
-        453.05171495223664
+        23975.695326534915,
+        675.7738994044964
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10758.691758375035
+            "perf_metric_value": 10333.563725378965
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4873.791178055619
+            "perf_metric_value": 5112.5329702960535
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 16018.142349512491
+            "perf_metric_value": 15812.670260851048
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 16.370163798832593
+            "perf_metric_value": 19.779825639679515
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7.259983498667911
+            "perf_metric_value": 6.436833395888227
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 47.90805309960038
+            "perf_metric_value": 38.924152937872186
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10.715440745783182
+            "perf_metric_value": 14.378237016716856
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.367130240055254
+            "perf_metric_value": 5.676463373919201
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 975.2895608656044
+            "perf_metric_value": 996.1938656370342
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7133.343594327644
+            "perf_metric_value": 8043.457972097627
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 21860.338179655857
+            "perf_metric_value": 22288.616282558643
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2100.531675221624
+            "perf_metric_value": 2008.2251736389535
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8670.630812242769
+            "perf_metric_value": 8502.185649124818
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5349.871656557709
+            "perf_metric_value": 5685.557541355921
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8118.8880400901135
+            "perf_metric_value": 8488.963904822358
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 26065.409129685446
+            "perf_metric_value": 27468.738598402517
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2674.014821048363
+            "perf_metric_value": 2767.6430830862673
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1470.5838167142256
+            "perf_metric_value": 1485.8803339848037
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4641.857377193749
+            "perf_metric_value": 4944.531859420242
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2994.804100896146
+            "perf_metric_value": 3010.0192503432813
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7265.632549025338
+            "perf_metric_value": 7423.794674477096
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22620.58710137489
+            "perf_metric_value": 23975.695326534915
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 766.4710772352788
+            "perf_metric_value": 778.111565647552
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1004.2954376391058
+            "perf_metric_value": 1131.9334072179877
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 796.6672485266845
+            "perf_metric_value": 828.2633586422576
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.1523218281420353
+            "perf_metric_value": 0.15630094720805565
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13963.575440510822
+            "perf_metric_value": 14392.617635730732
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 528.8636206448897
+            "perf_metric_value": 540.0068247341576
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 927.7378599556337
+            "perf_metric_value": 1098.439590807965
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 968.0008238131173
+            "perf_metric_value": 1101.532038654861
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.9840492186511862
+            "perf_metric_value": 0.9952310409487755
         }
     ],
     "placement_group_create/removal": [
-        766.4710772352788,
-        9.525367147478727
+        778.111565647552,
+        7.981708725854014
     ],
     "single_client_get_calls_Plasma_Store": [
-        10758.691758375035,
-        161.37868389449068
+        10333.563725378965,
+        389.2023743127916
     ],
     "single_client_get_object_containing_10k_refs": [
-        10.715440745783182,
-        0.03423213641168171
+        14.378237016716856,
+        0.11855184132074731
     ],
     "single_client_put_calls_Plasma_Store": [
-        4873.791178055619,
-        93.39872186416422
+        5112.5329702960535,
+        39.29531408930756
     ],
     "single_client_put_gigabytes": [
-        16.370163798832593,
-        8.28607777964688
+        19.779825639679515,
+        6.749863485083383
     ],
     "single_client_tasks_and_get_batch": [
-        7.259983498667911,
-        0.25823170234335685
+        6.436833395888227,
+        2.8622339282405638
     ],
     "single_client_tasks_async": [
-        7133.343594327644,
-        421.3215558940858
+        8043.457972097627,
+        406.843862288408
     ],
     "single_client_tasks_sync": [
-        975.2895608656044,
-        15.938596328864557
+        996.1938656370342,
+        14.340827740501947
     ],
     "single_client_wait_1k_refs": [
-        5.367130240055254,
-        0.12488840214033954
+        5.676463373919201,
+        0.11671521593589637
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 12.7140335,
+    "broadcast_time": 12.932390226999999,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.7140335
+            "perf_metric_value": 12.932390226999999
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.54721164899999,
-    "get_time": 24.133820766,
+    "args_time": 19.185585022000005,
+    "get_time": 23.77290556300001,
     "large_object_size": 107374182400,
-    "large_object_time": 29.832562440000004,
+    "large_object_time": 30.17560686500002,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.54721164899999
+            "perf_metric_value": 19.185585022000005
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.791661208000008
+            "perf_metric_value": 5.9146832560000036
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 24.133820766
+            "perf_metric_value": 23.77290556300001
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 189.11093958500004
+            "perf_metric_value": 194.40329999600002
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 29.832562440000004
+            "perf_metric_value": 30.17560686500002
         }
     ],
-    "queued_time": 189.11093958500004,
-    "returns_time": 5.791661208000008,
+    "queued_time": 194.40329999600002,
+    "returns_time": 5.9146832560000036,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 0.726184561252594,
-    "max_iteration_time": 2.2697196006774902,
-    "min_iteration_time": 0.08619499206542969,
+    "avg_iteration_time": 1.0785841965675353,
+    "max_iteration_time": 3.5641191005706787,
+    "min_iteration_time": 0.05080008506774902,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.726184561252594
+            "perf_metric_value": 1.0785841965675353
         }
     ],
     "success": 1,
-    "total_time": 72.6185929775238
+    "total_time": 107.858571767807
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 7.508195400238037
+            "perf_metric_value": 7.8552281856536865
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.552423691749572
+            "perf_metric_value": 12.454452514648438
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 38.96002230644226
+            "perf_metric_value": 38.947781038284305
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.3092761039733887
+            "perf_metric_value": 1.7129392623901367
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2052.3795640468597
+            "perf_metric_value": 1864.2597482204437
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.20646123231684818
+            "perf_metric_value": 0.6700886516435743
         }
     ],
-    "stage_0_time": 7.508195400238037,
-    "stage_1_avg_iteration_time": 12.552423691749572,
-    "stage_1_max_iteration_time": 13.073823690414429,
-    "stage_1_min_iteration_time": 11.235809803009033,
-    "stage_1_time": 125.52429366111755,
-    "stage_2_avg_iteration_time": 38.96002230644226,
-    "stage_2_max_iteration_time": 40.04894542694092,
-    "stage_2_min_iteration_time": 38.31258225440979,
-    "stage_2_time": 194.8006236553192,
-    "stage_3_creation_time": 1.3092761039733887,
-    "stage_3_time": 2052.3795640468597,
-    "stage_4_spread": 0.20646123231684818,
+    "stage_0_time": 7.8552281856536865,
+    "stage_1_avg_iteration_time": 12.454452514648438,
+    "stage_1_max_iteration_time": 13.01986289024353,
+    "stage_1_min_iteration_time": 11.176378011703491,
+    "stage_1_time": 124.54459071159363,
+    "stage_2_avg_iteration_time": 38.947781038284305,
+    "stage_2_max_iteration_time": 39.10041952133179,
+    "stage_2_min_iteration_time": 38.528122425079346,
+    "stage_2_time": 194.73944878578186,
+    "stage_3_creation_time": 1.7129392623901367,
+    "stage_3_time": 1864.2597482204437,
+    "stage_4_spread": 0.6700886516435743,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 1.5375056531531037,
-    "avg_pg_remove_time_ms": 1.3262595690691725,
+    "avg_pg_create_time_ms": 1.5408077492495722,
+    "avg_pg_remove_time_ms": 1.2982101096095486,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.5375056531531037
+            "perf_metric_value": 1.5408077492495722
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.3262595690691725
+            "perf_metric_value": 1.2982101096095486
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 85.42%: tasks_per_second (THROUGHPUT) regresses from 563.3604483841477 to 82.12632410337037 in benchmarks/many_tasks.json
REGRESSION 35.64%: pgs_per_second (THROUGHPUT) regresses from 22.55708308512839 to 14.517908227524005 in benchmarks/many_pgs.json
REGRESSION 28.85%: tasks_per_second (THROUGHPUT) regresses from 357.7562004234592 to 254.54948431672497 in benchmarks/many_nodes.json
REGRESSION 18.75%: multi_client_put_gigabytes (THROUGHPUT) regresses from 47.90805309960038 to 38.924152937872186 in microbenchmark.json
REGRESSION 11.34%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 7.259983498667911 to 6.436833395888227 in microbenchmark.json
REGRESSION 4.39%: 1_1_actor_calls_sync (THROUGHPUT) regresses from 2100.531675221624 to 2008.2251736389535 in microbenchmark.json
REGRESSION 3.95%: single_client_get_calls_Plasma_Store (THROUGHPUT) regresses from 10758.691758375035 to 10333.563725378965 in microbenchmark.json
REGRESSION 1.94%: 1_1_actor_calls_async (THROUGHPUT) regresses from 8670.630812242769 to 8502.185649124818 in microbenchmark.json
REGRESSION 1.28%: multi_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 16018.142349512491 to 15812.670260851048 in microbenchmark.json
REGRESSION 224.56%: stage_4_spread (LATENCY) regresses from 0.20646123231684818 to 0.6700886516435743 in stress_tests/stress_test_many_tasks.json
REGRESSION 48.53%: avg_iteration_time (LATENCY) regresses from 0.726184561252594 to 1.0785841965675353 in stress_tests/stress_test_dead_actors.json
REGRESSION 30.83%: stage_3_creation_time (LATENCY) regresses from 1.3092761039733887 to 1.7129392623901367 in stress_tests/stress_test_many_tasks.json
REGRESSION 24.72%: dashboard_p50_latency_ms (LATENCY) regresses from 61.359 to 76.527 in benchmarks/many_actors.json
REGRESSION 9.34%: 10000_args_time (LATENCY) regresses from 17.54721164899999 to 19.185585022000005 in scalability/single_node.json
REGRESSION 5.81%: dashboard_p50_latency_ms (LATENCY) regresses from 4.011 to 4.244 in benchmarks/many_nodes.json
REGRESSION 4.62%: stage_0_time (LATENCY) regresses from 7.508195400238037 to 7.8552281856536865 in stress_tests/stress_test_many_tasks.json
REGRESSION 2.80%: 1000000_queued_time (LATENCY) regresses from 189.11093958500004 to 194.40329999600002 in scalability/single_node.json
REGRESSION 2.12%: 3000_returns_time (LATENCY) regresses from 5.791661208000008 to 5.9146832560000036 in scalability/single_node.json
REGRESSION 1.72%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 12.7140335 to 12.932390226999999 in scalability/object_store.json
REGRESSION 1.15%: 107374182400_large_object_time (LATENCY) regresses from 29.832562440000004 to 30.17560686500002 in scalability/single_node.json
REGRESSION 0.21%: avg_pg_create_time_ms (LATENCY) regresses from 1.5375056531531037 to 1.5408077492495722 in stress_tests/stress_test_placement_group.json
```