### PR TITLE
[core] De-glob all cc targets

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -240,9 +240,7 @@ cc_grpc_library(
 # worker server and client.
 ray_cc_library(
     name = "worker_rpc",
-    srcs = [
-        "src/ray/rpc/worker/core_worker_client_pool.cc",
-    ],
+    srcs = ["src/ray/rpc/worker/core_worker_client_pool.cc"],
     hdrs = [
         "src/ray/rpc/worker/core_worker_client.h",
         "src/ray/rpc/worker/core_worker_client_pool.h",
@@ -675,20 +673,49 @@ ray_cc_library(
 
 ray_cc_library(
     name = "scheduler",
-    srcs = glob(
-        [
-            "src/ray/raylet/scheduling/**/*.cc",
-        ],
-        exclude = [
-            "src/ray/raylet/scheduling/**/*_test.cc",
-        ],
-    ),
-    hdrs = glob(
-        [
-            "src/ray/raylet/scheduling/**/*.h",
-            "src/ray/core_worker/common.h",
-        ],
-    ),
+    srcs = [
+        "src/ray/raylet/scheduling/cluster_resource_manager.cc",
+        "src/ray/raylet/scheduling/cluster_resource_scheduler.cc",
+        "src/ray/raylet/scheduling/cluster_task_manager.cc",
+        "src/ray/raylet/scheduling/local_resource_manager.cc",
+        "src/ray/raylet/scheduling/policy/affinity_with_bundle_scheduling_policy.cc",
+        "src/ray/raylet/scheduling/policy/bundle_scheduling_policy.cc",
+        "src/ray/raylet/scheduling/policy/composite_scheduling_policy.cc",
+        "src/ray/raylet/scheduling/policy/hybrid_scheduling_policy.cc",
+        "src/ray/raylet/scheduling/policy/node_affinity_scheduling_policy.cc",
+        "src/ray/raylet/scheduling/policy/node_label_scheduling_policy.cc",
+        "src/ray/raylet/scheduling/policy/random_scheduling_policy.cc",
+        "src/ray/raylet/scheduling/policy/scorer.cc",
+        "src/ray/raylet/scheduling/policy/spread_scheduling_policy.cc",
+        "src/ray/raylet/scheduling/scheduler_resource_reporter.cc",
+        "src/ray/raylet/scheduling/scheduler_stats.cc",
+        "src/ray/raylet/scheduling/scheduling_policy.cc",
+    ],
+    hdrs = [
+        "src/ray/core_worker/common.h",
+        "src/ray/raylet/scheduling/cluster_resource_manager.h",
+        "src/ray/raylet/scheduling/cluster_resource_scheduler.h",
+        "src/ray/raylet/scheduling/cluster_task_manager.h",
+        "src/ray/raylet/scheduling/cluster_task_manager_interface.h",
+        "src/ray/raylet/scheduling/internal.h",
+        "src/ray/raylet/scheduling/local_resource_manager.h",
+        "src/ray/raylet/scheduling/local_task_manager_interface.h",
+        "src/ray/raylet/scheduling/policy/affinity_with_bundle_scheduling_policy.h",
+        "src/ray/raylet/scheduling/policy/bundle_scheduling_policy.h",
+        "src/ray/raylet/scheduling/policy/composite_scheduling_policy.h",
+        "src/ray/raylet/scheduling/policy/hybrid_scheduling_policy.h",
+        "src/ray/raylet/scheduling/policy/node_affinity_scheduling_policy.h",
+        "src/ray/raylet/scheduling/policy/node_label_scheduling_policy.h",
+        "src/ray/raylet/scheduling/policy/random_scheduling_policy.h",
+        "src/ray/raylet/scheduling/policy/scheduling_context.h",
+        "src/ray/raylet/scheduling/policy/scheduling_options.h",
+        "src/ray/raylet/scheduling/policy/scheduling_policy.h",
+        "src/ray/raylet/scheduling/policy/scorer.h",
+        "src/ray/raylet/scheduling/policy/spread_scheduling_policy.h",
+        "src/ray/raylet/scheduling/scheduler_resource_reporter.h",
+        "src/ray/raylet/scheduling/scheduler_stats.h",
+        "src/ray/raylet/scheduling/scheduling_policy.h",
+    ],
     linkopts = select({
         "@platforms//os:windows": [
         ],
@@ -796,12 +823,14 @@ ray_cc_library(
 
 ray_cc_library(
     name = "raylet_client_lib",
-    srcs = glob([
-        "src/ray/raylet_client/*.cc",
-    ]),
-    hdrs = glob([
-        "src/ray/raylet_client/*.h",
-    ]),
+    srcs = [
+        "src/ray/raylet_client/raylet_client.cc",
+        "src/ray/raylet_client/raylet_connection.cc",
+    ],
+    hdrs = [
+        "src/ray/raylet_client/raylet_client.h",
+        "src/ray/raylet_client/raylet_connection.h",
+    ],
     linkopts = select({
         "@platforms//os:windows": [
         ],
@@ -821,23 +850,72 @@ ray_cc_library(
 
 ray_cc_library(
     name = "core_worker_lib",
-    srcs = glob(
-        [
-            "src/ray/core_worker/*.cc",
-            "src/ray/core_worker/store_provider/*.cc",
-            "src/ray/core_worker/store_provider/memory_store/*.cc",
-            "src/ray/core_worker/transport/*.cc",
-        ],
-        exclude = [
-            "src/ray/core_worker/**/*_test.cc",
-        ],
-    ),
-    hdrs = glob([
-        "src/ray/core_worker/*.h",
-        "src/ray/core_worker/store_provider/*.h",
-        "src/ray/core_worker/store_provider/memory_store/*.h",
-        "src/ray/core_worker/transport/*.h",
-    ]),
+    srcs = [
+        "src/ray/core_worker/actor_handle.cc", "src/ray/core_worker/actor_manager.cc",
+        "src/ray/core_worker/common.cc",
+        "src/ray/core_worker/context.cc", "src/ray/core_worker/core_worker.cc",
+        "src/ray/core_worker/core_worker_process.cc",
+        "src/ray/core_worker/experimental_mutable_object_manager.cc",
+        "src/ray/core_worker/experimental_mutable_object_provider.cc",
+        "src/ray/core_worker/future_resolver.cc",
+        "src/ray/core_worker/generator_waiter.cc",
+        "src/ray/core_worker/lease_policy.cc",
+        "src/ray/core_worker/object_recovery_manager.cc",
+        "src/ray/core_worker/profile_event.cc",
+        "src/ray/core_worker/reference_count.cc",
+        "src/ray/core_worker/store_provider/memory_store/memory_store.cc",
+        "src/ray/core_worker/store_provider/plasma_store_provider.cc",
+        "src/ray/core_worker/task_event_buffer.cc", "src/ray/core_worker/task_manager.cc",
+        "src/ray/core_worker/transport/actor_scheduling_queue.cc",
+        "src/ray/core_worker/transport/actor_task_submitter.cc",
+        "src/ray/core_worker/transport/concurrency_group_manager.cc",
+        "src/ray/core_worker/transport/dependency_resolver.cc",
+        "src/ray/core_worker/transport/normal_scheduling_queue.cc",
+        "src/ray/core_worker/transport/normal_task_submitter.cc",
+        "src/ray/core_worker/transport/out_of_order_actor_scheduling_queue.cc",
+        "src/ray/core_worker/transport/out_of_order_actor_submit_queue.cc",
+        "src/ray/core_worker/transport/scheduling_util.cc",
+        "src/ray/core_worker/transport/sequential_actor_submit_queue.cc",
+        "src/ray/core_worker/transport/task_receiver.cc",
+        "src/ray/core_worker/transport/thread_pool.cc",
+    ],
+    hdrs = [
+        "src/ray/core_worker/actor_creator.h",
+        "src/ray/core_worker/actor_handle.h",
+        "src/ray/core_worker/actor_manager.h",
+        "src/ray/core_worker/common.h",
+        "src/ray/core_worker/context.h",
+        "src/ray/core_worker/core_worker.h",
+        "src/ray/core_worker/core_worker_options.h",
+        "src/ray/core_worker/core_worker_process.h",
+        "src/ray/core_worker/experimental_mutable_object_manager.h",
+        "src/ray/core_worker/experimental_mutable_object_provider.h",
+        "src/ray/core_worker/fiber.h",
+        "src/ray/core_worker/future_resolver.h",
+        "src/ray/core_worker/generator_waiter.h",
+        "src/ray/core_worker/lease_policy.h",
+        "src/ray/core_worker/object_recovery_manager.h",
+        "src/ray/core_worker/profile_event.h",
+        "src/ray/core_worker/reference_count.h",
+        "src/ray/core_worker/store_provider/memory_store/memory_store.h",
+        "src/ray/core_worker/store_provider/plasma_store_provider.h",
+        "src/ray/core_worker/task_event_buffer.h",
+        "src/ray/core_worker/task_manager.h",
+        "src/ray/core_worker/transport/actor_scheduling_queue.h",
+        "src/ray/core_worker/transport/actor_submit_queue.h",
+        "src/ray/core_worker/transport/actor_task_submitter.h",
+        "src/ray/core_worker/transport/concurrency_group_manager.h",
+        "src/ray/core_worker/transport/dependency_resolver.h",
+        "src/ray/core_worker/transport/normal_scheduling_queue.h",
+        "src/ray/core_worker/transport/normal_task_submitter.h",
+        "src/ray/core_worker/transport/out_of_order_actor_scheduling_queue.h",
+        "src/ray/core_worker/transport/out_of_order_actor_submit_queue.h",
+        "src/ray/core_worker/transport/scheduling_queue.h",
+        "src/ray/core_worker/transport/scheduling_util.h",
+        "src/ray/core_worker/transport/sequential_actor_submit_queue.h",
+        "src/ray/core_worker/transport/task_receiver.h",
+        "src/ray/core_worker/transport/thread_pool.h",
+    ],
     deps = [
         ":gcs",
         ":gcs_client_lib",
@@ -2424,17 +2502,19 @@ ray_cc_test(
 
 ray_cc_library(
     name = "gcs",
-    srcs = glob(
-        [
-            "src/ray/gcs/*.cc",
-        ],
-        exclude = [
-            "src/ray/gcs/*_test.cc",
-        ],
-    ),
-    hdrs = glob([
-        "src/ray/gcs/*.h",
-    ]),
+    srcs = [
+        "//:src/ray/gcs/pb_utils.cc",
+        "//:src/ray/gcs/redis_async_context.cc",
+        "//:src/ray/gcs/redis_client.cc",
+        "//:src/ray/gcs/redis_context.cc",
+    ],
+    hdrs = [
+        "//:src/ray/gcs/callback.h",
+        "//:src/ray/gcs/pb_util.h",
+        "//:src/ray/gcs/redis_async_context.h",
+        "//:src/ray/gcs/redis_client.h",
+        "//:src/ray/gcs/redis_context.h",
+    ],
     deps = [
         ":hiredis",
         ":node_manager_fbs",


### PR DESCRIPTION
Followup PR for https://github.com/ray-project/ray/pull/50243, which deglobs ALL cc targets.

I will followup with other PRs to split targets:
- Place CC targets under certain directory
- Split one giant targets into smaller ones