### PR TITLE
[Data] Fixed `make_async_gen` util to provide deterministic ordering guarantees

### DIFF
--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -7,12 +7,13 @@ import sys
 import threading
 import time
 import urllib.parse
-from collections import deque
+from queue import Empty, Full, Queue
 from types import ModuleType
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Generator,
     Iterable,
     Iterator,
     List,
@@ -44,6 +45,9 @@ logger = logging.getLogger(__name__)
 KiB = 1024  # bytes
 MiB = 1024 * KiB
 GiB = 1024 * MiB
+
+
+SENTINEL = object()
 
 
 # NOTE: Make sure that these lower and upper bounds stay in sync with version
@@ -841,163 +845,267 @@ def get_attribute_from_class_name(class_name: str) -> Any:
     return getattr(import_module(module_name), attribute_name)
 
 
-class Queue:
-    """A thread-safe queue implementation for multiple producers and consumers.
-
-    Provide `release()` to exit producer threads cooperatively for resource release.
-    """
-
-    def __init__(self, queue_size: int):
-        # The queue shared across multiple producer threads.
-        self._queue = deque()
-        # The boolean varilable to indicate whether producer threads should exit.
-        self._threads_exit = False
-        # The semaphore for producer threads to put item into queue.
-        self._producer_semaphore = threading.Semaphore(queue_size)
-        # The semaphore for consumer threads to get item from queue.
-        self._consumer_semaphore = threading.Semaphore(0)
-        # The mutex lock to guard access of `self._queue` and `self._threads_exit`.
-        self._mutex = threading.Lock()
-
-    def put(self, item: Any) -> bool:
-        """Put an item into the queue.
-
-        Block if necessary until a free slot is available in queue.
-        This method is called by producer threads.
-
-        Returns:
-            True if the caller thread should exit immediately.
-        """
-        self._producer_semaphore.acquire()
-        with self._mutex:
-            if self._threads_exit:
-                return True
-            else:
-                self._queue.append(item)
-        self._consumer_semaphore.release()
-        return False
-
-    def get(self) -> Any:
-        """Remove and return an item from the queue.
-
-        Block if necessary until an item is available in queue.
-        This method is called by consumer threads.
-        """
-        self._consumer_semaphore.acquire()
-        with self._mutex:
-            next_item = self._queue.popleft()
-        self._producer_semaphore.release()
-        return next_item
-
-    def release(self, num_threads: int):
-        """Release `num_threads` of producers so they would exit cooperatively."""
-        with self._mutex:
-            self._threads_exit = True
-        for _ in range(num_threads):
-            # NOTE: After Python 3.9+, Semaphore.release(n) can be used to
-            # release all threads at once.
-            self._producer_semaphore.release()
-
-    def qsize(self):
-        """Return the size of the queue."""
-        with self._mutex:
-            return len(self._queue)
-
-
 T = TypeVar("T")
 U = TypeVar("U")
