### PR TITLE
[core] Add pipe redirection test

### DIFF
--- a/src/ray/util/tests/BUILD
+++ b/src/ray/util/tests/BUILD
@@ -256,6 +256,26 @@ ray_cc_test(
 )
 
 ray_cc_test(
+    name = "stream_redirection_flush_test",
+    srcs = ["stream_redirection_flush_test.cc"],
+    deps = [
+        "//src/ray/common/test:testing",
+        "//src/ray/util",
+        "//src/ray/util:stream_redirection_utils",
+        "@com_google_googletest//:gtest_main",
+    ],
+    size = "small",
+    tags = [
+        "team:core",
+        # TSAN fails to understand synchroization logic, from the stacktrace, it shows we flush
+        # ostream concurrently at pipe dumper thread and main thread, which we have ordered
+        # properly. Disable the complete test suite here since it always contains exactly one test
+        # case.
+        "no_tsan",
+    ],
+)
+
+ray_cc_test(
     name = "cmd_line_utils_test",
     srcs = ["cmd_line_utils_test.cc"],
     deps = [


### PR DESCRIPTION
This PR adds an addition test, which tests if we (1) don't write newliner to the stream; nor (2) close the pipe, if we could read whole content after a flush.