### PR TITLE
Fix torch tensor serialization logic

### DIFF
--- a/doc/source/ray-core/api/exceptions.rst
+++ b/doc/source/ray-core/api/exceptions.rst
@@ -35,6 +35,7 @@ Exceptions
     ray.exceptions.RayChannelError
     ray.exceptions.RayChannelTimeoutError
     ray.exceptions.RayCgraphCapacityExceeded
+    ray.exceptions.RayAdagDeviceMismatchError
     ray.exceptions.RuntimeEnvSetupError
     ray.exceptions.CrossLanguageError
     ray.exceptions.RaySystemError

--- a/doc/source/ray-core/api/exceptions.rst
+++ b/doc/source/ray-core/api/exceptions.rst
@@ -35,7 +35,7 @@ Exceptions
     ray.exceptions.RayChannelError
     ray.exceptions.RayChannelTimeoutError
     ray.exceptions.RayCgraphCapacityExceeded
-    ray.exceptions.RayAdagDeviceMismatchError
+    ray.exceptions.RayCgraphDeviceMismatchError
     ray.exceptions.RuntimeEnvSetupError
     ray.exceptions.CrossLanguageError
     ray.exceptions.RaySystemError

--- a/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
@@ -409,8 +409,9 @@ def test_torch_tensor_nccl_disallows_driver(ray_start_regular):
         match=(r"Driver cannot participate in the NCCL group\."),
     ):
         dag.experimental_compile()
-        
-#TODO(anm): Fix test
+
+
+# TODO(anm): Fix test
 def test_torch_tensor_as_dag_output(ray_start_regular):
     if not USE_GPU:
         pytest.skip("Only working with gpus")
@@ -446,6 +447,7 @@ def test_torch_tensor_as_dag_output(ray_start_regular):
     with pytest.raises(ray.exceptions.RayAdagDeviceMismatchError):
         ray.get(ref)
     breakpoint()
+
 
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
 def test_torch_tensor_custom_comm(ray_start_regular):
@@ -1951,8 +1953,8 @@ def test_torch_nccl_channel_with_all_local_readers(ray_start_regular):
         ),
     ):
         dag.experimental_compile()
-        
-        
+
+
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
 def test_torch_cpu_tensor_to_cpu(ray_start_regular):
     """Verify TorchTensorType(transport="nccl") sends cpu tensor to cpu."""

--- a/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
@@ -409,7 +409,43 @@ def test_torch_tensor_nccl_disallows_driver(ray_start_regular):
         match=(r"Driver cannot participate in the NCCL group\."),
     ):
         dag.experimental_compile()
+        
+#TODO(anm): Fix test
+def test_torch_tensor_as_dag_output(ray_start_regular):
+    if not USE_GPU:
+        pytest.skip("Only working with gpus")
 
+    @ray.remote(num_gpus=1)
+    class A:
+        def f(self, x: int):
+            return torch.tensor([x], device="cuda")
+
+    a = A.remote()
+
+    with InputNode() as inp:
+        out = a.f.bind(inp)
+        dag = out.with_type_hint(TorchTensorType(_device="cpu"))
+
+    compiled_dag = dag.experimental_compile()
+    for i in range(3):
+        ref = compiled_dag.execute(i)
+        result = ray.get(ref)
+        assert result == i
+
+    compiled_dag.teardown()
+
+    # If we don't specify a conversion, it will raise an error.
+    with InputNode() as inp:
+        dag = a.f.bind(inp)
+        # When the device is not specified, it assumes it goes to the
+        # same device.
+        # dag = dag.with_type_hint(TorchTensorType())
+
+    compiled_dag = dag.experimental_compile()
+    ref = compiled_dag.execute(1)
+    with pytest.raises(ray.exceptions.RayAdagDeviceMismatchError):
+        ray.get(ref)
+    breakpoint()
 
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
 def test_torch_tensor_custom_comm(ray_start_regular):
@@ -1915,6 +1951,43 @@ def test_torch_nccl_channel_with_all_local_readers(ray_start_regular):
         ),
     ):
         dag.experimental_compile()
