### PR TITLE
[core] Fix ray.wait race that results in ready > num_objects

### DIFF
--- a/cpp/src/ray/runtime/object/local_mode_object_store.cc
+++ b/cpp/src/ray/runtime/object/local_mode_object_store.cc
@@ -90,11 +90,13 @@ std::vector<bool> LocalModeObjectStore::Wait(const std::vector<ObjectID> &ids,
     memory_object_ids.insert(object_id);
   }
   absl::flat_hash_set<ObjectID> ready;
+  absl::flat_hash_set<ObjectID> unused_plasma_object_ids;
   ::ray::Status status = memory_store_->Wait(memory_object_ids,
                                              num_objects,
                                              timeout_ms,
                                              local_mode_ray_tuntime_.GetWorkerContext(),
-                                             &ready);
+                                             &ready,
+                                             &unused_plasma_object_ids);
   if (!status.ok()) {
     throw RayException("Wait object error: " + status.ToString());
   }

--- a/cpp/src/ray/runtime/object/local_mode_object_store.cc
+++ b/cpp/src/ray/runtime/object/local_mode_object_store.cc
@@ -95,7 +95,8 @@ std::vector<bool> LocalModeObjectStore::Wait(const std::vector<ObjectID> &ids,
                           timeout_ms,
                           local_mode_ray_tuntime_.GetWorkerContext());
   if (!status_or_ready_and_plasma_object_ids.ok()) {
-    throw RayException("Wait object error: " + status.ToString());
+    throw RayException("Wait object error: " +
+                       status_or_ready_and_plasma_object_ids.status().ToString());
   }
   const auto &ready = status_or_ready_and_plasma_object_ids.value().first;
   std::vector<bool> result;

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2003,23 +2003,6 @@ Status CoreWorker::Contains(const ObjectID &object_id,
   return Status::OK();
 }
 
-// For any objects that are ErrorType::OBJECT_IN_PLASMA, we need to move them from
-// the ready set into the plasma_object_ids set to wait on them there.
-void MoveReadyPlasmaObjectsToPlasmaSet(
-    std::shared_ptr<CoreWorkerMemoryStore> &memory_store,
-    const absl::flat_hash_set<ObjectID> &memory_object_ids,
-    absl::flat_hash_set<ObjectID> &plasma_object_ids,
-    absl::flat_hash_set<ObjectID> &ready) {
-  for (auto iter = memory_object_ids.begin(); iter != memory_object_ids.end(); iter++) {
-    const auto &obj_id = *iter;
-    auto found = memory_store->GetIfExists(obj_id);
-    if (found != nullptr && found->IsInPlasmaError()) {
-      plasma_object_ids.insert(obj_id);
-      ready.erase(obj_id);
-    }
-  }
-}
-
 Status CoreWorker::Wait(const std::vector<ObjectID> &ids,
                         int num_objects,
                         int64_t timeout_ms,
@@ -2039,7 +2022,6 @@ Status CoreWorker::Wait(const std::vector<ObjectID> &ids,
         "Number of objects to wait for must be between 1 and the number of ids.");
   }
 
-  absl::flat_hash_set<ObjectID> plasma_object_ids;
   absl::flat_hash_set<ObjectID> memory_object_ids(ids.begin(), ids.end());
 
   if (memory_object_ids.size() != ids.size()) {
@@ -2078,33 +2060,40 @@ Status CoreWorker::Wait(const std::vector<ObjectID> &ids,
     }
   }
 
+  absl::flat_hash_set<ObjectID> plasma_object_ids;
   absl::flat_hash_set<ObjectID> ready;
