### PR TITLE
[core] mark failing workflow tests are manual

### DIFF
--- a/python/ray/workflow/BUILD
+++ b/python/ray/workflow/BUILD
@@ -31,6 +31,12 @@ LARGE_ALL_CORE_TESTS = [
     "tests/test_events.py",
 ]
 
+# Tests that are failing and need to be fixed.
+# Tagging these tests are "manual" so they are not run by default.
+FAILING_TESTS = [
+    "tests/test_events_with_crash.py",
+]
+
 py_test_module_list(
     size = "medium",
     extra_srcs = SRCS,
@@ -39,10 +45,22 @@ py_test_module_list(
             "tests/test_*.py",
             "examples/**/*.py",
         ],
-        exclude = LARGE_TESTS + LARGE_ALL_CORE_TESTS,
+        exclude = LARGE_TESTS + LARGE_ALL_CORE_TESTS + FAILING_TESTS,
     ),
     tags = [
         "exclusive",
+        "team:core",
+    ],
+    deps = ["//:ray_lib"],
+)
+
+py_test_module_list(
+    size = "medium",
+    extra_srcs = SRCS,
+    files = FAILING_TESTS,
+    tags = [
+        "exclusive",
+        "manual",
         "team:core",
     ],
     deps = ["//:ray_lib"],


### PR DESCRIPTION
so they will not block releases

related issue: https://github.com/ray-project/ray/issues/50193