### PR TITLE
[data] Replace usage of torchvision MNIST with FashionMNIST in data tests

### DIFF
--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -1665,7 +1665,7 @@ def test_from_tf_e2e(ray_start_regular_shared):
 def test_from_torch_e2e(ray_start_regular_shared, tmp_path):
     import torchvision
 
-    torch_dataset = torchvision.datasets.MNIST(tmp_path, download=True)
+    torch_dataset = torchvision.datasets.FashionMNIST(tmp_path, download=True)
 
     ray_dataset = ray.data.from_torch(torch_dataset)
 

--- a/python/ray/data/tests/test_formats.py
+++ b/python/ray/data/tests/test_formats.py
@@ -181,7 +181,7 @@ def test_from_tf(ray_start_regular_shared):
 
 @pytest.mark.parametrize("local_read", [True, False])
 def test_from_torch(shutdown_only, local_read, tmp_path):
-    torch_dataset = torchvision.datasets.MNIST(tmp_path, download=True)
+    torch_dataset = torchvision.datasets.FashionMNIST(tmp_path, download=True)
     expected_data = list(torch_dataset)
 
     ray_dataset = ray.data.from_torch(torch_dataset, local_read=local_read)
@@ -191,14 +191,14 @@ def test_from_torch(shutdown_only, local_read, tmp_path):
 
     import torch
 
-    class IterMNIST(torch.utils.data.IterableDataset):
+    class IterFashionMNIST(torch.utils.data.IterableDataset):
         def __len__(self):
             return len(torch_dataset)
 
         def __iter__(self):
             return iter(torch_dataset)
 
-    iter_torch_dataset = IterMNIST()
+    iter_torch_dataset = IterFashionMNIST()
     ray_dataset = ray.data.from_torch(iter_torch_dataset)
 
     actual_data = extract_values("item", list(ray_dataset.take_all()))


### PR DESCRIPTION
## Why are these changes needed?
`torchvision.datasets.MNIST` is hosted on [yann.lecun.com](https://yann.lecun.com/) which seems to be timing out in tests now. This replaces the two usages of `torchvision.datasets.MNIST` with `torchvision.datasets.FashionMNIST`. This is a slightly bigger dataset (11MB download vs 29MB download), but the next smallest dataset within `torchvision.datasets`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
