### PR TITLE
Update performance metrics for 2.41.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 429.38368,
+    "_dashboard_memory_usage_mb": 425.73824,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.73,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1250\t7.77GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4016\t1.85GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5453\t0.92GiB\tpython distributed/test_many_actors.py\n2144\t0.3GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4132\t0.24GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n1033\t0.15GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3713\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4299\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n4301\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n4383\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
-    "actors_per_second": 573.9193627849573,
+    "_peak_memory": 3.78,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1110\t8.12GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3495\t1.79GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5107\t0.89GiB\tpython distributed/test_many_actors.py\n3611\t0.37GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2744\t0.35GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n583\t0.14GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3121\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3805\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n3807\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3835\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
+    "actors_per_second": 605.527621831549,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 573.9193627849573
+            "perf_metric_value": 605.527621831549
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 61.359
+            "perf_metric_value": 138.675
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2647.381
+            "perf_metric_value": 3213.567
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4086.815
+            "perf_metric_value": 4703.106
         }
     ],
     "success": "1",
-    "time": 17.4240505695343
+    "time": 16.51452326774597
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 210.870272,
+    "_dashboard_memory_usage_mb": 225.501184,
     "_dashboard_test_success": true,
     "_peak_memory": 1.67,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3497\t0.53GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1252\t0.24GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2647\t0.22GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3613\t0.19GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4584\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1047\t0.14GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3780\t0.1GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n2558\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4826\t0.08GiB\tray::StateAPIGeneratorActor.start\n3782\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n6321\t0.52GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n1088\t0.27GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2914\t0.26GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n6437\t0.21GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n7449\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n6628\t0.1GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n2881\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n7718\t0.08GiB\tray::StateAPIGeneratorActor.start\n6630\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n6721\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 357.7562004234592
+            "perf_metric_value": 471.21245501533576
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4.011
+            "perf_metric_value": 4.347
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.241
+            "perf_metric_value": 39.196
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 85.322
+            "perf_metric_value": 89.057
         }
     ],
     "success": "1",
-    "tasks_per_second": 357.7562004234592,
-    "time": 302.79519963264465,
+    "tasks_per_second": 471.21245501533576,
+    "time": 302.12218499183655,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 179.154944,
+    "_dashboard_memory_usage_mb": 171.487232,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.14,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1227\t6.99GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3385\t0.91GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4360\t0.43GiB\tpython distributed/test_many_pgs.py\n2443\t0.42GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1033\t0.15GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3501\t0.11GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n2367\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3670\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n3672\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3696\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
+    "_peak_memory": 2.16,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1107\t7.43GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3511\t0.96GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4510\t0.36GiB\tpython distributed/test_many_pgs.py\n2880\t0.27GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n585\t0.14GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3629\t0.14GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n3053\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3822\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n3824\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti\n3848\t0.07GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --no-",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22.55708308512839
+            "perf_metric_value": 22.635892345065848
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.755
+            "perf_metric_value": 3.253
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 30.541
+            "perf_metric_value": 10.134
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 351.637
+            "perf_metric_value": 832.35
         }
     ],
-    "pgs_per_second": 22.55708308512839,
+    "pgs_per_second": 22.635892345065848,
     "success": "1",
-    "time": 44.3319730758667
+    "time": 44.177626609802246
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 785.780736,
+    "_dashboard_memory_usage_mb": 768.884736,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.46,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1250\t7.37GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3426\t1.12GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3542\t0.78GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4331\t0.73GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n2099\t0.19GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1035\t0.15GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n2315\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3709\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n4604\t0.08GiB\tray::StateAPIGeneratorActor.start\n3711\t0.07GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/runti",
+    "_peak_memory": 3.56,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3463\t1.13GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3579\t0.84GiB\t/home/ray/anaconda3/bin/python /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dashboa\n4464\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n2768\t0.24GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1076\t0.24GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n580\t0.12GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3772\t0.09GiB\t/home/ray/anaconda3/bin/python -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/agen\n2955\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4609\t0.08GiB\tray::DashboardTester.run\n4665\t0.08GiB\tray::StateAPIGeneratorActor.start",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 563.3604483841477
+            "perf_metric_value": 552.9063643030292
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 112.338
+            "perf_metric_value": 148.169
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 506.419
+            "perf_metric_value": 626.809
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 759.07
+            "perf_metric_value": 873.471
         }
     ],
     "success": "1",
