### PR TITLE
[core] Populate obj store memory even if 0 + less copies in resource managers

### DIFF
--- a/src/ray/common/scheduling/resource_set.cc
+++ b/src/ray/common/scheduling/resource_set.cc
@@ -190,13 +190,10 @@ NodeResourceSet::NodeResourceSet(
 }
 
 NodeResourceSet &NodeResourceSet::Set(ResourceID resource_id, FixedPoint value) {
-  if (value == ResourceDefaultValue(resource_id)) {
-    // We should still store object_store_memory even if it is 0.
-    if (resource_id == ResourceID::ObjectStoreMemory()) {
-      resources_[resource_id] = value;
-    } else {
-      resources_.erase(resource_id);
-    }
+  if (value == ResourceDefaultValue(resource_id) &&
+      resource_id != ResourceID::ObjectStoreMemory()) {
+    // We should still store object_store_memory and cpu even if it is 0.
+    resources_.erase(resource_id);
   } else {
     resources_[resource_id] = value;
   }

--- a/src/ray/common/scheduling/resource_set.cc
+++ b/src/ray/common/scheduling/resource_set.cc
@@ -191,7 +191,12 @@ NodeResourceSet::NodeResourceSet(
 
 NodeResourceSet &NodeResourceSet::Set(ResourceID resource_id, FixedPoint value) {
   if (value == ResourceDefaultValue(resource_id)) {
-    resources_.erase(resource_id);
+    // We should still store object_store_memory even if it is 0.
+    if (resource_id == ResourceID::ObjectStoreMemory()) {
+      resources_[resource_id] = value;
+    } else {
+      resources_.erase(resource_id);
+    }
   } else {
     resources_[resource_id] = value;
   }
@@ -239,6 +244,7 @@ FixedPoint NodeResourceSet::ResourceDefaultValue(ResourceID resource_id) const {
 
 absl::flat_hash_map<std::string, double> NodeResourceSet::GetResourceMap() const {
   absl::flat_hash_map<std::string, double> result;
+  result.reserve(resources_.size());
   for (const auto &[id, quantity] : resources_) {
     result[id.Binary()] = quantity.Double();
   }

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.cc
@@ -88,14 +88,14 @@ void GcsResourceManager::HandleGetAllAvailableResources(
     if (node_resources_entry.first == local_scheduling_node_id) {
       continue;
     }
-    rpc::AvailableResources resource;
+    rpc::AvailableResources &resource = *reply->add_resources_list();
     resource.set_node_id(node_resources_entry.first.Binary());
     const auto &node_resources = node_resources_entry.second.GetLocalView();
     const auto node_id = NodeID::FromBinary(node_resources_entry.first.Binary());
     bool using_resource_reports = RayConfig::instance().gcs_actor_scheduling_enabled() &&
                                   node_resource_usages_.contains(node_id);
     for (const auto &resource_id : node_resources.available.ExplicitResourceIds()) {
-      const auto &resource_name = resource_id.Binary();
+      auto resource_name = resource_id.Binary();
       // Because gcs scheduler does not directly update the available resources of
       // `cluster_resource_manager_`, use the record from resource reports (stored in
       // `node_resource_usages_`) instead.
@@ -104,15 +104,14 @@ void GcsResourceManager::HandleGetAllAvailableResources(
             node_resource_usages_[node_id].resources_available().find(resource_name);
         if (resource_iter != node_resource_usages_[node_id].resources_available().end()) {
           resource.mutable_resources_available()->insert(
-              {resource_name, resource_iter->second});
+              {std::move(resource_name), resource_iter->second});
         }
       } else {
         const auto &resource_value = node_resources.available.Get(resource_id);
         resource.mutable_resources_available()->insert(
-            {resource_name, resource_value.Double()});
+            {std::move(resource_name), resource_value.Double()});
       }
     }
-    reply->add_resources_list()->CopyFrom(resource);
   }
   GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
   ++counts_[CountType::GET_ALL_AVAILABLE_RESOURCES_REQUEST];

--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -87,8 +87,8 @@ bool ClusterResourceManager::UpdateNode(
   NodeResources local_view;
   RAY_CHECK(GetNodeResources(node_id, &local_view));
 
-  local_view.total = node_resources.total;
-  local_view.available = node_resources.available;
+  local_view.total = std::move(node_resources.total);
+  local_view.available = std::move(node_resources.available);
   local_view.object_pulls_queued = resource_view_sync_message.object_pulls_queued();
 
   // Update the idle duration for the node in terms of resources usage.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We should populate the object store memory when reporting resources to the cluster_resource_manager even if it is 0 (all the obj store memory is used up). Otherwise any api that relies on available_resources will not have object_store_memory at all.

Note: this PR also removes some unnecessary copies of objects around gcs resource manager and cluster resource manager.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
