### PR TITLE
[Core] Fix check failure due to negative available resource

### DIFF
--- a/src/ray/common/BUILD
+++ b/src/ray/common/BUILD
@@ -182,6 +182,7 @@ ray_cc_library(
         ":runtime_env",
         "//:node_manager_fbs",
         "//src/ray/util",
+        "//src/ray/util:container_util",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/strings",

--- a/src/ray/common/bundle_spec.cc
+++ b/src/ray/common/bundle_spec.cc
@@ -138,6 +138,23 @@ std::string GetOriginalResourceNameFromWildcardResource(const std::string &resou
   }
 }
 
+bool IsCPUOrPlacementGroupCPUResource(ResourceID resource_id) {
+  // Check whether the resource is CPU resource or CPU resource inside PG.
+  if (resource_id == ResourceID::CPU()) {
+    return true;
+  }
+
+  auto possible_pg_resource = ParsePgFormattedResource(resource_id.Binary(),
+                                                       /*for_wildcard_resource*/ true,
+                                                       /*for_indexed_resource*/ true);
+  if (possible_pg_resource.has_value() &&
+      possible_pg_resource->original_resource == ResourceID::CPU().Binary()) {
+    return true;
+  }
+
+  return false;
+}
+
 std::optional<PgFormattedResourceData> ParsePgFormattedResource(
     const std::string &resource, bool for_wildcard_resource, bool for_indexed_resource) {
   // Check if it is a wildcard pg resource.

--- a/src/ray/common/bundle_spec.h
+++ b/src/ray/common/bundle_spec.h
@@ -126,6 +126,8 @@ std::string GetOriginalResourceName(const std::string &resource);
 // Returns "" if the resource is not a wildcard resource.
 std::string GetOriginalResourceNameFromWildcardResource(const std::string &resource);
 
+/// Return whether the resource specified by the resource_id is a CPU resource
+/// or CPU resource inside a placement group.
 bool IsCPUOrPlacementGroupCPUResource(ResourceID resource_id);
 
 /// Parse the given resource and get the pg related information.

--- a/src/ray/common/bundle_spec.h
+++ b/src/ray/common/bundle_spec.h
@@ -126,6 +126,8 @@ std::string GetOriginalResourceName(const std::string &resource);
 // Returns "" if the resource is not a wildcard resource.
 std::string GetOriginalResourceNameFromWildcardResource(const std::string &resource);
 
+bool IsCPUOrPlacementGroupCPUResource(ResourceID resource_id);
+
 /// Parse the given resource and get the pg related information.
 ///
 /// \param resource name of the resource.

--- a/src/ray/common/scheduling/resource_instance_set.cc
+++ b/src/ray/common/scheduling/resource_instance_set.cc
@@ -374,6 +374,7 @@ void NodeResourceInstanceSet::AllocateWithReference(
     if (available[i] < ref_allocation[i]) {
       // Only CPU resource can go negative due to the behavior
       // that ray.get() will temporarily release the CPU resource.
+      // See https://github.com/ray-project/ray/pull/50517.
       RAY_CHECK(IsCPUOrPlacementGroupCPUResource(resource_id));
     }
     available[i] -= ref_allocation[i];

--- a/src/ray/common/scheduling/resource_instance_set.cc
+++ b/src/ray/common/scheduling/resource_instance_set.cc
@@ -19,6 +19,7 @@
 #include <utility>
 
 #include "ray/common/bundle_spec.h"
+#include "ray/util/container_util.h"
 #include "ray/util/logging.h"
 
 namespace ray {
@@ -375,7 +376,10 @@ void NodeResourceInstanceSet::AllocateWithReference(
       // Only CPU resource can go negative due to the behavior
       // that ray.get() will temporarily release the CPU resource.
       // See https://github.com/ray-project/ray/pull/50517.
-      RAY_CHECK(IsCPUOrPlacementGroupCPUResource(resource_id));
+      RAY_CHECK(IsCPUOrPlacementGroupCPUResource(resource_id))
+          << "Resource " << resource_id.Binary()
+          << " has less availability than requested. Available: "
+          << debug_string(available) << ", requested: " << debug_string(ref_allocation);
     }
     available[i] -= ref_allocation[i];
   }

--- a/src/ray/common/scheduling/resource_instance_set.cc
+++ b/src/ray/common/scheduling/resource_instance_set.cc
@@ -371,7 +371,11 @@ void NodeResourceInstanceSet::AllocateWithReference(
   RAY_CHECK_EQ(available.size(), ref_allocation.size());
 
   for (size_t i = 0; i < ref_allocation.size(); i++) {
-    RAY_CHECK_GE(available[i], ref_allocation[i]);
+    if (available[i] < ref_allocation[i]) {
+      // Only CPU resource can go negative due to the behavior
+      // that ray.get() will temporarily release the CPU resource.
+      RAY_CHECK(IsCPUOrPlacementGroupCPUResource(resource_id));
+    }
     available[i] -= ref_allocation[i];
   }
 

--- a/src/ray/common/scheduling/resource_instance_set.h
+++ b/src/ray/common/scheduling/resource_instance_set.h
@@ -152,7 +152,7 @@ class NodeResourceInstanceSet {
   ///
   /// The function assumes and also verifies that (1) the resource_id exists in the
   /// node; (2) the available resources with resource_id on the node can satisfy the
-  /// provided ref_allocation.
+  /// provided ref_allocation (with the exception of CPU resources which can go negative).
   ///
   /// \param ref_allocation: The reference allocation used to allocate the resource_id
   /// \param resource_id: The id of the resource to be allocated

--- a/src/ray/raylet/local_task_manager.cc
+++ b/src/ray/raylet/local_task_manager.cc
@@ -24,23 +24,6 @@
 namespace ray {
 namespace raylet {
 
-bool IsCPUOrPlacementGroupCPUResource(ResourceID resource_id) {
-  // Check whether the resource is CPU resource or CPU resource inside PG.
-  if (resource_id == ResourceID::CPU()) {
-    return true;
-  }
-
-  auto possible_pg_resource = ParsePgFormattedResource(resource_id.Binary(),
-                                                       /*for_wildcard_resource*/ true,
-                                                       /*for_indexed_resource*/ true);
-  if (possible_pg_resource.has_value() &&
-      possible_pg_resource->original_resource == ResourceID::CPU().Binary()) {
-    return true;
-  }
-
-  return false;
-}
-
 LocalTaskManager::LocalTaskManager(
     const NodeID &self_node_id,
     ClusterResourceScheduler &cluster_resource_scheduler,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The sequence of events that can trigger the check failure:
1. A node has PG resources `{"CPU_group_aaa": 2, "CPU_group_0_aaa": 1, "CPU_group_1_aaa": 1}`
2. Worker1 acquires 1 PG CPU resource, node available resource becomes `{"CPU_group_aaa": 1, "CPU_group_0_aaa": 0, "CPU_group_1_aaa": 1}`
3. Worker1 calls ray.get() which temporarily released its CPU resource, node available resource becomes  `{"CPU_group_aaa": 2, "CPU_group_0_aaa": 1, "CPU_group_1_aaa": 1}`
4. Worker2 acquires 1 PG CPU resource, node available resource becomes `{"CPU_group_aaa": 1, "CPU_group_0_aaa": 0, "CPU_group_1_aaa": 1}`
5. ray.get() returns from worker1 and it acquires back the resource, node available resource becomes `{"CPU_group_aaa": 0, "CPU_group_0_aaa": -1, "CPU_group_1_aaa": 1}`
6. Worker3 acquires 1 PG CPU resource and the check failure happens since it can get `CPU_group_1_aaa` but not `CPU_group_aaa`. The fix is that we allow `CPU_group_aaa` to go negative as well to match the indexed PG CPU resources.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes #50433
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
