### PR TITLE
[core] Fix pipe logger exit

### DIFF
--- a/src/ray/util/pipe_logger.cc
+++ b/src/ray/util/pipe_logger.cc
@@ -84,7 +84,11 @@ size_t Read(int read_fd, char *data, size_t len) {
   return bytes_read;
 }
 void CompleteWriteEOFIndicator(int write_fd) {
-  ssize_t bytes_written = write(write_fd, kEofIndicator.data(), kEofIndicator.length());
+  // Write a newliner to mark the end of application logging.
+  ssize_t bytes_written = write(write_fd, "\n", /*count=*/1);
+  RAY_CHECK_EQ(bytes_written, 1);
+  // Write EOF indicator.
+  bytes_written = write(write_fd, kEofIndicator.data(), kEofIndicator.length());
   RAY_CHECK_EQ(bytes_written, static_cast<ssize_t>(kEofIndicator.length()));
   bytes_written = write(write_fd, "\n", /*count=*/1);
   RAY_CHECK_EQ(bytes_written, 1);

--- a/src/ray/util/tests/pipe_logger_test.cc
+++ b/src/ray/util/tests/pipe_logger_test.cc
@@ -117,13 +117,15 @@ TEST(PipeLoggerTestWithoutNewliner, CompletionTest) {
 
   StreamRedirectionOption stream_redirection_opt{};
   stream_redirection_opt.file_path = test_file_path;
+  stream_redirection_opt.tee_to_stdout = true;
 
   auto stream_redirection_handle = CreateRedirectionFileHandle(stream_redirection_opt);
   stream_redirection_handle.CompleteWrite(kContent.data(), kContent.length());
   stream_redirection_handle.Close();
 
   // Check log content after completion.
-  EXPECT_EQ(CompleteReadFile(test_file_path), kContent);
+  // Logger appends newliner to the end of line, if there's not an existing one.
+  EXPECT_EQ(CompleteReadFile(test_file_path), absl::StrFormat("%s\n", kContent));
 
   // Delete temporary file.
   EXPECT_TRUE(std::filesystem::remove(test_file_path));

--- a/src/ray/util/tests/pipe_logger_test.cc
+++ b/src/ray/util/tests/pipe_logger_test.cc
@@ -20,6 +20,7 @@
 #include <unistd.h>
 
 #include <cstdint>
+#include <filesystem>
 #include <future>
 #include <string_view>
 
@@ -105,7 +106,29 @@ TEST_P(PipeLoggerTest, PipeWrite) {
 
 INSTANTIATE_TEST_SUITE_P(PipeLoggerTest, PipeLoggerTest, testing::Values(1024, 3));
 
-// TODO(hjiang): Add more test cases on different combinations.
+// Write content with no trailing newliner, check whether stream redirection handler could
+// exit normally.
+TEST(PipeLoggerTestWithoutNewliner, CompletionTest) {
+  static constexpr std::string_view kContent = "helloworld";
+
+  // TODO(hjiang): We should have a better test util, which allows us to create a
+  // temporary testing directory.
+  const std::string test_file_path = absl::StrFormat("%s.out", GenerateUUIDV4());
+
+  StreamRedirectionOption stream_redirection_opt{};
+  stream_redirection_opt.file_path = test_file_path;
+
+  auto stream_redirection_handle = CreateRedirectionFileHandle(stream_redirection_opt);
+  stream_redirection_handle.CompleteWrite(kContent.data(), kContent.length());
+  stream_redirection_handle.Close();
+
+  // Check log content after completion.
+  EXPECT_EQ(CompleteReadFile(test_file_path), kContent);
+
+  // Delete temporary file.
+  EXPECT_TRUE(std::filesystem::remove(test_file_path));
+}
+
 TEST(PipeLoggerTestWithTee, RedirectionWithTee) {
   // TODO(core): We should have a better test util, which allows us to create a temporary
   // testing directory.


### PR DESCRIPTION
This PR is to fix a bug: on exit, we notify reader thread the exit information via appending an EOF indicator; but if the application content doesn't end with newliner, EOF indicator will be a suffix of previous message, so reader thread cannot exit.