### PR TITLE
[Core] Remove the Deprecated Logging Configuration Function

### DIFF
--- a/python/ray/_private/ray_logging/logging_config.py
+++ b/python/ray/_private/ray_logging/logging_config.py
@@ -5,7 +5,7 @@ from ray._private.ray_logging import default_impl
 from ray._private.ray_logging.constants import LOGRECORD_STANDARD_ATTRS
 from ray._private.ray_logging.formatters import TextFormatter
 from ray._private.ray_logging.filters import CoreContextFilter
-from ray.util.annotations import PublicAPI, Deprecated
+from ray.util.annotations import PublicAPI
 
 from dataclasses import dataclass, field
 

--- a/python/ray/_private/ray_logging/logging_config.py
+++ b/python/ray/_private/ray_logging/logging_config.py
@@ -17,15 +17,9 @@ class LoggingConfigurator(ABC):
     def get_supported_encodings(self) -> Set[str]:
         raise NotImplementedError
 
-    @Deprecated
-    def configure_logging(self, encoding: str, log_level: str):
-        raise NotImplementedError
-
-    # Should be marked as @abstractmethod, but we can't do that because of backwards
-    # compatibility.
-    # Also, assuming the function will only be called inside LoggingConfig._apply()
+    @abstractmethod
     def configure(self, logging_config: "LoggingConfig"):
-        self.configure_logging(logging_config.encoding, logging_config.log_level)
+        raise NotImplementedError
 
 
 class DefaultLoggingConfigurator(LoggingConfigurator):
@@ -36,10 +30,6 @@ class DefaultLoggingConfigurator(LoggingConfigurator):
 
     def get_supported_encodings(self) -> Set[str]:
         return self._encoding_to_formatter.keys()
-
-    @Deprecated
-    def configure_logging(self, encoding: str, log_level: str):
-        self.configure(LoggingConfig(encoding=encoding, log_level=log_level))
 
     def configure(self, logging_config: "LoggingConfig"):
         formatter = self._encoding_to_formatter[logging_config.encoding]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The PR cleans up the deprecated `configure_logging` function in the `LoggingConfigurator` after migrate the usage in both OSS and rayturbo to the new `configure` function.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#49502

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
