### PR TITLE
[RLlib] Old API stack IMPALA/APPO: Re-introduce mixin-replay-buffer pass, even if `replay-ratio=0` (fixes a memory leak).

### DIFF
--- a/rllib/algorithms/impala/impala.py
+++ b/rllib/algorithms/impala/impala.py
@@ -555,8 +555,6 @@ class IMPALA(Algorithm):
 
         # Queue of data to be sent to the Learner.
         self.data_to_place_on_learner = []
-        # The local mixin buffer (if required).
-        self.local_mixin_buffer = None
         self._batch_being_built = []  # @OldAPIStack
 
         # Create extra aggregation workers and assign each rollout worker to
@@ -566,18 +564,17 @@ class IMPALA(Algorithm):
             i: [] for i in range(self.config.num_learners or 1)
         }
 
-        # Create our local mixin buffer if the num of aggregation workers is 0.
+        # Create our local mixin buffer.
         if not self.config.enable_rl_module_and_learner:
-            if self.config.replay_proportion > 0.0:
-                self.local_mixin_buffer = MixInMultiAgentReplayBuffer(
-                    capacity=(
-                        self.config.replay_buffer_num_slots
-                        if self.config.replay_buffer_num_slots > 0
-                        else 1
-                    ),
-                    replay_ratio=self.config.replay_ratio,
-                    replay_mode=ReplayMode.LOCKSTEP,
-                )
+            self.local_mixin_buffer = MixInMultiAgentReplayBuffer(
+                capacity=(
+                    self.config.replay_buffer_num_slots
+                    if self.config.replay_buffer_num_slots > 0
+                    else 1
+                ),
+                replay_ratio=self.config.replay_ratio,
+                replay_mode=ReplayMode.LOCKSTEP,
+            )
 
         # This variable is used to keep track of the statistics from the most recent
         # update of the learner group
@@ -1092,9 +1089,8 @@ class IMPALA(Algorithm):
             batch = batch.decompress_if_needed()
             # Only make a pass through the buffer, if replay proportion is > 0.0 (and
             # we actually have one).
-            if self.local_mixin_buffer:
-                self.local_mixin_buffer.add(batch)
-                batch = self.local_mixin_buffer.replay(_ALL_POLICIES)
+            self.local_mixin_buffer.add(batch)
+            batch = self.local_mixin_buffer.replay(_ALL_POLICIES)
             if batch:
                 processed_batches.append(batch)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Old API stack IMPALA/APPO: Re-introduce mixin-replay-buffer pass, even if `replay-ratio=0` (fixes a memory leak).

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
