### PR TITLE
[bazel] enable strict action env for all platforms

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,9 @@
 # Must be first. Enables build:windows, build:linux, build:macos, build:freebsd, build:openbsd
 build --enable_platform_specific_config
+
+# Make hermetic, deterministic build possible.
+build --incompatible_strict_action_env
+
 ###############################################################################
 # On       Windows, provide: BAZEL_SH, and BAZEL_LLVM (if using clang-cl)
 # On all platforms, provide: PYTHON3_BIN_PATH=python
@@ -71,8 +75,6 @@ build:iwyu --experimental_action_listener=//:iwyu_cpp
 build:windows --attempt_to_print_relative_paths
 # Save disk space by hardlinking cache hits instead of copying
 build:windows --experimental_repository_cache_hardlinks
-# Clean the environment before building, to make builds more deterministic
-build:windows --incompatible_strict_action_env
 # For colored output (seems necessary on Windows)
 build:windows --color=yes
 # For compiler colored output (seems necessary on Windows)


### PR DESCRIPTION
this should stop local builds from rebuilding when some env var changes the value.

this does not affect CI that much, as CI jobs mostly run in container images that are more deterministic.
