### PR TITLE
[serve] Cache expensive calls to `inspect.signature`

### DIFF
--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1139,7 +1139,8 @@ class UserCallableWrapper:
             )
 
         info = UserMethodInfo.from_callable(
-            callable, is_asgi_app=isinstance(self._callable, ASGIAppReplicaWrapper),
+            callable,
+            is_asgi_app=isinstance(self._callable, ASGIAppReplicaWrapper),
         )
         self._cached_user_method_info[method_name] = info
         return info

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1026,12 +1026,12 @@ class UserMethodInfo:
     takes_grpc_context_kwarg: bool
 
     @classmethod
-    def from_callable(cls, c: Callable) -> "UserMethodInfo":
+    def from_callable(cls, c: Callable, *, is_asgi_app: bool) -> "UserMethodInfo":
         params = inspect.signature(c).parameters
         return cls(
             callable=c,
             name=c.__name__,
-            is_asgi_app=isinstance(c, ASGIAppReplicaWrapper),
+            is_asgi_app=is_asgi_app,
             takes_any_args=len(params) > 0,
             takes_grpc_context_kwarg=GRPC_CONTEXT_ARG_NAME in params,
         )
@@ -1138,7 +1138,9 @@ class UserCallableWrapper:
                 f"{methods}."
             )
 
-        info = UserMethodInfo.from_callable(callable)
+        info = UserMethodInfo.from_callable(
+            callable, is_asgi_app=isinstance(self._callable, ASGIAppReplicaWrapper),
+        )
         self._cached_user_method_info[method_name] = info
         return info
 

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1014,9 +1014,11 @@ class ReplicaActor:
                 "the RAY_SERVE_ENABLE_CPU_PROFILING env var."
             )
 
+
 @dataclass
 class UserMethodInfo:
     """Wrapper for a user method and its relevant metadata."""
+
     callable: Callable
     name: str
     is_asgi_app: bool
@@ -1033,6 +1035,7 @@ class UserMethodInfo:
             takes_any_args=len(params) > 0,
             takes_grpc_context_kwarg=GRPC_CONTEXT_ARG_NAME in params,
         )
+
 
 class UserCallableWrapper:
     """Wraps a user-provided callable that is used to handle requests to a replica."""
@@ -1401,7 +1404,8 @@ class UserCallableWrapper:
         """
         request_kwargs = (
             {GRPC_CONTEXT_ARG_NAME: request_metadata.grpc_context}
-            if user_method_info.takes_grpc_context_kwarg else {}
+            if user_method_info.takes_grpc_context_kwarg
+            else {}
         )
         return (request.user_request_proto,), request_kwargs
 
@@ -1500,9 +1504,7 @@ class UserCallableWrapper:
         user_method = None
         receive_task = None
         try:
-            user_method_info = self._get_user_method_info(
-                request_metadata.call_method
-            )
+            user_method_info = self._get_user_method_info(request_metadata.call_method)
             if request_metadata.is_http_request:
                 assert len(request_args) == 1 and isinstance(
                     request_args[0], StreamingHTTPRequest

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1504,8 +1504,8 @@ class UserCallableWrapper:
 
         result = None
         asgi_args = None
-        user_method = None
         receive_task = None
+        user_method_info = None
         try:
             user_method_info = self._get_user_method_info(request_metadata.call_method)
             if request_metadata.is_http_request:
@@ -1552,6 +1552,7 @@ class UserCallableWrapper:
             if (
                 request_metadata.is_http_request
                 and asgi_args is not None
+                and user_method_info is not None
                 # If the callable is an ASGI app, it already sent a 500 status response.
                 and not user_method_info.is_asgi_app
             ):

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1118,9 +1118,9 @@ class UserCallableWrapper:
             return self._cached_user_method_info[method_name]
 
         if self._is_function:
-            callable = self._callable
+            user_method = self._callable
         elif hasattr(self._callable, method_name):
-            callable = getattr(self._callable, method_name)
+            user_method = getattr(self._callable, method_name)
         else:
             # Filter to methods that don't start with '__' prefix.
             def callable_method_filter(attr):
@@ -1139,7 +1139,7 @@ class UserCallableWrapper:
             )
 
         info = UserMethodInfo.from_callable(
-            callable,
+            user_method,
             is_asgi_app=isinstance(self._callable, ASGIAppReplicaWrapper),
         )
         self._cached_user_method_info[method_name] = info

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -11,6 +11,7 @@ import traceback
 import warnings
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
+from dataclasses import dataclass
 from importlib import import_module
 from typing import (
     Any,
@@ -1013,6 +1014,25 @@ class ReplicaActor:
                 "the RAY_SERVE_ENABLE_CPU_PROFILING env var."
             )
 
+@dataclass
+class UserMethodInfo:
+    """Wrapper for a user method and its relevant metadata."""
+    callable: Callable
+    name: str
+    is_asgi_app: bool
+    takes_any_args: bool
+    takes_grpc_context_kwarg: bool
+
+    @classmethod
+    def from_callable(cls, c: Callable) -> "UserMethodInfo":
+        params = inspect.signature(c).parameters
+        return cls(
+            callable=c,
+            name=c.__name__,
+            is_asgi_app=isinstance(c, ASGIAppReplicaWrapper),
+            takes_any_args=len(params) > 0,
+            takes_grpc_context_kwarg=GRPC_CONTEXT_ARG_NAME in params,
+        )
 
 class UserCallableWrapper:
     """Wraps a user-provided callable that is used to handle requests to a replica."""
@@ -1040,6 +1060,7 @@ class UserCallableWrapper:
         self._destructor_called = False
         self._run_sync_methods_in_threadpool = run_sync_methods_in_threadpool
         self._warned_about_sync_method_change = False
+        self._cached_user_method_info: Dict[str, UserMethodInfo] = {}
 
         # Will be populated in `initialize_callable`.
         self._callable = None
@@ -1085,11 +1106,19 @@ class UserCallableWrapper:
         # be run on the user code event loop.
         to_thread.current_default_thread_limiter().total_tokens = limit
 
-    def _get_user_callable_method(self, method_name: str) -> Callable:
-        if self._is_function:
-            return self._callable
+    def _get_user_method_info(self, method_name: str) -> UserMethodInfo:
+        """Get UserMethodInfo for the provided call method name.
 
