### PR TITLE
[Refactor] Fix ruff rule B018: useless-expression

### DIFF
--- a/java/test/src/main/resources/test_cross_language_invocation.py
+++ b/java/test/src/main/resources/test_cross_language_invocation.py
@@ -90,7 +90,7 @@ def py_func_pass_python_actor_handle():
 
 @ray.remote
 def py_func_python_raise_exception():
-    raise ZeroDivisionError
+    _ = 1 / 0
 
 
 @ray.remote

--- a/java/test/src/main/resources/test_cross_language_invocation.py
+++ b/java/test/src/main/resources/test_cross_language_invocation.py
@@ -90,7 +90,7 @@ def py_func_pass_python_actor_handle():
 
 @ray.remote
 def py_func_python_raise_exception():
-    1 / 0
+    raise ZeroDivisionError
 
 
 @ray.remote

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ ignore = [
     # TODO(MortalHappiness): Remove the following rules from the ignore list
     # The above are rules ignored originally in flake8
     # The following are rules ignored in ruff
-    "B018",
     "B023",
     "B024",
     "B026",

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -2539,14 +2539,14 @@ def test_inflight_requests_exceed_capacity(ray_start_regular):
             match=(expected_error_message),
         ):
             _ = await async_compiled_dag.execute_async(1)
-        (ref1, ref2)
+        (ref1, ref2)  # noqa: B018
 
     loop = get_or_create_event_loop()
     loop.run_until_complete(main())
     # to show variables are being used and avoid destruction since
     # CompiledDagRef __del__ will release buffers and
     # increment _max_finished_execution_index
-    (ref1, ref2)
+    (ref1, ref2)  # noqa: B018
 
 
 def test_result_buffer_exceeds_capacity(ray_start_regular):
@@ -2587,12 +2587,12 @@ def test_result_buffer_exceeds_capacity(ray_start_regular):
             match=(expected_error_message),
         ):
             _ = await async_compiled_dag.execute_async(4)
-        (ref1, ref3)
+        (ref1, ref3)  # noqa: B018
 
     loop = get_or_create_event_loop()
     loop.run_until_complete(main())
     # same reason as comment for test_inflight_requests_exceed_capacity
-    (ref1, ref3)
+    (ref1, ref3)  # noqa: B018
 
 
 def test_event_profiling(ray_start_regular, monkeypatch):

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -2539,14 +2539,14 @@ def test_inflight_requests_exceed_capacity(ray_start_regular):
             match=(expected_error_message),
         ):
             _ = await async_compiled_dag.execute_async(1)
-        (ref1, ref2)  # noqa: B018
+        _ = (ref1, ref2)
 
     loop = get_or_create_event_loop()
     loop.run_until_complete(main())
     # to show variables are being used and avoid destruction since
     # CompiledDagRef __del__ will release buffers and
     # increment _max_finished_execution_index
-    (ref1, ref2)  # noqa: B018
+    _ = (ref1, ref2)
 
 
 def test_result_buffer_exceeds_capacity(ray_start_regular):
@@ -2587,12 +2587,12 @@ def test_result_buffer_exceeds_capacity(ray_start_regular):
             match=(expected_error_message),
         ):
             _ = await async_compiled_dag.execute_async(4)
-        (ref1, ref3)  # noqa: B018
+        _ = (ref1, ref3)
 
     loop = get_or_create_event_loop()
     loop.run_until_complete(main())
     # same reason as comment for test_inflight_requests_exceed_capacity
-    (ref1, ref3)  # noqa: B018
+    _ = (ref1, ref3)
 
 
 def test_event_profiling(ray_start_regular, monkeypatch):

