### PR TITLE
[ray.serve.llm] Fix setting up AutoProcessor

### DIFF
--- a/python/ray/llm/_internal/serve/configs/server_models.py
+++ b/python/ray/llm/_internal/serve/configs/server_models.py
@@ -373,9 +373,15 @@ class LLMConfig(BaseModelExtended):
         hf_config = PretrainedConfig.from_pretrained(model_id_or_path)
         self._supports_vision = hasattr(hf_config, "vision_config")
 
-    def apply_checkpoint_info(self, model_id_or_path: str) -> None:
+    def apply_checkpoint_info(
+        self, model_id_or_path: str, trust_remote_code: bool = False
+    ) -> None:
         """Apply the checkpoint info to the model config."""
         self._infer_supports_vision(model_id_or_path)
+        self._prompt_format.set_processor(
+            model_id_or_path,
+            trust_remote_code=trust_remote_code,
+        )
 
     @property
     def supports_vision(self) -> bool:

--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
@@ -232,7 +232,7 @@ class VLLMEngine:
         assert isinstance(
             llm_config, LLMConfig
         ), f"Got invalid config {llm_config} of type {type(llm_config)}"
-        self.llm_config = llm_config.model_copy(deep=True)
+        self.llm_config = llm_config
         self.engine_config = VLLMEngineConfig.from_llm_config(llm_config)
 
         self._stats = VLLMEngineStatTracker()

--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_models.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_models.py
@@ -12,9 +12,6 @@ from ray.util.placement_group import (
 from vllm.lora.request import LoRARequest
 
 from ray.llm._internal.serve.observability.logging import get_logger
-from ray.llm._internal.serve.configs.prompt_formats import (
-    HuggingFacePromptFormat,
-)
 from ray.llm._internal.serve.configs.server_models import (
     BaseModelExtended,
     DiskMultiplexConfig,
@@ -58,7 +55,6 @@ class VLLMEngineConfig(BaseModelExtended):
         description="The type of accelerator to use. This is used to determine the placement group strategy.",
     )
     runtime_env: Optional[Dict[str, Any]] = None
-    prompt_format: HuggingFacePromptFormat
     engine_kwargs: Dict[str, Any] = {}
 
     @property
@@ -113,7 +109,6 @@ class VLLMEngineConfig(BaseModelExtended):
             s3_mirror_config=s3_mirror_config,
             gcs_mirror_config=gcs_mirror_config,
             accelerator_type=llm_config.accelerator_type,
-            prompt_format=llm_config.prompt_format,
             engine_kwargs=llm_config.engine_kwargs,
             runtime_env=llm_config.runtime_env,
         )

--- a/python/ray/llm/_internal/serve/deployments/utils/node_initialization_utils.py
+++ b/python/ray/llm/_internal/serve/deployments/utils/node_initialization_utils.py
@@ -233,7 +233,10 @@ async def initialize_node(llm_config: LLMConfig) -> InitializeNodeOutput:
             download_extra_files=True,
         )
 
-    llm_config.apply_checkpoint_info(engine_config.actual_hf_model_id)
+    llm_config.apply_checkpoint_info(
+        engine_config.actual_hf_model_id,
+        trust_remote_code=engine_config.trust_remote_code,
+    )
 
     return InitializeNodeOutput(
         placement_group=pg, runtime_env=runtime_env, extra_init_kwargs=extra_init_kwargs

--- a/python/ray/llm/_internal/serve/deployments/utils/node_initialization_utils.py
+++ b/python/ray/llm/_internal/serve/deployments/utils/node_initialization_utils.py
@@ -267,9 +267,3 @@ def _initialize_local_node(
         engine_config.actual_hf_model_id,
         trust_remote_code=engine_config.trust_remote_code,
     )
-    prompt_format = engine_config.prompt_format
-    # Note (genesu): The prompt format is always loaded from HF.
-    prompt_format.set_processor(
-        engine_config.actual_hf_model_id,
-        trust_remote_code=engine_config.trust_remote_code,
-    )

--- a/python/ray/llm/tests/serve/conftest.py
+++ b/python/ray/llm/tests/serve/conftest.py
@@ -102,7 +102,7 @@ def get_rayllm_testing_model(
 
 
 @pytest.fixture
-def testing_model(shutdown_ray_and_serve, use_mock_vllm_engine, model_pixtral_12b):
+def testing_model(shutdown_ray_and_serve, model_pixtral_12b):
     test_model_path = get_test_model_path("mock_vllm_model.yaml")
 
     with open(test_model_path, "r") as f:

--- a/python/ray/llm/tests/serve/conftest.py
+++ b/python/ray/llm/tests/serve/conftest.py
@@ -102,7 +102,7 @@ def get_rayllm_testing_model(
 
 
 @pytest.fixture
-def testing_model(shutdown_ray_and_serve, model_pixtral_12b):
+def testing_model(shutdown_ray_and_serve, use_mock_vllm_engine, model_pixtral_12b):
     test_model_path = get_test_model_path("mock_vllm_model.yaml")
 
     with open(test_model_path, "r") as f:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Was doing an end to end test and found out a different `AutoProcessor` was set on the vllm engine start vs used in the vlllm deployment. Remove the deep copy on `llm_config` during constructing of the vllm engine and moved `set_processor` call into `apply_checkpoint_info`. Also start to use real vllm engine in `testing_model` which is used by `test_openai_compatibility.py` to catch those types of issues.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
