### PR TITLE
[docs] add missing packages: ray[serve] and torch

### DIFF
--- a/doc/source/serve/tutorials/streaming.md
+++ b/doc/source/serve/tutorials/streaming.md
@@ -20,7 +20,7 @@ This tutorial should help you with following use cases:
 This tutorial serves the [DialoGPT](https://huggingface.co/microsoft/DialoGPT-small) language model. Install the Hugging Face library to access it:
 
 ```
-pip install transformers
+pip install "ray[serve]" transformers torch
 ```
 
 ## Create a streaming deployment


### PR DESCRIPTION
Otherwise the example errors out; it can't find fastapi or pytorch.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
