### PR TITLE
[train v2] Add telemetry for trainer usage

### DIFF
--- a/python/ray/air/_internal/usage.py
+++ b/python/ray/air/_internal/usage.py
@@ -97,7 +97,7 @@ def tag_train_v2_trainer(trainer):
 
     assert isinstance(trainer, DataParallelTrainer)
     trainer_name = _find_class_name(trainer, "ray.train", AIR_TRAINERS)
-    record_extra_usage_tag(TagKey.AIR_TRAINER, trainer_name)
+    record_extra_usage_tag(TagKey.TRAIN_ENTRYPOINT, trainer_name)
 
 
 def tag_searcher(searcher: Union["BasicVariantGenerator", "Searcher"]):

--- a/python/ray/air/_internal/usage.py
+++ b/python/ray/air/_internal/usage.py
@@ -92,6 +92,14 @@ def tag_air_trainer(trainer: "BaseTrainer"):
     record_extra_usage_tag(TagKey.AIR_TRAINER, trainer_name)
 
 
+def tag_train_v2_trainer(trainer):
+    from ray.train.v2.api.data_parallel_trainer import DataParallelTrainer
+
+    assert isinstance(trainer, DataParallelTrainer)
+    trainer_name = _find_class_name(trainer, "ray.train", AIR_TRAINERS)
+    record_extra_usage_tag(TagKey.AIR_TRAINER, trainer_name)
+
+
 def tag_searcher(searcher: Union["BasicVariantGenerator", "Searcher"]):
     from ray.tune.search import BasicVariantGenerator, Searcher
 

--- a/python/ray/air/_internal/usage.py
+++ b/python/ray/air/_internal/usage.py
@@ -22,6 +22,14 @@ AIR_TRAINERS = {
     "XGBoostTrainer",
 }
 
