### PR TITLE
cherrypick version switcher fixes to 2.36.0

### DIFF
--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -398,6 +398,6 @@ table.autosummary tr > td:first-child > p > a > code > span {
 }
 
 /* Hide the RTD version switcher since we are using PyData theme one */
-#rtd-footer-container {
-  display: none;
+readthedocs-flyout {
+  display: none !important;
 }

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -304,16 +304,13 @@ html_theme_options = {
     },
     "navbar_start": ["navbar-ray-logo"],
     "navbar_end": [
+        "theme-switcher",
         "version-switcher",
         "navbar-icon-links",
         "navbar-anyscale",
     ],
     "navbar_center": ["navbar-links"],
     "navbar_align": "left",
-    "navbar_persistent": [
-        "search-button-field",
-        "theme-switcher",
-    ],
     "secondary_sidebar_items": [
         "page-toc",
         "edit-on-github",
@@ -326,7 +323,9 @@ html_theme_options = {
     "pygment_dark_style": "stata-dark",
     "switcher": {
         "json_url": "https://docs.ray.io/en/master/_static/versions.json",
-        "version_match": os.getenv("READTHEDOCS_VERSION", "master"),
+        "version_match": (
+            lambda v: v if v in ["master", "latest"] else f"releases/{v}"
+        )(os.getenv("READTHEDOCS_VERSION", "master")),
     },
 }
 
@@ -339,9 +338,11 @@ html_context = {
 
 html_sidebars = {
     "**": [
-        "main-sidebar-readthedocs"
-        if os.getenv("READTHEDOCS") == "True"
-        else "main-sidebar"
+        (
+            "main-sidebar-readthedocs"
+            if os.getenv("READTHEDOCS") == "True"
+            else "main-sidebar"
+        )
     ],
     "ray-overview/examples": [],
 }

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -323,9 +323,7 @@ html_theme_options = {
     "pygment_dark_style": "stata-dark",
     "switcher": {
         "json_url": "https://docs.ray.io/en/master/_static/versions.json",
-        "version_match": (
-            lambda v: v if v in ["master", "latest"] else f"releases/{v}"
-        )(os.getenv("READTHEDOCS_VERSION", "master")),
+        "version_match": os.getenv("READTHEDOCS_VERSION", "master"),
     },
 }
 

--- a/doc/source/custom_directives.py
+++ b/doc/source/custom_directives.py
@@ -1297,7 +1297,7 @@ def generate_versions_json():
     for version in git_versions:
         version_json_data.append(
             {
-                "version": f"releases/{version}",
+                "version": f"releases-{version}",
                 "url": generate_version_url(f"releases-{version}"),
             }
         )


### PR DESCRIPTION
Cherry picks the following PRs to version 2.36.0 to fix version switcher issues

https://github.com/ray-project/ray/pull/49892
https://github.com/ray-project/ray/pull/50292

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
