### PR TITLE
[core] Introduces MutexProtected for reader and writer locks

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -537,7 +537,7 @@ ray_cc_library(
         "src/ray/gcs/gcs_server/store_client_kv.cc",
         "src/ray/gcs/gcs_server/usage_stats_client.cc",
     ],
-    hdrs =[
+    hdrs = [
         "src/ray/gcs/gcs_server/gcs_actor_manager.h",
         "src/ray/gcs/gcs_server/gcs_actor_scheduler.h",
         "src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.h",
@@ -849,6 +849,7 @@ ray_cc_library(
         "//src/ray/protobuf:worker_cc_proto",
         "//src/ray/util",
         "//src/ray/util:container_util",
+        "//src/ray/util:mutex_protected",
         "//src/ray/util:shared_lru",
         "@boost//:circular_buffer",
         "@boost//:fiber",
@@ -2034,9 +2035,9 @@ ray_cc_library(
         ":pubsub_lib",
         ":ray_common",
         ":redis_store_client",
+        "//src/ray/protobuf:usage_cc_proto",
         "//src/ray/util:container_util",
         "//src/ray/util:sequencer",
-        "//src/ray/protobuf:usage_cc_proto",
     ],
 )
 

--- a/src/ray/core_worker/core_worker_process.cc
+++ b/src/ray/core_worker/core_worker_process.cc
@@ -137,8 +137,8 @@ CoreWorkerProcessImpl::CoreWorkerProcessImpl(const CoreWorkerOptions &options)
   {
     // Initialize global worker instance.
     auto worker = std::make_shared<CoreWorker>(options_, worker_id_);
-    auto write_lockeded = core_worker_.LockForWrite();
-    write_lockeded.Get() = worker;
+    auto write_locked = core_worker_.LockForWrite();
+    write_locked.Get() = worker;
   }
 
   // Initialize event framework.

--- a/src/ray/core_worker/core_worker_process.cc
+++ b/src/ray/core_worker/core_worker_process.cc
@@ -137,8 +137,8 @@ CoreWorkerProcessImpl::CoreWorkerProcessImpl(const CoreWorkerOptions &options)
   {
     // Initialize global worker instance.
     auto worker = std::make_shared<CoreWorker>(options_, worker_id_);
-    absl::WriterMutexLock lock(&mutex_);
-    core_worker_ = worker;
+    auto write_lockeded = core_worker_.LockForWrite();
+    write_lockeded.Get() = worker;
   }
 
   // Initialize event framework.
@@ -255,8 +255,8 @@ void CoreWorkerProcessImpl::RunWorkerTaskExecutionLoop() {
   core_worker->RunTaskExecutionLoop();
   RAY_LOG(INFO) << "Task execution loop terminated. Removing the global worker.";
   {
-    absl::WriterMutexLock lock(&mutex_);
-    core_worker_.reset();
+    auto write_locked = core_worker_.LockForWrite();
+    write_locked.Get().reset();
   }
 }
 
@@ -269,19 +269,19 @@ void CoreWorkerProcessImpl::ShutdownDriver() {
                             /*exit_detail*/ "Shutdown by ray.shutdown().");
   global_worker->Shutdown();
   {
-    absl::WriterMutexLock lock(&mutex_);
-    core_worker_.reset();
+    auto write_locked = core_worker_.LockForWrite();
+    write_locked.Get().reset();
   }
 }
 
 std::shared_ptr<CoreWorker> CoreWorkerProcessImpl::TryGetCoreWorker() const {
-  absl::ReaderMutexLock lock(&mutex_);
-  return core_worker_;
+  const auto read_locked = core_worker_.LockForRead();
+  return read_locked.Get();
 }
 
 std::shared_ptr<CoreWorker> CoreWorkerProcessImpl::GetCoreWorker() const {
-  absl::ReaderMutexLock lock(&mutex_);
-  if (!core_worker_) {
+  const auto read_locked = core_worker_.LockForRead();
+  if (!read_locked.Get()) {
     // This could only happen when the worker has already been shutdown.
     // In this case, we should exit without crashing.
     // TODO (scv119): A better solution could be returning error code
@@ -297,8 +297,8 @@ std::shared_ptr<CoreWorker> CoreWorkerProcessImpl::GetCoreWorker() const {
     }
     QuickExit();
   }
-  RAY_CHECK(core_worker_) << "core_worker_ must not be NULL";
-  return core_worker_;
+  RAY_CHECK(read_locked.Get()) << "core_worker_ must not be NULL";
+  return read_locked.Get();
 }
 
 }  // namespace core

--- a/src/ray/core_worker/core_worker_process.h
+++ b/src/ray/core_worker/core_worker_process.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include "ray/util/mutex_protected.h"
+
 namespace ray {
 namespace core {
 
@@ -141,13 +143,10 @@ class CoreWorkerProcessImpl {
   const CoreWorkerOptions options_;
 
   /// The core worker instance of this worker process.
-  std::shared_ptr<CoreWorker> core_worker_ ABSL_GUARDED_BY(mutex_);
+  MutexProtected<std::shared_ptr<CoreWorker>> core_worker_;
 
   /// The worker ID of this worker.
   const WorkerID worker_id_;
-
-  /// To protect access to core_worker_
-  mutable absl::Mutex mutex_;
 };
 }  // namespace core
 }  // namespace ray

--- a/src/ray/util/BUILD
+++ b/src/ray/util/BUILD
@@ -30,8 +30,8 @@ ray_cc_library(
 
 ray_cc_library(
     name = "exponential_backoff",
-    hdrs = ["exponential_backoff.h"],
     srcs = ["exponential_backoff.cc"],
+    hdrs = ["exponential_backoff.h"],
     deps = [
         ":logging",
     ],
@@ -39,8 +39,8 @@ ray_cc_library(
 
 ray_cc_library(
     name = "logging",
-    hdrs = ["logging.h"],
     srcs = ["logging.cc"],
+    hdrs = ["logging.h"],
     deps = [
         ":event_label",
         ":macros",
@@ -56,8 +56,8 @@ ray_cc_library(
 
 ray_cc_library(
     name = "filesystem",
-    hdrs = ["filesystem.h"],
     srcs = ["filesystem.cc"],
+    hdrs = ["filesystem.h"],
     deps = [
         "//src/ray/common:status_or",
     ],
@@ -75,13 +75,13 @@ ray_cc_library(
 
 ray_cc_library(
     name = "process",
-    hdrs = [
-        "process.h",
-        "subreaper.h",
-    ],
     srcs = [
         "process.cc",
         "subreaper.cc",
+    ],
+    hdrs = [
+        "process.h",
+        "subreaper.h",
     ],
     deps = [
         ":cmd_line_utils",
@@ -107,13 +107,14 @@ ray_cc_library(
     hdrs = ["counter_map.h"],
     deps = [
         ":logging",
+        ":mutex_protected",
     ],
 )
 
 ray_cc_library(
     name = "event",
-    hdrs = ["event.h"],
     srcs = ["event.cc"],
+    hdrs = ["event.h"],
     deps = [
         ":logging",
         ":random",
@@ -145,14 +146,14 @@ ray_cc_library(
 
 ray_cc_library(
     name = "string_utils",
-    hdrs = ["string_utils.h"],
     srcs = ["string_utils.cc"],
+    hdrs = ["string_utils.h"],
 )
 
 ray_cc_library(
     name = "memory",
-    hdrs = ["memory.h"],
     srcs = ["memory.cc"],
+    hdrs = ["memory.h"],
 )
 
 ray_cc_library(
@@ -184,8 +185,8 @@ ray_cc_library(
 
 ray_cc_library(
     name = "cmd_line_utils",
-    hdrs = ["cmd_line_utils.h"],
     srcs = ["cmd_line_utils.cc"],
+    hdrs = ["cmd_line_utils.h"],
     deps = [
         ":logging",
         ":string_utils",
@@ -195,8 +196,8 @@ ray_cc_library(
 # TODO(hjiang): Split URL related functions into a separate util target.
 ray_cc_library(
     name = "util",
-    hdrs = ["util.h"],
     srcs = ["util.cc"],
+    hdrs = ["util.h"],
     deps = [
         ":filesystem",
         ":logging",
@@ -215,9 +216,8 @@ ray_cc_library(
 
 ray_cc_library(
     name = "thread_checker",
-    hdrs = ["thread_checker.h"],
     srcs = ["thread_checker.cc"],
-
+    hdrs = ["thread_checker.h"],
 )
 
 ray_cc_library(
@@ -252,8 +252,8 @@ ray_cc_library(
 
 ray_cc_library(
     name = "pipe_logger",
-    hdrs = ["pipe_logger.h"],
     srcs = ["pipe_logger.cc"],
+    hdrs = ["pipe_logger.h"],
     deps = [
         ":compat",
         ":spdlog_fd_sink",
@@ -268,8 +268,8 @@ ray_cc_library(
 
 ray_cc_library(
     name = "stream_redirection_utils",
-    hdrs = ["stream_redirection_utils.h"],
     srcs = ["stream_redirection_utils.cc"],
+    hdrs = ["stream_redirection_utils.h"],
     deps = [
         ":pipe_logger",
         ":stream_redirection_options",
@@ -289,10 +289,18 @@ ray_cc_library(
 
 ray_cc_library(
     name = "temporary_directory",
-    hdrs = ["temporary_directory.h"],
     srcs = ["temporary_directory.cc"],
+    hdrs = ["temporary_directory.h"],
     deps = [
         ":util",
         "@com_google_absl//absl/strings:str_format",
+    ],
+)
+
+ray_cc_library(
+    name = "mutex_protected",
+    hdrs = ["mutex_protected.h"],
+    deps = [
+        "@com_google_absl//absl/synchronization",
     ],
 )

--- a/src/ray/util/counter_map.h
+++ b/src/ray/util/counter_map.h
@@ -21,6 +21,7 @@
 #include "absl/container/flat_hash_set.h"
 #include "absl/synchronization/mutex.h"
 #include "ray/util/logging.h"
+#include "ray/util/mutex_protected.h"
 
 /// \class CounterMap
 ///
@@ -151,64 +152,61 @@ class CounterMapThreadSafe {
  public:
   CounterMapThreadSafe() = default;
 
-  void SetOnChangeCallback(std::function<void(const K &)> on_change)
-      ABSL_LOCKS_EXCLUDED(mutex_) {
-    absl::WriterMutexLock lock(&mutex_);
-    counter_map_.SetOnChangeCallback(std::move(on_change));
+  void SetOnChangeCallback(std::function<void(const K &)> on_change) {
+    auto write_locked = counter_map_.LockForWrite();
+    write_locked.Get().SetOnChangeCallback(std::move(on_change));
   }
 
-  void FlushOnChangeCallbacks() ABSL_LOCKS_EXCLUDED(mutex_) {
-    absl::WriterMutexLock lock(&mutex_);
-    counter_map_.FlushOnChangeCallbacks();
+  void FlushOnChangeCallbacks() {
+    auto write_locked = counter_map_.LockForWrite();
+    write_locked.Get().FlushOnChangeCallbacks();
   }
 
-  void Increment(const K &key, int64_t val = 1) ABSL_LOCKS_EXCLUDED(mutex_) {
-    absl::WriterMutexLock lock(&mutex_);
-    counter_map_.Increment(key, val);
+  void Increment(const K &key, int64_t val = 1) {
+    auto write_locked = counter_map_.LockForWrite();
+    write_locked.Get().Increment(key, val);
   }
 
-  void Decrement(const K &key, int64_t val = 1) ABSL_LOCKS_EXCLUDED(mutex_) {
-    absl::WriterMutexLock lock(&mutex_);
-    counter_map_.Decrement(key, val);
+  void Decrement(const K &key, int64_t val = 1) {
+    auto write_locked = counter_map_.LockForWrite();
+    write_locked.Get().Decrement(key, val);
   }
 
-  int64_t Get(const K &key) {
-    absl::ReaderMutexLock lock(&mutex_);
-    return counter_map_.Get(key);
+  int64_t Get(const K &key) const {
+    const auto read_locked = counter_map_.LockForRead();
+    return read_locked.Get().Get(key);
   }
 
-  void Swap(const K &old_key, const K &new_key, int64_t val = 1)
-      ABSL_LOCKS_EXCLUDED(mutex_) {
-    absl::WriterMutexLock lock(&mutex_);
-    counter_map_.Swap(old_key, new_key, val);
+  void Swap(const K &old_key, const K &new_key, int64_t val = 1) {
+    auto write_locked = counter_map_.LockForWrite();
+    write_locked.Get().Swap(old_key, new_key, val);
   }
 
-  size_t Size() {
-    absl::ReaderMutexLock lock(&mutex_);
-    return counter_map_.Size();
+  size_t Size() const {
+    const auto read_locked = counter_map_.LockForRead();
+    return read_locked.Get().Size();
   }
 
-  size_t Total() {
-    absl::ReaderMutexLock lock(&mutex_);
-    return counter_map_.Total();
+  size_t Total() const {
+    const auto read_locked = counter_map_.LockForRead();
+    return read_locked.Get().Total();
   }
 
-  size_t NumPendingCallbacks() {
-    absl::ReaderMutexLock lock(&mutex_);
-    return counter_map_.NumPendingCallbacks();
+  size_t NumPendingCallbacks() const {
+    const auto read_locked = counter_map_.LockForRead();
+    return read_locked.Get().NumPendingCallbacks();
   }
 
-  void ForEachEntry(std::function<void(const K &, int64_t)> callback) {
-    absl::ReaderMutexLock lock(&mutex_);
-    counter_map_.ForEachEntry(std::move(callback));
+  void ForEachEntry(std::function<void(const K &, int64_t)> callback) const {
+    const auto read_locked = counter_map_.LockForRead();
+    read_locked.Get().ForEachEntry(std::move(callback));
   }
 
-  absl::flat_hash_map<K, int64_t> GetAll() {
-    absl::ReaderMutexLock lock(&mutex_);
-    return counter_map_.GetAll();
+  absl::flat_hash_map<K, int64_t> GetAll() const {
+    const auto read_locked = counter_map_.LockForRead();
+    return read_locked.Get().GetAll();
   }
 
  private:
-  absl::Mutex mutex_;
-  CounterMap<K> counter_map_;
+  ray::MutexProtected<CounterMap<K>> counter_map_;
 };

--- a/src/ray/util/mutex_protected.h
+++ b/src/ray/util/mutex_protected.h
@@ -1,0 +1,70 @@
+// Copyright 2024 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <type_traits>
+#include <utility>
+
+#include "absl/synchronization/mutex.h"
+
+namespace ray {
+
+// A wrapper class that protects a value with a mutex. One can get a const& with a reader
+// lock and a mutable & with a writer lock.
+//
+// Limitation: we only protect a single value. For the classes where a mutex protects
+// multiple values, or with methods that requires/excludes locks, we have to write an
+// impl class to be protected.
+template <typename T>
+class MutexProtected {
+ public:
+  explicit MutexProtected(T initialValue) : value_(std::move(initialValue)) {}
+
+  // Default constructor enabled only if T is default-constructible
+  template <typename = typename std::enable_if_t<std::is_default_constructible_v<T>>>
+  explicit MutexProtected() {}
+
+  class ReadLocked {
+   public:
+    ReadLocked(absl::Mutex *mutex, const T &value) : lock_(mutex), value_(value) {}
+
+    const T &Get() const { return value_; }
+
+   private:
+    absl::ReaderMutexLock lock_;
+    const T &value_;
+  };
+
+  class WriteLocked {
+   public:
+    WriteLocked(absl::Mutex *mutex, T &value) : lock_(mutex), value_(value) {}
+
+    T &Get() { return value_; }
+
+   private:
+    absl::WriterMutexLock lock_;
+    T &value_;
+  };
+
+  ReadLocked LockForRead() const { return ReadLocked(&mutex_, value_); }
+
+  WriteLocked LockForWrite() { return WriteLocked(&mutex_, value_); }
+
+ private:
+  T value_;
+  mutable absl::Mutex mutex_;
+};
+
+}  // namespace ray

--- a/src/ray/util/mutex_protected.h
+++ b/src/ray/util/mutex_protected.h
@@ -30,11 +30,10 @@ namespace ray {
 template <typename T>
 class MutexProtected {
  public:
-  explicit MutexProtected(T initialValue) : value_(std::move(initialValue)) {}
+  template <typename... Args>
+  explicit MutexProtected(Args &&...args) : value_(std::forward(args)...) {}
 
-  // Default constructor enabled only if T is default-constructible
-  template <typename = typename std::enable_if_t<std::is_default_constructible_v<T>>>
-  explicit MutexProtected() {}
+  MutexProtected() = default;
 
   class ReadLocked {
    public:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Picking up ruiyang's pr that was in response to mine to have a safer abstraction for using reader writer locks.

Giving you an RAII object that will only give you const l-value ref on LockForRead() and a mutable l-value ref on LockForWrite().

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
