### PR TITLE
[docs] fix version picker selected version

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -515,8 +515,8 @@ def _autogen_apis(app: sphinx.application.Sphinx):
 
 def setup(app):
     # Only generate versions JSON during RTD build
-    # if os.getenv("READTHEDOCS") == "True":
-    generate_versions_json()
+    if os.getenv("READTHEDOCS") == "True":
+        generate_versions_json()
 
     pregenerate_example_rsts(app)
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -329,9 +329,7 @@ html_theme_options = {
     "pygment_dark_style": "stata-dark",
     "switcher": {
         "json_url": "https://docs.ray.io/en/master/_static/versions.json",
-        "version_match": (
-            lambda v: v if v in ["master", "latest"] else f"releases/{v}"
-        )(os.getenv("READTHEDOCS_VERSION", "master")),
+        "version_match": os.getenv("READTHEDOCS_VERSION", "master"),
     },
 }
 
@@ -517,8 +515,8 @@ def _autogen_apis(app: sphinx.application.Sphinx):
 
 def setup(app):
     # Only generate versions JSON during RTD build
-    if os.getenv("READTHEDOCS") == "True":
-        generate_versions_json()
+    # if os.getenv("READTHEDOCS") == "True":
+    generate_versions_json()
 
     pregenerate_example_rsts(app)
 

--- a/doc/source/custom_directives.py
+++ b/doc/source/custom_directives.py
@@ -1298,7 +1298,7 @@ def generate_versions_json():
     for version in git_versions:
         version_json_data.append(
             {
-                "version": f"releases/{version}",
+                "version": f"releases-{version}",
                 "url": generate_version_url(f"releases-{version}"),
             }
         )


### PR DESCRIPTION
## Why are these changes needed?
The version picker was not properly respecting the selected version. This is due to the generated versions in the json being incorrect.

Fixed by updating the json generation logic to use versions of the form `releases-2.42.0` instead `releases/2.24.0` and updated the version match logic in `conf.py` back to just reading the version directly

Before:
![Screenshot 2025-02-06 at 12 31 55 PM](https://github.com/user-attachments/assets/7ca7669e-8a71-4612-b875-94955ed955fd)

After:
![Screenshot 2025-02-06 at 12 31 19 PM](https://github.com/user-attachments/assets/928581b8-2360-4b18-a87c-3b670212165e)



## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
