### PR TITLE
[core] skip ray installation on cpp tests

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -275,6 +275,7 @@ steps:
     instance_type: medium
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --build-type clang
+        --skip-ray-installation
         --parallelism-per-worker 2
 
   - label: ":ray: core: cpp asan tests"
@@ -282,6 +283,7 @@ steps:
     instance_type: medium
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --build-type asan-clang
+        --skip-ray-installation
         --parallelism-per-worker 2
 
   - label: ":ray: core: cpp ubsan tests"
@@ -289,6 +291,7 @@ steps:
     instance_type: large
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --build-type ubsan
+        --skip-ray-installation
         --except-tags no_ubsan
         --parallelism-per-worker 2
 
@@ -297,6 +300,7 @@ steps:
     instance_type: medium
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --build-type tsan-clang
+        --skip-ray-installation
         --except-tags no_tsan
         --parallelism-per-worker 2
 

--- a/.buildkite/windows.rayci.yml
+++ b/.buildkite/windows.rayci.yml
@@ -37,6 +37,7 @@ steps:
       - bash ci/ray_ci/windows/install_tools.sh
       - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core
         --build-name windowsbuild
+        --skip-ray-installation
         --operating-system windows
         --except-tags no_windows
         --test-env=CI="1"


### PR DESCRIPTION
cpp tests do not require building & installing the ray wheel.

