### PR TITLE
[Data] Fixing unnecessarily retaining duplicated schema objects inside `BlockMetadata`

### DIFF
--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -275,7 +275,7 @@ class ActorPoolMapOperator(MapOperator):
         # parallelization across the actor pool. We only know this information after
         # execution has completed.
         min_workers = self._actor_pool.min_size()
-        if len(self._output_metadata) < min_workers:
+        if len(self._output_blocks_stats) < min_workers:
             # The user created a stream that has too few blocks to begin with.
             logger.warning(
                 "To ensure full parallelization across an actor pool of size "

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -45,7 +45,14 @@ from ray.data._internal.execution.operators.map_transformer import (
     MapTransformer,
 )
 from ray.data._internal.stats import StatsDict
-from ray.data.block import Block, BlockAccessor, BlockExecStats, BlockMetadata
+from ray.data.block import (
+    Block,
+    BlockAccessor,
+    BlockExecStats,
+    BlockMetadata,
+    BlockStats,
+    to_stats,
+)
 from ray.data.context import DataContext
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
@@ -88,7 +95,7 @@ class MapOperator(OneToOneOperator, ABC):
         # Queue for task outputs, either ordered or unordered (this is set by start()).
         self._output_queue: _OutputQueue = None
         # Output metadata, added to on get_next().
-        self._output_metadata: List[BlockMetadata] = []
+        self._output_blocks_stats: List[BlockStats] = []
         # All active `DataOpTask`s.
         self._data_tasks: Dict[int, DataOpTask] = {}
         self._next_data_task_idx = 0
@@ -428,7 +435,7 @@ class MapOperator(OneToOneOperator, ABC):
         assert self._started
         bundle = self._output_queue.get_next()
         self._metrics.on_output_dequeued(bundle)
-        self._output_metadata.extend(bundle.metadata)
+        self._output_blocks_stats.extend(to_stats(bundle.metadata))
         return bundle
 
     @abstractmethod
@@ -439,7 +446,7 @@ class MapOperator(OneToOneOperator, ABC):
         return {"ray_remote_args": dict(sorted(self._remote_args_for_metrics.items()))}
 
     def get_stats(self) -> StatsDict:
-        return {self._name: self._output_metadata}
+        return {self._name: self._output_blocks_stats}
 
     def get_map_transformer(self) -> MapTransformer:
         return self._map_transformer

--- a/python/ray/data/_internal/execution/operators/zip_operator.py
+++ b/python/ray/data/_internal/execution/operators/zip_operator.py
@@ -13,6 +13,7 @@ from ray.data.block import (
     BlockExecStats,
     BlockMetadata,
     BlockPartition,
+    to_stats,
 )
 from ray.data.context import DataContext
 
@@ -205,7 +206,7 @@ class ZipOperator(PhysicalOperator):
                     owns_blocks=input_owned,
                 )
             )
-        stats = {self._name: output_metadata}
+        stats = {self._name: to_stats(output_metadata)}
 
         # Clean up inputs.
         for ref in left_input:

--- a/python/ray/data/_internal/planner/exchange/pull_based_shuffle_task_scheduler.py
+++ b/python/ray/data/_internal/planner/exchange/pull_based_shuffle_task_scheduler.py
@@ -10,6 +10,7 @@ from ray.data._internal.planner.exchange.interfaces import (
 from ray.data._internal.remote_fn import cached_remote_fn
 from ray.data._internal.stats import StatsDict
 from ray.data._internal.util import convert_bytes_to_human_readable_str
+from ray.data.block import to_stats
 
 logger = logging.getLogger(__name__)
 
@@ -142,8 +143,8 @@ class PullBasedShuffleTaskScheduler(ExchangeTaskScheduler):
                 )
             )
         stats = {
-            "map": shuffle_map_metadata,
-            "reduce": new_metadata,
+            "map": to_stats(shuffle_map_metadata),
+            "reduce": to_stats(new_metadata),
         }
 
         return (output, stats)

