### PR TITLE
[core] Implement tag based shared pointer factory function

### DIFF
--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -117,7 +117,7 @@ Status ConnectSocketRetry(local_stream_socket &socket,
 std::shared_ptr<ServerConnection> ServerConnection::Create(local_stream_socket &&socket) {
   // C++ limitation: std::make_shared cannot be used because std::shared_ptr cannot invoke
   // protected constructors.
-  std::shared_ptr<ServerConnection> self(new ServerConnection(std::move(socket)));
+  auto self = std::make_shared<ServerConnection>(Tag{}, std::move(socket));
   return self;
 }
 
@@ -421,11 +421,12 @@ std::shared_ptr<ClientConnection> ClientConnection::Create(
     int64_t error_message_type) {
   // C++ limitation: std::make_shared cannot be used because std::shared_ptr cannot invoke
   // protected constructors.
-  std::shared_ptr<ClientConnection> self(new ClientConnection(message_handler,
-                                                              std::move(socket),
-                                                              debug_label,
-                                                              message_type_enum_names,
-                                                              error_message_type));
+  auto self = std::make_shared<ClientConnection>(Tag{},
+                                                 message_handler,
+                                                 std::move(socket),
+                                                 debug_label,
+                                                 message_type_enum_names,
+                                                 error_message_type);
   // Let our manager process our new connection.
   client_handler(*self);
   return self;

--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -115,10 +115,7 @@ Status ConnectSocketRetry(local_stream_socket &socket,
 }
 
 std::shared_ptr<ServerConnection> ServerConnection::Create(local_stream_socket &&socket) {
-  // C++ limitation: std::make_shared cannot be used because std::shared_ptr cannot invoke
-  // protected constructors.
-  auto self = std::make_shared<ServerConnection>(Tag{}, std::move(socket));
-  return self;
+  return std::make_shared<ServerConnection>(Tag{}, std::move(socket));
 }
 
 ServerConnection::ServerConnection(Tag, local_stream_socket &&socket)
@@ -419,8 +416,6 @@ std::shared_ptr<ClientConnection> ClientConnection::Create(
     const std::string &debug_label,
     const std::vector<std::string> &message_type_enum_names,
     int64_t error_message_type) {
-  // C++ limitation: std::make_shared cannot be used because std::shared_ptr cannot invoke
-  // protected constructors.
   auto self = std::make_shared<ClientConnection>(Tag{},
                                                  message_handler,
                                                  std::move(socket),

--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -121,7 +121,7 @@ std::shared_ptr<ServerConnection> ServerConnection::Create(local_stream_socket &
   return self;
 }
 
-ServerConnection::ServerConnection(local_stream_socket &&socket)
+ServerConnection::ServerConnection(Tag, local_stream_socket &&socket)
     : socket_(std::move(socket)),
       async_write_max_messages_(1),
       async_write_queue_(),
@@ -433,6 +433,7 @@ std::shared_ptr<ClientConnection> ClientConnection::Create(
 }
 
 ClientConnection::ClientConnection(
+    Tag,
     MessageHandler &message_handler,
     local_stream_socket &&socket,
     const std::string &debug_label,

--- a/src/ray/common/client_connection.h
+++ b/src/ray/common/client_connection.h
@@ -139,7 +139,8 @@ class ServerConnection : public std::enable_shared_from_this<ServerConnection> {
 
  protected:
   /// A private constructor for a server connection.
-  explicit ServerConnection(local_stream_socket &&socket);
+  explicit ServerConnection(local_stream_socket &&socket)
+      : ServerConnection(Tag{}, std::move(socket)) {}
 
   /// A message that is queued for writing asynchronously.
   struct AsyncWriteBuffer {
@@ -251,7 +252,13 @@ class ClientConnection : public ServerConnection {
                    local_stream_socket &&socket,
                    const std::string &debug_label,
                    const std::vector<std::string> &message_type_enum_names,
-                   int64_t error_message_type);
+                   int64_t error_message_type)
+      : ClientConnection(Tag{},
+                         message_handler,
+                         std::move(socket),
+                         debug_label,
+                         message_type_enum_names,
+                         error_message_type) {}
   /// Process an error from the last operation, then process the  message
   /// header from the client.
   void ProcessMessageHeader(const boost::system::error_code &error);

--- a/src/ray/common/client_connection.h
+++ b/src/ray/common/client_connection.h
@@ -49,6 +49,7 @@ Status ConnectSocketRetry(local_stream_socket &socket,
 /// can be used to write messages synchronously to the server.
 class ServerConnection : public std::enable_shared_from_this<ServerConnection> {
  private:
+  // Tag to allow `make_shared` inside of the class.
   struct Tag {};
 
  public:
@@ -198,6 +199,7 @@ using MessageHandler = std::function<void(
 /// also be used to process messages asynchronously from client.
 class ClientConnection : public ServerConnection {
  private:
+  // Tag to allow `make_shared` inside of the class.
   struct Tag {};
 
  public:

--- a/src/ray/common/client_connection.h
+++ b/src/ray/common/client_connection.h
@@ -48,7 +48,11 @@ Status ConnectSocketRetry(local_stream_socket &socket,
 /// A generic type representing a client connection to a server. This typename
 /// can be used to write messages synchronously to the server.
 class ServerConnection : public std::enable_shared_from_this<ServerConnection> {
+ private:
+  struct Tag {};
+
  public:
+  ServerConnection(Tag, local_stream_socket &&socket);
   ServerConnection(const ServerConnection &) = delete;
   ServerConnection &operator=(const ServerConnection &) = delete;
 
@@ -135,7 +139,7 @@ class ServerConnection : public std::enable_shared_from_this<ServerConnection> {
 
  protected:
   /// A private constructor for a server connection.
-  ServerConnection(local_stream_socket &&socket);
+  explicit ServerConnection(local_stream_socket &&socket);
 
   /// A message that is queued for writing asynchronously.
   struct AsyncWriteBuffer {
@@ -192,8 +196,18 @@ using MessageHandler = std::function<void(
 /// writing messages to the client, like in ServerConnection, this typename can
 /// also be used to process messages asynchronously from client.
 class ClientConnection : public ServerConnection {
+ private:
+  struct Tag {};
+
  public:
   using std::enable_shared_from_this<ServerConnection>::shared_from_this;
+
+  ClientConnection(Tag,
+                   MessageHandler &message_handler,
+                   local_stream_socket &&socket,
+                   const std::string &debug_label,
+                   const std::vector<std::string> &message_type_enum_names,
+                   int64_t error_message_type);
 
   ClientConnection(const ClientConnection &) = delete;
   ClientConnection &operator=(const ClientConnection &) = delete;


### PR DESCRIPTION
This PR leverages tag-based constructor, to avoid using `new` operator to construct shared pointer.

Why `make_shared` is preferred:
- Performance, `make_shared` takes one heap allocation, while `shared_ptr<>(new)` takes 2
- Exception safety (though we don't ensure in ray)
- Reference: effective modern C++ item-21