### PR TITLE
[train] Disable `local_shuffle_buffer_size` in train data ingest benchmark

### DIFF
--- a/release/train_tests/benchmark/config.py
+++ b/release/train_tests/benchmark/config.py
@@ -1,6 +1,7 @@
+import argparse
 import enum
 
-import pydantic
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class DataloaderType(enum.Enum):
@@ -8,7 +9,18 @@ class DataloaderType(enum.Enum):
     MOCK = "mock"
 
 
-class BenchmarkConfig(pydantic.BaseModel):
+class DataLoaderConfig(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    train_batch_size: int = 32
+    validation_batch_size: int = 256
+
+
+class RayDataConfig(DataLoaderConfig):
+    local_buffer_shuffle_size: int = None
+
+
+class BenchmarkConfig(BaseModel):
     # ScalingConfig
     num_workers: int = 1
 
@@ -17,16 +29,70 @@ class BenchmarkConfig(pydantic.BaseModel):
 
     # Data
     dataloader_type: DataloaderType = DataloaderType.RAY_DATA
+    dataloader_config: DataLoaderConfig = Field(
+        default_factory=lambda: DataLoaderConfig(),
+    )
 
     # Training
     num_epochs: int = 1
     skip_train_step: bool = False
-    train_batch_size: int = 32
 
     # Validation
     validate_every_n_steps: int = -1
     skip_validation_at_epoch_end: bool = False
-    validation_batch_size: int = 256
 
     # Logging
     log_metrics_every_n_steps: int = 512
+
+
+def _is_pydantic_model(field_type) -> bool:
+    """Check if a type is a subclass of Pydantic's BaseModel."""
+    return isinstance(field_type, type) and issubclass(field_type, BaseModel)
+
+
+def _add_field_to_parser(parser: argparse.ArgumentParser, field: str, field_info):
+    field_type = field_info.annotation
+    if field_type is bool:
+        assert (
+            not field_info.default
+        ), "Only supports bool flags that are False by default."
+        parser.add_argument(
+            f"--{field}", action="store_true", default=field_info.default
+        )
+    else:
+        parser.add_argument(f"--{field}", type=field_type, default=field_info.default)
+
+
+def cli_to_config() -> BenchmarkConfig:
+    parser = argparse.ArgumentParser()
+
+    nested_fields = []
+    for field, field_info in BenchmarkConfig.model_fields.items():
+        # Skip nested configs for now
+        if _is_pydantic_model(field_info.annotation):
+            nested_fields.append(field)
+            continue
+
+        _add_field_to_parser(parser, field, field_info)
+
+    top_level_args, _ = parser.parse_known_args()
+
+    # Handle nested configs that depend on top-level args
+    nested_configs = {}
+    for nested_field in nested_fields:
+        nested_parser = argparse.ArgumentParser()
+        config_cls = BenchmarkConfig.model_fields[nested_field].annotation
+
+        if (
+            config_cls == DataLoaderConfig
+            and top_level_args.dataloader_type == DataloaderType.RAY_DATA
+        ):
+            config_cls = RayDataConfig
+
+        for field, field_info in config_cls.model_fields.items():
+            _add_field_to_parser(nested_parser, field, field_info)
+
+        args, _ = nested_parser.parse_known_args()
+        nested_configs[nested_field] = config_cls(**vars(args))
+
+    return BenchmarkConfig(**vars(top_level_args), **nested_configs)

--- a/release/train_tests/benchmark/config.py
+++ b/release/train_tests/benchmark/config.py
@@ -10,6 +10,7 @@ class DataloaderType(enum.Enum):
 
 
 class DataLoaderConfig(BaseModel):
+    # NOTE: Workaround for optional types not playing well with argparse.
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     train_batch_size: int = 32

--- a/release/train_tests/benchmark/config.py
+++ b/release/train_tests/benchmark/config.py
@@ -1,7 +1,7 @@
 import argparse
 import enum
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, Field
 
 
 class DataloaderType(enum.Enum):
@@ -10,15 +10,13 @@ class DataloaderType(enum.Enum):
 
 
 class DataLoaderConfig(BaseModel):
-    # NOTE: Workaround for optional types not playing well with argparse.
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
     train_batch_size: int = 32
     validation_batch_size: int = 256
 
 
 class RayDataConfig(DataLoaderConfig):
-    local_buffer_shuffle_size: int = None
+    # NOTE: Optional[int] doesn't play well with argparse.
+    local_buffer_shuffle_size: int = -1
 
 
 class BenchmarkConfig(BaseModel):

--- a/release/train_tests/benchmark/factory.py
+++ b/release/train_tests/benchmark/factory.py
@@ -26,14 +26,10 @@ class BenchmarkFactory(ABC):
         raise NotImplementedError
 
     def get_train_dataloader(self):
-        return self.dataloader_factory.get_train_dataloader(
-            batch_size=self.benchmark_config.train_batch_size
-        )
+        return self.dataloader_factory.get_train_dataloader()
 
     def get_val_dataloader(self):
-        return self.dataloader_factory.get_val_dataloader(
-            batch_size=self.benchmark_config.validation_batch_size
-        )
+        return self.dataloader_factory.get_val_dataloader()
 
     def get_dataloader_metrics(self):
         return self.dataloader_factory.get_metrics()

--- a/release/train_tests/benchmark/train_benchmark.py
+++ b/release/train_tests/benchmark/train_benchmark.py
@@ -256,9 +256,6 @@ def main():
 
     if benchmark_config.task == "image_classification":
         factory = ImageClassificationFactory(benchmark_config)
-        import ipdb
-
-        ipdb.set_trace()
     else:
         raise ValueError
 

--- a/release/train_tests/benchmark/train_benchmark.py
+++ b/release/train_tests/benchmark/train_benchmark.py
@@ -1,4 +1,3 @@
-import argparse
 import collections
 import os
 import pprint
@@ -14,7 +13,7 @@ from ray.train.torch import TorchTrainer
 from ray.train.v2._internal.util import date_str
 import torch
 
-from config import BenchmarkConfig
+from config import BenchmarkConfig, cli_to_config
 from factory import BenchmarkFactory
 from image_classification.factory import ImageClassificationFactory
 
@@ -251,33 +250,15 @@ def train_fn_per_worker(config):
             json.dump(metrics, f)
 
 
-def parse_cli_args():
-    parser = argparse.ArgumentParser()
-    for field, field_info in BenchmarkConfig.model_fields.items():
-        field_type = field_info.annotation
-        assert field_type
-
-        if field_type is bool:
-            assert (
-                not field_info.default
-            ), "Only supports bool flags that are False by default."
-            parser.add_argument(
-                f"--{field}", action="store_true", default=field_info.default
-            )
-        else:
-            parser.add_argument(
-                f"--{field}", type=field_type, default=field_info.default
-            )
-    args = parser.parse_args()
-    return BenchmarkConfig(**vars(args))
-
-
 def main():
-    benchmark_config = parse_cli_args()
-    print(benchmark_config.model_dump_json(indent=2))
+    benchmark_config: BenchmarkConfig = cli_to_config()
+    pprint.pprint(benchmark_config.__dict__, indent=2)
 
     if benchmark_config.task == "image_classification":
         factory = ImageClassificationFactory(benchmark_config)
+        import ipdb
+
+        ipdb.set_trace()
     else:
         raise ValueError
 


### PR DESCRIPTION
## Summary

`local_shuffle_buffer_size` is known to be a bottleneck, so for now, we'll exclude this from the benchmark and tackle the other bottlenecks in data ingestion.

`local_shuffle_buffer_size` is not scalable by its current design, since it happens on the iterator side, which is just the train worker. We will consider adding a distributed version of the shuffle buffer in the future (that's in-between no shuffling and a global shuffle).

This PR also adds some more config utilities to the release test fixture. You can now add nested configs in the `BenchmarkConfig` and also dynamically choosing which configs are available as CLI arguments depending on certain top-level configs.
* For example, `dataloader_type=RAY_DATA` enables all configs in `RayDataConfig` to be accessible.

## Benchmark Results

See https://github.com/ray-project/ray/pull/50019 for the original results WITH `local_shuffle_buffer_size=8*32 (8x batch size)`. 

### `variant=.skip_training`

| Metric                         | Value                      |
|---------------------------------|----------------------------|
| **train/global_throughput**    | 7478.26 rows/s             |
| train/local_throughput         | 467.39 rows/s              |
| producer_throughput            | 8049.64 rows/s             |
| block_to_batch-avg             | 0.001 s                   |
| collate-avg                    | 0.0078 s                   |
| fetch_block-avg                | 0.2508 s                   |
| format_batch-avg               | 0.02469 s                   |
| train/iter_batch-total | 159.16 |
| train/iter_first_batch-total | 12.1381 s |
| train/step-total | 0 s |

[See here for the full set of raw metrics.](https://buildkite.com/ray-project/release/builds/32172#0194dfbd-a086-4b2f-ad25-8a6e2ad3b188)

### `variant=.full_training`

Here’s the markdown table summarizing the relevant training metrics:

| Metric                        | Value                      |
|--------------------------------|----------------------------|
| **train/global_throughput**       | 1639.28 rows/s                   |
| train/local_throughput        | 102.45 rows/s                    |
| producer_throughput           | 1983.55 rows/s                    |
| fetch_block-avg               | 0.01149 s                    |
| block_to_batch-avg            | 0.00076 s                     |
| format_batch-avg              | 0.01796 s                    |
| collate-avg                   | 0.2569 s                     |
| train/iter_batch-total | 0.1710 s |
| train/iter_first_batch-total | 12.60 s |
| train/step-total | 768.76 s |

[See here for the full set of raw metrics.](https://buildkite.com/ray-project/release/builds/32172#0194dfbd-a085-443d-b764-b679678f64a4)
