### PR TITLE
[llm] Fixing some bugs in ray.data.llm

### DIFF
--- a/python/ray/llm/_internal/batch/processor/base.py
+++ b/python/ray/llm/_internal/batch/processor/base.py
@@ -71,17 +71,24 @@ class Processor:
         self.postprocess = None
         self.stages: OrderedDict[str, StatefulStage] = OrderedDict()
 
-        if preprocess is not None:
-            self.preprocess = wrap_preprocess(
-                preprocess,
-                self.data_column,
-            )
+        # NOTE (Kourosh): If pre/postprocess is not provided, use the identity function.
+        # Wrapping is required even if they are identity functions, b/c data_column 
+        # gets inserted/removed via wrap_preprocess/wrap_postprocess.
+        if preprocess is None:
+            preprocess = lambda row: row
+        if postprocess is None:
+            postprocess = lambda row: row
+        
+            
+        self.preprocess = wrap_preprocess(
+            preprocess,
+            self.data_column,
+        )
 
-        if postprocess is not None:
-            self.postprocess = wrap_postprocess(
-                postprocess,
-                self.data_column,
-            )
+        self.postprocess = wrap_postprocess(
+            postprocess,
+            self.data_column,
+        )
 
         for stage in stages:
             self._append_stage(stage)

--- a/python/ray/llm/_internal/batch/processor/base.py
+++ b/python/ray/llm/_internal/batch/processor/base.py
@@ -74,12 +74,9 @@ class Processor:
         # NOTE (Kourosh): If pre/postprocess is not provided, use the identity function.
         # Wrapping is required even if they are identity functions, b/c data_column 
         # gets inserted/removed via wrap_preprocess/wrap_postprocess.
-        if preprocess is None:
-            preprocess = lambda row: row
-        if postprocess is None:
-            postprocess = lambda row: row
+        preprocess = preprocess or (lambda row: row)
+        postprocess = postprocess or (lambda row: row)
         
