### PR TITLE
[RLlib] Enable separate CUDA stream for batch loading.

### DIFF
--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -891,12 +891,25 @@ class SampleBatch(dict):
         return self
 
     @ExperimentalAPI
-    def to_device(self, device, framework: str = "torch", pin_memory: bool = False):
+    def to_device(
+        self,
+        device,
+        framework: str = "torch",
+        pin_memory: bool = False,
+        use_stream: bool = False,
+        stream: Optional[Union["torch.cuda.Stream", "torch.cuda.Stream"]] = None,
+    ):
         """TODO: transfer batch to given device as framework tensor."""
         if framework == "torch":
             assert torch is not None
             for k, v in self.items():
-                self[k] = convert_to_torch_tensor(v, device, pin_memory=pin_memory)
+                self[k] = convert_to_torch_tensor(
+                    v,
+                    device,
+                    pin_memory=pin_memory,
+                    use_stream=use_stream,
+                    stream=stream,
+                )
         else:
             raise NotImplementedError
         return self
@@ -1491,13 +1504,24 @@ class MultiAgentBatch:
         )
 
     @ExperimentalAPI
-    def to_device(self, device, framework="torch", pin_memory: bool = False):
+    def to_device(
+        self,
+        device,
+        framework="torch",
+        pin_memory: bool = False,
+        use_stream: bool = False,
+        stream: Optional[Union["torch.cuda.Stream", "torch.cuda.Stream"]] = None,
+    ):
         """TODO: transfer batch to given device as framework tensor."""
         if framework == "torch":
             assert torch is not None
             for pid, policy_batch in self.policy_batches.items():
                 self.policy_batches[pid] = policy_batch.to_device(
-                    device, framework=framework, pin_memory=pin_memory
+                    device,
+                    framework=framework,
+                    pin_memory=pin_memory,
+                    use_stream=use_stream,
+                    stream=stream,
                 )
         else:
             raise NotImplementedError

--- a/rllib/utils/torch_utils.py
+++ b/rllib/utils/torch_utils.py
@@ -233,66 +233,97 @@ def concat_multi_gpu_td_errors(
 
 @PublicAPI
 def convert_to_torch_tensor(
-    x: TensorStructType,
+    x,
     device: Optional[str] = None,
     pin_memory: bool = False,
+    use_stream: bool = False,
+    stream: Optional["torch.cuda.Stream"] = None,
 ):
-    """Converts any struct to torch.Tensors.
+    """
+    Converts any (possibly nested) structure to torch.Tensors.
 
     Args:
-        x: Any (possibly nested) struct, the values in which will be
-            converted and returned as a new struct with all leaves converted
-            to torch tensors.
-        device: The device to create the tensor on.
-        pin_memory: If True, will call the `pin_memory()` method on the created tensors.
+        x: The input structure whose leaves will be converted.
+        device: The device to create the tensor on (e.g. "cuda:0" or "cpu").
+        pin_memory: If True, calls `pin_memory()` on the created tensors.
+        use_stream: If True, uses a separate CUDA stream for `Tensor.to()`.
+        stream: An optional CUDA stream for the host-to-device copy in `Tensor.to()`.
 
     Returns:
-        Any: A new struct with the same structure as `x`, but with all
-        values converted to torch Tensor types. This does not convert possibly
-        nested elements that are None because torch has no representation for that.
+        A new structure with the same layout as `x` but with all leaves converted
+        to torch.Tensors. Leaves that are None are left unchanged.
     """
 
+    # Convert the provided device (if any) to a torch.device; default to CPU.
+    device = torch.device(device) if device is not None else torch.device("cpu")
+    is_cuda = (device.type == "cuda") and torch.cuda.is_available()
+
+    # Determine the appropriate stream.
+    if is_cuda:
+        if use_stream:
+            if stream is not None:
+                # Ensure the provided stream is of an acceptable type.
+                assert isinstance(
+                    stream, (torch.cuda.Stream, torch.cuda.classes.Stream)
+                ), f"`stream` must be a torch.cuda.Stream but got {type(stream)}."
+            else:
+                stream = torch.cuda.Stream()
+        else:
+            stream = torch.cuda.default_stream(device=device)
+    else:
+        stream = None
+
     def mapping(item):
+        # Pass through None values.
         if item is None:
-            # Torch has no representation for `None`, so we return None
             return item
 
-        # Special handling of "Repeated" values.
+        # Special handling for "RepeatedValues" types.
         if isinstance(item, RepeatedValues):
             return RepeatedValues(
-                tree.map_structure(mapping, item.values), item.lengths, item.max_len
+                tree.map_structure(mapping, item.values),
+                item.lengths,
+                item.max_len,
             )
 
-        # Already torch tensor -> make sure it's on right device.
+        # Convert to a tensor if not already one.
         if torch.is_tensor(item):
             tensor = item
-        # Numpy arrays.
         elif isinstance(item, np.ndarray):
-            # Object type (e.g. info dicts in train batch): leave as-is.
-            # str type (e.g. agent_id in train batch): leave as-is.
+            # Leave object or string arrays as is.
             if item.dtype == object or item.dtype.type is np.str_:
                 return item
-            # Non-writable numpy-arrays will cause PyTorch warning.
-            elif item.flags.writeable is False:
+            # If the numpy array is not writable, suppress warnings.
+            if not item.flags.writeable:
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore")
                     tensor = torch.from_numpy(item)
-            # Already numpy: Wrap as torch tensor.
             else:
                 tensor = torch.from_numpy(item)
-        # Everything else: Convert to numpy, then wrap as torch tensor.
         else:
             tensor = torch.from_numpy(np.asarray(item))
 
-        # Floatify all float64 tensors (but leave float16 as-is).
-        if tensor.is_floating_point() and str(tensor.dtype) != "torch.float16":
+        # Convert floating-point tensors from float64 to float32 (unless they are float16).
+        if tensor.is_floating_point() and tensor.dtype != torch.float16:
             tensor = tensor.float()
 
-        # Pin the tensor's memory (for faster transfer to GPU later).
-        if pin_memory and torch.cuda.is_available():
-            tensor.pin_memory()
+        # Optionally pin memory for faster host-to-GPU copies.
+        if pin_memory and is_cuda:
+            tensor = tensor.pin_memory()
 
-        return tensor if device is None else tensor.to(device, non_blocking=True)
+        # Move the tensor to the desired device.
+        # For CUDA devices, use the provided stream context if available.
+        if is_cuda:
+            if stream is not None:
+                with torch.cuda.stream(stream):
+                    tensor = tensor.to(device, non_blocking=True)
+            else:
+                tensor = tensor.to(device, non_blocking=True)
+        else:
+            # For CPU (or non-CUDA), this is a no-op if already on the target device.
+            tensor = tensor.to(device)
+
+        return tensor
 
     return tree.map_structure(mapping, x)
 

--- a/rllib/utils/torch_utils.py
+++ b/rllib/utils/torch_utils.py
@@ -237,7 +237,7 @@ def convert_to_torch_tensor(
     device: Optional[str] = None,
     pin_memory: bool = False,
     use_stream: bool = False,
-    stream: Optional["torch.cuda.Stream"] = None,
+    stream: Optional[Union["torch.cuda.Stream", "torch.cuda.classes.Stream"]] = None,
 ):
     """
     Converts any (possibly nested) structure to torch.Tensors.


### PR DESCRIPTION
## Why are these changes needed?

Separate CUDA streams can bring in some scenarios (like H2D memcopies) performance gains. This PR enables the option to use separate streams in `convert_to_torch_tensor`, `SampleBatch.to_device`, and `MultiAgentBatch.to_device`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
