### PR TITLE
[core] De-glob bazel dependencies

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -119,6 +119,8 @@ ray_cc_library(
         "src/ray/rpc/server_call.cc",
     ],
     hdrs = [
+        "src/ray/raylet_client/raylet_client.h",
+        "src/ray/raylet_client/raylet_connection.h",
         "src/ray/rpc/client_call.h",
         "src/ray/rpc/common.h",
         "src/ray/rpc/grpc_client.h",
@@ -127,7 +129,7 @@ ray_cc_library(
         "src/ray/rpc/retryable_grpc_client.h",
         "src/ray/rpc/rpc_chaos.h",
         "src/ray/rpc/server_call.h",
-    ] + glob(["src/ray/raylet_client/*.h"]),
+    ],
     deps = [
         ":stats_metric",
         "//src/ray/common:asio",
@@ -153,12 +155,12 @@ cc_grpc_library(
 # Node manager server and client.
 ray_cc_library(
     name = "node_manager_rpc",
-    srcs = glob([
-        "src/ray/rpc/node_manager/*.cc",
-    ]),
-    hdrs = glob([
-        "src/ray/rpc/node_manager/*.h",
-    ]),
+    srcs = ["src/ray/rpc/node_manager/node_manager_client_pool.cc"],
+    hdrs = [
+        "src/ray/rpc/node_manager/node_manager_client.h",
+        "src/ray/rpc/node_manager/node_manager_client_pool.h",
+        "src/ray/rpc/node_manager/node_manager_server.h",
+    ],
     deps = [
         ":grpc_common_lib",
         ":node_manager_cc_grpc",
@@ -237,12 +239,14 @@ cc_grpc_library(
 # worker server and client.
 ray_cc_library(
     name = "worker_rpc",
-    srcs = glob([
-        "src/ray/rpc/worker/*.cc",
-    ]),
-    hdrs = glob([
-        "src/ray/rpc/worker/*.h",
-    ]),
+    srcs = [
+        "src/ray/rpc/worker/core_worker_client_pool.cc",
+    ],
+    hdrs = [
+        "src/ray/rpc/worker/core_worker_client.h",
+        "src/ray/rpc/worker/core_worker_client_pool.h",
+        "src/ray/rpc/worker/core_worker_server.h",
+    ],
     deps = [
         ":grpc_common_lib",
         ":pubsub_lib",
@@ -265,9 +269,9 @@ cc_grpc_library(
 # Metrics Agent client.
 ray_cc_library(
     name = "reporter_rpc",
-    hdrs = glob([
+    hdrs = [
         "src/ray/rpc/metrics_agent_client.h",
-    ]),
+    ],
     deps = [
         ":grpc_common_lib",
         ":reporter_cc_grpc",
@@ -1987,16 +1991,8 @@ ray_cc_library(
 
 ray_cc_library(
     name = "global_state_accessor_lib",
-    srcs = glob(
-        [
-            "src/ray/gcs/gcs_client/global_state_accessor.cc",
-        ],
-    ),
-    hdrs = glob(
-        [
-            "src/ray/gcs/gcs_client/global_state_accessor.h",
-        ],
-    ),
+    srcs = ["src/ray/gcs/gcs_client/global_state_accessor.cc"],
+    hdrs = ["src/ray/gcs/gcs_client/global_state_accessor.h"],
     deps = [
         ":gcs_client_lib",
     ],
@@ -2094,14 +2090,30 @@ ray_cc_test(
 
 ray_cc_library(
     name = "object_manager",
-    srcs = glob([
-        "src/ray/object_manager/*.cc",
-        "src/ray/object_manager/notification/*.cc",
-    ]),
-    hdrs = glob([
-        "src/ray/object_manager/*.h",
-        "src/ray/object_manager/notification/*.h",
-    ]),
+    srcs = [
+        "src/ray/object_manager/chunk_object_reader.cc",
+        "src/ray/object_manager/common.cc",
+        "src/ray/object_manager/memory_object_reader.cc",
+        "src/ray/object_manager/object_buffer_pool.cc",
+        "src/ray/object_manager/object_manager.cc",
+        "src/ray/object_manager/ownership_based_object_directory.cc",
+        "src/ray/object_manager/pull_manager.cc",
+        "src/ray/object_manager/push_manager.cc",
+        "src/ray/object_manager/spilled_object_reader.cc",
+    ],
+    hdrs = [
+        "src/ray/object_manager/chunk_object_reader.h",
+        "src/ray/object_manager/common.h",
+        "src/ray/object_manager/memory_object_reader.h",
+        "src/ray/object_manager/object_buffer_pool.h",
+        "src/ray/object_manager/object_directory.h",
+        "src/ray/object_manager/object_manager.h",
+        "src/ray/object_manager/object_reader.h",
+        "src/ray/object_manager/ownership_based_object_directory.h",
+        "src/ray/object_manager/pull_manager.h",
+        "src/ray/object_manager/push_manager.h",
+        "src/ray/object_manager/spilled_object_reader.h",
+    ],
     deps = [
         ":core_worker_lib",
         ":gcs",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -216,9 +216,10 @@ cc_grpc_library(
 # Object manager rpc server and client.
 ray_cc_library(
     name = "object_manager_rpc",
-    hdrs = glob([
-        "src/ray/rpc/object_manager/*.h",
-    ]),
+    hdrs = [
+        "src/ray/rpc/object_manager/object_manager_client.h",
+        "src/ray/rpc/object_manager/object_manager_server.h",
+    ],
     deps = [
         ":grpc_common_lib",
         ":object_manager_cc_grpc",
@@ -513,20 +514,54 @@ ray_cc_library(
 
 ray_cc_library(
     name = "gcs_server_lib",
-    srcs = glob(
-        [
-            "src/ray/gcs/gcs_server/*.cc",
-        ],
-        exclude = [
-            "src/ray/gcs/gcs_server/gcs_server_main.cc",
-            "src/ray/gcs/gcs_server/test/*.cc",
-        ],
-    ),
-    hdrs = glob(
-        [
-            "src/ray/gcs/gcs_server/*.h",
-        ],
-    ),
+    srcs = [
+        "src/ray/gcs/gcs_server/gcs_actor_manager.cc",
+        "src/ray/gcs/gcs_server/gcs_actor_scheduler.cc",
+        "src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.cc",
+        "src/ray/gcs/gcs_server/gcs_health_check_manager.cc",
+        "src/ray/gcs/gcs_server/gcs_init_data.cc",
+        "src/ray/gcs/gcs_server/gcs_job_manager.cc",
+        "src/ray/gcs/gcs_server/gcs_kv_manager.cc",
+        "src/ray/gcs/gcs_server/gcs_node_manager.cc",
+        "src/ray/gcs/gcs_server/gcs_placement_group_manager.cc",
+        "src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc",
+        "src/ray/gcs/gcs_server/gcs_redis_failure_detector.cc",
+        "src/ray/gcs/gcs_server/gcs_resource_manager.cc",
+        "src/ray/gcs/gcs_server/gcs_server.cc",
+        "src/ray/gcs/gcs_server/gcs_table_storage.cc",
+        "src/ray/gcs/gcs_server/gcs_task_manager.cc",
+        "src/ray/gcs/gcs_server/gcs_worker_manager.cc",
+        "src/ray/gcs/gcs_server/pubsub_handler.cc",
+        "src/ray/gcs/gcs_server/runtime_env_handler.cc",
+        "src/ray/gcs/gcs_server/state_util.cc",
+        "src/ray/gcs/gcs_server/store_client_kv.cc",
+        "src/ray/gcs/gcs_server/usage_stats_client.cc",
+    ],
+    hdrs =[
+        "src/ray/gcs/gcs_server/gcs_actor_manager.h",
+        "src/ray/gcs/gcs_server/gcs_actor_scheduler.h",
+        "src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.h",
+        "src/ray/gcs/gcs_server/gcs_function_manager.h",
+        "src/ray/gcs/gcs_server/gcs_health_check_manager.h",
+        "src/ray/gcs/gcs_server/gcs_init_data.h",
+        "src/ray/gcs/gcs_server/gcs_job_manager.h",
+        "src/ray/gcs/gcs_server/gcs_kv_manager.h",
+        "src/ray/gcs/gcs_server/gcs_node_manager.h",
+        "src/ray/gcs/gcs_server/gcs_placement_group_manager.h",
+        "src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h",
+        "src/ray/gcs/gcs_server/gcs_redis_failure_detector.h",
+        "src/ray/gcs/gcs_server/gcs_resource_manager.h",
+        "src/ray/gcs/gcs_server/gcs_server.h",
+        "src/ray/gcs/gcs_server/gcs_server_io_context_policy.h",
+        "src/ray/gcs/gcs_server/gcs_table_storage.h",
+        "src/ray/gcs/gcs_server/gcs_task_manager.h",
+        "src/ray/gcs/gcs_server/gcs_worker_manager.h",
+        "src/ray/gcs/gcs_server/pubsub_handler.h",
+        "src/ray/gcs/gcs_server/runtime_env_handler.h",
+        "src/ray/gcs/gcs_server/state_util.h",
+        "src/ray/gcs/gcs_server/store_client_kv.h",
+        "src/ray/gcs/gcs_server/usage_stats_client.h",
+    ],
     deps = [
         ":autoscaler_rpc",
         ":gcs",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -602,12 +602,14 @@ ray_cc_binary(
 # Ray native pubsub module.
 ray_cc_library(
     name = "pubsub_lib",
-    srcs = glob([
-        "src/ray/pubsub/*.cc",
-    ]),
-    hdrs = glob([
-        "src/ray/pubsub/*.h",
-    ]),
+    srcs = [
+        "src/ray/pubsub/publisher.cc",
+        "src/ray/pubsub/subscriber.cc",
+    ],
+    hdrs = [
+        "src/ray/pubsub/publisher.h",
+        "src/ray/pubsub/subscriber.h",
+    ],
     deps = [
         ":pubsub_rpc",
         "@boost//:any",
@@ -718,25 +720,39 @@ ray_cc_library(
 
 ray_cc_library(
     name = "raylet_lib",
-    srcs = glob(
-        [
-            "src/ray/raylet/**/*.cc",
-        ],
-        exclude = [
-            "src/ray/raylet/**/*_test.cc",
-            "src/ray/raylet/scheduling/**/*.cc",
-            "src/ray/raylet/main.cc",
-        ],
-    ),
-    hdrs = glob(
-        [
-            "src/ray/raylet/**/*.h",
-        ],
-        exclude = [
-            "src/ray/raylet/scheduling/**/*.h",
-            "src/ray/raylet/main.cc",
-        ],
-    ),
+    srcs = [
+        "src/ray/raylet/agent_manager.cc",
+        "src/ray/raylet/dependency_manager.cc",
+        "src/ray/raylet/local_object_manager.cc",
+        "src/ray/raylet/local_task_manager.cc",
+        "src/ray/raylet/node_manager.cc",
+        "src/ray/raylet/placement_group_resource_manager.cc",
+        "src/ray/raylet/raylet.cc",
+        "src/ray/raylet/runtime_env_agent_client.cc",
+        "src/ray/raylet/wait_manager.cc",
+        "src/ray/raylet/worker.cc",
+        "src/ray/raylet/worker_killing_policy.cc",
+        "src/ray/raylet/worker_killing_policy_group_by_owner.cc",
+        "src/ray/raylet/worker_killing_policy_retriable_fifo.cc",
+        "src/ray/raylet/worker_pool.cc",
+    ],
+    hdrs = [
+        "src/ray/raylet/agent_manager.h",
+        "src/ray/raylet/dependency_manager.h",
+        "src/ray/raylet/local_object_manager.h",
+        "src/ray/raylet/local_task_manager.h",
+        "src/ray/raylet/node_manager.h",
+        "src/ray/raylet/placement_group_resource_manager.h",
+        "src/ray/raylet/raylet.h",
+        "src/ray/raylet/runtime_env_agent_client.h",
+        "src/ray/raylet/test/util.h",
+        "src/ray/raylet/wait_manager.h",
+        "src/ray/raylet/worker.h",
+        "src/ray/raylet/worker_killing_policy.h",
+        "src/ray/raylet/worker_killing_policy_group_by_owner.h",
+        "src/ray/raylet/worker_killing_policy_retriable_fifo.h",
+        "src/ray/raylet/worker_pool.h",
+    ],
     linkopts = select({
         "@platforms//os:windows": [
         ],


### PR DESCRIPTION
Followup PR for https://github.com/ray-project/ray/pull/50199

Targets come from `bazel query --output=build <target>`