### PR TITLE
[core][cgraph] Add release_buffer to ChannelInterface

### DIFF
--- a/python/ray/experimental/channel/cached_channel.py
+++ b/python/ray/experimental/channel/cached_channel.py
@@ -101,7 +101,7 @@ class CachedChannel(ChannelInterface):
         # improvements.
         # https://github.com/ray-project/ray/issues/47409
         return ctx.get_data(self._channel_id)
-    
+
     def release_buffer(self, timeout: Optional[float] = None) -> None:
         self.read(timeout)
 

--- a/python/ray/experimental/channel/cached_channel.py
+++ b/python/ray/experimental/channel/cached_channel.py
@@ -101,6 +101,9 @@ class CachedChannel(ChannelInterface):
         # improvements.
         # https://github.com/ray-project/ray/issues/47409
         return ctx.get_data(self._channel_id)
+    
+    def release_buffer(self, timeout: Optional[float] = None) -> None:
+        self.read(timeout)
 
     def close(self) -> None:
         from ray.experimental.channel import ChannelContext

--- a/python/ray/experimental/channel/common.py
+++ b/python/ray/experimental/channel/common.py
@@ -255,6 +255,20 @@ class ChannelInterface:
         """
         raise NotImplementedError
 
+    def release_buffer(self, timeout: Optional[float] = None) -> None:
+        """
+        Reads the latest value out of the buffer without actually deserializing it.
+        We use this throughout when dagrefs are destructed without ever having ray.get
+        called on them, so that we can avoid the cost of deserializing.
+
+        Args:
+            timeout: The maximum time in seconds to wait to read the value.
+                None means using default timeout, 0 means immediate timeout
+                (immediate success or timeout without blocking), -1 means
+                infinite timeout (block indefinitely).
+        """
+        raise NotImplementedError
+
     def close(self) -> None:
         """
         Close this channel. This method must not block and it must be made

--- a/python/ray/experimental/channel/intra_process_channel.py
+++ b/python/ray/experimental/channel/intra_process_channel.py
@@ -65,6 +65,9 @@ class IntraProcessChannel(ChannelInterface):
         ctx = ChannelContext.get_current().serialization_context
         return ctx.get_data(self._channel_id)
 
+    def release_buffer(self, timeout: Optional[float] = None) -> None:
+        self.read(timeout)
+
     def close(self) -> None:
         ctx = ChannelContext.get_current().serialization_context
         ctx.reset_data(self._channel_id)

--- a/python/ray/experimental/channel/intra_process_channel.py
+++ b/python/ray/experimental/channel/intra_process_channel.py
@@ -58,9 +58,8 @@ class IntraProcessChannel(ChannelInterface):
         ctx = ChannelContext.get_current().serialization_context
         ctx.set_data(self._channel_id, value, self._num_readers)
 
-    def read(self, timeout: Optional[float] = None, deserialize: bool = True) -> Any:
+    def read(self, timeout: Optional[float] = None) -> Any:
         self.ensure_registered_as_reader()
-        assert deserialize, "Data passed from the actor to itself is never serialized"
         # No need to check timeout as the operation is non-blocking.
         ctx = ChannelContext.get_current().serialization_context
         return ctx.get_data(self._channel_id)

--- a/python/ray/experimental/channel/shared_memory_channel.py
+++ b/python/ray/experimental/channel/shared_memory_channel.py
@@ -236,9 +236,9 @@ class Channel(ChannelInterface):
             self._writer_node_id = (
                 ray.runtime_context.get_runtime_context().get_node_id()
             )
-            self._writer_ref = _create_channel_ref(self, typ.buffer_size_bytes)
+            self._writer_ref = _create_channel_ref(self, self._buffer_size_bytes)
 
-            self._create_reader_refs(typ.buffer_size_bytes)
+            self._create_reader_refs(self._buffer_size_bytes)
         else:
             assert (
                 _writer_node_id is not None

--- a/python/ray/experimental/channel/shared_memory_channel.py
+++ b/python/ray/experimental/channel/shared_memory_channel.py
@@ -190,7 +190,7 @@ class Channel(ChannelInterface):
         if typ is None:
             buffer_size_bytes = DEFAULT_MAX_BUFFER_SIZE
         elif isinstance(typ, int):
-            buffer_size_bytes = SharedMemoryType(buffer_size_bytes=typ)
+            buffer_size_bytes = typ
         else:
             buffer_size_bytes = typ.buffer_size_bytes
 

--- a/python/ray/experimental/channel/torch_tensor_nccl_channel.py
+++ b/python/ray/experimental/channel/torch_tensor_nccl_channel.py
@@ -270,7 +270,8 @@ class TorchTensorNcclChannel(ChannelInterface):
             self._send_cpu_and_gpu_data(value, timeout)
 
     def _recv_cpu_and_gpu_data(
-        self, tensors: List["torch.Tensor"],
+        self,
+        tensors: List["torch.Tensor"],
         timeout: Optional[float] = None,
         release_buffer: bool = False,
     ) -> Any:
@@ -302,7 +303,9 @@ class TorchTensorNcclChannel(ChannelInterface):
 
         return None if release_buffer else data
 
-    def read(self, timeout: Optional[float] = None, release_buffer: bool = False) -> Any:
+    def read(
+        self, timeout: Optional[float] = None, release_buffer: bool = False
+    ) -> Any:
         """
         Read a value that may contain torch.Tensors sent via external
         transport.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
release_buffer is called on channels without checking the type or anything. We should assure that all channels have a release_buffer function even if it just calls read.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