-    "tasks_per_second": 563.3604483841477,
-    "time": 317.7506248950958,
+    "tasks_per_second": 552.9063643030292,
+    "time": 318.08624505996704,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.40.0"}
+{"release_version": "2.41.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8670.630812242769,
-        106.83987787916737
+        8398.56885282787,
+        90.64470042092343
     ],
     "1_1_actor_calls_concurrent": [
-        5349.871656557709,
-        262.76145872329056
+        5268.769788618396,
+        118.51034431437533
     ],
     "1_1_actor_calls_sync": [
-        2100.531675221624,
-        45.884459150638435
+        2071.6501933724253,
+        66.54602398051257
     ],
     "1_1_async_actor_calls_async": [
-        4641.857377193749,
-        229.84033542194967
+        4594.0039367756,
+        180.69800094596656
     ],
     "1_1_async_actor_calls_sync": [
-        1470.5838167142256,
-        61.994313956259205
+        1507.4722826901059,
+        38.639742834270045
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2994.804100896146,
-        72.1671038495112
+        2906.3799497984073,
+        162.39581991600068
     ],
     "1_n_actor_calls_async": [
-        8118.8880400901135,
-        51.66079706586818
+        8087.002681858739,
+        179.1488833569923
     ],
     "1_n_async_actor_calls_async": [
-        7265.632549025338,
-        100.08002254309318
+        7747.258573610084,
+        159.28066572462012
     ],
     "client__1_1_actor_calls_async": [
-        927.7378599556337,
-        32.80234721559512
+        1041.3583204574459,
+        11.15719859730251
     ],
     "client__1_1_actor_calls_concurrent": [
-        968.0008238131173,
-        29.311573682343898
+        1040.0631707535902,
+        5.885662397510047
     ],
     "client__1_1_actor_calls_sync": [
-        528.8636206448897,
-        6.436001638898678
+        529.5868989134584,
+        4.437050021111481
     ],
     "client__get_calls": [
-        1004.2954376391058,
-        76.06541415192476
+        984.938248602108,
+        19.39903981382506
     ],
     "client__put_calls": [
-        796.6672485266845,
-        42.64509793165841
+        782.2028385276735,
+        22.37727916683932
     ],
     "client__put_gigabytes": [
-        0.1523218281420353,
-        0.0017062706720517254
+        0.15273001910830053,
+        0.0003966330505155439
     ],
     "client__tasks_and_get_batch": [
-        0.9840492186511862,
-        0.010660110600558213
+        0.9748684492189577,
+        0.013917827149089729
     ],
     "client__tasks_and_put_batch": [
-        13963.575440510822,
-        302.4709584876189
+        14510.26499948894,
+        142.94582485457454
     ],
     "multi_client_put_calls_Plasma_Store": [
-        16018.142349512491,
-        110.30685859732601
+        16476.91701973554,
+        153.5268006228045
     ],
     "multi_client_put_gigabytes": [
-        47.90805309960038,
-        3.9883369373484028
+        45.59421490337185,
+        4.252528426368044
     ],
     "multi_client_tasks_async": [
-        21860.338179655857,
-        3613.2906958577523
+        23754.393304342077,
+        3937.6238945605232
     ],
     "n_n_actor_calls_async": [
-        26065.409129685446,
-        842.8691955339091
+        27627.813056199215,
+        851.4280591592274
     ],
     "n_n_actor_calls_with_arg_async": [
-        2674.014821048363,
-        20.95074522247394
+        2707.177086616588,
+        18.84646363376401
     ],
     "n_n_async_actor_calls_async": [
-        22620.58710137489,
-        453.05171495223664
+        23879.523989612106,
+        487.9621758881768
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10758.691758375035
+            "perf_metric_value": 10641.803495982997
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4873.791178055619
+            "perf_metric_value": 4953.332414166378
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 16018.142349512491
+            "perf_metric_value": 16476.91701973554
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 16.370163798832593
+            "perf_metric_value": 17.025876066565033
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7.259983498667911
+            "perf_metric_value": 8.246266578072571
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 47.90805309960038
+            "perf_metric_value": 45.59421490337185
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10.715440745783182
+            "perf_metric_value": 13.400670287257304
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.367130240055254
+            "perf_metric_value": 5.5615049020254625
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 975.2895608656044
+            "perf_metric_value": 1010.2085841645662
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7133.343594327644
+            "perf_metric_value": 7963.424588687801
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 21860.338179655857
+            "perf_metric_value": 23754.393304342077
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2100.531675221624
+            "perf_metric_value": 2071.6501933724253
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8670.630812242769
+            "perf_metric_value": 8398.56885282787
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5349.871656557709
+            "perf_metric_value": 5268.769788618396
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8118.8880400901135
+            "perf_metric_value": 8087.002681858739
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 26065.409129685446
+            "perf_metric_value": 27627.813056199215
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2674.014821048363
+            "perf_metric_value": 2707.177086616588
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1470.5838167142256
+            "perf_metric_value": 1507.4722826901059
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4641.857377193749
+            "perf_metric_value": 4594.0039367756
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2994.804100896146
+            "perf_metric_value": 2906.3799497984073
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7265.632549025338
+            "perf_metric_value": 7747.258573610084
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22620.58710137489
+            "perf_metric_value": 23879.523989612106
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 766.4710772352788
+            "perf_metric_value": 758.764762704843
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1004.2954376391058
+            "perf_metric_value": 984.938248602108
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 796.6672485266845
+            "perf_metric_value": 782.2028385276735
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.1523218281420353
+            "perf_metric_value": 0.15273001910830053
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13963.575440510822
+            "perf_metric_value": 14510.26499948894
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 528.8636206448897
+            "perf_metric_value": 529.5868989134584
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 927.7378599556337
+            "perf_metric_value": 1041.3583204574459
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 968.0008238131173
+            "perf_metric_value": 1040.0631707535902
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.9840492186511862
+            "perf_metric_value": 0.9748684492189577
         }
     ],
     "placement_group_create/removal": [
-        766.4710772352788,
-        9.525367147478727
+        758.764762704843,
+        2.5049732038490395
     ],
     "single_client_get_calls_Plasma_Store": [
-        10758.691758375035,
-        161.37868389449068
+        10641.803495982997,
+        150.88664147721323
     ],
     "single_client_get_object_containing_10k_refs": [
-        10.715440745783182,
-        0.03423213641168171
+        13.400670287257304,
+        0.3357627983063862
     ],
     "single_client_put_calls_Plasma_Store": [
-        4873.791178055619,
-        93.39872186416422
+        4953.332414166378,
+        28.875351193249827
     ],
     "single_client_put_gigabytes": [
-        16.370163798832593,
-        8.28607777964688
+        17.025876066565033,
+        10.326642986853164
     ],
     "single_client_tasks_and_get_batch": [
-        7.259983498667911,
-        0.25823170234335685
+        8.246266578072571,
+        0.522110999548341
     ],
     "single_client_tasks_async": [
-        7133.343594327644,
-        421.3215558940858
+        7963.424588687801,
+        461.55034927417944
     ],
     "single_client_tasks_sync": [
-        975.2895608656044,
-        15.938596328864557
+        1010.2085841645662,
+        6.557428364155709
     ],
     "single_client_wait_1k_refs": [
-        5.367130240055254,
-        0.12488840214033954
+        5.5615049020254625,
+        0.1315180945429515
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 12.7140335,
+    "broadcast_time": 16.12803921599999,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.7140335
+            "perf_metric_value": 16.12803921599999
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.54721164899999,
-    "get_time": 24.133820766,
+    "args_time": 18.440583357999998,
+    "get_time": 24.405157770000002,
     "large_object_size": 107374182400,
-    "large_object_time": 29.832562440000004,
+    "large_object_time": 33.19615447799998,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.54721164899999
+            "perf_metric_value": 18.440583357999998
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.791661208000008
+            "perf_metric_value": 5.834724514999991
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 24.133820766
+            "perf_metric_value": 24.405157770000002
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 189.11093958500004
+            "perf_metric_value": 186.31882492000003
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 29.832562440000004
+            "perf_metric_value": 33.19615447799998
         }
     ],
