### PR TITLE
[RLlib; Offline] - Add single learner gpu training with preloading in `OfflinePreLearner`.

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -853,7 +853,6 @@ class Algorithm(Checkpointable, Trainable, AlgorithmBase):
                     rl_module_state=rl_module_state,
                 )
             # TODO (simon): Update modules in DataWorkers.
-
             if self.offline_data:
                 # If the learners are remote we need to provide specific
                 # information and the learner's actor handles.
@@ -870,13 +869,12 @@ class Algorithm(Checkpointable, Trainable, AlgorithmBase):
                     # Provide the actor handles for the learners for module
                     # updating during preprocessing.
                     self.offline_data.learner_handles = self.learner_group._workers
-                    # Provide the module_spec. Note, in the remote case this is needed
-                    # because the learner module cannot be copied, but must be built.
-                    self.offline_data.module_spec = module_spec
                 # Otherwise we can simply pass in the local learner.
                 else:
                     self.offline_data.learner_handles = [self.learner_group._learner]
-
+                # Provide the module_spec. Note, in the remote case this is needed
+                # because the learner module cannot be copied, but must be built.
+                self.offline_data.module_spec = module_spec
                 # Provide the `OfflineData` instance with space information. It might
                 # need it for reading recorded experiences.
                 self.offline_data.spaces = spaces

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -4943,6 +4943,17 @@ class AlgorithmConfig(_Config):
                 "`True`."
             )
 
