### PR TITLE
[Refactor] Fix ruff rule E721: type-comparison

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ ignore = [
     # TODO(MortalHappiness): Remove the following rules from the ignore list
     # The above are rules ignored originally in flake8
     # The following are rules ignored in ruff
-    "E721",
     "F841",
     "B018",
     "B023",

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1627,7 +1627,7 @@ def start_raylet(
     Returns:
         ProcessInfo for the process that was started.
     """
-    assert node_manager_port is not None and type(node_manager_port) == int
+    assert node_manager_port is not None and type(node_manager_port) is int
 
     if use_valgrind and use_profiler:
         raise ValueError("Cannot use valgrind and profiler at the same time.")

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -868,7 +868,7 @@ def wait_until_succeeded_without_exception(
     Return:
         Whether exception occurs within a timeout.
     """
-    if type(exceptions) != tuple:
+    if isinstance(type(exceptions), tuple):
         raise Exception("exceptions arguments should be given as a tuple")
 
     time_elapsed = 0

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -1065,7 +1065,7 @@ class CompiledDAG:
                         "the driver cannot participate in the NCCL group"
                     )
 
-            if type(dag_node.type_hint) == ChannelOutputType:
+            if type(dag_node.type_hint) is ChannelOutputType:
                 # No type hint specified by the user. Replace
                 # with the default type hint for this DAG.
                 dag_node.with_type_hint(self._default_type_hint)
@@ -2593,16 +2593,16 @@ class CompiledDAG:
         if channel in self._channel_dict and self._channel_dict[channel] != channel:
             channel = self._channel_dict[channel]
             channel_details += f"\n{type(channel).__name__}"
-            if type(channel) == CachedChannel:
+            if type(channel) is CachedChannel:
                 channel_details += f", {channel._channel_id[:6]}..."
         # get inner channel
         if (
-            type(channel) == CompositeChannel
+            type(channel) is CompositeChannel
             and downstream_actor_id in channel._channel_dict
         ):
             inner_channel = channel._channel_dict[downstream_actor_id]
             channel_details += f"\n{type(inner_channel).__name__}"
-            if type(inner_channel) == IntraProcessChannel:
+            if type(inner_channel) is IntraProcessChannel:
                 channel_details += f", {inner_channel._channel_id[:6]}..."
         return channel_details
 
@@ -2766,7 +2766,7 @@ class CompiledDAG:
                             task.output_channels[0],
                             (
                                 downstream_node._get_actor_handle()._actor_id.hex()
-                                if type(downstream_node) == ClassMethodNode
+                                if type(downstream_node) is ClassMethodNode
                                 else self._proxy_actor._actor_id.hex()
                             ),
                         )
@@ -2784,7 +2784,7 @@ class CompiledDAG:
                             task.dag_node._get_actor_handle()._actor_id.hex(),
                         )
                     dot.edge(str(idx), str(downstream_idx), label=edge_label)
-            if type(task.dag_node) == InputAttributeNode:
+            if type(task.dag_node) is InputAttributeNode:
                 # Add an edge from the InputAttributeNode to the InputNode
                 dot.edge(str(self.input_task_idx), str(idx))
         dot.render(filename, view=view)

--- a/python/ray/dashboard/tests/test_dashboard.py
+++ b/python/ray/dashboard/tests/test_dashboard.py
@@ -787,7 +787,7 @@ def test_immutable_types():
     d["list"][0] = {str(i): i for i in range(1000)}
     d["dict"] = {str(i): i for i in range(1000)}
     immutable_dict = dashboard_utils.make_immutable(d)
-    assert type(immutable_dict) == dashboard_utils.ImmutableDict
+    assert type(immutable_dict) is dashboard_utils.ImmutableDict
     assert immutable_dict == dashboard_utils.ImmutableDict(d)
     assert immutable_dict == d
     assert dashboard_utils.ImmutableDict(immutable_dict) == immutable_dict
@@ -799,14 +799,14 @@ def test_immutable_types():
     assert "512" in d["dict"]
 
     # Test type conversion
-    assert type(dict(immutable_dict)["list"]) == dashboard_utils.ImmutableList
-    assert type(list(immutable_dict["list"])[0]) == dashboard_utils.ImmutableDict
+    assert type(dict(immutable_dict)["list"]) is dashboard_utils.ImmutableList
+    assert type(list(immutable_dict["list"])[0]) is dashboard_utils.ImmutableDict
 
     # Test json dumps / loads
     json_str = json.dumps(immutable_dict, cls=dashboard_optional_utils.CustomEncoder)
     deserialized_immutable_dict = json.loads(json_str)
