### PR TITLE
Fix complex (dict) observation concatenation in single agent episode

### DIFF
--- a/rllib/env/single_agent_episode.py
+++ b/rllib/env/single_agent_episode.py
@@ -14,6 +14,7 @@ from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.utils.serialization import gym_space_from_dict, gym_space_to_dict
 from ray.rllib.utils.typing import AgentID, ModuleID
 from ray.util.annotations import PublicAPI
+from ray.rllib.utils.test_utils import check
 
 
 @PublicAPI(stability="alpha")
@@ -611,7 +612,10 @@ class SingleAgentEpisode:
         other.validate()
 
         # Make sure, end matches other episode chunk's beginning.
-        assert np.all(other.observations[0] == self.observations[-1])
+        if isinstance(self.observation_space, gym.spaces.Dict):
+            check(other.observations[0], self.observations[-1])
+        else:
+            assert np.all(other.observations[0] == self.observations[-1])
         # Pop out our last observations and infos (as these are identical
         # to the first obs and infos in the next episode).
         self.observations.pop()

--- a/rllib/env/utils/infinite_lookback_buffer.py
+++ b/rllib/env/utils/infinite_lookback_buffer.py
@@ -123,7 +123,7 @@ class InfiniteLookbackBuffer:
             #  probably rather do: `tree.map_structure(..., self.data,
             #  tree.map_structure(lambda *s: np.array(*s), *items)`)??
             self.data = tree.map_structure(
-                lambda d, i: np.concatenate([d, i], axis=0), self.data, np.array(items)
+                lambda d, i: np.concatenate([d, i], axis=0), self.data, items
             )
         else:
             for item in items:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When using an environment with complex observations (dictionary) with RLlib DQN, Single Agent Episode (used by default) does not seem to support dictionaries.

## Related issue number

#49916 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