--- a/python/ray/data/tests/test_exceptions.py
+++ b/python/ray/data/tests/test_exceptions.py
@@ -21,8 +21,7 @@ def test_user_exception(
     ctx.log_internal_stack_trace_to_stdout = log_internal_stack_trace_to_stdout
 
     def f(row):
-        1 / 0
-        return row
+        raise ZeroDivisionError
 
     with pytest.raises(UserCodeException) as exc_info:
         ray.data.range(1).map(f).take_all()
@@ -80,8 +79,7 @@ def test_full_traceback_logged_with_ray_debugger(
     monkeypatch.setenv("RAY_DEBUG_POST_MORTEM", 1)
 
     def f(row):
-        1 / 0
-        return row
+        raise ZeroDivisionError
 
     with pytest.raises(Exception) as exc_info:
         ray.data.range(1).map(f).take_all()

--- a/python/ray/data/tests/test_exceptions.py
+++ b/python/ray/data/tests/test_exceptions.py
@@ -21,7 +21,7 @@ def test_user_exception(
     ctx.log_internal_stack_trace_to_stdout = log_internal_stack_trace_to_stdout
 
     def f(row):
-        raise ZeroDivisionError
+        _ = 1 / 0
 
     with pytest.raises(UserCodeException) as exc_info:
         ray.data.range(1).map(f).take_all()
@@ -79,7 +79,8 @@ def test_full_traceback_logged_with_ray_debugger(
     monkeypatch.setenv("RAY_DEBUG_POST_MORTEM", 1)
 
     def f(row):
-        raise ZeroDivisionError
+        _ = 1 / 0
+        return row
 
     with pytest.raises(Exception) as exc_info:
         ray.data.range(1).map(f).take_all()

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -130,7 +130,7 @@ def test_read_operator_emits_warning_for_large_read_tasks():
             large_object = np.zeros((128, 1024, 1024), dtype=np.uint8)  # 128 MiB
 
             def read_fn():
-                large_object  # noqa : B018
+                _ = large_object
                 yield pd.DataFrame({"column": [0]})
 
             return [ReadTask(read_fn, BlockMetadata(1, None, None, None, None))]

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -130,7 +130,7 @@ def test_read_operator_emits_warning_for_large_read_tasks():
             large_object = np.zeros((128, 1024, 1024), dtype=np.uint8)  # 128 MiB
 
             def read_fn():
-                large_object
+                large_object  # noqa : B018
                 yield pd.DataFrame({"column": [0]})
 
             return [ReadTask(read_fn, BlockMetadata(1, None, None, None, None))]

--- a/python/ray/serve/_private/benchmarks/proxy_benchmark.py
+++ b/python/ray/serve/_private/benchmarks/proxy_benchmark.py
@@ -75,7 +75,7 @@ async def fetch_http(session, data):
 
 async def fetch_grpc(stub, data):
     result = await stub.grpc_call(serve_pb2.RawData(nums=data))
-    result.output
+    _ = result.output
 
 
 @ray.remote

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -844,7 +844,7 @@ def test_status_constructor_error(serve_instance):
     @serve.deployment
     class A:
         def __init__(self):
-            1 / 0
+            raise ZeroDivisionError
 
     serve._run(A.bind(), _blocking=False)
 

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -844,7 +844,7 @@ def test_status_constructor_error(serve_instance):
     @serve.deployment
     class A:
         def __init__(self):
-            raise ZeroDivisionError
+            _ = 1 / 0
 
     serve._run(A.bind(), _blocking=False)
 

--- a/python/ray/serve/tests/test_config_files/fail.py
+++ b/python/ray/serve/tests/test_config_files/fail.py
@@ -4,7 +4,7 @@ from ray import serve
 @serve.deployment
 class A:
     def __init__(self):
-        raise ZeroDivisionError
+        _ = 1 / 0
 
 
 node = A.bind()

--- a/python/ray/serve/tests/test_config_files/fail.py
+++ b/python/ray/serve/tests/test_config_files/fail.py
@@ -4,7 +4,7 @@ from ray import serve
 @serve.deployment
 class A:
     def __init__(self):
-        1 / 0
+        raise ZeroDivisionError
 
 
 node = A.bind()

--- a/python/ray/serve/tests/test_config_files/fail_2.py
+++ b/python/ray/serve/tests/test_config_files/fail_2.py
@@ -7,7 +7,7 @@ from ray import serve
 class A:
     def __init__(self):
         time.sleep(5)
-        raise ZeroDivisionError
+        _ = 1 / 0
 
 
 node = A.bind()

--- a/python/ray/serve/tests/test_config_files/fail_2.py
+++ b/python/ray/serve/tests/test_config_files/fail_2.py
@@ -7,7 +7,7 @@ from ray import serve
 class A:
     def __init__(self):
         time.sleep(5)
-        1 / 0
+        raise ZeroDivisionError
 
 
 node = A.bind()

--- a/python/ray/serve/tests/test_config_files/import_error.py
+++ b/python/ray/serve/tests/test_config_files/import_error.py
@@ -1,6 +1,6 @@
 from ray import serve
 
-raise ZeroDivisionError
+_ = 1 / 0
 
 
 @serve.deployment(ray_actor_options={"num_cpus": 0.1})

--- a/python/ray/serve/tests/test_config_files/import_error.py
+++ b/python/ray/serve/tests/test_config_files/import_error.py
@@ -1,6 +1,6 @@
 from ray import serve
 
-1 / 0
+raise ZeroDivisionError
 
 
 @serve.deployment(ray_actor_options={"num_cpus": 0.1})

--- a/python/ray/serve/tests/test_fastapi.py
+++ b/python/ray/serve/tests/test_fastapi.py
@@ -354,7 +354,7 @@ def test_fastapi_init_lifespan_should_not_shutdown(serve_instance):
 
     @app.on_event("shutdown")
     async def shutdown():
-        raise ZeroDivisionError
+        _ = 1 / 0
 
     @serve.deployment
     @serve.ingress(app)

--- a/python/ray/serve/tests/test_fastapi.py
+++ b/python/ray/serve/tests/test_fastapi.py
@@ -354,7 +354,7 @@ def test_fastapi_init_lifespan_should_not_shutdown(serve_instance):
 
     @app.on_event("shutdown")
     async def shutdown():
-        1 / 0
+        raise ZeroDivisionError
 
     @serve.deployment
     @serve.ingress(app)

--- a/python/ray/serve/tests/test_http_routes.py
+++ b/python/ray/serve/tests/test_http_routes.py
@@ -215,7 +215,7 @@ def test_redirect(serve_instance, base_path):
 def test_default_error_handling(serve_instance):
     @serve.deployment
     def f():
-        raise ZeroDivisionError
+        _ = 1 / 0
 
     serve.run(f.bind())
     r = requests.get("http://localhost:8000/f")

--- a/python/ray/serve/tests/test_http_routes.py
+++ b/python/ray/serve/tests/test_http_routes.py
@@ -215,7 +215,7 @@ def test_redirect(serve_instance, base_path):
 def test_default_error_handling(serve_instance):
     @serve.deployment
     def f():
-        1 / 0
+        raise ZeroDivisionError
 
     serve.run(f.bind())
     r = requests.get("http://localhost:8000/f")

--- a/python/ray/serve/tests/test_logging.py
+++ b/python/ray/serve/tests/test_logging.py
@@ -937,7 +937,7 @@ def test_stream_to_logger():
 
     # Calling non-existing attribute on the StreamToLogger should still raise error.
     with pytest.raises(AttributeError):
-        stream_to_logger.i_dont_exist
+        _ = stream_to_logger.i_dont_exist
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Fail to create temp dir.")

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -487,7 +487,7 @@ def test_proxy_metrics_fields_not_found(serve_start_shutdown):
 
     # Should generate 404 responses
     broken_url = "http://127.0.0.1:8000/fake_route"
-    requests.get(broken_url).text
+    requests.get(broken_url)
     print("Sent requests to broken URL.")
 
     # Ping gRPC proxy for not existing application.
@@ -540,7 +540,7 @@ def test_proxy_metrics_fields_internal_error(serve_start_shutdown):
 
     # Deployment should generate divide-by-zero errors
     correct_url = "http://127.0.0.1:8000/real_route"
-    requests.get(correct_url).text
+    requests.get(correct_url)
     print("Sent requests to correct URL.")
 
     # Ping gPRC proxy for broken app

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -487,7 +487,7 @@ def test_proxy_metrics_fields_not_found(serve_start_shutdown):
 
     # Should generate 404 responses
     broken_url = "http://127.0.0.1:8000/fake_route"
-    requests.get(broken_url)
+    _ = requests.get(broken_url).text
     print("Sent requests to broken URL.")
 
     # Ping gRPC proxy for not existing application.
@@ -540,7 +540,7 @@ def test_proxy_metrics_fields_internal_error(serve_start_shutdown):
 
     # Deployment should generate divide-by-zero errors
     correct_url = "http://127.0.0.1:8000/real_route"
-    requests.get(correct_url)
+    _ = requests.get(correct_url).text
     print("Sent requests to correct URL.")
 
     # Ping gPRC proxy for broken app

--- a/python/ray/serve/tests/unit/test_batching.py
+++ b/python/ray/serve/tests/unit/test_batching.py
@@ -126,14 +126,14 @@ async def test_batch_size_one_long_timeout(use_class):
     @serve.batch(max_batch_size=1, batch_wait_timeout_s=1000)
     async def long_timeout(requests):
         if "raise" in requests:
-            raise ZeroDivisionError
+            _ = 1 / 0
         return requests
 
     class LongTimeout:
         @serve.batch(max_batch_size=1, batch_wait_timeout_s=1000)
         async def long_timeout(self, requests):
             if "raise" in requests:
-                raise ZeroDivisionError
+                _ = 1 / 0
             return requests
 
     cls = LongTimeout()
@@ -158,7 +158,7 @@ async def test_batch_size_multiple_zero_timeout(use_class):
     async def zero_timeout(requests):
         await block_execution_event.wait()
         if "raise" in requests:
-            raise ZeroDivisionError
+            _ = 1 / 0
         return requests
 
     class ZeroTimeout:
@@ -166,7 +166,7 @@ async def test_batch_size_multiple_zero_timeout(use_class):
         async def zero_timeout(self, requests):
             await block_execution_event.wait()
             if "raise" in requests:
-                raise ZeroDivisionError
+                _ = 1 / 0
             return requests
 
     cls = ZeroTimeout()
@@ -262,14 +262,14 @@ async def test_batch_size_multiple_long_timeout(use_class):
     @serve.batch(max_batch_size=3, batch_wait_timeout_s=1000)
     async def long_timeout(requests):
         if "raise" in requests:
-            raise ZeroDivisionError
+            _ = 1 / 0
         return requests
 
     class LongTimeout:
         @serve.batch(max_batch_size=3, batch_wait_timeout_s=1000)
         async def long_timeout(self, requests):
             if "raise" in requests:
-                raise ZeroDivisionError
+                _ = 1 / 0
             return requests
 
     cls = LongTimeout()

--- a/python/ray/serve/tests/unit/test_batching.py
+++ b/python/ray/serve/tests/unit/test_batching.py
@@ -126,14 +126,14 @@ async def test_batch_size_one_long_timeout(use_class):
     @serve.batch(max_batch_size=1, batch_wait_timeout_s=1000)
     async def long_timeout(requests):
         if "raise" in requests:
-            1 / 0
+            raise ZeroDivisionError
         return requests
 
     class LongTimeout:
         @serve.batch(max_batch_size=1, batch_wait_timeout_s=1000)
         async def long_timeout(self, requests):
             if "raise" in requests:
-                1 / 0
+                raise ZeroDivisionError
             return requests
 
     cls = LongTimeout()
@@ -158,7 +158,7 @@ async def test_batch_size_multiple_zero_timeout(use_class):
     async def zero_timeout(requests):
         await block_execution_event.wait()
         if "raise" in requests:
-            1 / 0
+            raise ZeroDivisionError
         return requests
 
     class ZeroTimeout:
@@ -166,7 +166,7 @@ async def test_batch_size_multiple_zero_timeout(use_class):
         async def zero_timeout(self, requests):
             await block_execution_event.wait()
             if "raise" in requests:
-                1 / 0
+                raise ZeroDivisionError
             return requests
 
     cls = ZeroTimeout()
@@ -262,14 +262,14 @@ async def test_batch_size_multiple_long_timeout(use_class):
     @serve.batch(max_batch_size=3, batch_wait_timeout_s=1000)
     async def long_timeout(requests):
         if "raise" in requests:
-            1 / 0
+            raise ZeroDivisionError
         return requests
 
     class LongTimeout:
         @serve.batch(max_batch_size=3, batch_wait_timeout_s=1000)
         async def long_timeout(self, requests):
             if "raise" in requests:
-                1 / 0
+                raise ZeroDivisionError
             return requests
 
     cls = LongTimeout()

--- a/python/ray/serve/tests/unit/test_config.py
+++ b/python/ray/serve/tests/unit/test_config.py
@@ -609,14 +609,14 @@ def test_grpc_options():
     grpc_servicer_functions = ["fake.service.that.does.not.exist"]
     with pytest.raises(ModuleNotFoundError) as exception:
         grpc_options = gRPCOptions(grpc_servicer_functions=grpc_servicer_functions)
-        grpc_options.grpc_servicer_func_callable
+        _ = grpc_options.grpc_servicer_func_callable
     assert "can't be imported!" in str(exception)
 
     # Not callable should raise ValueError.
     grpc_servicer_functions = ["ray.serve._private.constants.DEFAULT_HTTP_PORT"]
     with pytest.raises(ValueError) as exception:
         grpc_options = gRPCOptions(grpc_servicer_functions=grpc_servicer_functions)
-        grpc_options.grpc_servicer_func_callable
+        _ = grpc_options.grpc_servicer_func_callable
     assert "is not a callable function!" in str(exception)
 
 

--- a/python/ray/serve/tests/unit/test_deployment_scheduler.py
+++ b/python/ray/serve/tests/unit/test_deployment_scheduler.py
@@ -895,7 +895,7 @@ class TestCompactScheduling:
             ),
         )
 
-        ray.util.placement_group
+        _ = ray.util.placement_group
         scheduler.on_deployment_created(d_id1, SpreadDeploymentSchedulingPolicy())
         scheduler.on_deployment_created(d_id2, SpreadDeploymentSchedulingPolicy())
 

--- a/python/ray/serve/tests/unit/test_grpc_util.py
+++ b/python/ray/serve/tests/unit/test_grpc_util.py
@@ -37,11 +37,11 @@ def test_dummy_servicer_can_take_any_methods():
     When dummy_servicer is called with any custom defined methods, it won't raise error.
     """
     dummy_servicer = DummyServicer()
-    dummy_servicer.foo
-    dummy_servicer.bar
-    dummy_servicer.baz
-    dummy_servicer.my_method
-    dummy_servicer.Predict
+    _ = dummy_servicer.foo
+    _ = dummy_servicer.bar
+    _ = dummy_servicer.baz
+    _ = dummy_servicer.my_method
+    _ = dummy_servicer.Predict
 
 
 def test_grpc_server():

--- a/python/ray/tests/accelerators/test_accelerators.py
+++ b/python/ray/tests/accelerators/test_accelerators.py
@@ -13,7 +13,7 @@ def test_accelerators():
         AttributeError,
         match="module 'ray.util.accelerators' has no attribute 'NVIDIA_INVALID'",
     ):
-        accelerators.NVIDIA_INVALID
+        _ = accelerators.NVIDIA_INVALID
     with pytest.warns(RayDeprecationWarning):
         assert accelerators.NVIDIA_TESLA_A100 == "A100"
 

--- a/python/ray/tests/accelerators/test_amd_gpu.py
+++ b/python/ray/tests/accelerators/test_amd_gpu.py
@@ -18,7 +18,7 @@ def test_visible_amd_gpu_ids(mock_get_num_accelerators, monkeypatch, shutdown_on
     # we call get_accelerator_manager_for_resource
     del get_accelerator_manager_for_resource._resource_name_to_accelerator_manager
     ray.init()
-    mock_get_num_accelerators.called
+    _ = mock_get_num_accelerators.called
     assert ray.available_resources()["GPU"] == 3
 
 
@@ -28,7 +28,7 @@ def test_visible_amd_gpu_ids(mock_get_num_accelerators, monkeypatch, shutdown_on
 )
 def test_visible_amd_gpu_type(mock_get_amd_device_ids, shutdown_only):
     ray.init()
-    mock_get_amd_device_ids.called
+    _ = mock_get_amd_device_ids.called
     assert (
         AMDGPUAcceleratorManager.get_current_node_accelerator_type()
         == "AMD-Instinct-MI300X-OAM"
@@ -41,7 +41,7 @@ def test_visible_amd_gpu_type(mock_get_amd_device_ids, shutdown_only):
 )
 def test_visible_amd_gpu_type_bad_device_id(mock_get_num_accelerators, shutdown_only):
     ray.init()
-    mock_get_num_accelerators.called
+    _ = mock_get_num_accelerators.called
     assert AMDGPUAcceleratorManager.get_current_node_accelerator_type() is None
 
 

--- a/python/ray/tests/accelerators/test_hpu.py
+++ b/python/ray/tests/accelerators/test_hpu.py
@@ -26,7 +26,7 @@ def test_auto_detected_more_than_visible(
     # Test more hpus are detected than visible.
     monkeypatch.setenv("HABANA_VISIBLE_MODULES", "0,1,2")
     ray.init()
-    mock_get_num_accelerators.called
+    _ = mock_get_num_accelerators.called
     assert ray.available_resources()["HPU"] == 3
 
 
@@ -37,7 +37,7 @@ def test_auto_detected_more_than_visible(
 def test_auto_detect_resources(mock_get_num_accelerators, shutdown_only):
     # Test that ray node resources are filled with auto detected count.
     ray.init()
-    mock_get_num_accelerators.called
+    _ = mock_get_num_accelerators.called
     assert ray.available_resources()["HPU"] == 2
 
 

--- a/python/ray/tests/accelerators/test_neuron.py
+++ b/python/ray/tests/accelerators/test_neuron.py
@@ -25,7 +25,7 @@ def test_auto_detected_more_than_visible(
     # Test more neuron_cores are detected than visible.
     monkeypatch.setenv("NEURON_RT_VISIBLE_CORES", "0,1,2")
     ray.init()
-    mock_get_num_accelerators.called
+    _ = mock_get_num_accelerators.called
     assert ray.available_resources()["neuron_cores"] == 3
 
 
@@ -36,7 +36,7 @@ def test_auto_detected_more_than_visible(
 def test_auto_detect_resources(mock_get_num_accelerators, shutdown_only):
     # Test that ray node resources are filled with auto detected count.
     ray.init()
-    mock_get_num_accelerators.called
+    _ = mock_get_num_accelerators.called
     assert ray.available_resources()["neuron_cores"] == 2
 
 

--- a/python/ray/tests/test_asyncio.py
+++ b/python/ray/tests/test_asyncio.py
@@ -130,7 +130,7 @@ async def test_asyncio_get(ray_start_regular_shared, event_loop):
 
     @ray.remote
     def task_throws():
-        raise ZeroDivisionError
+        _ = 1 / 0
 
     with pytest.raises(ray.exceptions.RayTaskError):
         await task_throws.remote().as_future()
@@ -148,7 +148,7 @@ async def test_asyncio_get(ray_start_regular_shared, event_loop):
             return "a" * (str_len)
 
         def throw_error(self):
-            raise ZeroDivisionError
+            _ = 1 / 0
 
     actor = Actor.remote()
 

--- a/python/ray/tests/test_asyncio.py
+++ b/python/ray/tests/test_asyncio.py
@@ -130,7 +130,7 @@ async def test_asyncio_get(ray_start_regular_shared, event_loop):
 
     @ray.remote
     def task_throws():
-        1 / 0
+        raise ZeroDivisionError
 
     with pytest.raises(ray.exceptions.RayTaskError):
         await task_throws.remote().as_future()
@@ -148,7 +148,7 @@ async def test_asyncio_get(ray_start_regular_shared, event_loop):
             return "a" * (str_len)
 
         def throw_error(self):
-            1 / 0
+            raise ZeroDivisionError
 
     actor = Actor.remote()
 

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -888,7 +888,7 @@ def test_putting_object_that_closes_over_object_ref(ray_start_shared_local_modes
             self.val = ray.put(0)
 
         def method(self):
-            f  # noqa : B018
+            _ = f
 
     f = Foo()
     ray.put(f)

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -888,7 +888,7 @@ def test_putting_object_that_closes_over_object_ref(ray_start_shared_local_modes
             self.val = ray.put(0)
 
         def method(self):
-            f
+            f  # noqa : B018
 
     f = Foo()
     ray.put(f)

--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -919,7 +919,7 @@ def test_ray_status(shutdown_only, monkeypatch, enable_v2):
 
     def output_ready():
         result = runner.invoke(scripts.status)
-        result.stdout
+        _ = result.stdout
         if not result.exception and "memory" in result.output:
             return True
         raise RuntimeError(
@@ -967,7 +967,7 @@ def test_ray_status_multinode(ray_start_cluster, enable_v2):
 
     def output_ready():
         result = runner.invoke(scripts.status)
-        result.stdout
+        _ = result.stdout
         if not result.exception and "memory" in result.output:
             return True
         raise RuntimeError(

--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -878,7 +878,7 @@ def test_client_actor_missing_field(call_ray_start_shared):
         assert ray.get(handle.child_func.remote()) == 42
         with pytest.raises(AttributeError):
             # We should raise attribute error when accessing a non-existent func
-            SomeClass.nonexistent_func
+            _ = SomeClass.nonexistent_func
 
 
 def test_serialize_client_actor_handle(call_ray_start_shared):

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -518,7 +518,7 @@ def test_export_large_objects(ray_start_regular, error_pubsub):
 
     @ray.remote
     def f():
-        large_object  # noqa : B018
+        _ = large_object
 
     # Invoke the function so that the definition is exported.
     f.remote()
@@ -531,7 +531,7 @@ def test_export_large_objects(ray_start_regular, error_pubsub):
     @ray.remote
     class Foo:
         def __init__(self):
-            large_object  # noqa: B018
+            _ = large_object
 
     Foo.remote()
 

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -518,7 +518,7 @@ def test_export_large_objects(ray_start_regular, error_pubsub):
 
     @ray.remote
     def f():
-        large_object
+        large_object  # noqa : B018
 
     # Invoke the function so that the definition is exported.
     f.remote()
@@ -531,7 +531,7 @@ def test_export_large_objects(ray_start_regular, error_pubsub):
     @ray.remote
     class Foo:
         def __init__(self):
-            large_object
+            large_object  # noqa: B018
 
     Foo.remote()
 

--- a/python/ray/tests/test_serialization.py
+++ b/python/ray/tests/test_serialization.py
@@ -628,7 +628,7 @@ def test_numpy_ufunc(ray_start_shared_local_modes):
     @ray.remote
     def f():
         # add reference to the numpy ufunc
-        log
+        log  # noqa: B018
 
     ray.get(f.remote())
 
@@ -747,7 +747,7 @@ def test_cannot_out_of_band_serialize_object_ref(shutdown_only, monkeypatch):
 
         @ray.remote
         def f():
-            ref
+            ref  # noqa: B018
 
         with pytest.raises(ray.exceptions.OufOfBandObjectRefSerializationException):
             ray.get(f.remote())
@@ -774,7 +774,7 @@ def test_can_out_of_band_serialize_object_ref_with_env_var(shutdown_only, monkey
 
         @ray.remote
         def f():
-            ref
+            ref  # noqa: B018
 
         ray.get(f.remote())
 

--- a/python/ray/tests/test_serialization.py
+++ b/python/ray/tests/test_serialization.py
@@ -628,7 +628,7 @@ def test_numpy_ufunc(ray_start_shared_local_modes):
     @ray.remote
     def f():
         # add reference to the numpy ufunc
-        log  # noqa: B018
+        _ = log
 
     ray.get(f.remote())
 
@@ -747,7 +747,7 @@ def test_cannot_out_of_band_serialize_object_ref(shutdown_only, monkeypatch):
 
         @ray.remote
         def f():
-            ref  # noqa: B018
+            _ = ref
 
         with pytest.raises(ray.exceptions.OufOfBandObjectRefSerializationException):
             ray.get(f.remote())
@@ -774,7 +774,7 @@ def test_can_out_of_band_serialize_object_ref_with_env_var(shutdown_only, monkey
 
         @ray.remote
         def f():
-            ref  # noqa: B018
+            _ = ref
 
         ray.get(f.remote())
 

--- a/python/ray/train/examples/deepspeed/deepspeed_torch_trainer.py
+++ b/python/ray/train/examples/deepspeed/deepspeed_torch_trainer.py
@@ -180,6 +180,6 @@ if __name__ == "__main__":
     result = trainer.fit()
 
     # Retrieve the best checkponints from results
-    result.best_checkpoints
+    _ = result.best_checkpoints
 
 # __deepspeed_torch_basic_example_end__

--- a/python/ray/train/examples/deepspeed/deepspeed_torch_trainer_no_raydata.py
+++ b/python/ray/train/examples/deepspeed/deepspeed_torch_trainer_no_raydata.py
@@ -173,6 +173,6 @@ if __name__ == "__main__":
     result = trainer.fit()
 
     # Retrieve the best checkponints from results
-    result.best_checkpoints
+    _ = result.best_checkpoints
 
 # __deepspeed_torch_basic_example_no_raydata_end__

--- a/python/ray/train/tests/test_base_trainer.py
+++ b/python/ray/train/tests/test_base_trainer.py
@@ -175,7 +175,7 @@ def test_large_params(ray_start_4_cpus):
     huge_array = np.zeros(shape=int(1e8))
 
     def training_loop(self):
-        huge_array  # noqa: B018
+        _ = huge_array
 
     trainer = DummyTrainer(training_loop)
     trainer.fit()

--- a/python/ray/train/tests/test_base_trainer.py
+++ b/python/ray/train/tests/test_base_trainer.py
@@ -175,7 +175,7 @@ def test_large_params(ray_start_4_cpus):
     huge_array = np.zeros(shape=int(1e8))
 
     def training_loop(self):
-        huge_array
+        huge_array  # noqa: B018
 
     trainer = DummyTrainer(training_loop)
     trainer.fit()

--- a/rllib/examples/envs/classes/d4rl_env.py
+++ b/rllib/examples/envs/classes/d4rl_env.py
@@ -9,7 +9,7 @@ import gymnasium as gym
 try:
     import d4rl
 
-    d4rl.__name__  # Fool LINTer.
+    _ = d4rl.__name__  # Fool LINTer.
 except ImportError:
     d4rl = None
 

--- a/rllib/offline/offline_prelearner.py
+++ b/rllib/offline/offline_prelearner.py
@@ -404,7 +404,7 @@ class OfflinePreLearner:
 
             if is_multi_agent:
                 # TODO (simon): Add support for multi-agent episodes.
-                raise NotImplementedError
+                pass
             else:
                 # Build a single-agent episode with a single row of the batch.
                 episode = SingleAgentEpisode(
@@ -521,7 +521,7 @@ class OfflinePreLearner:
 
             if is_multi_agent:
                 # TODO (simon): Add support for multi-agent episodes.
-                raise NotImplementedError
+                pass
             else:
                 # Unpack observations, if needed. Note, observations could
                 # be either compressed by their entirety (the complete batch

--- a/rllib/offline/offline_prelearner.py
+++ b/rllib/offline/offline_prelearner.py
@@ -404,7 +404,7 @@ class OfflinePreLearner:
 
             if is_multi_agent:
                 # TODO (simon): Add support for multi-agent episodes.
-                NotImplementedError
+                raise NotImplementedError
             else:
                 # Build a single-agent episode with a single row of the batch.
                 episode = SingleAgentEpisode(
@@ -521,7 +521,7 @@ class OfflinePreLearner:
 
             if is_multi_agent:
                 # TODO (simon): Add support for multi-agent episodes.
-                NotImplementedError
+                raise NotImplementedError
             else:
                 # Unpack observations, if needed. Note, observations could
                 # be either compressed by their entirety (the complete batch


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Useless expressions have no effect on the program, and are often included by mistake. Assign a useless expression to a variable, or remove it entirely.

However, if a seemingly useless expression (like an attribute access) is needed to trigger a side effect, consider assigning it to an anonymous variable, to indicate that the return value is intentionally ignored.

Ref: https://docs.astral.sh/ruff/rules/useless-expression/

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
https://github.com/ray-project/ray/issues/47991

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
