### PR TITLE
[RFC][dashboard] Use aiohttp client for inter dependencies.

### DIFF
--- a/python/ray/dashboard/modules/actor/actor_head.py
+++ b/python/ray/dashboard/modules/actor/actor_head.py
@@ -262,7 +262,18 @@ class ActorHead(dashboard_utils.DashboardHeadModule):
     @routes.get("/logical/actors")
     @dashboard_optional_utils.aiohttp_cache
     async def get_all_actors(self, req) -> aiohttp.web.Response:
-        actors = await DataOrganizer.get_actor_infos()
+        """
+        Gets multiple or all actors.
+
+        Params:
+            actor_ids: str (optional) Comma separated actor IDs in Hex. If provided,
+                       only returns actors with the given IDs. If any of the actor_ids
+                       are not found, they are ignored.
+        """
+        actor_ids = req.query.get("actor_ids")
+        if actor_ids is not None:
+            actor_ids = actor_ids.split(",")
+        actors = await DataOrganizer.get_actor_infos(actor_ids=actor_ids)
         return dashboard_optional_utils.rest_response(
             success=True,
             message="All actors fetched.",

--- a/python/ray/dashboard/optional_utils.py
+++ b/python/ray/dashboard/optional_utils.py
@@ -210,6 +210,11 @@ def aiohttp_cache(
                 #   * (Request, )
                 #   * (self, Request)
                 req = args[-1]
+                # Honor Cache-Control:no-cache. If set, this request will not read from
+                # cache and will not be cached.
+                if req.headers.get("Cache-Control") == "no-cache":
+                    logger.error("Cache-Control:no-cache, not using cache")
+                    return await handler(*args)
                 # Make key.
                 if req.method in _AIOHTTP_CACHE_NOBODY_METHODS:
                     key = req.path_qs


### PR DESCRIPTION
This PR is a request for comment on a design of using HTTP requests for inter-Head dependencies. It removes TrainHead usage of DataSource.

## Background

TrainHead uses `DataOrganizer.get_actor_infos` to get facts about Actors. This can't be easily reduced to simple singular GcsClient calls, because it comes from a merge of Actor infos and Worker infos (e.g. `actor["gpus"][0][processesPids"]` are from `DataSource.node_physical_stats` that roots to GCS `GetAllResourceUsage` rpc.

## Proposal

Let the TrainHead depend on ActorHead by directly calling HTTP requests. The overhead should be small since they are guaranteed to live in a same node.

## Scope?

We will do direct read to GCS as much as possible. For cases like this, where it's not trivial to adapt, and frequency is low, and (maybe) non critical, we can use http client.

## Changes

- In our cache middleware, add support for `Cache-Control: no-cache`.
- In ActorHead, add optional param `actor_ids` to API `GET /logical/actors`
- In TrainHead, call that API with no-cache

## Alternative

Now, ResourceUsage are subscribed by ReportHead and written to `DataSource.node_physical_stats` (moving to NodeHead in https://github.com/ray-project/ray/pull/49878). To do "true isolation" we will need to define a way to get snapshot info of ResourceUsage for a certain Node, which can be a bigger amount of change.