### PR TITLE
[serve] Remove extra `pickle` serialization for `gRPCRequest`

### DIFF
--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -573,6 +573,7 @@ class MultiplexedReplicaInfo:
 @dataclass
 class gRPCRequest:
     """Sent from the GRPC proxy to replicas on both unary and streaming codepaths."""
+
     user_request_proto: Any
 
 

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -1,7 +1,7 @@
 import json
 from dataclasses import asdict, dataclass, field
 from enum import Enum
-from typing import Awaitable, Callable, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from starlette.types import Scope
 
@@ -573,8 +573,7 @@ class MultiplexedReplicaInfo:
 @dataclass
 class gRPCRequest:
     """Sent from the GRPC proxy to replicas on both unary and streaming codepaths."""
-
-    grpc_user_request: bytes
+    user_request_proto: Any
 
 
 class RequestProtocol(str, Enum):

--- a/python/ray/serve/_private/proxy_request_response.py
+++ b/python/ray/serve/_private/proxy_request_response.py
@@ -7,7 +7,7 @@ from typing import Any, AsyncIterator, List, Tuple, Union
 import grpc
 from starlette.types import Receive, Scope, Send
 
-from ray.serve._private.common import gRPCRequest, StreamingHTTPRequest
+from ray.serve._private.common import StreamingHTTPRequest, gRPCRequest
 from ray.serve._private.constants import SERVE_LOGGER_NAME
 from ray.serve._private.utils import DEFAULT
 from ray.serve.grpc_util import RayServegRPCContext

--- a/python/ray/serve/_private/proxy_request_response.py
+++ b/python/ray/serve/_private/proxy_request_response.py
@@ -95,14 +95,13 @@ class ASGIProxyRequest(ProxyRequest):
     def set_root_path(self, root_path: str):
         self.scope["root_path"] = root_path
 
-    def request_object(
-        self,
-        proxy_actor_name: str,
-    ) -> StreamingHTTPRequest:
-        return StreamingHTTPRequest(
+    def serialized_replica_arg(self, proxy_actor_name: str) -> bytes:
+        # NOTE(edoakes): it's important that the request is sent as raw bytes to
+        # skip the Ray cloudpickle serialization codepath for performance.
+        return pickle.dumps(StreamingHTTPRequest(
             asgi_scope=self.scope,
             proxy_actor_name=proxy_actor_name,
-        )
+        ))
 
 
 class gRPCProxyRequest(ProxyRequest):
@@ -115,7 +114,7 @@ class gRPCProxyRequest(ProxyRequest):
         service_method: str,
         stream: bool,
     ):
-        self.request = request_proto
+        self._request_proto = request_proto
         self.context = context
         self.service_method = service_method
         self.stream = stream
@@ -131,7 +130,6 @@ class gRPCProxyRequest(ProxyRequest):
     def setup_variables(self):
         if not self.is_route_request and not self.is_health_request:
             service_method_split = self.service_method.split("/")
-            self.request = pickle.dumps(self.request)
             self.method_name = service_method_split[-1]
             for key, value in self.context.invocation_metadata():
                 if key == "application":
@@ -161,20 +159,16 @@ class gRPCProxyRequest(ProxyRequest):
     def is_health_request(self) -> bool:
         return self.service_method == "/ray.serve.RayServeAPIService/Healthz"
 
-    @property
-    def user_request(self) -> bytes:
-        return self.request
-
     def send_request_id(self, request_id: str):
         # Setting the trailing metadata on the ray_serve_grpc_context object, so it's
         # not overriding the ones set from the user and will be sent back to the
         # client altogether.
         self.ray_serve_grpc_context.set_trailing_metadata([("request_id", request_id)])
 
-    def request_object(self) -> gRPCRequest:
-        return gRPCRequest(
-            grpc_user_request=self.user_request,
-        )
+    def serialized_replica_arg(self) -> bytes:
+        # NOTE(edoakes): it's important that the request is sent as raw bytes to
+        # skip the Ray cloudpickle serialization codepath for performance.
+        return pickle.dumps(self._request_proto)
 
 
 @dataclass(frozen=True)

--- a/python/ray/serve/_private/proxy_request_response.py
+++ b/python/ray/serve/_private/proxy_request_response.py
@@ -170,9 +170,7 @@ class gRPCProxyRequest(ProxyRequest):
     def serialized_replica_arg(self) -> bytes:
         # NOTE(edoakes): it's important that the request is sent as raw bytes to
         # skip the Ray cloudpickle serialization codepath for performance.
-        return pickle.dumps(gRPCRequest(
-            user_request_proto=self._request_proto
-        ))
+        return pickle.dumps(gRPCRequest(user_request_proto=self._request_proto))
 
 
 @dataclass(frozen=True)

