### PR TITLE
[Data] Added support for type promotions 

### DIFF
--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -74,7 +74,8 @@ DEFAULT_OBJECT_STORE_MAX_MEMORY_BYTES = env_integer(
 )
 # The default proportion of available memory allocated to the object store
 DEFAULT_OBJECT_STORE_MEMORY_PROPORTION = env_float(
-    "RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION", 0.3
+    "RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION",
+    0.3,
 )
 # The smallest cap on the memory used by the object store that we allow.
 # This must be greater than MEMORY_RESOURCE_UNIT_BYTES

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1,5 +1,7 @@
 import asyncio
 import binascii
+import random
+import string
 from collections import defaultdict
 import contextlib
 import errno
@@ -75,6 +77,18 @@ PLACEMENT_GROUP_INDEXED_BUNDLED_RESOURCE_PATTERN = re.compile(
     r"(.+)_group_(\d+)_([0-9a-zA-Z]+)"
 )
 PLACEMENT_GROUP_WILDCARD_RESOURCE_PATTERN = re.compile(r"(.+)_group_([0-9a-zA-Z]+)")
+
+
+# Match the standard alphabet used for UUIDs.
+RANDOM_STRING_ALPHABET = string.ascii_lowercase + string.digits
+
+
+def get_random_alphanumeric_string(length: int):
+    """Generates random string of length consisting exclusively of
+    - Lower-case ASCII chars
+    - Digits
+    """
+    return "".join(random.choices(RANDOM_STRING_ALPHABET, k=length))
 
 
 def get_user_temp_dir():