-    assert type(deserialized_immutable_dict) == dict
-    assert type(deserialized_immutable_dict["list"]) == list
+    assert type(deserialized_immutable_dict) is dict
+    assert type(deserialized_immutable_dict["list"]) is list
     assert immutable_dict.mutable() == deserialized_immutable_dict
     dashboard_optional_utils.rest_response(True, "OK", data=immutable_dict)
     dashboard_optional_utils.rest_response(True, "OK", **immutable_dict)
@@ -819,12 +819,12 @@ def test_immutable_types():
 
     # Test get default immutable
     immutable_default_value = immutable_dict.get("not exist list", [1, 2])
-    assert type(immutable_default_value) == dashboard_utils.ImmutableList
+    assert type(immutable_default_value) is dashboard_utils.ImmutableList
 
     # Test recursive immutable
-    assert type(immutable_dict["list"]) == dashboard_utils.ImmutableList
-    assert type(immutable_dict["dict"]) == dashboard_utils.ImmutableDict
-    assert type(immutable_dict["list"][0]) == dashboard_utils.ImmutableDict
+    assert type(immutable_dict["list"]) is dashboard_utils.ImmutableList
+    assert type(immutable_dict["dict"]) is dashboard_utils.ImmutableDict
+    assert type(immutable_dict["list"][0]) is dashboard_utils.ImmutableDict
 
     # Test exception
     with pytest.raises(TypeError):

--- a/python/ray/data/_internal/datasource/tfrecords_datasource.py
+++ b/python/ray/data/_internal/datasource/tfrecords_datasource.py
@@ -355,7 +355,7 @@ def _cast_large_list_to_list(batch: pyarrow.Table):
 
     for column_name in old_schema.names:
         field_type = old_schema.field(column_name).type
-        if type(field_type) == pyarrow.lib.LargeListType:
+        if type(field_type) is pyarrow.lib.LargeListType:
             value_type = field_type.value_type
 
             if value_type == pyarrow.large_binary():

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -1442,7 +1442,7 @@ def test_map_batches_preserves_empty_block_format(ray_start_regular_shared):
     block_refs = _ref_bundles_iterator_to_block_refs_list(bundles)
 
     assert len(block_refs) == 1
-    assert type(ray.get(block_refs[0])) == pd.DataFrame
+    assert type(ray.get(block_refs[0])) is pd.DataFrame
 
 
 def test_map_with_objects_and_tensors(ray_start_regular_shared):

--- a/python/ray/data/tests/test_numpy_support.py
+++ b/python/ray/data/tests/test_numpy_support.py
@@ -24,7 +24,7 @@ def do_map_batches(data):
 
 
 def assert_structure_equals(a, b):
-    assert type(a) == type(b), (type(a), type(b))
+    assert type(a) is type(b), (type(a), type(b))
     assert type(a[0]) == type(b[0]), (type(a[0]), type(b[0]))  # noqa: E721
     assert a.dtype == b.dtype
     assert a.shape == b.shape

