### PR TITLE
Add instructions for creating anchor links in ipynb notebooks

### DIFF
--- a/doc/source/ray-contribute/docs.md
+++ b/doc/source/ray-contribute/docs.md
@@ -344,6 +344,21 @@ Apart from `hide-cell`, you also have `hide-input` and `hide-output` tags that h
 Also, if you need code that gets executed in the notebook, but you don't want to show it in the documentation,
 you can use the `remove-cell`, `remove-input`, and `remove-output` tags in the same way.
 
+### Reference section labels
+
+[Reference sections labels](https://jupyterbook.org/en/stable/content/references.html#reference-section-labels) are a way to link to specific parts of the documentation from within a notebook. Creating one inside a markdown cell is simple:
+
+```markdown
+(my-label)=
+# The thing to label
+```
+
+Then, you can link it in .rst files with the following syntax:
+
+```rst
+See {ref}`the thing that I labeled <my-label>` for more information.
+```
+
 ### Testing notebooks
 
 Removing cells can be particularly interesting for compute-intensive notebooks.


### PR DESCRIPTION
## Why are these changes needed?

With the help of @pcmoritz I figured out how to replace an rst-based tutorial anchor links with an ipynb tutorial . This PR adds instructions to the contributing guidelines.

## Related issue number

NA

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
