### PR TITLE
[docs] pip install instruction is missing "ray[serve]"

### DIFF
--- a/doc/source/serve/tutorials/serve-ml-models.md
+++ b/doc/source/serve/tutorials/serve-ml-models.md
@@ -25,7 +25,7 @@ Ray Serve is framework-agnostic--you can use any version of TensorFlow.
 This tutorial uses TensorFlow 2 and Keras. You also need `requests` to send HTTP requests to your model deployment. If you haven't already, install TensorFlow 2 and requests by running:
 
 ```console
-$ pip install "tensorflow>=2.0" requests
+$ pip install "tensorflow>=2.0" requests "ray[serve]"
 ```
 
 Open a new Python file called `tutorial_tensorflow.py`. First, import Ray Serve and some other helpers.
@@ -103,7 +103,7 @@ In particular, it shows:
 This tutorial requires PyTorch and Torchvision. Ray Serve is framework agnostic and works with any version of PyTorch. You also need `requests` to send HTTP requests to your model deployment. If you haven't already, install them by running:
 
 ```console
-$ pip install torch torchvision requests
+$ pip install torch torchvision requests  "ray[serve]"
 ```
 
 Open a new Python file called `tutorial_pytorch.py`. First, import Ray Serve and some other helpers.
@@ -172,7 +172,7 @@ In particular, it shows:
 Ray Serve is framework-agnostic. You can use any version of sklearn. You also need `requests` to send HTTP requests to your model deployment. If you haven't already, install scikit-learn and requests by running:
 
 ```console
-$ pip install scikit-learn requests
+$ pip install scikit-learn requests "ray[serve]"
 ```
 
 Open a new Python file called `tutorial_sklearn.py`. Import Ray Serve and some other helpers.


### PR DESCRIPTION
The tutorials assume that you have ray[serve] installed, but this is a problem if a reader tries this as a standalone example.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
