### PR TITLE
[data] Trigger `UDF.__del__` when an actor is about to exit

### DIFF
--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -410,6 +410,18 @@ class _MapWorker:
     def __repr__(self):
         return f"MapWorker({self.src_fn_name})"
 
+    def on_exit(self):
+        """Called when the actor is about to exist.
+        This allows performing cleanup operations in `UDF.__del__`.
+
+        Note, this only ensures cleanup is performed when the job exists gracefully.
+        If the driver or the actor is forcefully killed, `__del__` will not be called.
+        """
+        # `_map_actor_context` is a global variable that references the UDF object.
+        # Deleting it to trigger `UDF.__del__`.
+        del ray.data._map_actor_context
+        ray.data._map_actor_context = None
+
 
 @dataclass
 class _ActorState:
@@ -738,6 +750,9 @@ class _ActorPool(AutoscalingActorPool):
         # garbage collect the actor, instead of using ray.kill.
         # Because otherwise the actor cannot be restarted upon lineage reconstruction.
         if actor in self._running_actors:
+            # Call `on_exit` to trigger `UDF.__del__` which may perform
+            # cleanup operations.
+            actor.on_exit.remote()
             del self._running_actors[actor]
 
     def _get_location(self, bundle: RefBundle) -> Optional[NodeIdStr]:

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -412,13 +412,13 @@ class _MapWorker:
 
     def on_exit(self):
         """Called when the actor is about to exist.
-        This allows performing cleanup operations in `UDF.__del__`.
+        This enables performing cleanup operations via `UDF.__del__`.
 
         Note, this only ensures cleanup is performed when the job exists gracefully.
         If the driver or the actor is forcefully killed, `__del__` will not be called.
         """
         # `_map_actor_context` is a global variable that references the UDF object.
-        # Deleting it to trigger `UDF.__del__`.
+        # Delete it to trigger `UDF.__del__`.
         del ray.data._map_actor_context
         ray.data._map_actor_context = None
 

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -24,6 +24,9 @@ class PoolWorker:
     def get_location(self) -> str:
         return self.node_id
 
+    def on_exit(self):
+        pass
+
 
 class TestActorPool(unittest.TestCase):
     def setup_class(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

A stateful UDF may depend on external resources that may need to be cleaned up at the end. 
This PR allows performing the cleanup operations via `UDF.__del__`

Note, this only ensures cleanup is performed when the job exists gracefully.
If the driver or the actor is forcefully killed, `__del__` will not be called.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