--- a/python/ray/serve/_private/proxy_request_response.py
+++ b/python/ray/serve/_private/proxy_request_response.py
@@ -7,7 +7,7 @@ from typing import Any, AsyncIterator, List, Tuple, Union
 import grpc
 from starlette.types import Receive, Scope, Send
 
-from ray.serve._private.common import StreamingHTTPRequest, gRPCRequest
+from ray.serve._private.common import gRPCRequest, StreamingHTTPRequest
 from ray.serve._private.constants import SERVE_LOGGER_NAME
 from ray.serve._private.utils import DEFAULT
 from ray.serve.grpc_util import RayServegRPCContext
@@ -98,10 +98,12 @@ class ASGIProxyRequest(ProxyRequest):
     def serialized_replica_arg(self, proxy_actor_name: str) -> bytes:
         # NOTE(edoakes): it's important that the request is sent as raw bytes to
         # skip the Ray cloudpickle serialization codepath for performance.
-        return pickle.dumps(StreamingHTTPRequest(
-            asgi_scope=self.scope,
-            proxy_actor_name=proxy_actor_name,
-        ))
+        return pickle.dumps(
+            StreamingHTTPRequest(
+                asgi_scope=self.scope,
+                proxy_actor_name=proxy_actor_name,
+            )
+        )
 
 
 class gRPCProxyRequest(ProxyRequest):
@@ -168,7 +170,9 @@ class gRPCProxyRequest(ProxyRequest):
     def serialized_replica_arg(self) -> bytes:
         # NOTE(edoakes): it's important that the request is sent as raw bytes to
         # skip the Ray cloudpickle serialization codepath for performance.
