### PR TITLE
[core] Use spdlog fd sink within pipe logger

### DIFF
--- a/src/ray/util/BUILD
+++ b/src/ray/util/BUILD
@@ -269,6 +269,7 @@ ray_cc_library(
     srcs = ["pipe_logger.cc"],
     deps = [
         ":compat",
+        ":spdlog_fd_sink",
         ":stream_redirection_options",
         ":thread_utils",
         ":util",

--- a/src/ray/util/pipe_logger.cc
+++ b/src/ray/util/pipe_logger.cc
@@ -150,7 +150,7 @@ std::shared_ptr<spdlog::logger> CreateLogger(
                                   FALSE,
                                   DUPLICATE_SAME_ACCESS);
     RAY_CHECK(result) << "Fails to duplicate stdout handle";
-    auto stdout_sink = std::make_shared<non_owned_fd_sink>(duped_stdout_handle);
+    auto stdout_sink = std::make_shared<non_owned_fd_sink_st>(duped_stdout_handle);
     sinks.emplace_back(std::move(stdout_sink));
   }
   if (stream_redirect_opt.tee_to_stderr) {
@@ -163,7 +163,7 @@ std::shared_ptr<spdlog::logger> CreateLogger(
                                   FALSE,
                                   DUPLICATE_SAME_ACCESS);
     RAY_CHECK(result) << "Fails to duplicate stderr handle";
-    auto stderr_sink = std::make_shared<non_owned_fd_sink>(duped_stderr_handle);
+    auto stderr_sink = std::make_shared<non_owned_fd_sink_st>(duped_stderr_handle);
     sinks.emplace_back(std::move(stderr_sink));
   }
 #endif

--- a/src/ray/util/pipe_logger.cc
+++ b/src/ray/util/pipe_logger.cc
@@ -150,7 +150,7 @@ std::shared_ptr<spdlog::logger> CreateLogger(
                                   FALSE,
                                   DUPLICATE_SAME_ACCESS);
     RAY_CHECK(result) << "Fails to duplicate stdout handle";
-    auto stdout_sink = std::make_shared<non_owned_fd_sink>(duped_stdout_fd);
+    auto stdout_sink = std::make_shared<non_owned_fd_sink>(duped_stdout_handle);
     sinks.emplace_back(std::move(stdout_sink));
   }
   if (stream_redirect_opt.tee_to_stderr) {
@@ -163,7 +163,7 @@ std::shared_ptr<spdlog::logger> CreateLogger(
                                   FALSE,
                                   DUPLICATE_SAME_ACCESS);
     RAY_CHECK(result) << "Fails to duplicate stderr handle";
-    auto stderr_sink = std::make_shared<non_owned_fd_sink>(duped_stderr_fd);
+    auto stderr_sink = std::make_shared<non_owned_fd_sink>(duped_stderr_handle);
     sinks.emplace_back(std::move(stderr_sink));
   }
 #endif

--- a/src/ray/util/pipe_logger.cc
+++ b/src/ray/util/pipe_logger.cc
@@ -150,8 +150,8 @@ std::shared_ptr<spdlog::logger> CreateLogger(
                                   FALSE,
                                   DUPLICATE_SAME_ACCESS);
     RAY_CHECK(result) << "Fails to duplicate stdout handle";