+        
+        
+@pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
+def test_torch_cpu_tensor_to_cpu(ray_start_regular):
+    """Verify TorchTensorType(transport="nccl") sends cpu tensor to cpu."""
+    if not USE_GPU:
+        pytest.skip("This test requires GPU.")
+    assert sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 0
+
+    @ray.remote(num_gpus=1)
+    class A:
+        def send(self, x):
+            return {
+                "cpu_tensor": torch.tensor([x], device="cpu"),
+                "gpu_tensor": torch.tensor([x], device="cuda"),
+            }
+
+        def recv(self, data):
+            assert data["gpu_tensor"].device.type == "cuda"
+            assert data["cpu_tensor"].device.type == "cpu"
+
+    sender = A.remote()
+    receiver = A.remote()
+
+    # Test torch.Tensor sent between actors.
+    with InputNode() as inp:
+        mixed_tensor = sender.send.bind(inp)
+        mixed_tensor = mixed_tensor.with_type_hint(TorchTensorType(transport="nccl"))
+        dag = receiver.recv.bind(mixed_tensor)
+
+    compiled_dag = dag.experimental_compile()
+
+    for i in range(1):
+        ref = compiled_dag.execute(i)
+        ray.get(ref)
+
+    compiled_dag.teardown()
 
 
 if __name__ == "__main__":

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -901,6 +901,14 @@ class RayCgraphCapacityExceeded(RaySystemError):
     pass
 
 
+@PublicAPI(stability="alpha")
+class RayAdagDeviceMismatchError(RaySystemError):
+    """Raised when an output (e.g., tensor) doesn't match a device it is
+    supposed to be created."""
+
+    pass
+
+
 RAY_EXCEPTION_TYPES = [
     PlasmaObjectNotAvailable,
     RayError,
@@ -930,4 +938,5 @@ RAY_EXCEPTION_TYPES = [
     RayChannelTimeoutError,
     OufOfBandObjectRefSerializationException,
     RayCgraphCapacityExceeded,
+    RayAdagDeviceMismatchError,
 ]

--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -902,7 +902,7 @@ class RayCgraphCapacityExceeded(RaySystemError):
 
 
 @PublicAPI(stability="alpha")
-class RayAdagDeviceMismatchError(RaySystemError):
+class RayCgraphDeviceMismatchError(RaySystemError):
     """Raised when an output (e.g., tensor) doesn't match a device it is
     supposed to be created."""
 
@@ -938,5 +938,5 @@ RAY_EXCEPTION_TYPES = [
     RayChannelTimeoutError,
     OufOfBandObjectRefSerializationException,
     RayCgraphCapacityExceeded,
-    RayAdagDeviceMismatchError,
+    RayCgraphDeviceMismatchError,
 ]

--- a/python/ray/experimental/channel/serialization_context.py
+++ b/python/ray/experimental/channel/serialization_context.py
@@ -1,7 +1,7 @@
 import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Set, Literal, Optional, Tuple, Union
 
-from ray.exceptions import RayAdagDeviceMismatchError
+from ray.exceptions import RayCgraphDeviceMismatchError
 
 if TYPE_CHECKING:
     import numpy as np
@@ -84,7 +84,9 @@ class _SerializationContext:
         self._deserialized_tensor_placeholders = set()
         return prev_tensors, deserialized_tensor_placeholders
 
-    def serialize_tensor(self, tensor: "torch.Tensor") -> Union[int, Tuple["np.ndarray", "torch.dtype", str]]:
+    def serialize_tensor(
+        self, tensor: "torch.Tensor"
+    ) -> Union[int, Tuple["np.ndarray", "torch.dtype", str]]:
         from ray.experimental.channel import ChannelContext
 
         ctx = ChannelContext.get_current()
@@ -103,8 +105,8 @@ class _SerializationContext:
         self, tensor: "torch.Tensor"
     ) -> Tuple["np.ndarray", "torch.dtype", str]:
         import torch
-        
-        device_type = tensor.device.type
+
+        target_device_type = tensor.device.type
 
         # Transfer through Ray's shared memory store for now.
         # TODO(swang): This requires two copies, one to transfer from GPU to
@@ -117,9 +119,11 @@ class _SerializationContext:
         # Numpy does not have an equivalent dtype for all torch dtypes, so
         # instead of casting directly to numpy, we first use a view with a
         # common dtype and then view as numpy array.
-        return (tensor.view(torch.uint8).numpy(), tensor.dtype, device_type)
+        return (tensor.view(torch.uint8).numpy(), tensor.dtype, target_device_type)
 
-    def deserialize_tensor(self, val: Union[Tuple["np.ndarray", "torch.dtype", str], int]):
+    def deserialize_tensor(
+        self, val: Union[Tuple["np.ndarray", "torch.dtype", str], int]
+    ):
         # Found a placeholder for a tensor that was serialized via NCCL.
         # Replace it with the corresponding deserialized tensor.
         if isinstance(val, int):
