### PR TITLE
[data] Support retries across datasinks and sources

### DIFF
--- a/python/ray/data/_internal/datasource/bigquery_datasink.py
+++ b/python/ray/data/_internal/datasource/bigquery_datasink.py
@@ -8,8 +8,8 @@ from typing import Iterable, Optional
 import pyarrow.parquet as pq
 
 import ray
-from ray.data._internal.execution.interfaces import TaskContext
 from ray.data._internal.datasource import bigquery_datasource
+from ray.data._internal.execution.interfaces import TaskContext
 from ray.data._internal.remote_fn import cached_remote_fn
 from ray.data._internal.util import _check_import
 from ray.data.block import Block, BlockAccessor

--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -6,7 +6,6 @@ from ray.data._internal.arrow_ops.transform_pyarrow import concat
 from ray.data._internal.execution.interfaces import TaskContext
 from ray.data._internal.util import call_with_retry
 from ray.data.block import Block, BlockAccessor
-from ray.data.context import DataContext
 from ray.data.datasource.file_based_datasource import _resolve_kwargs
 from ray.data.datasource.file_datasink import _FileDatasink
 from ray.data.datasource.filename_provider import FilenameProvider
@@ -95,7 +94,7 @@ class ParquetDatasink(_FileDatasink):
         call_with_retry(
             write_blocks_to_path,
             description=f"write '{filename}' to '{self.path}'",
-            match=DataContext.get_current().retried_io_errors,
+            match=self._data_context.retried_io_errors,
             max_attempts=WRITE_FILE_MAX_ATTEMPTS,
             max_backoff_s=WRITE_FILE_RETRY_MAX_BACKOFF_SECONDS,
         )

--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -21,6 +21,7 @@ from ray._private.utils import _get_pyarrow_version
 from ray.data._internal.progress_bar import ProgressBar
 from ray.data._internal.remote_fn import cached_remote_fn
 from ray.data._internal.util import (
+    RetryingPyFileSystem,
     _check_pyarrow_version,
     _is_local_scheme,
     call_with_retry,
@@ -196,6 +197,9 @@ class ParquetDatasource(Datasource):
             )
 
         paths, filesystem = _resolve_paths_and_filesystem(paths, filesystem)
+        filesystem = RetryingPyFileSystem.wrap(
+            filesystem, context=DataContext.get_current()
+        )
 
         # HACK: PyArrow's `ParquetDataset` errors if input paths contain non-parquet
         # files. To avoid this, we expand the input paths with the default metadata

--- a/python/ray/data/_internal/datasource/webdataset_datasource.py
+++ b/python/ray/data/_internal/datasource/webdataset_datasource.py
@@ -9,7 +9,6 @@ import tarfile
 from functools import partial
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
-import ray
 from ray.data._internal.util import iterate_with_retry
 from ray.data.block import BlockAccessor
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
@@ -353,9 +352,10 @@ class WebDatasetDatasource(FileBasedDatasource):
             )
 
         # S3 can raise transient errors during iteration
-        ctx = ray.data.DataContext.get_current()
         files = iterate_with_retry(
-            get_tar_file_iterator, "iterate tar file", match=ctx.retried_io_errors
+            get_tar_file_iterator,
+            "iterate tar file",
+            match=self._data_context.retried_io_errors,
         )
 
         samples = _group_by_keys(files, meta=dict(__url__=path), suffixes=self.suffixes)

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -18,9 +18,11 @@ import numpy as np
 
 import ray
 from ray.data._internal.util import (
+    RetryingContextManager,
+    RetryingPyFileSystem,
     _check_pyarrow_version,
     _is_local_scheme,
-    call_with_retry,
+    iterate_with_retry,
     make_async_gen,
 )
 from ray.data.block import Block, BlockAccessor
@@ -54,12 +56,6 @@ FILE_SIZE_FETCH_PARALLELIZATION_THRESHOLD = 16
 
 # 16 file size fetches from S3 takes ~1.5 seconds with Arrow's S3FileSystem.
 PATHS_PER_FILE_SIZE_FETCH_TASK = 16