+        # Validate the device (GPU) settings for the `OfflinePreLearner` layer.
+        if OfflineData.map_batches_uses_gpus(self):
+            self._value_error(
+                "Setting GPUs in `map_batches_kwargs` is not allowed. Because "
+                "each `OfflinePreLearner` in `map_batches` generates batches "
+                "RLlib assigns a fraction (0.01) of a `Learner` GPU to corresponding "
+                "`OfflinePreLearner` to optimize memory operations on GPUs. "
+                "\nIn case that GPU devices should be provided in a customized form "
+                "set `_validate_config` in `AlgorithmConfig.experimental` to `False`."
+            )
+
         if (
             self.output
             and self.output_write_episodes

--- a/rllib/algorithms/cql/cql.py
+++ b/rllib/algorithms/cql/cql.py
@@ -23,6 +23,7 @@ from ray.rllib.execution.train_ops import (
     multi_gpu_train_one_step,
     train_one_step,
 )
+from ray.rllib.offline.offline_data import OfflineData
 from ray.rllib.policy.policy import Policy
 from ray.rllib.utils.annotations import OldAPIStack, override
 from ray.rllib.utils.deprecation import (
@@ -108,6 +109,16 @@ class CQLConfig(SACConfig):
         # .reporting()
         self.min_sample_timesteps_per_iteration = 0
         self.min_train_timesteps_per_iteration = 100
+
+        # .learners
+        # Reserve a fraction of the learner GPUs for the `OfflinePreLearner`. The
+        # latter should load batches onto the GPU device of the corresponding. learner.
+        # Note, GPU training does not work, yet, with a multi-learner setup.
+        # TODO (simon): Check, if and how the module should be loaded on GPU in the
+        # `OfflinePreLearner`s to run the GAE.
+        if self._validate_config and not OfflineData.map_batches_uses_gpus(self):
+            self.num_gpus_per_learner *= 0.99
+
         # fmt: on
         # __sphinx_doc_end__
 

--- a/rllib/algorithms/marwil/marwil.py
+++ b/rllib/algorithms/marwil/marwil.py
@@ -424,20 +424,7 @@ class MARWIL(Algorithm):
         # TODO (simon): Check, if and how the module should be loaded on GPU in the
         # `OfflinePreLearner`s to run the GAE.
         if config.num_gpus_per_learner and config._validate_config:
-            # TODO (simon): This is not clean here. Actually, we should use the
-            # OfflineData.default_map_batches_kwargs`' concurrency here, but this
-            # property needs an OfflineData instance (which creates already the
-            # dataset). A classmethod would not workm either because then users
-            # cannot override this property and use properties from the config in
-            # it.
-            concurrency = config.map_batches_kwargs.get("concurrency", 2)
-            self.config.map_batches_kwargs.update(
-                {
-                    "num_gpus": self.config.num_gpus_per_learner
-                    * round(0.01 / concurrency, 4)
-                }
-            )
-            self.config.num_gpus_per_learner *= 0.99
+            config.num_gpus_per_learner *= 0.99
 
         # Call the super's constructor first.
         super().__init__(config=config, *args, **kwargs)

--- a/rllib/algorithms/marwil/marwil.py
+++ b/rllib/algorithms/marwil/marwil.py
@@ -461,7 +461,7 @@ class MARWIL(Algorithm):
             batch_or_iterator = self.offline_data.sample(
                 num_samples=self.config.train_batch_size_per_learner,
                 num_shards=self.config.num_learners,
-                return_iterator=self.config.num_learners > 1,
+                return_iterator=True,  # self.config.num_learners > 1,
             )
 
         with self.metrics.log_time((TIMERS, LEARNER_UPDATE_TIMER)):

--- a/rllib/algorithms/marwil/marwil.py
+++ b/rllib/algorithms/marwil/marwil.py
@@ -424,9 +424,13 @@ class MARWIL(Algorithm):
         # TODO (simon): Check, if and how the module should be loaded on GPU in the
         # `OfflinePreLearner`s to run the GAE.
         if config.num_gpus_per_learner and config._validate_config:
-            concurrency = config.map_batches_kwargs.get(
-                "concurrency", OfflineData.default_map_batches_kwargs["concurrency"]
-            )
+            # TODO (simon): This is not clean here. Actually, we should use the
+            # OfflineData.default_map_batches_kwargs`' concurrency here, but this
+            # property needs an OfflineData instance (which creates already the
+            # dataset). A classmethod would not workm either because then users
+            # cannot override this property and use properties from the config in
+            # it.
+            concurrency = config.map_batches_kwargs.get("concurrency", 2)
             self.config.map_batches_kwargs.update(
                 {
                     "num_gpus": self.config.num_gpus_per_learner

--- a/rllib/core/learner/learner.py
+++ b/rllib/core/learner/learner.py
@@ -1250,6 +1250,9 @@ class Learner(Checkpointable):
 
         """
 
+    def get_device(self):
+        return self._device
+
     @override(Checkpointable)
     def get_state(
         self,

--- a/rllib/core/learner/learner_group.py
+++ b/rllib/core/learner/learner_group.py
@@ -414,8 +414,6 @@ class LearnerGroup(Checkpointable):
                     " local mode! Try setting `config.num_learners > 0`."
                 )
 
-            # If we have a `ray.data.DataIterator` use the `update_from_iterator` for
-            # training.
             if isinstance(batch, list) and isinstance(batch[0], ray.data.DataIterator):
                 results = [
                     _learner_update(
@@ -441,6 +439,7 @@ class LearnerGroup(Checkpointable):
                         **kwargs,
                     )
                 ]
+
         # One or more remote Learners: Shard batch/episodes into equal pieces (roughly
         # equal if multi-agent AND episodes) and send each Learner worker one of these
         # shards.

--- a/rllib/offline/offline_data.py
+++ b/rllib/offline/offline_data.py
@@ -106,6 +106,8 @@ class OfflineData:
         self.map_batches_kwargs = (
             self.default_map_batches_kwargs | self.config.map_batches_kwargs
         )
+        # Set the devices in the `map_batches_kwargs` if necessary.
+        self.map_batches_set_devices()
         self.iter_batches_kwargs = (
             self.default_iter_batches_kwargs | self.config.iter_batches_kwargs
         )
@@ -329,6 +331,20 @@ class OfflineData:
             )
         else:
             return False
+
+    def map_batches_set_devices(self):
+
+        if (
+            self.config._validate_config
+            or not self.map_batches_uses_gpus(self.config)
+            and self.config.num_gpus_per_learner > 0
+        ):
+            self.map_batches_kwargs.update(
+                {
+                    "num_gpus": self.config.num_gpus_per_learner
+                    * round(0.01 / self.map_batches_kwargs["concurrency"], 4),
+                }
+            )
 
     def get_devices(self):
         from ray.rllib.utils import force_list

--- a/rllib/offline/offline_prelearner.py
+++ b/rllib/offline/offline_prelearner.py
@@ -190,7 +190,7 @@ class OfflinePreLearner:
             episodes = OfflinePreLearner._map_sample_batch_to_episode(
                 self._is_multi_agent,
                 batch,
-                finalize=True,
+                to_numpy=True,
                 schema=SCHEMA | self.config.input_read_schema,
                 input_compress_columns=self.config.input_compress_columns,
             )["episodes"]
@@ -216,7 +216,7 @@ class OfflinePreLearner:
                 self._is_multi_agent,
                 batch,
                 schema=SCHEMA | self.config.input_read_schema,
-                finalize=True,
+                to_numpy=True,
                 input_compress_columns=self.config.input_compress_columns,
                 observation_space=self.observation_space,
                 action_space=self.action_space,
@@ -398,7 +398,7 @@ class OfflinePreLearner:
         is_multi_agent: bool,
         batch: Dict[str, Union[list, np.ndarray]],
         schema: Dict[str, str] = SCHEMA,
-        finalize: bool = False,
+        to_numpy: bool = False,
         input_compress_columns: Optional[List[str]] = None,
         observation_space: gym.Space = None,
         action_space: gym.Space = None,
@@ -513,8 +513,8 @@ class OfflinePreLearner:
                     len_lookback_buffer=0,
                 )
 
-                if finalize:
-                    episode.finalize()
+                if to_numpy:
+                    episode.to_numpy()
                 episodes.append(episode)
         # Note, `map_batches` expects a `Dict` as return value.
         return {"episodes": episodes}
@@ -525,7 +525,7 @@ class OfflinePreLearner:
         is_multi_agent: bool,
         batch: Dict[str, Union[list, np.ndarray]],
         schema: Dict[str, str] = SCHEMA,
-        finalize: bool = False,
+        to_numpy: bool = False,
         input_compress_columns: Optional[List[str]] = None,
     ) -> Dict[str, List[EpisodeType]]:
         """Maps an old stack `SampleBatch` to new stack episodes."""
@@ -677,8 +677,8 @@ class OfflinePreLearner:
                 # Finalize, if necessary.
                 # TODO (simon, sven): Check, if we should convert all data to lists
                 # before. Right now only obs are lists.
-                if finalize:
-                    episode.finalize()
+                if to_numpy:
+                    episode.to_numpy()
                 episodes.append(episode)
         # Note, `map_batches` expects a `Dict` as return value.
         return {"episodes": episodes}

--- a/rllib/tuned_examples/bc/cartpole_bc.py
+++ b/rllib/tuned_examples/bc/cartpole_bc.py
@@ -58,7 +58,6 @@ config = (
         map_batches_kwargs={
             "concurrency": 2,
             "num_cpus": 2,
-            "num_gpus": (args.num_gpus_per_learner or 0) * (0.01 / 2),
         },
         # This data set is small so do not prefetch too many batches and use no
         # local shuffle.

--- a/rllib/tuned_examples/bc/cartpole_bc.py
+++ b/rllib/tuned_examples/bc/cartpole_bc.py
@@ -67,7 +67,7 @@ config = (
         # mode in a single RLlib training iteration. Leave this to `None` to
         # run an entire epoch on the dataset during a single RLlib training
         # iteration. For single-learner mode, 1 is the only option.
-        dataset_num_iters_per_learner=10,
+        dataset_num_iters_per_learner=5 if not args.num_learners else None,
     )
     .training(
         train_batch_size_per_learner=2048,
@@ -98,6 +98,7 @@ stop = {
     f"{EVALUATION_RESULTS}/{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": 350.0,
     TRAINING_ITERATION: 350,
 }
+
 
 if __name__ == "__main__":
     run_rllib_example_script_experiment(config, args, stop=stop)

--- a/rllib/utils/test_utils.py
+++ b/rllib/utils/test_utils.py
@@ -1197,11 +1197,13 @@ def run_rllib_example_script_experiment(
                         break
                 if val is not None and not np.isnan(val) and val >= threshold:
                     print(f"Stop criterium ({key}={threshold}) fulfilled!")
+                    algo.stop()
                     if not keep_ray_up:
                         ray.shutdown()
                     return results
 
         if not keep_ray_up:
+            algo.stop()
             ray.shutdown()
         return results
 


### PR DESCRIPTION
## Why are these changes needed?

GPU training in Offline RL was not possible, yet, due to restrictions in the access to `OfflinePreLearner` instances running in Ray Data's `map_batches`. This PR proposes a solution with the following changes:
- A fraction of 1% of the `Learner` GPU is reserved for preloading batches onto the GPU in `OfflinePreLearner`s.
- An error is raised in config validation, if the user tries to assign GPUs in the `AlgorithmConfig.map_batches_kwargs`. This error can be turned off by using `AlgorithmConfig._validate_config=False`.
- When building the mapped dataset the `OfflienData` will check the user settings and retrieves the devices from the `Learner`, in case of the default settings.
- These `Learner` devices are passed towards the `OfflinePreLearner`s to be used when the learner connector pipeline is used, to put the batches on the correct device.
- Furthermore, it enables the single-learner settting to also use the `Learner.update_from_iterator`, which allows multiple updates during a single RLlib training iteration.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