+
+
+class _InterruptibleQueue(Queue):
+    """Extension of Python's `queue.Queue` providing ability to get interrupt its
+    method callers in other threads"""
+
+    INTERRUPTION_CHECK_FREQUENCY_SEC = 0.5
+
+    def __init__(
+        self, max_size: int, interrupted_event: Optional[threading.Event] = None
+    ):
+        super().__init__(maxsize=max_size)
+        self._interrupted_event = interrupted_event or threading.Event()
+
+    def get(self, block=True, timeout=None):
+        if not block or timeout is not None:
+            return super().get(block, timeout)
+
+        # In case when the call is blocking and no timeout is specified (ie blocking
+        # indefinitely) we apply the following protocol to make it interruptible:
+        #
+        #   1. `Queue.get` is invoked w/ 500ms timeout
+        #   2. `Empty` exception is intercepted (will be raised upon timeout elapsing)
+        #   3. If interrupted flag is set `InterruptedError` is raised
+        #   4. Otherwise, protocol retried (until interrupted or queue
+        #      becoming non-empty)
+        while True:
+            if self._interrupted_event.is_set():
+                raise InterruptedError()
+
+            try:
+                return super().get(
+                    block=True, timeout=self.INTERRUPTION_CHECK_FREQUENCY_SEC
+                )
+            except Empty:
+                pass
+
+    def put(self, item, block=True, timeout=None):
+        if not block or timeout is not None:
+            super().put(item, block, timeout)
+            return
+
+        # In case when the call is blocking and no timeout is specified (ie blocking
+        # indefinitely) we apply the following protocol to make it interruptible:
+        #
+        #   1. `Queue.pet` is invoked w/ 500ms timeout
+        #   2. `Full` exception is intercepted (will be raised upon timeout elapsing)
+        #   3. If interrupted flag is set `InterruptedError` is raised
+        #   4. Otherwise, protocol retried (until interrupted or queue
+        #      becomes non-full)
+        while True:
+            if self._interrupted_event.is_set():
+                raise InterruptedError()
+
+            try:
+                super().put(
+                    item, block=True, timeout=self.INTERRUPTION_CHECK_FREQUENCY_SEC
+                )
+                return
+            except Full:
+                pass
 
 
 def make_async_gen(
     base_iterator: Iterator[T],
     fn: Callable[[Iterator[T]], Iterator[U]],
     num_workers: int = 1,
-) -> Iterator[U]:
-    """Returns a new iterator with elements fetched from the base_iterator
-    in an async fashion using a threadpool.
+    queue_buffer_size: int = 2,
+) -> Generator[U, None, None]:
 
-    Each thread in the threadpool will fetch data from the base_iterator in a
-    thread-safe fashion, and apply the provided `fn` computation concurrently.
+    gen_id = random.randint(0, 2**31 - 1)
+
+    """Returns a generator (iterator) mapping items from the
+    provided iterator applying provided transformation in parallel (using a
+    thread-pool).
+
+    NOTE: Even though the mapping is performed in parallel across N
+          threads, this method provides crucial guarantee of preserving the
+          ordering of the source iterator, ie that
+
+            iterator = [A1, A2, ... An]
+            mapped iterator = [map(A1), map(A2), ..., map(An)]
+
+          Preserving ordering is crucial to eliminate non-determinism in producing
+          content of the blocks.
 
     Args:
-        base_iterator: The iterator to asynchronously fetch from.
-        fn: The function to run on the input iterator.
-        num_workers: The number of threads to use in the threadpool. Defaults to 1.
+        base_iterator: Iterator yielding elements to map
+        fn: Transformation to apply to each element
+        num_workers: The number of threads to use in the threadpool (defaults to 1)
+        buffer_size: Number of objects to be buffered in its input/output
+                     queues (per queue; defaults to 2). Total number of objects held
+                     in memory could be calculated as:
+
+                        num_workers * buffer_size * 2 (input and output)
 
     Returns:
