### PR TITLE
[core] [easy] [no-op] Use scoped temporary directory for pipe logger test

### DIFF
--- a/src/ray/util/tests/BUILD
+++ b/src/ray/util/tests/BUILD
@@ -217,6 +217,7 @@ ray_cc_test(
     name = "pipe_logger_test",
     srcs = ["pipe_logger_test.cc"],
     deps = [
+        "//src/ray/util:temporary_directory",
         "//src/ray/common/test:testing",
         "//src/ray/util",
         "//src/ray/util:pipe_logger",


### PR DESCRIPTION
Code quality improvement, which leverages RAII class to cleanup test files.