### PR TITLE
[Data] Fixing incorrect assertion inside `make_async_gen`

### DIFF
--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -1033,9 +1033,9 @@ def make_async_gen(
             #
             # NOTE: `queue.get` is blocking!
             input_queue_iter = iter(input_queue.get, SENTINEL)
-            iterator = _WorkerIterator(input_queue_iter, worker_id=worker_id)
+            wrapped_iter = _WorkerIterator(input_queue_iter, worker_id=worker_id)
 
-            mapped_iter = fn(iterator)
+            mapped_iter = fn(wrapped_iter)
             for result in mapped_iter:
                 # Enqueue result of the transformation
                 output_queue.put(result)

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -910,27 +910,6 @@ class _InterruptibleQueue(Queue):
                 pass
 
 
-class _WorkerIterator(Iterator):
-    """NOTE: This wrapper class is used to communicate worker-id to the
-    handler method"""
-
-    def __init__(self, source_iter: Iterator[T], *, worker_id: int):
-        super().__init__()
-
-        self._source_iter = source_iter
-        self._worker_id = worker_id
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        return next(self._source_iter)
-
-    @property
-    def worker_id(self) -> int:
-        return self._worker_id
-
-
 def make_async_gen(
     base_iterator: Iterator[T],
     fn: Callable[[Iterator[T]], Iterator[U]],
@@ -1033,9 +1012,8 @@ def make_async_gen(
             #
             # NOTE: `queue.get` is blocking!
             input_queue_iter = iter(input_queue.get, SENTINEL)
-            wrapped_iter = _WorkerIterator(input_queue_iter, worker_id=worker_id)
 
-            mapped_iter = fn(wrapped_iter)
+            mapped_iter = fn(input_queue_iter)
             for result in mapped_iter:
                 # Enqueue result of the transformation
                 output_queue.put(result)

--- a/python/ray/data/tests/block_batching/test_util.py
+++ b/python/ray/data/tests/block_batching/test_util.py
@@ -19,6 +19,9 @@ from ray.data._internal.block_batching.util import (
 from ray.data._internal.util import make_async_gen
 
 
+logger = logging.getLogger(__file__)
+
+
 def block_generator(num_rows: int, num_blocks: int):
     for _ in range(num_blocks):
         yield pa.table({"foo": [1] * num_rows})
@@ -131,7 +134,35 @@ def test_make_async_gen_fail(buffer_size: int):
     assert e.match("Fail")
 
 
-logger = logging.getLogger(__file__)
+@pytest.mark.parametrize("buffer_size", [0, 1, 2])
+def test_make_async_gen_varying_seq_lengths(buffer_size: int):
+    """Tests that iterators of varying lengths are handled appropriately"""
+
+    def _gen(base_iterator):
+        worker_id = base_iterator._worker_id
+
+        # Make workers produce sequences increasing the same order
+        # as worker-ids (so that for left workers sequences run out first)
+        target_length = worker_id + 1
+
+        return iter([f"worker_{worker_id}:{i}" for i in range(target_length)])
+
+    num_seqs = 3
+
+    iterator = make_async_gen(
+        base_iterator=iter(list(range(num_seqs))),
+        fn=_gen,
+        # Make sure individual elements are handle by diff workers
+        num_workers=num_seqs,
+        queue_buffer_size=buffer_size,
+    )
+
+    seq = list(iterator)
+
+    assert [
+               'worker_0:0',
+               'worker_1:0',
+               'worker_2:0', 'worker_1:1', 'worker_2:1', 'worker_2:2'] == seq
 
 
 @pytest.mark.parametrize("buffer_size", [0, 1, 2])

--- a/python/ray/data/tests/block_batching/test_util.py
+++ b/python/ray/data/tests/block_batching/test_util.py
@@ -139,7 +139,7 @@ def test_make_async_gen_varying_seq_lengths(buffer_size: int):
     """Tests that iterators of varying lengths are handled appropriately"""
 
     def _gen(base_iterator):
-        worker_id = base_iterator._worker_id
+        worker_id = base_iterator.worker_id
 
         # Make workers produce sequences increasing the same order
         # as worker-ids (so that for left workers sequences run out first)

--- a/python/ray/data/tests/block_batching/test_util.py
+++ b/python/ray/data/tests/block_batching/test_util.py
@@ -139,7 +139,7 @@ def test_make_async_gen_varying_seq_lengths(buffer_size: int):
     """Tests that iterators of varying lengths are handled appropriately"""
 
     def _gen(base_iterator):
-        worker_id = base_iterator.worker_id
+        worker_id = next(base_iterator)
 
         # Make workers produce sequences increasing the same order
         # as worker-ids (so that for left workers sequences run out first)

--- a/python/ray/data/tests/block_batching/test_util.py
+++ b/python/ray/data/tests/block_batching/test_util.py
@@ -160,9 +160,13 @@ def test_make_async_gen_varying_seq_lengths(buffer_size: int):
     seq = list(iterator)
 
     assert [
-               'worker_0:0',
-               'worker_1:0',
-               'worker_2:0', 'worker_1:1', 'worker_2:1', 'worker_2:2'] == seq
+        "worker_0:0",
+        "worker_1:0",
+        "worker_2:0",
+        "worker_1:1",
+        "worker_2:1",
+        "worker_2:2",
+    ] == seq
 
 
 @pytest.mark.parametrize("buffer_size", [0, 1, 2])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This change addresses incorrect assertion implemented in `make_async_gen` enforcing that the sequences produced by the provided mappers are expected to produce sequences of the same lengths, which is not necessarily true.

Added tests verifying this.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
