### PR TITLE
[core][compiled graphs] Remove microbenchmark unstable

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2732,56 +2732,6 @@
       frequency: weekly
       python: "3.12"
 
-- name: microbenchmark_unstable
-  group: core-daily-test
-  team: core
-  frequency: nightly
-  working_dir: microbenchmark
-
-  stable: false
-
-  cluster:
-    byod: {}
-    cluster_compute: tpl_64.yaml
-
-  run:
-    timeout: 1800
-    script: OMP_NUM_THREADS=64 RAY_ADDRESS=local python run_microbenchmark.py --experimental
-
-- name: microbenchmark_gpu_unstable
-  group: core-daily-test
-  team: core
-  frequency: nightly
-  working_dir: microbenchmark
-
-  stable: false
-
-  cluster:
-    byod:
-      type: gpu
-    cluster_compute: experimental/compute_gpu_2_aws.yaml
-
-  run:
-    timeout: 1800
-    script: python experimental/accelerated_dag_gpu_microbenchmark.py
-
-- name: microbenchmark_gpu_multinode_unstable
-  group: core-daily-test
-  team: core
-  frequency: nightly
-  working_dir: microbenchmark
-
-  stable: false
-
-  cluster:
-    byod:
-      type: gpu
-    cluster_compute: experimental/compute_gpu_2x1_aws.yaml
-
-  run:
-    timeout: 1800
-    script: python experimental/accelerated_dag_gpu_microbenchmark.py --distributed
-
 - name: compiled_graphs
   group: core-daily-test
   team: core


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Clean up the "Microbenchmark unstable" benchmarks: these are basically used for Compiled Graphs.
And we have already set up compiled graphs microbenchmarks the run the same tests.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
