### PR TITLE
[core] Implement scoped env setter

### DIFF
--- a/src/ray/util/BUILD
+++ b/src/ray/util/BUILD
@@ -133,6 +133,15 @@ ray_cc_library(
 )
 
 ray_cc_library(
+    name = "scoped_env_setter",
+    hdrs = ["scoped_env_setter.h"],
+    srcs = ["scoped_env_setter.cc"],
+    deps = [
+        ":util",
+    ],
+)
+
+ray_cc_library(
     name = "timestamp_utils",
     hdrs = ["timestamp_utils.h"],
 )

--- a/src/ray/util/scoped_env_setter.cc
+++ b/src/ray/util/scoped_env_setter.cc
@@ -1,0 +1,39 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/util/scoped_env_setter.h"
+
+#include <cstdlib>
+
+#include "ray/util/util.h"
+
+namespace ray {
+
+ScopedEnvSetter::ScopedEnvSetter(const char *env_name, const char *value)
+    : env_name_(env_name) {
+  const char *val = ::getenv(env_name);
+  if (val != nullptr) {
+    old_value_ = val;
+  }
+  setEnv(env_name, value);
+}
+
+ScopedEnvSetter::~ScopedEnvSetter() {
+  unsetEnv(env_name_.c_str());
+  if (old_value_.has_value()) {
+    setEnv(env_name_, *old_value_);
+  }
+}
+
+}  // namespace ray

--- a/src/ray/util/scoped_env_setter.h
+++ b/src/ray/util/scoped_env_setter.h
@@ -1,0 +1,36 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Create a scoped environment variable, which is set env at construction and unset and
+// recover to old value at destruction.
+
+#pragma once
+
+#include <cstring>
+#include <optional>
+#include <string>
+
+namespace ray {
+
+class ScopedEnvSetter {
+ public:
+  ScopedEnvSetter(const char *env_name, const char *value);
+  ~ScopedEnvSetter();
+
+ private:
+  std::string env_name_;
+  std::optional<std::string> old_value_;
+};
+
+}  // namespace ray

--- a/src/ray/util/scoped_env_setter.h
+++ b/src/ray/util/scoped_env_setter.h
@@ -28,6 +28,9 @@ class ScopedEnvSetter {
   ScopedEnvSetter(const char *env_name, const char *value);
   ~ScopedEnvSetter();
 
+  ScopedEnvSetter(const ScopedEnvSetter &) = delete;
+  ScopedEnvSetter &operator=(const ScopedEnvSetter &) = delete;
+
  private:
   std::string env_name_;
   std::optional<std::string> old_value_;

--- a/src/ray/util/tests/BUILD
+++ b/src/ray/util/tests/BUILD
@@ -223,6 +223,17 @@ ray_cc_test(
 )
 
 ray_cc_test(
+    name = "scoped_env_setter_test",
+    srcs = ["scoped_env_setter_test.cc"],
+    deps = [
+        "//src/ray/util:scoped_env_setter",
+        "@com_google_googletest//:gtest_main",
+    ],
+    size = "small",
+    tags = ["team:core"],
+)
+
+ray_cc_test(
     name = "pipe_logger_test",
     srcs = ["pipe_logger_test.cc"],
     deps = [

--- a/src/ray/util/tests/scoped_env_setter_test.cc
+++ b/src/ray/util/tests/scoped_env_setter_test.cc
@@ -1,0 +1,41 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/util/scoped_env_setter.h"
+
+#include <gtest/gtest.h>
+
+#include <string_view>
+
+namespace ray {
+
+namespace {
+
+constexpr std::string_view kEnvKey = "key";
+constexpr std::string_view kEnvVal = "val";
+
+TEST(ScopedEnvSetter, BasicTest) {
+  EXPECT_EQ(::getenv(kEnvKey.data()), nullptr);
+
+  {
+    ScopedEnvSetter env_setter{kEnvKey.data(), kEnvVal.data()};
+    EXPECT_STREQ(::getenv(kEnvKey.data()), kEnvVal.data());
+  }
+
+  EXPECT_EQ(::getenv(kEnvKey.data()), nullptr);
+}
+
+}  // namespace
+
+}  // namespace ray


### PR DESCRIPTION
When working on pipe logger (https://github.com/ray-project/ray/pull/50248), I found it necessary to test based on a scoped env, so make a formal util.