### PR TITLE
[core] Async get_cluster_status for dashboard api

### DIFF
--- a/python/ray/_private/gcs_aio_client.py
+++ b/python/ray/_private/gcs_aio_client.py
@@ -45,3 +45,4 @@ class GcsAioClient:
         self.get_all_actor_info = self.inner.async_get_all_actor_info
         self.get_all_node_info = self.inner.async_get_all_node_info
         self.kill_actor = self.inner.async_kill_actor
+        self.get_cluster_status = self.inner.async_get_cluster_status

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -555,6 +555,10 @@ cdef extern from "ray/gcs/gcs_client/accessor.h" nogil:
             c_string &serialized_reply
         )
 
+        CRayStatus AsyncGetClusterStatus(
+            int64_t timeout_ms,
+            const OptionalItemPyCallback[CGetClusterStatusReply] &callback)
+
         CRayStatus ReportAutoscalingState(
             int64_t timeout_ms,
             const c_string &serialized_state
@@ -725,6 +729,12 @@ cdef extern from "src/ray/protobuf/gcs.pb.h" nogil:
 
     cdef cppclass CActorTableData "ray::rpc::ActorTableData":
         CAddress address() const
+        void ParseFromString(const c_string &serialized)
+        const c_string &SerializeAsString() const
+
+cdef extern from "src/ray/protobuf/autoscaler.pb.h" nogil:
+    cdef cppclass CGetClusterStatusReply "ray::rpc::autoscaler::GetClusterStatusReply":
+        c_string serialized_cluster_status() const
         void ParseFromString(const c_string &serialized)
         const c_string &SerializeAsString() const
 

--- a/python/ray/includes/gcs_client.pxi
+++ b/python/ray/includes/gcs_client.pxi
@@ -28,9 +28,10 @@ from ray.includes.common cimport (
     MultiItemPyCallback,
     OptionalItemPyCallback,
     StatusPyCallback,
+    CGetClusterStatusReply,
 )
 from ray.includes.optional cimport optional, make_optional
-from ray.core.generated import gcs_pb2
+from ray.core.generated import gcs_pb2, autoscaler_pb2
 from cython.operator import dereference, postincrement
 cimport cpython
 
@@ -548,6 +549,28 @@ cdef class InnerGcsClient:
 
         return serialized_reply
 
+    def async_get_cluster_status(
+        self,
+        timeout_s=None
+    ) -> Future[autoscaler_pb2.GetClusterStatusReply]:
+        cdef:
+            int64_t timeout_ms = round(1000 * timeout_s) if timeout_s else -1
+            fut = incremented_fut()
+        with nogil:
+            check_status_timeout_as_rpc_error(
+                self.inner.get()
+                .Autoscaler()
+                .AsyncGetClusterStatus(
+                    timeout_ms,
+                    OptionalItemPyCallback[CGetClusterStatusReply](
+                        &convert_get_cluster_status_reply,
+                        assign_and_decrement_fut,
+                        fut
+                    )
+                )
+            )
+        return asyncio.wrap_future(fut)
+
     def report_autoscaling_state(
         self,
         serialzied_state: c_string,
@@ -697,6 +720,21 @@ cdef convert_get_all_actor_info(
             proto.ParseFromString(b)
             actor_table_data[ActorID.from_binary(proto.actor_id)] = proto
         return actor_table_data, None
+    except Exception as e:
+        return None, e
+
+cdef convert_get_cluster_status_reply(
+    CRayStatus status, optional[CGetClusterStatusReply]&& c_data
+) with gil: # -> Tuple[autoscaler_pb2.GetClusterStatusReply, Exception]
+    cdef c_string serialized_reply
+    try:
+        check_status_timeout_as_rpc_error(status)
+        assert c_data.has_value()
+        with nogil:
+            serialized_reply = c_data.value().SerializeAsString()
+        proto = autoscaler_pb2.GetClusterStatusReply()
+        proto.ParseFromString(serialized_reply)
+        return proto, None
     except Exception as e:
         return None, e
 

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -1494,6 +1494,26 @@ Status AutoscalerStateAccessor::GetClusterStatus(int64_t timeout_ms,
   return Status::OK();
 }
 
+Status AutoscalerStateAccessor::AsyncGetClusterStatus(
+    int64_t timeout_ms,
+    const OptionalItemCallback<rpc::autoscaler::GetClusterStatusReply> &callback) {
+  rpc::autoscaler::GetClusterStatusRequest request;
+  rpc::autoscaler::GetClusterStatusRequest reply;
+
+  client_impl_->GetGcsRpcClient().GetClusterStatus(
+      request,
+      [callback](const Status &status, rpc::autoscaler::GetClusterStatusReply &&reply) {
+        if (!status.ok()) {
+          callback(status, std::nullopt);
+          return;
+        }
+        callback(Status::OK(), std::move(reply));
+      },
+      timeout_ms);
+
+  return Status::OK();
+}
+
 Status AutoscalerStateAccessor::ReportAutoscalingState(
     int64_t timeout_ms, const std::string &serialized_state) {
   rpc::autoscaler::ReportAutoscalingStateRequest request;

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -22,6 +22,7 @@
 #include "ray/gcs/callback.h"
 #include "ray/rpc/client_call.h"
 #include "ray/util/sequencer.h"
+#include "src/ray/protobuf/autoscaler.pb.h"
 #include "src/ray/protobuf/gcs.pb.h"
 #include "src/ray/protobuf/gcs_service.pb.h"
 
@@ -990,6 +991,10 @@ class AutoscalerStateAccessor {
                                          std::string &serialized_reply);
 
   virtual Status GetClusterStatus(int64_t timeout_ms, std::string &serialized_reply);
+
+  virtual Status AsyncGetClusterStatus(
+      int64_t timeout_ms,
+      const OptionalItemCallback<rpc::autoscaler::GetClusterStatusReply> &callback);
 
   virtual Status ReportAutoscalingState(int64_t timeout_ms,
                                         const std::string &serialized_state);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently the /nodes path for dashboard api from the node_head calls this get_nodes_logical_resources function which makes a sync call to the gcs for the cluster status from the autoscaler_v2 sdk. This request happens on the main thread of the gcs and can end up blocking the dashboard process for a bit when the gcs is under load in large clusters.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
