### PR TITLE
[data] Simplify Operator.__repr__

### DIFF
--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -106,7 +106,7 @@ class StreamingExecutor(Executor, threading.Thread):
                 if log_path is not None:
                     message += f" Full logs are in {log_path}"
                 logger.info(message)
-                logger.info(f"Execution plan of Dataset: {dag}")
+                logger.info(f"Execution plan of Dataset: {dag.dag_str}")
 
             logger.debug("Execution config: %s", self._options)
 

--- a/python/ray/data/_internal/logical/interfaces/operator.py
+++ b/python/ray/data/_internal/logical/interfaces/operator.py
@@ -24,8 +24,8 @@ class Operator:
         return self._name
 
     @property
-    def full_name(self) -> str:
-        """Full name including all input dependencies."""
+    def dag_string(self) -> str:
+        """String representation of the whole DAG."""
         if self.input_dependencies:
             out_str = ", ".join([str(x) for x in self.input_dependencies])
             out_str += " -> "
@@ -57,7 +57,7 @@ class Operator:
         yield self
 
     def __repr__(self) -> str:
-        return self.name
+        return f"{self.__class__.__name__}[{self._name}]"
 
     def __str__(self) -> str:
         return repr(self)

--- a/python/ray/data/_internal/logical/interfaces/operator.py
+++ b/python/ray/data/_internal/logical/interfaces/operator.py
@@ -24,6 +24,17 @@ class Operator:
         return self._name
 
     @property
+    def full_name(self) -> str:
+        """Full name including all input dependencies."""
+        if self.input_dependencies:
+            out_str = ", ".join([str(x) for x in self.input_dependencies])
+            out_str += " -> "
+        else:
+            out_str = ""
+        out_str += f"{self.__class__.__name__}[{self._name}]"
+        return out_str
+
+    @property
     def input_dependencies(self) -> List["Operator"]:
         """List of operators that provide inputs for this operator."""
         assert hasattr(
@@ -46,13 +57,7 @@ class Operator:
         yield self
 
     def __repr__(self) -> str:
-        if self.input_dependencies:
-            out_str = ", ".join([str(x) for x in self.input_dependencies])
-            out_str += " -> "
-        else:
-            out_str = ""
-        out_str += f"{self.__class__.__name__}[{self._name}]"
-        return out_str
+        return self.name
 
     def __str__(self) -> str:
         return repr(self)

--- a/python/ray/data/_internal/logical/interfaces/operator.py
+++ b/python/ray/data/_internal/logical/interfaces/operator.py
@@ -27,7 +27,7 @@ class Operator:
     def dag_string(self) -> str:
         """String representation of the whole DAG."""
         if self.input_dependencies:
-            out_str = ", ".join([str(x) for x in self.input_dependencies])
+            out_str = ", ".join([x.dag_string for x in self.input_dependencies])
             out_str += " -> "
         else:
             out_str = ""

--- a/python/ray/data/_internal/logical/interfaces/operator.py
+++ b/python/ray/data/_internal/logical/interfaces/operator.py
@@ -24,10 +24,10 @@ class Operator:
         return self._name
 
     @property
-    def dag_string(self) -> str:
+    def dag_str(self) -> str:
         """String representation of the whole DAG."""
         if self.input_dependencies:
-            out_str = ", ".join([x.dag_string for x in self.input_dependencies])
+            out_str = ", ".join([x.dag_str for x in self.input_dependencies])
             out_str += " -> "
         else:
             out_str = ""

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -1745,7 +1745,7 @@ def test_schema_partial_execution(
     # Verify that ds.schema() executes only the first block, and not the
     # entire Dataset.
     assert not ds._plan.has_computed_output()
-    assert str(ds._plan._logical_plan.dag) == (
+    assert ds._plan._logical_plan.dag.dag_str == (
         "Read[ReadParquet] -> MapBatches[MapBatches(<lambda>)]"
     )
 

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -67,6 +67,21 @@ def _take_outputs(op: PhysicalOperator) -> List[Any]:
     return output
 
 
+def test_name_and_repr(ray_start_regular_shared):
+    inputs = make_ref_bundles([[1, 2], [3], [4, 5]])
+    input_op = InputDataBuffer(DataContext.get_current(), inputs)
+    map_op = MapOperator.create(
+        _mul2_map_data_prcessor,
+        input_op,
+        DataContext.get_current(),
+        name="TestMapper",
+    )
+
+    print(map_op.name)
+    print(map_op.full_name)
+    print(str(map_op))
+
+
 def test_input_data_buffer(ray_start_regular_shared):
     # Create with bundles.
     inputs = make_ref_bundles([[1, 2], [3], [4, 5]])

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -78,7 +78,7 @@ def test_name_and_repr(ray_start_regular_shared):
     )
 
     assert map_op1.name == "map1"
-    assert map_op1.dag_string == "InputDataBuffer[Input] -> TaskPoolMapOperator[map1]"
+    assert map_op1.dag_str "InputDataBuffer[Input] -> TaskPoolMapOperator[map1]"
     assert str(map_op1) == "TaskPoolMapOperator[map1]"
 
     map_op2 = MapOperator.create(
@@ -89,7 +89,7 @@ def test_name_and_repr(ray_start_regular_shared):
     )
     assert map_op2.name == "map2"
     assert (
-        map_op2.dag_string
+        map_op2.dag_str
         == "InputDataBuffer[Input] -> TaskPoolMapOperator[map1] -> TaskPoolMapOperator[map2]"
     )
     assert str(map_op2) == "TaskPoolMapOperator[map2]"

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -77,9 +77,11 @@ def test_name_and_repr(ray_start_regular_shared):
         name="TestMapper",
     )
 
-    print(map_op.name)
-    print(map_op.full_name)
-    print(str(map_op))
+    assert map_op.name == "TestMapper"
+    assert (
+        map_op.dag_string == "InputDataBuffer[Input] -> TaskPoolMapOperator[TestMapper]"
+    )
+    assert str(map_op) == "TaskPoolMapOperator[TestMapper]"
 
 
 def test_input_data_buffer(ray_start_regular_shared):

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -78,7 +78,7 @@ def test_name_and_repr(ray_start_regular_shared):
     )
 
     assert map_op1.name == "map1"
