### PR TITLE
[train] disable tensorflow test for python 3.12+

### DIFF
--- a/python/ray/air/tests/test_air_usage.py
+++ b/python/ray/air/tests/test_air_usage.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import sys
 from unittest.mock import MagicMock, patch
 
 import pyarrow.fs
@@ -203,6 +204,10 @@ def test_tag_air_entrypoint(ray_start_4_cpus, mock_record, entrypoint, tuner, tr
     assert mock_record[TagKey.AIR_ENTRYPOINT] == entrypoint.value
 
 
+@pytest.mark.skipif(
+    sys.version_info.major == 3 and sys.version_info.minor >= 12,
+    reason="Python 3.12+ does not have Tensorflow installed on CI due to dependency conflicts.",
+)
 def test_tag_train_entrypoint(mock_record):
     """Test that Train v2 entrypoints are recorded correctly."""
     from ray.train.v2.torch.torch_trainer import TorchTrainer


### PR DESCRIPTION
tensorflow is not installed in CI environment due to dependency conflicts
