### PR TITLE
[RLlib] Enable spliting and zero padding of Dict observation

### DIFF
--- a/rllib/utils/postprocessing/zero_padding.py
+++ b/rllib/utils/postprocessing/zero_padding.py
@@ -101,11 +101,11 @@ def split_and_zero_pad(
     # If the items in the list are dicts, split each key's value sequence
     # separately and then reassemble.
     if isinstance(item_list[0], dict):
-        split_dict = {}
-        # For each key, extract the sequence of values and split/pad them.
-        for key in item_list[0]:
-            key_items = [obs[key] for obs in item_list]
-            split_dict[key] = split_and_zero_pad(key_items, max_seq_len)
+        # split each leaf sequence into chunks
+        split_dict = tree.map_structure(
+            lambda *vals: split_and_zero_pad(list(vals), max_seq_len),
+            *item_list
+        )
         # All keys should now have the same number of chunks.
         num_chunks = len(next(iter(split_dict.values())))
         ret = []

--- a/rllib/utils/postprocessing/zero_padding.py
+++ b/rllib/utils/postprocessing/zero_padding.py
@@ -103,8 +103,7 @@ def split_and_zero_pad(
     if isinstance(item_list[0], dict):
         # split each leaf sequence into chunks
         split_dict = tree.map_structure(
-            lambda *vals: split_and_zero_pad(list(vals), max_seq_len),
-            *item_list
+            lambda *vals: split_and_zero_pad(list(vals), max_seq_len), *item_list
         )
         # All keys should now have the same number of chunks.
         num_chunks = len(next(iter(split_dict.values())))

--- a/rllib/utils/postprocessing/zero_padding.py
+++ b/rllib/utils/postprocessing/zero_padding.py
@@ -96,6 +96,25 @@ def split_and_zero_pad(
         data as `item_list`, but split into sub-chunks of size `max_seq_len`.
         The last item in the returned list may be zero-padded, if necessary.
     """
+
+    # --- Handle the dict case ---
+    # If the items in the list are dicts, split each key's value sequence
+    # separately and then reassemble.
+    if isinstance(item_list[0], dict):
+        split_dict = {}
+        # For each key, extract the sequence of values and split/pad them.
+        for key in item_list[0]:
+            key_items = [obs[key] for obs in item_list]
+            split_dict[key] = split_and_zero_pad(key_items, max_seq_len)
+        # All keys should now have the same number of chunks.
+        num_chunks = len(next(iter(split_dict.values())))
+        ret = []
+        for i in range(num_chunks):
+            # Reassemble the dict for chunk i.
+            ret.append({key: split_dict[key][i] for key in split_dict})
+        return ret
+
+    # --- Original processing for non-dict items ---
     zero_element = tree.map_structure(
         lambda s: np.zeros_like([s[0]] if isinstance(s, BatchedNdArray) else s),
         item_list[0],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

### TL;DR

 This PR fixes the `split_and_zero_pad` function to correctly handle the case where the input observation under the `Columns.OBS` key is a dictionary of arrays.

### Longer version
When running the [Action Masking Example](https://github.com/ray-project/ray/blob/e3b0aa6a4f8a4d5835700d968cf3f38d45dff3db/rllib/examples/rl_modules/action_masking_rl_module.py) with LSTM enabled (see the related issue), the `split_and_zero_pad` function cannot correctly handle the case where the input observation under the `Columns.OBS` key is a dictionary of arrays.

This is because the following [lines](https://github.com/ray-project/ray/blob/e3b0aa6a4f8a4d5835700d968cf3f38d45dff3db/rllib/utils/postprocessing/zero_padding.py#L118) of code skip the dictionary since it is not an instance of `BatchedNdArray`. 

```python
if isinstance(item, BatchedNdArray):
    t = max_seq_len - current_t
    current_time_row.append(item[:t])
    if len(item) <= t:
        current_t += len(item)
    else:
        current_t += t
        item_list.appendleft(item[t:])
# `item` is a single item (no batch axis): Append and continue with next item.
else:
    current_time_row.append(item)
    current_t += 1
```

However, when we are using the action masking technique, the observation under the `Columns.OBS` key is a dictionary and the `item` is as follows

```python
item = {
    "action_mask" = BatchedNdArray(),
    "observations" = BatchedNdArray()
}
```

In this PR, the modified function `split_and_zero_pad` first checks if the input observation is a dictionary.
- If it is, the function will recursively call itself on the dictionary values. This way, the function can correctly handle the case where the input observation under the `Columns.OBS` key is a dictionary of arrays.
- If it is not, the function will proceed as usual.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#50526

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've made sure the tests are passing. **(I actually have run the unit tests. However, some tests that are irrelevant to this PR are failing, for instance, the testing from the ray/dashboard, ray/llm, etc. It's my first time submitting a PR, please let me know what I should do in this case.)**
- Testing Strategy
   - [x] Unit tests. 
   - [x] Release tests
   - [ ] This PR is not tested :(