+TRAIN_V2_TRAINERS = {
+    "DataParallelTrainer",
+    "LightGBMTrainer",
+    "TensorflowTrainer",
+    "TorchTrainer",
+    "XGBoostTrainer",
+}
+
 # searchers implemented by Ray Tune.
 TUNE_SEARCHERS = {
     "AxSearch",
@@ -96,8 +104,8 @@ def tag_train_v2_trainer(trainer):
     from ray.train.v2.api.data_parallel_trainer import DataParallelTrainer
 
     assert isinstance(trainer, DataParallelTrainer)
-    trainer_name = _find_class_name(trainer, "ray.train", AIR_TRAINERS)
-    record_extra_usage_tag(TagKey.TRAIN_ENTRYPOINT, trainer_name)
+    trainer_name = _find_class_name(trainer, "ray.train", TRAIN_V2_TRAINERS)
+    record_extra_usage_tag(TagKey.TRAIN_TRAINER, trainer_name)
 
 
 def tag_searcher(searcher: Union["BasicVariantGenerator", "Searcher"]):

--- a/python/ray/air/tests/test_air_usage.py
+++ b/python/ray/air/tests/test_air_usage.py
@@ -203,6 +203,27 @@ def test_tag_air_entrypoint(ray_start_4_cpus, mock_record, entrypoint, tuner, tr
     assert mock_record[TagKey.AIR_ENTRYPOINT] == entrypoint.value
 
 
+def test_tag_train_entrypoint(mock_record):
+    """Test that Train v2 entrypoints are recorded correctly."""
+    from ray.train.v2.torch.torch_trainer import TorchTrainer
+    from ray.train.v2.tensorflow.tensorflow_trainer import TensorflowTrainer
+    from ray.train.v2.xgboost.xgboost_trainer import XGBoostTrainer
+    from ray.train.v2.lightgbm.lightgbm_trainer import LightGBMTrainer
+
+    trainer_classes = [
+        TorchTrainer,
+        TensorflowTrainer,
+        XGBoostTrainer,
+        LightGBMTrainer,
+    ]
+    for trainer_cls in trainer_classes:
+        trainer = trainer_cls(
+            train_loop_per_worker=train_fn,
+            scaling_config=train.ScalingConfig(num_workers=2),
+        )
+        assert mock_record[TagKey.TRAIN_ENTRYPOINT] == trainer.__class__.__name__
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/air/tests/test_air_usage.py
+++ b/python/ray/air/tests/test_air_usage.py
@@ -221,7 +221,7 @@ def test_tag_train_entrypoint(mock_record):
             train_loop_per_worker=train_fn,
             scaling_config=train.ScalingConfig(num_workers=2),
         )
-        assert mock_record[TagKey.TRAIN_ENTRYPOINT] == trainer.__class__.__name__
+        assert mock_record[TagKey.TRAIN_TRAINER] == trainer.__class__.__name__
 
 
 if __name__ == "__main__":

--- a/python/ray/train/v2/api/data_parallel_trainer.py
+++ b/python/ray/train/v2/api/data_parallel_trainer.py
@@ -83,6 +83,8 @@ class DataParallelTrainer:
         if metadata is not None:
             raise DeprecationWarning(_GET_METADATA_DEPRECATION_MESSAGE)
 
+        tag_train_v2_trainer(self)
+
     def fit(self) -> Result:
         """Launches the Ray Train controller to run training on workers.
 
@@ -94,8 +96,6 @@ class DataParallelTrainer:
                 and the number of retries configured in `FailureConfig`
                 is exhausted.
         """
-        tag_train_v2_trainer(self)
-
         train_fn = construct_train_func(
             self.train_loop_per_worker,
             config=self.train_loop_config,

--- a/python/ray/train/v2/api/data_parallel_trainer.py
+++ b/python/ray/train/v2/api/data_parallel_trainer.py
@@ -1,8 +1,9 @@
 import logging
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import ray
 from ray._private.ray_constants import env_bool
+from ray.air._internal.usage import tag_train_v2_trainer
 from ray.train import BackendConfig, Checkpoint
 from ray.train._internal.data_config import DataConfig
 from ray.train.base_trainer import (
@@ -29,6 +30,7 @@ from ray.train.v2._internal.constants import (
     RUN_CONTROLLER_AS_ACTOR_ENV_VAR,
     get_env_vars_to_propagate,
 )
+from ray.train.v2._internal.execution.callback import RayTrainCallback
 from ray.train.v2._internal.execution.context import TrainRunContext
 from ray.train.v2._internal.execution.controller import TrainController
 from ray.train.v2._internal.execution.failure_handling import DefaultFailurePolicy
@@ -45,6 +47,13 @@ logger = logging.getLogger(__name__)
 
 @DeveloperAPI
 class DataParallelTrainer:
+    """Base class for distributed data parallel training on Ray.
+
+    This class supports the SPMD parallelization pattern, where a single
+    training function is executed in parallel across multiple workers,
+    and different shards of data are processed by each worker.
+    """
+
     def __init__(
         self,
         train_loop_per_worker: Union[Callable[[], None], Callable[[Dict], None]],
@@ -75,6 +84,18 @@ class DataParallelTrainer:
             raise DeprecationWarning(_GET_METADATA_DEPRECATION_MESSAGE)
 
     def fit(self) -> Result:
+        """Launches the Ray Train controller to run training on workers.
+
+        Returns:
+            A Result object containing the training result.
+
+        Raises:
+            TrainingFailedError: If any failures occur during training
+                and the number of retries configured in `FailureConfig`
+                is exhausted.
+        """
+        tag_train_v2_trainer(self)
+
         train_fn = construct_train_func(
             self.train_loop_per_worker,
             config=self.train_loop_config,
@@ -82,6 +103,25 @@ class DataParallelTrainer:
             fn_arg_name="train_loop_per_worker",
         )
 
+        result = self._initialize_and_run_controller(
+            train_fn=train_fn,
+            scaling_policy=create_scaling_policy(self.scaling_config),
+            failure_policy=DefaultFailurePolicy(self.run_config.failure_config),
+            train_run_context=self.train_run_context,
+            callbacks=self._create_default_callbacks(),
+        )
+
+        if result.error:
+            # NOTE: If the training run errored out, raise an error back to the
+            # user's driver script.
+            # For example, if the Train `FailurePolicy` runs out of retries,
+            # and one of the workers errors. The controller will exit, and
+            # the error will be raised here.
+            raise result.error
+
+        return result
+
+    def _create_default_callbacks(self) -> List[RayTrainCallback]:
         accelerator_setup_callback = AcceleratorSetupCallback(
             self.backend_config, self.scaling_config
         )
@@ -119,24 +159,7 @@ class DataParallelTrainer:
         callbacks.extend(
             [cb for cb in self.run_config.callbacks if not isinstance(cb, UserCallback)]
         )
-
-        result = self._initialize_and_run_controller(
-            train_fn=train_fn,
-            scaling_policy=create_scaling_policy(self.scaling_config),
-            failure_policy=DefaultFailurePolicy(self.run_config.failure_config),
-            train_run_context=self.train_run_context,
-            callbacks=callbacks,
-        )
-
-        if result.error:
-            # NOTE: If the training run errored out, raise an error back to the
-            # user's driver script.
-            # For example, if the Train `FailurePolicy` runs out of retries,
-            # and one of the workers errors. The controller will exit, and
-            # the error will be raised here.
-            raise result.error
-
-        return result
+        return callbacks
 
     def _initialize_and_run_controller(self, **controller_init_kwargs) -> Result:
         run_controller_as_actor = env_bool(

--- a/src/ray/protobuf/usage.proto
+++ b/src/ray/protobuf/usage.proto
@@ -185,7 +185,7 @@ enum TagKey {
   // One of: "Trainer.fit", "Tuner.fit", "tune.run", "tune.run_experiments"
   AIR_ENTRYPOINT = 508;
 
-  // Train Utilities
+  // Train
   TRAIN_TORCH_GET_DEVICE = 509;
   TRAIN_TORCH_PREPARE_MODEL = 510;
   TRAIN_TORCH_PREPARE_DATALOADER = 511;
@@ -198,4 +198,7 @@ enum TagKey {
   TRAIN_TRANSFORMERS_PREPARE_TRAINER = 518;
   TRAIN_TRANSFORMERS_RAYTRAINREPORTCALLBACK = 519;
   TRAIN_TORCH_GET_DEVICES = 520;
+
+  // Train V2 Trainer name (e.g. "TorchTrainer")
+  TRAIN_ENTRYPOINT = 521;
 }

--- a/src/ray/protobuf/usage.proto
+++ b/src/ray/protobuf/usage.proto
@@ -200,5 +200,5 @@ enum TagKey {
   TRAIN_TORCH_GET_DEVICES = 520;
 
   // Train V2 Trainer name (e.g. "TorchTrainer")
-  TRAIN_ENTRYPOINT = 521;
+  TRAIN_TRAINER = 521;
 }


### PR DESCRIPTION
## Summary

Track Train V2 trainer usage telemetry. This is tracked separately from v1 trainer usage, and this is so that we can track the progress of OSS migration.