### PR TITLE
[Core] Fix the configure_logging Function to Correctly Pass in the LoggingConfig Object

### DIFF
--- a/python/ray/_private/ray_logging/logging_config.py
+++ b/python/ray/_private/ray_logging/logging_config.py
@@ -39,7 +39,7 @@ class DefaultLoggingConfigurator(LoggingConfigurator):
 
     @Deprecated
     def configure_logging(self, encoding: str, log_level: str):
-        self.configure(self)
+        self.configure(LoggingConfig(encoding=encoding, log_level=log_level))
 
     def configure(self, logging_config: "LoggingConfig"):
         formatter = self._encoding_to_formatter[logging_config.encoding]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The PR fix the test failure on rayturbo side by correctly passing in the LoggingConfig object in the configure_logging function.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
N/A

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
