### PR TITLE
[RLlib] APPO accelerate (vol 12): Enhance `broadcast_interval` logic. Don't broadcast more than once per `training_step()`.

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -808,7 +808,7 @@ class Algorithm(Checkpointable, Trainable, AlgorithmBase):
                     env_steps_sampled=self.metrics.peek(
                         (ENV_RUNNER_RESULTS, NUM_ENV_STEPS_SAMPLED_LIFETIME), default=0
                     ),
-                    rl_module_state=rl_module_state[COMPONENT_RL_MODULE],
+                    rl_module_state=rl_module_state,
                 )
             elif self.eval_env_runner_group:
                 self.eval_env_runner.set_state(rl_module_state)
@@ -817,7 +817,7 @@ class Algorithm(Checkpointable, Trainable, AlgorithmBase):
                     env_steps_sampled=self.metrics.peek(
                         (ENV_RUNNER_RESULTS, NUM_ENV_STEPS_SAMPLED_LIFETIME), default=0
                     ),
-                    rl_module_state=rl_module_state[COMPONENT_RL_MODULE],
+                    rl_module_state=rl_module_state,
                 )
             # TODO (simon): Update modules in DataWorkers.
 
@@ -1020,9 +1020,7 @@ class Algorithm(Checkpointable, Trainable, AlgorithmBase):
                 # Synchronize EnvToModule and ModuleToEnv connector states and broadcast
                 # new states back to all EnvRunners.
                 with self.metrics.log_time((TIMERS, SYNCH_ENV_CONNECTOR_STATES_TIMER)):
-                    self.env_runner_group.sync_env_runner_states(
-                        config=self.config,
-                    )
+                    self.env_runner_group.sync_env_runner_states(config=self.config)
             # Compile final ResultDict from `train_results` and `eval_results`. Note
             # that, as opposed to the old API stack, EnvRunner stats should already be
             # in `train_results` and `eval_results`.

--- a/rllib/algorithms/impala/impala.py
+++ b/rllib/algorithms/impala/impala.py
@@ -691,14 +691,15 @@ class IMPALA(Algorithm):
             rl_module_state = None
             num_learner_group_results_received = 0
 
-            for batch_ref_or_episode_list_ref in data_packages_for_learner_group:
-                return_state = (
-                    self.metrics.peek(
-                        NUM_TRAINING_STEP_CALLS_SINCE_LAST_SYNCH_WORKER_WEIGHTS,
-                        default=0,
-                    )
-                    >= self.config.broadcast_interval
+            return_state = (
+                self.metrics.peek(
+                    NUM_TRAINING_STEP_CALLS_SINCE_LAST_SYNCH_WORKER_WEIGHTS,
+                    default=0,
                 )
+                >= self.config.broadcast_interval
+            )
+
+            for batch_ref_or_episode_list_ref in data_packages_for_learner_group:
                 timesteps = {
                     NUM_ENV_STEPS_SAMPLED_LIFETIME: self.metrics.peek(
                         (ENV_RUNNER_RESULTS, NUM_ENV_STEPS_SAMPLED_LIFETIME), default=0
@@ -731,15 +732,12 @@ class IMPALA(Algorithm):
                         minibatch_size=self.config.minibatch_size,
                         shuffle_batch_per_epoch=self.config.shuffle_batch_per_epoch,
                     )
-                # TODO (sven): Rename this metric into a more fitting name: ex.
-                #  `NUM_LEARNER_UPDATED_SINCE_LAST_WEIGHTS_SYNC`.
-                self.metrics.log_value(
-                    NUM_TRAINING_STEP_CALLS_SINCE_LAST_SYNCH_WORKER_WEIGHTS,
-                    1,
-                    reduce="sum",
-                )
+                # Only request weights from 1st Learner - at most - once per
+                # `training_step` call.
+                return_state = False
 
                 num_learner_group_results_received += len(learner_results)
+                # Extract the last (most recent) weights matrix, if available.
                 for result_from_1_learner in learner_results:
                     rl_module_state = result_from_1_learner.pop(
                         "_rl_module_state_after_update", rl_module_state
@@ -752,6 +750,10 @@ class IMPALA(Algorithm):
                 key=(LEARNER_GROUP, MEAN_NUM_LEARNER_RESULTS_RECEIVED),
                 value=num_learner_group_results_received,
             )
+
+        self.metrics.log_value(
+            NUM_TRAINING_STEP_CALLS_SINCE_LAST_SYNCH_WORKER_WEIGHTS, 1, reduce="sum"
+        )
 
         # Update LearnerGroup's own stats.
         self.metrics.log_dict(self.learner_group.get_stats(), key=LEARNER_GROUP)

--- a/rllib/core/learner/learner.py
+++ b/rllib/core/learner/learner.py
@@ -1246,6 +1246,7 @@ class Learner(Checkpointable):
 
         state = {
             "should_module_be_updated": self.config.policies_to_train,
+            WEIGHTS_SEQ_NO: self._weights_seq_no,
         }
 
         if self._check_component(COMPONENT_RL_MODULE, components, not_components):
@@ -1256,7 +1257,6 @@ class Learner(Checkpointable):
                 ),
                 **kwargs,
             )
