### PR TITLE
[tune] fix worker node failure failure test

### DIFF
--- a/release/tune_tests/fault_tolerance_tests/workloads/terminate_node_aws.py
+++ b/release/tune_tests/fault_tolerance_tests/workloads/terminate_node_aws.py
@@ -127,7 +127,7 @@ class InstanceKillerActor:
                 "terminated_succesfully": terminated_succesfully,
             }
         )
-        safe_write_to_results_json(self.history)
+        # safe_write_to_results_json(self.history)
 
 
 def create_instance_killer(

--- a/release/tune_tests/fault_tolerance_tests/workloads/terminate_node_aws.py
+++ b/release/tune_tests/fault_tolerance_tests/workloads/terminate_node_aws.py
@@ -6,7 +6,8 @@ import logging
 
 import ray
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
-from ray._private.test_utils import safe_write_to_results_json
+
+# from ray._private.test_utils import safe_write_to_results_json
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The test is currently "failing" because these results are getting written to a file as a list where the test infra expects it to be a dict (see trace below).

The root cause seems to be that previously this actor was not scheduled on the head node, but now it somehow is?

Might be worth investigating why this just started happening now, but since these results were never used in the past, going to start by commenting out the step that writes to the file.

https://buildkite.com/ray-project/release/builds/31327#0194aa44-76e4-4e2c-9d24-0dd9f0b5e223

```
Traceback (most recent call last):
  File "/workdir/release/ray_release/scripts/run_release_test.py", line 183, in <module>
    main()
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/workdir/release/ray_release/scripts/run_release_test.py", line 159, in main
    result = run_release_test(
  File "/workdir/release/ray_release/glue.py", line 529, in run_release_test
    reporter.report_result(test, result)
  File "/workdir/release/ray_release/reporter/log.py", line 37, in report_result
    for key, val in results.items():
AttributeError: 'list' object has no attribute 'items'
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
