### PR TITLE
[core][cgraph] Fix compiled graph buffer release issues

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -871,7 +871,7 @@ class Worker:
                 returned list. If False, then the first found exception will be
                 raised.
             skip_deserialization: If true, only the buffer will be released and
-                the object associated with the buffer will not be deserailized.
+                the object associated with the buffer will not be deserialized.
         Returns:
             list: List of deserialized objects or None if skip_deserialization is True.
             bytes: UUID of the debugger breakpoint we should drop

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -2209,7 +2209,12 @@ class CompiledDAG:
         """
         if not self._has_execution_results(execution_index):
             for chan_idx, res in enumerate(result):
-                self._result_buffer[execution_index][chan_idx] = res
+                # avoid caching for any CompiledDAGRef that has already been destructed.
+                if not (
+                    execution_index in self._destructed_ref_idxs
+                    and chan_idx in self._destructed_ref_idxs[execution_index]
+                ):
+                    self._result_buffer[execution_index][chan_idx] = res
 
     def _get_execution_results(
         self, execution_index: int, channel_index: Optional[int]

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -2233,9 +2233,7 @@ class CompiledDAG:
         # execution index and channel index combination will not be requested multiple
         # times and therefore self._result_buffer will always have execution_index as
         # a key, we still do a sanity check to avoid misuses.
-        assert (
-            execution_index in self._result_buffer
-        ), f"{execution_index=} {self._result_buffer=}"
+        assert execution_index in self._result_buffer
 
         if channel_index is None:
             # Convert results stored in self._result_buffer back to original
@@ -2285,7 +2283,8 @@ class CompiledDAG:
         got_channel_idxs = self._got_ref_idxs.get(execution_index, set())
         if None in got_channel_idxs:
             assert len(got_channel_idxs) == 1, (
-                "channel_idx=None (all channels) cannot coexist with other channel_idxs",
+                "when None exists in got_channel_idxs, it means all channels, and "
+                "it should be the only value in the set",
             )
             should_release = True
         else:
@@ -2327,7 +2326,8 @@ class CompiledDAG:
         should_release = False
         if None in destructed_channel_idxs:
             assert len(destructed_channel_idxs) == 1, (
-                "channel_idx=None (all channels) cannot coexist with other channel_idxs",
+                "when None exists in destructed_channel_idxs, it means all channels, "
+                "and it should be the only value in the set",
             )
             should_release = True
         elif len(destructed_channel_idxs) == len(self.dag_output_channels):

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -2245,7 +2245,6 @@ class CompiledDAG:
                     key=lambda kv: kv[0],
                 )
             ]
-            assert execution_index not in self._result_buffer
         else:
             result = [self._result_buffer[execution_index].pop(channel_index)]
 
@@ -2300,9 +2299,9 @@ class CompiledDAG:
         if not should_release:
             return False
 
-        self._result_buffer.pop(execution_index, set())
-        self._destructed_ref_idxs.pop(execution_index, set())
-        self._got_ref_idxs.pop(execution_index, set())
+        self._result_buffer.pop(execution_index, None)
+        self._destructed_ref_idxs.pop(execution_index, None)
+        self._got_ref_idxs.pop(execution_index, None)
         return True
 
     def _try_release_native_buffer(
@@ -2461,10 +2460,6 @@ class CompiledDAG:
                 if not self._try_release_native_buffer(
                     self._max_finished_execution_index + 1, timeout
                 ):
-                    logger.info(
-                        f"getting results for execution index {self._max_finished_execution_index + 1}",
-                        stack_info=False,
-                    )
                     result = self._dag_output_fetcher.read(timeout)
                     self._cache_execution_results(
                         self._max_finished_execution_index + 1,

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -265,9 +265,16 @@ class TestDAGRefDestruction:
             dag = MultiOutputNode([a.inc.bind(inp), a.inc.bind(inp)])
         compiled_dag = dag.experimental_compile()
         ref_list = compiled_dag.execute(1)
+        assert compiled_dag._result_buffer == {}
+        assert compiled_dag._destructed_ref_idxs == {}
+        assert compiled_dag._got_ref_idxs == {}
         ref1, ref2 = compiled_dag.execute(2)
         del ref1
+        assert compiled_dag._result_buffer == {}
+        assert compiled_dag._destructed_ref_idxs == {1: {0}}
+        assert compiled_dag._got_ref_idxs == {}
         ray.get(ref2)
+        assert compiled_dag._result_buffer == {0: {0: 1, 1: 2}}
         ray.get(ref_list)
         # Test that that ref1 doesn't stay in result_buffer
         assert len(compiled_dag._result_buffer) == 0

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -297,7 +297,10 @@ class TestDAGRefDestruction:
             result = await futs[0]
             assert result == i
 
-        loop.run_until_complete(asyncio.gather(*[main(i) for i in range(12)]))
+        loop.run_until_complete(asyncio.gather(*[main(i) for i in range(5)]))
+        assert compiled_dag._result_buffer == {}
+        assert compiled_dag._destructed_ref_idxs == {}
+        assert compiled_dag._got_ref_idxs == {}
 
 
 @pytest.mark.parametrize("single_fetch", [True, False])

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -185,7 +185,7 @@ def test_asyncio_capacity(ray_start_regular):
     compiled_dag = dag.experimental_compile(enable_asyncio=True)
 
     async def main(i):
-        # asyncio.sleep(i)
+        await asyncio.sleep(i * 0.1)
         # if i != 0:
         futs = await compiled_dag.execute_async(i)
         assert len(futs) == 2
@@ -193,9 +193,9 @@ def test_asyncio_capacity(ray_start_regular):
         assert result == i
         # print(f"{i} {futs[1]._dag._max_finished_execution_index=}")
         # del futs
-        # asyncio.sleep(0)
+        await asyncio.sleep(0)
 
-    loop.run_until_complete(asyncio.gather(*[main(i) for i in range(6)]))
+    loop.run_until_complete(asyncio.gather(*[main(i) for i in range(12)]))
     # del loop
 
 

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -204,6 +204,9 @@ class TestDAGRefDestruction:
         result = ray.get(ref)
         assert (result == val).all()
         del ref
+        assert compiled_dag._result_buffer == {}
+        assert compiled_dag._destructed_ref_idxs == {}
+        assert compiled_dag._got_ref_idxs == {}
 
     def test_get_ref_before_destructed_ref(self, ray_start_regular):
         a = Actor.remote(0)
@@ -216,6 +219,9 @@ class TestDAGRefDestruction:
         # Test that ray.get() on ref still works properly even if
         # ref2 (corresponding to a later execution) is destructed first
         assert ray.get(ref) == 1
+        assert compiled_dag._result_buffer == {}
+        assert compiled_dag._destructed_ref_idxs == {}
+        assert compiled_dag._got_ref_idxs == {}
 
     def test_get_ref_after_destructed_ref(self, ray_start_regular):
         a = Actor.remote(0)
@@ -229,6 +235,9 @@ class TestDAGRefDestruction:
         del ref2
         # Test that ray.get() works correctly if preceding ref was destructed
         assert ray.get(ref3) == 6
+        assert compiled_dag._result_buffer == {}
+        assert compiled_dag._destructed_ref_idxs == {}
+        assert compiled_dag._got_ref_idxs == {}
 
     def test_release_buffer_on_execute(self, ray_start_regular):
         a = Actor.remote(0)
@@ -247,6 +256,9 @@ class TestDAGRefDestruction:
         # should be destructed and not counted in the inflight executions
         ref5 = compiled_dag.execute(3)
         assert ray.get(ref5) == 15
+        assert compiled_dag._result_buffer == {}
+        assert compiled_dag._destructed_ref_idxs == {}
+        assert compiled_dag._got_ref_idxs == {}
 
     def test_destruct_and_get_multioutput_ref(self, ray_start_regular):
         a = Actor.remote(0)
@@ -258,6 +270,9 @@ class TestDAGRefDestruction:
         # Test that ray.get() on ref1 still works properly even if
         # ref2 was destructed
         assert ray.get(ref1) == 1
+        assert compiled_dag._result_buffer == {}
+        assert compiled_dag._destructed_ref_idxs == {}
+        assert compiled_dag._got_ref_idxs == {}
 
     def test_destruct_and_get_multioutput_no_leak(self, ray_start_regular):
         a = Actor.remote(0)
@@ -277,7 +292,9 @@ class TestDAGRefDestruction:
         assert compiled_dag._result_buffer == {0: {0: 1, 1: 2}}
         ray.get(ref_list)
         # Test that that ref1 doesn't stay in result_buffer
-        assert len(compiled_dag._result_buffer) == 0
+        assert compiled_dag._result_buffer == {}
+        assert compiled_dag._destructed_ref_idxs == {}
+        assert compiled_dag._got_ref_idxs == {}
 
     def test_asyncio_destruction(self, ray_start_regular):
         a = Actor.remote(0)

--- a/python/ray/experimental/compiled_dag_ref.py
+++ b/python/ray/experimental/compiled_dag_ref.py
@@ -225,3 +225,14 @@ class CompiledDAGFuture:
             self._execution_index, self._channel_index
         )
         return _process_return_vals(return_vals, True)
+
+    def __del__(self):
+        if self._dag.is_teardown:
+            return
+        print(
+            "CompiledDAGFuture __del__ for execution_index {} and channel_index {}".format(
+                self._execution_index, self._channel_index
+            )
+        )
+        self._dag._destructed_ref_idxs[self._execution_index].add(self._channel_index)
+        self._dag._try_release_buffers()

--- a/python/ray/experimental/compiled_dag_ref.py
+++ b/python/ray/experimental/compiled_dag_ref.py
@@ -103,6 +103,7 @@ class CompiledDAGRef:
         # can based on the dag's current max_finished_execution_index.
         # if not self._ray_get_called:
         self._dag._destructed_ref_idxs[self._execution_index].add(self._channel_index)
+        self._dag._try_release_once(self._execution_index)
         self._dag._try_release_buffers()
 
     def get(self, timeout: Optional[float] = None):
@@ -120,6 +121,7 @@ class CompiledDAGRef:
             return_vals = self._dag._get_execution_results(
                 self._execution_index, self._channel_index
             )
+            self._dag._try_release_once(self._execution_index)
             self._dag._try_release_buffers()
         except RayChannelTimeoutError:
             raise
@@ -230,4 +232,5 @@ class CompiledDAGFuture:
             )
         )
         self._dag._destructed_ref_idxs[self._execution_index].add(self._channel_index)
+        self._dag._try_release_once(self._execution_index)
         self._dag._try_release_buffers()

--- a/python/ray/experimental/compiled_dag_ref.py
+++ b/python/ray/experimental/compiled_dag_ref.py
@@ -102,7 +102,10 @@ class CompiledDAGRef:
         # to the dag's _destructed_ref_idxs, and try to release any buffers we
         # can based on the dag's current max_finished_execution_index.
         # if not self._ray_get_called:
-        self._dag._destructed_ref_idxs[self._execution_index].add(self._channel_index)
+        if not self._ray_get_called:
+            self._dag._destructed_ref_idxs[self._execution_index].add(
+                self._channel_index
+            )
         self._dag._try_release_once(self._execution_index)
         self._dag._try_release_buffers()
 
@@ -235,6 +238,9 @@ class CompiledDAGFuture:
             )
         )
         if self._dag.is_teardown:
+            return
+
+        if self._fut is None:
             return
         self._dag._destructed_ref_idxs[self._execution_index].add(self._channel_index)
         self._dag._try_release_once(self._execution_index)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

#50381 reports an issue that `RayCgraphCapacityExceeded` when `execute_async()` is called. This is partially due to the behavior change that result_buffer size is also considered to determine in-flight executions: https://github.com/ray-project/ray/pull/49565/files#diff-4e8383fd120e69cb2c69ddc045707f86fad408749e34f5610bbd8fe47c434a08R1916
Another issue is that result_buffer leak: e.g., when the DAG has two output channels (two CompiledDAGFutures), one is awaited on, the other is destructed; then the result_buffer caches the result, which is never released. 

This PR fixes the following issues:
* CompiledDAGFuture does not properly release buffers, which could result in `RayCgraphCapacityExceeded` error
* `destructed_channel_idxs` itself is not cleaned up, resulting in leaks

Design:
* There are two types of buffers: a **native buffer** is the native Ray data buffer, and **result buffer** is the result buffer (a python dict) at the Compiled Graph driver that temporarily caches execution results
* We release a native buffer when all DAGRefs corresponding to the **next** execution_index are destructed
* We release a result buffer entry when the union of DAGRefs that have `get()` called and DAGRefs that are destructed equals all DAGRefs (i.e., correspond to all output channels of an execution)

Implementation:

* maintaining `_destructed_ref_idxs` and `_got_ref_idxs` when `__del__()` or `get()` is called, respectively
* lazily releasing native buffers or result buffers when all CompiledDAGRef/CompiledDAGFuture have get() or `__del__()` called
* cleaning up `_destructed_ref_idxs` and `_got_ref_idxs` when buffers are released

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #50381

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
