### PR TITLE
[data/preprocessors] feat: allow discretizers to be used in append mode

### DIFF
--- a/python/ray/data/preprocessor.py
+++ b/python/ray/data/preprocessor.py
@@ -293,7 +293,7 @@ class Preprocessor(abc.ABC):
 
         if output_columns and len(columns) != len(output_columns):
             raise ValueError(
-                "Invalid output_columns: Got len(columns) != len(output_columns)."
+                "Invalid output_columns: Got len(columns) != len(output_columns). "
                 "The length of columns and output_columns must match."
             )
         return output_columns or columns

--- a/python/ray/data/tests/preprocessors/test_discretizer.py
+++ b/python/ray/data/tests/preprocessors/test_discretizer.py
@@ -79,7 +79,8 @@ def test_uniform_kbins_discretizer(
     assert out_df["C"].equals(in_df["C"])
 
     # append mode
-    with pytest.raises(ValueError):
+    expected_message = "The length of columns and output_columns must match."
+    with pytest.raises(ValueError, match=expected_message):
         UniformKBinsDiscretizer(["A", "B"], bins=bins, output_columns=["A_discretized"])
 
     discretizer = UniformKBinsDiscretizer(
@@ -194,7 +195,8 @@ def test_custom_kbins_discretizer(
     assert out_df["C"].equals(in_df["C"])
 
     # append mode
-    with pytest.raises(ValueError):
+    expected_message = "The length of columns and output_columns must match."
+    with pytest.raises(ValueError, match=expected_message):
         CustomKBinsDiscretizer(["A", "B"], bins=bins, output_columns=["A_discretized"])
 
     discretizer = CustomKBinsDiscretizer(

--- a/python/ray/data/tests/preprocessors/test_discretizer.py
+++ b/python/ray/data/tests/preprocessors/test_discretizer.py
@@ -78,6 +78,45 @@ def test_uniform_kbins_discretizer(
     # Check that the remaining column was not modified
     assert out_df["C"].equals(in_df["C"])
 
+    # append mode
+    with pytest.raises(ValueError):
+        UniformKBinsDiscretizer(["A", "B"], bins=bins, output_columns=["A_discretized"])
+
+    discretizer = UniformKBinsDiscretizer(
+        ["A", "B"],
+        bins=bins,
+        dtypes=dtypes,
+        right=right,
+        include_lowest=include_lowest,
+        output_columns=["A_discretized", "B_discretized"],
+    )
+
+    transformed = discretizer.fit_transform(ds)
+    out_df = transformed.to_pandas()
+
+    assert out_df["A_discretized"].equals(
+        pd.cut(
+            in_df["A"],
+            bins_A,
+            labels=labels_A,
+            ordered=ordered_A,
+            right=right,
+            include_lowest=include_lowest,
+        )
+    )
+    assert out_df["B_discretized"].equals(
+        pd.cut(
+            in_df["B"],
+            bins_B,
+            labels=labels_B,
+            ordered=ordered_B,
+            right=right,
+            include_lowest=include_lowest,
+        )
+    )
+    # Check that the remaining column was not modified
+    assert out_df["C"].equals(in_df["C"])
+
 
 @pytest.mark.parametrize(
     "bins", ([3, 4, 6, 9], {"A": [3, 4, 6, 8, 9], "B": [3, 4, 6, 9]})
@@ -142,6 +181,45 @@ def test_custom_kbins_discretizer(
         )
     )
     assert out_df["B"].equals(
+        pd.cut(
+            in_df["B"],
+            bins_B,
+            labels=labels_B,
+            ordered=ordered_B,
+            right=right,
+            include_lowest=include_lowest,
+        )
+    )
+    # Check that the remaining column was not modified
+    assert out_df["C"].equals(in_df["C"])
+
+    # append mode
+    with pytest.raises(ValueError):
+        CustomKBinsDiscretizer(["A", "B"], bins=bins, output_columns=["A_discretized"])
+
+    discretizer = CustomKBinsDiscretizer(
+        ["A", "B"],
+        bins=bins,
+        dtypes=dtypes,
+        right=right,
+        include_lowest=include_lowest,
+        output_columns=["A_discretized", "B_discretized"],
+    )
+
+    transformed = discretizer.fit_transform(ds)
+    out_df = transformed.to_pandas()
+
+    assert out_df["A_discretized"].equals(
+        pd.cut(
+            in_df["A"],
+            bins_A,
+            labels=labels_A,
+            ordered=ordered_A,
+            right=right,
+            include_lowest=include_lowest,
+        )
+    )
+    assert out_df["B_discretized"].equals(
         pd.cut(
             in_df["B"],
             bins_B,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is part of https://github.com/ray-project/ray/issues/48133. Continuing the approach taken in https://github.com/ray-project/ray/pull/49426, make all the discretizers work in append mode

## Related issue number

https://github.com/ray-project/ray/issues/48133

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