-    "queued_time": 189.11093958500004,
-    "returns_time": 5.791661208000008,
+    "queued_time": 186.31882492000003,
+    "returns_time": 5.834724514999991,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 0.726184561252594,
-    "max_iteration_time": 2.2697196006774902,
-    "min_iteration_time": 0.08619499206542969,
+    "avg_iteration_time": 0.7329249548912048,
+    "max_iteration_time": 1.9340107440948486,
+    "min_iteration_time": 0.049217939376831055,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.726184561252594
+            "perf_metric_value": 0.7329249548912048
         }
     ],
     "success": 1,
-    "total_time": 72.6185929775238
+    "total_time": 73.29262828826904
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 7.508195400238037
+            "perf_metric_value": 4.95395827293396
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.552423691749572
+            "perf_metric_value": 12.305748534202575
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 38.96002230644226
+            "perf_metric_value": 39.20367703437805
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.3092761039733887
+            "perf_metric_value": 1.1791002750396729
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2052.3795640468597
+            "perf_metric_value": 1931.609727859497
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.20646123231684818
+            "perf_metric_value": 0.2312385877525104
         }
     ],
-    "stage_0_time": 7.508195400238037,
-    "stage_1_avg_iteration_time": 12.552423691749572,
-    "stage_1_max_iteration_time": 13.073823690414429,
-    "stage_1_min_iteration_time": 11.235809803009033,
-    "stage_1_time": 125.52429366111755,
-    "stage_2_avg_iteration_time": 38.96002230644226,
-    "stage_2_max_iteration_time": 40.04894542694092,
-    "stage_2_min_iteration_time": 38.31258225440979,
-    "stage_2_time": 194.8006236553192,
-    "stage_3_creation_time": 1.3092761039733887,
-    "stage_3_time": 2052.3795640468597,
-    "stage_4_spread": 0.20646123231684818,
+    "stage_0_time": 4.95395827293396,
+    "stage_1_avg_iteration_time": 12.305748534202575,
+    "stage_1_max_iteration_time": 13.314747333526611,
+    "stage_1_min_iteration_time": 10.843807458877563,
+    "stage_1_time": 123.05753707885742,
+    "stage_2_avg_iteration_time": 39.20367703437805,
+    "stage_2_max_iteration_time": 39.455753803253174,
+    "stage_2_min_iteration_time": 39.00661754608154,
+    "stage_2_time": 196.01891422271729,
+    "stage_3_creation_time": 1.1791002750396729,
+    "stage_3_time": 1931.609727859497,
+    "stage_4_spread": 0.2312385877525104,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 1.5375056531531037,
-    "avg_pg_remove_time_ms": 1.3262595690691725,
+    "avg_pg_create_time_ms": 1.5571090375378522,
+    "avg_pg_remove_time_ms": 1.248110743243383,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.5375056531531037
+            "perf_metric_value": 1.5571090375378522
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.3262595690691725
+            "perf_metric_value": 1.248110743243383
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 4.83%: multi_client_put_gigabytes (THROUGHPUT) regresses from 47.90805309960038 to 45.59421490337185 in microbenchmark.json
REGRESSION 3.14%: 1_1_actor_calls_async (THROUGHPUT) regresses from 8670.630812242769 to 8398.56885282787 in microbenchmark.json
REGRESSION 2.95%: 1_1_async_actor_calls_with_args_async (THROUGHPUT) regresses from 2994.804100896146 to 2906.3799497984073 in microbenchmark.json
REGRESSION 1.93%: client__get_calls (THROUGHPUT) regresses from 1004.2954376391058 to 984.938248602108 in microbenchmark.json
REGRESSION 1.86%: tasks_per_second (THROUGHPUT) regresses from 563.3604483841477 to 552.9063643030292 in benchmarks/many_tasks.json
REGRESSION 1.82%: client__put_calls (THROUGHPUT) regresses from 796.6672485266845 to 782.2028385276735 in microbenchmark.json
REGRESSION 1.52%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 5349.871656557709 to 5268.769788618396 in microbenchmark.json
REGRESSION 1.37%: 1_1_actor_calls_sync (THROUGHPUT) regresses from 2100.531675221624 to 2071.6501933724253 in microbenchmark.json
REGRESSION 1.09%: single_client_get_calls_Plasma_Store (THROUGHPUT) regresses from 10758.691758375035 to 10641.803495982997 in microbenchmark.json
REGRESSION 1.03%: 1_1_async_actor_calls_async (THROUGHPUT) regresses from 4641.857377193749 to 4594.0039367756 in microbenchmark.json
REGRESSION 1.01%: placement_group_create/removal (THROUGHPUT) regresses from 766.4710772352788 to 758.764762704843 in microbenchmark.json
REGRESSION 0.93%: client__tasks_and_get_batch (THROUGHPUT) regresses from 0.9840492186511862 to 0.9748684492189577 in microbenchmark.json
REGRESSION 0.39%: 1_n_actor_calls_async (THROUGHPUT) regresses from 8118.8880400901135 to 8087.002681858739 in microbenchmark.json
REGRESSION 136.71%: dashboard_p99_latency_ms (LATENCY) regresses from 351.637 to 832.35 in benchmarks/many_pgs.json
REGRESSION 127.34%: dashboard_p95_latency_ms (LATENCY) regresses from 17.241 to 39.196 in benchmarks/many_nodes.json
REGRESSION 126.01%: dashboard_p50_latency_ms (LATENCY) regresses from 61.359 to 138.675 in benchmarks/many_actors.json
REGRESSION 31.90%: dashboard_p50_latency_ms (LATENCY) regresses from 112.338 to 148.169 in benchmarks/many_tasks.json
REGRESSION 26.85%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 12.7140335 to 16.12803921599999 in scalability/object_store.json
REGRESSION 23.77%: dashboard_p95_latency_ms (LATENCY) regresses from 506.419 to 626.809 in benchmarks/many_tasks.json
REGRESSION 21.39%: dashboard_p95_latency_ms (LATENCY) regresses from 2647.381 to 3213.567 in benchmarks/many_actors.json
REGRESSION 15.08%: dashboard_p99_latency_ms (LATENCY) regresses from 4086.815 to 4703.106 in benchmarks/many_actors.json
REGRESSION 15.07%: dashboard_p99_latency_ms (LATENCY) regresses from 759.07 to 873.471 in benchmarks/many_tasks.json
REGRESSION 12.00%: stage_4_spread (LATENCY) regresses from 0.20646123231684818 to 0.2312385877525104 in stress_tests/stress_test_many_tasks.json
REGRESSION 11.27%: 107374182400_large_object_time (LATENCY) regresses from 29.832562440000004 to 33.19615447799998 in scalability/single_node.json
REGRESSION 8.38%: dashboard_p50_latency_ms (LATENCY) regresses from 4.011 to 4.347 in benchmarks/many_nodes.json
REGRESSION 5.09%: 10000_args_time (LATENCY) regresses from 17.54721164899999 to 18.440583357999998 in scalability/single_node.json
REGRESSION 4.38%: dashboard_p99_latency_ms (LATENCY) regresses from 85.322 to 89.057 in benchmarks/many_nodes.json
REGRESSION 1.28%: avg_pg_create_time_ms (LATENCY) regresses from 1.5375056531531037 to 1.5571090375378522 in stress_tests/stress_test_placement_group.json
REGRESSION 1.12%: 10000_get_time (LATENCY) regresses from 24.133820766 to 24.405157770000002 in scalability/single_node.json
REGRESSION 0.93%: avg_iteration_time (LATENCY) regresses from 0.726184561252594 to 0.7329249548912048 in stress_tests/stress_test_dead_actors.json
REGRESSION 0.74%: 3000_returns_time (LATENCY) regresses from 5.791661208000008 to 5.834724514999991 in scalability/single_node.json
REGRESSION 0.63%: stage_2_avg_iteration_time (LATENCY) regresses from 38.96002230644226 to 39.20367703437805 in stress_tests/stress_test_many_tasks.json
```