### PR TITLE
[serve] Properly propagate backpressure error

### DIFF
--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -81,7 +81,11 @@ from ray.serve._private.utils import parse_import_path
 from ray.serve._private.version import DeploymentVersion
 from ray.serve.config import AutoscalingConfig
 from ray.serve.deployment import Deployment
-from ray.serve.exceptions import RayServeException
+from ray.serve.exceptions import (
+    BackPressureError,
+    DeploymentUnavailableError,
+    RayServeException,
+)
 from ray.serve.schema import LoggingConfig
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
@@ -1623,7 +1627,10 @@ class UserCallableWrapper:
                 receive_task.cancel()
 
             return final_result
-        except Exception:
+        except Exception as e:
+            unavailable_error = isinstance(
+                e, (BackPressureError, DeploymentUnavailableError)
+            )
             if (
                 request_metadata.is_http_request
                 and asgi_args is not None
@@ -1631,12 +1638,15 @@ class UserCallableWrapper:
                 # If the callable is an ASGI app, it already sent a 500 status response.
                 and not user_method_info.is_asgi_app
             ):
-                await self._send_user_result_over_asgi(
-                    starlette.responses.Response(
+                response = (
+                    starlette.responses.Response(e.message, status_code=503)
+                    if unavailable_error
+                    else starlette.responses.Response(
                         "Internal Server Error", status_code=500
-                    ),
-                    asgi_args,
+                    )
                 )
+                logger.info(f"sending {response} from replica")
+                await self._send_user_result_over_asgi(response, asgi_args)
 
             if receive_task is not None and not receive_task.done():
                 receive_task.cancel()

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1645,7 +1645,6 @@ class UserCallableWrapper:
                         "Internal Server Error", status_code=500
                     )
                 )
-                logger.info(f"sending {response} from replica")
                 await self._send_user_result_over_asgi(response, asgi_args)
 
             if receive_task is not None and not receive_task.done():

--- a/python/ray/serve/exceptions.py
+++ b/python/ray/serve/exceptions.py
@@ -14,13 +14,17 @@ class RayServeException(Exception):
 class BackPressureError(RayServeException):
     """Raised when max_queued_requests is exceeded on a DeploymentHandle."""
 
-    def __init__(self, *, num_queued_requests: int, max_queued_requests: int):
+    def __init__(self, num_queued_requests: int, max_queued_requests: int):
+        super().__init__(num_queued_requests, max_queued_requests)
         self._message = (
             f"Request dropped due to backpressure "
             f"(num_queued_requests={num_queued_requests}, "
             f"max_queued_requests={max_queued_requests})."
         )
-        super().__init__(self._message)
+        # super().__init__(self._message)
+
+    def __str__(self) -> str:
+        return self._message
 
     @property
     def message(self) -> str:

--- a/python/ray/serve/exceptions.py
+++ b/python/ray/serve/exceptions.py
@@ -21,7 +21,6 @@ class BackPressureError(RayServeException):
             f"(num_queued_requests={num_queued_requests}, "
             f"max_queued_requests={max_queued_requests})."
         )
-        # super().__init__(self._message)
 
     def __str__(self) -> str:
         return self._message

--- a/python/ray/serve/tests/BUILD
+++ b/python/ray/serve/tests/BUILD
@@ -26,7 +26,7 @@ py_test_module_list(
         "test_deployment_version.py",
         "test_expected_versions.py",
         "test_http_cancellation.py",
-        "test_max_queued_requests.py",
+        "test_backpressure.py",
         "test_persistence.py",
         "test_proxy.py",
         "test_proxy_actor_wrapper.py",

--- a/python/ray/serve/tests/test_backpressure.py
+++ b/python/ray/serve/tests/test_backpressure.py
@@ -1,5 +1,3 @@
-import asyncio
-import pickle
 import sys
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from typing import Tuple
@@ -12,8 +10,7 @@ from starlette.requests import Request
 import ray
 from ray import serve
 from ray._private.test_utils import SignalActor, wait_for_condition
-from ray.exceptions import RayTaskError
-from ray.serve.exceptions import BackPressureError, RayServeException
+from ray.serve.exceptions import BackPressureError
 from ray.serve.generated import serve_pb2, serve_pb2_grpc
 
 


### PR DESCRIPTION
## Why are these changes needed?

If a downstream Serve deployment raises backpressure error, it wasn't properly propagated up the chain and back from the proxy. There are multiple issues here:

1. pickle doesn't play nice with:
  a. Exceptions
  b. Classes that require keyword arguments with `*`.
This was causing errors like `TypeError: __init__() takes 1 positional argument but 2 were given`.

2. Even if the pickle issue is fixed, and a replica is raising the `BackPressureError` correctly, it's not correctly sent back as 503 from the proxy. The root issues here are:
  a. We're sending 500 error code ASGI messages back from the replica (which is incorrect, we should be sending 503)
  b. We are catching the replica's backpressure error in the proxy, and handling it _as if the proxy's deployment handle raise a backpressure error_, aka sending a new set of ASGI messages. This causes `RuntimeError: Unexpected ASGI message 'http.response.start' sent, after response already completed.` errors because we are sending multiple sets of {`http.response.start`, `http.response.body`} messages.

This PR fixes all of these issues and adds a test.

## Related issue number

closes https://github.com/ray-project/ray/issues/50211