### PR TITLE
[Data] Adding support for type promotion when concatenating blocks

### DIFF
--- a/python/ray/data/BUILD
+++ b/python/ray/data/BUILD
@@ -243,7 +243,7 @@ py_test(
 
 py_test(
     name = "test_image",
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_image.py"],
     tags = ["team:data", "exclusive"],
     deps = ["//:ray_lib", ":conftest"],
@@ -353,8 +353,6 @@ py_test(
     deps = ["//:ray_lib", ":conftest"],
 )
 
-# Added "data_non_parallel" tag to prevent parallel execution of this test.
-# It needs about 5GB memory.
 py_test(
     name = "test_dynamic_block_split",
     size = "medium",
@@ -505,7 +503,7 @@ py_test(
     name = "test_sort",
     size = "enormous",
     srcs = ["tests/test_sort.py"],
-    tags = ["team:data", "exclusive"],
+    tags = ["team:data", "exclusive", "data_non_parallel"],
     deps = ["//:ray_lib", ":conftest"],
 )
 

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -146,7 +146,7 @@ class ArrowBlockBuilder(TableBlockBuilder):
 
     @staticmethod
     def _concat_tables(tables: List[Block]) -> Block:
-        return transform_pyarrow.concat(tables)
+        return transform_pyarrow.concat(tables, promote_types=True)
 
     @staticmethod
     def _concat_would_copy() -> bool:

--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -125,7 +125,7 @@ class ParquetDatasink(_FileDatasink):
         import pyarrow as pa
         import pyarrow.parquet as pq
 
-        table = concat(tables)
+        table = concat(tables, promote_types=False)
         # Create unique combinations of the partition columns
         table_fields = [
             field for field in output_schema if field.name not in self.partition_cols

--- a/python/ray/data/tests/test_all_to_all.py
+++ b/python/ray/data/tests/test_all_to_all.py
@@ -7,12 +7,13 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
-from pkg_resources import parse_version
 
 import ray
+from packaging.version import parse as parse_version
 from ray._private.utils import _get_pyarrow_version
 from ray.data._internal.arrow_ops.transform_pyarrow import (
     MIN_PYARROW_VERSION_TYPE_PROMOTION,
+    combine_chunks,
 )
 from ray.data._internal.util import is_nan
 from ray.data._internal.execution.interfaces.ref_bundle import (
@@ -649,9 +650,7 @@ def test_groupby_tabular_max(
     ray_start_regular_shared_2_cpus, ds_format, num_parts, configure_shuffle_method
 ):
     # Test built-in max aggregation
-    seed = int(time.time())
-    print(f"Seeding RNG for test_groupby_tabular_max with: {seed}")
-    random.seed(seed)
+    random.seed(1738727165)
     xs = list(range(100))
     random.shuffle(xs)
 
@@ -1193,7 +1192,10 @@ def test_groupby_map_groups_for_pandas(
     expected = pd.DataFrame(
         {"A": ["a", "a", "b"], "B": [0.5, 0.5, 1.000000], "C": [0.4, 0.6, 1.0]}
     )
-    assert mapped.to_pandas().equals(expected)
+
+    result = mapped.sort(["A", "C"]).to_pandas()
+
+    pd.testing.assert_frame_equal(expected, result)
 
 
 @pytest.mark.parametrize("num_parts", [1, 2, 30])
@@ -1220,8 +1222,10 @@ def test_groupby_map_groups_for_arrow(
     expected = pa.Table.from_pydict(
         {"A": ["a", "a", "b"], "B": [0.5, 0.5, 1], "C": [0.4, 0.6, 1]}
     )
-    result = pa.Table.from_pandas(mapped.to_pandas())
-    assert result.equals(expected)
+
+    result = mapped.sort(["A", "C"]).take_batch(batch_format="pyarrow")
+
+    assert expected == combine_chunks(result)
 
 
 def test_groupby_map_groups_for_numpy(
@@ -1241,9 +1245,12 @@ def test_groupby_map_groups_for_numpy(
         return {"group": group["group"] + 1, "value": group["value"] + 1}
 
     ds = ds.groupby("group").map_groups(func, batch_format="numpy")
+
     expected = pa.Table.from_pydict({"group": [2, 2, 3, 3], "value": [2, 3, 4, 5]})
-    result = pa.Table.from_pandas(ds.to_pandas())
-    assert result.equals(expected)
+
+    result = ds.sort(["group", "value"]).take_batch(batch_format="pyarrow")
+
+    assert expected == result
 
 
 def test_groupby_map_groups_with_different_types(
@@ -1258,13 +1265,13 @@ def test_groupby_map_groups_with_different_types(
         ]
     )
 
-    def func(group):
+    def func(batch):
         # Test output type is Python list, different from input type.
-        value = int(group["value"][0])
-        return {"out": np.array([value])}
+        return {"group": [batch["group"][0]], "out": [min(batch["value"])]}
 
     ds = ds.groupby("group").map_groups(func)
-    assert sorted([x["out"] for x in ds.take()]) == [1, 3]
+
+    assert [x["out"] for x in ds.sort("group").take_all()] == [1, 3]
 
 
 @pytest.mark.parametrize("num_parts", [1, 30])
@@ -1317,6 +1324,11 @@ def test_groupby_map_groups_extra_args(
     assert sorted([x["value"] for x in ds.take()]) == [6, 8, 10, 12]
 
 
+_NEED_UNWRAP_ARROW_SCALAR = parse_version(_get_pyarrow_version()) <= parse_version(
+    "9.0.0"
+)
+
+
 @pytest.mark.parametrize("num_parts", [1, 30])
 @pytest.mark.parametrize("ds_format", ["pyarrow", "pandas", "numpy"])
 def test_groupby_map_groups_multicolumn(
@@ -1334,17 +1346,32 @@ def test_groupby_map_groups_multicolumn(
         num_parts
     )
 
+    should_unwrap_pa_scalars = ds_format == "pyarrow" and _NEED_UNWRAP_ARROW_SCALAR
+
+    def _map_group(df):
+        # NOTE: Since we're grouping by A and B, these columns will be bearing
+        #       the same values.
+        a = df["A"][0]
+        b = df["B"][0]
+        return {
+            # NOTE: PA 9.0 requires explicit unwrapping into Python objects
+            "A": [a.as_py() if should_unwrap_pa_scalars else a],
+            "B": [b.as_py() if should_unwrap_pa_scalars else b],
+            "count": [len(df["A"])],
+        }
+
     agg_ds = ds.groupby(["A", "B"]).map_groups(
-        lambda df: {"count": [len(df["A"])]}, batch_format=ds_format
+        _map_group,
+        batch_format=ds_format,
     )
-    assert agg_ds.count() == 6
-    assert agg_ds.take_all() == [
-        {"count": 17},
-        {"count": 16},
-        {"count": 17},
-        {"count": 17},
-        {"count": 17},
-        {"count": 16},
+
+    assert agg_ds.sort(["A", "B"]).take_all() == [
+        {"A": 0, "B": 0, "count": 17},
+        {"A": 0, "B": 1, "count": 16},
+        {"A": 0, "B": 2, "count": 17},
+        {"A": 1, "B": 0, "count": 17},
+        {"A": 1, "B": 1, "count": 17},
+        {"A": 1, "B": 2, "count": 16},
     ]
 
 
@@ -1372,19 +1399,41 @@ def test_groupby_map_groups_multicolumn_with_nan(
         ]
     ).repartition(num_parts)
 
+    should_unwrap_pa_scalars = ds_format == "pyarrow" and _NEED_UNWRAP_ARROW_SCALAR
+
+    def _map_group(df):
+        # NOTE: Since we're grouping by A and B, these columns will be bearing
+        #       the same values
+        a = df["A"][0]
+        b = df["B"][0]
+        return {
+            # NOTE: PA 9.0 requires explicit unwrapping into Python objects
+            "A": [a.as_py() if should_unwrap_pa_scalars else a],
+            "B": [b.as_py() if should_unwrap_pa_scalars else b],
+            "count": [len(df["A"])],
+        }
+
     agg_ds = ds.groupby(["A", "B"]).map_groups(
-        lambda df: {"count": [len(df["A"])]}, batch_format=ds_format
+        _map_group,
+        batch_format=ds_format,
     )
-    assert agg_ds.count() == 7
-    assert agg_ds.take_all() == [
-        {"count": 16},
-        {"count": 16},
-        {"count": 16},
-        {"count": 16},
-        {"count": 16},
-        {"count": 15},
-        {"count": 5},
+
+    rows = agg_ds.sort(["A", "B"]).take_all()
+
+    # NOTE: Nans are not comparable directly, hence
+    #       we have to split the assertion in 2
+    assert rows[:-1] == [
+        {"A": 0.0, "B": 0.0, "count": 16},
+        {"A": 0.0, "B": 1.0, "count": 16},
+        {"A": 0.0, "B": 2.0, "count": 16},
+        {"A": 1.0, "B": 0.0, "count": 16},
+        {"A": 1.0, "B": 1.0, "count": 16},
+        {"A": 1.0, "B": 2.0, "count": 15},
     ]
+
+    assert (
+        np.isnan(rows[-1]["A"]) and np.isnan(rows[-1]["B"]) and rows[-1]["count"] == 5
+    )
 
 
 def test_groupby_map_groups_with_partial():

--- a/python/ray/data/tests/test_all_to_all.py
+++ b/python/ray/data/tests/test_all_to_all.py
@@ -7,8 +7,13 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
+from pkg_resources import parse_version
 
 import ray
+from ray._private.utils import _get_pyarrow_version
+from ray.data._internal.arrow_ops.transform_pyarrow import (
+    MIN_PYARROW_VERSION_TYPE_PROMOTION,
+)
 from ray.data._internal.util import is_nan
 from ray.data._internal.execution.interfaces.ref_bundle import (
     _ref_bundles_iterator_to_block_refs_list,

--- a/python/ray/data/tests/test_all_to_all.py
+++ b/python/ray/data/tests/test_all_to_all.py
@@ -12,7 +12,6 @@ import ray
 from packaging.version import parse as parse_version
 from ray._private.utils import _get_pyarrow_version
 from ray.data._internal.arrow_ops.transform_pyarrow import (
-    MIN_PYARROW_VERSION_TYPE_PROMOTION,
     combine_chunks,
 )
 from ray.data._internal.util import is_nan

--- a/python/ray/data/tests/test_transform_pyarrow.py
+++ b/python/ray/data/tests/test_transform_pyarrow.py
@@ -13,9 +13,9 @@ from ray.air.util.tensor_extensions.arrow import ArrowTensorTypeV2
 from ray.data import DataContext
 from ray.data._internal.arrow_ops.transform_pyarrow import (
     concat,
-    MIN_PYARROW_VERSION_TYPE_PROMOTION,
-    unify_schemas,
     try_combine_chunked_columns,
+    unify_schemas,
+    MIN_PYARROW_VERSION_TYPE_PROMOTION,
 )
 from ray.data.block import BlockAccessor
 from ray.data.extensions import (

--- a/python/ray/data/tests/test_transform_pyarrow.py
+++ b/python/ray/data/tests/test_transform_pyarrow.py
@@ -953,6 +953,11 @@ def test_fallback_to_pandas_on_incompatible_data(
     assert isinstance(block, pd.DataFrame)
 
 
+_PYARROW_SUPPORTS_TYPE_PROMOTION = (
+    parse_version(_get_pyarrow_version()) >= MIN_PYARROW_VERSION_TYPE_PROMOTION
+)
+
+
 @pytest.mark.parametrize(
     "op, data, should_fail, expected_type",
     [
@@ -960,9 +965,15 @@ def test_fallback_to_pandas_on_incompatible_data(
         ("map_batches", [1, 2**100], False, ArrowPythonObjectType()),
         ("map_batches", [1.0, 2**100], False, ArrowPythonObjectType()),
         ("map_batches", ["1.0", 2**100], False, ArrowPythonObjectType()),
-        # Case B: No fallback to `ArrowPythonObjectType` and hence arrow is enforcing
-        #         deduced schema
-        ("map_batches", [1.0, 2**4], True, None),
+        # Case B: No fallback to `ArrowPythonObjectType`, but type promotion allows
+        #         int to be promoted to a double
+        (
+            "map_batches",
+            [1.0, 2**4],
+            not _PYARROW_SUPPORTS_TYPE_PROMOTION,
+            pa.float64(),
+        ),
+        # Case C: No fallback to `ArrowPythonObjectType` and no type promotion possible
         ("map_batches", ["1.0", 2**4], True, None),
     ],
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This change enables type promotion for Arrow blocks when concatenating tables.

Addresses https://github.com/ray-project/ray/issues/50255

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
