### PR TITLE
[core] Implement get or create for lru cache

### DIFF
--- a/release/benchmarks/distributed/test_many_tasks.py
+++ b/release/benchmarks/distributed/test_many_tasks.py
@@ -18,7 +18,7 @@ sleep_time = 300
 def test_max_running_tasks(num_tasks):
     cpus_per_task = 0.25
 
-    @ray.remote(num_cpus=cpus_per_task)
+    @ray.remote(num_cpus=cpus_per_task, runtime_env={"env_vars": {"FOO": "bar"}})
     def task():
         time.sleep(sleep_time)
 

--- a/release/benchmarks/distributed/test_many_tasks.py
+++ b/release/benchmarks/distributed/test_many_tasks.py
@@ -18,7 +18,7 @@ sleep_time = 300
 def test_max_running_tasks(num_tasks):
     cpus_per_task = 0.25
 
-    @ray.remote(num_cpus=cpus_per_task, runtime_env={"env_vars": {"FOO": "bar"}})
+    @ray.remote(num_cpus=cpus_per_task)
     def task():
         time.sleep(sleep_time)
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2308,19 +2308,22 @@ json CoreWorker::OverrideRuntimeEnv(const json &child,
   return result_runtime_env;
 }
 
+std::shared_ptr<rpc::RuntimeEnvInfo> CoreWorker::OverrideTaskOrActorRuntimeEnvInfo(
+    const std::string &serialized_runtime_env_info) const {
+  auto factory = [this](const std::string &serialized_runtime_env_info) {
+    return OverrideTaskOrActorRuntimeEnvInfoImpl(serialized_runtime_env_info);
+  };
+  return runtime_env_json_serialization_cache_.GetOrCreate(serialized_runtime_env_info,
+                                                           std::move(factory));
+}
+
 // TODO(hjiang): Current implementation is not the most ideal version, since it acquires a
 // global lock for all operations; it's acceptable for now since no heavy-lifted operation
 // is involved (considering the overall scheduling overhead is single-digit millisecond
 // magnitude). But a better solution is LRU cache native providing a native support for
 // sharding and `GetOrCreate` API.
-std::shared_ptr<rpc::RuntimeEnvInfo> CoreWorker::OverrideTaskOrActorRuntimeEnvInfo(
+std::shared_ptr<rpc::RuntimeEnvInfo> CoreWorker::OverrideTaskOrActorRuntimeEnvInfoImpl(
     const std::string &serialized_runtime_env_info) const {
-  if (auto cached_runtime_env_info =
-          runtime_env_json_serialization_cache_.Get(serialized_runtime_env_info);
-      cached_runtime_env_info != nullptr) {
-    return cached_runtime_env_info;
-  }
-
   // TODO(Catch-Bull,SongGuyang): task runtime env not support the field eager_install
   // yet, we will overwrite the filed eager_install when it did.
   std::shared_ptr<json> parent = nullptr;

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2317,11 +2317,6 @@ std::shared_ptr<rpc::RuntimeEnvInfo> CoreWorker::OverrideTaskOrActorRuntimeEnvIn
                                                            std::move(factory));
 }
 
