### PR TITLE
[core] support dir includes env for working dir

### DIFF
--- a/python/ray/_private/runtime_env/py_modules.py
+++ b/python/ray/_private/runtime_env/py_modules.py
@@ -99,8 +99,11 @@ def upload_py_modules_if_needed(
             if Path(module_path).is_dir() or Path(module_path).suffix == ".py":
                 is_dir = Path(module_path).is_dir()
                 excludes = runtime_env.get("excludes", None)
+                includes = runtime_env.get("includes", None)
                 if is_dir:
-                    module_uri = get_uri_for_directory(module_path, excludes=excludes)
+                    module_uri = get_uri_for_directory(
+                        module_path, excludes=excludes, includes=includes
+                    )
                 else:
                     module_uri = get_uri_for_file(module_path)
                 if upload_fn is None:
@@ -110,6 +113,7 @@ def upload_py_modules_if_needed(
                             scratch_dir,
                             module_path,
                             excludes=excludes,
+                            includes=includes,
                             include_parent_dir=is_dir,
                             logger=logger,
                         )

--- a/python/ray/_private/runtime_env/working_dir.py
+++ b/python/ray/_private/runtime_env/working_dir.py
@@ -61,8 +61,11 @@ def upload_working_dir_if_needed(
         return runtime_env
 
     excludes = runtime_env.get("excludes", None)
+    includes = runtime_env.get("includes", None)
     try:
-        working_dir_uri = get_uri_for_directory(working_dir, excludes=excludes)
+        working_dir_uri = get_uri_for_directory(
+            working_dir, excludes=excludes, includes=includes
+        )
     except ValueError:  # working_dir is not a directory
         package_path = Path(working_dir)
         if not package_path.exists() or package_path.suffix != ".zip":
@@ -88,6 +91,7 @@ def upload_working_dir_if_needed(
                 working_dir,
                 include_parent_dir=False,
                 excludes=excludes,
+                includes=includes,
                 logger=logger,
             )
         except Exception as e:

--- a/python/ray/dashboard/modules/dashboard_sdk.py
+++ b/python/ray/dashboard/modules/dashboard_sdk.py
@@ -333,6 +333,7 @@ class SubmissionClient:
         package_path: str,
         include_parent_dir: Optional[bool] = False,
         excludes: Optional[List[str]] = None,
+        includes: Optional[List[str]] = None,
         is_file: bool = False,
     ) -> bool:
         logger.info(f"Uploading package {package_uri}.")
@@ -347,6 +348,7 @@ class SubmissionClient:
                     package_file,
                     include_parent_dir=include_parent_dir,
                     excludes=excludes,
+                    includes=includes,
                 )
             try:
                 r = self._do_request(
@@ -366,12 +368,15 @@ class SubmissionClient:
         package_path: str,
         include_parent_dir: bool = False,
         excludes: Optional[List[str]] = None,
+        includes: Optional[List[str]] = None,
         is_file: bool = False,
     ) -> str:
         if is_file:
             package_uri = get_uri_for_package(Path(package_path))
         else:
-            package_uri = get_uri_for_directory(package_path, excludes=excludes)
+            package_uri = get_uri_for_directory(
+                package_path, excludes=excludes, includes=includes
+            )
 
         if not self._package_exists(package_uri):
             self._upload_package(
@@ -387,20 +392,25 @@ class SubmissionClient:
         return package_uri
 
     def _upload_working_dir_if_needed(self, runtime_env: Dict[str, Any]):
-        def _upload_fn(working_dir, excludes, is_file=False):
+        def _upload_fn(working_dir, excludes, includes, is_file=False):
             self._upload_package_if_needed(
                 working_dir,
                 include_parent_dir=False,
                 excludes=excludes,
+                includes=includes,
                 is_file=is_file,
             )
 
         upload_working_dir_if_needed(runtime_env, upload_fn=_upload_fn)
 
     def _upload_py_modules_if_needed(self, runtime_env: Dict[str, Any]):
-        def _upload_fn(module_path, excludes, is_file=False):
+        def _upload_fn(module_path, excludes, includes, is_file=False):
             self._upload_package_if_needed(
-                module_path, include_parent_dir=True, excludes=excludes, is_file=is_file
+                module_path,
+                include_parent_dir=True,
+                excludes=excludes,
+                includes=includes,
+                is_file=is_file,
             )
 
         upload_py_modules_if_needed(runtime_env, upload_fn=_upload_fn)

--- a/python/ray/runtime_env/runtime_env.py
+++ b/python/ray/runtime_env/runtime_env.py
@@ -287,6 +287,7 @@ class RuntimeEnv(dict):
         "uv",
         "container",
         "excludes",
+        "includes",
         "env_vars",
         "_ray_release",
         "_ray_commit",


### PR DESCRIPTION
ref: https://github.com/ray-project/ray/issues/49136

**Description**
Today, Ray's runtime environment supports "exclude" argument to exclude files when creating the runtime environment. The ask is to also support "include" to only include certain files to the runtime environment.

**Use case**
For the use cases where only a small amount of files under a large directory is needed for the runtime environment

**Newly added user case**
```
ray.init(
    runtime_env={
        "working_dir": ".",  # Upload the current directory
        "includes": [
            "*.py",  
        ]
    }
)

```



<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