-    assert map_op1.dag_str "InputDataBuffer[Input] -> TaskPoolMapOperator[map1]"
+    assert map_op1.dag_str == "InputDataBuffer[Input] -> TaskPoolMapOperator[map1]"
     assert str(map_op1) == "TaskPoolMapOperator[map1]"
 
     map_op2 = MapOperator.create(

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -70,18 +70,29 @@ def _take_outputs(op: PhysicalOperator) -> List[Any]:
 def test_name_and_repr(ray_start_regular_shared):
     inputs = make_ref_bundles([[1, 2], [3], [4, 5]])
     input_op = InputDataBuffer(DataContext.get_current(), inputs)
-    map_op = MapOperator.create(
+    map_op1 = MapOperator.create(
         _mul2_map_data_prcessor,
         input_op,
         DataContext.get_current(),
-        name="TestMapper",
+        name="map1",
     )
 
-    assert map_op.name == "TestMapper"
-    assert (
-        map_op.dag_string == "InputDataBuffer[Input] -> TaskPoolMapOperator[TestMapper]"
+    assert map_op1.name == "map1"
+    assert map_op1.dag_string == "InputDataBuffer[Input] -> TaskPoolMapOperator[map1]"
+    assert str(map_op1) == "TaskPoolMapOperator[map1]"
+
+    map_op2 = MapOperator.create(
+        _mul2_map_data_prcessor,
+        map_op1,
+        DataContext.get_current(),
+        name="map2",
     )
-    assert str(map_op) == "TaskPoolMapOperator[TestMapper]"
+    assert map_op2.name == "map2"
+    assert (
+        map_op2.dag_string
+        == "InputDataBuffer[Input] -> TaskPoolMapOperator[map1] -> TaskPoolMapOperator[map2]"
+    )
+    assert str(map_op2) == "TaskPoolMapOperator[map2]"
 
 
 def test_input_data_buffer(ray_start_regular_shared):

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1602,8 +1602,7 @@ def test_op_metrics_logging():
             + gen_expected_metrics(is_map=False)
         )  # .replace("'obj_store_mem_used': N", "'obj_store_mem_used': Z")
         map_str = (
-            "Operator InputDataBuffer[Input] -> "
-            "TaskPoolMapOperator[ReadRange->MapBatches(<lambda>)] completed. "
+            "Operator TaskPoolMapOperator[ReadRange->MapBatches(<lambda>)] completed. "
             "Operator Metrics:\n"
         ) + STANDARD_EXTRA_METRICS_TASK_BACKPRESSURE
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, `Operator.__repr__` prints the full DAG. It's too verbose. 
Simplify it to only print the current operator. Added `dag_string` for the full DAG.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