-// TODO(hjiang): Current implementation is not the most ideal version, since it acquires a
-// global lock for all operations; it's acceptable for now since no heavy-lifted operation
-// is involved (considering the overall scheduling overhead is single-digit millisecond
-// magnitude). But a better solution is LRU cache native providing a native support for
-// sharding and `GetOrCreate` API.
 std::shared_ptr<rpc::RuntimeEnvInfo> CoreWorker::OverrideTaskOrActorRuntimeEnvInfoImpl(
     const std::string &serialized_runtime_env_info) const {
   // TODO(Catch-Bull,SongGuyang): task runtime env not support the field eager_install

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1384,6 +1384,9 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   std::shared_ptr<rpc::RuntimeEnvInfo> OverrideTaskOrActorRuntimeEnvInfo(
       const std::string &serialized_runtime_env_info) const;
 
+  std::shared_ptr<rpc::RuntimeEnvInfo> OverrideTaskOrActorRuntimeEnvInfoImpl(
+      const std::string &serialized_runtime_env_info) const;
+
   void BuildCommonTaskSpec(
       TaskSpecBuilder &builder,
       const JobID &job_id,

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1384,6 +1384,8 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   std::shared_ptr<rpc::RuntimeEnvInfo> OverrideTaskOrActorRuntimeEnvInfo(
       const std::string &serialized_runtime_env_info) const;
 
+  // Used as the factory function for [OverrideTaskOrActorRuntimeEnvInfo] to create in LRU
+  // cache.
   std::shared_ptr<rpc::RuntimeEnvInfo> OverrideTaskOrActorRuntimeEnvInfoImpl(
       const std::string &serialized_runtime_env_info) const;
 

--- a/src/ray/util/shared_lru.h
+++ b/src/ray/util/shared_lru.h
@@ -199,8 +199,8 @@ class ThreadSafeSharedLruCache final {
   // WARNING: Currently factory cannot have exception thrown.
   // TODO(hjiang): [factory] should support template.
   template <typename KeyLike>
-  std::shared_ptr<Val> GetOrCreate(KeyLike &&key,
-                                   std::function<std::shared_ptr<Val>(Key)> factory) {
+  std::shared_ptr<Val> GetOrCreate(
+      KeyLike &&key, std::function<std::shared_ptr<Val>(const Key &)> factory) {
     std::shared_ptr<CreationToken> creation_token;
 
     {
@@ -222,13 +222,12 @@ class ThreadSafeSharedLruCache final {
         });
 
         // Creation finished.
-        auto val = creation_token->val;
         --creation_token->count;
         if (creation_token->count == 0) {
           // [creation_iter] could be invalidated here due to new insertion/deletion.
           ongoing_creation_.erase(key);
         }
-        return val;
+        return creation_token->val;
       }
 
       // Current thread is the first one to request for the key-value pair, perform

--- a/src/ray/util/shared_lru.h
+++ b/src/ray/util/shared_lru.h
@@ -27,11 +27,11 @@
 // // Check and consume `val`.
 //
 // TODO(hjiang):
-// 1. Add a `GetOrCreate` interface, which takes factory function to creation value.
-// 2. For thread-safe cache, add a sharded container wrapper to reduce lock contention.
+// For thread-safe cache, add a sharded container wrapper to reduce lock contention.
 
 #pragma once
 
+#include <condition_variable>
 #include <cstdint>
 #include <list>
 #include <memory>
@@ -194,6 +194,69 @@ class ThreadSafeSharedLruCache final {
     return cache_.Get(std::forward<KeyLike>(key));
   }
 
+  // Get or creation for cached key-value pairs.
+  //
+  // WARNING: Currently factory cannot have exception thrown.
+  // TODO(hjiang): [factory] should support template.
+  template <typename KeyLike>
+  std::shared_ptr<Val> GetOrCreate(KeyLike &&key,
+                                   std::function<std::shared_ptr<Val>(Key)> factory) {
+    std::shared_ptr<CreationToken> creation_token;
+
+    {
+      std::unique_lock lck(mu_);
+      auto cached_val = cache_.Get(key);
+      if (cached_val != nullptr) {
+        return cached_val;
+      }
+
+      auto creation_iter = ongoing_creation_.find(key);
+
+      // Another thread has requested for the same key-value pair, simply wait for its
+      // completion.
+      if (creation_iter != ongoing_creation_.end()) {
+        creation_token = creation_iter->second;
+        ++creation_token->count;
+        creation_token->cv.wait(lck, [creation_token = creation_token.get()]() {
+          return creation_token->val != nullptr;
+        });
+
+        // Creation finished.
+        auto val = creation_token->val;
+        --creation_token->count;
+        if (creation_token->count == 0) {
+          // [creation_iter] could be invalidated here due to new insertion/deletion.
+          ongoing_creation_.erase(key);
+        }
+        return val;
+      }
+
+      // Current thread is the first one to request for the key-value pair, perform
+      // factory function.
+      creation_iter =
+          ongoing_creation_.emplace(key, std::make_shared<CreationToken>()).first;
+      creation_token = creation_iter->second;
+      creation_token->count = 1;
+    }
+
+    // Place factory out of critical section.
+    std::shared_ptr<Val> val = factory(key);
+
+    {
+      std::lock_guard lck(mu_);
+      cache_.Put(key, val);
+      creation_token->val = val;
+      creation_token->cv.notify_all();
+      int new_count = --creation_token->count;
+      if (new_count == 0) {
+        // [creation_iter] could be invalidated here due to new insertion/deletion.
+        ongoing_creation_.erase(key);
+      }
+    }
+
+    return val;
+  }
+
   // Clear the cache.
   void Clear() {
     std::lock_guard lck(mu_);
@@ -204,8 +267,19 @@ class ThreadSafeSharedLruCache final {
   size_t max_entries() const { return cache_.max_entries(); }
 
  private:
+  struct CreationToken {
+    std::condition_variable cv;
+    // Nullptr indicate creation unfinished.
+    std::shared_ptr<Val> val;
+    // Counter for ongoing creation.
+    int count = 0;
+  };
+
   std::mutex mu_;
   SharedLruCache<Key, Val> cache_;
+
+  // Ongoing creation.
+  absl::flat_hash_map<Key, std::shared_ptr<CreationToken>> ongoing_creation_;
 };
 
 // Same interfaces as `SharedLruCache`, but all cached values are


### PR DESCRIPTION
This PR implements a TODO item on `GetOrCreate` feature for LRU cache (which is suggested by @dayshah before), and apply it to core worker.

The reason to revisit it here is, I found large number of task creation at the beginning meanwhile at roughly the same time leads to unnecessary repeated computation.
But overall this PR is not intended to be an optimization latency wise, just to save possible recomputation.

Performance impact based on `many_tasks` test:
- baseline benchmark: throughput = 387 tasks / second
  + branch: https://github.com/ray-project/ray/pull/50352
  + perf page: https://buildkite.com/ray-project/release/builds/32279
- after this PR: throughput = 399 tasks / second
  + perf page: https://buildkite.com/ray-project/release/builds/32277#0194e4c7-bd88-4669-b8a6-5ffab6fed1c8