--- a/python/ray/data/BUILD
+++ b/python/ray/data/BUILD
@@ -163,7 +163,7 @@ py_test(
 
 py_test(
     name = "test_all_to_all",
-    size = "large",
+    size = "enormous",
     srcs = ["tests/test_all_to_all.py"],
     tags = ["team:data", "exclusive"],
     deps = ["//:ray_lib", ":conftest"],

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Dict, List, Union, Dict
+from typing import TYPE_CHECKING, List, Union, Dict
 
 import numpy as np
 from packaging.version import parse as parse_version

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -562,7 +562,7 @@ def to_numpy(
         )
 
 
-def try_combine_chunks(table: "pyarrow.Table") -> "pyarrow.Table":
+def try_combine_chunked_columns(table: "pyarrow.Table") -> "pyarrow.Table":
     """This method attempts to coalesce table by combining any of its
     columns exceeding threshold of `MIN_NUM_CHUNKS_TO_TRIGGER_COMBINE_CHUNKS`
     chunks in its `ChunkedArray`.

--- a/python/ray/data/_internal/batcher.py
+++ b/python/ray/data/_internal/batcher.py
@@ -3,19 +3,14 @@ from typing import Optional
 
 from ray.data._internal.arrow_block import ArrowBlockAccessor
 from ray.data._internal.arrow_ops import transform_pyarrow
+from ray.data._internal.arrow_ops.transform_pyarrow import (
+    MIN_NUM_CHUNKS_TO_TRIGGER_COMBINE_CHUNKS,
+)
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.execution.util import memory_string
 from ray.data._internal.util import get_total_obj_store_mem_on_node
 from ray.data.block import Block, BlockAccessor
 from ray.util import log_once
-
-# pyarrow.Table.slice is slow when the table has many chunks
-# so we combine chunks into a single one to make slice faster
-# with the cost of an extra copy.
-# See https://github.com/ray-project/ray/issues/31108 for more details.
-# TODO(jjyao): remove this once
-# https://github.com/apache/arrow/issues/35126 is resolved.
-MIN_NUM_CHUNKS_TO_TRIGGER_COMBINE_CHUNKS = 10
 
 # Delay compaction until the shuffle buffer has reached this ratio over the min
 # shuffle buffer size. Setting this to 1 minimizes memory usage, at the cost of
@@ -137,15 +132,14 @@ class Batcher(BatcherInterface):
                 output.add_block(accessor.to_block())
                 needed -= accessor.num_rows()
             else:
-                if (
-                    isinstance(accessor, ArrowBlockAccessor)
-                    and block.num_columns > 0
-                    and block.column(0).num_chunks
-                    >= MIN_NUM_CHUNKS_TO_TRIGGER_COMBINE_CHUNKS
-                ):
+                # Try de-fragmenting table in case its columns
+                # have too many chunks (potentially hindering performance of
+                # subsequent slicing operation)
+                if isinstance(accessor, ArrowBlockAccessor):
                     accessor = BlockAccessor.for_block(
-                        transform_pyarrow.combine_chunks(block)
+                        transform_pyarrow.try_combine_chunks(block)
                     )
+
                 # We only need part of the block to fill out a batch.
                 output.add_block(accessor.slice(0, needed, copy=False))
                 # Add the rest of the block to the leftovers.

--- a/python/ray/data/_internal/batcher.py
+++ b/python/ray/data/_internal/batcher.py
@@ -137,7 +137,7 @@ class Batcher(BatcherInterface):
                 # subsequent slicing operation)
                 if isinstance(accessor, ArrowBlockAccessor):
                     accessor = BlockAccessor.for_block(
-                        transform_pyarrow.try_combine_chunks(block)
+                        transform_pyarrow.try_combine_chunked_columns(block)
                     )
 
                 # We only need part of the block to fill out a batch.

--- a/python/ray/data/_internal/execution/interfaces/execution_options.py
+++ b/python/ray/data/_internal/execution/interfaces/execution_options.py
@@ -43,8 +43,8 @@ class ExecutionResources:
     ):
         """Create an ExecutionResources object from a resource dict."""
         return ExecutionResources(
-            cpu=resource_dict.get("CPU", None),
-            gpu=resource_dict.get("GPU", None),
+            cpu=resource_dict.get("CPU", None) or resource_dict.get("num_cpus", None),
+            gpu=resource_dict.get("GPU", None) or resource_dict.get("num_gpus", None),
             object_store_memory=resource_dict.get("object_store_memory", None),
             default_to_inf=default_to_inf,
         )

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -336,6 +336,11 @@ class PhysicalOperator(Operator):
                 input. For most operators, this is always `0` since there is only
                 one upstream input operator.
         """
+        assert 0 <= input_index < len(self._input_dependencies), (
+            f"Input index out of bounds (total inputs {len(self._input_dependencies)}, "
+            f"index is {input_index})"
+        )
+
         self._metrics.on_input_received(refs)
         self._add_input_inner(refs, input_index)
 

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -26,12 +26,20 @@ class OpTask(ABC):
     The task can be either a regular task or an actor task.
     """
 
-    def __init__(self, task_index: int):
-        self._task_index = task_index
+    def __init__(
+        self,
+        task_index: int,
+        task_resource_bundle: Optional[ExecutionResources] = None,
+    ):
+        self._task_index: int = task_index
+        self._task_resource_bundle: Optional[ExecutionResources] = task_resource_bundle
 
     def task_index(self) -> int:
         """Return the index of the task."""
         return self._task_index
+
+    def get_requested_resource_bundle(self) -> Optional[ExecutionResources]:
+        return self._task_resource_bundle
 
     @abstractmethod
     def get_waitable(self) -> Waitable:
@@ -48,6 +56,7 @@ class DataOpTask(OpTask):
         streaming_gen: ObjectRefGenerator,
         output_ready_callback: Callable[[RefBundle], None],
         task_done_callback: Callable[[Optional[Exception]], None],
+        task_resource_bundle: Optional[ExecutionResources] = None,
     ):
         """
         Args:
@@ -56,7 +65,7 @@ class DataOpTask(OpTask):
                 from the generator.
             task_done_callback: The callback to call when the task is done.
         """
-        super().__init__(task_index)
+        super().__init__(task_index, task_resource_bundle)
         # TODO(hchen): Right now, the streaming generator is required to yield a Block
         # and a BlockMetadata each time. We should unify task submission with an unified
         # interface. So each individual operator don't need to take care of the
@@ -118,13 +127,14 @@ class MetadataOpTask(OpTask):
         task_index: int,
         object_ref: ray.ObjectRef,
         task_done_callback: Callable[[], None],
+        task_resource_bundle: Optional[ExecutionResources] = None,
     ):
         """
         Args:
             object_ref: The ObjectRef of the task.
             task_done_callback: The callback to call when the task is done.
         """
-        super().__init__(task_index)
+        super().__init__(task_index, task_resource_bundle)
         self._object_ref = object_ref
         self._task_done_callback = task_done_callback
 
@@ -505,7 +515,7 @@ class PhysicalOperator(Operator):
     def implements_accurate_memory_accounting(self) -> bool:
         """Return whether this operator implements accurate memory accounting.
 
-        An operator that implements accurate memory accounting should should properly
+        An operator that implements accurate memory accounting should properly
         report its memory usage via the following APIs:
           - `self._metrics.on_input_queued`.
           - `self._metrics.on_input_dequeued`.

--- a/python/ray/data/_internal/logical/operators/n_ary_operator.py
+++ b/python/ray/data/_internal/logical/operators/n_ary_operator.py
@@ -28,7 +28,7 @@ class Zip(NAry):
     ):
         """
         Args:
-            left_input_ops: The input operator at left hand side.
+            left_input_op: The input operator at left hand side.
             right_input_op: The input operator at right hand side.
         """
         super().__init__(left_input_op, right_input_op)

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -23,7 +23,7 @@ from ray.air.util.tensor_extensions.utils import _is_ndarray_tensor
 from ray.data._internal.numpy_support import convert_to_numpy, validate_numpy_batch
 from ray.data._internal.row import TableRow
 from ray.data._internal.table_block import TableBlockAccessor, TableBlockBuilder
-from ray.data._internal.util import find_partitions, keys_equal
+from ray.data._internal.util import find_partitions, keys_equal, NULL_SENTINEL, is_nan
 from ray.data.block import (
     Block,
     BlockAccessor,
@@ -653,35 +653,46 @@ class PandasBlockAccessor(TableBlockAccessor):
         stats = BlockExecStats.builder()
         keys = sort_key.get_columns()
 
-        def key_fn(r):
+        def _key_fn(r):
             if keys:
                 return tuple(r[keys])
             else:
                 return (0,)
 
+        # Replace `None`s and `np.nan` with NULL_SENTINEL to make sure
+        # we can order the elements (both of these are incomparable)
+        def safe_key_fn(r):
+            values = _key_fn(r)
+            return tuple(
+                [NULL_SENTINEL if v is None or is_nan(v) else v for v in values]
+            )
+
         # Handle blocks of different types.
-        blocks = TableBlockAccessor.normalize_block_types(blocks, "pandas")
+        blocks = TableBlockAccessor.normalize_block_types(blocks, BlockType.PANDAS)
 
         iter = heapq.merge(
             *[
                 PandasBlockAccessor(block).iter_rows(public_row_format=False)
                 for block in blocks
             ],
-            key=key_fn,
+            key=safe_key_fn,
         )
+
         next_row = None
         builder = PandasBlockBuilder()
+
         while True:
             try:
                 if next_row is None:
                     next_row = next(iter)
-                next_keys = key_fn(next_row)
+
+                next_keys = _key_fn(next_row)
                 next_key_columns = keys
 
                 def gen():
                     nonlocal iter
                     nonlocal next_row
-                    while keys_equal(key_fn(next_row), next_keys):
+                    while keys_equal(_key_fn(next_row), next_keys):
                         yield next_row
                         try:
                             next_row = next(iter)

--- a/python/ray/data/_internal/planner/exchange/sort_task_spec.py
+++ b/python/ray/data/_internal/planner/exchange/sort_task_spec.py
@@ -81,7 +81,7 @@ class SortKey:
                     raise ValueError(
                         f"You specified the column '{column}', but there's no such "
                         "column in the dataset. The dataset has columns: "
-                        f"{schema_names_set}"
+                        f"{schema.names}"
                     )
 
     @property

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -718,7 +718,7 @@ def unify_block_metadata_schema(
             pa = None
         # If the result contains PyArrow schemas, unify them
         if pa is not None and all(isinstance(s, pa.Schema) for s in schemas_to_unify):
-            return unify_schemas(schemas_to_unify)
+            return unify_schemas(schemas_to_unify, promote_types=True)
         # Otherwise, if the resulting schemas are simple types (e.g. int),
         # return the first schema.
         return schemas_to_unify[0]

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -77,10 +77,10 @@ class _NullSentinel:
         return isinstance(other, _NullSentinel)
 
     def __gt__(self, other):
-        return True
+        return not self.__le__(other)
 
     def __ge__(self, other):
-        return True
+        return not self.__lt__(other)
 
     def __hash__(self):
         return id(self)

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -5314,6 +5314,10 @@ class Dataset:
 
         if not isinstance(on, list):
             on = [on]
+
+        if len(on) == 0:
+            raise ValueError("At least 1 column to aggregate on has to be provided")
+
         return [agg_cls(on_, *args, **kwargs) for on_ in on]
 
     def _aggregate_result(self, result: Union[Tuple, Mapping]) -> U:

--- a/python/ray/data/tests/test_all_to_all.py
+++ b/python/ray/data/tests/test_all_to_all.py
@@ -1023,16 +1023,6 @@ def test_groupby_agg_bad_on(ray_start_regular_shared_2_cpus, configure_shuffle_m
 def test_groupby_arrow_multi_agg(
     ray_start_regular_shared_2_cpus, num_parts, configure_shuffle_method
 ):
-    current = DataContext.get_current()
-    if (
-        current.shuffle_strategy == ShuffleStrategy.HASH_SHUFFLE
-        and parse_version(_get_pyarrow_version()) < MIN_PYARROW_VERSION_TYPE_PROMOTION
-    ):
-        pytest.skip(
-            "Pyarrow < 14.0 doesn't support type promotions (hence fails "
-            "promoting from int64 to double)"
-        )
-
     # NOTE: Do not change the seed
     random.seed(1738379113)
 
@@ -1096,16 +1086,6 @@ def test_groupby_arrow_multi_agg(
 def test_groupby_arrow_multi_agg_alias(
     ray_start_regular_shared_2_cpus, num_parts, configure_shuffle_method
 ):
-    current = DataContext.get_current()
-    if (
-        current.shuffle_strategy == ShuffleStrategy.HASH_SHUFFLE
-        and parse_version(_get_pyarrow_version()) < MIN_PYARROW_VERSION_TYPE_PROMOTION
-    ):
-        pytest.skip(
-            "Pyarrow < 14.0 doesn't support type promotions (hence fails "
-            "promoting from int64 to double)"
-        )
-
     # NOTE: Do not change the seed
     random.seed(1738379859)
 

--- a/python/ray/data/tests/test_all_to_all.py
+++ b/python/ray/data/tests/test_all_to_all.py
@@ -9,6 +9,7 @@ import pyarrow as pa
 import pytest
 
 import ray
+from packaging.version import parse as parse_version
 from ray._private.utils import _get_pyarrow_version
 from ray.data._internal.arrow_ops.transform_pyarrow import (
     MIN_PYARROW_VERSION_TYPE_PROMOTION,

--- a/python/ray/data/tests/test_all_to_all.py
+++ b/python/ray/data/tests/test_all_to_all.py
@@ -9,6 +9,11 @@ import pyarrow as pa
 import pytest
 
 import ray
+from ray._private.utils import _get_pyarrow_version
+from ray.data._internal.arrow_ops.transform_pyarrow import (
+    MIN_PYARROW_VERSION_TYPE_PROMOTION,
+)
+from ray.data._internal.util import is_nan
 from ray.data._internal.execution.interfaces.ref_bundle import (
     _ref_bundles_iterator_to_block_refs_list,
 )
@@ -186,7 +191,7 @@ def test_groupby_arrow(ray_start_regular_shared_2_cpus, configure_shuffle_method
     assert agg_ds.count() == 0
 
 
-def test_groupby_none(ray_start_regular_shared_2_cpus):
+def test_groupby_none(ray_start_regular_shared_2_cpus, configure_shuffle_method):
     ds = ray.data.range(10)
     assert ds.groupby(None).min().take_all() == [{"min(id)": 0}]
     assert ds.groupby(None).max().take_all() == [{"max(id)": 9}]
@@ -201,7 +206,7 @@ def test_groupby_errors(ray_start_regular_shared_2_cpus):
         ds.groupby("foo").count().show()
 
 
-def test_map_groups_with_gpus(shutdown_only):
+def test_map_groups_with_gpus(shutdown_only, configure_shuffle_method):
     ray.shutdown()
     ray.init(num_gpus=1)
 
@@ -212,7 +217,9 @@ def test_map_groups_with_gpus(shutdown_only):
     assert rows == [{"id": 0}]
 
 
-def test_map_groups_with_actors(ray_start_regular_shared_2_cpus):
+def test_map_groups_with_actors(
+    ray_start_regular_shared_2_cpus, configure_shuffle_method
+):
     class Identity:
         def __call__(self, batch):
             return batch
@@ -224,7 +231,9 @@ def test_map_groups_with_actors(ray_start_regular_shared_2_cpus):
     assert rows == [{"id": 0}]
 
 
-def test_map_groups_with_actors_and_args(ray_start_regular_shared_2_cpus):
+def test_map_groups_with_actors_and_args(
+    ray_start_regular_shared_2_cpus, configure_shuffle_method
+):
     class Fn:
         def __init__(self, x: int, y: Optional[int] = None):
             self.x = x
@@ -250,7 +259,9 @@ def test_map_groups_with_actors_and_args(ray_start_regular_shared_2_cpus):
     assert rows == [{"x": 0, "y": 1, "q": 2, "r": 3}]
 
 
-def test_groupby_large_udf_returns(ray_start_regular_shared_2_cpus):
+def test_groupby_large_udf_returns(
+    ray_start_regular_shared_2_cpus, configure_shuffle_method
+):
     # Test for https://github.com/ray-project/ray/issues/44861.
 
     # Each UDF return is 128 MiB. If Ray Data doesn't incrementally yield outputs, the
@@ -267,7 +278,7 @@ def test_groupby_large_udf_returns(ray_start_regular_shared_2_cpus):
 
 
 @pytest.mark.parametrize("keys", ["A", ["A", "B"]])
-def test_agg_inputs(ray_start_regular_shared_2_cpus, keys):
+def test_agg_inputs(ray_start_regular_shared_2_cpus, keys, configure_shuffle_method):
     xs = list(range(100))
     ds = ray.data.from_items([{"A": (x % 3), "B": x, "C": (x % 2)} for x in xs])
 
@@ -304,7 +315,7 @@ def test_agg_inputs(ray_start_regular_shared_2_cpus, keys):
     output.take_all()
 
 
-def test_agg_errors(ray_start_regular_shared_2_cpus):
+def test_agg_errors(ray_start_regular_shared_2_cpus, configure_shuffle_method):
     from ray.data.aggregate import Max
 
     ds = ray.data.range(100)
@@ -318,7 +329,9 @@ def test_agg_errors(ray_start_regular_shared_2_cpus):
 
 
 @pytest.mark.parametrize("num_parts", [1, 30])
-def test_groupby_agg_name_conflict(ray_start_regular_shared_2_cpus, num_parts):
+def test_groupby_agg_name_conflict(
+    ray_start_regular_shared_2_cpus, num_parts, configure_shuffle_method
+):
     # Test aggregation name conflict.
     xs = list(range(100))
     grouped_ds = (
@@ -351,7 +364,9 @@ def test_groupby_agg_name_conflict(ray_start_regular_shared_2_cpus, num_parts):
 
 
 @pytest.mark.parametrize("ds_format", ["pyarrow", "numpy", "pandas"])
-def test_groupby_nans(ray_start_regular_shared_2_cpus, ds_format):
+def test_groupby_nans(
+    ray_start_regular_shared_2_cpus, ds_format, configure_shuffle_method
+):
     ds = ray.data.from_items(
         [
             1.0,
@@ -363,7 +378,11 @@ def test_groupby_nans(ray_start_regular_shared_2_cpus, ds_format):
     )
     ds = ds.map_batches(lambda x: x, batch_format=ds_format)
     ds = ds.groupby("item").count()
-    ds = ds.filter(lambda v: np.isnan(v["item"]))
+
+    # NOTE: Hash-based shuffling will convert the block to Arrow, which
+    #       in turn convert NaNs into Nones
+    ds = ds.filter(lambda v: v["item"] is None or is_nan(v["item"]))
+
     result = ds.take_all()
     assert result[0]["count()"] == 2
 
@@ -382,9 +401,6 @@ def test_groupby_tabular_count(
     random.seed(seed)
     xs = list(range(100))
     random.shuffle(xs)
-
-    def _to_pandas(ds):
-        return ds.map_batches(lambda x: x, batch_size=None, batch_format="pandas")
 
     ds = ray.data.from_items([{"A": (x % 3), "B": x} for x in xs]).repartition(
         num_parts
@@ -509,7 +525,9 @@ def test_groupby_tabular_sum(
 
 @pytest.mark.parametrize("num_parts", [1, 30])
 @pytest.mark.parametrize("ds_format", ["arrow", "pandas"])
-def test_global_tabular_sum(ray_start_regular_shared_2_cpus, ds_format, num_parts):
+def test_global_tabular_sum(
+    ray_start_regular_shared_2_cpus, ds_format, num_parts, configure_shuffle_method
+):
     seed = int(time.time())
     print(f"Seeding RNG for test_global_arrow_sum with: {seed}")
     random.seed(seed)
@@ -550,7 +568,9 @@ def test_global_tabular_sum(ray_start_regular_shared_2_cpus, ds_format, num_part
 
 @pytest.mark.parametrize("num_parts", [1, 30])
 @pytest.mark.parametrize("ds_format", ["arrow", "pandas"])
-def test_groupby_tabular_min(ray_start_regular_shared_2_cpus, ds_format, num_parts):
+def test_groupby_tabular_min(
+    ray_start_regular_shared_2_cpus, ds_format, num_parts, configure_shuffle_method
+):
     # Test built-in min aggregation
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_tabular_min with: {seed}")
@@ -624,7 +644,9 @@ def test_groupby_tabular_min(ray_start_regular_shared_2_cpus, ds_format, num_par
 
 @pytest.mark.parametrize("num_parts", [1, 30])
 @pytest.mark.parametrize("ds_format", ["arrow", "pandas"])
-def test_groupby_tabular_max(ray_start_regular_shared_2_cpus, ds_format, num_parts):
+def test_groupby_tabular_max(
+    ray_start_regular_shared_2_cpus, ds_format, num_parts, configure_shuffle_method
+):
     # Test built-in max aggregation
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_tabular_max with: {seed}")
@@ -698,7 +720,9 @@ def test_groupby_tabular_max(ray_start_regular_shared_2_cpus, ds_format, num_par
 
 @pytest.mark.parametrize("num_parts", [1, 30])
 @pytest.mark.parametrize("ds_format", ["arrow", "pandas"])
-def test_groupby_tabular_mean(ray_start_regular_shared_2_cpus, ds_format, num_parts):
+def test_groupby_tabular_mean(
+    ray_start_regular_shared_2_cpus, ds_format, num_parts, configure_shuffle_method
+):
     # Test built-in mean aggregation
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_tabular_mean with: {seed}")
@@ -772,7 +796,9 @@ def test_groupby_tabular_mean(ray_start_regular_shared_2_cpus, ds_format, num_pa
 
 @pytest.mark.parametrize("num_parts", [1, 30])
 @pytest.mark.parametrize("ds_format", ["arrow", "pandas"])
-def test_groupby_tabular_std(ray_start_regular_shared_2_cpus, ds_format, num_parts):
+def test_groupby_tabular_std(
+    ray_start_regular_shared_2_cpus, ds_format, num_parts, configure_shuffle_method
+):
     # Test built-in std aggregation
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_tabular_std with: {seed}")
@@ -785,21 +811,29 @@ def test_groupby_tabular_std(ray_start_regular_shared_2_cpus, ds_format, num_par
 
     df = pd.DataFrame({"A": [x % 3 for x in xs], "B": xs})
     ds = ray.data.from_pandas(df).repartition(num_parts)
+
     if ds_format == "arrow":
         ds = _to_arrow(ds)
+
     agg_ds = ds.groupby("A").std("B")
     assert agg_ds.count() == 3
-    result = agg_ds.to_pandas()["std(B)"].to_numpy()
+
+    result = agg_ds.to_pandas().sort_values("A")["std(B)"].to_numpy()
     expected = df.groupby("A")["B"].std().to_numpy()
+
     np.testing.assert_array_almost_equal(result, expected)
+
     # ddof of 0
     ds = ray.data.from_pandas(df).repartition(num_parts)
     if ds_format == "arrow":
         ds = _to_arrow(ds)
+
     agg_ds = ds.groupby("A").std("B", ddof=0)
     assert agg_ds.count() == 3
-    result = agg_ds.to_pandas()["std(B)"].to_numpy()
+
+    result = agg_ds.to_pandas().sort_values("A")["std(B)"].to_numpy()
     expected = df.groupby("A")["B"].std(ddof=0).to_numpy()
+
     np.testing.assert_array_almost_equal(result, expected)
 
     # Test built-in std aggregation with nans
@@ -810,30 +844,43 @@ def test_groupby_tabular_std(ray_start_regular_shared_2_cpus, ds_format, num_par
     nan_grouped_ds = ds.groupby("A")
     nan_agg_ds = nan_grouped_ds.std("B")
     assert nan_agg_ds.count() == 3
-    result = nan_agg_ds.to_pandas()["std(B)"].to_numpy()
+
+    result = nan_agg_ds.to_pandas().sort_values("A")["std(B)"].to_numpy()
     expected = nan_df.groupby("A")["B"].std().to_numpy()
+
     np.testing.assert_array_almost_equal(result, expected)
+
     # Test ignore_nulls=False
     nan_agg_ds = nan_grouped_ds.std("B", ignore_nulls=False)
     assert nan_agg_ds.count() == 3
-    result = nan_agg_ds.to_pandas()["std(B)"].to_numpy()
+
+    result = nan_agg_ds.to_pandas().sort_values("A")["std(B)"].to_numpy()
     expected = nan_df.groupby("A")["B"].std().to_numpy()
+
     assert result[0] is None or np.isnan(result[0])
+
     np.testing.assert_array_almost_equal(result[1:], expected[1:])
+
     # Test all nans
     nan_df = pd.DataFrame({"A": [x % 3 for x in xs], "B": [None] * len(xs)})
     ds = ray.data.from_pandas(nan_df).repartition(num_parts)
+
     if ds_format == "arrow":
         ds = _to_arrow(ds)
+
     nan_agg_ds = ds.groupby("A").std("B", ignore_nulls=False)
     assert nan_agg_ds.count() == 3
-    result = nan_agg_ds.to_pandas()["std(B)"].to_numpy()
+
+    result = nan_agg_ds.to_pandas().sort_values("A")["std(B)"].to_numpy()
     expected = pd.Series([None] * 3)
+
     np.testing.assert_array_equal(result, expected)
 
 
 @pytest.mark.parametrize("num_parts", [1, 30])
-def test_groupby_arrow_multicolumn(ray_start_regular_shared_2_cpus, num_parts):
+def test_groupby_arrow_multicolumn(
+    ray_start_regular_shared_2_cpus, num_parts, configure_shuffle_method
+):
     # Test built-in mean aggregation on multiple columns
     seed = int(time.time())
     print(f"Seeding RNG for test_groupby_arrow_multicolumn with: {seed}")
@@ -868,51 +915,126 @@ def test_groupby_arrow_multicolumn(ray_start_regular_shared_2_cpus, num_parts):
     assert result_row["mean(B)"] == df["B"].mean()
 
 
-def test_groupby_agg_bad_on(ray_start_regular_shared_2_cpus):
+def test_groupby_agg_bad_on(ray_start_regular_shared_2_cpus, configure_shuffle_method):
     # Test bad on for groupby aggregation
     xs = list(range(100))
-    df = pd.DataFrame({"A": [x % 3 for x in xs], "B": xs, "C": [2 * x for x in xs]})
+    df = pd.DataFrame(
+        np.array([[x % 3 for x in xs], xs, [2 * x for x in xs]]).T,
+        columns=["A", "B", "C"],
+    )
+
     # Wrong type.
-    with pytest.raises(Exception):
+    with pytest.raises(Exception) as exc_info:
         ray.data.from_pandas(df).groupby("A").mean(5).materialize()
-    with pytest.raises(Exception):
+
+    assert "Key must be a string or a list of strings, but got 5." in str(
+        exc_info.value
+    )
+
+    with pytest.raises(Exception) as exc_info:
         ray.data.from_pandas(df).groupby("A").mean([5]).materialize()
+
+    assert "Key must be a string or a list of strings, but got 5." in str(
+        exc_info.value
+    )
+
     # Empty list.
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc_info:
         ray.data.from_pandas(df).groupby("A").mean([]).materialize()
+
+    assert "At least 1 column to aggregate on has to be provided" in str(exc_info.value)
+
     # Nonexistent column.
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc_info:
         ray.data.from_pandas(df).groupby("A").mean("D").materialize()
-    with pytest.raises(ValueError):
+
+    assert (
+        "You specified the column 'D', but there's no such column in the dataset. The dataset has columns: ['A', 'B', 'C']"
+        in str(exc_info.value)
+    )
+
+    with pytest.raises(ValueError) as exc_info:
         ray.data.from_pandas(df).groupby("A").mean(["B", "D"]).materialize()
+
+    assert (
+        "You specified the column 'D', but there's no such column in the dataset. The dataset has columns: ['A', 'B', 'C']"
+        in str(exc_info.value)
+    )
+
     # Columns for simple Dataset.
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc_info:
         ray.data.from_items(xs).groupby(lambda x: x % 3 == 0).mean("A").materialize()
+
+    assert "Key must be a string or a list of strings, but got <function" in str(
+        exc_info.value
+    )
 
     # Test bad on for global aggregation
     # Wrong type.
-    with pytest.raises(Exception):
+    with pytest.raises(Exception) as exc_info:
         ray.data.from_pandas(df).mean(5).materialize()
-    with pytest.raises(Exception):
+
+    assert "Key must be a string or a list of strings, but got 5." in str(
+        exc_info.value
+    )
+
+    with pytest.raises(Exception) as exc_info:
         ray.data.from_pandas(df).mean([5]).materialize()
+
+    assert "Key must be a string or a list of strings, but got 5." in str(
+        exc_info.value
+    )
+
     # Empty list.
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc_info:
         ray.data.from_pandas(df).mean([]).materialize()
+
+    assert "At least 1 column to aggregate on has to be provided" in str(exc_info.value)
+
     # Nonexistent column.
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc_info:
         ray.data.from_pandas(df).mean("D").materialize()
-    with pytest.raises(ValueError):
+
+    assert (
+        "You specified the column 'D', but there's no such column in the dataset. The dataset has columns: ['A', 'B', 'C']"
+        in str(exc_info.value)
+    )
+
+    with pytest.raises(ValueError) as exc_info:
         ray.data.from_pandas(df).mean(["B", "D"]).materialize()
+
+    assert (
+        "You specified the column 'D', but there's no such column in the dataset. The dataset has columns: ['A', 'B', 'C']"
+        in str(exc_info.value)
+    )
+
     # Columns for simple Dataset.
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc_info:
         ray.data.from_items(xs).mean("A").materialize()
+
+    assert (
+        "You specified the column 'A', but there's no such column in the dataset. The dataset has columns: ['item']"
+        in str(exc_info.value)
+    )
 
 
 @pytest.mark.parametrize("num_parts", [1, 30])
-def test_groupby_arrow_multi_agg(ray_start_regular_shared_2_cpus, num_parts):
-    seed = int(time.time())
-    print(f"Seeding RNG for test_groupby_arrow_multi_agg with: {seed}")
-    random.seed(seed)
+def test_groupby_arrow_multi_agg(
+    ray_start_regular_shared_2_cpus, num_parts, configure_shuffle_method
+):
+    current = DataContext.get_current()
+    if (
+        current.shuffle_strategy == ShuffleStrategy.HASH_SHUFFLE
+        and parse_version(_get_pyarrow_version()) < MIN_PYARROW_VERSION_TYPE_PROMOTION
+    ):
+        pytest.skip(
+            "Pyarrow < 14.0 doesn't support type promotions (hence fails "
+            "promoting from int64 to double)"
+        )
+
+    # NOTE: Do not change the seed
+    random.seed(1738379113)
+
     xs = list(range(100))
     random.shuffle(xs)
     df = pd.DataFrame({"A": [x % 3 for x in xs], "B": xs})
@@ -931,8 +1053,12 @@ def test_groupby_arrow_multi_agg(ray_start_regular_shared_2_cpus, num_parts):
         )
     )
     assert agg_ds.count() == 3
-    agg_df = agg_ds.to_pandas()
+
+    # NOTE: Make sure resulting dataset is sorted by the grouped column
+    agg_df = agg_ds.to_pandas().sort_values(by="A")
+
     expected_grouped = df.groupby("A")["B"]
+
     np.testing.assert_array_equal(agg_df["count()"].to_numpy(), [34, 33, 33])
     for agg in ["sum", "min", "max", "mean", "quantile", "std"]:
         result = agg_df[f"{agg}(B)"].to_numpy()
@@ -966,10 +1092,22 @@ def test_groupby_arrow_multi_agg(ray_start_regular_shared_2_cpus, num_parts):
 
 
 @pytest.mark.parametrize("num_parts", [1, 30])
-def test_groupby_arrow_multi_agg_alias(ray_start_regular_shared_2_cpus, num_parts):
-    seed = int(time.time())
-    print(f"Seeding RNG for test_groupby_arrow_multi_agg with: {seed}")
-    random.seed(seed)
+def test_groupby_arrow_multi_agg_alias(
+    ray_start_regular_shared_2_cpus, num_parts, configure_shuffle_method
+):
+    current = DataContext.get_current()
+    if (
+        current.shuffle_strategy == ShuffleStrategy.HASH_SHUFFLE
+        and parse_version(_get_pyarrow_version()) < MIN_PYARROW_VERSION_TYPE_PROMOTION
+    ):
+        pytest.skip(
+            "Pyarrow < 14.0 doesn't support type promotions (hence fails "
+            "promoting from int64 to double)"
+        )
+
+    # NOTE: Do not change the seed
+    random.seed(1738379859)
+
     xs = list(range(100))
     random.shuffle(xs)
     df = pd.DataFrame({"A": [x % 3 for x in xs], "B": xs})
@@ -987,8 +1125,11 @@ def test_groupby_arrow_multi_agg_alias(ray_start_regular_shared_2_cpus, num_part
         )
     )
 
-    agg_df = agg_ds.to_pandas()
+    # NOTE: Make sure resulting dataset is sorted by the grouped column
+    agg_df = agg_ds.to_pandas().sort_values(by=["A"])
+
     expected_grouped = df.groupby("A")["B"]
+
     for agg in ["sum", "min", "max", "mean", "quantile", "std"]:
         result = agg_df[f"{agg}_b"].to_numpy()
         print(agg)
@@ -1026,7 +1167,7 @@ def test_groupby_arrow_multi_agg_alias(ray_start_regular_shared_2_cpus, num_part
 
 @pytest.mark.parametrize("num_parts", [1, 2, 30])
 def test_groupby_map_groups_for_none_groupkey(
-    ray_start_regular_shared_2_cpus, num_parts
+    ray_start_regular_shared_2_cpus, num_parts, configure_shuffle_method
 ):
     ds = ray.data.from_items(list(range(100)))
     mapped = (
@@ -1038,7 +1179,9 @@ def test_groupby_map_groups_for_none_groupkey(
     assert mapped.take_all() == named_values("out", [99])
 
 
-def test_groupby_map_groups_perf(ray_start_regular_shared_2_cpus):
+def test_groupby_map_groups_perf(
+    ray_start_regular_shared_2_cpus, configure_shuffle_method
+):
     data_list = [x % 100 for x in range(5000000)]
     ds = ray.data.from_pandas(pd.DataFrame({"A": data_list}))
     start = time.perf_counter()
@@ -1049,8 +1192,10 @@ def test_groupby_map_groups_perf(ray_start_regular_shared_2_cpus):
     assert end - start < 60
 
 
-@pytest.mark.parametrize("num_parts", [1, 2, 3, 30])
-def test_groupby_map_groups_for_pandas(ray_start_regular_shared_2_cpus, num_parts):
+@pytest.mark.parametrize("num_parts", [1, 2, 30])
+def test_groupby_map_groups_for_pandas(
+    ray_start_regular_shared_2_cpus, num_parts, configure_shuffle_method
+):
     df = pd.DataFrame({"A": "a a b".split(), "B": [1, 1, 3], "C": [4, 6, 5]})
     grouped = ray.data.from_pandas(df).repartition(num_parts).groupby("A")
 
@@ -1070,8 +1215,10 @@ def test_groupby_map_groups_for_pandas(ray_start_regular_shared_2_cpus, num_part
     assert mapped.to_pandas().equals(expected)
 
 
-@pytest.mark.parametrize("num_parts", [1, 2, 3, 30])
-def test_groupby_map_groups_for_arrow(ray_start_regular_shared_2_cpus, num_parts):
+@pytest.mark.parametrize("num_parts", [1, 2, 30])
+def test_groupby_map_groups_for_arrow(
+    ray_start_regular_shared_2_cpus, num_parts, configure_shuffle_method
+):
     at = pa.Table.from_pydict({"A": "a a b".split(), "B": [1, 1, 3], "C": [4, 6, 5]})
     grouped = ray.data.from_arrow(at).repartition(num_parts).groupby("A")
 
@@ -1096,7 +1243,9 @@ def test_groupby_map_groups_for_arrow(ray_start_regular_shared_2_cpus, num_parts
     assert result.equals(expected)
 
 
-def test_groupby_map_groups_for_numpy(ray_start_regular_shared_2_cpus):
+def test_groupby_map_groups_for_numpy(
+    ray_start_regular_shared_2_cpus, configure_shuffle_method
+):
     ds = ray.data.from_items(
         [
             {"group": 1, "value": 1},
@@ -1116,7 +1265,9 @@ def test_groupby_map_groups_for_numpy(ray_start_regular_shared_2_cpus):
     assert result.equals(expected)
 
 
-def test_groupby_map_groups_with_different_types(ray_start_regular_shared_2_cpus):
+def test_groupby_map_groups_with_different_types(
+    ray_start_regular_shared_2_cpus, configure_shuffle_method
+):
     ds = ray.data.from_items(
         [
             {"group": 1, "value": 1},
@@ -1137,7 +1288,7 @@ def test_groupby_map_groups_with_different_types(ray_start_regular_shared_2_cpus
 
 @pytest.mark.parametrize("num_parts", [1, 30])
 def test_groupby_map_groups_multiple_batch_formats(
-    ray_start_regular_shared_2_cpus, num_parts
+    ray_start_regular_shared_2_cpus, num_parts, configure_shuffle_method
 ):
     # Reproduces https://github.com/ray-project/ray/issues/39206
     def identity(batch):
@@ -1161,7 +1312,9 @@ def test_groupby_map_groups_multiple_batch_formats(
     ]
 
 
-def test_groupby_map_groups_extra_args(ray_start_regular_shared_2_cpus):
+def test_groupby_map_groups_extra_args(
+    ray_start_regular_shared_2_cpus, configure_shuffle_method
+):
     ds = ray.data.from_items(
         [
             {"group": 1, "value": 1},
@@ -1458,7 +1611,7 @@ def test_random_shuffle_spread(ray_start_cluster, configure_shuffle_method):
         locations.extend(location_data[block]["node_ids"])
     assert "2 nodes used" in ds.stats()
 
-    if configure_shuffle_method != ShuffleStrategy.SORT_SHUFFLE_PUSH_BASED:
+    if not configure_shuffle_method:
         # We don't check this for push-based shuffle since it will try to
         # colocate reduce tasks to improve locality.
         assert set(locations) == {node1_id, node2_id}

--- a/python/ray/data/tests/test_all_to_all.py
+++ b/python/ray/data/tests/test_all_to_all.py
@@ -9,17 +9,12 @@ import pyarrow as pa
 import pytest
 
 import ray
-from packaging.version import parse as parse_version
-from ray._private.utils import _get_pyarrow_version
-from ray.data._internal.arrow_ops.transform_pyarrow import (
-    MIN_PYARROW_VERSION_TYPE_PROMOTION,
-)
 from ray.data._internal.util import is_nan
 from ray.data._internal.execution.interfaces.ref_bundle import (
     _ref_bundles_iterator_to_block_refs_list,
 )
 from ray.data.aggregate import AggregateFn, Count, Max, Mean, Min, Quantile, Std, Sum
-from ray.data.context import DataContext, ShuffleStrategy
+from ray.data.context import DataContext
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.util import named_values
 from ray.tests.conftest import *  # noqa

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -1035,7 +1035,7 @@ def test_read_map_batches_operator_fusion_with_sort_operator(
 
 
 def test_read_map_batches_operator_fusion_with_aggregate_operator(
-    ray_start_regular_shared_2_cpus,
+    ray_start_regular_shared_2_cpus, configure_shuffle_method
 ):
     from ray.data.aggregate import AggregateFn
 

--- a/python/ray/data/tests/test_transform_pyarrow.py
+++ b/python/ray/data/tests/test_transform_pyarrow.py
@@ -11,7 +11,7 @@ from ray._private.utils import _get_pyarrow_version
 import ray
 from ray.air.util.tensor_extensions.arrow import ArrowTensorTypeV2
 from ray.data import DataContext
-from ray.data._internal.arrow_ops.transform_pyarrow import concat, unify_schemas
+from ray.data._internal.arrow_ops.transform_pyarrow import concat, unify_schemas, MIN_PYARROW_VERSION_TYPE_PROMOTION
 from ray.data.block import BlockAccessor
 from ray.data.extensions import (
     ArrowConversionError,
@@ -707,6 +707,65 @@ def test_unify_schemas():
             ("col_fixed_tensor", ArrowVariableShapedTensorType(pa.int32(), 3)),
             ("col_var_tensor", ArrowVariableShapedTensorType(pa.int16(), 5)),
         ]
+    )
+
+
+@pytest.mark.skipif(
+    parse_version(_get_pyarrow_version()) < MIN_PYARROW_VERSION_TYPE_PROMOTION,
+    reason="Requires Arrow version of at least 14.0.0",
+)
+def test_unify_schemas_type_promotion():
+    s_non_null = pa.schema(
+        [
+            pa.field("A", pa.int32()),
+        ]
+    )
+
+    s_nullable = pa.schema(
+        [
+            pa.field("A", pa.int32(), nullable=True),
+        ]
+    )
+
+    # No type promotion
+    assert (
+        unify_schemas(
+            [s_non_null, s_nullable],
+            promote_types=False,
+        )
+        == s_nullable
+    )
+
+    s1 = pa.schema(
+        [
+            pa.field("A", pa.int64()),
+        ]
+    )
+
+    s2 = pa.schema(
+        [
+            pa.field("A", pa.float64()),
+        ]
+    )
+
+    # No type promotion
+    with pytest.raises(pa.lib.ArrowTypeError) as exc_info:
+        unify_schemas(
+            [s1, s2],
+            promote_types=False,
+        )
+
+    assert "Unable to merge: Field A has incompatible types: int64 vs double" == str(
+        exc_info.value
+    )
+
+    # Type promoted
+    assert (
+        unify_schemas(
+            [s1, s2],
+            promote_types=True,
+        )
+        == s2
     )
 
 

--- a/python/ray/data/tests/test_transform_pyarrow.py
+++ b/python/ray/data/tests/test_transform_pyarrow.py
@@ -11,7 +11,11 @@ from ray._private.utils import _get_pyarrow_version
 import ray
 from ray.air.util.tensor_extensions.arrow import ArrowTensorTypeV2
 from ray.data import DataContext
-from ray.data._internal.arrow_ops.transform_pyarrow import concat, unify_schemas, MIN_PYARROW_VERSION_TYPE_PROMOTION
+from ray.data._internal.arrow_ops.transform_pyarrow import (
+    concat,
+    unify_schemas,
+    MIN_PYARROW_VERSION_TYPE_PROMOTION,
+)
 from ray.data.block import BlockAccessor
 from ray.data.extensions import (
     ArrowConversionError,

--- a/python/ray/data/tests/test_transform_pyarrow.py
+++ b/python/ray/data/tests/test_transform_pyarrow.py
@@ -15,7 +15,7 @@ from ray.data._internal.arrow_ops.transform_pyarrow import (
     concat,
     MIN_PYARROW_VERSION_TYPE_PROMOTION,
     unify_schemas,
-    try_combine_chunks,
+    try_combine_chunked_columns,
 )
 from ray.data.block import BlockAccessor
 from ray.data.extensions import (
@@ -40,7 +40,7 @@ def test_try_defragment_table():
 
     assert len(t["id"].chunks) == 10
 
-    dt = try_combine_chunks(t)
+    dt = try_combine_chunked_columns(t)
 
     assert len(dt["id"].chunks) == 1
     assert dt == t

--- a/python/ray/serve/_private/utils.py
+++ b/python/ray/serve/_private/utils.py
@@ -4,8 +4,6 @@ import importlib
 import inspect
 import logging
 import os
-import random
-import string
 import time
 import uuid
 from abc import ABC, abstractmethod
@@ -19,7 +17,7 @@ import requests
 import ray
 import ray.util.serialization_addons
 from ray._private.resource_spec import HEAD_NODE_RESOURCE_NAME
-from ray._private.utils import import_attr
+from ray._private.utils import get_random_alphanumeric_string, import_attr
 from ray._private.worker import LOCAL_MODE, SCRIPT_MODE
 from ray._raylet import MessagePackSerializer
 from ray.actor import ActorHandle
@@ -140,12 +138,8 @@ def block_until_http_ready(
         time.sleep(backoff_time_s)
 
 
-# Match the standard alphabet used for UUIDs.
-RANDOM_STRING_ALPHABET = string.ascii_lowercase + string.digits
-
-
-def get_random_string(length=8):
-    return "".join(random.choices(RANDOM_STRING_ALPHABET, k=length))
+def get_random_string(length: int = 8):
+    return get_random_alphanumeric_string(length)
 
 
 def format_actor_name(actor_name, *modifiers):

--- a/python/ray/serve/_private/utils.py
+++ b/python/ray/serve/_private/utils.py
@@ -4,6 +4,7 @@ import importlib
 import inspect
 import logging
 import os
+import random
 import time
 import uuid
 from abc import ABC, abstractmethod


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This change

1. Adds support for type promotions when unifying schemas b/w the blocks (not supported for PA < 14.0)
2. Fixes semantic around `np.nan` handling for Pandas/Arrow blocks
3. Enables all tests to run against every implementation of shuffling
4. Makes sure tasks actual resource bundles are captured by `PhysicalOperator`
5. Fixed tests

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
