### PR TITLE
add missing xgboost pip requirement

### DIFF
--- a/doc/source/train/examples/xgboost/xgboost_example.ipynb
+++ b/doc/source/train/examples/xgboost/xgboost_example.ipynb
@@ -50,7 +50,7 @@
     }
    ],
    "source": [
-    "!pip install -qU \"ray[data,train]\""
+    "!pip install -qU \"ray[data,train]\" xgboost"
    ]
   },
   {


### PR DESCRIPTION
## Why are these changes needed?

The [XGboost example](https://docs.ray.io/en/latest/train/examples/xgboost/xgboost_example.html) in the docs do not run because it is missing the xgboost pip installs. This PR adds the missing pip requirement

## Related issue number

N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
