### PR TITLE
[train] refactor TrainControllerState

### DIFF
--- a/python/ray/train/v2/_internal/execution/callback.py
+++ b/python/ray/train/v2/_internal/execution/callback.py
@@ -86,7 +86,6 @@ class ControllerCallback(RayTrainCallback):
     def before_controller_execute_scaling_decision(
         self,
         scaling_decision: "ScalingDecision",
-        worker_group_status: "WorkerGroupStatus",
     ):
         """Called before the controller executes a scaling decision."""
         pass

--- a/python/ray/train/v2/_internal/execution/controller/__init__.py
+++ b/python/ray/train/v2/_internal/execution/controller/__init__.py
@@ -1,0 +1,3 @@
+from .controller import TrainController
+
+__all__ = ["TrainController"]

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -504,4 +504,3 @@ class TrainController:
             return controller_state.training_failed_error
 
         return None
-

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -150,9 +150,6 @@ class TrainController:
             callbacks=worker_group_callbacks_to_propagate,
         )
         self._state = InitializingState()
-        self._latest_iteration_result: Optional[
-            TrainControllerLoopIterationResult
-        ] = None
 
         # TODO: These can be attributes of a RunAttempt?
         self._latest_poll_time = float("-inf")
@@ -201,10 +198,7 @@ class TrainController:
             return TrainControllerLoopIterationResult(
                 run_attempt_id=self._get_run_attempt_id(),
                 previous_state=controller_state,
-                next_state=RunningState(
-                    worker_group_status=worker_group_status,
-                    failure_decision=failure_decision,
-                ),
+                next_state=RunningState(),
             )
 
         errors_str = "\n".join(
@@ -224,8 +218,6 @@ class TrainController:
                 worker_failures=worker_group_status.errors
             )
             next_state = RestartingState(
-                worker_group_status=worker_group_status,
-                failure_decision=failure_decision,
                 training_failed_error=training_failed_error,
             )
             return TrainControllerLoopIterationResult(
@@ -244,8 +236,6 @@ class TrainController:
                 worker_failures=worker_group_status.errors
             )
             next_state = ErroredState(
-                worker_group_status=worker_group_status,
-                failure_decision=failure_decision,
                 training_failed_error=training_failed_error,
             )
             return TrainControllerLoopIterationResult(
@@ -371,7 +361,7 @@ class TrainController:
                 return TrainControllerLoopIterationResult(
                     run_attempt_id=self._get_run_attempt_id(),
                     previous_state=controller_state,
-                    next_state=FinishedState(worker_group_status=worker_group_status),
+                    next_state=FinishedState(),
                 )
             if worker_group_status.errors:
                 failure_decision = self._failure_policy.make_decision(
@@ -389,11 +379,10 @@ class TrainController:
 
                 if isinstance(scaling_decision, ResizeDecision):
                     next_state = ResizingState(
-                        worker_group_status=worker_group_status,
                         scaling_decision=scaling_decision,
                     )
                 elif isinstance(scaling_decision, NoopDecision):
-                    next_state = RunningState(worker_group_status=worker_group_status)
+                    next_state = RunningState()
                 else:
                     raise ValueError(f"Unexpected scaling decision: {scaling_decision}")
 
@@ -442,13 +431,12 @@ class TrainController:
             Query the scaling policy for a scaling decision and execute it.
         """
         controller_state = self.get_state()
-        assert controller_state.is_active()
+        assert not controller_state.is_terminal()
 
         if controller_state.needs_new_run_attempt():
             self._generate_run_attempt_id()
 
         result = self._step()
-        self._latest_iteration_result = result
 
         self._set_state(result.next_state)
 
@@ -457,7 +445,7 @@ class TrainController:
         """Run the main control loop. Exits when training is finished or errored."""
         self._start()
 
-        while self.get_state().is_active():
+        while not self.get_state().is_terminal():
             self._run_control_loop_iteration()
 
         self._shutdown()
@@ -496,7 +484,7 @@ class TrainController:
         """Get the final training result from the TrainController."""
 
         controller_state = self.get_state()
-        if controller_state.is_active():
+        if not controller_state.is_terminal():
             raise ValueError(
                 f"Cannot get result when controller is in state {controller_state}"
             )
@@ -504,7 +492,16 @@ class TrainController:
         return self._build_result()
 
     def get_training_failed_error(self) -> Optional[TrainingFailedError]:
-        """Get the training failed error from the latest iteration result."""
-        if self._latest_iteration_result is not None:
-            return self._latest_iteration_result.training_failed_error
+        """Get the training failed error from the controller state.
+
+        Returns:
+            The training failed error if the controller is in an errored state,
+            None otherwise.
+        """
+        controller_state = self.get_state()
+
+        if isinstance(controller_state, ErroredState):
+            return controller_state.training_failed_error
+
         return None
+

--- a/python/ray/train/v2/_internal/execution/controller/state.py
+++ b/python/ray/train/v2/_internal/execution/controller/state.py
@@ -1,12 +1,9 @@
 from enum import Enum
-from typing import Optional
 
 from ray.train.v2._internal.exceptions import TrainingFailedError
-from ray.train.v2._internal.execution.failure_handling import FailureDecision
 from ray.train.v2._internal.execution.scaling_policy.scaling_policy import (
     ScalingDecision,
 )
-from ray.train.v2._internal.execution.worker_group.worker_group import WorkerGroupStatus
 
 
 class TrainControllerStateType(Enum):

--- a/python/ray/train/v2/_internal/execution/controller/state.py
+++ b/python/ray/train/v2/_internal/execution/controller/state.py
@@ -1,0 +1,142 @@
+from enum import Enum
+from typing import Optional
+
+from ray.train.v2._internal.exceptions import TrainingFailedError
+from ray.train.v2._internal.execution.failure_handling import FailureDecision
+from ray.train.v2._internal.execution.scaling_policy.scaling_policy import (
+    ScalingDecision,
+)
+from ray.train.v2._internal.execution.worker_group.worker_group import WorkerGroupStatus
+
+
+class TrainControllerStateType(Enum):
+    """Enum representing different states of the train controller.
+    Each enum value is a tuple of (name, is_active, needs_new_run_attempt).
+
+    States:
+       INITIALIZING: The train controller is starting up. This is always the initial
+           state of the controller.
+       SCHEDULING: The training controller is in the process of scheduling a new worker
+           group.
+       RESCHEDULING: The train controller is in the process of rescheduling the worker
+           group.
+       RUNNING: The train controller is actively running training tasks.
+       RESTARTING: The train controller is in the process of recovering from an error.
+       RESIZING: The train controller is in the process of resizing a running worker
+           group.
+       ERRORED: A terminal state indicating that training has encountered an error and
+           cannot continue.
+       FINISHED: A terminal state indicating that training has completed.
+    """
+
+    INITIALIZING = ("INITIALIZING", True, True)
+    SCHEDULING = ("SCHEDULING", True, False)
+    RESCHEDULING = ("RESCHEDULING", True, False)
+    RUNNING = ("RUNNING", True, False)
+    RESTARTING = ("RESTARTING", True, True)
+    RESIZING = ("RESIZING", True, True)
+    ERRORED = ("ERRORED", False, False)
+    FINISHED = ("FINISHED", False, False)
+
+    def __init__(self, state_name: str, is_active: bool, needs_new_run_attempt: bool):
+        self.state_name = state_name
+        self.is_active = is_active
+        self.needs_new_run_attempt = needs_new_run_attempt
+
+
+class TrainControllerState:
+    """Base class for all train controller states.
+
+    Methods:
+        get_type() -> TrainControllerStateType: Returns the type of the state.
+        is_active() -> bool: Returns whether the state is active.
+        needs_new_run_attempt() -> bool: Returns whether a new run attempt is needed.
+    """
+
+    def __init__(self, state_type: TrainControllerStateType):
+        self._state_type = state_type
+
+    def __repr__(self) -> str:
+        attrs = {
+            "type": self._state_type.name,
+            "is_active": self._state_type.is_active,
+            "needs_new_run_attempt": self._state_type.needs_new_run_attempt,
+            **{k: v for k, v in vars(self).items() if not k.startswith("_")},
+        }
+        attrs_str = "\n    ".join(f"{k}={v}" for k, v in attrs.items())
+        return f"{self.__class__.__name__}(\n    {attrs_str}\n)"
+
+    def is_active(self) -> bool:
+        return self._state_type.is_active
+
+    def needs_new_run_attempt(self) -> bool:
+        return self._state_type.needs_new_run_attempt
+
+
+class InitializingState(TrainControllerState):
+    def __init__(self):
+        super().__init__(state_type=TrainControllerStateType.INITIALIZING)
+
+
+class SchedulingState(TrainControllerState):
+    def __init__(self, scaling_decision: ScalingDecision):
+        super().__init__(state_type=TrainControllerStateType.SCHEDULING)
+        self.scaling_decision = scaling_decision
+
+
+class ReschedulingState(TrainControllerState):
+    def __init__(self):
+        super().__init__(state_type=TrainControllerStateType.RESCHEDULING)
+
+
+class RunningState(TrainControllerState):
+    # TODO: Split into multiple states where each state has exact non-optional fields.
+    def __init__(
+        self,
+        worker_group_status: Optional[WorkerGroupStatus] = None,
+        failure_decision: Optional[FailureDecision] = None,
+    ):
+        super().__init__(state_type=TrainControllerStateType.RUNNING)
+        self.worker_group_status = worker_group_status
+        self.failure_decision = failure_decision
+
+
+class RestartingState(TrainControllerState):
+    def __init__(
+        self,
+        worker_group_status: WorkerGroupStatus,
+        failure_decision: FailureDecision,
+        training_failed_error: TrainingFailedError,
+    ):
+        super().__init__(state_type=TrainControllerStateType.RESTARTING)
+        self.worker_group_status = worker_group_status
+        self.failure_decision = failure_decision
+        self.training_failed_error = training_failed_error
+
+
+class ResizingState(TrainControllerState):
+    def __init__(
+        self, worker_group_status: WorkerGroupStatus, scaling_decision: ScalingDecision
+    ):
+        super().__init__(state_type=TrainControllerStateType.RESIZING)
+        self.worker_group_status = worker_group_status
+        self.scaling_decision = scaling_decision
+
+
+class ErroredState(TrainControllerState):
+    def __init__(
+        self,
+        worker_group_status: WorkerGroupStatus,
+        failure_decision: FailureDecision,
+        training_failed_error: TrainingFailedError,
+    ):
+        super().__init__(state_type=TrainControllerStateType.ERRORED)
+        self.worker_group_status = worker_group_status
+        self.failure_decision = failure_decision
+        self.training_failed_error = training_failed_error
+
+
+class FinishedState(TrainControllerState):
+    def __init__(self, worker_group_status: WorkerGroupStatus):
+        super().__init__(state_type=TrainControllerStateType.FINISHED)
+        self.worker_group_status = worker_group_status

--- a/python/ray/train/v2/_internal/execution/controller/state.py
+++ b/python/ray/train/v2/_internal/execution/controller/state.py
@@ -11,7 +11,6 @@ from ray.train.v2._internal.execution.worker_group.worker_group import WorkerGro
 
 class TrainControllerStateType(Enum):
     """Enum representing different states of the train controller.
-    Each enum value is a tuple of (name, is_active, needs_new_run_attempt).
 
     States:
        INITIALIZING: The train controller is starting up. This is always the initial
@@ -27,20 +26,27 @@ class TrainControllerStateType(Enum):
        ERRORED: A terminal state indicating that training has encountered an error and
            cannot continue.
        FINISHED: A terminal state indicating that training has completed.
+
+    Args:
+        state_name: The name of the state.
+        is_terminal: Whether this is a terminal state that should not be further processed.
+        needs_new_run_attempt: Whether this state requires starting a new run attempt, where
+            a run attempt is a logical unit that encompasses both scheduling workers and
+            executing training on those workers.
     """
 
-    INITIALIZING = ("INITIALIZING", True, True)
-    SCHEDULING = ("SCHEDULING", True, False)
-    RESCHEDULING = ("RESCHEDULING", True, False)
-    RUNNING = ("RUNNING", True, False)
-    RESTARTING = ("RESTARTING", True, True)
-    RESIZING = ("RESIZING", True, True)
-    ERRORED = ("ERRORED", False, False)
-    FINISHED = ("FINISHED", False, False)
+    INITIALIZING = ("INITIALIZING", False, True)
+    SCHEDULING = ("SCHEDULING", False, False)
+    RESCHEDULING = ("RESCHEDULING", False, False)
+    RUNNING = ("RUNNING", False, False)
+    RESTARTING = ("RESTARTING", False, True)
+    RESIZING = ("RESIZING", False, True)
+    ERRORED = ("ERRORED", True, False)
+    FINISHED = ("FINISHED", True, False)
 
-    def __init__(self, state_name: str, is_active: bool, needs_new_run_attempt: bool):
+    def __init__(self, state_name: str, is_terminal: bool, needs_new_run_attempt: bool):
         self.state_name = state_name
-        self.is_active = is_active
+        self.is_terminal = is_terminal
         self.needs_new_run_attempt = needs_new_run_attempt
 
 
@@ -49,7 +55,7 @@ class TrainControllerState:
 
     Methods:
         get_type() -> TrainControllerStateType: Returns the type of the state.
-        is_active() -> bool: Returns whether the state is active.
+        is_terminal() -> bool: Returns whether the state is terminal.
         needs_new_run_attempt() -> bool: Returns whether a new run attempt is needed.
     """
 
@@ -59,15 +65,15 @@ class TrainControllerState:
     def __repr__(self) -> str:
         attrs = {
             "type": self._state_type.name,
-            "is_active": self._state_type.is_active,
+            "is_terminal": self._state_type.is_terminal,
             "needs_new_run_attempt": self._state_type.needs_new_run_attempt,
             **{k: v for k, v in vars(self).items() if not k.startswith("_")},
         }
         attrs_str = "\n    ".join(f"{k}={v}" for k, v in attrs.items())
         return f"{self.__class__.__name__}(\n    {attrs_str}\n)"
 
-    def is_active(self) -> bool:
-        return self._state_type.is_active
+    def is_terminal(self) -> bool:
+        return self._state_type.is_terminal
 
     def needs_new_run_attempt(self) -> bool:
         return self._state_type.needs_new_run_attempt
@@ -90,53 +96,39 @@ class ReschedulingState(TrainControllerState):
 
 
 class RunningState(TrainControllerState):
-    # TODO: Split into multiple states where each state has exact non-optional fields.
-    def __init__(
-        self,
-        worker_group_status: Optional[WorkerGroupStatus] = None,
-        failure_decision: Optional[FailureDecision] = None,
-    ):
+    # TODO: Split into multiple more granular states, or add more fields.
+    # For example, we may want to indicate if any health checks failed.
+    def __init__(self):
         super().__init__(state_type=TrainControllerStateType.RUNNING)
-        self.worker_group_status = worker_group_status
-        self.failure_decision = failure_decision
 
 
 class RestartingState(TrainControllerState):
     def __init__(
         self,
-        worker_group_status: WorkerGroupStatus,
-        failure_decision: FailureDecision,
         training_failed_error: TrainingFailedError,
     ):
         super().__init__(state_type=TrainControllerStateType.RESTARTING)
-        self.worker_group_status = worker_group_status
-        self.failure_decision = failure_decision
         self.training_failed_error = training_failed_error
 
 
 class ResizingState(TrainControllerState):
     def __init__(
-        self, worker_group_status: WorkerGroupStatus, scaling_decision: ScalingDecision
+        self,
+        scaling_decision: ScalingDecision,
     ):
         super().__init__(state_type=TrainControllerStateType.RESIZING)
-        self.worker_group_status = worker_group_status
         self.scaling_decision = scaling_decision
 
 
 class ErroredState(TrainControllerState):
     def __init__(
         self,
-        worker_group_status: WorkerGroupStatus,
-        failure_decision: FailureDecision,
         training_failed_error: TrainingFailedError,
     ):
         super().__init__(state_type=TrainControllerStateType.ERRORED)
-        self.worker_group_status = worker_group_status
-        self.failure_decision = failure_decision
         self.training_failed_error = training_failed_error
 
 
 class FinishedState(TrainControllerState):
-    def __init__(self, worker_group_status: WorkerGroupStatus):
+    def __init__(self):
         super().__init__(state_type=TrainControllerStateType.FINISHED)
-        self.worker_group_status = worker_group_status

--- a/python/ray/train/v2/_internal/execution/scaling_policy/fixed.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/fixed.py
@@ -9,7 +9,7 @@ from ray.train.v2._internal.execution.worker_group import WorkerGroupStatus
 
 class FixedScalingPolicy(ScalingPolicy):
     def make_decision_for_non_running_worker_group(
-        self, worker_group_status: WorkerGroupStatus
+        self,
     ) -> ScalingDecision:
         return ResizeDecision(
             num_workers=self.scaling_config.num_workers,

--- a/python/ray/train/v2/_internal/execution/scaling_policy/scaling_policy.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/scaling_policy.py
@@ -36,9 +36,7 @@ class ScalingPolicy(abc.ABC, ControllerCallback):
         self.scaling_config = scaling_config
 
     @abc.abstractmethod
-    def make_decision_for_non_running_worker_group(
-        self, worker_group_status: WorkerGroupStatus
-    ) -> ScalingDecision:
+    def make_decision_for_non_running_worker_group(self) -> ScalingDecision:
         """Makes a scaling decision when the worker group is initializing
         or recovering from an error."""
         raise NotImplementedError

--- a/python/ray/train/v2/_internal/execution/scaling_policy/scaling_policy.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/scaling_policy.py
@@ -32,6 +32,9 @@ class ScalingPolicy(abc.ABC, ControllerCallback):
     Upscale decisions are optional and are made when workers are healthy.
     """
 
+    # TODO: Restructure these APIs to consider different TrainControllerStates
+    # instead of just running and non-running worker groups.
+
     def __init__(self, scaling_config: ScalingConfig):
         self.scaling_config = scaling_config
 

--- a/python/ray/train/v2/tests/test_controller.py
+++ b/python/ray/train/v2/tests/test_controller.py
@@ -163,8 +163,6 @@ def test_resize():
     )
     worker_group = controller.get_worker_group()
 
-    controller._checkpoint_handler = MagicMock()
-
     decisions = [
         NoopDecision(),
         ResizeDecision(num_workers=2, resources_per_worker={}),
@@ -231,8 +229,6 @@ def test_failure_handling():
     )
     worker_group = controller.get_worker_group()
 
-    controller._checkpoint_handler = MagicMock()
-
     assert isinstance(controller.get_state(), InitializingState)
     scaling_policy.queue_recovery_decision(
         ResizeDecision(num_workers=2, resources_per_worker={})
@@ -275,7 +271,6 @@ def test_worker_group_start_failure(error_type):
         scaling_policy=scaling_policy,
         failure_policy=failure_policy,
     )
-    controller._checkpoint_handler = MagicMock()
 
     worker_group: DummyWorkerGroup = controller.get_worker_group()
     worker_group.set_start_failure(error_type)
@@ -378,7 +373,6 @@ def test_controller_callback():
         failure_policy=failure_policy,
         callbacks=[callback],
     )
-    controller._checkpoint_handler = MagicMock()
     worker_group = controller.get_worker_group()
 
     controller._start()

--- a/python/ray/train/v2/tests/test_controller.py
+++ b/python/ray/train/v2/tests/test_controller.py
@@ -11,8 +11,15 @@ from ray.train.v2._internal.exceptions import (
 )
 from ray.train.v2._internal.execution.callback import ControllerCallback
 from ray.train.v2._internal.execution.context import TrainRunContext
-from ray.train.v2._internal.execution.controller import (
-    TrainController,
+from ray.train.v2._internal.execution.controller import TrainController
+from ray.train.v2._internal.execution.controller.state import (
+    InitializingState,
+    SchedulingState,
+    ReschedulingState,
+    RunningState,
+    RestartingState,
+    ResizingState,
+    ErroredState,
     TrainControllerState,
 )
 from ray.train.v2._internal.execution.failure_handling import (
@@ -94,9 +101,7 @@ class MockScalingPolicy(ScalingPolicy):
 
         super().__init__(scaling_config)
 
-    def make_decision_for_non_running_worker_group(
-        self, worker_group_status: WorkerGroupStatus
-    ) -> ScalingDecision:
+    def make_decision_for_non_running_worker_group(self) -> ScalingDecision:
         if self._recovery_decision_queue:
             return self._recovery_decision_queue.pop(0)
         return NoopDecision()
@@ -173,27 +178,45 @@ def test_resize():
         ResizeDecision(num_workers=5, resources_per_worker={}),
     ]
 
+    assert isinstance(controller.get_state(), InitializingState)
+    worker_group_status = worker_group.poll_status()
+    assert worker_group_status.num_workers == 0
+
     # Start with 1 worker
     scaling_policy.queue_recovery_decision(
         ResizeDecision(num_workers=1, resources_per_worker={})
     )
     controller._run_control_loop_iteration()
-    prev_worker_group_status = worker_group.poll_status()
-    assert prev_worker_group_status.num_workers == 1
+    assert isinstance(controller.get_state(), SchedulingState)
+    worker_group_status = worker_group.poll_status()
+    assert worker_group_status.num_workers == 0
+
+    controller._run_control_loop_iteration()
+    assert isinstance(controller.get_state(), RunningState)
+    worker_group_status = worker_group.poll_status()
+    assert worker_group_status.num_workers == 1
 
     for decision in decisions:
+        prev_worker_group_status = worker_group_status
+
         scaling_policy.queue_monitor_decision(decision)
-        controller._run_control_loop_iteration()
-        worker_group_status = worker_group.poll_status()
 
         if isinstance(decision, NoopDecision):
+            controller._run_control_loop_iteration()
+            assert isinstance(controller.get_state(), RunningState)
+            worker_group_status = worker_group.poll_status()
             assert (
                 worker_group_status.num_workers == prev_worker_group_status.num_workers
             )
         else:
+            controller._run_control_loop_iteration()
+            assert isinstance(controller.get_state(), ResizingState)
+            controller._run_control_loop_iteration()
+            assert isinstance(controller.get_state(), SchedulingState)
+            controller._run_control_loop_iteration()
+            assert isinstance(controller.get_state(), RunningState)
+            worker_group_status = worker_group.poll_status()
             assert worker_group_status.num_workers == decision.num_workers
-
-        prev_worker_group_status = worker_group_status
 
 
 def test_failure_handling():
@@ -210,28 +233,32 @@ def test_failure_handling():
 
     controller._checkpoint_handler = MagicMock()
 
-    assert controller.get_state() == TrainControllerState.INITIALIZING
+    assert isinstance(controller.get_state(), InitializingState)
     scaling_policy.queue_recovery_decision(
         ResizeDecision(num_workers=2, resources_per_worker={})
     )
     controller._run_control_loop_iteration()
-    assert controller.get_state() == TrainControllerState.RUNNING
+    assert isinstance(controller.get_state(), SchedulingState)
+    controller._run_control_loop_iteration()
+    assert isinstance(controller.get_state(), RunningState)
 
     worker_group.error_worker(1)
     failure_policy.queue_decision(FailureDecision.RESTART)
     controller._run_control_loop_iteration()
-    assert controller.get_state() == TrainControllerState.RECOVERING
+    assert isinstance(controller.get_state(), RestartingState)
 
     scaling_policy.queue_recovery_decision(
         ResizeDecision(num_workers=4, resources_per_worker={})
     )
     controller._run_control_loop_iteration()
-    assert controller.get_state() == TrainControllerState.RUNNING
+    assert isinstance(controller.get_state(), SchedulingState)
+    controller._run_control_loop_iteration()
+    assert isinstance(controller.get_state(), RunningState)
 
     worker_group.error_worker(3)
     failure_policy.queue_decision(FailureDecision.RAISE)
     controller._run_control_loop_iteration()
-    assert controller.get_state() == TrainControllerState.ERRORED
+    assert isinstance(controller.get_state(), ErroredState)
 
 
 @pytest.mark.parametrize(
@@ -253,21 +280,31 @@ def test_worker_group_start_failure(error_type):
     worker_group: DummyWorkerGroup = controller.get_worker_group()
     worker_group.set_start_failure(error_type)
 
+    assert isinstance(controller.get_state(), InitializingState)
+
     scaling_policy.queue_recovery_decision(
         ResizeDecision(num_workers=2, resources_per_worker={})
     )
-    # Worker group will fail to start, but controller should not raise
-    # and should go into RECOVERING state.
+
     controller._run_control_loop_iteration()
-    assert controller.get_state() == TrainControllerState.RECOVERING
+    assert isinstance(controller.get_state(), SchedulingState)
+
+    # Worker group will fail to start, but controller should not raise
+    # and should go into RESCHEDULING state.
+    controller._run_control_loop_iteration()
+    assert isinstance(controller.get_state(), ReschedulingState)
 
     # Let the worker group start successfully the 2nd time.
     worker_group.set_start_failure(None)
     scaling_policy.queue_recovery_decision(
         ResizeDecision(num_workers=2, resources_per_worker={})
     )
+
     controller._run_control_loop_iteration()
-    assert controller.get_state() == TrainControllerState.RUNNING
+    assert isinstance(controller.get_state(), SchedulingState)
+
+    controller._run_control_loop_iteration()
+    assert isinstance(controller.get_state(), RunningState)
 
 
 def test_poll_frequency(monkeypatch):
@@ -322,7 +359,6 @@ def test_controller_callback():
         def before_controller_execute_scaling_decision(
             self,
             scaling_decision: ScalingDecision,
-            worker_group_status: WorkerGroupStatus,
         ):
             self.scaling_decision_called = True
 
@@ -351,21 +387,25 @@ def test_controller_callback():
     scaling_policy.queue_recovery_decision(
         ResizeDecision(num_workers=2, resources_per_worker={})
     )
+
+    controller._run_control_loop_iteration()
+    assert not callback.scaling_decision_called
+    assert isinstance(callback.latest_state_update[0], InitializingState)
+    assert isinstance(callback.latest_state_update[1], SchedulingState)
+
     controller._run_control_loop_iteration()
     assert callback.scaling_decision_called
-    assert callback.latest_state_update == (
-        TrainControllerState.INITIALIZING,
-        TrainControllerState.RUNNING,
-    )
+    assert isinstance(callback.latest_state_update[0], SchedulingState)
+    assert isinstance(callback.latest_state_update[1], RunningState)
 
     worker_group.error_worker(1)
     failure_policy.queue_decision(FailureDecision.RAISE)
+
+    assert not callback.failure_decision_called
     controller._run_control_loop_iteration()
     assert callback.failure_decision_called
-    assert callback.latest_state_update == (
-        TrainControllerState.RUNNING,
-        TrainControllerState.ERRORED,
-    )
+    assert isinstance(callback.latest_state_update[0], RunningState)
+    assert isinstance(callback.latest_state_update[1], ErroredState)
 
     controller._shutdown()
     assert callback.shutdown_called


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Overview 
This PR refactors the `TrainController` state management to use a more explicit state machine pattern with dedicated state classes. This makes each step more granular and modular so that it is easier to track and debug indivudal steps.

## Major Changes

1. Moved from a simple enum-based state to full state classes that can carry relevant context data.
2. Introduced a new `_step` method to handle state-specific logic within `_run_control_loop_iteration`.
    1. `_step` acts based on the current state, and determines the next state.
    2. `_run_control_loop_iteration` actually modifies the controller state.
4. Created a new `state.py` module to house state-related code.
5. Introduced `TrainControllerLoopIterationResult` to track state transitions.
6. Added `run_attempt_id` tracking for better debugging and monitoring.

| Before | After |
|--------|--------|
| ![Train Dashboard](https://github.com/user-attachments/assets/37264498-6662-46b8-bbb0-72ffea108ab4) | ![Train Dashboard (1)](https://github.com/user-attachments/assets/7a2bd55e-05cc-49e0-86d5-ed0ca16749a5) |

**Key:** 
| Color | Before | After |
|--------|--------|--------|
| Grey | Initial startup state or scheduling |  Initial startup state |
| Yellow | | Scheduling new worker group | 
| Orange | Scheduling or rescheduling  | Rescheduling after failure | 
| Blue | Normal operation state | Normal operation state |
| Green | Terminal (succeeded) | Terminal (succeeded) |
| Red | Terminal (failed) | Terminal (failed) |
| Purple lines |  | New run attempt |



## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