-        if not hasattr(self._callable, method_name):
+        This method is cached to avoid repeated expensive calls to `inspect.signature`.
+        """
+        if method_name in self._cached_user_method_info:
+            return self._cached_user_method_info[method_name]
+
+        if self._is_function:
+            callable = self._callable
+        elif hasattr(self._callable, method_name):
+            callable = getattr(self._callable, method_name)
+        else:
             # Filter to methods that don't start with '__' prefix.
             def callable_method_filter(attr):
                 if attr.startswith("__"):
@@ -1106,7 +1135,9 @@ class UserCallableWrapper:
                 f"{methods}."
             )
 
-        return getattr(self._callable, method_name)
+        info = UserMethodInfo.from_callable(callable)
+        self._cached_user_method_info[method_name] = info
+        return info
 
     async def _send_user_result_over_asgi(
         self,
@@ -1316,9 +1347,8 @@ class UserCallableWrapper:
         self,
         request: StreamingHTTPRequest,
         request_metadata: RequestMetadata,
-        user_method_params: Dict[str, inspect.Parameter],
+        user_method_info: UserMethodInfo,
         *,
-        is_asgi_app: bool,
         generator_result_callback: Optional[Callable] = None,
     ) -> Tuple[Tuple[Any], ASGIArgs, asyncio.Task]:
         """Prepare arguments for a user method handling an HTTP request.
@@ -1345,9 +1375,9 @@ class UserCallableWrapper:
             receive=receive,
             send=_send,
         )
-        if is_asgi_app:
+        if user_method_info.is_asgi_app:
             request_args = asgi_args.to_args_tuple()
-        elif len(user_method_params) == 0:
+        elif not user_method_info.takes_any_args:
             # Edge case to support empty HTTP handlers: don't pass the Request
             # argument if the callable has no parameters.
             request_args = tuple()
@@ -1361,7 +1391,7 @@ class UserCallableWrapper:
         self,
         request: gRPCRequest,
         request_metadata: RequestMetadata,
-        user_method_params: Dict[str, inspect.Parameter],
+        user_method_info: UserMethodInfo,
     ) -> Tuple[Tuple[Any], Dict[str, Any]]:
         """Prepare args and kwargs for a user method handling a gRPC request.
 
@@ -1369,22 +1399,20 @@ class UserCallableWrapper:
 
         If the method has a "context" kwarg, we pass the gRPC context, else no kwargs.
         """
