### PR TITLE
[ci] simplify gpu ci base

### DIFF
--- a/ci/docker/base.build.Dockerfile
+++ b/ci/docker/base.build.Dockerfile
@@ -3,14 +3,15 @@ FROM $DOCKER_IMAGE_BASE_TEST
 
 ENV RAY_INSTALL_JAVA=1
 
-RUN apt-get install -y -qq maven openjdk-8-jre openjdk-8-jdk
-
 COPY . .
 
 RUN <<EOF
 #!/bin/bash -i
 
 set -euo pipefail
+
+apt-get update -y
+apt-get install -y -qq maven openjdk-8-jre openjdk-8-jdk
 
 BUILD=1 ./ci/ci.sh init
 

--- a/ci/docker/base.gpu.Dockerfile
+++ b/ci/docker/base.gpu.Dockerfile
@@ -54,7 +54,5 @@ WORKDIR /ray
 COPY . .
 
 RUN bash --login -ie -c '\
-    BUILD=1 ./ci/env/install-dependencies.sh \
-    RLLIB_TESTING=1 TRAIN_TESTING=1 TUNE_TESTING=1 ./ci/env/install-dependencies.sh \
-    pip uninstall -y ray \
+    BUILD=1 SKIP_PYTHON_PACKAGES=1 ./ci/env/install-dependencies.sh \
 '

--- a/ci/docker/base.gpu.py39.wanda.yaml
+++ b/ci/docker/base.gpu.py39.wanda.yaml
@@ -10,23 +10,11 @@ dockerfile: ci/docker/base.gpu.Dockerfile
 srcs:
   - .bazelrc
   - .bazelversion
-  - ci/ci.sh
   - ci/env/install-dependencies.sh
   - ci/env/install-llvm-binaries.sh
   - ci/env/install-bazel.sh
   - ci/env/install-miniconda.sh
   - ci/suppress_output
-  - python/requirements.txt
-  - python/requirements_compiled.txt
-  - python/requirements/test-requirements.txt
-  - python/requirements/ml/rllib-requirements.txt
-  - python/requirements/ml/rllib-test-requirements.txt
-  - python/requirements/ml/train-requirements.txt
-  - python/requirements/ml/train-test-requirements.txt
-  - python/requirements/ml/tune-requirements.txt
-  - python/requirements/ml/tune-test-requirements.txt
-  - python/requirements/ml/dl-cpu-requirements.txt
-  - python/requirements/ml/core-requirements.txt
 build_args:
   - REMOTE_CACHE_URL=$BUILDKITE_BAZEL_CACHE_URL
 tags:

--- a/ci/docker/base.gpu.wanda.yaml
+++ b/ci/docker/base.gpu.wanda.yaml
@@ -4,23 +4,11 @@ dockerfile: ci/docker/base.gpu.Dockerfile
 srcs:
   - .bazelrc
   - .bazelversion
-  - ci/ci.sh
   - ci/env/install-dependencies.sh
   - ci/env/install-llvm-binaries.sh
   - ci/env/install-bazel.sh
   - ci/env/install-miniconda.sh
   - ci/suppress_output
-  - python/requirements.txt
-  - python/requirements_compiled.txt
-  - python/requirements/test-requirements.txt
-  - python/requirements/ml/rllib-requirements.txt
-  - python/requirements/ml/rllib-test-requirements.txt
-  - python/requirements/ml/train-requirements.txt
-  - python/requirements/ml/train-test-requirements.txt
-  - python/requirements/ml/tune-requirements.txt
-  - python/requirements/ml/tune-test-requirements.txt
-  - python/requirements/ml/dl-cpu-requirements.txt
-  - python/requirements/ml/core-requirements.txt
 build_args:
   - REMOTE_CACHE_URL=$BUILDKITE_BAZEL_CACHE_URL
   - PYTHON

--- a/ci/docker/docgpu.build.wanda.yaml
+++ b/ci/docker/docgpu.build.wanda.yaml
@@ -15,5 +15,7 @@ srcs:
   - python/requirements/ml/tune-test-requirements.txt
   - python/requirements/ml/data-requirements.txt
   - python/requirements/ml/data-test-requirements.txt
+  - python/requirements/ml/rllib-requirements.txt
+  - python/requirements/ml/rllib-test-requirements.txt
 tags:
   - cr.ray.io/rayproject/docgpubuild

--- a/ci/docker/llm.build.Dockerfile
+++ b/ci/docker/llm.build.Dockerfile
@@ -14,7 +14,7 @@ RUN <<EOF
 
 set -euo pipefail
 
-MINIMAL_INSTALL=1 ./ci/env/install-dependencies.sh
+SKIP_PYTHON_PACKAGES=1 ./ci/env/install-dependencies.sh
 
 pip install --no-deps -r python/requirements_compiled_rayllm_test_py311.txt
 

--- a/ci/docker/ml.build.Dockerfile
+++ b/ci/docker/ml.build.Dockerfile
@@ -16,6 +16,8 @@ RUN <<EOF
 
 set -euo pipefail
 
+set -x
+
 if [[ "${PYTHON-}" == "3.12" ]]; then
   # hebo and doc test depdencies are not needed for 3.12 test jobs
   TRAIN_TESTING=1 TUNE_TESTING=1 DATA_PROCESSING_TESTING=1 \

--- a/ci/docker/ml.build.wanda.yaml
+++ b/ci/docker/ml.build.wanda.yaml
@@ -17,6 +17,8 @@ srcs:
   - python/requirements/ml/tune-test-requirements.txt
   - python/requirements/ml/data-requirements.txt
   - python/requirements/ml/data-test-requirements.txt
+  - python/requirements/ml/rllib-requirements.txt
+  - python/requirements/ml/rllib-test-requirements.txt
 build_args:
   - DOCKER_IMAGE_BASE_BUILD=$IMAGE_FROM
   - RAYCI_IS_GPU_BUILD

--- a/ci/docker/mllightning2gpu.build.wanda.yaml
+++ b/ci/docker/mllightning2gpu.build.wanda.yaml
@@ -17,6 +17,8 @@ srcs:
   - python/requirements/ml/tune-test-requirements.txt
   - python/requirements/ml/data-requirements.txt
   - python/requirements/ml/data-test-requirements.txt
+  - python/requirements/ml/rllib-requirements.txt
+  - python/requirements/ml/rllib-test-requirements.txt
 build_args:
   - DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/oss-ci-base_gpu
   - RAYCI_IS_GPU_BUILD=true

--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -257,7 +257,7 @@ install_pip_packages() {
     pip install --no-dependencies mlagents==0.28.0
 
     # Install MuJoCo.
-    sudo apt install libosmesa6-dev libgl1-mesa-glx libglfw3 patchelf -y
+    sudo apt-get install -y libosmesa6-dev libgl1-mesa-glx libglfw3 patchelf
     wget https://github.com/google-deepmind/mujoco/releases/download/2.1.1/mujoco-2.1.1-linux-x86_64.tar.gz
     mkdir -p /root/.mujoco
     mv mujoco-2.1.1-linux-x86_64.tar.gz /root/.mujoco/.
@@ -446,7 +446,7 @@ install_dependencies() {
     "${SCRIPT_DIR}"/install-hdfs.sh
   fi
 
-  if [ "${MINIMAL_INSTALL-}" != "1" ]; then
+  if [[ "${MINIMAL_INSTALL:-}" != "1" && "${SKIP_PYTHON_PACKAGES:-}" != "1" ]]; then
     install_pip_packages
   fi
 


### PR DESCRIPTION
stop installing python dependencies; they should be installed in the later layers.
