### PR TITLE
[Refactor] Fix ruff rule F841: unused-variable

### DIFF
--- a/ci/lint/git-clang-format
+++ b/ci/lint/git-clang-format
@@ -590,7 +590,7 @@ def apply_changes(old_tree, new_tree, force=False, patch_mode=False):
         # right, since it won't be applied to the user's index, but oh well.
         with temporary_index_file(old_tree):
             subprocess.check_call(["git", "checkout", "--patch", new_tree])
-        index_tree = old_tree
+        index_tree = old_tree  # noqa: F841
     else:
         with temporary_index_file(new_tree):
             run("git", "checkout-index", "-a", "-f")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ ignore = [
     # TODO(MortalHappiness): Remove the following rules from the ignore list
     # The above are rules ignored originally in flake8
     # The following are rules ignored in ruff
-    "F841",
     "B018",
     "B023",
     "B024",

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -223,7 +223,7 @@ class TestDAGRefDestruction:
         with InputNode() as inp:
             dag = a.inc.bind(inp)
         compiled_dag = dag.experimental_compile()
-        ref = compiled_dag.execute(2)
+        _ = compiled_dag.execute(2)
         ref2 = compiled_dag.execute(2)
         ref3 = compiled_dag.execute(2)
         del ref2
@@ -241,7 +241,7 @@ class TestDAGRefDestruction:
         del ref2
         del ref3
         ray.get(ref)
-        ref4 = compiled_dag.execute(3)
+        _ = compiled_dag.execute(3)
         # Test that max_inflight error is not raised as ref2 and ref3
         # should be destructed and not counted in the inflight executions
         ref5 = compiled_dag.execute(3)

--- a/python/ray/workflow/tests/test_basic_workflows_3.py
+++ b/python/ray/workflow/tests/test_basic_workflows_3.py
@@ -60,11 +60,8 @@ def test_run_off_main_thread(workflow_start_regular_shared):
     def fake_data(num: int):
         return list(range(num))
 
-    succ = False
-
     # Start new thread here ⚠️
     def run():
-        global succ
         # Setup the workflow.
         assert workflow.run(fake_data.bind(10), workflow_id="run") == list(range(10))
 

--- a/release/release_logs/compare_perf_metrics
+++ b/release/release_logs/compare_perf_metrics
@@ -131,7 +131,6 @@ def get_regressions(old_path, new_path):
         new_values.keys(),
     )
 
-    regressions = []
     throughput_regressions = []
     latency_regression = []
     for perf_metric_name in to_compare:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
A variable that is defined but not used is likely a mistake, and should be removed to avoid confusion.

If a variable is intentionally defined-but-not-used, it should be prefixed with an underscore, or some other value that adheres to the [lint.dummy-variable-rgx](https://docs.astral.sh/ruff/settings/#lint_dummy-variable-rgx) pattern.

Ref: https://docs.astral.sh/ruff/rules/unused-variable/

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
https://github.com/ray-project/ray/issues/47991
## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