-        if GRPC_CONTEXT_ARG_NAME in user_method_params:
-            request_kwargs = {GRPC_CONTEXT_ARG_NAME: request_metadata.grpc_context}
-        else:
-            request_kwargs = {}
-
+        request_kwargs = (
+            {GRPC_CONTEXT_ARG_NAME: request_metadata.grpc_context}
+            if user_method_info.takes_grpc_context_kwarg else {}
+        )
         return (request.user_request_proto,), request_kwargs
 
     async def _handle_user_method_result(
         self,
         result: Any,
-        user_method_name: str,
         request_metadata: RequestMetadata,
+        user_method_info: UserMethodInfo,
         *,
         sync_gen_consumed: bool,
         generator_result_callback: Optional[Callable],
-        is_asgi_app: bool,
         asgi_args: Optional[ASGIArgs],
     ) -> Any:
         """Postprocess the result of a user method.
@@ -1412,7 +1440,7 @@ class UserCallableWrapper:
                     if request_metadata.is_grpc_request:
                         r = (request_metadata.grpc_context, r.SerializeToString())
                     generator_result_callback(r)
-            elif request_metadata.is_http_request and not is_asgi_app:
+            elif request_metadata.is_http_request and not user_method_info.is_asgi_app:
                 # For the FastAPI codepath, the response has already been sent over
                 # ASGI, but for the vanilla deployment codepath we need to send it.
                 await self._send_user_result_over_asgi(result, asgi_args)
@@ -1423,7 +1451,7 @@ class UserCallableWrapper:
                 # returns a generator, because it's provided the result queue as its
                 # ASGI `send` interface to stream back results.
                 raise TypeError(
-                    f"Called method '{user_method_name}' with "
+                    f"Called method '{user_method_info.name}' with "
                     "`handle.options(stream=True)` but it did not return a "
                     "generator."
                 )
@@ -1434,7 +1462,7 @@ class UserCallableWrapper:
 
             if result_is_gen or result_is_async_gen:
                 raise TypeError(
-                    f"Method '{user_method_name}' returned a generator. "
+                    f"Method '{user_method_info.name}' returned a generator. "
                     "You must use `handle.options(stream=True)` to call "
                     "generators on a deployment."
                 )
@@ -1471,12 +1499,10 @@ class UserCallableWrapper:
         asgi_args = None
         user_method = None
         receive_task = None
-        user_method_name = "unknown"
         try:
-            is_asgi_app = isinstance(self._callable, ASGIAppReplicaWrapper)
-            user_method = self._get_user_callable_method(request_metadata.call_method)
-            user_method_name = user_method.__name__
-            user_method_params = inspect.signature(user_method).parameters
+            user_method_info = self._get_user_method_info(
+                request_metadata.call_method
+            )
             if request_metadata.is_http_request:
                 assert len(request_args) == 1 and isinstance(
                     request_args[0], StreamingHTTPRequest
@@ -1488,8 +1514,7 @@ class UserCallableWrapper:
                 ) = self._prepare_args_for_http_request(
                     request_args[0],
                     request_metadata,
-                    user_method_params,
-                    is_asgi_app=is_asgi_app,
+                    user_method_info,
                     generator_result_callback=generator_result_callback,
                 )
             elif request_metadata.is_grpc_request:
@@ -1497,11 +1522,11 @@ class UserCallableWrapper:
                     request_args[0], gRPCRequest
                 )
                 request_args, request_kwargs = self._prepare_args_for_grpc_request(
-                    request_args[0], request_metadata, user_method_params
+                    request_args[0], request_metadata, user_method_info
                 )
 
             result, sync_gen_consumed = await self._call_func_or_gen(
-                user_method,
+                user_method_info.callable,
                 args=request_args,
                 kwargs=request_kwargs,
                 request_metadata=request_metadata,
@@ -1511,11 +1536,10 @@ class UserCallableWrapper:
             )
             return await self._handle_user_method_result(
                 result,
-                user_method_name,
                 request_metadata,
+                user_method_info,
                 sync_gen_consumed=sync_gen_consumed,
                 generator_result_callback=generator_result_callback,
-                is_asgi_app=is_asgi_app,
                 asgi_args=asgi_args,
             )
 
@@ -1524,7 +1548,7 @@ class UserCallableWrapper:
                 request_metadata.is_http_request
                 and asgi_args is not None
                 # If the callable is an ASGI app, it already sent a 500 status response.
-                and not is_asgi_app
+                and not user_method_info.is_asgi_app
             ):
                 await self._send_user_result_over_asgi(
                     starlette.responses.Response(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Discovered in profiling that this call is quite expensive. Cached the call and added a convenient wrapper dataclass for methods + their metadata.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
