### PR TITLE
[ci] upgrade forge to use 22.04

### DIFF
--- a/ci/docker/forge.Dockerfile
+++ b/ci/docker/forge.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3-labs
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG BUILDKITE_BAZEL_CACHE_URL
 

--- a/ci/docker/forge.aarch64.wanda.yaml
+++ b/ci/docker/forge.aarch64.wanda.yaml
@@ -1,6 +1,6 @@
 name: "forge-aarch64"
 froms:
-  - ubuntu:20.04
+  - ubuntu:22.04
 build_args:
   - BUILDKITE_BAZEL_CACHE_URL
 dockerfile: ci/docker/forge.Dockerfile

--- a/ci/docker/forge.wanda.yaml
+++ b/ci/docker/forge.wanda.yaml
@@ -1,6 +1,6 @@
 name: "forge"
 froms:
-  - ubuntu:20.04
+  - ubuntu:22.04
 build_args:
   - BUILDKITE_BAZEL_CACHE_URL
 dockerfile: ci/docker/forge.Dockerfile


### PR DESCRIPTION
so that the default python is not python 3.8 anymore