-    auto stderr_sink = std::make_shared<non_owned_fd_sink>(duped_stderr_fd);
-    sinks.emplace_back(std::move(stderr_sink));
+    auto stdout_sink = std::make_shared<non_owned_fd_sink>(duped_stdout_fd);
+    sinks.emplace_back(std::move(stdout_sink));
   }
   if (stream_redirect_opt.tee_to_stderr) {
     HANDLE duped_stderr_handle;

--- a/src/ray/util/pipe_logger.cc
+++ b/src/ray/util/pipe_logger.cc
@@ -202,11 +202,11 @@ RedirectionFileHandle OpenFileForRedirection(const std::string &file_path) {
       std::make_shared<boost::iostreams::stream<boost::iostreams::file_descriptor_sink>>(
           std::move(fd_sink));
 
+  // In this case, we don't write to the file via logger, so no need to set formatter.
+  // spglog is used here merely to reuse the same [RedirectionFileHandle] interface.
   auto logger_sink = std::make_shared<non_owned_fd_sink_st>(handle);
   auto logger = std::make_shared<spdlog::logger>(
       /*name=*/absl::StrFormat("pipe-logger-%s", file_path), std::move(logger_sink));
-  logger->set_level(spdlog::level::info);
-  logger->set_pattern("%v");  // Only message string is logged.
 
   // Lifecycle for the file handle is bound at [ostream] thus [close_fn].
   auto close_fn = [ostream = std::move(ostream)]() { ostream->close(); };

--- a/src/ray/util/pipe_logger.h
+++ b/src/ray/util/pipe_logger.h
@@ -105,10 +105,11 @@ class RedirectionFileHandle {
   // https://github.com/ray-project/ray/pull/50170
   void CompleteWrite(const char *data, size_t len) {
 #if defined(__APPLE__) || defined(__linux__)
-    (void)write(write_handle_, data, len);
+    [[maybe_unused]] auto x = write(write_handle_, data, len);
 #elif defined(_WIN32)
     DWORD bytes_written;
-    (void)WriteFile(fd, data, (DWORD)len, &bytes_written, NULL);
+    [[maybe_unused]] auto x =
+        WriteFile(write_handle_, data, (DWORD)len, &bytes_written, NULL);
 #endif
   }
 

--- a/src/ray/util/tests/pipe_logger_test.cc
+++ b/src/ray/util/tests/pipe_logger_test.cc
@@ -150,7 +150,7 @@ TEST(PipeLoggerCompatTest, CompatibilityTest) {
     stream_redirection_handle.Close();
 
     const std::string stdout_content = testing::internal::GetCapturedStdout();
-    EXPECT_EQ(stdout_content, kContent);
+    EXPECT_EQ(stdout_content, "hello\n");
 
     // Pipe logger automatically adds a newliner at the end.
     const auto actual_content = ReadEntireFile(test_file_path);
@@ -175,7 +175,7 @@ TEST(PipeLoggerCompatTest, CompatibilityTest) {
     stream_redirection_handle.Close();
 
     const std::string stdout_content = testing::internal::GetCapturedStdout();
-    EXPECT_EQ(stdout_content, kContent);
+    EXPECT_EQ(stdout_content, "hello\n");
 
     const auto actual_content = ReadEntireFile(test_file_path);
     RAY_ASSERT_OK(actual_content);
@@ -199,7 +199,7 @@ TEST(PipeLoggerCompatTest, CompatibilityTest) {
     stream_redirection_handle.Close();
 
     const std::string stdout_content = testing::internal::GetCapturedStdout();
-    EXPECT_EQ(stdout_content, kContent);
+    EXPECT_EQ(stdout_content, "hello\nworld\n");
 
     // Pipe logger automatically adds a newliner at the end.
     const auto actual_content = ReadEntireFile(test_file_path);
@@ -224,7 +224,7 @@ TEST(PipeLoggerCompatTest, CompatibilityTest) {
     stream_redirection_handle.Close();
 
     const std::string stdout_content = testing::internal::GetCapturedStdout();
-    EXPECT_EQ(stdout_content, kContent);
+    EXPECT_EQ(stdout_content, "hello\nworld\n");
 
     const auto actual_content = ReadEntireFile(test_file_path);
     RAY_EXPECT_OK(actual_content);
@@ -248,7 +248,7 @@ TEST(PipeLoggerCompatTest, CompatibilityTest) {
     stream_redirection_handle.Close();
 
     const std::string stdout_content = testing::internal::GetCapturedStdout();
-    EXPECT_EQ(stdout_content, kContent);
+    EXPECT_EQ(stdout_content, "helloworld\n\n\n");
 
     const auto actual_content = ReadEntireFile(test_file_path);
     RAY_EXPECT_OK(actual_content);
@@ -272,7 +272,7 @@ TEST(PipeLoggerCompatTest, CompatibilityTest) {
     stream_redirection_handle.Close();
 
     const std::string stdout_content = testing::internal::GetCapturedStdout();
-    EXPECT_EQ(stdout_content, kContent);
+    EXPECT_EQ(stdout_content, "hello\n\n\nworld\n");
 
     // Pipe logger automatically adds a newliner at the end.
     const auto actual_content = ReadEntireFile(test_file_path);
@@ -297,7 +297,7 @@ TEST(PipeLoggerCompatTest, CompatibilityTest) {
     stream_redirection_handle.Close();
 
     const std::string stdout_content = testing::internal::GetCapturedStdout();
-    EXPECT_EQ(stdout_content, kContent);
+    EXPECT_EQ(stdout_content, "hello\n\nworld\n\n");
 
     // Pipe logger automatically adds a newliner at the end.
     const auto actual_content = ReadEntireFile(test_file_path);

--- a/src/ray/util/tests/pipe_logger_test.cc
+++ b/src/ray/util/tests/pipe_logger_test.cc
@@ -150,12 +150,12 @@ TEST(PipeLoggerCompatTest, CompatibilityTest) {
     stream_redirection_handle.Close();
 
     const std::string stdout_content = testing::internal::GetCapturedStdout();
-    EXPECT_EQ(stdout_content, "hello\n");
+    EXPECT_EQ(stdout_content, kContent);
 
     // Pipe logger automatically adds a newliner at the end.
     const auto actual_content = ReadEntireFile(test_file_path);
     RAY_ASSERT_OK(actual_content);
-    EXPECT_EQ(*actual_content, "hello\n");
+    EXPECT_EQ(*actual_content, kContent);
 
     EXPECT_TRUE(std::filesystem::remove(test_file_path));
   }
@@ -175,11 +175,11 @@ TEST(PipeLoggerCompatTest, CompatibilityTest) {
     stream_redirection_handle.Close();
 
     const std::string stdout_content = testing::internal::GetCapturedStdout();
-    EXPECT_EQ(stdout_content, "hello\n");
+    EXPECT_EQ(stdout_content, kContent);
 
     const auto actual_content = ReadEntireFile(test_file_path);
     RAY_ASSERT_OK(actual_content);
-    EXPECT_EQ(*actual_content, "hello\n");
+    EXPECT_EQ(*actual_content, kContent);
 
     EXPECT_TRUE(std::filesystem::remove(test_file_path));
   }
@@ -199,12 +199,12 @@ TEST(PipeLoggerCompatTest, CompatibilityTest) {
     stream_redirection_handle.Close();
 
     const std::string stdout_content = testing::internal::GetCapturedStdout();
-    EXPECT_EQ(stdout_content, "hello\nworld\n");
+    EXPECT_EQ(stdout_content, kContent);
 
     // Pipe logger automatically adds a newliner at the end.
     const auto actual_content = ReadEntireFile(test_file_path);
     RAY_EXPECT_OK(actual_content);
-    EXPECT_EQ(*actual_content, "hello\nworld\n");
+    EXPECT_EQ(*actual_content, kContent);
 
     EXPECT_TRUE(std::filesystem::remove(test_file_path));
   }
@@ -224,11 +224,11 @@ TEST(PipeLoggerCompatTest, CompatibilityTest) {
     stream_redirection_handle.Close();
 
     const std::string stdout_content = testing::internal::GetCapturedStdout();
-    EXPECT_EQ(stdout_content, "hello\nworld\n");
+    EXPECT_EQ(stdout_content, kContent);
 
     const auto actual_content = ReadEntireFile(test_file_path);
     RAY_EXPECT_OK(actual_content);
-    EXPECT_EQ(*actual_content, "hello\nworld\n");
+    EXPECT_EQ(*actual_content, kContent);
 
     EXPECT_TRUE(std::filesystem::remove(test_file_path));
   }
@@ -248,11 +248,11 @@ TEST(PipeLoggerCompatTest, CompatibilityTest) {
     stream_redirection_handle.Close();
 
     const std::string stdout_content = testing::internal::GetCapturedStdout();
-    EXPECT_EQ(stdout_content, "helloworld\n\n\n");
+    EXPECT_EQ(stdout_content, kContent);
 
     const auto actual_content = ReadEntireFile(test_file_path);
     RAY_EXPECT_OK(actual_content);
-    EXPECT_EQ(*actual_content, "helloworld\n\n\n");
+    EXPECT_EQ(*actual_content, kContent);
 
     EXPECT_TRUE(std::filesystem::remove(test_file_path));
   }
@@ -272,12 +272,12 @@ TEST(PipeLoggerCompatTest, CompatibilityTest) {
     stream_redirection_handle.Close();
 
     const std::string stdout_content = testing::internal::GetCapturedStdout();
-    EXPECT_EQ(stdout_content, "hello\n\n\nworld\n");
+    EXPECT_EQ(stdout_content, kContent);
 
     // Pipe logger automatically adds a newliner at the end.
     const auto actual_content = ReadEntireFile(test_file_path);
     RAY_EXPECT_OK(actual_content);
-    EXPECT_EQ(*actual_content, "hello\n\n\nworld\n");
+    EXPECT_EQ(*actual_content, kContent);
 
     EXPECT_TRUE(std::filesystem::remove(test_file_path));
   }
@@ -297,12 +297,12 @@ TEST(PipeLoggerCompatTest, CompatibilityTest) {
     stream_redirection_handle.Close();
 
     const std::string stdout_content = testing::internal::GetCapturedStdout();
-    EXPECT_EQ(stdout_content, "hello\n\nworld\n\n");
+    EXPECT_EQ(stdout_content, kContent);
 
     // Pipe logger automatically adds a newliner at the end.
     const auto actual_content = ReadEntireFile(test_file_path);
     RAY_ASSERT_OK(actual_content);
-    EXPECT_EQ(*actual_content, "hello\n\nworld\n\n");
+    EXPECT_EQ(*actual_content, kContent);
 
     EXPECT_TRUE(std::filesystem::remove(test_file_path));
   }


### PR DESCRIPTION
This PR is the followup for https://github.com/ray-project/ray/pull/50144, which integrates FD sink to the pipe logger.
The benefit is we have less file descriptor related code within pipe logger, and all write, flush and close feature handled in spdlog logger.

One behavior change, we use default formatter for all possible sinks, which appends newliner to each message.