@@ -131,22 +135,28 @@ class _SerializationContext:
         np_array, dtype, target_device_type = val
         return self.deserialize_from_numpy(np_array, dtype, target_device_type)
 
-    def deserialize_from_numpy(self, np_array: "np.ndarray", dtype: "torch.dtype", target_device_type: str):
+    def deserialize_from_numpy(
+        self, np_array: "np.ndarray", dtype: "torch.dtype", target_device_type: str
+    ):
         import torch
 
         from ray.experimental.channel import ChannelContext
 
         ctx = ChannelContext.get_current()
-        
+        default_device_type = (
+            "cpu" if ctx.torch_device is None else ctx.torch_device.type
+        )
+
+        # If target is CUDA, we must have CUDA device
+        if target_device_type == "cuda" and default_device_type != "cuda":
+            # TODO: Improve the error message to include the upstream task.
+            raise RayCgraphDeviceMismatchError(
+                f"The tensor should be created to a device type '{target_device_type}', "
+                f"but there's only '{default_device_type}' available."
+            )
         # TODO(swang): Support local P2P transfers if available.
-        # If there is a GPU assigned to this worker, move it there.
-        if ctx.torch_device is not None and ctx.torch_device.type == "cuda":
-            if target_device_type != "cuda":
-                #TODO: Improve the error message to include the upstream task.
-                raise RayAdagDeviceMismatchError(
-                    f"The tensor should be created to a device type '{target_device_type}', "
-                    f"but there's only '{ctx.torch_device.type}' available."
-                )
+        if target_device_type == "cuda":
+
             def convert_numpy_to_tensor(np_array, ctx):
                 # It does zero-copy convert np_array inside shared memroy to
                 # a tensor. Since we move data to GPU immediately, it is safe.
@@ -177,4 +187,6 @@ class _SerializationContext:
         # TODO(swang): Use zero-copy from_numpy() if np_array.flags.writeable
         # is True. This is safe to set when deserializing np_array if the
         # upstream task has num_readers=1.
-        return torch.tensor(np_array, device=ctx.torch_device).view(dtype)
+        # For CPU target, use CPU device regardless of default device
+        target_device = None if target_device_type == "cpu" else ctx.torch_device
+        return torch.tensor(np_array, device=target_device).view(dtype)

--- a/python/test_tensor_dag_driver.py
+++ b/python/test_tensor_dag_driver.py
@@ -1,0 +1,68 @@
+import ray
+import torch
+import logging
+import numpy as np
+from ray.dag import InputNode
+
+
+ray.init(logging_level=logging.DEBUG, log_to_driver=True)
+
+
+@ray.remote(num_gpus=1)
+class Actor:
+    def send(self, value: int, device: str):
+        return torch.ones(10, device=device) * value
+
+    def recv(self, tensor):
+        return (tensor[0].item(), str(tensor.device))
+
+
+# sender = Actor.remote()
+
+
+# # Test torch.Tensor sent between actors.
+# with InputNode() as inp:
+#     dag = sender.send.bind(inp[0], inp[1])
+
+# compiled_dag = dag.experimental_compile()
+# ref = compiled_dag.execute(1, "cuda")
+# print(ray.get(ref))
+
+# ref = compiled_dag.execute(2, "cpu")
+# print(ray.get(ref))
+
+
+@ray.remote(num_gpus=1)
+class A:
+    def f(self, x: int):
+        return torch.tensor([x], device="cuda")
+
+    def to_cpu(self, x: torch.Tensor):
+        return x.cpu()
+
+
+a = A.remote()
+
+# with InputNode() as inp:
+#     out = a.f.bind(inp)
+#     dag = a.to_cpu.bind(out)
+
+# compiled_dag = dag.experimental_compile()
+# for i in range(3):
+#     ref = compiled_dag.execute(i)
+#     result = ray.get(ref)
+#     assert result == i
+
+# compiled_dag.teardown()
+
+# If we don't move to cpu on worker, it will raise an error.
+with InputNode() as inp:
+    dag = a.f.bind(inp)
+
+compiled_dag = dag.experimental_compile()
+ref = compiled_dag.execute(1)
+print(ray.get(ref))
+
+# with pytest.raises(ray.exceptions.RayAdagDeviceMismatchError):
+#     ray.get(ref)
+# breakpoint()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When we send torch tensors between actors, we want to keep them on their original device. That is:
1) CPU tensors stay on CPU even if the default device for receiving actor is GPU
2) CUDA tensors require CUDA device available on destination actor, otherwise raise an error
This is similar to an old PR #47742

## Related issue number

Fixes #50452


## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
