### PR TITLE
[kuberay] fix deserialisation of custom resources in autoscaler config

### DIFF
--- a/python/ray/autoscaler/_private/kuberay/autoscaling_config.py
+++ b/python/ray/autoscaler/_private/kuberay/autoscaling_config.py
@@ -416,9 +416,6 @@ def _get_custom_resources(
         return {}
     resources_string = ray_start_params["resources"]
     try:
-        # Drop the extra pair of quotes and remove the backslash escapes.
-        # resources_json should be a json string.
-        resources_json = resources_string[1:-1].replace("\\", "")
         # Load a dict from the json string.
         resources = json.loads(resources_json)
         assert isinstance(resources, dict)


### PR DESCRIPTION
## Why are these changes needed?

Currently the autoscaler and the ray start command both read from the rayStartParams in kuberay, but both expect different formats. This PR fixes it.

## Related issue number

Closes #47866

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [] Unit tests
   - [ ] Release tests
   - [X] This PR is not tested :(
