### PR TITLE
[data] Fix parquet partition cols to support tensors types

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -124,9 +124,15 @@ class ParquetDatasink(_FileDatasink):
     ) -> None:
         import pyarrow as pa
         import pyarrow.parquet as pq
+        import pyarrow.compute as pc
 
         table = concat(tables, promote_types=False)
         # Create unique combinations of the partition columns
+        partition_col_values: List[Dict[str, Any]] = (
+            table.select(self.partition_cols)
+            .group_by(self.partition_cols)
+            .aggregate([])
+        ).to_pylist()
         table_fields = [
             field for field in output_schema if field.name not in self.partition_cols
         ]
@@ -134,30 +140,15 @@ class ParquetDatasink(_FileDatasink):
         output_schema = pa.schema(
             [field for field in output_schema if field.name not in self.partition_cols]
         )
-        # Group the table by partition keys
-        # For each partition key combination fetch list of values
-        # for the non partition columns
-        # Ex: Here original table contain
-        # two columns (a, b). We are paritioning by column a. The schema
-        # of `groups` grouped Table is as follows
-        # b_list: [[[0,0],[1,1],[2,2]]]
-        # a: [[1,2,3]]
-        groups = table.group_by(self.partition_cols).aggregate(
-            [(col_name, "list") for col_name in non_partition_cols]
-        )
-        grouped_keys = [groups.column(k) for k in self.partition_cols]
 
-        for i in range(groups.num_rows):
-            # See https://github.com/apache/arrow/issues/14882 for recommended approach
-            values = [
-                groups.column(f"{col.name}_list")[i].values for col in table_fields
-            ]
-            group_table = pa.Table.from_arrays(values, names=non_partition_cols)
+        for combo in partition_col_values:
+            filters = [pc.equal(table[col], value) for col, value in combo.items()]
+            combined_filter = filters[0]
+            for filter_ in filters[1:]:
+                combined_filter = pc.and_(combined_filter, filter_)
+            group_table = table.filter(combined_filter).select(non_partition_cols)
             partition_path = "/".join(
-                [
-                    f"{col}={values[i]}"
-                    for col, values in zip(self.partition_cols, grouped_keys)
-                ]
+                [f"{col}={value}" for col, value in combo.items()]
             )
             write_path = posixpath.join(self.path, partition_path)
             self._create_dir(write_path)

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -63,6 +63,8 @@ def test_write_parquet_partition_cols(ray_start_regular_shared, tmp_path):
             "b": list(range(num_partitions)) * rows_per_partition,
             "c": list(range(num_rows)),
             "d": list(range(num_rows)),
+            # Make sure algorithm does not fail for tensor types.
+            "e": list(np.random.random((num_rows, 128))),
         }
     )
 
@@ -78,6 +80,7 @@ def test_write_parquet_partition_cols(ray_start_regular_shared, tmp_path):
         d_expected = [k * i for k in range(rows_per_partition)].sort()
         assert c_expected == dsf_partition["c"].tolist().sort()
         assert d_expected == dsf_partition["d"].tolist().sort()
+        assert dsf_partition["e"].shape == (rows_per_partition,)
 
     # Test that partition are read back properly into original dataset schema
     ds1 = ray.data.read_parquet(tmp_path)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Writing data containing a tensor column to `ParquetDatasink` with partition column(s) fails because there is no pyarrow kernel for `hash_list`.
This is because current implementation uses pyarrow `groupby.aggregate`. Aggregate doesnt have kernels for tensor types (see snippet below).

This PR rewrites the implementation without aggregation on non partition cols, thus avoiding this issue.

```
import pyarrow.parquet as pq

tensor_type = pa.fixed_shape_tensor(pa.int32(), [2, 2])

x = {"category": ["a", "b"] * 10, "tensor": list(np.random.random((20, 128)))}
schema = pa.schema(
    [
        ("category", pa.dictionary(pa.int32(), pa.string())),
        ("tensor", pa.fixed_shape_tensor(value_type=pa.float32(), shape=(128,))),
    ]
)
t = pa.Table.from_pydict(x, schema=schema)
t.group_by("category").aggregate([("tensor", "list")])

>> 
Traceback (most recent call last):
  File "/Users/praveengorthy/anyscale/rayturbo/python/ray/data/test_dataset.py", line 63, in <module>
    t.group_by("category").aggregate([("tensor", "list")])
  File "pyarrow/table.pxi", line 5562, in pyarrow.lib.TableGroupBy.aggregate
  File "/opt/miniconda3/lib/python3.9/site-packages/pyarrow/acero.py", line 308, in _group_by
    return decl.to_table(use_threads=use_threads)
  File "pyarrow/_acero.pyx", line 511, in pyarrow._acero.Declaration.to_table
  File "pyarrow/error.pxi", line 154, in pyarrow.lib.pyarrow_internal_check_status
  File "pyarrow/error.pxi", line 91, in pyarrow.lib.check_status
pyarrow.lib.ArrowNotImplementedError: Function 'hash_list' has no kernel matching input types (extension<arrow.fixed_shape_tensor[value_type=float, shape=[128]]>, uint32)
```

## Related issue number

Closes #50506


## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
