### PR TITLE
[core] marking workflow tests to run only on postmerge

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -130,6 +130,8 @@ steps:
     tags:
       - python
       - workflow
+      - oss
+      - skip-on-premerge
     instance_type: medium
     parallelism: 2
     commands:


### PR DESCRIPTION
so that the flaky tests are not blocking. the feature is being deprecated
