### PR TITLE
[core] Fix last word in pipe

### DIFF
--- a/src/ray/util/pipe_logger.cc
+++ b/src/ray/util/pipe_logger.cc
@@ -110,6 +110,9 @@ void StartStreamDump(ReadFunc read_func,
         {
           absl::MutexLock lock(&stream_dumper->mu);
           stream_dumper->stopped = true;
+          if (!last_line.empty()) {
+            stream_dumper->content.emplace_back(std::move(last_line));
+          }
         }
 
         // Place IO operation out of critical section.


### PR DESCRIPTION
This PR fix a bug, if we have another non-empty string in pipe, we should flush it into sinks also.