### PR TITLE
[serve] Fix batch hanging bug

### DIFF
--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1641,7 +1641,7 @@ class UserCallableWrapper:
                 # because we cannot guarantee cancelling the batched
                 # call, so in the case that the call continues executing
                 # we should continue fetching data from the client.
-                if not getattr(user_method_info.callable, "set_max_batch_size"):
+                if not hasattr(user_method_info.callable, "set_max_batch_size"):
                     receive_task.cancel()
 
             raise

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -50,10 +50,10 @@ from ray.serve._private.constants import (
     GRPC_CONTEXT_ARG_NAME,
     HEALTH_CHECK_METHOD,
     RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE,
+    RAY_SERVE_METRICS_EXPORT_INTERVAL_MS,
     RAY_SERVE_REPLICA_AUTOSCALING_METRIC_RECORD_PERIOD_S,
     RAY_SERVE_RUN_SYNC_IN_THREADPOOL,
     RAY_SERVE_RUN_SYNC_IN_THREADPOOL_WARNING,
-    RAY_SERVE_METRICS_EXPORT_INTERVAL_MS,
     RECONFIGURE_METHOD,
     SERVE_CONTROLLER_NAME,
     SERVE_LOGGER_NAME,
@@ -1601,7 +1601,7 @@ class UserCallableWrapper:
                 if request_metadata.is_streaming
                 else None,
             )
-            return await self._handle_user_method_result(
+            final_result = await self._handle_user_method_result(
                 result,
                 request_metadata,
                 user_method_info,
@@ -1610,6 +1610,10 @@ class UserCallableWrapper:
                 asgi_args=asgi_args,
             )
 
+            if receive_task is not None and not receive_task.done():
+                receive_task.cancel()
+
+            return final_result
         except Exception:
             if (
                 request_metadata.is_http_request
@@ -1625,10 +1629,25 @@ class UserCallableWrapper:
                     asgi_args,
                 )
 
-            raise
-        finally:
             if receive_task is not None and not receive_task.done():
                 receive_task.cancel()
+
+            raise
+        except asyncio.CancelledError:
+            user_method_info = self._get_user_method_info(request_metadata.call_method)
+            if receive_task is not None and not receive_task.done():
+                # Do NOT cancel the receive task if the request has been
+                # cancelled, but the call is a batched call. This is
+                # because we cannot guarantee cancelling the batched
+                # call, so in the case that the call continues executing
+                # we should continue fetching data from the client.
+                if not getattr(user_method_info.callable, "set_max_batch_size"):
+                    receive_task.cancel()
+                else:
+                    # logger.info("NOT cancelling receive task")
+                    receive_task.cancel()
+
+            raise
 
     @_run_on_user_code_event_loop
     async def call_destructor(self):

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1643,9 +1643,6 @@ class UserCallableWrapper:
                 # we should continue fetching data from the client.
                 if not getattr(user_method_info.callable, "set_max_batch_size"):
                     receive_task.cancel()
-                else:
-                    # logger.info("NOT cancelling receive task")
-                    receive_task.cancel()
 
             raise
 

--- a/python/ray/serve/batching.py
+++ b/python/ray/serve/batching.py
@@ -290,7 +290,13 @@ class _BatchQueue:
         """Processes queued request batch."""
 
         batch: List[_SingleRequest] = await self.wait_for_batch()
-        assert len(batch) > 0
+        # Remove requests that have been cancelled from the batch. If
+        # all requests have been cancelled, simply return and wait for
+        # the next batch.
+        batch = [req for req in batch if not req.future.cancelled()]
+        if len(batch) == 0:
+            return
+
         futures = [item.future for item in batch]
 
         # Most of the logic in the function should be wrapped in this try-


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When the requests in a batch are cancelled, sometimes we can run into a race condition where:
1. The `enqueue_request` wrapper that's waiting on the future is cancelled.
2. The task that's fetching data from the client and putting it onto the receive queue is cancelled before any data is put onto the queue.
3. The request is pulled from the queue, batched, and executed, and a call to `await request.json()` hangs because there is no data on the queue.

To mitigate this, in the specific case where the `enqueue_request` wrapper has exited because of an `asyncio.CancelledError` __and__ the call is a batched call (i.e. decorated with `@serve.batch`), we don't cancel the receive task (which in itself is a smart optimization, so there shouldn't be side effects).

This PR also improves the handling of cancelled batched requests by removing requests that have already been cancelled during the batch waiting period, before executing a batch.

Testing: tested manually. Since this is caused by a race condition, it is hard to write a test for it. I will follow up in a separate PR once I come up with an appropriate test.

Run:
```
@serve.deployment(max_ongoing_requests=10)
class Model:
    @serve.batch(max_batch_size=8, batch_wait_timeout_s=0.001)
    async def __call__(self, http_request: List[Request]):
        model_input = [await req.json() for req in http_request]
        await asyncio.sleep(float(model_input[0]["time"]))
        return [1 for _ in http_request]
```

Then send requests using `ab -n 2000 -c 50 -p data.json http://127.0.0.1:8000/` and ctrl-C before the load test finishes so that a bunch of requests get cancelled from client-disconnect. This should cause the replica to get stuck with high probability before this PR, and this PR should completely fix it.

## Related issue number

Closes https://github.com/ray-project/ray/issues/50046

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
