### PR TITLE
[serve] Fix flaky `test_backpressure_model_composition`

### DIFF
--- a/python/ray/serve/tests/test_backpressure.py
+++ b/python/ray/serve/tests/test_backpressure.py
@@ -163,7 +163,9 @@ def test_model_composition_backpressure(serve_instance):
 
         # Send second request, it should get queued.
         queued_fut = exc.submit(send_request)
-        done, _ = wait([executing_fut, queued_fut], timeout=0.1, return_when=FIRST_COMPLETED)
+        done, _ = wait(
+            [executing_fut, queued_fut], timeout=0.1, return_when=FIRST_COMPLETED
+        )
 
         # Send third request, it should get rejected.
         rejected_fut = exc.submit(send_request)

--- a/python/ray/serve/tests/test_backpressure.py
+++ b/python/ray/serve/tests/test_backpressure.py
@@ -168,20 +168,13 @@ def test_model_composition_backpressure(serve_instance):
         # Send third request, it should get rejected.
         rejected_fut = exc.submit(send_request)
         assert rejected_fut.result().status_code == 503
-        assert "Request dropped due to backpressure" in rejected_fut.result().text
-        print("Received 503 response.")
 
         # Send signal, check the two requests succeed.
-        print("Releasing first signal.")
-        ray.get(signal.send.remote())
-        print("Waiting?????")
-        assert executing_fut.result() == "ok"
-        print("First done.")
-        wait_for_condition(lambda: ray.get(signal_actor.cur_num_waiters.remote()) == 1)
-        print("First done.")
-        ray.get(signal.send.remote())
-        print("Second done.")
-        assert queued_fut.result() == "ok"
+        ray.get(signal_actor.send.remote(clear=False))
+        assert executing_fut.result().status_code == 200
+        assert executing_fut.result().text == "ok"
+        assert queued_fut.result().status_code == 200
+        assert queued_fut.result().text == "ok"
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_backpressure.py
+++ b/python/ray/serve/tests/test_backpressure.py
@@ -166,6 +166,7 @@ def test_model_composition_backpressure(serve_instance):
         done, _ = wait(
             [executing_fut, queued_fut], timeout=0.1, return_when=FIRST_COMPLETED
         )
+        assert len(done) == 0
 
         # Send third request, it should get rejected.
         rejected_fut = exc.submit(send_request)

--- a/python/ray/serve/tests/test_backpressure.py
+++ b/python/ray/serve/tests/test_backpressure.py
@@ -134,12 +134,12 @@ def test_grpc_backpressure(serve_instance):
 
 
 def test_model_composition_backpressure(serve_instance):
-    signal = SignalActor.remote()
+    signal_actor = SignalActor.remote()
 
     @serve.deployment(max_ongoing_requests=1, max_queued_requests=1)
     class Child:
         async def __call__(self):
-            await signal.wait.remote()
+            await signal_actor.wait.remote()
             return "ok"
 
     @serve.deployment
@@ -155,17 +155,33 @@ def test_model_composition_backpressure(serve_instance):
 
     serve.run(Parent.bind(child=Child.bind()))
     with ThreadPoolExecutor(max_workers=3) as exc:
-        futures = [exc.submit(send_request) for _ in range(3)]
-        done, _ = wait(futures, return_when=FIRST_COMPLETED)
-        assert len(done) == 1
-        for f in done:
-            assert f.result().status_code == 503
-            assert "Request dropped due to backpressure" in f.result().text
-            print("Received 503 response.")
+        # Send first request, wait for it to be blocked while executing.
+        executing_fut = exc.submit(send_request)
+        wait_for_condition(lambda: ray.get(signal_actor.cur_num_waiters.remote()) == 1)
+        done, _ = wait([executing_fut], timeout=0.1, return_when=FIRST_COMPLETED)
+        assert len(done) == 0
 
-        print("Releasing signal.")
+        # Send second request, it should get queued.
+        queued_fut = exc.submit(send_request)
+        done, _ = wait([executing_fut, queued_fut], timeout=0.1, return_when=FIRST_COMPLETED)
+
+        # Send third request, it should get rejected.
+        rejected_fut = exc.submit(send_request)
+        assert rejected_fut.result().status_code == 503
+        assert "Request dropped due to backpressure" in rejected_fut.result().text
+        print("Received 503 response.")
+
+        # Send signal, check the two requests succeed.
+        print("Releasing first signal.")
         ray.get(signal.send.remote())
-        assert sorted([f.result().status_code for f in futures]) == [200, 200, 503]
+        print("Waiting?????")
+        assert executing_fut.result() == "ok"
+        print("First done.")
+        wait_for_condition(lambda: ray.get(signal_actor.cur_num_waiters.remote()) == 1)
+        print("First done.")
+        ray.get(signal.send.remote())
+        print("Second done.")
+        assert queued_fut.result() == "ok"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The test could flake because all requests were submitted in a batch, so it's possible the first request is still queued and both of the subsequent requests are rejected.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