-
-# The max retry backoff in seconds for opening file.
-OPEN_FILE_RETRY_MAX_BACKOFF_SECONDS = 32
-
-# The max number of attempts for opening file.
-OPEN_FILE_MAX_ATTEMPTS = 10
 
 
 @DeveloperAPI
@@ -137,6 +133,7 @@ class FileBasedDatasource(Datasource):
             )
 
         self._schema = schema
+        self._data_context = DataContext.get_current()
         self._open_stream_args = open_stream_args
         self._meta_provider = meta_provider
         self._partition_filter = partition_filter
@@ -144,6 +141,9 @@ class FileBasedDatasource(Datasource):
         self._ignore_missing_paths = ignore_missing_paths
         self._include_paths = include_paths
         paths, self._filesystem = _resolve_paths_and_filesystem(paths, filesystem)
+        self._filesystem = RetryingPyFileSystem.wrap(
+            self._filesystem, context=self._data_context
+        )
         paths, file_sizes = map(
             list,
             zip(
@@ -214,7 +214,6 @@ class FileBasedDatasource(Datasource):
     def get_read_tasks(self, parallelism: int) -> List[ReadTask]:
         import numpy as np
 
-        ctx = DataContext.get_current()
         open_stream_args = self._open_stream_args
         partitioning = self._partitioning
 
@@ -229,34 +228,33 @@ class FileBasedDatasource(Datasource):
             ]
             paths, file_sizes = list(map(list, zip(*shuffled_files_metadata)))
 
-        read_stream = self._read_stream
         filesystem = _wrap_s3_serialization_workaround(self._filesystem)
 
         if open_stream_args is None:
             open_stream_args = {}
-
-        open_input_source = self._open_input_source
 
         def read_files(
             read_paths: Iterable[str],
         ) -> Iterable[Block]:
             nonlocal filesystem, open_stream_args, partitioning
 
-            DataContext._set_current(ctx)
             fs = _unwrap_s3_serialization_workaround(filesystem)
+
             for read_path in read_paths:
                 partitions: Dict[str, str] = {}
                 if partitioning is not None:
                     parse = PathPartitionParser(partitioning)
                     partitions = parse(read_path)
 
-                with _open_file_with_retry(
-                    read_path,
-                    lambda read_path=read_path: open_input_source(
-                        fs, read_path, **open_stream_args
-                    ),
+                with RetryingContextManager(
+                    self._open_input_source(fs, read_path, **open_stream_args),
+                    context=self._data_context,
                 ) as f:
-                    for block in read_stream(f, read_path):
+                    for block in iterate_with_retry(
+                        lambda: self._read_stream(f, read_path),
+                        description="read stream iteratively",
+                        match=self._data_context.retried_io_errors,
+                    ):
                         if partitions:
                             block = _add_partitions(block, partitions)
                         if self._include_paths:
@@ -272,7 +270,7 @@ class FileBasedDatasource(Datasource):
 
                 # TODO: We should refactor the code so that we can get the results in
                 # order even when using multiple threads.
-                if ctx.execution_options.preserve_order:
+                if self._data_context.execution_options.preserve_order:
                     num_threads = 0
 
                 if num_threads > 0:
@@ -322,23 +320,21 @@ class FileBasedDatasource(Datasource):
 
     def _open_input_source(
         self,
-        filesystem: "pyarrow.fs.FileSystem",
+        filesystem: "RetryingPyFileSystem",
         path: str,
         **open_args,
     ) -> "pyarrow.NativeFile":
         """Opens a source path for reading and returns the associated Arrow NativeFile.
 
         The default implementation opens the source path as a sequential input stream,
-        using ctx.streaming_read_buffer_size as the buffer size if none is given by the
-        caller.
+        using self._data_context.streaming_read_buffer_size as the buffer size if none
+        is given by the caller.
 
         Implementations that do not support streaming reads (e.g. that require random
         access) should override this method.
         """
         import pyarrow as pa
         from pyarrow.fs import HadoopFileSystem
-
-        ctx = DataContext.get_current()
 
         compression = open_args.get("compression", None)
         if compression is None:
@@ -359,7 +355,7 @@ class FileBasedDatasource(Datasource):
 
         buffer_size = open_args.pop("buffer_size", None)
         if buffer_size is None:
-            buffer_size = ctx.streaming_read_buffer_size
+            buffer_size = self._data_context.streaming_read_buffer_size
 
         if compression == "snappy":
             # Arrow doesn't support streaming Snappy decompression since the canonical
@@ -369,19 +365,13 @@ class FileBasedDatasource(Datasource):
         else:
             open_args["compression"] = compression
 
-        file = call_with_retry(
-            lambda: filesystem.open_input_stream(
-                path, buffer_size=buffer_size, **open_args
-            ),
-            description=f"open file {path}",
-            match=ctx.retried_io_errors,
-        )
+        file = filesystem.open_input_stream(path, buffer_size=buffer_size, **open_args)
 
         if compression == "snappy":
             import snappy
 
             stream = io.BytesIO()
-            if isinstance(filesystem, HadoopFileSystem):
+            if isinstance(filesystem.unwrap(), HadoopFileSystem):
                 snappy.hadoop_snappy.stream_decompress(src=file, dst=stream)
             else:
                 snappy.stream_decompress(src=file, dst=stream)
@@ -483,23 +473,43 @@ def _wrap_s3_serialization_workaround(filesystem: "pyarrow.fs.FileSystem"):
     import pyarrow as pa
     import pyarrow.fs
 
-    if isinstance(filesystem, pa.fs.S3FileSystem):
-        return _S3FileSystemWrapper(filesystem)
+    wrap_retries = False
+    fs_to_be_wrapped = filesystem  # Only unwrap for S3FileSystemWrapper
+    context = None
+    if isinstance(fs_to_be_wrapped, RetryingPyFileSystem):
+        wrap_retries = True
+        context = fs_to_be_wrapped.data_context
+        fs_to_be_wrapped = fs_to_be_wrapped.unwrap()
+    if isinstance(fs_to_be_wrapped, pa.fs.S3FileSystem):
+        return _S3FileSystemWrapper(
+            fs_to_be_wrapped, wrap_retries=wrap_retries, context=context
+        )
     return filesystem
 
 
 def _unwrap_s3_serialization_workaround(
-    filesystem: Union["pyarrow.fs.FileSystem", "_S3FileSystemWrapper"]
+    filesystem: Union["pyarrow.fs.FileSystem", "_S3FileSystemWrapper"],
+    context: Optional[DataContext] = None,
 ):
     if isinstance(filesystem, _S3FileSystemWrapper):
-        return filesystem.unwrap()
-    else:
-        return filesystem
+        wrap_retries = filesystem._wrap_retries
+        context = filesystem._context
+        filesystem = filesystem.unwrap()
+        if wrap_retries:
+            filesystem = RetryingPyFileSystem.wrap(filesystem, context=context)
+    return filesystem
 
 
 class _S3FileSystemWrapper:
-    def __init__(self, fs: "pyarrow.fs.S3FileSystem"):
+    def __init__(
+        self,
+        fs: "pyarrow.fs.S3FileSystem",
+        wrap_retries: bool = False,
+        context: Optional[DataContext] = None,
+    ):
         self._fs = fs
+        self._wrap_retries = wrap_retries
+        self._context = context
 
     def unwrap(self):
         return self._fs
@@ -536,30 +546,6 @@ def _resolve_kwargs(
         kwarg_overrides = kwargs_fn()
         kwargs.update(kwarg_overrides)
     return kwargs
-
-
-def _open_file_with_retry(
-    file_path: str,
-    open_file: Callable[[], "pyarrow.NativeFile"],
-) -> "pyarrow.NativeFile":
-    """Open file with an exponential backoff retry strategy.
-
-    This is to avoid transient task failure with remote storage (such as S3),
-    when the remote storage throttles the requests.
-    """
-    if OPEN_FILE_MAX_ATTEMPTS < 1:
-        raise ValueError(
-            "OPEN_FILE_MAX_ATTEMPTS cannot be negative or 0. Get: "
-            f"{OPEN_FILE_MAX_ATTEMPTS}"
-        )
-
-    return call_with_retry(
-        open_file,
-        description=f"open file {file_path}",
-        match=DataContext.get_current().retried_io_errors,
-        max_attempts=OPEN_FILE_MAX_ATTEMPTS,
-        max_backoff_s=OPEN_FILE_RETRY_MAX_BACKOFF_SECONDS,
-    )
 
 
 def _validate_shuffle_arg(shuffle: Optional[str]) -> None:

--- a/python/ray/data/tests/test_file_based_datasource.py
+++ b/python/ray/data/tests/test_file_based_datasource.py
@@ -8,11 +8,7 @@ import pytest
 import ray
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data.block import Block
-from ray.data.datasource.file_based_datasource import (
-    OPEN_FILE_MAX_ATTEMPTS,
-    FileBasedDatasource,
-    _open_file_with_retry,
-)
+from ray.data.datasource.file_based_datasource import FileBasedDatasource
 from ray.data.datasource.path_util import _has_file_extension, _is_local_windows_path
 
 
@@ -94,36 +90,35 @@ def test_file_extensions(ray_start_regular_shared, tmp_path):
     assert ds.input_files() == [csv_path]
 
 
-def test_open_file_with_retry(ray_start_regular_shared):
-    class FlakyFileOpener:
-        def __init__(self, max_attempts: int):
-            self.retry_attempts = 0
-            self.max_attempts = max_attempts
+def test_flaky_datasource(ray_start_regular_shared):
 
-        def open(self):
-            self.retry_attempts += 1
-            if self.retry_attempts < self.max_attempts:
-                raise OSError(
-                    "When creating key x in bucket y: AWS Error SLOW_DOWN during "
-                    "PutObject operation: Please reduce your request rate."
-                )
-            return "dummy"
+    from ray.data._internal.datasource.csv_datasource import CSVDatasource
 
-    original_max_attempts = OPEN_FILE_MAX_ATTEMPTS
-    try:
-        # Test openning file successfully after retries.
-        opener = FlakyFileOpener(3)
-        assert _open_file_with_retry("dummy", lambda: opener.open()) == "dummy"
+    class Counter:
+        def __init__(self):
+            self.value = 0
 
-        # Test exhausting retries and failed eventually.
-        ray.data.datasource.file_based_datasource.OPEN_FILE_MAX_ATTEMPTS = 3
-        opener = FlakyFileOpener(4)
-        with pytest.raises(OSError):
-            _open_file_with_retry("dummy", lambda: opener.open())
-    finally:
-        ray.data.datasource.file_based_datasource.OPEN_FILE_MAX_ATTEMPTS = (
-            original_max_attempts
-        )
+        def increment(self):
+            self.value += 1
+            return self.value
+
+    class FlakyCSVDatasource(CSVDatasource):
+        def __init__(self, paths, **csv_datasource_kwargs):
+            super().__init__(paths, **csv_datasource_kwargs)
+            CounterActor = ray.remote(Counter)
+            self.counter = CounterActor.remote()
+
+        def _read_stream(self, f: "pyarrow.NativeFile", path: str):
+            count = self.counter.increment.remote()
+            if ray.get(count) == 1:
+                raise RuntimeError("AWS Error INTERNAL_FAILURE")
+            else:
+                for block in CSVDatasource._read_stream(self, f, path):
+                    yield block
+
+    datasource = FlakyCSVDatasource(["example://iris.csv"])
+    ds = ray.data.read_datasource(datasource)
+    assert len(ds.take()) == 20
 
 
 def test_windows_path():


### PR DESCRIPTION
## Why are these changes needed?

* Wraps all filesystem calls with RetryingPyFileSystem
* Avoids sprawling redundant changes on Reader and Datasource objects by capturing the access point with iterate_with_retry
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