-        An iterator with the same elements as outputted from `fn`.
+        An generator (iterator) of the elements corresponding to the source
+        elements mapped by provided transformation (while *preserving the ordering*)
     """
 
     if num_workers < 1:
         raise ValueError("Size of threadpool must be at least 1.")
 
-    # Use a lock to fetch from the base_iterator in a thread-safe fashion.
-    def convert_to_threadsafe_iterator(base_iterator: Iterator[T]) -> Iterator[T]:
-        class ThreadSafeIterator:
-            def __init__(self, it):
-                self.lock = threading.Lock()
-                self.it = it
+    # To apply transformations to elements in parallel *and* preserve the ordering
+    # following invariants are established:
+    #   - Every worker is handled by standalone thread
+    #   - Every worker is assigned an input and an output queue
+    #
+    # And following protocol is implemented:
+    #   - Filling worker traverses input iterator round-robin'ing elements across
+    #     the input queues (in order!)
+    #   - Transforming workers traverse respective input queue in-order: de-queueing
+    #     element, applying transformation and enqueuing the result into the output
+    #     queue
+    #   - Generator (returned from this method) traverses output queues (in the same
+    #     order as input queues) dequeues 1 mapped element at a time from each output
+    #     queue and yields it
+    #
+    # Signal handler used to interrupt workers when terminating
+    interrupted_event = threading.Event()
 
-            def __next__(self):
-                with self.lock:
-                    return next(self.it)
-
-            def __iter__(self):
-                return self
-
-        return ThreadSafeIterator(base_iterator)
-
-    thread_safe_generator = convert_to_threadsafe_iterator(base_iterator)
-
-    class Sentinel:
-        def __init__(self, thread_index: int):
-            self.thread_index = thread_index
-
-    output_queue = Queue(1)
-
-    # Because pulling from the base iterator cannot happen concurrently,
-    # we must execute the expensive computation in a separate step which
-    # can be parallelized via a threadpool.
-    def execute_computation(thread_index: int):
-        try:
-            for item in fn(thread_safe_generator):
-                if output_queue.put(item):
-                    # Return early when it's instructed to do so.
-                    return
-            output_queue.put(Sentinel(thread_index))
-        except Exception as e:
-            output_queue.put(e)
-
-    # Use separate threads to produce output batches.
-    threads = [
-        threading.Thread(target=execute_computation, args=(i,), daemon=True)
-        for i in range(num_workers)
+    input_queues = [
+        _InterruptibleQueue(queue_buffer_size, interrupted_event)
+        for _ in range(num_workers)
+    ]
+    output_queues = [
+        _InterruptibleQueue(queue_buffer_size, interrupted_event)
+        for _ in range(num_workers)
     ]
 
-    for thread in threads:
-        thread.start()
+    # Filling worker
+    def _run_filling_worker():
+        try:
+            # First, round-robin elements from the iterator into
+            # corresponding input queues (one by one)
+            for idx, item in enumerate(base_iterator):
+                input_queues[idx % num_workers].put(item)
 
-    # Use main thread to consume output batches.
-    num_threads_finished = 0
+            # Enqueue sentinel objects to signal end of the line
+            for idx in range(num_workers):
+                input_queues[idx].put(SENTINEL)
+
+        except InterruptedError:
+            pass
+
+        except Exception as e:
+            logger.warning("Caught exception in filling worker!", exc_info=e)
+            # In case of filling worker encountering an exception we have to propagate
+            # it back to the (main) iterating thread. To achieve that we're traversing
+            # output queues *backwards* relative to the order of iterator-thread such
+            # that they are more likely to meet w/in a single iteration.
+            for output_queue in reversed(output_queues):
+                output_queue.put(e)
+
+    # Transforming worker
+    def _run_transforming_worker(worker_id: int):
+        input_queue = input_queues[worker_id]
+        output_queue = output_queues[worker_id]
+
+        try:
+            # Create iterator draining the queue, until it receives sentinel
+            #
+            # NOTE: `queue.get` is blocking!
+            input_queue_iter = iter(input_queue.get, SENTINEL)
+
+            mapped_iter = fn(input_queue_iter)
+            for result in mapped_iter:
+                # Enqueue result of the transformation
+                output_queue.put(result)
+
+            # Enqueue sentinel (to signal that transformations are completed)
+            output_queue.put(SENTINEL)
+
+        except InterruptedError:
+            pass
+
+        except Exception as e:
+            logger.warning("Caught exception in transforming worker!", exc_info=e)
+            # NOTE: In this case we simply enqueue the exception rather than
+            #       interrupting
+            output_queue.put(e)
+
+    # Start workers threads
+    filling_worker_thread = threading.Thread(
+        target=_run_filling_worker,
+        name=f"map_tp_filling_worker-{gen_id}",
+        daemon=True,
+    )
+    filling_worker_thread.start()
+
+    transforming_worker_threads = [
+        threading.Thread(
+            target=_run_transforming_worker,
+            name=f"map_tp_transforming_worker-{gen_id}-{worker_idx}",
+            args=(worker_idx,),
+            daemon=True,
+        )
+        for worker_idx in range(num_workers)
+    ]
+
+    for t in transforming_worker_threads:
+        t.start()
+
+    # Use main thread to yield output batches
     try:
-        while True:
-            next_item = output_queue.get()
-            if isinstance(next_item, Exception):
-                raise next_item
-            if isinstance(next_item, Sentinel):
-                num_threads_finished += 1
-            else:
-                yield next_item
-            if num_threads_finished >= num_workers:
-                break
+        # Keep track of remaining non-empty output queues
+        remaining_output_queues = output_queues
+
+        while len(remaining_output_queues) > 0:
+            # To provide deterministic ordering of the produced iterator we rely
+            # on the following invariants:
+            #
+            #   - Elements from the original iterator are round-robin'd into
+            #     input queues (in order)
+            #   - Individual workers drain their respective input queues populating
+            #     output queues with the results of applying transformation to the
+            #     original item (and hence preserving original ordering of the input
+            #     queue)
+            #   - To yield from the generator output queues are traversed in the same
+            #     order and one single element is dequeued (in a blocking way!) at a
+            #     time from every individual output queue
+            #
+            non_empty_queues = []
+            empty_queues = []
+
+            # At every iteration only remaining non-empty queues
+            # are traversed (to prevent blocking on exhausted queue)
+            for output_queue in remaining_output_queues:
+                # NOTE: This is blocking!
+                item = output_queue.get()
+
+                if isinstance(item, Exception):
+                    raise item
+
+                if item is SENTINEL:
+                    empty_queues.append(output_queue)
+                else:
+                    non_empty_queues.append(output_queue)
+                    yield item
+
+            assert (
+                non_empty_queues + empty_queues == remaining_output_queues
+            ), "Exhausted non-trailing queue!"
+
+            remaining_output_queues = non_empty_queues
+
     finally:
-        # Cooperatively exit all producer threads.
-        # This is to avoid these daemon threads hanging there with holding batches in
-        # memory, which can cause GRAM OOM easily. This can happen when caller breaks
-        # in the middle of iteration.
-        num_threads_alive = num_workers - num_threads_finished
-        if num_threads_alive > 0:
-            output_queue.release(num_threads_alive)
+        # Set flag to interrupt workers (to make sure no dangling
+        # threads holding the objects are left behind)
+        #
+        # NOTE: Interrupted event is set to interrupt the running threads
+        #       that might be blocked otherwise waiting on inputs from respective
+        #       queues. However, even though we're interrupting the threads we can't
+        #       guarantee that threads will be interrupted in time (as this is
+        #       dependent on Python's GC finalizer to close the generator by raising
+        #       `GeneratorExit`) and hence we can't join on either filling or
+        #       transforming workers.
+        interrupted_event.set()
 
 
 def call_with_retry(

--- a/python/ray/data/tests/block_batching/test_util.py
+++ b/python/ray/data/tests/block_batching/test_util.py
@@ -1,4 +1,4 @@
-import threading
+import logging
 import time
 
 import numpy as np
@@ -16,7 +16,7 @@ from ray.data._internal.block_batching.util import (
     format_batches,
     resolve_block_refs,
 )
-from ray.data._internal.util import Queue, make_async_gen
+from ray.data._internal.util import make_async_gen
 
 
 def block_generator(num_rows: int, num_blocks: int):
@@ -110,14 +110,19 @@ def test_finalize():
         assert batch.data == pa.table({"bar": [1] * 2})
 
 
-def test_make_async_gen_fail():
+@pytest.mark.parametrize("buffer_size", [0, 1, 2])
+def test_make_async_gen_fail(buffer_size: int):
     """Tests that any errors raised in async threads are propagated to the main
     thread."""
 
     def gen(base_iterator):
         raise ValueError("Fail")
 
-    iterator = make_async_gen(base_iterator=iter([1]), fn=gen)
+    iterator = make_async_gen(
+        base_iterator=iter([1]),
+        fn=gen,
+        queue_buffer_size=buffer_size,
+    )
 
     with pytest.raises(ValueError) as e:
         for _ in iterator:
@@ -126,22 +131,29 @@ def test_make_async_gen_fail():
     assert e.match("Fail")
 
 
-def test_make_async_gen():
+logger = logging.getLogger(__file__)
+
+
+@pytest.mark.parametrize("buffer_size", [0, 1, 2])
+def test_make_async_gen(buffer_size: int):
     """Tests that make_async_gen overlaps compute."""
 
-    num_items = 10
+    num_items = 5
 
     def gen(base_iterator):
         for i in base_iterator:
-            time.sleep(2)
+            time.sleep(1)
             yield i
 
     def sleep_udf(item):
-        time.sleep(3)
+        time.sleep(2)
         return item
 
     iterator = make_async_gen(
-        base_iterator=iter(range(num_items)), fn=gen, num_workers=1
+        base_iterator=iter(range(num_items)),
+        fn=gen,
+        num_workers=1,
+        queue_buffer_size=buffer_size,
     )
 
     start_time = time.time()
@@ -151,46 +163,58 @@ def test_make_async_gen():
         outputs.append(sleep_udf(item))
     end_time = time.time()
 
+    # Assert ordering is preserved
     assert outputs == list(range(num_items))
 
     # Three second buffer.
-    assert end_time - start_time < num_items * 3 + 3
+    assert end_time - start_time < num_items * 2 + 3
 
 
-def test_make_async_gen_multiple_threads():
+@pytest.mark.parametrize("buffer_size", [0, 1, 2])
+def test_make_async_gen_multiple_threads(buffer_size: int):
     """Tests that using multiple threads can overlap compute even more."""
 
     num_items = 5
 
+    gen_sleep = 2
+    iter_sleep = 3
+
     def gen(base_iterator):
         for i in base_iterator:
-            time.sleep(4)
+            time.sleep(gen_sleep)
             yield i
 
     def sleep_udf(item):
-        time.sleep(5)
+        time.sleep(iter_sleep)
         return item
 
     # All 5 items should be fetched concurrently.
     iterator = make_async_gen(
-        base_iterator=iter(range(num_items)), fn=gen, num_workers=5
+        base_iterator=iter(range(num_items)),
+        fn=gen,
+        num_workers=5,
+        queue_buffer_size=buffer_size,
     )
 
     start_time = time.time()
 
     # Only sleep for first item.
-    sleep_udf(next(iterator))
+    elements = [sleep_udf(next(iterator))] + list(iterator)
 
     # All subsequent items should already be prefetched and should be ready.
-    for _ in iterator:
-        pass
     end_time = time.time()
 
-    # 4 second for first item, 5 seconds for udf, 0.5 seconds buffer
-    assert end_time - start_time < 9.5
+    # Assert ordering is preserved
+    assert elements == list(range(num_items))
+
+    # - 2 second for every worker to handle their single element
+    # - 3 seconds for overlapping one
+    # - 0.5 seconds buffer
+    assert end_time - start_time < gen_sleep + iter_sleep + 0.5
 
 
-def test_make_async_gen_multiple_threads_unfinished():
+@pytest.mark.parametrize("buffer_size", [0, 1, 2])
+def test_make_async_gen_multiple_threads_unfinished(buffer_size: int):
     """Tests that using multiple threads can overlap compute even more.
     Do not finish iteration with break in the middle.
     """
@@ -208,7 +232,10 @@ def test_make_async_gen_multiple_threads_unfinished():
 
     # All 5 items should be fetched concurrently.
     iterator = make_async_gen(
-        base_iterator=iter(range(num_items)), fn=gen, num_workers=5
+        base_iterator=iter(range(num_items)),
+        fn=gen,
+        num_workers=5,
+        queue_buffer_size=buffer_size,
     )
 
     start_time = time.time()
@@ -224,50 +251,6 @@ def test_make_async_gen_multiple_threads_unfinished():
 
     # 4 second for first item, 5 seconds for udf, 0.5 seconds buffer
     assert end_time - start_time < 9.5
-
-
-def test_queue():
-    queue = Queue(5)
-    num_producers = 10
-    num_producers_finished = 0
-    num_items = 20
-
-    def execute_computation():
-        for item in range(num_items):
-            if queue.put(item):
-                # Return early when it's instructed to do so.
-                break
-        # Put -1 as indicator of thread being finished.
-        queue.put(-1)
-
-    # Use separate threads as producers.
-    threads = [
-        threading.Thread(target=execute_computation, daemon=True)
-        for _ in range(num_producers)
-    ]
-
-    for thread in threads:
-        thread.start()
-
-    for i in range(num_producers * num_items):
-        item = queue.get()
-        if item == -1:
-            num_producers_finished += 1
-        if i > num_producers * num_items / 2:
-            num_producers_alive = num_producers - num_producers_finished
-            # Check there are some alive producers.
-            assert num_producers_alive > 0, num_producers_alive
-            # Release the alive producers.
-            queue.release(num_producers_alive)
-            # Consume the remaining items in queue.
-            while queue.qsize() > 0:
-                queue.get()
-            break
-
-    # Sleep 5 seconds to allow producer threads to exit.
-    time.sleep(5)
-    # Then check the queue is still empty.
-    assert queue.qsize() == 0
 
 
 def test_calculate_ref_hits(ray_start_regular_shared):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Fixing `make_async_gen` util to provide deterministic ordering guarantees which is crucial for our ability to rely on lineage reconstruction for reconstructing lost blocks.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
