### PR TITLE
[LLM Batch] Support out-of-order UDF outputs

### DIFF
--- a/python/ray/llm/_internal/batch/stages/base.py
+++ b/python/ray/llm/_internal/batch/stages/base.py
@@ -175,6 +175,7 @@ class StatefulStageUDF:
             is_outputed[idx_in_batch] = True
 
             # Add stage outputs to the data column of the row.
+            inputs[idx_in_batch].pop(self.idx_in_batch_column)
             inputs[idx_in_batch].update(output)
             yield {self.data_column: [inputs[idx_in_batch]]}
 

--- a/python/ray/llm/_internal/batch/stages/chat_template_stage.py
+++ b/python/ray/llm/_internal/batch/stages/chat_template_stage.py
@@ -37,12 +37,18 @@ class ChatTemplateUDF(StatefulStageUDF):
         Yields:
             A generator of rows with the chat template applied.
         """
-        for prompt in self.tokenizer.apply_chat_template(
-            [row["messages"].tolist() for row in batch],
-            tokenize=False,
-            add_generation_prompt=True,
+        for row, prompt in zip(
+            batch,
+            self.tokenizer.apply_chat_template(
+                [row["messages"].tolist() for row in batch],
+                tokenize=False,
+                add_generation_prompt=True,
+            ),
         ):
-            yield {"prompt": prompt}
+            yield {
+                self.idx_in_batch_column: row[self.idx_in_batch_column],
+                "prompt": prompt,
+            }
 
     @property
     def expected_input_keys(self) -> List[str]:

--- a/python/ray/llm/_internal/batch/stages/chat_template_stage.py
+++ b/python/ray/llm/_internal/batch/stages/chat_template_stage.py
@@ -46,7 +46,7 @@ class ChatTemplateUDF(StatefulStageUDF):
 
         for row, prompt in zip(batch, prompts):
             yield {
-                self.idx_in_batch_column: row[self.idx_in_batch_column],
+                self.IDX_IN_BATCH_COLUMN: row[self.IDX_IN_BATCH_COLUMN],
                 "prompt": prompt,
             }
 

--- a/python/ray/llm/_internal/batch/stages/chat_template_stage.py
+++ b/python/ray/llm/_internal/batch/stages/chat_template_stage.py
@@ -37,14 +37,14 @@ class ChatTemplateUDF(StatefulStageUDF):
         Yields:
             A generator of rows with the chat template applied.
         """
-        for row, prompt in zip(
-            batch,
-            self.tokenizer.apply_chat_template(
-                [row["messages"].tolist() for row in batch],
-                tokenize=False,
-                add_generation_prompt=True,
-            ),
-        ):
+        prompts = self.tokenizer.apply_chat_template(
+            [row["messages"].tolist() for row in batch],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        assert len(batch) == len(prompts)
+
+        for row, prompt in zip(batch, prompts):
             yield {
                 self.idx_in_batch_column: row[self.idx_in_batch_column],
                 "prompt": prompt,

--- a/python/ray/llm/_internal/batch/stages/http_request_stage.py
+++ b/python/ray/llm/_internal/batch/stages/http_request_stage.py
@@ -74,19 +74,19 @@ class HttpRequestUDF(StatefulStageUDF):
                     headers=headers,
                     json=json_body,
                 )
-                pending_requests.append((row[self.idx_in_batch_column], request))
+                pending_requests.append((row[self.IDX_IN_BATCH_COLUMN], request))
 
             # Now receive all responses
             for idx_in_batch, request in pending_requests:
                 async with await request as response:
                     resp_json = await response.json()
-                    if self.idx_in_batch_column in resp_json:
+                    if self.IDX_IN_BATCH_COLUMN in resp_json:
                         raise ValueError(
                             "The response of the HTTP request must not contain "
-                            f"the column {self.idx_in_batch_column}."
+                            f"the column {self.IDX_IN_BATCH_COLUMN}."
                         )
                     yield {
-                        self.idx_in_batch_column: idx_in_batch,
+                        self.IDX_IN_BATCH_COLUMN: idx_in_batch,
                         **resp_json,
                     }
 

--- a/python/ray/llm/_internal/batch/stages/prepare_image_stage.py
+++ b/python/ray/llm/_internal/batch/stages/prepare_image_stage.py
@@ -351,9 +351,8 @@ class PrepareImageUDF(StatefulStageUDF):
         for image_info_per_req in all_image_info:
             num_images_in_req = len(image_info_per_req)
             ret = {self.idx_in_batch_column: idx_in_batch}
-            if num_images_in_req == 0:
-                yield ret
-            else:
+            idx_in_batch += 1
+            if num_images_in_req > 0:
                 images = flat_all_images[
                     img_start_idx : img_start_idx + num_images_in_req
                 ]
@@ -363,9 +362,8 @@ class PrepareImageUDF(StatefulStageUDF):
                         "image_sizes": [(img.width, img.height) for img in images],
                     }
                 )
