### PR TITLE
[build] use strict action env on linux ray package building

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,10 @@
 # Must be first. Enables build:windows, build:linux, build:macos, build:freebsd, build:openbsd
 build --enable_platform_specific_config
+
+# Provides users an option to turn on strict action env.
+# TODO(aslonnie): make this default; fix the python tests..
+build:strict --incompatible_strict_action_env
+
 ###############################################################################
 # On       Windows, provide: BAZEL_SH, and BAZEL_LLVM (if using clang-cl)
 # On all platforms, provide: PYTHON3_BIN_PATH=python

--- a/doc/source/ray-contribute/development.rst
+++ b/doc/source/ray-contribute/development.rst
@@ -306,7 +306,7 @@ You can tweak the build with the following environment variables (when running `
 - ``BAZEL_ARGS``: If set, pass a space-separated set of arguments to Bazel. This can be useful
   for restricting resource usage during builds, for example. See https://bazel.build/docs/user-manual
   for more information about valid arguments.
-- ``IS_AUTOMATED_BUILD``: Used in CI to tweak the build for the CI machines
+- ``IS_AUTOMATED_BUILD``: Used in conda-forge CI to tweak the build for the managed CI machines
 - ``SRC_DIR``: Can be set to the root of the source checkout, defaults to
   ``None`` which is ``cwd()``
 - ``BAZEL_SH``: used on Windows to find a ``bash.exe``, see below


### PR DESCRIPTION
especially on building c/c++ parts. this should makes the use of build caches much more efficient