### PR TITLE
[tune] Remove loguniform's base

### DIFF
--- a/doc/source/tune/examples/tune-xgboost.ipynb
+++ b/doc/source/tune/examples/tune-xgboost.ipynb
@@ -544,7 +544,7 @@
     "  has the same chance to be sampled.\n",
     "- `tune.uniform(min, max)` samples a floating point number between *min* and *max*.\n",
     "  Note that *max* is exclusive here, too.\n",
-    "- `tune.loguniform(min, max, base=10)` samples a floating point number between *min* and *max*,\n",
+    "- `tune.loguniform(min, max)` samples a floating point number between *min* and *max*,\n",
     "  but applies a logarithmic transformation to these boundaries first. Thus, this makes\n",
     "  it easy to sample values from different orders of magnitude.\n",
     "\n",

--- a/python/ray/tune/search/hebo/hebo_search.py
+++ b/python/ray/tune/search/hebo/hebo_search.py
@@ -420,7 +420,6 @@ class HEBOSearch(Searcher):
                         "type": "pow",
                         "lb": domain.lower,
                         "ub": domain.upper,
-                        "base": sampler.base,
                     }
                 elif isinstance(sampler, Uniform):
                     return {
@@ -437,7 +436,6 @@ class HEBOSearch(Searcher):
                         "type": "pow_int",
                         "lb": domain.lower,
                         "ub": domain.upper - 1,  # Upper bound exclusive
-                        "base": sampler.base,
                     }
                 elif isinstance(sampler, Uniform):
                     return {

--- a/python/ray/tune/search/nevergrad/nevergrad_search.py
+++ b/python/ray/tune/search/nevergrad/nevergrad_search.py
@@ -1,5 +1,6 @@
 import inspect
 import logging
+import math
 import pickle
 from typing import Dict, List, Optional, Sequence, Type, Union
 
@@ -341,7 +342,7 @@ class NevergradSearch(Searcher):
             if isinstance(domain, Float):
                 if isinstance(sampler, LogUniform):
                     return ng.p.Log(
-                        lower=domain.lower, upper=domain.upper, exponent=sampler.base
+                        lower=domain.lower, upper=domain.upper, exponent=math.e
                     )
                 return ng.p.Scalar(lower=domain.lower, upper=domain.upper)
 
@@ -350,7 +351,7 @@ class NevergradSearch(Searcher):
                     return ng.p.Log(
                         lower=domain.lower,
                         upper=domain.upper - 1,  # Upper bound exclusive
-                        exponent=sampler.base,
+                        exponent=math.e,
                     ).set_integer_casting()
                 return ng.p.Scalar(
                     lower=domain.lower,

--- a/python/ray/tune/search/sample.py
+++ b/python/ray/tune/search/sample.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from copy import copy
 from inspect import signature
 from math import isclose
@@ -7,7 +8,7 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 import numpy as np
 
 # Backwards compatibility
-from ray.util.annotations import DeveloperAPI, PublicAPI
+from ray.util.annotations import DeveloperAPI, PublicAPI, RayDeprecationWarning
 
 try:
     # Added in numpy>=1.17 but we require numpy>=1.16
@@ -21,6 +22,20 @@ except AttributeError:
     LEGACY_RNG = True
 
 logger = logging.getLogger(__name__)
+
+
+_MISSING = object()  # Sentinel for missing parameters.
+
+
+def _warn_for_base() -> None:
+    warnings.warn(
+        (
+            "The `base` argument is deprecated. "
+            "Please remove it as it is not actually needed in this method."
+        ),
+        RayDeprecationWarning,
+        stacklevel=2,
+    )
 
 
 class _BackwardsCompatibleNumpyRng:
@@ -158,9 +173,9 @@ class Uniform(Sampler):
 
 @DeveloperAPI
 class LogUniform(Sampler):
-    def __init__(self, base: float = 10):
-        self.base = base
-        assert self.base > 0, "Base has to be strictly greater than 0"
+    def __init__(self, base: object = _MISSING):
+        if base is not _MISSING:
+            _warn_for_base()
 
     def __str__(self):
         return "LogUniform"
@@ -223,10 +238,10 @@ class Float(Domain):
             assert (
                 0 < domain.upper < float("inf")
             ), "LogUniform needs a upper bound greater than 0"
-            logmin = np.log(domain.lower) / np.log(self.base)
-            logmax = np.log(domain.upper) / np.log(self.base)
+            logmin = np.log(domain.lower)
+            logmax = np.log(domain.upper)
 
-            items = self.base ** (random_state.uniform(logmin, logmax, size=size))
+            items = np.exp(random_state.uniform(logmin, logmax, size=size))
             return items if len(items) > 1 else domain.cast(items[0])
 
     class _Normal(Normal):
@@ -273,7 +288,9 @@ class Float(Domain):
         new.set_sampler(self._Uniform())
         return new
 
-    def loguniform(self, base: float = 10):
+    def loguniform(self, base: object = _MISSING):
+        if base is not _MISSING:
+            _warn_for_base()
         if not self.lower > 0:
             raise ValueError(
                 "LogUniform requires a lower bound greater than 0."
@@ -289,7 +306,7 @@ class Float(Domain):
                 "instead."
             )
         new = copy(self)
-        new.set_sampler(self._LogUniform(base))
+        new.set_sampler(self._LogUniform())
         return new
 
     def normal(self, mean=0.0, sd=1.0):
@@ -354,10 +371,10 @@ class Integer(Domain):
             assert (
                 0 < domain.upper < float("inf")
             ), "LogUniform needs a upper bound greater than 0"
-            logmin = np.log(domain.lower) / np.log(self.base)
-            logmax = np.log(domain.upper) / np.log(self.base)
+            logmin = np.log(domain.lower)
+            logmax = np.log(domain.upper)
 
-            items = self.base ** (random_state.uniform(logmin, logmax, size=size))
+            items = np.exp(random_state.uniform(logmin, logmax, size=size))
             items = np.floor(items).astype(int)
             return items if len(items) > 1 else domain.cast(items[0])
 
@@ -380,7 +397,9 @@ class Integer(Domain):
         new.set_sampler(self._Uniform())
         return new
 
-    def loguniform(self, base: float = 10):
+    def loguniform(self, base: object = _MISSING):
+        if base is not _MISSING:
+            _warn_for_base()
         if not self.lower > 0:
             raise ValueError(
                 "LogUniform requires a lower bound greater than 0."
@@ -396,7 +415,7 @@ class Integer(Domain):
                 "instead."
             )
         new = copy(self)
-        new.set_sampler(self._LogUniform(base))
+        new.set_sampler(self._LogUniform())
         return new
 
     def is_valid(self, value: int):
@@ -484,9 +503,11 @@ class Function(Domain):
                 random_state = _BackwardsCompatibleNumpyRng(random_state)
             if domain.pass_config:
                 items = [
-                    self.__try_fn(domain, config[i])
-                    if isinstance(config, list)
-                    else self.__try_fn(domain, config)
+                    (
+                        self.__try_fn(domain, config[i])
+                        if isinstance(config, list)
+                        else self.__try_fn(domain, config)
+                    )
                     for i in range(size)
                 ]
             else:
@@ -601,20 +622,21 @@ def quniform(lower: float, upper: float, q: float):
 
 
 @PublicAPI
-def loguniform(lower: float, upper: float, base: float = 10):
+def loguniform(lower: float, upper: float, base: object = _MISSING):
     """Sugar for sampling in different orders of magnitude.
 
     Args:
         lower: Lower boundary of the output interval (e.g. 1e-4)
         upper: Upper boundary of the output interval (e.g. 1e-2)
-        base: Base of the log. Defaults to 10.
 
     """
-    return Float(lower, upper).loguniform(base)
+    if base is not _MISSING:
+        _warn_for_base()
+    return Float(lower, upper).loguniform()
 
 
 @PublicAPI
-def qloguniform(lower: float, upper: float, q: float, base: float = 10):
+def qloguniform(lower: float, upper: float, q: float, base: object = _MISSING):
     """Sugar for sampling in different orders of magnitude.
 
     The value will be quantized, i.e. rounded to an integer increment of ``q``.
@@ -626,10 +648,11 @@ def qloguniform(lower: float, upper: float, q: float, base: float = 10):
         upper: Upper boundary of the output interval (e.g. 1e-2)
         q: Quantization number. The result will be rounded to an
             integer increment of this value.
-        base: Base of the log. Defaults to 10.
 
     """
-    return Float(lower, upper).loguniform(base).quantized(q)
+    if base is not _MISSING:
+        _warn_for_base()
+    return Float(lower, upper).loguniform().quantized(q)
 
 
 @PublicAPI
@@ -662,9 +685,8 @@ def randint(lower: int, upper: int):
 
 
 @PublicAPI
-def lograndint(lower: int, upper: int, base: float = 10):
-    """Sample an integer value log-uniformly between ``lower`` and ``upper``,
-    with ``base`` being the base of logarithm.
+def lograndint(lower: int, upper: int, base: object = _MISSING):
+    """Sample an integer value log-uniformly between ``lower`` and ``upper``.
 
     ``lower`` is inclusive, ``upper`` is exclusive.
 
@@ -674,7 +696,9 @@ def lograndint(lower: int, upper: int, base: float = 10):
         the bounds stated in the docstring above.
 
     """
-    return Integer(lower, upper).loguniform(base)
+    if base is not _MISSING:
+        _warn_for_base()
+    return Integer(lower, upper).loguniform()
 
 
 @PublicAPI
@@ -696,9 +720,8 @@ def qrandint(lower: int, upper: int, q: int = 1):
 
 
 @PublicAPI
-def qlograndint(lower: int, upper: int, q: int, base: float = 10):
-    """Sample an integer value log-uniformly between ``lower`` and ``upper``,
-    with ``base`` being the base of logarithm.
+def qlograndint(lower: int, upper: int, q: int, base: object = _MISSING):
+    """Sample an integer value log-uniformly between ``lower`` and ``upper``.
 
     ``lower`` is inclusive, ``upper`` is also inclusive (!).
 
@@ -711,7 +734,9 @@ def qlograndint(lower: int, upper: int, q: int, base: float = 10):
         the bounds stated in the docstring above.
 
     """
-    return Integer(lower, upper).loguniform(base).quantized(q)
+    if base is not _MISSING:
+        _warn_for_base()
+    return Integer(lower, upper).loguniform().quantized(q)
 
 
 @PublicAPI

--- a/python/ray/tune/tests/test_var.py
+++ b/python/ray/tune/tests/test_var.py
@@ -326,7 +326,7 @@ class VariantGeneratorTest(unittest.TestCase):
         assert abs(np.log(min(results)) / np.log(10) - -10) < 0.1
         assert abs(np.log(max(results)) / np.log(10) - -1) < 0.1
 
-        sampler_e = tune.loguniform(np.e**-4, np.e, base=np.e)
+        sampler_e = tune.loguniform(np.e**-4, np.e)
         results_e = sampler_e.sample(None, 1000)
         assert abs(np.log(min(results_e)) - -4) < 0.1
         assert abs(np.log(max(results_e)) - 1) < 0.1


### PR DESCRIPTION
Analytically, the base doesn't have any effect on the calculation. Numerically, it seems that the base can only make the calculation less precise, and definitely adds computation.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Fixes https://github.com/ray-project/ray/issues/50413

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [x] This PR is not tested :(
