### PR TITLE
[Data] Persist ParquetDatasource metadata.

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -199,9 +199,10 @@ class ParquetDatasource(Datasource):
                 ray.get_runtime_context().get_node_id(), soft=False
             )
 
-        paths, filesystem = _resolve_paths_and_filesystem(paths, filesystem)
+        self._unresolved_paths = paths
+        paths, self._filesystem = _resolve_paths_and_filesystem(paths, filesystem)
         filesystem = RetryingPyFileSystem.wrap(
-            filesystem, context=DataContext.get_current()
+            self._filesystem, context=DataContext.get_current()
         )
 
         # HACK: PyArrow's `ParquetDataset` errors if input paths contain non-parquet


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The `ParquetDatasource` currently does not persist information about the filesystem and unresolved paths, unlike the `FileBasedDatasource`. This PR aims to achieve greater coverage in collecting metadata about input data used in Ray by allowing `ParquetDatasource` to persist this information.


## Changes implemented
* Added functionality to persist filesystem and unresolved path information for `ParquetDatasource`
* Aligned `ParquetDatasource` behavior with `FileBasedDatasource` for consistency
* Enhanced metadata collection for input data used in Ray

### Benefits
* Improved data traceability and reproducibility
* Consistent behavior across datasource implementations
* Enhanced debugging and analysis capabilities

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