+  ready.reserve(num_objects);
   int64_t start_time = current_time_ms();
   RAY_RETURN_NOT_OK(memory_store_->Wait(
       memory_object_ids,
       std::min(static_cast<int>(memory_object_ids.size()), num_objects),
       timeout_ms,
       worker_context_,
-      &ready));
+      &ready,
+      &plasma_object_ids));
   RAY_CHECK(static_cast<int>(ready.size()) <= num_objects);
   if (timeout_ms > 0) {
     timeout_ms =
         std::max(0, static_cast<int>(timeout_ms - (current_time_ms() - start_time)));
   }
   if (fetch_local) {
-    MoveReadyPlasmaObjectsToPlasmaSet(
-        memory_store_, memory_object_ids, plasma_object_ids, ready);
     // We make the request to the plasma store even if we have num_objects ready since we
     // want to at least make the request to pull these objects if the user specified
     // fetch_local so the pulling can start.
     if (!plasma_object_ids.empty()) {
-      RAY_RETURN_NOT_OK(plasma_store_provider_->Wait(
-          plasma_object_ids,
-          std::min(static_cast<int>(plasma_object_ids.size()),
-                   num_objects - static_cast<int>(ready.size())),
-          timeout_ms,
-          worker_context_,
-          &ready));
+      RAY_RETURN_NOT_OK(
+          plasma_store_provider_->Wait(plasma_object_ids,
+                                       num_objects - static_cast<int>(ready.size()),
+                                       timeout_ms,
+                                       worker_context_,
+                                       &ready));
+    }
+  } else {
+    for (const auto &object_id : plasma_object_ids) {
+      if (ready.size() == num_objects) {
+        break;
+      }
+      ready.insert(object_id);
     }
   }
   RAY_CHECK(static_cast<int>(ready.size()) <= num_objects);

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2090,8 +2090,8 @@ Status CoreWorker::Wait(const std::vector<ObjectID> &ids,
           &ready));
     }
   } else {
-    // When we don't need to fetch_local, we can simply just add the object_ids that we
-    // know are ready in plasma until we have num_objects.
+    // When we don't need to fetch_local, we don't need to wait for the objects to be
+    // pulled to the local object store, so we can directly add them to the ready set.
     for (const auto &object_id : plasma_object_ids) {
       if (ready.size() == static_cast<size_t>(num_objects)) {
         break;

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2090,7 +2090,7 @@ Status CoreWorker::Wait(const std::vector<ObjectID> &ids,
     }
   } else {
     for (const auto &object_id : plasma_object_ids) {
-      if (ready.size() == num_objects) {
+      if (static_cast<int>(ready.size()) == num_objects) {
         break;
       }
       ready.insert(object_id);

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2081,12 +2081,13 @@ Status CoreWorker::Wait(const std::vector<ObjectID> &ids,
     // want to at least make the request to pull these objects if the user specified
     // fetch_local so the pulling can start.
     if (!plasma_object_ids.empty()) {
-      RAY_RETURN_NOT_OK(
-          plasma_store_provider_->Wait(plasma_object_ids,
-                                       num_objects - static_cast<int>(ready.size()),
-                                       timeout_ms,
-                                       worker_context_,
-                                       &ready));
+      RAY_RETURN_NOT_OK(plasma_store_provider_->Wait(
+          plasma_object_ids,
+          std::min(static_cast<int>(plasma_object_ids.size()),
+                   num_objects - static_cast<int>(ready.size())),
+          timeout_ms,
+          worker_context_,
+          &ready));
     }
   } else {
     for (const auto &object_id : plasma_object_ids) {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2077,9 +2077,9 @@ Status CoreWorker::Wait(const std::vector<ObjectID> &ids,
         std::max(0, static_cast<int>(timeout_ms - (current_time_ms() - start_time)));
   }
   if (fetch_local) {
-    // We make the request to the plasma store even if we have num_objects ready since we
-    // want to at least make the request to pull these objects if the user specified
-    // fetch_local so the pulling can start.
+    // With fetch_local we want to start fetching plasma_object_ids from other nodes'
+    // plasma stores. We make the request to the plasma store even if we have num_objects
+    // ready since we want to at least make the request to start pulling these objects.
     if (!plasma_object_ids.empty()) {
       RAY_RETURN_NOT_OK(plasma_store_provider_->Wait(
           plasma_object_ids,
@@ -2090,6 +2090,8 @@ Status CoreWorker::Wait(const std::vector<ObjectID> &ids,
           &ready));
     }
   } else {
+    // When we don't need to fetch_local, we can simply just add the object_ids that we
+    // know are ready in plasma until we have num_objects.
     for (const auto &object_id : plasma_object_ids) {
       if (ready.size() == static_cast<size_t>(num_objects)) {
         break;

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.cc
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.cc
@@ -472,6 +472,9 @@ CoreWorkerMemoryStore::Wait(const absl::flat_hash_set<ObjectID> &object_ids,
     if (result_objects[i] != nullptr) {
       if (result_objects[i]->IsInPlasmaError()) {
         plasma_object_ids.insert(id_vector[i]);
+        if (ready.size() < static_cast<size_t>(num_objects)) {
+          ready.insert(id_vector[i]);
+        }
       } else if (ready.size() < static_cast<size_t>(num_objects)) {
         ready.insert(id_vector[i]);
       }

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.cc
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.cc
@@ -472,10 +472,8 @@ CoreWorkerMemoryStore::Wait(const absl::flat_hash_set<ObjectID> &object_ids,
     if (result_objects[i] != nullptr) {
       if (result_objects[i]->IsInPlasmaError()) {
         plasma_object_ids.insert(id_vector[i]);
-        if (ready.size() < static_cast<size_t>(num_objects)) {
-          ready.insert(id_vector[i]);
-        }
-      } else if (ready.size() < static_cast<size_t>(num_objects)) {
+      }
+      if (ready.size() < static_cast<size_t>(num_objects)) {
         ready.insert(id_vector[i]);
       }
     }

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.cc
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.cc
@@ -267,7 +267,8 @@ Status CoreWorkerMemoryStore::Get(const std::vector<ObjectID> &object_ids,
                  ctx,
                  remove_after_get,
                  results,
-                 /*abort_if_any_object_is_exception=*/true);
+                 /*abort_if_any_object_is_exception=*/true,
+                 /*abort_after_num_objects=*/true);
 }
 
 Status CoreWorkerMemoryStore::GetImpl(const std::vector<ObjectID> &object_ids,
@@ -276,11 +277,12 @@ Status CoreWorkerMemoryStore::GetImpl(const std::vector<ObjectID> &object_ids,
                                       const WorkerContext &ctx,
                                       bool remove_after_get,
                                       std::vector<std::shared_ptr<RayObject>> *results,
-                                      bool abort_if_any_object_is_exception) {
+                                      bool abort_if_any_object_is_exception,
+                                      bool abort_after_num_objects) {
   (*results).resize(object_ids.size(), nullptr);
 
   std::shared_ptr<GetRequest> get_request;
-  int count = 0;
+  int num_found = 0;
 
   {
     absl::flat_hash_set<ObjectID> remaining_ids;
@@ -289,7 +291,7 @@ Status CoreWorkerMemoryStore::GetImpl(const std::vector<ObjectID> &object_ids,
 
     absl::MutexLock lock(&mu_);
     // Check for existing objects and see if this get request can be fullfilled.
-    for (size_t i = 0; i < object_ids.size() && count < num_objects; i++) {
+    for (size_t i = 0; i < object_ids.size(); i++) {
       const auto &object_id = object_ids[i];
       auto iter = objects_.find(object_id);
       if (iter != objects_.end()) {
@@ -300,13 +302,17 @@ Status CoreWorkerMemoryStore::GetImpl(const std::vector<ObjectID> &object_ids,
           // because `object_ids` might have duplicate ids.
           ids_to_remove.insert(object_id);
         }
-        count += 1;
+        num_found += 1;
         if (abort_if_any_object_is_exception && iter->second->IsException() &&
             !iter->second->IsInPlasmaError()) {
           existing_objects_has_exception = true;
         }
       } else {
         remaining_ids.insert(object_id);
+      }
+      // Only wait sets abort_after_num_objects to false.
+      if (num_found >= num_objects && abort_after_num_objects) {
+        break;
       }
     }
 
@@ -319,11 +325,11 @@ Status CoreWorkerMemoryStore::GetImpl(const std::vector<ObjectID> &object_ids,
 
     // Return if all the objects are obtained, or any existing objects are known to have
     // exception.
-    if (remaining_ids.empty() || count >= num_objects || existing_objects_has_exception) {
+    if (num_found >= num_objects || existing_objects_has_exception) {
       return Status::OK();
     }
 
-    size_t required_objects = num_objects - (object_ids.size() - remaining_ids.size());
+    size_t required_objects = num_objects - num_found;
 
     // Otherwise, create a GetRequest to track remaining objects.
     get_request = std::make_shared<GetRequest>(std::move(remaining_ids),
@@ -442,7 +448,8 @@ Status CoreWorkerMemoryStore::Wait(const absl::flat_hash_set<ObjectID> &object_i
                                    int num_objects,
                                    int64_t timeout_ms,
                                    const WorkerContext &ctx,
-                                   absl::flat_hash_set<ObjectID> *ready) {
+                                   absl::flat_hash_set<ObjectID> *ready,
+                                   absl::flat_hash_set<ObjectID> *plasma_object_ids) {
   std::vector<ObjectID> id_vector(object_ids.begin(), object_ids.end());
   std::vector<std::shared_ptr<RayObject>> result_objects;
   RAY_CHECK(object_ids.size() == id_vector.size());
@@ -452,15 +459,19 @@ Status CoreWorkerMemoryStore::Wait(const absl::flat_hash_set<ObjectID> &object_i
                         ctx,
                         false,
                         &result_objects,
-                        /*abort_if_any_object_is_exception=*/false);
+                        /*abort_if_any_object_is_exception=*/false,
+                        /*abort_after_num_objects=*/false);
   // Ignore TimedOut statuses since we return ready objects explicitly.
   if (!status.IsTimedOut()) {
     RAY_RETURN_NOT_OK(status);
   }
-
   for (size_t i = 0; i < id_vector.size(); i++) {
     if (result_objects[i] != nullptr) {
-      ready->insert(id_vector[i]);
+      if (result_objects[i]->IsInPlasmaError()) {
+        plasma_object_ids->insert(id_vector[i]);
+      } else if (ready->size() < num_objects) {
+        ready->insert(id_vector[i]);
+      }
     }
   }
 

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.cc
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.cc
@@ -325,7 +325,8 @@ Status CoreWorkerMemoryStore::GetImpl(const std::vector<ObjectID> &object_ids,
 
     // Return if all the objects are obtained, or any existing objects are known to have
     // exception.
-    if (num_found >= num_objects || existing_objects_has_exception) {
+    if (remaining_ids.empty() || num_found >= num_objects ||
+        existing_objects_has_exception) {
       return Status::OK();
     }
 

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.cc
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.cc
@@ -466,14 +466,12 @@ CoreWorkerMemoryStore::Wait(const absl::flat_hash_set<ObjectID> &object_ids,
     RAY_RETURN_NOT_OK(status);
   }
   absl::flat_hash_set<ObjectID> ready;
-  ready.reserve(num_objects);
   absl::flat_hash_set<ObjectID> plasma_object_ids;
   for (size_t i = 0; i < id_vector.size(); i++) {
     if (result_objects[i] != nullptr) {
       if (result_objects[i]->IsInPlasmaError()) {
         plasma_object_ids.insert(id_vector[i]);
-      }
-      if (ready.size() < static_cast<size_t>(num_objects)) {
+      } else if (ready.size() < static_cast<size_t>(num_objects)) {
         ready.insert(id_vector[i]);
       }
     }

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.cc
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.cc
@@ -469,7 +469,7 @@ Status CoreWorkerMemoryStore::Wait(const absl::flat_hash_set<ObjectID> &object_i
     if (result_objects[i] != nullptr) {
       if (result_objects[i]->IsInPlasmaError()) {
         plasma_object_ids->insert(id_vector[i]);
-      } else if (ready->size() < num_objects) {
+      } else if (static_cast<int>(ready->size()) < num_objects) {
         ready->insert(id_vector[i]);
       }
     }

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.cc
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.cc
@@ -268,7 +268,7 @@ Status CoreWorkerMemoryStore::Get(const std::vector<ObjectID> &object_ids,
                  remove_after_get,
                  results,
                  /*abort_if_any_object_is_exception=*/true,
-                 /*abort_after_num_objects=*/true);
+                 /*at_most_num_objects=*/true);
 }
 
 Status CoreWorkerMemoryStore::GetImpl(const std::vector<ObjectID> &object_ids,
@@ -278,7 +278,7 @@ Status CoreWorkerMemoryStore::GetImpl(const std::vector<ObjectID> &object_ids,
                                       bool remove_after_get,
                                       std::vector<std::shared_ptr<RayObject>> *results,
                                       bool abort_if_any_object_is_exception,
-                                      bool abort_after_num_objects) {
+                                      bool at_most_num_objects) {
   (*results).resize(object_ids.size(), nullptr);
 
   std::shared_ptr<GetRequest> get_request;
@@ -310,8 +310,8 @@ Status CoreWorkerMemoryStore::GetImpl(const std::vector<ObjectID> &object_ids,
       } else {
         remaining_ids.insert(object_id);
       }
-      // Only wait sets abort_after_num_objects to false.
-      if (num_found >= num_objects && abort_after_num_objects) {
+      // Only wait sets at_most_num_objects to false.
+      if (num_found >= num_objects && at_most_num_objects) {
         break;
       }
     }
@@ -460,7 +460,7 @@ CoreWorkerMemoryStore::Wait(const absl::flat_hash_set<ObjectID> &object_ids,
                         false,
                         &result_objects,
                         /*abort_if_any_object_is_exception=*/false,
-                        /*abort_after_num_objects=*/false);
+                        /*at_most_num_objects=*/false);
   // Ignore TimedOut statuses since we return ready objects explicitly.
   if (!status.IsTimedOut()) {
     RAY_RETURN_NOT_OK(status);

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.h
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.h
@@ -93,6 +93,9 @@ class CoreWorkerMemoryStore {
              bool *got_exception);
 
   /// Waits for a number of objects to be ready from the list of object_ids given.
+  /// \return A pair of sets of object IDs. The first set contains the object IDs that
+  /// are ready in the core worker memory store (capped to num_objects), and the second
+  /// set contains the object IDs are ready in the plasma object store (not capped).
   StatusOr<std::pair<absl::flat_hash_set<ObjectID>, absl::flat_hash_set<ObjectID>>> Wait(
       const absl::flat_hash_set<ObjectID> &object_ids,
       int num_objects,
@@ -175,8 +178,9 @@ class CoreWorkerMemoryStore {
   /// See the public version of `Get` for meaning of the other arguments.
   /// \param[in] abort_if_any_object_is_exception Whether we should abort if any object
   /// resources. is an exception.
-  /// \param[in] abort_after_num_objects Whether we should abort the loop that fills
-  /// results after after we find num_objects. False only for Wait.
+  /// \param[in] at_most_num_objects Whether this function will return *at most*
+  /// num_objects even if more are ready. We will still stop waiting when we have
+  /// num_objects.
   Status GetImpl(const std::vector<ObjectID> &object_ids,
                  int num_objects,
                  int64_t timeout_ms,
@@ -184,7 +188,7 @@ class CoreWorkerMemoryStore {
                  bool remove_after_get,
                  std::vector<std::shared_ptr<RayObject>> *results,
                  bool abort_if_any_object_is_exception,
-                 bool abort_after_num_objects);
+                 bool at_most_num_objects);
 
   /// Called when an object is deleted from the store.
   void OnDelete(std::shared_ptr<RayObject> obj);

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.h
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.h
@@ -22,6 +22,7 @@
 #include "ray/common/asio/asio_util.h"
 #include "ray/common/id.h"
 #include "ray/common/status.h"
+#include "ray/common/status_or.h"
 #include "ray/core_worker/context.h"
 #include "ray/core_worker/reference_count.h"
 
@@ -91,13 +92,12 @@ class CoreWorkerMemoryStore {
              absl::flat_hash_map<ObjectID, std::shared_ptr<RayObject>> *results,
              bool *got_exception);
 
-  /// Convenience wrapper around Get() that stores ready objects in a given result set.
-  Status Wait(const absl::flat_hash_set<ObjectID> &object_ids,
-              int num_objects,
-              int64_t timeout_ms,
-              const WorkerContext &ctx,
-              absl::flat_hash_set<ObjectID> *ready,
-              absl::flat_hash_set<ObjectID> *plasma_object_ids);
+  /// Waits for a number of objects to be ready from the list of object_ids given.
+  StatusOr<std::pair<absl::flat_hash_set<ObjectID>, absl::flat_hash_set<ObjectID>>> Wait(
+      const absl::flat_hash_set<ObjectID> &object_ids,
+      int num_objects,
+      int64_t timeout_ms,
+      const WorkerContext &ctx);
 
   /// Get an object if it exists.
   ///

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.h
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.h
@@ -96,7 +96,8 @@ class CoreWorkerMemoryStore {
               int num_objects,
               int64_t timeout_ms,
               const WorkerContext &ctx,
-              absl::flat_hash_set<ObjectID> *ready);
+              absl::flat_hash_set<ObjectID> *ready,
+              absl::flat_hash_set<ObjectID> *plasma_object_ids);
 
   /// Get an object if it exists.
   ///
@@ -174,13 +175,16 @@ class CoreWorkerMemoryStore {
   /// See the public version of `Get` for meaning of the other arguments.
   /// \param[in] abort_if_any_object_is_exception Whether we should abort if any object
   /// resources. is an exception.
+  /// \param[in] abort_after_num_objects Whether we should abort the loop that fills
+  /// results after after we find num_objects. False only for Wait.
   Status GetImpl(const std::vector<ObjectID> &object_ids,
                  int num_objects,
                  int64_t timeout_ms,
                  const WorkerContext &ctx,
                  bool remove_after_get,
                  std::vector<std::shared_ptr<RayObject>> *results,
-                 bool abort_if_any_object_is_exception);
+                 bool abort_if_any_object_is_exception,
+                 bool abort_after_num_objects);
 
   /// Called when an object is deleted from the store.
   void OnDelete(std::shared_ptr<RayObject> obj);

--- a/src/ray/raylet/format/node_manager.fbs
+++ b/src/ray/raylet/format/node_manager.fbs
@@ -223,7 +223,7 @@ table WaitRequest {
   // The RPC addresses of the workers that own the objects in object_ids.
   owner_addresses: [Address];
   // Number of objects expected to be returned, if available.
-  num_ready_objects: int;
+  num_required_objects: int;
   // timeout
   timeout: long;
   // The current task ID.

--- a/src/ray/raylet/format/node_manager.fbs
+++ b/src/ray/raylet/format/node_manager.fbs
@@ -222,7 +222,8 @@ table WaitRequest {
   object_ids: [string];
   // The RPC addresses of the workers that own the objects in object_ids.
   owner_addresses: [Address];
-  // Number of objects expected to be returned, if available.
+  // Minimum number of objects to wait for before returning.
+  // At most this many objects will be returned even if more are ready.
   num_required_objects: int;
   // timeout
   timeout: long;

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1758,7 +1758,7 @@ void NodeManager::ProcessWaitRequestMessage(
                         current_task_id,
                         /*ray_get=*/false);
   }
-  if (message->num_ready_objects() == 0) {
+  if (message->num_required_objects() == 0) {
     // If we don't need to wait for any, return immediately after making the pull
     // requests through AsyncResolveObjects above.
     flatbuffers::FlatBufferBuilder fbb;

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1783,7 +1783,7 @@ void NodeManager::ProcessWaitRequestMessage(
     }
     return;
   }
-  uint64_t num_required_objects = static_cast<uint64_t>(message->num_ready_objects());
+  uint64_t num_required_objects = static_cast<uint64_t>(message->num_required_objects());
   wait_manager_.Wait(
       object_ids,
       message->timeout(),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We had a ray.wait race condition where we could have more ready objects than requested because we create `plasma_object_ids` after creating the initial `ready` set. We merged this attempted fix https://github.com/ray-project/ray/pull/49218, however it resulted in major ray data performance regressions. 

This fixes the initial race condition by creating the `ready` set and `plasma_object_ids` at the same time in the core worker memory store wait.

It maintains ray data performance because plasma_object_ids still contains all the possible objects that are ready in the plasma store and makes the request to other raylets to start pulling the objects. Basically plasma_object_ids is still created from the entire list of object_ids requested and is not capped by `num_objects`/`num_returns`
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
