### PR TITLE
[core] [easy] [no-op] Unify exponential backoff

### DIFF
--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -1015,7 +1015,7 @@ bool TaskManager::RetryTaskIfPossible(const TaskID &task_id,
     // TODO(clarng): clean up and remove task_retry_delay_ms that is relied
     // on by some tests.
     int32_t delay_ms = task_failed_due_to_oom
-                           ? ExponentialBackOff::GetBackoffMs(
+                           ? ExponentialBackoff::GetBackoffMs(
                                  spec.AttemptNumber(),
                                  RayConfig::instance().task_oom_retry_delay_base_ms())
                            : RayConfig::instance().task_retry_delay_ms();

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -1015,7 +1015,7 @@ bool TaskManager::RetryTaskIfPossible(const TaskID &task_id,
     // TODO(clarng): clean up and remove task_retry_delay_ms that is relied
     // on by some tests.
     int32_t delay_ms = task_failed_due_to_oom
-                           ? ExponentialBackoff::GetBackoffMs(
+                           ? ExponentialBackOff::GetBackoffMs(
                                  spec.AttemptNumber(),
                                  RayConfig::instance().task_oom_retry_delay_base_ms())
                            : RayConfig::instance().task_retry_delay_ms();

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -28,7 +28,7 @@ namespace gcs {
 
 namespace {
 
-ExponentialBackOff CreateDefaultBackoff() {
+ExponentialBackoff CreateDefaultBackoff() {
   // std::chrono conversions are unwieldy but safer.
   // ms -> ns
   using std::chrono::duration_cast;
@@ -44,7 +44,7 @@ ExponentialBackOff CreateDefaultBackoff() {
           milliseconds(
               RayConfig::instance().gcs_create_placement_group_retry_max_interval_ms()))
           .count();
-  return ExponentialBackOff(
+  return ExponentialBackoff(
       initial_delay_ns,
       RayConfig::instance().gcs_create_placement_group_retry_multiplier(),
       max_delay_ns);
@@ -307,7 +307,7 @@ PlacementGroupID GcsPlacementGroupManager::GetPlacementGroupIDByName(
 
 void GcsPlacementGroupManager::OnPlacementGroupCreationFailed(
     std::shared_ptr<GcsPlacementGroup> placement_group,
-    ExponentialBackOff backoff,
+    ExponentialBackoff backoff,
     bool is_feasible) {
   RAY_LOG(DEBUG).WithField(placement_group->GetPlacementGroupID())
       << "Failed to create placement group " << placement_group->GetName()
@@ -758,7 +758,7 @@ void GcsPlacementGroupManager::WaitPlacementGroup(
 void GcsPlacementGroupManager::AddToPendingQueue(
     std::shared_ptr<GcsPlacementGroup> pg,
     std::optional<int64_t> rank,
-    std::optional<ExponentialBackOff> exp_backer) {
+    std::optional<ExponentialBackoff> exp_backer) {
   if (!rank) {
     rank = absl::GetCurrentTimeNanos();
   }

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
@@ -303,7 +303,7 @@ class GcsPlacementGroupManager : public rpc::PlacementGroupInfoHandler {
   /// \param placement_group The placement_group whose creation task is infeasible.
   /// \param is_feasible whether the scheduler can be retry or not currently.
   void OnPlacementGroupCreationFailed(std::shared_ptr<GcsPlacementGroup> placement_group,
-                                      ExponentialBackOff backoff,
+                                      ExponentialBackoff backoff,
                                       bool is_feasible);
 
   /// Handle placement_group creation task success. This should be called when the
@@ -408,7 +408,7 @@ class GcsPlacementGroupManager : public rpc::PlacementGroupInfoHandler {
   /// it's not set. This will be used to generate the deferred time for this pg.
   void AddToPendingQueue(std::shared_ptr<GcsPlacementGroup> pg,
                          std::optional<int64_t> rank = std::nullopt,
-                         std::optional<ExponentialBackOff> exp_backer = std::nullopt);
+                         std::optional<ExponentialBackoff> exp_backer = std::nullopt);
   void RemoveFromPendingQueue(const PlacementGroupID &pg_id);
 
   /// Try to create placement group after a short time.
@@ -471,7 +471,7 @@ class GcsPlacementGroupManager : public rpc::PlacementGroupInfoHandler {
   /// need to post retry job to io context. And when schedule pending placement
   /// group, we always start with the one with the smallest key.
   absl::btree_multimap<int64_t,
-                       std::pair<ExponentialBackOff, std::shared_ptr<GcsPlacementGroup>>>
+                       std::pair<ExponentialBackoff, std::shared_ptr<GcsPlacementGroup>>>
       pending_placement_groups_;
 
   /// The infeasible placement_groups that can't be scheduled currently.

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_mock_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_mock_test.cc
@@ -118,7 +118,7 @@ TEST_F(GcsPlacementGroupManagerMockTest, PendingQueuePriorityFailed) {
   pg->UpdateState(rpc::PlacementGroupTableData::PENDING);
   now = absl::GetCurrentTimeNanos();
   request.failure_callback(pg, true);
-  auto exp_backer = ExponentialBackOff(
+  auto exp_backer = ExponentialBackoff(
       1000000 * RayConfig::instance().gcs_create_placement_group_retry_min_interval_ms(),
       RayConfig::instance().gcs_create_placement_group_retry_multiplier(),
       1000000 * RayConfig::instance().gcs_create_placement_group_retry_max_interval_ms());

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
@@ -158,7 +158,7 @@ class GcsPlacementGroupManagerTest : public ::testing::Test {
 
   void RunIOService() { io_service_.poll(); }
 
-  ExponentialBackOff GetExpBackOff() { return ExponentialBackOff(0, 1); }
+  ExponentialBackoff GetExpBackOff() { return ExponentialBackoff(0, 1); }
 
   std::shared_ptr<MockPlacementGroupScheduler> mock_placement_group_scheduler_;
   std::unique_ptr<gcs::GcsPlacementGroupManager> gcs_placement_group_manager_;

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -120,7 +120,7 @@ struct RedisRequestContext {
   void Run();
 
  private:
-  ExponentialBackOff exp_back_off_;
+  ExponentialBackoff exp_back_off_;
   instrumented_io_context &io_service_;
   RedisAsyncContext *redis_context_;
   size_t pending_retries_;

--- a/src/ray/util/exponential_backoff.cc
+++ b/src/ray/util/exponential_backoff.cc
@@ -18,7 +18,7 @@
 
 namespace ray {
 
-uint64_t ExponentialBackOff::GetBackoffMs(uint64_t attempt,
+uint64_t ExponentialBackoff::GetBackoffMs(uint64_t attempt,
                                           uint64_t base_ms,
                                           uint64_t max_backoff_ms) {
   uint64_t delay = static_cast<uint64_t>(pow(2, attempt));

--- a/src/ray/util/exponential_backoff.cc
+++ b/src/ray/util/exponential_backoff.cc
@@ -14,13 +14,11 @@
 
 #include "ray/util/exponential_backoff.h"
 
-#include <math.h>
-
-#include "ray/util/logging.h"
+#include <cmath>
 
 namespace ray {
 
-uint64_t ExponentialBackoff::GetBackoffMs(uint64_t attempt,
+uint64_t ExponentialBackOff::GetBackoffMs(uint64_t attempt,
                                           uint64_t base_ms,
                                           uint64_t max_backoff_ms) {
   uint64_t delay = static_cast<uint64_t>(pow(2, attempt));

--- a/src/ray/util/exponential_backoff.h
+++ b/src/ray/util/exponential_backoff.h
@@ -14,15 +14,33 @@
 
 #pragma once
 
-#include <gtest/gtest_prod.h>
-#include <stdint.h>
+#include <cstdint>
+#include <limits>
+
+#include "ray/util/logging.h"
 
 namespace ray {
 
 /// Provides the exponential backoff algorithm that is typically used
 /// for throttling.
-class ExponentialBackoff {
+class ExponentialBackOff {
  public:
+  /// Construct an exponential back off counter.
+  ///
+  /// \param[in] initial_value The start value for this counter
+  /// \param[in] multiplier The multiplier for this counter.
+  /// \param[in] max_value The maximum value for this counter. By default it's
+  ///    infinite double.
+  ExponentialBackOff(uint64_t initial_value,
+                     double multiplier,
+                     uint64_t max_value = std::numeric_limits<uint64_t>::max())
+      : curr_value_(initial_value),
+        initial_value_(initial_value),
+        max_value_(max_value),
+        multiplier_(multiplier) {
+    RAY_CHECK(multiplier > 0.0) << "Multiplier must be greater than 0";
+  }
+
   /// Computes the backoff delay using the exponential backoff algorithm,
   /// using the formula
   ///
@@ -33,11 +51,28 @@ class ExponentialBackoff {
   /// @return the delay in ms based on the formula
   static uint64_t GetBackoffMs(uint64_t attempt,
                                uint64_t base_ms,
-                               uint64_t max_backoff_ms = kMaxBackoffMs);
+                               uint64_t max_backoff_ms = kDefaultMaxBackoffMs);
+
+  uint64_t Next() {
+    auto ret = curr_value_;
+    curr_value_ = curr_value_ * multiplier_;
+    curr_value_ = std::min(curr_value_, max_value_);
+    return ret;
+  }
+
+  uint64_t Current() { return curr_value_; }
+
+  void Reset() { curr_value_ = initial_value_; }
 
  private:
+ private:
+  uint64_t curr_value_;
+  uint64_t initial_value_;
+  uint64_t max_value_;
+  double multiplier_;
+
   // The default cap on the backoff delay.
-  static constexpr uint64_t kMaxBackoffMs = 1 * 60 * 1000;
+  static constexpr uint64_t kDefaultMaxBackoffMs = 1 * 60 * 1000;
 };
 
 }  // namespace ray

--- a/src/ray/util/exponential_backoff.h
+++ b/src/ray/util/exponential_backoff.h
@@ -23,7 +23,7 @@ namespace ray {
 
 /// Provides the exponential backoff algorithm that is typically used
 /// for throttling.
-class ExponentialBackOff {
+class ExponentialBackoff {
  public:
   /// Construct an exponential back off counter.
   ///
@@ -31,7 +31,7 @@ class ExponentialBackOff {
   /// \param[in] multiplier The multiplier for this counter.
   /// \param[in] max_value The maximum value for this counter. By default it's
   ///    infinite double.
-  ExponentialBackOff(uint64_t initial_value,
+  ExponentialBackoff(uint64_t initial_value,
                      double multiplier,
                      uint64_t max_value = std::numeric_limits<uint64_t>::max())
       : curr_value_(initial_value),

--- a/src/ray/util/tests/exponential_backoff_test.cc
+++ b/src/ray/util/tests/exponential_backoff_test.cc
@@ -20,26 +20,26 @@
 
 namespace ray {
 
-TEST(ExponentialBackoffTest, TestExponentialIncrease) {
-  ASSERT_EQ(ExponentialBackoff::GetBackoffMs(0, 157), 157 * 1);
-  ASSERT_EQ(ExponentialBackoff::GetBackoffMs(1, 157), 157 * 2);
-  ASSERT_EQ(ExponentialBackoff::GetBackoffMs(2, 157), 157 * 4);
-  ASSERT_EQ(ExponentialBackoff::GetBackoffMs(3, 157), 157 * 8);
+TEST(ExponentialBackOffTest, TestExponentialIncrease) {
+  ASSERT_EQ(ExponentialBackOff::GetBackoffMs(0, 157), 157 * 1);
+  ASSERT_EQ(ExponentialBackOff::GetBackoffMs(1, 157), 157 * 2);
+  ASSERT_EQ(ExponentialBackOff::GetBackoffMs(2, 157), 157 * 4);
+  ASSERT_EQ(ExponentialBackOff::GetBackoffMs(3, 157), 157 * 8);
 
-  ASSERT_EQ(ExponentialBackoff::GetBackoffMs(10, 0), 0);
-  ASSERT_EQ(ExponentialBackoff::GetBackoffMs(11, 0), 0);
+  ASSERT_EQ(ExponentialBackOff::GetBackoffMs(10, 0), 0);
+  ASSERT_EQ(ExponentialBackOff::GetBackoffMs(11, 0), 0);
 }
 
-TEST(ExponentialBackoffTest, TestExceedMaxBackoffReturnsMaxBackoff) {
-  auto backoff = ExponentialBackoff::GetBackoffMs(
+TEST(ExponentialBackOffTest, TestExceedMaxBackoffReturnsMaxBackoff) {
+  auto backoff = ExponentialBackOff::GetBackoffMs(
       /*attempt*/ 10, /*base_ms*/ 1, /*max_backoff_ms*/ 5);
   ASSERT_EQ(backoff, 5);
 }
 
-TEST(ExponentialBackoffTest, TestOverflowReturnsMaxBackoff) {
+TEST(ExponentialBackOffTest, TestOverflowReturnsMaxBackoff) {
   // 2 ^ 64+ will overflow.
   for (int i = 64; i < 10000; i++) {
-    auto backoff = ExponentialBackoff::GetBackoffMs(
+    auto backoff = ExponentialBackOff::GetBackoffMs(
         /*attempt*/ i,
         /*base_ms*/ 1,
         /*max_backoff_ms*/ 1234);
@@ -47,9 +47,21 @@ TEST(ExponentialBackoffTest, TestOverflowReturnsMaxBackoff) {
   }
 }
 
-}  // namespace ray
-
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+TEST(ExponentialBackOffTest, GetNext) {
+  auto exp = ExponentialBackOff{1, 2, 9};
+  ASSERT_EQ(1, exp.Next());
+  ASSERT_EQ(2, exp.Next());
+  ASSERT_EQ(4, exp.Next());
+  ASSERT_EQ(8, exp.Next());
+  ASSERT_EQ(9, exp.Next());
+  ASSERT_EQ(9, exp.Next());
+  exp.Reset();
+  ASSERT_EQ(1, exp.Next());
+  ASSERT_EQ(2, exp.Next());
+  ASSERT_EQ(4, exp.Next());
+  ASSERT_EQ(8, exp.Next());
+  ASSERT_EQ(9, exp.Next());
+  ASSERT_EQ(9, exp.Next());
 }
+
+}  // namespace ray

--- a/src/ray/util/tests/exponential_backoff_test.cc
+++ b/src/ray/util/tests/exponential_backoff_test.cc
@@ -20,26 +20,26 @@
 
 namespace ray {
 
-TEST(ExponentialBackOffTest, TestExponentialIncrease) {
-  ASSERT_EQ(ExponentialBackOff::GetBackoffMs(0, 157), 157 * 1);
-  ASSERT_EQ(ExponentialBackOff::GetBackoffMs(1, 157), 157 * 2);
-  ASSERT_EQ(ExponentialBackOff::GetBackoffMs(2, 157), 157 * 4);
-  ASSERT_EQ(ExponentialBackOff::GetBackoffMs(3, 157), 157 * 8);
+TEST(ExponentialBackoffTest, TestExponentialIncrease) {
+  ASSERT_EQ(ExponentialBackoff::GetBackoffMs(0, 157), 157 * 1);
+  ASSERT_EQ(ExponentialBackoff::GetBackoffMs(1, 157), 157 * 2);
+  ASSERT_EQ(ExponentialBackoff::GetBackoffMs(2, 157), 157 * 4);
+  ASSERT_EQ(ExponentialBackoff::GetBackoffMs(3, 157), 157 * 8);
 
-  ASSERT_EQ(ExponentialBackOff::GetBackoffMs(10, 0), 0);
-  ASSERT_EQ(ExponentialBackOff::GetBackoffMs(11, 0), 0);
+  ASSERT_EQ(ExponentialBackoff::GetBackoffMs(10, 0), 0);
+  ASSERT_EQ(ExponentialBackoff::GetBackoffMs(11, 0), 0);
 }
 
-TEST(ExponentialBackOffTest, TestExceedMaxBackoffReturnsMaxBackoff) {
-  auto backoff = ExponentialBackOff::GetBackoffMs(
+TEST(ExponentialBackoffTest, TestExceedMaxBackoffReturnsMaxBackoff) {
+  auto backoff = ExponentialBackoff::GetBackoffMs(
       /*attempt*/ 10, /*base_ms*/ 1, /*max_backoff_ms*/ 5);
   ASSERT_EQ(backoff, 5);
 }
 
-TEST(ExponentialBackOffTest, TestOverflowReturnsMaxBackoff) {
+TEST(ExponentialBackoffTest, TestOverflowReturnsMaxBackoff) {
   // 2 ^ 64+ will overflow.
   for (int i = 64; i < 10000; i++) {
-    auto backoff = ExponentialBackOff::GetBackoffMs(
+    auto backoff = ExponentialBackoff::GetBackoffMs(
         /*attempt*/ i,
         /*base_ms*/ 1,
         /*max_backoff_ms*/ 1234);
@@ -47,8 +47,8 @@ TEST(ExponentialBackOffTest, TestOverflowReturnsMaxBackoff) {
   }
 }
 
-TEST(ExponentialBackOffTest, GetNext) {
-  auto exp = ExponentialBackOff{1, 2, 9};
+TEST(ExponentialBackoffTest, GetNext) {
+  auto exp = ExponentialBackoff{1, 2, 9};
   ASSERT_EQ(1, exp.Next());
   ASSERT_EQ(2, exp.Next());
   ASSERT_EQ(4, exp.Next());

--- a/src/ray/util/tests/util_test.cc
+++ b/src/ray/util/tests/util_test.cc
@@ -109,8 +109,8 @@ TEST(UtilTest, ParseCommandLineTest) {
   ASSERT_EQ(ParseCommandLine(R"(x' a \b')", win32), ArgList({R"(x')", R"(a)", R"(\b')"}));
 }
 
-TEST(UtilTest, ExponentialBackOffTest) {
-  auto exp = ExponentialBackOff(1, 2, 9);
+TEST(UtilTest, ExponentialBackoffTest) {
+  auto exp = ExponentialBackoff(1, 2, 9);
   ASSERT_EQ(1, exp.Next());
   ASSERT_EQ(2, exp.Next());
   ASSERT_EQ(4, exp.Next());


### PR DESCRIPTION
We have two exponential backoff class, one with `Off` in uppercase, another one with `off` in lowercase, which is confusion; and I think it doesn't make sense to have two classes serving strongly relavent feature.

This PR is originally part of the refactor PR, suggested by @jjyao to make a separate one.
Refactor PR for reference: https://github.com/ray-project/ray/pull/49938
Jiajun's comment: https://github.com/ray-project/ray/pull/49938#discussion_r1921420809