-            state[WEIGHTS_SEQ_NO] = self._weights_seq_no
         if self._check_component(COMPONENT_OPTIMIZER, components, not_components):
             state[COMPONENT_OPTIMIZER] = self._get_optimizer_state()
 

--- a/rllib/core/learner/learner_group.py
+++ b/rllib/core/learner/learner_group.py
@@ -385,18 +385,20 @@ class LearnerGroup(Checkpointable):
                     **_kwargs,
                 )
             if _return_state and result:
-                result["_rl_module_state_after_update"] = ray.put(
-                    _learner.get_state(
-                        # Only return the state of those RLModules that actually returned
-                        # results and thus got probably updated.
-                        components=[
-                            COMPONENT_RL_MODULE + "/" + mid
-                            for mid in result
-                            if mid != ALL_MODULES
-                        ],
-                        inference_only=True,
-                    )[COMPONENT_RL_MODULE]
+                learner_state = _learner.get_state(
+                    # Only return the state of those RLModules that actually
+                    # returned results and thus got probably updated.
+                    components=[
+                        COMPONENT_RL_MODULE + "/" + mid
+                        for mid in result
+                        if mid != ALL_MODULES
+                    ],
+                    inference_only=True,
                 )
+                learner_state[COMPONENT_RL_MODULE] = ray.put(
+                    learner_state[COMPONENT_RL_MODULE]
+                )
+                result["_rl_module_state_after_update"] = learner_state
 
             return result
 

--- a/rllib/env/env_runner_group.py
+++ b/rllib/env/env_runner_group.py
@@ -414,11 +414,7 @@ class EnvRunnerGroup:
                         if env_steps_sampled is not None
                         else {}
                     ),
-                    **(
-                        {COMPONENT_RL_MODULE: rl_module_state}
-                        if rl_module_state is not None
-                        else {}
-                    ),
+                    **(rl_module_state or {}),
                 }
             )
             return
@@ -500,7 +496,7 @@ class EnvRunnerGroup:
 
         # Update the rl_module component of the EnvRunner states, if necessary:
         if rl_module_state:
-            env_runner_states.update({COMPONENT_RL_MODULE: rl_module_state})
+            env_runner_states.update(rl_module_state)
 
         # If we do NOT want remote EnvRunners to get their Connector states updated,
         # only update the local worker here (with all state components) and then remove


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

APPO accelerate (vol 12): Enhance `broadcast_interval` logic. Don't broadcast more than once per `training_step()`.

In some calls to `training_step`, `LearnerGroup.update_from_...()` may be called more than once. In these cases, we would request the entire weights matrix to be sent to the object store for each of these calls, even though the weights are only synched once at the end of the `training_step()` method, making all but a single weight request superfluous.

This PR makes sure, we only request the weights - at most - once per `training_step`.

The behavior of `config.broadcast_interval` does not change with this PR. It still means: Every how many `training_step()` calls do we update the weights on all `EnvRunners`?

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
