### PR TITLE
[data] Fix Databricks host URL handling in Ray Data

### DIFF
--- a/python/ray/data/_internal/datasource/databricks_uc_datasource.py
+++ b/python/ray/data/_internal/datasource/databricks_uc_datasource.py
@@ -40,7 +40,6 @@ class DatabricksUCDatasource(Datasource):
         if not host.startswith(('http://', 'https://')):
             self.host = f'https://{host}'
 
-
         url_base = f"{self.host}/api/2.0/sql/statements/"
 
         payload = json.dumps(

--- a/python/ray/data/_internal/datasource/databricks_uc_datasource.py
+++ b/python/ray/data/_internal/datasource/databricks_uc_datasource.py
@@ -37,6 +37,9 @@ class DatabricksUCDatasource(Datasource):
         self.schema = schema
         self.query = query
 
+        if not host.startswith(('http://', 'https://')):
+            self.host = f'https://{host}'
+
         url_base = f"{self.host}/api/2.0/sql/statements/"
 
         payload = json.dumps(

--- a/python/ray/data/_internal/datasource/databricks_uc_datasource.py
+++ b/python/ray/data/_internal/datasource/databricks_uc_datasource.py
@@ -40,6 +40,7 @@ class DatabricksUCDatasource(Datasource):
         if not host.startswith(('http://', 'https://')):
             self.host = f'https://{host}'
 
+
         url_base = f"{self.host}/api/2.0/sql/statements/"
 
         payload = json.dumps(

--- a/python/ray/data/_internal/datasource/databricks_uc_datasource.py
+++ b/python/ray/data/_internal/datasource/databricks_uc_datasource.py
@@ -37,7 +37,7 @@ class DatabricksUCDatasource(Datasource):
         self.schema = schema
         self.query = query
 
-        url_base = f"https://{self.host}/api/2.0/sql/statements/"
+        url_base = f"{self.host}/api/2.0/sql/statements/"
 
         payload = json.dumps(
             {

--- a/python/ray/data/_internal/datasource/databricks_uc_datasource.py
+++ b/python/ray/data/_internal/datasource/databricks_uc_datasource.py
@@ -37,8 +37,8 @@ class DatabricksUCDatasource(Datasource):
         self.schema = schema
         self.query = query
 
-        if not host.startswith(('http://', 'https://')):
-            self.host = f'https://{host}'
+        if not host.startswith(("http://", "https://")):
+            self.host = f"https://{host}"
 
         url_base = f"{self.host}/api/2.0/sql/statements/"
 

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -2272,6 +2272,16 @@ def read_databricks_tables(
     )
     from ray.util.spark.utils import get_spark_session, is_in_databricks_runtime
 
+    def _normalize_databricks_host(host: str) -> str:
+        """Normalize Databricks host URL to ensure compatibility with MLflow."""
+        if not host:
+            return host
+
+        # If no protocol specified, add https://
+        if not host.startswith(('http://', 'https://')):
+            host = f'https://{host}'
+
+        return host
     def get_dbutils():
         no_dbutils_error = RuntimeError("No dbutils module found.")
         try:
@@ -2294,7 +2304,7 @@ def read_databricks_tables(
             "databricks workspace access token."
         )
 
-    host = os.environ.get("DATABRICKS_HOST")
+    host = _normalize_databricks_host(os.environ.get("DATABRICKS_HOST"))
     if not host:
         if is_in_databricks_runtime():
             ctx = (

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -2272,16 +2272,6 @@ def read_databricks_tables(
     )
     from ray.util.spark.utils import get_spark_session, is_in_databricks_runtime
 
-    def _normalize_databricks_host(host: str) -> str:
-        """Normalize Databricks host URL to ensure compatibility with MLflow."""
-        if not host:
-            return host
-
-        # If no protocol specified, add https://
-        if not host.startswith(('http://', 'https://')):
-            host = f'https://{host}'
-
-        return host
     def get_dbutils():
         no_dbutils_error = RuntimeError("No dbutils module found.")
         try:
@@ -2304,7 +2294,7 @@ def read_databricks_tables(
             "databricks workspace access token."
         )
 
-    host = _normalize_databricks_host(os.environ.get("DATABRICKS_HOST"))
+    host = os.environ.get("DATABRICKS_HOST")
     if not host:
         if is_in_databricks_runtime():
             ctx = (


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The current Databricks integration in Ray Data requires providing the Databricks host URL without the "https://" prefix. However, this creates compatibility issues when using Ray Data alongside MLflow, as MLflow's Databricks integration (which uses the same DATABRICKS_HOST environment variable) expects the URL to include the "https://" prefix.

## Related issue number

Closes #49925 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