--- a/python/ray/data/_internal/planner/exchange/push_based_shuffle_task_scheduler.py
+++ b/python/ray/data/_internal/planner/exchange/push_based_shuffle_task_scheduler.py
@@ -13,7 +13,7 @@ from ray.data._internal.progress_bar import ProgressBar
 from ray.data._internal.remote_fn import cached_remote_fn
 from ray.data._internal.stats import StatsDict
 from ray.data._internal.util import convert_bytes_to_human_readable_str
-from ray.data.block import Block, BlockAccessor, BlockExecStats, BlockMetadata
+from ray.data.block import Block, BlockAccessor, BlockExecStats, BlockMetadata, to_stats
 from ray.data.context import DataContext
 from ray.types import ObjectRef
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
@@ -643,10 +643,11 @@ class PushBasedShuffleTaskScheduler(ExchangeTaskScheduler):
                     owns_blocks=input_owned,
                 )
             )
+
         stats = {
-            "map": map_stage_metadata,
-            "merge": merge_stage_metadata,
-            "reduce": reduce_stage_metadata,
+            "map": to_stats(map_stage_metadata),
+            "merge": to_stats(merge_stage_metadata),
+            "reduce": to_stats(reduce_stage_metadata),
         }
 
         return (output, stats)

--- a/python/ray/data/_internal/planner/randomize_blocks.py
+++ b/python/ray/data/_internal/planner/randomize_blocks.py
@@ -32,9 +32,9 @@ def generate_randomize_blocks_fn(
             input_owned = all(b.owns_blocks for b in refs)
             random.shuffle(blocks_with_metadata)
             output = []
-            meta_list = []
+            stats_list = []
             for block, meta in blocks_with_metadata:
-                meta_list.append(meta)
+                stats_list.append(meta.to_stats())
                 output.append(
                     RefBundle(
                         [
@@ -46,6 +46,6 @@ def generate_randomize_blocks_fn(
                         owns_blocks=input_owned,
                     )
                 )
-            return output, {op._name: meta_list}
+            return output, {op._name: stats_list}
 
     return fn

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -17,7 +17,7 @@ from ray.data._internal.execution.interfaces.op_runtime_metrics import (
     OpRuntimeMetrics,
 )
 from ray.data._internal.util import capfirst
-from ray.data.block import BlockMetadata
+from ray.data.block import BlockMetadata, BlockStats
 from ray.data.context import DataContext
 from ray.util.annotations import DeveloperAPI
 from ray.util.metrics import Gauge
@@ -29,7 +29,7 @@ STATS_ACTOR_NAME = "datasets_stats_actor"
 STATS_ACTOR_NAMESPACE = "_dataset_stats_actor"
 
 
-StatsDict = Dict[str, List[BlockMetadata]]
+StatsDict = Dict[str, List[BlockStats]]
 
 
 def fmt(seconds: float) -> str:
@@ -717,11 +717,11 @@ class DatasetStats:
 
         operators_stats = []
         is_sub_operator = len(self.metadata) > 1
-        for name, meta in self.metadata.items():
+        for name, stats in self.metadata.items():
             operators_stats.append(
                 OperatorStatsSummary.from_block_metadata(
                     name,
-                    meta,
+                    stats,
                     is_sub_operator=is_sub_operator,
                 )
             )
@@ -1055,20 +1055,20 @@ class OperatorStatsSummary:
     def from_block_metadata(
         cls,
         operator_name: str,
-        block_metas: List[BlockMetadata],
+        block_stats: List[BlockStats],
         is_sub_operator: bool,
     ) -> "OperatorStatsSummary":
         """Calculate the stats for a operator from a given list of blocks,
         and generates a `OperatorStatsSummary` object with the results.
 
         Args:
-            block_metas: List of `BlockMetadata` to calculate stats of
+            block_stats: List of `BlockStats` to calculate stats of
             operator_name: Name of operator associated with `blocks`
             is_sub_operator: Whether this set of blocks belongs to a sub operator.
         Returns:
             A `OperatorStatsSummary` object initialized with the calculated statistics
         """
-        exec_stats = [m.exec_stats for m in block_metas if m.exec_stats is not None]
+        exec_stats = [m.exec_stats for m in block_stats if m.exec_stats is not None]
         rounded_total = 0
         time_total_s = 0
         earliest_start_time, latest_end_time = 0, 0
@@ -1097,7 +1097,7 @@ class OperatorStatsSummary:
             exec_summary_str += "\n"
 
         task_rows = collections.defaultdict(int)
-        for meta in block_metas:
+        for meta in block_stats:
             if meta.num_rows is not None and meta.exec_stats is not None:
                 task_rows[meta.exec_stats.task_idx] += meta.num_rows
         task_rows_stats = None
@@ -1144,7 +1144,7 @@ class OperatorStatsSummary:
             }
 
         output_num_rows_stats = None
-        output_num_rows = [m.num_rows for m in block_metas if m.num_rows is not None]
+        output_num_rows = [m.num_rows for m in block_stats if m.num_rows is not None]
         if output_num_rows:
             output_num_rows_stats = {
                 "min": min(output_num_rows),
@@ -1155,7 +1155,7 @@ class OperatorStatsSummary:
 
         output_size_bytes_stats = None
         output_size_bytes = [
-            m.size_bytes for m in block_metas if m.size_bytes is not None
+            m.size_bytes for m in block_stats if m.size_bytes is not None
         ]
         if output_size_bytes:
             output_size_bytes_stats = {

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -2,7 +2,7 @@ import collections
 import logging
 import os
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict, fields
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -132,6 +132,10 @@ def _apply_batch_size(
         return given_batch_size
 
 
+def to_stats(metas: List["BlockMetadata"]) -> List["BlockStats"]:
+    return [m.to_stats() for m in metas]
+
+
 @DeveloperAPI
 class BlockExecStats:
     """Execution stats for this block.
@@ -204,28 +208,47 @@ class _BlockExecStatsBuilder:
 
 @DeveloperAPI
 @dataclass
-class BlockMetadata:
-    """Metadata about the block."""
+class BlockStats:
+    """Statistics about the block produced"""
 
     #: The number of rows contained in this block, or None.
     num_rows: Optional[int]
     #: The approximate size in bytes of this block, or None.
     size_bytes: Optional[int]
+    #: Execution stats for this block.
+    exec_stats: Optional[BlockExecStats]
+
+    def __post_init__(self):
+        if self.size_bytes is not None:
+            # Require size_bytes to be int, ray.util.metrics objects
+            # will not take other types like numpy.int64
+            assert isinstance(self.size_bytes, int)
+
+
+_BLOCK_STATS_FIELD_NAMES = {f.name for f in fields(BlockStats)}
+
+
+@DeveloperAPI
+@dataclass
+class BlockMetadata(BlockStats):
+    """Metadata about the block."""
+
     #: The pyarrow schema or types of the block elements, or None.
     schema: Optional[Union[type, "pyarrow.lib.Schema"]]
     #: The list of file paths used to generate this block, or
     #: the empty list if indeterminate.
     input_files: Optional[List[str]]
-    #: Execution stats for this block.
-    exec_stats: Optional[BlockExecStats]
+
+    def to_stats(self):
+        return BlockStats(
+            **{k: v for k, v in asdict(self).items() if k in _BLOCK_STATS_FIELD_NAMES}
+        )
 
     def __post_init__(self):
+        super().__post_init__()
+
         if self.input_files is None:
             self.input_files = []
-        if self.size_bytes is not None:
-            # Require size_bytes to be int, ray.util.metrics objects
-            # will not take other types like numpy.int64
-            assert isinstance(self.size_bytes, int)
 
 
 @DeveloperAPI

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -132,6 +132,7 @@ def _apply_batch_size(
         return given_batch_size
 
 
+@DeveloperAPI
 def to_stats(metas: List["BlockMetadata"]) -> List["BlockStats"]:
     return [m.to_stats() for m in metas]
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, we yield schema along with every block yielded which is not necessary and in case of large schemas could entail OOMs on due to some operators retaining schemas (as part of corresponding `BlockMetadata`) 

### Changes

 - Abstracted BlockStats from BlockMetadata
 - Rebased all operators to only retain BlockStats and not BlockMetadata

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