-            
         self.preprocess = wrap_preprocess(
             preprocess,
             self.data_column,

--- a/python/ray/llm/_internal/batch/processor/base.py
+++ b/python/ray/llm/_internal/batch/processor/base.py
@@ -72,11 +72,11 @@ class Processor:
         self.stages: OrderedDict[str, StatefulStage] = OrderedDict()
 
         # NOTE (Kourosh): If pre/postprocess is not provided, use the identity function.
-        # Wrapping is required even if they are identity functions, b/c data_column 
+        # Wrapping is required even if they are identity functions, b/c data_column
         # gets inserted/removed via wrap_preprocess/wrap_postprocess.
         preprocess = preprocess or (lambda row: row)
         postprocess = postprocess or (lambda row: row)
-        
+
         self.preprocess = wrap_preprocess(
             preprocess,
             self.data_column,

--- a/python/ray/llm/_internal/batch/stages/base.py
+++ b/python/ray/llm/_internal/batch/stages/base.py
@@ -1,6 +1,6 @@
 """The base class for all stages."""
 import logging
-from typing import Any, Dict, AsyncIterator, List, Callable
+from typing import Any, Dict, AsyncIterator, List, Callable, Type
 
 import pyarrow
 from pydantic import BaseModel, Field
@@ -235,7 +235,7 @@ class StatefulStage(BaseModel):
     A basic building block to compose a Processor.
     """
 
-    fn: StatefulStageUDF = Field(
+    fn: Type[StatefulStageUDF] = Field(
         description="The well-optimized stateful UDF for this stage."
     )
     fn_constructor_kwargs: Dict[str, Any] = Field(

--- a/python/ray/llm/_internal/batch/stages/chat_template_stage.py
+++ b/python/ray/llm/_internal/batch/stages/chat_template_stage.py
@@ -1,6 +1,6 @@
 """Apply chat template stage"""
 
-from typing import Any, Dict, AsyncIterator, List
+from typing import Any, Dict, AsyncIterator, List, Type
 
 from ray.llm._internal.batch.stages.base import (
     StatefulStage,
@@ -61,7 +61,7 @@ class ChatTemplateStage(StatefulStage):
     A stage that applies chat template.
     """
 
-    fn: StatefulStageUDF = ChatTemplateUDF
+    fn: Type[StatefulStageUDF] = ChatTemplateUDF
     fn_constructor_kwargs: Dict[str, Any]
     map_batches_kwargs: Dict[str, Any] = dict(
         concurrency=1,

--- a/python/ray/llm/_internal/batch/stages/http_request_stage.py
+++ b/python/ray/llm/_internal/batch/stages/http_request_stage.py
@@ -94,6 +94,7 @@ class HttpRequestUDF(StatefulStageUDF):
     def expected_input_keys(self) -> List[str]:
         return ["payload"]
 
+
 class HttpRequestStage(StatefulStage):
     """
     A stage that sends HTTP requests.

--- a/python/ray/llm/_internal/batch/stages/http_request_stage.py
+++ b/python/ray/llm/_internal/batch/stages/http_request_stage.py
@@ -62,7 +62,7 @@ class HttpRequestUDF(StatefulStageUDF):
 
                 # Normalize the row to a JSON body.
                 json_body = {}
-                for key, value in row.items():
+                for key, value in row["payload"].items():
                     if isinstance(value, np.ndarray):
                         json_body[key] = value.tolist()
                     else:
@@ -87,9 +87,12 @@ class HttpRequestUDF(StatefulStageUDF):
                         )
                     yield {
                         self.IDX_IN_BATCH_COLUMN: idx_in_batch,
-                        **resp_json,
+                        "http_response": resp_json,
                     }
 
+    @property
+    def expected_input_keys(self) -> List[str]:
+        return ["payload"]
 
 class HttpRequestStage(StatefulStage):
     """

--- a/python/ray/llm/_internal/batch/stages/http_request_stage.py
+++ b/python/ray/llm/_internal/batch/stages/http_request_stage.py
@@ -4,7 +4,7 @@ import aiohttp
 import asyncio
 import time
 import numpy as np
-from typing import Any, Dict, AsyncIterator, Optional, List
+from typing import Any, Dict, AsyncIterator, Optional, List, Type
 
 from ray.llm._internal.batch.stages.base import StatefulStage, StatefulStageUDF
 
@@ -99,7 +99,7 @@ class HttpRequestStage(StatefulStage):
     A stage that sends HTTP requests.
     """
 
-    fn: StatefulStageUDF = HttpRequestUDF
+    fn: Type[StatefulStageUDF] = HttpRequestUDF
     fn_constructor_kwargs: Dict[str, Any]
     map_batches_kwargs: Dict[str, Any] = dict(
         concurrency=1,

--- a/python/ray/llm/_internal/batch/stages/tokenize_stage.py
+++ b/python/ray/llm/_internal/batch/stages/tokenize_stage.py
@@ -1,6 +1,6 @@
 """Tokenize and detokenize stage"""
 
-from typing import Any, Dict, AsyncIterator, List
+from typing import Any, Dict, AsyncIterator, List, Type
 
 from ray.llm._internal.batch.stages.base import (
     StatefulStage,
@@ -57,7 +57,7 @@ class TokenizeStage(StatefulStage):
     A stage that tokenizes the input.
     """
 
-    fn: StatefulStageUDF = TokenizeUDF
+    fn: Type[StatefulStageUDF] = TokenizeUDF
     fn_constructor_kwargs: Dict[str, Any]
     map_batches_kwargs: Dict[str, Any] = dict(
         concurrency=1,
@@ -115,7 +115,7 @@ class DetokenizeStage(StatefulStage):
     A stage that detokenizes the input.
     """
 
-    fn: StatefulStageUDF = DetokenizeUDF
+    fn: Type[StatefulStageUDF] = DetokenizeUDF
     fn_constructor_kwargs: Dict[str, Any]
     map_batches_kwargs: Dict[str, Any] = dict(
         concurrency=1,

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -7,7 +7,7 @@ import time
 import uuid
 from functools import partial
 from pydantic import BaseModel, Field, root_validator
-from typing import Any, Dict, AsyncIterator, Optional, List, Tuple
+from typing import Any, Dict, AsyncIterator, Optional, List, Tuple, Type
 
 import ray
 from ray.llm._internal.batch.stages.base import (
@@ -464,7 +464,7 @@ class vLLMEngineStage(StatefulStage):
     A stage that runs vLLM engine.
     """
 
-    fn: StatefulStageUDF = vLLMEngineStageUDF
+    fn: Type[StatefulStageUDF] = vLLMEngineStageUDF
     fn_constructor_kwargs: Dict[str, Any]
     map_batches_kwargs: Dict[str, Any] = dict(
         concurrency=1,

--- a/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
+++ b/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
@@ -34,11 +34,11 @@ def test_empty_processor():
         assert "val" not in row
         assert "id" in row
         assert "result" in row
-        
-        
+
+
 def test_processor_with_no_preprocess_or_postprocess():
     """Test processor with no preprocess or postprocess."""
-    
+
     processor = Processor(
         config=ProcessorConfig(
             batch_size=64,
@@ -50,9 +50,8 @@ def test_processor_with_no_preprocess_or_postprocess():
 
     ds = ray.data.range(5)
     ds = processor(ds).take_all()
-    for row in ds: 
+    for row in ds:
         assert "id" in row
-
 
 
 @pytest.mark.parametrize("has_extra", [True, False])

--- a/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
+++ b/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, AsyncIterator, Dict, List
+from typing import Any, AsyncIterator, Dict, List, Type
 
 import pytest
 
@@ -67,7 +67,7 @@ def test_processor_with_stages(has_extra: bool):
             return ["val"]
 
     class DummyStage(StatefulStage):
-        fn: StatefulStageUDF = DummyStatefulStageUDF
+        fn: Type[StatefulStageUDF] = DummyStatefulStageUDF
         fn_constructor_kwargs: Dict[str, Any] = {}
         map_batches_kwargs: Dict[str, Any] = dict(concurrency=1)
 
@@ -125,7 +125,7 @@ def test_builder():
                 yield row
 
     class DummyStage(StatefulStage):
-        fn: StatefulStageUDF = DummyStatefulStageUDF
+        fn: Type[StatefulStageUDF] = DummyStatefulStageUDF
         fn_constructor_kwargs: Dict[str, Any] = {}
         map_batches_kwargs: Dict[str, Any] = {}
 

--- a/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
+++ b/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
@@ -34,6 +34,25 @@ def test_empty_processor():
         assert "val" not in row
         assert "id" in row
         assert "result" in row
+        
+        
+def test_processor_with_no_preprocess_or_postprocess():
+    """Test processor with no preprocess or postprocess."""
+    
+    processor = Processor(
+        config=ProcessorConfig(
+            batch_size=64,
+            accelerator_type=None,
+            concurrency=1,
+        ),
+        stages=[],
+    )
+
+    ds = ray.data.range(5)
+    ds = processor(ds).take_all()
+    for row in ds: 
+        assert "id" in row
+
 
 
 @pytest.mark.parametrize("has_extra", [True, False])

--- a/python/ray/llm/tests/batch/cpu/stages/test_http_request_stage.py
+++ b/python/ray/llm/tests/batch/cpu/stages/test_http_request_stage.py
@@ -32,7 +32,7 @@ async def test_http_request_udf_basic():
         qps=None,
     )
 
-    batch = {"__data": [{"text": "hello", "metadata": "test"}]}
+    batch = {"__data": [{"payload": {"text": "hello", "metadata": "test"}}]}
 
     with patch("aiohttp.ClientSession") as mock_session_cls:
         session = AsyncMock()
@@ -42,7 +42,7 @@ async def test_http_request_udf_basic():
         mock_session_cls.return_value.__aenter__.return_value = session
 
         async for result in udf(batch):
-            assert result["__data"][0]["response"] == "test"
+            assert result["__data"][0]["http_response"]["response"] == "test"
 
         session.post.assert_called_once_with(
             "http://test.com/api",
@@ -50,7 +50,7 @@ async def test_http_request_udf_basic():
                 "Content-Type": "application/json",
                 "Authorization": "Bearer 1234567890",
             },
-            json={"text": "hello", "metadata": "test", "__idx_in_batch": 0},
+            json={"text": "hello", "metadata": "test"},
         )
 
 
@@ -62,7 +62,7 @@ async def test_http_request_udf_with_qps():
         qps=2,
     )
 
-    batch = {"__data": [{"text": "hello1"}, {"text": "hello2"}]}
+    batch = {"__data": [{"payload": {"text": "hello1"}}, {"payload": {"text": "hello2"}}]}
 
     with patch("aiohttp.ClientSession") as mock_session_cls, patch(
         "time.time"

--- a/python/ray/llm/tests/batch/cpu/stages/test_http_request_stage.py
+++ b/python/ray/llm/tests/batch/cpu/stages/test_http_request_stage.py
@@ -62,7 +62,9 @@ async def test_http_request_udf_with_qps():
         qps=2,
     )
 
-    batch = {"__data": [{"payload": {"text": "hello1"}}, {"payload": {"text": "hello2"}}]}
+    batch = {
+        "__data": [{"payload": {"text": "hello1"}}, {"payload": {"text": "hello2"}}]
+    }
 
     with patch("aiohttp.ClientSession") as mock_session_cls, patch(
         "time.time"

--- a/python/ray/llm/tests/batch/cpu/stages/test_stage_base.py
+++ b/python/ray/llm/tests/batch/cpu/stages/test_stage_base.py
@@ -120,15 +120,13 @@ class TestStatefulStageUDF:
 
 
 def test_stateful_stage():
-    udf = TestStatefulStageUDF.SimpleUDF(data_column="__data")
-
     stage = StatefulStage(
-        fn=udf,
+        fn=TestStatefulStageUDF.SimpleUDF,
         fn_constructor_kwargs={"data_column": "__data"},
         map_batches_kwargs={"batch_size": 10},
     )
 
-    assert stage.fn == udf
+    assert stage.fn == TestStatefulStageUDF.SimpleUDF
     assert stage.fn_constructor_kwargs == {"data_column": "__data"}
     assert stage.map_batches_kwargs == {"batch_size": 10}
 

--- a/python/ray/llm/tests/batch/cpu/stages/test_stage_base.py
+++ b/python/ray/llm/tests/batch/cpu/stages/test_stage_base.py
@@ -4,7 +4,6 @@ from typing import List, Any, AsyncIterator, Dict
 from ray.llm._internal.batch.stages.base import (
     wrap_preprocess,
     wrap_postprocess,
-    StatefulStage,
     StatefulStageUDF,
 )
 
@@ -117,18 +116,6 @@ class TestStatefulStageUDF:
         with pytest.raises(ValueError):
             async for _ in udf(batch):
                 pass
-
-
-def test_stateful_stage():
-    stage = StatefulStage(
-        fn=TestStatefulStageUDF.SimpleUDF,
-        fn_constructor_kwargs={"data_column": "__data"},
-        map_batches_kwargs={"batch_size": 10},
-    )
-
-    assert stage.fn == TestStatefulStageUDF.SimpleUDF
-    assert stage.fn_constructor_kwargs == {"data_column": "__data"}
-    assert stage.map_batches_kwargs == {"batch_size": 10}
 
 
 if __name__ == "__main__":

--- a/python/ray/setup-dev.py
+++ b/python/ray/setup-dev.py
@@ -121,6 +121,7 @@ if __name__ == "__main__":
     if not args.yes:
         print("NOTE: Use '-y' to override all python files without confirmation.")
 
+    do_link("llm", force=args.yes, skip_list=args.skip)
     do_link("rllib", force=args.yes, skip_list=args.skip, local_path="../../../rllib")
     do_link("air", force=args.yes, skip_list=args.skip)
     do_link("tune", force=args.yes, skip_list=args.skip)


### PR DESCRIPTION
Bug fixes: 

1. The fn in Stage abstraction should actually be Type[StatefulStage] but it was StatefulStage instead. 
2. preprocess / postprocess fns could not be set to None before. None means identity now
3. the endpoint you hit in http processor can reject extra keys. So it's important to take the output of preprocessor as is as the payload and sent it without extra fields to the underlying endpoint. Same thing on the output. It should not be flattened out to clutter the output results. http_response will be the thing you index on to get the response from the endpoint.