### PR TITLE
[rllib] mark `rllib_learning_tests_pong_appo_torch` as manual

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2428,7 +2428,9 @@
 
   stable: true
 
-  frequency: nightly
+  # frequency was nightly.
+  # TODO(#50217): re-enable after fixing the flakiness.
+  frequency: manual
   team: rllib
   cluster:
     byod:


### PR DESCRIPTION
flaky right now
