### PR TITLE
[core][compiled graph] Add checks for release_buffer

### DIFF
--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -1930,7 +1930,7 @@ class CompiledDAG:
         Returns:
             True if a deadlock is detected; otherwise, False.
         """
-        logger.warning("Deadlock detection has not been implemented yet.")
+        logger.debug("Deadlock detection has not been implemented yet.")
         return False
 
     def _monitor_failures(self):

--- a/python/ray/experimental/channel/common.py
+++ b/python/ray/experimental/channel/common.py
@@ -421,6 +421,12 @@ class SynchronousReader(ReaderInterface):
     def release_channel_buffers(self, timeout: Optional[float] = None) -> None:
         for c in self._input_channels:
             start_time = time.monotonic()
+            assert hasattr(
+                c, "release_buffer"
+            ), "release_buffer() is only supported for shared memory channel "
+            "(e.g., Channel, BufferedSharedMemoryChannel, CompositeChannel) "
+            "between the last actor and the driver, but got a channel of type "
+            f"{type(c)}."
             c.release_buffer(timeout)
             if timeout is not None:
                 timeout -= time.monotonic() - start_time

--- a/python/ray/experimental/channel/common.py
+++ b/python/ray/experimental/channel/common.py
@@ -425,8 +425,8 @@ class SynchronousReader(ReaderInterface):
                 c, "release_buffer"
             ), "release_buffer() is only supported for shared memory channel "
             "(e.g., Channel, BufferedSharedMemoryChannel, CompositeChannel) "
-            "between the last actor and the driver, but got a channel of type "
-            f"{type(c)}."
+            "and used between the last actor and the driver, but got a channel"
+            f" of type {type(c)}."
             c.release_buffer(timeout)
             if timeout is not None:
                 timeout -= time.monotonic() - start_time


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Add additional checks and informative error message for `release_buffer()` as it is only available for shared memory buffers.

Also reduce log level for "deadlock detection disabled" which could be confusing to users.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
