### PR TITLE
[Autoscaler] Remove duplicate util function `is_head_node`

### DIFF
--- a/python/ray/autoscaler/v2/instance_manager/reconciler.py
+++ b/python/ray/autoscaler/v2/instance_manager/reconciler.py
@@ -26,7 +26,7 @@ from ray.autoscaler.v2.instance_manager.subscribers.ray_stopper import RayStopEr
 from ray.autoscaler.v2.metrics_reporter import AutoscalerMetricsReporter
 from ray.autoscaler.v2.scheduler import IResourceScheduler, SchedulingRequest
 from ray.autoscaler.v2.schema import AutoscalerInstance, NodeType
-from ray.autoscaler.v2.sdk import is_head_node
+from ray.autoscaler.v2.utils import is_head_node
 from ray.core.generated.autoscaler_pb2 import (
     AutoscalingState,
     ClusterResourceState,

--- a/python/ray/autoscaler/v2/sdk.py
+++ b/python/ray/autoscaler/v2/sdk.py
@@ -9,7 +9,6 @@ from ray.core.generated.autoscaler_pb2 import (
     ClusterResourceState,
     GetClusterResourceStateReply,
     GetClusterStatusReply,
-    NodeState,
 )
 
 DEFAULT_RPC_TIMEOUT_S = 10

--- a/python/ray/autoscaler/v2/sdk.py
+++ b/python/ray/autoscaler/v2/sdk.py
@@ -95,16 +95,3 @@ def get_cluster_resource_state(gcs_client: GcsClient) -> ClusterResourceState:
     reply = GetClusterResourceStateReply()
     reply.ParseFromString(str_reply)
     return reply.cluster_resource_state
-
-
-def is_head_node(node_state: NodeState) -> bool:
-    """
-    Check if the node is a head node from the node state.
-    Args:
-        node_state: the node state
-    Returns:
-        is_head: True if the node is a head node, False otherwise.
-    """
-    # TODO: we should include this bit of information in the future. e.g.
-    # from labels.
-    return "node:__internal_head__" in dict(node_state.total_resources)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The following two functions are the same.

https://github.com/ray-project/ray/blob/30df6a43a7324eaf65b83b94b5c1511b0f954a39/python/ray/autoscaler/v2/utils.py#L840-L851

https://github.com/ray-project/ray/blob/30df6a43a7324eaf65b83b94b5c1511b0f954a39/python/ray/autoscaler/v2/sdk.py#L100-L110

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
