### PR TITLE
fix using dict as logging config in local mode

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -459,10 +459,15 @@ def _run(
     validate_route_prefix(route_prefix)
 
     if _local_testing_mode:
+        if logging_config is None:
+            logging_config = LoggingConfig()
+        elif isinstance(logging_config, dict):
+            logging_config = LoggingConfig(**logging_config)
+
         configure_component_logger(
             component_name="local_test",
             component_id="-",
-            logging_config=logging_config or LoggingConfig(),
+            logging_config=logging_config,
             stream_handler_only=True,
         )
         built_app = build_app(

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -460,9 +460,7 @@ def _run(
 
     if _local_testing_mode:
         if logging_config is None:
-            logging_config = LoggingConfig()
-        elif isinstance(logging_config, dict):
-            logging_config = LoggingConfig(**logging_config)
+            logging_config = LoggingConfig(**(logging_config or {}))
 
         configure_component_logger(
             component_name="local_test",

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -459,7 +459,7 @@ def _run(
     validate_route_prefix(route_prefix)
 
     if _local_testing_mode:
-        if logging_config is None:
+        if not isinstance(logging_config, LoggingConfig):
             logging_config = LoggingConfig(**(logging_config or {}))
 
         configure_component_logger(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Serve's `configure_component_logger()` takes `logging_config` as the `LoggingConfig` object, but when using local mode, the dictionary `logging_config` is getting passed directly into `configure_component_logger()`. Doing this TDD way and added the logic to covert dictionary `logging_config` into `LoggingConfig` before passing into `configure_component_logger()`

## Related issue number

Closes https://github.com/ray-project/ray/issues/50052

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
