### PR TITLE
[core] 1/N. ray.wait(_, num_returns=1) performance improvements

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2047,31 +2047,36 @@ Status CoreWorker::Wait(const std::vector<ObjectID> &ids,
     return Status::Invalid("Duplicate object IDs not supported in wait.");
   }
 
-  size_t missing_owners = 0;
+  size_t objs_without_owners = 0;
+  size_t objs_with_owners = 0;
   std::ostringstream ids_stream;
 
   for (size_t i = 0; i < ids.size(); i++) {
     if (!HasOwner(ids[i])) {
       ids_stream << ids[i] << " ";
-      missing_owners += 1;
+      ++objs_without_owners;
+    } else {
+      ++objs_with_owners;
     }
-  }
-
-  int objects_with_known_owners = ids.size() - missing_owners;
-  // If we are requesting more items than items available, then return a failed status.
-  if (missing_owners > 0 && num_objects > objects_with_known_owners) {
-    std::ostringstream stream;
-    stream << "An application is trying to access a Ray object whose owner is unknown"
-           << "(" << ids_stream.str()
-           << "). "
-              "Please make sure that all Ray objects you are trying to access are part"
-              " of the current Ray session. Note that "
-              "object IDs generated randomly (ObjectID.from_random()) or out-of-band "
-              "(ObjectID.from_binary(...)) cannot be passed as a task argument because"
-              " Ray does not know which task created them. "
-              "If this was not how your object ID was generated, please file an issue "
-              "at https://github.com/ray-project/ray/issues/";
-    return Status::ObjectUnknownOwner(stream.str());
+    // enough owned objects to process this batch
+    if (objs_with_owners == static_cast<size_t>(num_objects)) {
+      break;
+    }
+    // not enough objects with owners to process the batch
+    if (static_cast<size_t>(num_objects) > ids.size() - objs_without_owners) {
+      std::ostringstream stream;
+      stream << "An application is trying to access a Ray object whose owner is unknown"
+             << "(" << ids_stream.str()
+             << "). "
+                "Please make sure that all Ray objects you are trying to access are part"
+                " of the current Ray session. Note that "
+                "object IDs generated randomly (ObjectID.from_random()) or out-of-band "
+                "(ObjectID.from_binary(...)) cannot be passed as a task argument because"
+                " Ray does not know which task created them. "
+                "If this was not how your object ID was generated, please file an issue "
+                "at https://github.com/ray-project/ray/issues/";
+      return Status::ObjectUnknownOwner(stream.str());
+    }
   }
 
   absl::flat_hash_set<ObjectID> ready;


### PR DESCRIPTION
Improve performance of `ray.wait(_, num_returns=1)` by early exiting the search for owned objects.

Before
```Python
In [9]: @ray.remote
   ...: def f(i):
   ...:     return str(i)


In [9]: def g(rest, n_ret):
   ...:     while True:
   ...:         done, rest = ray.wait(rest, num_returns=n_ret)
   ...:         if (len(rest) == 0):
   ...:             return
   ...:         ray.get(done)


In [9]: objs = [ f.remote(i) for i in range(10000) ]

// Before
In [8]: %time g(objs, 1)
CPU times: user 15.1 s, sys: 120 ms, total: 15.2 s
Wall time: 15.1 s

// After
In [7]: %time g(objs, 1)
CPU times: user 15.5 s, sys: 1.89 s, total: 17.4 s
Wall time: 13.5 s
```

CPU Time Before (20% time spend in ReferenceCounter::HasOwner)
![head_100k_perf](https://github.com/user-attachments/assets/6384cc1b-38d6-46a4-812c-c2cdb782611a)

CPU Time After 
![head_100k_early-exit](https://github.com/user-attachments/assets/b70ba243-d7a9-417b-ac2a-bf8eabc339a0)
(ReferenceCounter::HasOwner has no overhead)

There are still more improvements to be made. See #49905 for more details.