### PR TITLE
[bazel] add no-cache back to genrules.

### DIFF
--- a/bazel/ray.bzl
+++ b/bazel/ray.bzl
@@ -116,6 +116,7 @@ def copy_to_workspace(name, srcs, dstdir = ""):
             dstdir = "." + ("/" + dstdir.replace("\\", "/")).rstrip("/") + "/",
         ),
         local = 1,
+        tags = ["no-cache"],
     )
 
 def native_java_binary(module_name, name, native_binary_name):

--- a/java/BUILD.bazel
+++ b/java/BUILD.bazel
@@ -293,6 +293,7 @@ genrule(
         done
     """,
     local = 1,
+    tags = ["no-cache"],
 )
 
 # Generates the dependencies needed by maven.
@@ -323,6 +324,7 @@ genrule(
         done
     """,
     local = 1,
+    tags = ["no-cache"],
 )
 
 genrule(
@@ -351,6 +353,7 @@ genrule(
         if [[ "$$OSTYPE" =~ ^darwin ]]; then shasum "$${FILES[@]}" > $@ ; else sha1sum "$${FILES[@]}" >> $@ ; fi
     """,
     local = 1,
+    tags = ["no-cache"],
 )
 
 java_binary(
@@ -394,4 +397,5 @@ genrule(
         if [[ "$$OSTYPE" =~ ^darwin ]]; then shasum "$$OUTPUT_JAR" >> $@ ; else sha1sum "$$OUTPUT_JAR" >> $@ ; fi
     """,
     local = 1,
+    tags = ["no-cache"],
 )


### PR DESCRIPTION
otherwise it will not re-generate the artifacts..

hopefully the content-addressed output will help skipping the rebuild downstream.