### PR TITLE
[ci] remove buildkite env vars from test env

### DIFF
--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -16,6 +16,7 @@ if [ -d "/tmp/artifacts/test-summaries" ] && [ "$(ls -A /tmp/artifacts/test-summ
     # Only upload annotations if there are at least 2 files in the directory:
     # 1 header and 1 failed test.
     if [ "$(find /tmp/artifacts/test-summaries -maxdepth 1 -name '*.txt' | wc -l)" -ge 2 ]; then
+      echo "Test summaries for ${BUILDKITE_JOB_ID} ${BUILDKITE_LABEL}" | buildkite-agent annotate --job "${BUILDKITE_JOB_ID}" --style error --context "${BUILDKITE_JOB_ID}"
       cat /tmp/artifacts/test-summaries/*.txt | head -n 20 | buildkite-agent annotate --job "${BUILDKITE_JOB_ID}" --append --style error --context "${BUILDKITE_JOB_ID}"
     fi
 

--- a/ci/run/bazel_export_options
+++ b/ci/run/bazel_export_options
@@ -10,7 +10,6 @@ event_json_flag=--build_event_json_file=$(mktemp /tmp/bazel_event_logs/bazel_log
 logs_archive_flag=--test_env=RAY_TEST_FAILURE_LOGS_ARCHIVE_DIR="${artifact_mount_path}"/failed_test_logs
 summary_directory_flag=--test_env=RAY_TEST_SUMMARY_DIR="${artifact_mount_path}"/test-summaries
 summary_directory_host_flag=--test_env=RAY_TEST_SUMMARY_DIR_HOST=/tmp/artifacts/test-summaries
-buildkite_env_vars="--test_env=BUILDKITE_COMMIT --test_env=BUILDKITE_LABEL --test_env=BUILDKITE_JOB_ID"
 mujoco_env_var="--test_env=LD_LIBRARY_PATH=/root/.mujoco/mujoco210/bin"
 
-echo "${event_json_flag} ${logs_archive_flag} ${summary_directory_flag} ${summary_directory_host_flag} ${buildkite_env_vars} ${mujoco_env_var}"
+echo "${event_json_flag} ${logs_archive_flag} ${summary_directory_flag} ${summary_directory_host_flag} ${mujoco_env_var}"

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -14,7 +14,7 @@ import time
 from contextlib import contextmanager
 from pathlib import Path
 from tempfile import gettempdir
-from typing import List, Optional, Tuple
+from typing import List, Optional
 from unittest import mock
 import psutil
 import pytest
@@ -1198,7 +1198,6 @@ def append_short_test_summary(rep):
         # ":" is not legal in filenames in windows
         test_name = test_name.replace(":", "$")
 
-    header_file = os.path.join(summary_dir, "000_header.txt")
     summary_file = os.path.join(summary_dir, test_name + ".txt")
 
     if rep.passed and os.path.exists(summary_file):
@@ -1219,13 +1218,6 @@ def append_short_test_summary(rep):
     if not hasattr(rep.longrepr, "chain"):
         return
 
-    if not os.path.exists(header_file):
-        with open(header_file, "wt") as fp:
-            test_label = os.environ.get("BUILDKITE_LABEL", "Unknown")
-            job_id = os.environ.get("BUILDKITE_JOB_ID")
-
-            fp.write(f"### Pytest failures for: [{test_label}](#{job_id})\n\n")
-
     # Use `wt` here to overwrite so we only have one result per test (exclude retries)
     with open(summary_file, "wt") as fp:
         fp.write(_get_markdown_annotation(rep))
@@ -1244,12 +1236,10 @@ def _get_markdown_annotation(rep) -> str:
     markdown += "<details>\n"
     markdown += f"<summary>{short_message}</summary>\n\n"
 
-    # Add link to test definition
+    # Add location to the test definition
     test_file, test_lineno, _test_node = rep.location
-    test_path, test_url = _get_repo_github_path_and_link(
-        os.path.abspath(test_file), test_lineno
-    )
-    markdown += f"Link to test: [{test_path}:{test_lineno}]({test_url})\n\n"
+    test_path = os.path.abspath(test_file)
+    markdown += f"Test location: {test_path}:{test_lineno}\n\n"
 
     # Print main traceback
     markdown += "##### Traceback\n\n"
@@ -1257,27 +1247,20 @@ def _get_markdown_annotation(rep) -> str:
     markdown += str(main_tb)
     markdown += "\n```\n\n"
 
-    # Print link to test definition in github
-    path, url = _get_repo_github_path_and_link(main_loc.path, main_loc.lineno)
-    markdown += f"[{path}:{main_loc.lineno}]({url})\n\n"
+    # Print test definition location
+    markdown += f"{main_loc.path}:{main_loc.lineno}\n\n"
 
     # If this is a longer exception chain, users can expand the full traceback
     if len(rep.longrepr.chain) > 1:
         markdown += "<details><summary>Full traceback</summary>\n\n"
 
-        # Here we just print each traceback and the link to the respective
-        # lines in GutHub
+        # Here we just print each traceback and the respective lines.
         for tb, loc, _ in rep.longrepr.chain:
-            if loc:
-                path, url = _get_repo_github_path_and_link(loc.path, loc.lineno)
-                github_link = f"[{path}:{loc.lineno}]({url})\n\n"
-            else:
-                github_link = ""
-
             markdown += "```\n"
             markdown += str(tb)
             markdown += "\n```\n\n"
-            markdown += github_link
+            if loc:
+                markdown += f"{loc.path}:{loc.lineno}\n\n"
 
         markdown += "</details>\n"
 
@@ -1298,19 +1281,6 @@ def _get_pip_packages() -> List[str]:
         return list(freeze.freeze())
     except Exception:
         return ["invalid"]
-
-
-def _get_repo_github_path_and_link(file: str, lineno: int) -> Tuple[str, str]:
-    base_url = "https://github.com/ray-project/ray/blob/{commit}/{path}#L{lineno}"
-
-    commit = os.environ.get("BUILDKITE_COMMIT")
-
-    if not commit:
-        return file, ""
-
-    path = file.split("com_github_ray_project_ray/")[-1]
-
-    return path, base_url.format(commit=commit, path=path, lineno=lineno)
 
 
 def create_ray_logs_for_failed_test(rep):


### PR DESCRIPTION
printing info in post-command directly, and removing commit related github links that are generated from test results.

these changes are required for cacheable test results
