### PR TITLE
[core] [easy] [no-op] Unnecessary code cleanup

### DIFF
--- a/src/ray/util/tests/BUILD
+++ b/src/ray/util/tests/BUILD
@@ -231,7 +231,6 @@ ray_cc_test(
         "//src/ray/util",
         "//src/ray/util:pipe_logger",
         "@com_google_googletest//:gtest_main",
-        "@com_google_absl//absl/cleanup",
     ],
     size = "small",
     tags = ["team:core"],

--- a/src/ray/util/tests/pipe_logger_test.cc
+++ b/src/ray/util/tests/pipe_logger_test.cc
@@ -22,7 +22,6 @@
 #include <future>
 #include <string_view>
 
-#include "absl/cleanup/cleanup.h"
 #include "ray/common/test/testing.h"
 #include "ray/util/filesystem.h"
 #include "ray/util/temporary_directory.h"
@@ -38,11 +37,6 @@ constexpr std::string_view kLogLine2 = "world\n";
 TEST(PipeLoggerTest, RedirectionTest) {
   ScopedTemporaryDirectory scoped_directory;
   const auto test_file_path = scoped_directory.GetDirectory() / GenerateUUIDV4();
-
-  // Delete temporary file.
-  absl::Cleanup cleanup_test_file = [&test_file_path]() {
-    EXPECT_TRUE(std::filesystem::remove(test_file_path));
-  };
 
   // Take the default option, which doesn't have rotation enabled.
   StreamRedirectionOption stream_redirection_opt{};
@@ -62,11 +56,6 @@ TEST(PipeLoggerTest, RedirectionTest) {
 TEST(PipeLoggerTestWithTee, RedirectionWithTee) {
   ScopedTemporaryDirectory scoped_directory;
   const auto test_file_path = scoped_directory.GetDirectory() / GenerateUUIDV4();
-
-  // Delete temporary file.
-  absl::Cleanup cleanup_test_file = [&test_file_path]() {
-    EXPECT_TRUE(std::filesystem::remove(test_file_path));
-  };
 
   StreamRedirectionOption stream_redirection_opt{};
   stream_redirection_opt.file_path = test_file_path.string();
@@ -97,12 +86,6 @@ TEST(PipeLoggerTestWithTee, RotatedRedirectionWithTee) {
   const auto log_file_path1 = test_file_path;
   const auto log_file_path2 =
       scoped_directory.GetDirectory() / absl::StrFormat("%s.1", uuid);
-
-  // Delete temporary file.
-  absl::Cleanup cleanup_test_file = [&log_file_path1, &log_file_path2]() {
-    EXPECT_TRUE(std::filesystem::remove(log_file_path1));
-    EXPECT_TRUE(std::filesystem::remove(log_file_path2));
-  };
 
   StreamRedirectionOption stream_redirection_opt{};
   stream_redirection_opt.file_path = test_file_path.string();


### PR DESCRIPTION
We already use scoped temporary directory, no need to manually delete test file.