### PR TITLE
[core] Redact redis password in log

### DIFF
--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -892,7 +892,8 @@ def main():
     )
 
     hostport = "%s:%d" % (args.host, args.port)
-    logger.info(f"Starting Ray Client server on {hostport}, args {args}")
+    args_str = str(args).replace(args.redis_password, "****") if args.redis_password else args_str
+    logger.info(f"Starting Ray Client server on {hostport}, args {args_str}")
     if args.mode == "proxy":
         server = serve_proxier(
             hostport,

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -892,11 +892,9 @@ def main():
     )
 
     hostport = "%s:%d" % (args.host, args.port)
-    args_str = (
-        str(args).replace(args.redis_password, "****")
-        if args.redis_password
-        else args_str
-    )
+    args_str = str(args)
+    if args.redis_password:
+        args_str = args_str.replace(args.redis_password, "****")
     logger.info(f"Starting Ray Client server on {hostport}, args {args_str}")
     if args.mode == "proxy":
         server = serve_proxier(

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -892,7 +892,11 @@ def main():
     )
 
     hostport = "%s:%d" % (args.host, args.port)
-    args_str = str(args).replace(args.redis_password, "****") if args.redis_password else args_str
+    args_str = (
+        str(args).replace(args.redis_password, "****")
+        if args.redis_password
+        else args_str
+    )
     logger.info(f"Starting Ray Client server on {hostport}, args {args_str}")
     if args.mode == "proxy":
         server = serve_proxier(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This change is needed to prevent redis password been logged in the standard logging. This is a secure vulnerability.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #50266

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
