### PR TITLE
[ci] skip chaos tests on microcheck

### DIFF
--- a/.buildkite/kuberay.rayci.yml
+++ b/.buildkite/kuberay.rayci.yml
@@ -25,6 +25,7 @@ steps:
       - python
       - docker
       - oss
+      - skip-on-microcheck
     instance_type: medium
     commands:
       - bash ci/k8s/run-chaos-test.sh {{matrix.fault}} {{matrix.workload}}


### PR DESCRIPTION
these are heavy tests at the end of the dependency chain, not supported by microcheck smart filtering, yet rarely breaks
