### PR TITLE
[core] split raylet_client_lib bazel target

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -976,30 +976,30 @@ ray_cc_library(
 )
 
 ray_cc_library(
-    name = "raylet_client_lib",
-    srcs = [
-        "src/ray/raylet_client/raylet_client.cc",
-        "src/ray/raylet_client/raylet_connection.cc",
-    ],
-    hdrs = [
-        "src/ray/raylet_client/raylet_client.h",
-        "src/ray/raylet_client/raylet_connection.h",
-    ],
-    linkopts = select({
-        "@platforms//os:windows": [
-        ],
-        "//conditions:default": [
-            "-lpthread",
-        ],
-    }),
+    name = "raylet_client_connection_lib",
+    srcs = ["src/ray/raylet_client/raylet_connection.cc"],
+    hdrs = ["src/ray/raylet_client/raylet_connection.h"],
     deps = [
-        ":node_manager_fbs",
-        ":node_manager_rpc",
-        ":ray_common",
+        "//src/ray/common:asio",
         "//src/ray/common:network",
-        "//src/ray/protobuf:gcs_cc_proto",
-        "//src/ray/util",
-        "@boost//:asio",
+    ],
+)
+
+ray_cc_library(
+    name = "raylet_client_lib",
+    srcs = ["src/ray/raylet_client/raylet_client.cc"],
+    hdrs = ["src/ray/raylet_client/raylet_client.h"],
+    deps = [
+        ":raylet_client_connection_lib",
+        ":node_manager_rpc",
+        "//src/ray/common:id",
+        "//src/ray/common:asio",
+        "//src/ray/common:ray_object",
+        "//src/ray/common:status",
+        "//src/ray/common:network",
+        "//src/ray/common:task_common",
+        "//src/ray/util:logging",
+        "//src/ray/protobuf:common_cc_proto",
     ],
 )
 

--- a/cpp/BUILD.bazel
+++ b/cpp/BUILD.bazel
@@ -60,6 +60,7 @@ cc_library(
         "//:global_state_accessor_lib",
         "//:ray_common",
         "//src/ray/util",
+        "//src/ray/util:process",
         "//src/ray/util:cmd_line_utils",
         "@boost//:callable_traits",
         "@boost//:dll",

--- a/cpp/src/ray/config_internal.h
+++ b/cpp/src/ray/config_internal.h
@@ -21,6 +21,7 @@
 #include <unordered_map>
 
 #include "ray/core_worker/common.h"
+#include "ray/util/process.h"
 
 namespace ray {
 namespace internal {

--- a/src/ray/raylet_client/raylet_client.cc
+++ b/src/ray/raylet_client/raylet_client.cc
@@ -27,7 +27,6 @@
 #include "ray/common/task/task_spec.h"
 #include "ray/raylet/format/node_manager_generated.h"
 #include "ray/util/logging.h"
-#include "ray/util/util.h"
 
 using MessageType = ray::protocol::MessageType;
 

--- a/src/ray/raylet_client/raylet_client.h
+++ b/src/ray/raylet_client/raylet_client.h
@@ -29,7 +29,6 @@
 #include "ray/common/task/task_spec.h"
 #include "ray/raylet_client/raylet_connection.h"
 #include "ray/rpc/node_manager/node_manager_client.h"
-#include "ray/util/process.h"
 #include "src/ray/protobuf/common.pb.h"
 #include "src/ray/protobuf/gcs.pb.h"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Hi @dentiny, this PR addresses the raylet client part in the https://github.com/ray-project/ray/issues/50586:
1. Split out `raylet_client_connection_lib` from the `raylet_client_lib`.
2. Flatten dependencies related to `src/ray/common` and `src/ray/util`.



## Related issue number

Closes https://github.com/ray-project/ray/issues/50672

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