--- a/python/ray/serve/multiplex.py
+++ b/python/ray/serve/multiplex.py
@@ -173,7 +173,7 @@ class _ModelMultiplexWrapper:
             The user-constructed model object.
         """
 
-        if type(model_id) != str:
+        if type(model_id) is not str:
             raise TypeError("The model ID must be a string.")
 
         if not model_id:

--- a/python/ray/tests/gcp/test_gcp_tpu_command_runner.py
+++ b/python/ray/tests/gcp/test_gcp_tpu_command_runner.py
@@ -242,7 +242,7 @@ def test_max_active_connections_env_var():
     cmd_runner = TPUCommandRunner(**args)
     os.environ[ray_constants.RAY_TPU_MAX_CONCURRENT_CONNECTIONS_ENV_VAR] = "1"
     num_connections = cmd_runner.num_connections
-    assert type(num_connections) == int
+    assert type(num_connections) is int
     assert num_connections == 1
 
 

--- a/python/ray/tests/modin/modin_test_utils.py
+++ b/python/ray/tests/modin/modin_test_utils.py
@@ -105,7 +105,7 @@ def df_equals(df1, df2):
     if isinstance(df1, pandas.DataFrame) and isinstance(df2, pandas.DataFrame):
         if (df1.empty and not df2.empty) or (df2.empty and not df1.empty):
             assert False, "One of the passed frames is empty, when other isn't"
-        elif df1.empty and df2.empty and type(df1) != type(df2):
+        elif df1.empty and df2.empty and type(df1) is not type(df2):
             assert (
                 False
             ), f"Empty frames have different types: {type(df1)} != {type(df2)}"

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -866,9 +866,9 @@ def test_passing_arguments_by_value_out_of_the_box(ray_start_shared_local_modes)
     assert ray.get(f.remote(s)) == s
 
     # Test types.
-    assert ray.get(f.remote(int)) == int
-    assert ray.get(f.remote(float)) == float
-    assert ray.get(f.remote(str)) == str
+    assert ray.get(f.remote(int)) is int
+    assert ray.get(f.remote(float)) is float
+    assert ray.get(f.remote(str)) is str
 
     class Foo:
         def __init__(self):

--- a/python/ray/tests/test_client_builder.py
+++ b/python/ray/tests/test_client_builder.py
@@ -51,7 +51,7 @@ def test_client(address):
     if address in ("local", None):
         assert isinstance(builder, client_builder._LocalClientBuilder)
     else:
-        assert type(builder) == client_builder.ClientBuilder
+        assert type(builder) is client_builder.ClientBuilder
         assert builder.address == address.replace("ray://", "")
 
 

--- a/python/ray/tests/test_joblib.py
+++ b/python/ray/tests/test_joblib.py
@@ -36,7 +36,7 @@ def test_ray_backend(shutdown_only):
     from ray.util.joblib.ray_backend import RayBackend
 
     with joblib.parallel_backend("ray"):
-        assert type(joblib.parallel.get_active_backend()[0]) == RayBackend
+        assert type(joblib.parallel.get_active_backend()[0]) is RayBackend
 
 
 def test_svm_single_node(shutdown_only):

--- a/python/ray/tests/test_serialization.py
+++ b/python/ray/tests/test_serialization.py
@@ -23,12 +23,12 @@ logger = logging.getLogger(__name__)
 def is_named_tuple(cls):
     """Return True if cls is a namedtuple and False otherwise."""
     b = cls.__bases__
-    if len(b) != 1 or b[0] != tuple:
+    if len(b) != 1 or b[0] is not tuple:
         return False
     f = getattr(cls, "_fields", None)
     if not isinstance(f, tuple):
         return False
-    return all(type(n) == str for n in f)
+    return all(type(n) is str for n in f)
 
 
 @pytest.mark.parametrize(
@@ -95,8 +95,8 @@ def test_simple_serialization(ray_start_regular):
         # TODO(rkn): The numpy dtypes currently come back as regular integers
         # or floats.
         if type(obj).__module__ != "numpy":
-            assert type(obj) == type(new_obj_1)
-            assert type(obj) == type(new_obj_2)
+            assert type(obj) is type(new_obj_1)
+            assert type(obj) is type(new_obj_2)
 
 
 @pytest.mark.parametrize(

--- a/python/ray/tune/tests/test_sample.py
+++ b/python/ray/tune/tests/test_sample.py
@@ -29,7 +29,7 @@ def assertDictAlmostEqual(a, b):
         assert k in b, f"Key {k} not found in {b}"
         w = b[k]
 
-        assert type(v) == type(w), f"Type {type(v)} is not {type(w)}"
+        assert type(v) is type(w), f"Type {type(v)} is not {type(w)}"
 
         if isinstance(v, dict):
             assert assertDictAlmostEqual(v, w), f"Subdict {v} != {w}"

--- a/rllib/connectors/action/pipeline.py
+++ b/rllib/connectors/action/pipeline.py
@@ -45,7 +45,7 @@ class ActionConnectorPipeline(ConnectorPipeline, ActionConnector):
     @staticmethod
     def from_state(ctx: ConnectorContext, params: Any):
         assert (
-            type(params) == list
+            type(params) is list
         ), "ActionConnectorPipeline takes a list of connector params."
         connectors = []
         for state in params:

--- a/rllib/connectors/agent/clip_reward.py
+++ b/rllib/connectors/agent/clip_reward.py
@@ -25,7 +25,7 @@ class ClipRewardAgentConnector(AgentConnector):
     def transform(self, ac_data: AgentConnectorDataType) -> AgentConnectorDataType:
         d = ac_data.data
         assert (
-            type(d) == dict
+            type(d) is dict
         ), "Single agent data must be of type Dict[str, TensorStructType]"
 
         if SampleBatch.REWARDS not in d:

--- a/rllib/connectors/agent/mean_std_filter.py
+++ b/rllib/connectors/agent/mean_std_filter.py
@@ -52,7 +52,7 @@ class MeanStdObservationFilterAgentConnector(SyncedFilterAgentConnector):
     def transform(self, ac_data: AgentConnectorDataType) -> AgentConnectorDataType:
         d = ac_data.data
         assert (
-            type(d) == dict
+            type(d) is dict
         ), "Single agent data must be of type Dict[str, TensorStructType]"
         if SampleBatch.OBS in d:
             d[SampleBatch.OBS] = self.filter(

--- a/rllib/connectors/agent/obs_preproc.py
+++ b/rllib/connectors/agent/obs_preproc.py
@@ -44,7 +44,7 @@ class ObsPreprocessorConnector(AgentConnector):
 
     def transform(self, ac_data: AgentConnectorDataType) -> AgentConnectorDataType:
         d = ac_data.data
-        assert type(d) == dict, (
+        assert type(d) is dict, (
             "Single agent data must be of type Dict[str, TensorStructType] but is of "
             "type {}".format(type(d))
         )

--- a/rllib/connectors/agent/pipeline.py
+++ b/rllib/connectors/agent/pipeline.py
@@ -56,7 +56,7 @@ class AgentConnectorPipeline(ConnectorPipeline, AgentConnector):
     @staticmethod
     def from_state(ctx: ConnectorContext, params: List[Any]):
         assert (
-            type(params) == list
+            type(params) is list
         ), "AgentConnectorPipeline takes a list of connector params."
         connectors = []
         for state in params:

--- a/rllib/connectors/util.py
+++ b/rllib/connectors/util.py
@@ -54,7 +54,7 @@ def get_agent_connectors_from_config(
     clip_rewards = __clip_rewards(config)
     if clip_rewards is True:
         connectors.append(ClipRewardAgentConnector(ctx, sign=True))
-    elif type(clip_rewards) == float:
+    elif type(clip_rewards) is float:
         connectors.append(ClipRewardAgentConnector(ctx, limit=abs(clip_rewards)))
 
     if __preprocessing_enabled(config):

--- a/rllib/env/wrappers/dm_control_wrapper.py
+++ b/rllib/env/wrappers/dm_control_wrapper.py
@@ -47,10 +47,10 @@ def _spec_to_box(spec):
     def extract_min_max(s):
         assert s.dtype == np.float64 or s.dtype == np.float32
         dim = np.int_(np.prod(s.shape))
-        if type(s) == specs.Array:
+        if type(s) is specs.Array:
             bound = np.inf * np.ones(dim, dtype=np.float32)
             return -bound, bound
-        elif type(s) == specs.BoundedArray:
+        elif type(s) is specs.BoundedArray:
             zeros = np.zeros(dim, dtype=np.float32)
             return s.minimum + zeros, s.maximum + zeros
 

--- a/rllib/utils/replay_buffers/tests/test_multi_agent_mixin_replay_buffer.py
+++ b/rllib/utils/replay_buffers/tests/test_multi_agent_mixin_replay_buffer.py
@@ -63,7 +63,7 @@ class TestMixInMultiAgentReplayBuffer(unittest.TestCase):
         for _ in range(20):
             buffer.add(batch)
             sample = buffer.sample(2)
-            assert type(sample) == MultiAgentBatch
+            assert type(sample) is MultiAgentBatch
             results.append(len(sample.policy_batches[DEFAULT_POLICY_ID]))
         # One sample in the episode does not belong the the episode on thus
         # gets dropped. Full episodes are of length two.
@@ -88,7 +88,7 @@ class TestMixInMultiAgentReplayBuffer(unittest.TestCase):
         for _ in range(400):
             buffer.add(batch)
             sample = buffer.sample(10)
-            assert type(sample) == MultiAgentBatch
+            assert type(sample) is MultiAgentBatch
             results.append(len(sample.policy_batches[DEFAULT_POLICY_ID]))
         self.assertAlmostEqual(np.mean(results), 2 * len(batch), delta=0.1)
 
@@ -113,7 +113,7 @@ class TestMixInMultiAgentReplayBuffer(unittest.TestCase):
             buffer.add(batch)
             buffer.add(batch)
             sample = buffer.sample(3)
-            assert type(sample) == MultiAgentBatch
+            assert type(sample) is MultiAgentBatch
             results.append(len(sample.policy_batches[DEFAULT_POLICY_ID]))
         self.assertAlmostEqual(np.mean(results), 3.0, delta=0.2)
 
@@ -125,7 +125,7 @@ class TestMixInMultiAgentReplayBuffer(unittest.TestCase):
         for _ in range(100):
             buffer.add(batch)
             sample = buffer.sample(5)
-            assert type(sample) == MultiAgentBatch
+            assert type(sample) is MultiAgentBatch
             results.append(len(sample.policy_batches[DEFAULT_POLICY_ID]))
         self.assertAlmostEqual(np.mean(results), 1.5, delta=0.2)
 
@@ -142,7 +142,7 @@ class TestMixInMultiAgentReplayBuffer(unittest.TestCase):
         for _ in range(100):
             buffer.add(batch)
             sample = buffer.sample(10)
-            assert type(sample) == MultiAgentBatch
+            assert type(sample) is MultiAgentBatch
             results.append(len(sample.policy_batches[DEFAULT_POLICY_ID]))
         self.assertAlmostEqual(np.mean(results), 10.0, delta=0.2)
 
@@ -156,12 +156,12 @@ class TestMixInMultiAgentReplayBuffer(unittest.TestCase):
         buffer.add(batch)
         # Expect exactly 1 batch to be returned.
         sample = buffer.sample(1)
-        assert type(sample) == MultiAgentBatch
+        assert type(sample) is MultiAgentBatch
         self.assertTrue(len(sample) == 1)
         # Expect exactly 0 sample to be returned (nothing new to be returned;
         # no replay allowed (replay_ratio=0.0)).
         sample = buffer.sample(1)
-        assert type(sample) == MultiAgentBatch
+        assert type(sample) is MultiAgentBatch
         assert len(sample.policy_batches) == 0
         # If we insert and replay n times, expect roughly return batches of
         # len 1 (replay_ratio=0.0 -> 0% replayed samples -> 1 new and 0 old samples
@@ -170,7 +170,7 @@ class TestMixInMultiAgentReplayBuffer(unittest.TestCase):
         for _ in range(100):
             buffer.add(batch)
             sample = buffer.sample(1)
-            assert type(sample) == MultiAgentBatch
+            assert type(sample) is MultiAgentBatch
             results.append(len(sample.policy_batches[DEFAULT_POLICY_ID]))
         self.assertAlmostEqual(np.mean(results), 1.0, delta=0.2)
 
@@ -187,11 +187,11 @@ class TestMixInMultiAgentReplayBuffer(unittest.TestCase):
         buffer.add(batch)
         # Expect exactly 1 sample to be returned (the new batch).
         sample = buffer.sample(1)
-        assert type(sample) == MultiAgentBatch
+        assert type(sample) is MultiAgentBatch
         self.assertTrue(len(sample) == 1)
         # Another replay -> Expect exactly 1 sample to be returned.
         sample = buffer.sample(1)
-        assert type(sample) == MultiAgentBatch
+        assert type(sample) is MultiAgentBatch
         self.assertTrue(len(sample) == 1)
         # If we replay n times, expect roughly return batches of
         # len 1 (replay_ratio=1.0 -> 100% replayed samples -> 0 new and 1 old samples
@@ -199,7 +199,7 @@ class TestMixInMultiAgentReplayBuffer(unittest.TestCase):
         results = []
         for _ in range(100):
             sample = buffer.sample(1)
-            assert type(sample) == MultiAgentBatch
+            assert type(sample) is MultiAgentBatch
             results.append(len(sample.policy_batches[DEFAULT_POLICY_ID]))
         self.assertAlmostEqual(np.mean(results), 1.0)
 

--- a/rllib/utils/replay_buffers/tests/test_multi_agent_prioritized_replay_buffer.py
+++ b/rllib/utils/replay_buffers/tests/test_multi_agent_prioritized_replay_buffer.py
@@ -186,7 +186,7 @@ class TestMultiAgentPrioritizedReplayBuffer(unittest.TestCase):
 
         # Fetch records, their indices and weights.
         mabatch = buffer.sample(3)
-        assert type(mabatch) == MultiAgentBatch
+        assert type(mabatch) is MultiAgentBatch
         samplebatch = mabatch.policy_batches[DEFAULT_POLICY_ID]
 
         weights = samplebatch["weights"]
@@ -211,9 +211,9 @@ class TestMultiAgentPrioritizedReplayBuffer(unittest.TestCase):
         # (which still has a weight of 1.0).
         for _ in range(10):
             mabatch = buffer.sample(1000)
-            assert type(mabatch) == MultiAgentBatch
+            assert type(mabatch) is MultiAgentBatch
             samplebatch = mabatch.policy_batches[DEFAULT_POLICY_ID]
-            assert type(mabatch) == MultiAgentBatch
+            assert type(mabatch) is MultiAgentBatch
             indices = samplebatch["batch_indexes"]
             self.assertTrue(1900 < np.sum(indices) < 2200)
         # Test get_state/set_state.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Unlike a direct type comparison, `isinstance` will also check if an object is an instance of a class or a subclass thereof.
If you want to check for an exact type match, use `is` or `is not`.

Ref: https://docs.astral.sh/ruff/rules/type-comparison/

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
https://github.com/ray-project/ray/issues/47991

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