-                yield ret
                 img_start_idx += num_images_in_req
-                idx_in_batch += 1
+            yield ret
 
     @property
     def expected_input_keys(self) -> List[str]:

--- a/python/ray/llm/_internal/batch/stages/prepare_image_stage.py
+++ b/python/ray/llm/_internal/batch/stages/prepare_image_stage.py
@@ -350,7 +350,7 @@ class PrepareImageUDF(StatefulStageUDF):
         idx_in_batch = 0
         for image_info_per_req in all_image_info:
             num_images_in_req = len(image_info_per_req)
-            ret = {self.idx_in_batch_column: idx_in_batch}
+            ret = {self.IDX_IN_BATCH_COLUMN: idx_in_batch}
             idx_in_batch += 1
             if num_images_in_req > 0:
                 images = flat_all_images[

--- a/python/ray/llm/_internal/batch/stages/tokenize_stage.py
+++ b/python/ray/llm/_internal/batch/stages/tokenize_stage.py
@@ -41,7 +41,10 @@ class TokenizeUDF(StatefulStageUDF):
             batch,
             self.tokenizer([row["prompt"] for row in batch])["input_ids"],
         ):
-            yield {"tokenized_prompt": prompt_token_ids}
+            yield {
+                self.idx_in_batch_column: row[self.idx_in_batch_column],
+                "tokenized_prompt": prompt_token_ids,
+            }
 
     @property
     def expected_input_keys(self) -> List[str]:
@@ -96,7 +99,10 @@ class DetokenizeUDF(StatefulStageUDF):
                 skip_special_tokens=True,
             ),
         ):
-            yield {"generated_text": generated_text}
+            yield {
+                self.idx_in_batch_column: row[self.idx_in_batch_column],
+                "generated_text": generated_text,
+            }
 
     @property
     def expected_input_keys(self) -> List[str]:

--- a/python/ray/llm/_internal/batch/stages/tokenize_stage.py
+++ b/python/ray/llm/_internal/batch/stages/tokenize_stage.py
@@ -42,7 +42,7 @@ class TokenizeUDF(StatefulStageUDF):
             self.tokenizer([row["prompt"] for row in batch])["input_ids"],
         ):
             yield {
-                self.idx_in_batch_column: row[self.idx_in_batch_column],
+                self.IDX_IN_BATCH_COLUMN: row[self.IDX_IN_BATCH_COLUMN],
                 "tokenized_prompt": prompt_token_ids,
             }
 
@@ -100,7 +100,7 @@ class DetokenizeUDF(StatefulStageUDF):
             ),
         ):
             yield {
-                self.idx_in_batch_column: row[self.idx_in_batch_column],
+                self.IDX_IN_BATCH_COLUMN: row[self.IDX_IN_BATCH_COLUMN],
                 "generated_text": generated_text,
             }
 

--- a/python/ray/llm/tests/batch/processor/test_base.py
+++ b/python/ray/llm/tests/batch/processor/test_base.py
@@ -59,7 +59,7 @@ def test_processor_with_stages(has_extra: bool):
                 yield {
                     # Use the same name to chain multiple dummy stages.
                     "val": answer,
-                    self.idx_in_batch_column: row[self.idx_in_batch_column],
+                    self.IDX_IN_BATCH_COLUMN: row[self.IDX_IN_BATCH_COLUMN],
                 }
 
         @property

--- a/python/ray/llm/tests/batch/processor/test_base.py
+++ b/python/ray/llm/tests/batch/processor/test_base.py
@@ -59,6 +59,7 @@ def test_processor_with_stages(has_extra: bool):
                 yield {
                     # Use the same name to chain multiple dummy stages.
                     "val": answer,
+                    self.idx_in_batch_column: row[self.idx_in_batch_column],
                 }
 
         @property

--- a/python/ray/llm/tests/batch/stages/test_base.py
+++ b/python/ray/llm/tests/batch/stages/test_base.py
@@ -58,7 +58,7 @@ class TestStatefulStageUDF:
             for row in rows[::-1]:
                 ret = {"processed": row["value"] * 2}
                 if not self.udf_output_missing_idx_in_batch_column:
-                    ret[self.idx_in_batch_column] = row[self.idx_in_batch_column]
+                    ret[self.IDX_IN_BATCH_COLUMN] = row[self.IDX_IN_BATCH_COLUMN]
                 yield ret
 
         @property

