### PR TITLE
[core] Optimize RAY_LOG

### DIFF
--- a/src/ray/util/BUILD
+++ b/src/ray/util/BUILD
@@ -57,6 +57,7 @@ ray_cc_library(
         ":thread_utils",
         "@com_github_spdlog//:spdlog",
         "@com_google_absl//absl/debugging:failure_signal_handler",
+        "@com_google_absl//absl/strings:internal",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_googletest//:gtest_prod",
         "@nlohmann_json",

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -61,6 +61,7 @@
 #include <string>
 #include <vector>
 
+#include "absl/strings/internal/ostringstream.h"
 #include "ray/util/macros.h"
 #include "ray/util/string_utils.h"
 
@@ -397,11 +398,14 @@ class RayLog {
   /// Whether current log is fatal or not.
   bool is_fatal_ = false;
   /// String stream of the log message
-  std::ostringstream msg_osstream_;
+  std::string msg_osstream_buf_;
+  absl::strings_internal::OStringStream msg_osstream_;
   /// String stream of the log context: a list of key-value pairs.
-  std::ostringstream context_osstream_;
+  std::string context_osstream_buf_;
+  absl::strings_internal::OStringStream context_osstream_;
   /// String stream of exposed fatal log content.
-  std::ostringstream expose_fatal_osstream_;
+  std::string expose_fatal_osstream_buf_;
+  absl::strings_internal::OStringStream expose_fatal_osstream_;
 
   /// Whether or not the log is initialized.
   static std::atomic<bool> initialized_;


### PR DESCRIPTION
This PR uses abseil ostream to optimize RAY_LOG to replace std::ostringstream.
Abseil implementation is better 
- in terms of performance: https://github.com/abseil/abseil-cpp/blob/33d9ce727c128879e016f0ffae6a63d12c317ddf/absl/strings/internal/ostringstream.h#L31-L33
- provides move semantics when consolidating into a string, otherwise we have to copy every single byte written through `RAY_LOG`
- Advanced usage for ostreamstring appear at C++20, like view and rvalue overload

I think it's useful for GCS, which has been complaint by multiple users to crash their local disk due to large volumes of logging , and it appears in critical path.
It's not a concern to use internal namespace for abseil, since bazel visibility is public:
https://github.com/abseil/abseil-cpp/blob/33d9ce727c128879e016f0ffae6a63d12c317ddf/absl/strings/BUILD.bazel#L118-L140