### PR TITLE
repro

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2725,3 +2725,11 @@ genrule(
     """,
     local = 1,
 )
+
+ray_cc_binary(
+    name = "pipe",
+    srcs = ["pipe.cc"],
+    deps = [
+        "@boost//:iostreams",
+    ],
+)

--- a/pipe.cc
+++ b/pipe.cc
@@ -1,0 +1,3 @@
+#include <boost/iostreams/device/file_descriptor.hpp>
+
+int main() { return 0; }

--- a/src/ray/util/BUILD
+++ b/src/ray/util/BUILD
@@ -83,6 +83,7 @@ ray_cc_library(
     deps = [
         ":compat",
         ":util",
+        "@boost//:iostreams",
         "@com_github_spdlog//:spdlog",
         "@com_google_absl//absl/strings",
     ],

--- a/src/ray/util/pipe/pipe.cc
+++ b/src/ray/util/pipe/pipe.cc
@@ -1,0 +1,3 @@
+#include <boost/iostreams/device/file_descriptor.hpp>
+
+int main() { return 0; }


### PR DESCRIPTION
```
bazel build //src/ray/util/tests:pipe_logger_test

src/ray/util/pipe_logger.cc:17:10: fatal error: 'boost/iostreams/device/file_descriptor.hpp' file not found
#include <boost/iostreams/device/file_descriptor.hpp>
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```