### PR TITLE
[core][cgraph] Revive max_buffered_result arg

### DIFF
--- a/python/ray/dag/context.py
+++ b/python/ray/dag/context.py
@@ -22,6 +22,11 @@ DEFAULT_MAX_INFLIGHT_EXECUTIONS = int(
     os.environ.get("RAY_CGRAPH_max_inflight_executions", 10)
 )
 
+# The default number of results that can be buffered at the driver.
+DEFAULT_MAX_BUFFERED_RESULTS = int(
+    os.environ.get("RAY_CGRAPH_max_buffered_results", 1000)
+)
+
 DEFAULT_OVERLAP_GPU_COMMUNICATION = bool(
     os.environ.get("RAY_CGRAPH_overlap_gpu_communication", 0)
 )
@@ -75,6 +80,7 @@ class DAGContext:
     read_iteration_timeout: float = DEFAULT_READ_ITERATION_TIMEOUT_S
     buffer_size_bytes: int = DEFAULT_BUFFER_SIZE_BYTES
     max_inflight_executions: int = DEFAULT_MAX_INFLIGHT_EXECUTIONS
+    max_buffered_results: int = DEFAULT_MAX_BUFFERED_RESULTS
     overlap_gpu_communication: bool = DEFAULT_OVERLAP_GPU_COMMUNICATION
 
     def __post_init__(self):

--- a/python/ray/dag/dag_node.py
+++ b/python/ray/dag/dag_node.py
@@ -227,6 +227,7 @@ class DAGNode(DAGNodeBase):
         _buffer_size_bytes: Optional[int] = None,
         enable_asyncio: bool = False,
         _max_inflight_executions: Optional[int] = None,
+        _max_buffered_results: Optional[int] = None,
         _overlap_gpu_communication: Optional[bool] = None,
         _default_communicator: Optional[Union[Communicator, str]] = "create",
     ) -> "ray.dag.CompiledDAG":
@@ -246,6 +247,14 @@ class DAGNode(DAGNodeBase):
                 can be submitted via `execute` or `execute_async` before consuming
                 the output using `ray.get()`. If the caller submits more executions,
                 `RayCgraphCapacityExceeded` is raised.
+            _max_buffered_results: The maximum number of results that can be
+                buffered at the driver. If more than this number of results
+                are buffered, `RayCgraphCapacityExceeded` is raised. Note that
+                when result corresponding to an execution is retrieved
+                (by calling `ray.get()` on a `CompiledDAGRef` or
+                `CompiledDAGRef` or await on a `CompiledDAGFuture), results
+                corresponding to earlier executions that have not been retrieved
+                yet are buffered.
             _overlap_gpu_communication: (experimental) Whether to overlap GPU
                 communication with computation during DAG execution. If True, the
                 communication and computation can be overlapped, which can improve
@@ -293,6 +302,7 @@ class DAGNode(DAGNodeBase):
             _buffer_size_bytes,
             enable_asyncio,
             _max_inflight_executions,
+            _max_buffered_results,
             _overlap_gpu_communication,
             _default_communicator,
         )

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -1395,6 +1395,76 @@ class TestDAGExceptionCompileMultipleTimes:
             branch2.experimental_compile()
 
 
+def test_exceed_max_buffered_results(ray_start_regular):
+    a = Actor.remote(0)
+    with InputNode() as i:
+        dag = a.inc.bind(i)
+
+    compiled_dag = dag.experimental_compile(_max_buffered_results=1)
+
+    refs = []
+    for i in range(2):
+        ref = compiled_dag.execute(1)
+        # Hold the refs to avoid get() being called on the ref
+        # when it goes out of scope
+        refs.append(ref)
+
+    # ray.get() on the 2nd ref fails because the DAG cannot buffer 2 results.
+    with pytest.raises(
+        ray.exceptions.RayCgraphCapacityExceeded,
+        match=(
+            "The compiled graph can't have more than 1 buffered results, "
+            r"and you currently have 1 buffered results. Call `ray.get\(\)` on "
+            r"CompiledDAGRef's \(or await on CompiledDAGFuture's\) to retrieve "
+            "results, or increase `_max_buffered_results` if buffering is "
+            "desired, note that this will increase driver memory usage."
+        ),
+    ):
+        ray.get(ref)
+
+    del refs
+
+
+@pytest.mark.parametrize("single_fetch", [True, False])
+def test_exceed_max_buffered_results_multi_output(ray_start_regular, single_fetch):
+    a = Actor.remote(0)
+    b = Actor.remote(0)
+    with InputNode() as inp:
+        dag = MultiOutputNode([a.inc.bind(inp), b.inc.bind(inp)])
+
+    compiled_dag = dag.experimental_compile(_max_buffered_results=1)
+
+    refs = []
+    for _ in range(2):
+        ref = compiled_dag.execute(1)
+        # Hold the refs to avoid get() being called on the ref
+        # when it goes out of scope
+        refs.append(ref)
+
+    if single_fetch:
+        # If there are results not fetched from an execution, that execution
+        # still counts towards the number of buffered results.
+        ray.get(refs[0][0])
+
+    # ray.get() on the 2nd ref fails because the DAG cannot buffer 2 results.
+    with pytest.raises(
+        ray.exceptions.RayCgraphCapacityExceeded,
+        match=(
+            "The compiled graph can't have more than 1 buffered results, "
+            r"and you currently have 1 buffered results. Call `ray.get\(\)` on "
+            r"CompiledDAGRef's \(or await on CompiledDAGFuture's\) to retrieve "
+            "results, or increase `_max_buffered_results` if buffering is "
+            "desired, note that this will increase driver memory usage."
+        ),
+    ):
+        if single_fetch:
+            ray.get(ref[0])
+        else:
+            ray.get(ref)
+
+    del refs
+
+
 def test_compiled_dag_ref_del(ray_start_regular):
     a = Actor.remote(0)
     with InputNode() as inp:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

https://github.com/ray-project/ray/pull/49565 merged max_buffered_results and max_inflight_executions for conciseness of the arg list. After further discussion, we'd like to keep these two args separate for finer-grained control of the compiled graph behavior. 

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #50381

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
