### PR TITLE
[data] Make iter_torch_batches release test only use GPU for the head node

### DIFF
--- a/release/nightly_tests/dataset/autoscaling_gpu_compute.yaml
+++ b/release/nightly_tests/dataset/autoscaling_gpu_compute.yaml
@@ -8,9 +8,7 @@ advanced_configurations_json:
 
 head_node_type:
     name: head-node
-    # Use a GPU head node so we can test `iter_torch_batches` with `device='cuda'`.
-    # We use the same number of vCPUs and memory as the default m5.2xlarge head node.
-    instance_type: g4dn.2xlarge
+    instance_type: m5.2xlarge
     resources:
       cpu: 0
 

--- a/release/nightly_tests/dataset/autoscaling_gpu_head_compute.yaml
+++ b/release/nightly_tests/dataset/autoscaling_gpu_head_compute.yaml
@@ -1,0 +1,22 @@
+# This config matches the default config for Anyscale workspaces with autoscaling,
+# except instead of using CPU instances, it uses GPU instances.
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west-2
+
+advanced_configurations_json:
+    IamInstanceProfile: {"Name": "ray-autoscaler-v1"}
+
+head_node_type:
+    name: head-node
+    # Use a GPU head node so we can test `iter_torch_batches` with `device='cuda'`.
+    # We use the same number of vCPUs and memory as the default m5.2xlarge head node.
+    instance_type: g4dn.2xlarge
+    resources:
+      cpu: 0
+
+worker_node_types:
+    - name: worker-node
+      instance_type: m5.2xlarge
+      min_workers: 0
+      max_workers: 10
+      use_spot: false

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -235,7 +235,7 @@
 - name: iter_torch_batches
 
   cluster:
-    cluster_compute: autoscaling_gpu_compute.yaml
+    cluster_compute: autoscaling_gpu_head_compute.yaml
 
   run:
     timeout: 2400


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* `iter_torch_batches` release test only needs GPU for the head node. Make it use CPU worker nodes. 
* Batch inference release tests don't need GPU for the head node. Update its compute config.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