--- a/python/ray/llm/tests/batch/stages/test_chat_template_stage.py
+++ b/python/ray/llm/tests/batch/stages/test_chat_template_stage.py
@@ -24,25 +24,23 @@ async def test_chat_template_udf_basic(mock_tokenizer_setup):
         model="test-model",
     )
 
-    batch = [
-        {
-            "messages": MagicMock(
-                tolist=lambda: [{"role": "user", "content": "Hello AI"}]
-            )
-        }
-    ]
+    batch = {
+        "__data": [
+            {
+                "messages": MagicMock(
+                    tolist=lambda: [{"role": "user", "content": "Hello AI"}]
+                )
+            }
+        ]
+    }
 
     results = []
-    async for result in udf.udf(batch):
+    async for result in udf(batch):
         results.append(result)
 
     assert len(results) == 1
-    assert results[0] == {"prompt": "<chat>Hello AI</chat>"}
-    mock_tokenizer.apply_chat_template.assert_called_once_with(
-        [batch[0]["messages"].tolist()],
-        tokenize=False,
-        add_generation_prompt=True,
-    )
+    assert results[0]["__data"][0]["prompt"] == "<chat>Hello AI</chat>"
+    mock_tokenizer.apply_chat_template.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -58,31 +56,29 @@ async def test_chat_template_udf_multiple_messages(mock_tokenizer_setup):
         model="test-model",
     )
 
-    batch = [
-        {
-            "messages": MagicMock(
-                tolist=lambda: [{"role": "user", "content": "Hello AI"}]
-            )
-        },
-        {
-            "messages": MagicMock(
-                tolist=lambda: [{"role": "user", "content": "How are you?"}]
-            )
-        },
-    ]
+    batch = {
+        "__data": [
+            {
+                "messages": MagicMock(
+                    tolist=lambda: [{"role": "user", "content": "Hello AI"}]
+                )
+            },
+            {
+                "messages": MagicMock(
+                    tolist=lambda: [{"role": "user", "content": "How are you?"}],
+                )
+            },
+        ]
+    }
 
     results = []
-    async for result in udf.udf(batch):
+    async for result in udf(batch):
         results.append(result)
 
     assert len(results) == 2
-    assert results[0] == {"prompt": "<chat>Hello AI</chat>"}
-    assert results[1] == {"prompt": "<chat>How are you?</chat>"}
-    mock_tokenizer.apply_chat_template.assert_called_once_with(
-        [msg["messages"].tolist() for msg in batch],
-        tokenize=False,
-        add_generation_prompt=True,
-    )
+    assert results[0]["__data"][0]["prompt"] == "<chat>Hello AI</chat>"
+    assert results[1]["__data"][0]["prompt"] == "<chat>How are you?</chat>"
+    mock_tokenizer.apply_chat_template.assert_called_once()
 
 
 def test_chat_template_udf_expected_input_keys(mock_tokenizer_setup):

--- a/python/ray/llm/tests/batch/stages/test_tokenize_stage.py
+++ b/python/ray/llm/tests/batch/stages/test_tokenize_stage.py
@@ -26,11 +26,11 @@ async def test_tokenize_udf_basic(mock_tokenizer_setup):
     ]
 
     udf = TokenizeUDF(data_column="__data", model="test-model")
-    batch = [{"prompt": "Hello"}, {"prompt": "World"}]
+    batch = {"__data": [{"prompt": "Hello"}, {"prompt": "World"}]}
 
     results = []
-    async for result in udf.udf(batch):
-        results.append(result)
+    async for result in udf(batch):
+        results.append(result["__data"][0])
 
     assert len(results) == 2
     assert all(result["tokenized_prompt"] == [1, 2, 3] for result in results)
@@ -46,14 +46,16 @@ async def test_detokenize_udf_basic(mock_tokenizer_setup):
     mock_tokenizer.batch_decode.return_value = ["Hello", "World"]
 
     udf = DetokenizeUDF(data_column="__data", model="test-model")
-    batch = [
-        {"generated_tokens": [1, 2, 3]},
-        {"generated_tokens": [4, 5, 6]},
-    ]
+    batch = {
+        "__data": [
+            {"generated_tokens": [1, 2, 3]},
+            {"generated_tokens": [4, 5, 6]},
+        ]
+    }
 
     results = []
-    async for result in udf.udf(batch):
-        results.append(result)
+    async for result in udf(batch):
+        results.append(result["__data"][0])
 
     assert len(results) == 2
     assert results[0]["generated_text"] == "Hello"


### PR DESCRIPTION
## Why are these changes needed?

The processor stage UDF may output the rows out of order to achieve better streaming, because in this case we won't be blocked by a particular slow request. To achieve this, we attach `__idx_in_batch` to each row before sending to the UDF, and enforce all UDFs to carry this column in the outputs.


## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
