### PR TITLE
[core][collective] Avoid creation of `gloo_queue` in race condition

### DIFF
--- a/python/ray/util/collective/collective_group/gloo_collective_group.py
+++ b/python/ray/util/collective/collective_group/gloo_collective_group.py
@@ -130,14 +130,20 @@ class Rendezvous:
                 except ValueError:
                     if self._context.rank == 0:
                         if not q:
-                            ray.remote(gloo_util.glooQueue).options(
-                                name="gloo_queue", lifetime="detached"
-                            ).remote(1000)
+                            try:
+                                ray.remote(gloo_util.glooQueue).options(
+                                    name="gloo_queue", lifetime="detached"
+                                ).remote(1000)
+                            except ValueError:
+                                pass
                         if not s:
-                            gloo_util.SignalActor.options(
-                                name=f"gloo_{self._group_name}_signal",
-                                lifetime="detached",
-                            ).remote(self._context.size)
+                            try:
+                                gloo_util.SignalActor.options(
+                                    name=f"gloo_{self._group_name}_signal",
+                                    lifetime="detached",
+                                ).remote(self._context.size)
+                            except ValueError:
+                                pass
                     else:
                         time.sleep(0.1)
                 elapsed = datetime.datetime.now() - start_time

--- a/python/ray/util/collective/tests/single_node_cpu_tests/test_gloo_group_isolation.py
+++ b/python/ray/util/collective/tests/single_node_cpu_tests/test_gloo_group_isolation.py
@@ -40,6 +40,13 @@ def test_two_groups_in_one_cluster(ray_start_regular_shared):
     assert ray.get(w2.get_gloo_timeout.remote(name2)) == time2
 
 
+def test_multi_simultaneous_groups_creation_in_one_cluster(ray_start_regular_shared):
+    num = 8
+    workers = [Worker.remote() for _ in range(num)]
+    rets = [workers[i].init_gloo_group.remote(1, 0, f"name_{i}") for i in range(num)]
+    assert all(ray.get(ret) for ret in rets)
+
+
 def test_failure_when_initializing(shutdown_only):
     # job1
     ray.init()


### PR DESCRIPTION
## Why are these changes needed?

When there are 2 or more gloo communication groups get created at the same time, the current code which checks `gloo_queue` already exists will experience a race condition. This PR handles this by do a try expect when creating `gloo_queue`, and ignore the expection since it will return back to the loop:

```
Traceback (most recent call last):
  File runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File site-packages/ray/_private/auto_init_hook.py", line 21, in auto_init_wrapper
    return fn(*args, **kwargs)
  File site-packages/ray/_private/client_mode_hook.py", line 103, in wrapper
    return func(*args, **kwargs)
  File site-packages/ray/_private/worker.py", line 2772, in get
    values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
  File site-packages/ray/_private/worker.py", line 919, in get_objects
    raise value.as_instanceof_cause()
ray.exceptions.RayTaskError(ValueError): ray::ActorModelRayActor.fit()
  File "python/ray/includes/common.pxi", line 87, in ray._raylet.check_status
ValueError: Failed to look up actor with name 'gloo_queue'. This could because 1. You are trying to look up a named actor you didn't create. 2. The named actor died. 3. You did not use a namespace matching the namespace of the actor.

During handling of the above exception, another exception occurred:

ray::ActorModelRayActor.fit()
  File site-packages/ray/util/collective/collective.py", line 148, in init_collective_group
    _group_mgr.create_collective_group(backend, world_size, rank, group_name)
  File site-packages/ray/util/collective/collective.py", line 63, in create_collective_group
    g = GLOOGroup(
  File site-packages/ray/util/collective/collective_group/gloo_collective_group.py", line 209, in __init__
    self._rendezvous.meet()
  File site-packages/ray/util/collective/collective_group/gloo_collective_group.py", line 135, in meet
    ).remote(1000)
  File site-packages/ray/actor.py", line 869, in remote
    return actor_cls._remote(args=args, kwargs=kwargs, **updated_options)
  File site-packages/ray/actor.py", line 1202, in _remote
    actor_id = worker.core_worker.create_actor(
  File "python/ray/includes/common.pxi", line 77, in ray._raylet.check_status
ValueError: Actor with name 'gloo_queue' already exists in the namespace d6ea1122-1997-4005-be1e-f37de912a68d
```

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

<!-- Please give a short summary of the change and the problem this solves. -->

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [X] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests
