### PR TITLE
[core][autoscaler] fix indentation of `use_podman`

### DIFF
--- a/python/ray/autoscaler/ray-schema.json
+++ b/python/ray/autoscaler/ray-schema.json
@@ -269,10 +269,10 @@
                     "description": "disable Ray from automatically detecting /dev/shm size for the container",
                     "default": false
                 },
-              "use_podman"  :  {
-                "type": "boolean",
-                "description": "Use 'podman' command in place of 'docker'",
-                "default": false
+                "use_podman"  :  {
+                    "type": "boolean",
+                    "description": "Use 'podman' command in place of 'docker'",
+                    "default": false
                 }
             }
         },


### PR DESCRIPTION
in ray-schema.json

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