-        return pickle.dumps(self._request_proto)
+        return pickle.dumps(gRPCRequest(
+            user_request_proto=self._request_proto
+        ))
 
 
 @dataclass(frozen=True)

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -39,8 +39,8 @@ from ray.serve._private.common import (
     ReplicaQueueLengthInfo,
     RequestMetadata,
     ServeComponentType,
-    gRPCRequest,
     StreamingHTTPRequest,
+    gRPCRequest,
 )
 from ray.serve._private.config import DeploymentConfig
 from ray.serve._private.constants import (

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1357,23 +1357,21 @@ class UserCallableWrapper:
 
         return request_args, asgi_args, receive_task
 
-    def _prepare_args_for_grpc_request(
+    def _prepare_kwargs_for_grpc_request(
         self,
-        request: gRPCRequest,
         request_metadata: RequestMetadata,
         user_method_params: Dict[str, inspect.Parameter],
-    ) -> Tuple[Tuple[Any], Dict[str, Any]]:
-        """Prepare arguments for a user method handling a gRPC request.
+    ) -> Dict[str, Any]:
+        """Prepare kwargs for a user method handling a gRPC request.
 
-        Returns (request_args, request_kwargs).
+        If the method has a "context" kwarg, we pass it the gRPC context, else nothing.
         """
-        request_args = (pickle.loads(request.grpc_user_request),)
         if GRPC_CONTEXT_ARG_NAME in user_method_params:
             request_kwargs = {GRPC_CONTEXT_ARG_NAME: request_metadata.grpc_context}
         else:
             request_kwargs = {}
 
-        return request_args, request_kwargs
+        return request_kwargs
 
     async def _handle_user_method_result(
         self,
@@ -1492,12 +1490,10 @@ class UserCallableWrapper:
                     generator_result_callback=generator_result_callback,
                 )
             elif request_metadata.is_grpc_request:
-                # Ensure the request args are a single gRPCRequest object.
-                assert len(request_args) == 1 and isinstance(
-                    request_args[0], gRPCRequest
-                )
-                request_args, request_kwargs = self._prepare_args_for_grpc_request(
-                    request_args[0], request_metadata, user_method_params
+                # The sole request argument is the user proto request object.
+                assert len(request_args) == 1
+                request_kwargs = self._prepare_kwargs_for_grpc_request(
+                    request_metadata, user_method_params
                 )
 
             result, sync_gen_consumed = await self._call_func_or_gen(

--- a/python/ray/serve/tests/unit/test_proxy_request_response.py
+++ b/python/ray/serve/tests/unit/test_proxy_request_response.py
@@ -219,7 +219,6 @@ class TestgRPCProxyRequest:
         )
         assert isinstance(proxy_request, ProxyRequest)
         assert proxy_request.route_path == application
-        assert pickle.loads(proxy_request.request) == request_proto
         assert proxy_request.method_name == method_name
         assert proxy_request.app_name == application
         assert proxy_request.request_id == request_id
@@ -232,9 +231,11 @@ class TestgRPCProxyRequest:
             ("request_id", request_id)
         ]
 
-        request_object = proxy_request.request_object()
+        serialized_arg = proxy_request.serialized_replica_arg()
+        assert isinstance(serialized_arg, bytes)
+        request_object = pickle.loads(serialized_arg)
         assert isinstance(request_object, gRPCRequest)
-        assert pickle.loads(request_object.grpc_user_request) == request_proto
+        assert request_object.user_request_proto == request_proto
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_user_callable_wrapper.py
+++ b/python/ray/serve/tests/unit/test_user_callable_wrapper.py
@@ -16,6 +16,7 @@ from ray.serve._private.common import (
     DeploymentID,
     RequestMetadata,
     RequestProtocol,
+    gRPCRequest,
     StreamingHTTPRequest,
 )
 from ray.serve._private.replica import UserCallableWrapper
@@ -555,10 +556,10 @@ def test_grpc_unary_request(run_sync_methods_in_threadpool: bool):
     )
     user_callable_wrapper.initialize_callable().result()
 
-    request_proto = serve_pb2.UserDefinedResponse(greeting="world")
+    grpc_request = gRPCRequest(serve_pb2.UserDefinedResponse(greeting="world"))
     request_metadata = _make_request_metadata(call_method="greet", is_grpc_request=True)
     _, result_bytes = user_callable_wrapper.call_user_method(
-        request_metadata, (request_proto,), dict()
+        request_metadata, (grpc_request,), dict()
     ).result()
     assert isinstance(result_bytes, bytes)
 
@@ -575,7 +576,7 @@ def test_grpc_streaming_request(run_sync_methods_in_threadpool: bool):
     )
     user_callable_wrapper.initialize_callable()
 
-    request_proto = serve_pb2.UserDefinedResponse(greeting="world")
+    grpc_request = gRPCRequest(serve_pb2.UserDefinedResponse(greeting="world"))
 
     result_list = []
 
@@ -584,7 +585,7 @@ def test_grpc_streaming_request(run_sync_methods_in_threadpool: bool):
     )
     user_callable_wrapper.call_user_method(
         request_metadata,
-        (request_proto,),
+        (grpc_request,),
         dict(),
         generator_result_callback=result_list.append,
     ).result()

--- a/python/ray/serve/tests/unit/test_user_callable_wrapper.py
+++ b/python/ray/serve/tests/unit/test_user_callable_wrapper.py
@@ -16,8 +16,8 @@ from ray.serve._private.common import (
     DeploymentID,
     RequestMetadata,
     RequestProtocol,
-    gRPCRequest,
     StreamingHTTPRequest,
+    gRPCRequest,
 )
 from ray.serve._private.replica import UserCallableWrapper
 from ray.serve.generated import serve_pb2

--- a/python/ray/serve/tests/unit/test_user_callable_wrapper.py
+++ b/python/ray/serve/tests/unit/test_user_callable_wrapper.py
@@ -17,7 +17,6 @@ from ray.serve._private.common import (
     RequestMetadata,
     RequestProtocol,
     StreamingHTTPRequest,
-    gRPCRequest,
 )
 from ray.serve._private.replica import UserCallableWrapper
 from ray.serve.generated import serve_pb2
@@ -556,13 +555,10 @@ def test_grpc_unary_request(run_sync_methods_in_threadpool: bool):
     )
     user_callable_wrapper.initialize_callable().result()
 
-    grpc_request = gRPCRequest(
-        pickle.dumps(serve_pb2.UserDefinedResponse(greeting="world"))
-    )
-
+    request_proto = serve_pb2.UserDefinedResponse(greeting="world")
     request_metadata = _make_request_metadata(call_method="greet", is_grpc_request=True)
     _, result_bytes = user_callable_wrapper.call_user_method(
-        request_metadata, (grpc_request,), dict()
+        request_metadata, (request_proto,), dict()
     ).result()
     assert isinstance(result_bytes, bytes)
 
@@ -579,9 +575,7 @@ def test_grpc_streaming_request(run_sync_methods_in_threadpool: bool):
     )
     user_callable_wrapper.initialize_callable()
 
-    grpc_request = gRPCRequest(
-        pickle.dumps(serve_pb2.UserDefinedResponse(greeting="world"))
-    )
+    request_proto = serve_pb2.UserDefinedResponse(greeting="world")
 
     result_list = []
 
@@ -590,7 +584,7 @@ def test_grpc_streaming_request(run_sync_methods_in_threadpool: bool):
     )
     user_callable_wrapper.call_user_method(
         request_metadata,
-        (grpc_request,),
+        (request_proto,),
         dict(),
         generator_result_callback=result_list.append,
     ).result()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We were pickling the inner proto message, then again pickling the `gRPCRequest` object. No need to do both.

Also cleaned up the `request_object` method signature for clarity.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
