### PR TITLE
[train v2] Expose `WorkerGroupState` to the `ScalingPolicy`

### DIFF
--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -387,10 +387,9 @@ class TrainController:
                     failure_decision, worker_group_status
                 )
             else:
-                scaling_decision = (
-                    self._scaling_policy.make_decision_for_running_worker_group(
-                        worker_group_status
-                    )
+                scaling_decision = self._scaling_policy.make_decision_for_running_worker_group(
+                    worker_group_state=self.get_worker_group().get_worker_group_state(),
+                    worker_group_status=worker_group_status,
                 )
 
                 if isinstance(scaling_decision, ResizeDecision):

--- a/python/ray/train/v2/_internal/execution/scaling_policy/fixed.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/fixed.py
@@ -4,7 +4,10 @@ from ray.train.v2._internal.execution.scaling_policy import (
     ScalingDecision,
     ScalingPolicy,
 )
-from ray.train.v2._internal.execution.worker_group import WorkerGroupPollStatus
+from ray.train.v2._internal.execution.worker_group import (
+    WorkerGroupPollStatus,
+    WorkerGroupState,
+)
 
 
 class FixedScalingPolicy(ScalingPolicy):
@@ -17,6 +20,8 @@ class FixedScalingPolicy(ScalingPolicy):
         )
 
     def make_decision_for_running_worker_group(
-        self, worker_group_status: WorkerGroupPollStatus
+        self,
+        worker_group_state: WorkerGroupState,
+        worker_group_status: WorkerGroupPollStatus,
     ) -> ScalingDecision:
         return NoopDecision()

--- a/python/ray/train/v2/_internal/execution/scaling_policy/scaling_policy.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/scaling_policy.py
@@ -3,7 +3,10 @@ from dataclasses import dataclass
 from typing import Dict
 
 from ray.train.v2._internal.execution.callback import ControllerCallback
-from ray.train.v2._internal.execution.worker_group import WorkerGroupPollStatus
+from ray.train.v2._internal.execution.worker_group import (
+    WorkerGroupPollStatus,
+    WorkerGroupState,
+)
 from ray.train.v2.api.config import ScalingConfig
 
 
@@ -46,7 +49,9 @@ class ScalingPolicy(abc.ABC, ControllerCallback):
 
     @abc.abstractmethod
     def make_decision_for_running_worker_group(
-        self, worker_group_status: WorkerGroupPollStatus
+        self,
+        worker_group_state: WorkerGroupState,
+        worker_group_status: WorkerGroupPollStatus,
     ) -> ScalingDecision:
         """Makes a scaling decision when monitoring healthy, running workers."""
         raise NotImplementedError

--- a/python/ray/train/v2/_internal/execution/worker_group/state.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/state.py
@@ -29,6 +29,10 @@ class WorkerGroupState:
     workers: List[Worker]
     sync_actor: ActorHandle
 
+    @property
+    def num_workers(self) -> int:
+        return len(self.workers)
+
     def shutdown(self):
         _shutdown_workers(self.workers)
         _shutdown_placement_group(self.placement_group)

--- a/python/ray/train/v2/tests/test_controller.py
+++ b/python/ray/train/v2/tests/test_controller.py
@@ -33,12 +33,10 @@ from ray.train.v2._internal.execution.scaling_policy import (
 )
 from ray.train.v2._internal.execution.worker_group import (
     WorkerGroup,
-    WorkerGroupPollStatus,
-    WorkerStatus,
-)
-from ray.train.v2._internal.execution.worker_group.worker_group import (
     WorkerGroupContext,
+    WorkerGroupPollStatus,
     WorkerGroupState,
+    WorkerStatus,
 )
 from ray.train.v2._internal.util import time_monotonic
 from ray.train.v2.api.config import RunConfig, ScalingConfig
@@ -103,7 +101,9 @@ class MockScalingPolicy(ScalingPolicy):
         return NoopDecision()
 
     def make_decision_for_running_worker_group(
-        self, worker_group_status: WorkerGroupPollStatus
+        self,
+        worker_group_state: WorkerGroupState,
+        worker_group_status: WorkerGroupPollStatus,
     ) -> ScalingDecision:
         if self._monitor_decision_queue:
             return self._monitor_decision_queue.pop(0)


### PR DESCRIPTION
## Summary

https://github.com/ray-project/ray/pull/50181 updated the internal `WorkerGroup`, which impacted the `ScalingPolicy` and `FailurePolicy` input APIs. Note that these are all internal-facing developer APIs.

This PR restores parity to the information available to the `ScalingPolicy` in the `make_decision_for_running_worker_group` method. In particular, this PR exposes the `WorkerGroupState`, which contains the latest worker group's `start_time`.