### PR TITLE
[Core] Split pubsub into smaller targets to improve build performance

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -735,7 +735,6 @@ ray_cc_library(
     hdrs = ["src/ray/pubsub/publisher.h"],
     deps = [
         ":pubsub_rpc",
-        "@boost//:any",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/synchronization",
@@ -756,13 +755,12 @@ ray_cc_library(
     ],
 )
 
-# PubSub RPC module
 ray_cc_library(
     name = "pubsub_rpc",
+    # TODO(core): Revisit this dependency after grpc_common_lib is broken down into smaller targets.
     deps = [
         ":pubsub_cc_grpc",
-        ":grpc_common_lib",
-        ":ray_common",
+        ":grpc_common_lib",  # This is a large dependency, should be refined in the future.
     ],
 )
 
@@ -772,7 +770,6 @@ ray_cc_library(
     deps = [
         ":publisher_lib",
         ":subscriber_lib",
-        ":pubsub_rpc",
     ],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -298,15 +298,6 @@ cc_grpc_library(
     ],
 )
 
-ray_cc_library(
-    name = "pubsub_rpc",
-    deps = [
-        "pubsub_cc_grpc",
-        ":grpc_common_lib",
-        ":ray_common",
-    ],
-)
-
 cc_grpc_library(
     name = "autoscaler_cc_grpc",
     srcs = ["//src/ray/protobuf:autoscaler_proto"],
@@ -739,21 +730,49 @@ ray_cc_binary(
 
 # Ray native pubsub module.
 ray_cc_library(
-    name = "pubsub_lib",
-    srcs = [
-        "src/ray/pubsub/publisher.cc",
-        "src/ray/pubsub/subscriber.cc",
-    ],
-    hdrs = [
-        "src/ray/pubsub/publisher.h",
-        "src/ray/pubsub/subscriber.h",
-    ],
+    name = "publisher_lib",
+    srcs = ["src/ray/pubsub/publisher.cc"],
+    hdrs = ["src/ray/pubsub/publisher.h"],
     deps = [
         ":pubsub_rpc",
         "@boost//:any",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/synchronization",
+    ],
+)
+
+# Subscriber module
+ray_cc_library(
+    name = "subscriber_lib",
+    srcs = ["src/ray/pubsub/subscriber.cc"],
+    hdrs = ["src/ray/pubsub/subscriber.h"],
+    deps = [
+        ":pubsub_rpc",
+        "@boost//:any",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/synchronization",
+    ],
+)
+
+# PubSub RPC module
+ray_cc_library(
+    name = "pubsub_rpc",
+    deps = [
+        ":pubsub_cc_grpc",
+        ":grpc_common_lib",
+        ":ray_common",
+    ],
+)
+
+# Combined PubSub Library
+ray_cc_library(
+    name = "pubsub_lib",
+    deps = [
+        ":publisher_lib",
+        ":subscriber_lib",
+        ":pubsub_rpc",
     ],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -748,7 +748,6 @@ ray_cc_library(
     hdrs = ["src/ray/pubsub/subscriber.h"],
     deps = [
         ":pubsub_rpc",
-        "@boost//:any",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/synchronization",

--- a/src/ray/pubsub/subscriber.h
+++ b/src/ray/pubsub/subscriber.h
@@ -17,7 +17,6 @@
 #include <grpcpp/grpcpp.h>
 #include <gtest/gtest_prod.h>
 
-#include <boost/any.hpp>
 #include <queue>
 
 #include "absl/container/flat_hash_map.h"


### PR DESCRIPTION
## Why are these changes needed?
As of now, ray core uses [bazel](https://bazel.build/) as build system, which encourages small targets.
Ray core is not following the best practice, which bundles all related files into several giant targets.

## Related issue number
Closes: #50599 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
