### PR TITLE
use correct mean and standard deviation norm values in image tutorials

### DIFF
--- a/doc/source/templates/05_dreambooth_finetuning/dreambooth/dataset.py
+++ b/doc/source/templates/05_dreambooth_finetuning/dreambooth/dataset.py
@@ -65,7 +65,7 @@ def get_train_dataset(args, image_resolution=512):
                 antialias=True,
             ),
             transforms.RandomCrop(image_resolution),
-            transforms.Normalize([0.5], [0.5]),
+            transforms.Normalize([0.5], [0.5]),  # use appropriate mean and std for your dataset
         ]
     )
 

--- a/doc/source/templates/05_dreambooth_finetuning/dreambooth/dataset.py
+++ b/doc/source/templates/05_dreambooth_finetuning/dreambooth/dataset.py
@@ -65,7 +65,8 @@ def get_train_dataset(args, image_resolution=512):
                 antialias=True,
             ),
             transforms.RandomCrop(image_resolution),
-            transforms.Normalize([0.5], [0.5]),  # use appropriate mean and std for your dataset
+            # use the appropriate mean and std for your dataset
+            transforms.Normalize([0.5], [0.5]),
         ]
     )
 

--- a/doc/source/train/getting-started-pytorch-lightning.rst
+++ b/doc/source/train/getting-started-pytorch-lightning.rst
@@ -76,7 +76,7 @@ Compare a PyTorch Lightning training script with and without Ray Train.
                     return torch.optim.Adam(self.model.parameters(), lr=0.001)
 
             # Data
-            transform = Compose([ToTensor(), Normalize((0.5,), (0.5,))])
+            transform = Compose([ToTensor(), Normalize((0.28604,), (0.32025,))])
             train_data = FashionMNIST(root='./data', train=True, download=True, transform=transform)
             train_dataloader = DataLoader(train_data, batch_size=128, shuffle=True)
 
@@ -130,7 +130,7 @@ Compare a PyTorch Lightning training script with and without Ray Train.
 
             def train_func():
                 # Data
-                transform = Compose([ToTensor(), Normalize((0.5,), (0.5,))])
+                transform = Compose([ToTensor(), Normalize((0.28604,), (0.32025,))])
                 data_dir = os.path.join(tempfile.gettempdir(), "data")
                 train_data = FashionMNIST(root=data_dir, train=True, download=True, transform=transform)
                 train_dataloader = DataLoader(train_data, batch_size=128, shuffle=True)

--- a/doc/source/train/getting-started-pytorch.rst
+++ b/doc/source/train/getting-started-pytorch.rst
@@ -68,7 +68,7 @@ Compare a PyTorch training script with and without Ray Train.
             optimizer = Adam(model.parameters(), lr=0.001)
 
             # Data
-            transform = Compose([ToTensor(), Normalize((0.5,), (0.5,))])
+            transform = Compose([ToTensor(), Normalize((0.28604,), (0.32025,))])
             train_data = FashionMNIST(root='./data', train=True, download=True, transform=transform)
             train_loader = DataLoader(train_data, batch_size=128, shuffle=True)
 
@@ -121,7 +121,7 @@ Compare a PyTorch training script with and without Ray Train.
                 optimizer = Adam(model.parameters(), lr=0.001)
 
                 # Data
-                transform = Compose([ToTensor(), Normalize((0.5,), (0.5,))])
+                transform = Compose([ToTensor(), Normalize((0.28604,), (0.32025,))])
                 data_dir = os.path.join(tempfile.gettempdir(), "data")
                 train_data = FashionMNIST(root=data_dir, train=True, download=True, transform=transform)
                 train_loader = DataLoader(train_data, batch_size=128, shuffle=True)

--- a/python/ray/train/examples/experiment_tracking/torch_exp_tracking_mlflow.py
+++ b/python/ray/train/examples/experiment_tracking/torch_exp_tracking_mlflow.py
@@ -45,7 +45,7 @@ def train_func(config):
 
     # Data
     transform = transforms.Compose(
-        [transforms.ToTensor(), transforms.Normalize((0.5,), (0.5,))]
+        [transforms.ToTensor(), transforms.Normalize((0.28604,), (0.32025,))]
     )
     with FileLock("./data.lock"):
         train_data = datasets.FashionMNIST(

--- a/python/ray/train/examples/experiment_tracking/torch_exp_tracking_wandb.py
+++ b/python/ray/train/examples/experiment_tracking/torch_exp_tracking_wandb.py
@@ -41,7 +41,7 @@ def train_func(config):
 
     # Data
     transform = transforms.Compose(
-        [transforms.ToTensor(), transforms.Normalize((0.5,), (0.5,))]
+        [transforms.ToTensor(), transforms.Normalize((0.28604,), (0.32025,))]
     )
     with FileLock("./data.lock"):
         train_data = datasets.FashionMNIST(

--- a/python/ray/train/examples/pytorch/torch_fashion_mnist_example.py
+++ b/python/ray/train/examples/pytorch/torch_fashion_mnist_example.py
@@ -16,7 +16,7 @@ from ray.train.torch import TorchTrainer
 
 def get_dataloaders(batch_size):
     # Transform to normalize the input images
-    transform = transforms.Compose([ToTensor(), Normalize((0.5,), (0.5,))])
+    transform = transforms.Compose([ToTensor(), Normalize((0.28604,), (0.32025,))])
 
     with FileLock(os.path.expanduser("~/data.lock")):
         # Download training data from open datasets

--- a/python/ray/tune/examples/pbt_dcgan_mnist/common.py
+++ b/python/ray/tune/examples/pbt_dcgan_mnist/common.py
@@ -50,7 +50,7 @@ def get_data_loader(data_dir="~/data"):
             [
                 transforms.Resize(image_size),
                 transforms.ToTensor(),
-                transforms.Normalize((0.5,), (0.5,)),
+                transforms.Normalize((0.13066,), (0.30131,)),
             ]
         ),
     )


### PR DESCRIPTION


## Why are these changes needed?

Updates docs to use correct normalization values in image datasets.

## Related issue number

Closes #50239 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
