### PR TITLE
Revert Python 3.13 changes

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -13,7 +13,6 @@ steps:
       - "3.10"
       - "3.11"
       - "3.12"
-      - "3.13"
     depends_on:
       - manylinux
       - forge

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,13 +40,6 @@ repos:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]
 
-  - repo: https://github.com/cpplint/cpplint
-    rev: 2.0.0
-    hooks:
-      - id: cpplint
-        args: ["--filter=-whitespace/line_length,-build/c++11,-build/c++14,-build/c++17,-readability/braces,-whitespace/indent_namespace,-runtime/int,-runtime/references,-build/include_order"]
-        files: ^src/ray/(util|raylet_client)/.*\.(h|cc)$
-
   - repo: https://github.com/psf/black
     rev: 22.10.0
     hooks:

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -195,8 +195,8 @@ def ray_deps_setup():
     auto_http_archive(
         name = "cython",
         build_file = True,
-        url = "https://github.com/cython/cython/archive/refs/tags/3.0.12.tar.gz",
-        sha256 = "a156fff948c2013f2c8c398612c018e2b52314fdf0228af8fbdb5585e13699c2",
+        url = "https://github.com/cython/cython/archive/refs/tags/0.29.37.tar.gz",
+        sha256 = "824eb14045d85c5af677536134199dd6709db8fb0835452fd2d54bc3c8df8887",
     )
 
     auto_http_archive(

--- a/ci/build/build-manylinux-wheel.sh
+++ b/ci/build/build-manylinux-wheel.sh
@@ -8,7 +8,7 @@ export RAY_BUILD_ENV="manylinux_py${PYTHON}"
 
 mkdir -p .whl
 cd python
-/opt/python/"${PYTHON}"/bin/pip install -q cython==3.0.12 setuptools==75.8.0
+/opt/python/"${PYTHON}"/bin/pip install -q cython==0.29.37
 # Set the commit SHA in _version.py.
 if [[ -n "$TRAVIS_COMMIT" ]]; then
   sed -i.bak "s/{{RAY_COMMIT_SHA}}/$TRAVIS_COMMIT/g" ray/_version.py && rm ray/_version.py.bak

--- a/ci/ray_ci/builder_container.py
+++ b/ci/ray_ci/builder_container.py
@@ -21,7 +21,6 @@ PYTHON_VERSIONS = {
     "3.10": PythonVersionInfo(bin_path="cp310-cp310"),
     "3.11": PythonVersionInfo(bin_path="cp311-cp311"),
     "3.12": PythonVersionInfo(bin_path="cp312-cp312"),
-    "3.13": PythonVersionInfo(bin_path="cp313-cp313"),
 }
 DEFAULT_PYTHON_VERSION = "3.9"
 DEFAULT_BUILD_TYPE = "optimized"

--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -10,7 +10,7 @@ DOWNLOAD_DIR=python_downloads
 
 NODE_VERSION="14"
 
-PY_MMS=("3.9" "3.10" "3.11" "3.12" "3.13")
+PY_MMS=("3.9" "3.10" "3.11" "3.12")
 
 if [[ -n "${SKIP_DEP_RES}" ]]; then
   ./ci/env/install-bazel.sh

--- a/python/build-wheel-manylinux2014.sh
+++ b/python/build-wheel-manylinux2014.sh
@@ -10,7 +10,6 @@ PYTHON_VERSIONS=(
   "py310 cp310-cp310"
   "py311 cp311-cp311"
   "py312 cp312-cp312"
-  "py313 cp313-cp313"
 )
 
 # Add the repo folder to the safe.directory global variable to avoid the failure

--- a/python/ray/_raylet.pxd
+++ b/python/ray/_raylet.pxd
@@ -150,8 +150,7 @@ cdef class CoreWorker:
             worker, outputs,
             const CAddress &caller_address,
             c_vector[c_pair[CObjectID, shared_ptr[CRayObject]]] *returns,
-            ref_generator_id=*, # CObjectID
-        )
+            CObjectID ref_generator_id=*)
     cdef make_actor_handle(self, ActorHandleSharedPtr c_actor_handle,
                            c_bool weak_ref)
     cdef c_function_descriptors_to_python(

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -440,7 +440,7 @@ class ObjectRefGenerator:
 
     def _next_sync(
         self,
-        timeout_s: Optional[int | float] = None
+        timeout_s: Optional[float] = None
     ) -> ObjectRef:
         """Waits for timeout_s and returns the object ref if available.
 
@@ -509,7 +509,7 @@ class ObjectRefGenerator:
 
     async def _next_async(
             self,
-            timeout_s: Optional[int | float] = None
+            timeout_s: Optional[float] = None
     ):
         """Same API as _next_sync, but it is for async context."""
         core_worker = self.worker.core_worker
@@ -1529,7 +1529,7 @@ cdef create_generator_return_obj(
         worker, [output],
         caller_address,
         &intermediate_result,
-        generator_id.Binary())
+        generator_id)
 
     return_object[0] = intermediate_result.back()
 
@@ -1657,7 +1657,7 @@ cdef execute_dynamic_generator_and_store_task_outputs(
             worker, generator,
             caller_address,
             dynamic_returns,
-            generator_id.Binary())
+            generator_id)
     except Exception as error:
         is_retryable_error[0] = determine_if_retryable(
             should_retry_exceptions,
@@ -4322,7 +4322,7 @@ cdef class CoreWorker:
                             const CAddress &caller_address,
                             c_vector[c_pair[CObjectID, shared_ptr[CRayObject]]]
                             *returns,
-                            ref_generator_id=None):
+                            CObjectID ref_generator_id=CObjectID.Nil()):
         cdef:
             CObjectID return_id
             size_t data_size
@@ -4330,14 +4330,10 @@ cdef class CoreWorker:
             c_vector[CObjectID] contained_id
             int64_t task_output_inlined_bytes
             int64_t num_returns = -1
-            CObjectID c_ref_generator_id = CObjectID.Nil()
             shared_ptr[CRayObject] *return_ptr
 
-        if ref_generator_id:
-            c_ref_generator_id = CObjectID.FromBinary(ref_generator_id)
-
         num_outputs_stored = 0
-        if not c_ref_generator_id.IsNil():
+        if not ref_generator_id.IsNil():
             # The task specified a dynamic number of return values. Determine
             # the expected number of return values.
             if returns[0].size() > 0:
@@ -4407,7 +4403,7 @@ cdef class CoreWorker:
 
             if not self.store_task_output(
                     serialized_object, return_id,
-                    c_ref_generator_id,
+                    ref_generator_id,
                     data_size, metadata, contained_id, caller_address,
                     &task_output_inlined_bytes, return_ptr):
                 # If the object already exists, but we fail to pin the copy, it
@@ -4415,7 +4411,7 @@ cdef class CoreWorker:
                 # create another copy.
                 self.store_task_output(
                         serialized_object, return_id,
-                        c_ref_generator_id,
+                        ref_generator_id,
                         data_size, metadata,
                         contained_id, caller_address, &task_output_inlined_bytes,
                         return_ptr)

--- a/python/ray/includes/gcs_client.pxi
+++ b/python/ray/includes/gcs_client.pxi
@@ -16,7 +16,7 @@ Binding of C++ ray::gcs::GcsClient.
 #
 # For how async API are implemented, see src/ray/gcs/gcs_client/python_callbacks.h
 from asyncio import Future
-from typing import List, Sequence
+from typing import List
 from libcpp.utility cimport move
 import concurrent.futures
 from ray.includes.common cimport (
@@ -277,7 +277,7 @@ cdef class InnerGcsClient:
     # NodeInfo methods
     #############################################################
     def check_alive(
-        self, node_ips: List[bytes], timeout: Optional[int | float] = None
+        self, node_ips: List[bytes], timeout: Optional[float] = None
     ) -> List[bool]:
         cdef:
             int64_t timeout_ms = round(1000 * timeout) if timeout else -1
@@ -290,7 +290,7 @@ cdef class InnerGcsClient:
         return raise_or_return(convert_multi_bool(status, move(results)))
 
     def async_check_alive(
-        self, node_ips: List[bytes], timeout: Optional[int | float] = None
+        self, node_ips: List[bytes], timeout: Optional[float] = None
     ) -> Future[List[bool]]:
         cdef:
             int64_t timeout_ms = round(1000 * timeout) if timeout else -1
@@ -307,7 +307,7 @@ cdef class InnerGcsClient:
         return asyncio.wrap_future(fut)
 
     def drain_nodes(
-        self, node_ids: Sequence[bytes], timeout: Optional[int | float] = None
+        self, node_ids: List[bytes], timeout: Optional[float] = None
     ) -> List[bytes]:
         """returns a list of node_ids that are successfully drained."""
         cdef:
@@ -316,14 +316,14 @@ cdef class InnerGcsClient:
             c_vector[c_string] results
             CRayStatus status
         for node_id in node_ids:
-            c_node_ids.push_back(<CNodeID>CUniqueID.FromBinary(node_id))
+            c_node_ids.push_back(CNodeID.FromBinary(node_id))
         with nogil:
             status = self.inner.get().Nodes().DrainNodes(
                 c_node_ids, timeout_ms, results)
         return raise_or_return(convert_multi_str(status, move(results)))
 
     def get_all_node_info(
-        self, timeout: Optional[int | float] = None
+        self, timeout: Optional[float] = None
     ) -> Dict[NodeID, gcs_pb2.GcsNodeInfo]:
         cdef int64_t timeout_ms = round(1000 * timeout) if timeout else -1
         cdef c_vector[CGcsNodeInfo] reply
@@ -333,7 +333,7 @@ cdef class InnerGcsClient:
         return raise_or_return(convert_get_all_node_info(status, move(reply)))
 
     def async_get_all_node_info(
-        self, node_id: Optional[NodeID] = None, timeout: Optional[int | float] = None
+        self, node_id: Optional[NodeID] = None, timeout: Optional[float] = None
     ) -> Future[Dict[NodeID, gcs_pb2.GcsNodeInfo]]:
         cdef:
             int64_t timeout_ms = round(1000 * timeout) if timeout else -1
@@ -356,7 +356,7 @@ cdef class InnerGcsClient:
     # NodeResources methods
     #############################################################
     def get_all_resource_usage(
-        self, timeout: Optional[int | float] = None
+        self, timeout: Optional[float] = None
     ) -> GetAllResourceUsageReply:
         cdef int64_t timeout_ms = round(1000 * timeout) if timeout else -1
         cdef CGetAllResourceUsageReply c_reply
@@ -381,7 +381,7 @@ cdef class InnerGcsClient:
         actor_id: Optional[ActorID] = None,
         job_id: Optional[JobID] = None,
         actor_state_name: Optional[str] = None,
-        timeout: Optional[int | float] = None
+        timeout: Optional[float] = None
     ) -> Future[Dict[ActorID, gcs_pb2.ActorTableData]]:
         cdef:
             int64_t timeout_ms = round(1000 * timeout) if timeout else -1
@@ -409,7 +409,7 @@ cdef class InnerGcsClient:
 
     def async_kill_actor(
         self, actor_id: ActorID, c_bool force_kill, c_bool no_restart,
-        timeout: Optional[int | float] = None
+        timeout: Optional[float] = None
     ) -> ConcurrentFuture[None]:
         """
         On success: returns None.
@@ -439,7 +439,7 @@ cdef class InnerGcsClient:
         self, *, job_or_submission_id: Optional[str] = None,
         skip_submission_job_info_field: bool = False,
         skip_is_running_tasks_field: bool = False,
-        timeout: Optional[int | float] = None
+        timeout: Optional[float] = None
     ) -> Dict[JobID, gcs_pb2.JobTableData]:
         cdef c_string c_job_or_submission_id
         cdef optional[c_string] c_optional_job_or_submission_id = nullopt
@@ -462,7 +462,7 @@ cdef class InnerGcsClient:
         self, *, job_or_submission_id: Optional[str] = None,
         skip_submission_job_info_field: bool = False,
         skip_is_running_tasks_field: bool = False,
-        timeout: Optional[int | float] = None
+        timeout: Optional[float] = None
     ) -> Future[Dict[JobID, gcs_pb2.JobTableData]]:
         cdef:
             c_string c_job_or_submission_id
@@ -507,7 +507,7 @@ cdef class InnerGcsClient:
     #############################################################
     def request_cluster_resource_constraint(
             self,
-            bundles: c_vector[unordered_map[c_string, cython.double]],
+            bundles: c_vector[unordered_map[c_string, double]],
             count_array: c_vector[int64_t],
             timeout_s=None):
         cdef:
@@ -629,7 +629,7 @@ cdef incremented_fut():
     cpython.Py_INCREF(fut)
     return fut
 
-cdef void assign_and_decrement_fut(result, fut) noexcept with gil:
+cdef void assign_and_decrement_fut(result, fut) with gil:
     assert isinstance(fut, concurrent.futures.Future)
 
     assert not fut.done()

--- a/python/ray/includes/global_state_accessor.pxi
+++ b/python/ray/includes/global_state_accessor.pxi
@@ -195,7 +195,7 @@ cdef class GlobalStateAccessor:
 
     def get_worker_info(self, worker_id):
         cdef unique_ptr[c_string] worker_info
-        cdef CWorkerID cworker_id = <CWorkerID>CUniqueID.FromBinary(worker_id.binary())
+        cdef CWorkerID cworker_id = CWorkerID.FromBinary(worker_id.binary())
         with nogil:
             worker_info = self.inner.get().GetWorkerInfo(cworker_id)
         if worker_info:
@@ -211,14 +211,14 @@ cdef class GlobalStateAccessor:
 
     def get_worker_debugger_port(self, worker_id):
         cdef c_uint32_t result
-        cdef CWorkerID cworker_id = <CWorkerID>CUniqueID.FromBinary(worker_id.binary())
+        cdef CWorkerID cworker_id = CWorkerID.FromBinary(worker_id.binary())
         with nogil:
             result = self.inner.get().GetWorkerDebuggerPort(cworker_id)
         return result
 
     def update_worker_debugger_port(self, worker_id, debugger_port):
         cdef c_bool result
-        cdef CWorkerID cworker_id = <CWorkerID>CUniqueID.FromBinary(worker_id.binary())
+        cdef CWorkerID cworker_id = CWorkerID.FromBinary(worker_id.binary())
         cdef c_uint32_t cdebugger_port = debugger_port
         with nogil:
             result = self.inner.get().UpdateWorkerDebuggerPort(
@@ -228,7 +228,7 @@ cdef class GlobalStateAccessor:
 
     def update_worker_num_paused_threads(self, worker_id, num_paused_threads_delta):
         cdef c_bool result
-        cdef CWorkerID cworker_id = <CWorkerID>CUniqueID.FromBinary(worker_id.binary())
+        cdef CWorkerID cworker_id = CWorkerID.FromBinary(worker_id.binary())
         cdef c_int32_t cnum_paused_threads_delta = num_paused_threads_delta
 
         with nogil:

--- a/python/ray/includes/object_ref.pxi
+++ b/python/ray/includes/object_ref.pxi
@@ -71,7 +71,7 @@ cdef class ObjectRef(BaseID):
                 pass
 
     cdef CObjectID native(self):
-        return <CObjectID>self.data
+        return self.data
 
     def binary(self):
         return self.data.Binary()

--- a/python/ray/includes/unique_ids.pxd
+++ b/python/ray/includes/unique_ids.pxd
@@ -2,13 +2,20 @@ from libcpp cimport bool as c_bool
 from libcpp.string cimport string as c_string
 from libc.stdint cimport uint8_t, uint32_t, int64_t
 
-# Note: we removed the staticmethod declarations in
-# https://github.com/ray-project/ray/pull/47984 due
-# to a compiler bug in Cython 3.0.x -- we should see
-# if we can bring them back in Cython 3.1.x if the
-# bug is fixed.
 cdef extern from "ray/common/id.h" namespace "ray" nogil:
     cdef cppclass CBaseID[T]:
+        @staticmethod
+        T FromBinary(const c_string &binary)
+
+        @staticmethod
+        T FromHex(const c_string &hex_str)
+
+        @staticmethod
+        const T Nil()
+
+        @staticmethod
+        size_t Size()
+
         size_t Hash() const
         c_bool IsNil() const
         c_bool operator==(const CBaseID &rhs) const
@@ -18,7 +25,7 @@ cdef extern from "ray/common/id.h" namespace "ray" nogil:
         c_string Binary() const
         c_string Hex() const
 
-    cdef cppclass CUniqueID "ray::UniqueID"(CBaseID[CUniqueID]):
+    cdef cppclass CUniqueID "ray::UniqueID"(CBaseID):
         CUniqueID()
 
         @staticmethod
@@ -33,7 +40,13 @@ cdef extern from "ray/common/id.h" namespace "ray" nogil:
         @staticmethod
         const CUniqueID Nil()
 
-    cdef cppclass CActorClassID "ray::ActorClassID"(CBaseID[CActorClassID]):
+        @staticmethod
+        size_t Size()
+
+    cdef cppclass CActorClassID "ray::ActorClassID"(CUniqueID):
+
+        @staticmethod
+        CActorClassID FromBinary(const c_string &binary)
 
         @staticmethod
         CActorClassID FromHex(const c_string &hex_str)
@@ -58,7 +71,10 @@ cdef extern from "ray/common/id.h" namespace "ray" nogil:
 
         CJobID JobId()
 
-    cdef cppclass CNodeID "ray::NodeID"(CBaseID[CNodeID]):
+    cdef cppclass CNodeID "ray::NodeID"(CUniqueID):
+
+        @staticmethod
+        CNodeID FromBinary(const c_string &binary)
 
         @staticmethod
         CNodeID FromHex(const c_string &hex_str)
@@ -66,10 +82,15 @@ cdef extern from "ray/common/id.h" namespace "ray" nogil:
         @staticmethod
         const CNodeID Nil()
 
-    cdef cppclass CConfigID "ray::ConfigID"(CBaseID[CConfigID]):
-        pass
+    cdef cppclass CConfigID "ray::ConfigID"(CUniqueID):
 
-    cdef cppclass CFunctionID "ray::FunctionID"(CBaseID[CFunctionID]):
+        @staticmethod
+        CConfigID FromBinary(const c_string &binary)
+
+    cdef cppclass CFunctionID "ray::FunctionID"(CUniqueID):
+
+        @staticmethod
+        CFunctionID FromBinary(const c_string &binary)
 
         @staticmethod
         CFunctionID FromHex(const c_string &hex_str)
@@ -154,7 +175,10 @@ cdef extern from "ray/common/id.h" namespace "ray" nogil:
 
         CTaskID TaskId() const
 
-    cdef cppclass CClusterID "ray::ClusterID"(CBaseID[CClusterID]):
+    cdef cppclass CClusterID "ray::ClusterID"(CUniqueID):
+
+        @staticmethod
+        CClusterID FromBinary(const c_string &binary)
 
         @staticmethod
         CClusterID FromHex(const c_string &hex_str)
@@ -165,7 +189,10 @@ cdef extern from "ray/common/id.h" namespace "ray" nogil:
         @staticmethod
         const CClusterID Nil()
 
-    cdef cppclass CWorkerID "ray::WorkerID"(CBaseID[CWorkerID]):
+    cdef cppclass CWorkerID "ray::WorkerID"(CUniqueID):
+
+        @staticmethod
+        CWorkerID FromBinary(const c_string &binary)
 
         @staticmethod
         CWorkerID FromHex(const c_string &hex_str)

--- a/python/ray/includes/unique_ids.pxi
+++ b/python/ray/includes/unique_ids.pxi
@@ -218,7 +218,7 @@ cdef class NodeID(UniqueID):
 
     def __init__(self, id):
         check_id(id)
-        self.data = CUniqueID.FromBinary(<c_string>id)
+        self.data = CNodeID.FromBinary(<c_string>id)
 
     @classmethod
     def from_hex(cls, hex_id):
@@ -276,7 +276,7 @@ cdef class WorkerID(UniqueID):
 
     def __init__(self, id):
         check_id(id)
-        self.data = CUniqueID.FromBinary(<c_string>id)
+        self.data = CWorkerID.FromBinary(<c_string>id)
 
     @classmethod
     def from_hex(cls, hex_id):
@@ -344,7 +344,7 @@ cdef class FunctionID(UniqueID):
 
     def __init__(self, id):
         check_id(id)
-        self.data = CUniqueID.FromBinary(<c_string>id)
+        self.data = CFunctionID.FromBinary(<c_string>id)
 
     @classmethod
     def from_hex(cls, hex_id):
@@ -359,7 +359,7 @@ cdef class ActorClassID(UniqueID):
 
     def __init__(self, id):
         check_id(id)
-        self.data = CUniqueID.FromBinary(<c_string>id)
+        self.data = CActorClassID.FromBinary(<c_string>id)
 
     @classmethod
     def from_hex(cls, hex_id):
@@ -373,7 +373,7 @@ cdef class ClusterID(UniqueID):
 
     def __init__(self, id):
         check_id(id)
-        self.data = CUniqueID.FromBinary(<c_string>id)
+        self.data = CClusterID.FromBinary(<c_string>id)
 
     @classmethod
     def from_hex(cls, hex_id):

--- a/python/setup.py
+++ b/python/setup.py
@@ -27,7 +27,7 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-SUPPORTED_PYTHONS = [(3, 9), (3, 10), (3, 11), (3, 12), (3, 13)]
+SUPPORTED_PYTHONS = [(3, 9), (3, 10), (3, 11), (3, 12)]
 # When the bazel version is updated, make sure to update it
 # in WORKSPACE file as well.
 
@@ -829,7 +829,7 @@ setuptools.setup(
     # The BinaryDistribution argument triggers build_ext.
     distclass=BinaryDistribution,
     install_requires=setup_spec.install_requires,
-    setup_requires=["cython >= 3.0.12", "pip", "wheel"],
+    setup_requires=["cython >= 0.29.32", "wheel"],
     extras_require=setup_spec.extras,
     entry_points={
         "console_scripts": [

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2056,16 +2056,12 @@
   alert: default
 
   variations:
-    - __suffix__: aws0
-    - __suffix__: aws1
-    - __suffix__: aws2
-    - __suffix__: aws3
-    - __suffix__: aws4
-    - __suffix__: aws5
-    - __suffix__: aws6
-    - __suffix__: aws7
-    - __suffix__: aws8
-    - __suffix__: aws9
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      frequency: manual
+      cluster:
+        cluster_compute: compute_tpl_single_node_gce.yaml
 
 - name: serve_resnet_benchmark
   group: Serve tests

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2056,12 +2056,16 @@
   alert: default
 
   variations:
-    - __suffix__: aws
-    - __suffix__: gce
-      env: gce
-      frequency: manual
-      cluster:
-        cluster_compute: compute_tpl_single_node_gce.yaml
+    - __suffix__: aws0
+    - __suffix__: aws1
+    - __suffix__: aws2
+    - __suffix__: aws3
+    - __suffix__: aws4
+    - __suffix__: aws5
+    - __suffix__: aws6
+    - __suffix__: aws7
+    - __suffix__: aws8
+    - __suffix__: aws9
 
 - name: serve_resnet_benchmark
   group: Serve tests

--- a/src/ray/util/cmd_line_utils.cc
+++ b/src/ray/util/cmd_line_utils.cc
@@ -14,9 +14,6 @@
 
 #include "ray/util/cmd_line_utils.h"
 
-#include <string>
-#include <vector>
-
 #include "ray/util/logging.h"
 #include "ray/util/string_utils.h"
 

--- a/src/ray/util/container_util.h
+++ b/src/ray/util/container_util.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <algorithm>
 #include <array>
 #include <deque>
 #include <map>
@@ -24,7 +23,6 @@
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
-#include <utility>
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"

--- a/src/ray/util/event.cc
+++ b/src/ray/util/event.cc
@@ -17,11 +17,7 @@
 #include <google/protobuf/struct.pb.h>
 #include <google/protobuf/util/json_util.h>
 
-#include <algorithm>
 #include <filesystem>
-#include <memory>
-#include <string>
-#include <vector>
 
 #include "absl/base/call_once.h"
 #include "absl/time/time.h"

--- a/src/ray/util/event.h
+++ b/src/ray/util/event.h
@@ -24,8 +24,6 @@
 #include <iostream>
 #include <memory>
 #include <sstream>
-#include <string>
-#include <variant>
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
@@ -82,8 +80,6 @@ namespace ray {
 // interface of event reporter
 class BaseEventReporter {
  public:
-  virtual ~BaseEventReporter() = default;
-
   virtual void Init() = 0;
 
   virtual void Report(const rpc::Event &event, const nlohmann::json &custom_fields) = 0;
@@ -105,11 +101,12 @@ class LogEventReporter : public BaseEventReporter {
                    int rotate_max_file_size = 100,
                    int rotate_max_file_num = 20);
 
-  ~LogEventReporter() override;
+  virtual ~LogEventReporter();
 
-  void Report(const rpc::Event &event, const nlohmann::json &custom_fields) override;
+  virtual void Report(const rpc::Event &event,
+                      const nlohmann::json &custom_fields) override;
 
-  void ReportExportEvent(const rpc::ExportEvent &export_event) override;
+  virtual void ReportExportEvent(const rpc::ExportEvent &export_event) override;
 
  private:
   virtual std::string replaceLineFeed(std::string message);
@@ -119,13 +116,13 @@ class LogEventReporter : public BaseEventReporter {
 
   virtual std::string ExportEventToString(const rpc::ExportEvent &export_event);
 
-  void Init() override {}
+  virtual void Init() override {}
 
-  void Close() override {}
+  virtual void Close() override {}
 
   virtual void Flush();
 
-  std::string GetReporterKey() override { return "log.event.reporter"; }
+  virtual std::string GetReporterKey() override { return "log.event.reporter"; }
 
  protected:
   std::string log_dir_;
@@ -330,8 +327,7 @@ using ExportEventDataPtr = std::variant<std::shared_ptr<rpc::ExportTaskEventData
                                         std::shared_ptr<rpc::ExportDriverJobEventData>>;
 class RayExportEvent {
  public:
-  explicit RayExportEvent(ExportEventDataPtr event_data_ptr)
-      : event_data_ptr_(event_data_ptr) {}
+  RayExportEvent(ExportEventDataPtr event_data_ptr) : event_data_ptr_(event_data_ptr) {}
 
   ~RayExportEvent();
 

--- a/src/ray/util/exponential_backoff.cc
+++ b/src/ray/util/exponential_backoff.cc
@@ -14,7 +14,6 @@
 
 #include "ray/util/exponential_backoff.h"
 
-#include <algorithm>
 #include <cmath>
 
 namespace ray {

--- a/src/ray/util/exponential_backoff.h
+++ b/src/ray/util/exponential_backoff.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <algorithm>
 #include <cstdint>
 #include <limits>
 
@@ -65,6 +64,7 @@ class ExponentialBackoff {
 
   void Reset() { curr_value_ = initial_value_; }
 
+ private:
  private:
   uint64_t curr_value_;
   uint64_t initial_value_;

--- a/src/ray/util/filesystem.cc
+++ b/src/ray/util/filesystem.cc
@@ -16,7 +16,6 @@
 
 #include <cstdlib>
 #include <fstream>
-#include <string>
 
 #ifdef _WIN32
 #include <Windows.h>

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -31,13 +31,8 @@
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
-#include <limits>
-#include <memory>
 #include <sstream>
-#include <string>
 #include <string_view>
-#include <utility>
-#include <vector>
 
 #include "absl/debugging/failure_signal_handler.h"
 #include "absl/debugging/stacktrace.h"
@@ -62,12 +57,12 @@ constexpr char kLogFormatJsonPattern[] =
     "{\"asctime\":\"%Y-%m-%d %H:%M:%S,%e\",\"levelname\":\"%L\"%v}";
 
 RayLogLevel RayLog::severity_threshold_ = RayLogLevel::INFO;
-std::string RayLog::app_name_ = "";        // NOLINT
-std::string RayLog::component_name_ = "";  // NOLINT
+std::string RayLog::app_name_ = "";
+std::string RayLog::component_name_ = "";
 bool RayLog::log_format_json_ = false;
-std::string RayLog::log_format_pattern_ = kLogFormatTextPattern;  // NOLINT
+std::string RayLog::log_format_pattern_ = kLogFormatTextPattern;
 
-std::string RayLog::logger_name_ = "ray_log_sink";  // NOLINT
+std::string RayLog::logger_name_ = "ray_log_sink";
 bool RayLog::is_failure_signal_handler_installed_ = false;
 std::atomic<bool> RayLog::initialized_ = false;
 

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -54,7 +54,6 @@
 #include <chrono>
 #include <functional>
 #include <iostream>
-#include <limits>
 #include <memory>
 #include <optional>
 #include <sstream>

--- a/src/ray/util/pipe_logger.cc
+++ b/src/ray/util/pipe_logger.cc
@@ -19,13 +19,9 @@
 #include <deque>
 #include <future>
 #include <iostream>
-#include <limits>
-#include <memory>
 #include <mutex>
-#include <string>
 #include <string_view>
 #include <thread>
-#include <utility>
 
 #include "absl/container/inlined_vector.h"
 #include "absl/strings/str_split.h"

--- a/src/ray/util/process.cc
+++ b/src/ray/util/process.cc
@@ -36,10 +36,7 @@
 #include <cstdio>
 #include <cstring>
 #include <fstream>
-#include <functional>
-#include <memory>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include "ray/util/cmd_line_utils.h"
@@ -92,7 +89,7 @@ class ProcessFD {
  public:
   ~ProcessFD();
   ProcessFD();
-  explicit ProcessFD(pid_t pid, intptr_t fd = -1);
+  ProcessFD(pid_t pid, intptr_t fd = -1);
   ProcessFD(ProcessFD &&other);
   ProcessFD &operator=(ProcessFD &&other);
 
@@ -754,7 +751,7 @@ namespace std {
 
 bool equal_to<ray::Process>::operator()(const ray::Process &x,
                                         const ray::Process &y) const {
-  using namespace ray;  // NOLINT
+  using namespace ray;
   return !x.IsNull()
              ? !y.IsNull()
                    ? x.IsValid()
@@ -766,7 +763,7 @@ bool equal_to<ray::Process>::operator()(const ray::Process &x,
 }
 
 size_t hash<ray::Process>::operator()(const ray::Process &value) const {
-  using namespace ray;  // NOLINT
+  using namespace ray;
   return !value.IsNull() ? value.IsValid() ? hash<pid_t>()(value.GetId())
                                            : hash<void const *>()(value.Get())
                          : size_t();

--- a/src/ray/util/random.h
+++ b/src/ray/util/random.h
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <limits>
-
 #include "absl/random/random.h"
 
 /// A helper function to fill random bytes into the `data`.

--- a/src/ray/util/sample.h
+++ b/src/ray/util/sample.h
@@ -15,9 +15,6 @@
 #pragma once
 
 #include <random>
-#include <string>
-#include <utility>
-#include <vector>
 
 #include "absl/time/clock.h"
 

--- a/src/ray/util/spdlog_newliner_sink.h
+++ b/src/ray/util/spdlog_newliner_sink.h
@@ -17,10 +17,7 @@
 #include <spdlog/sinks/base_sink.h>
 
 #include <iostream>
-#include <string>
 #include <string_view>
-#include <utility>
-#include <vector>
 
 #include "absl/strings/str_split.h"
 #include "ray/util/compat.h"

--- a/src/ray/util/stream_redirection_utils.cc
+++ b/src/ray/util/stream_redirection_utils.cc
@@ -17,7 +17,6 @@
 #include <cstring>
 #include <functional>
 #include <mutex>
-#include <utility>
 #include <vector>
 
 #include "ray/util/compat.h"

--- a/src/ray/util/stream_redirection_utils.h
+++ b/src/ray/util/stream_redirection_utils.h
@@ -14,8 +14,6 @@
 
 // This file contains a few logging related util functions.
 
-#pragma once
-
 #include "ray/util/stream_redirection_options.h"
 
 namespace ray {

--- a/src/ray/util/string_utils.cc
+++ b/src/ray/util/string_utils.cc
@@ -14,9 +14,6 @@
 
 #include "ray/util/string_utils.h"
 
-#include <cstdio>
-#include <string>
-
 namespace ray {
 
 std::string StringToHex(const std::string &str) {

--- a/src/ray/util/subreaper.cc
+++ b/src/ray/util/subreaper.cc
@@ -16,8 +16,6 @@
 
 #include <string.h>
 
-#include <algorithm>
-#include <memory>
 #include <vector>
 
 #ifdef __linux__
@@ -104,8 +102,8 @@ void SetupSigchldHandlerRemoveKnownChildren(boost::asio::io_context &io_service)
 // It's done by checking the list of child processes and killing the ones that are not
 // created via Process::spawnvpe.
 //
-// TODO(core): Checking PIDs is not 100% reliable because of PID recycling. If we find
-// issues later due to this, we can use pidfd.
+// TODO: Checking PIDs is not 100% reliable because of PID recycling. If we find issues
+// later due to this, we can use pidfd.
 void KillUnknownChildren() {
   auto to_kill =
       KnownChildrenTracker::instance().ListUnknownChildren([]() -> std::vector<pid_t> {

--- a/src/ray/util/temporary_directory.cc
+++ b/src/ray/util/temporary_directory.cc
@@ -15,7 +15,6 @@
 #include "ray/util/temporary_directory.h"
 
 #include <cstdlib>
-#include <string>
 
 #include "ray/util/util.h"
 

--- a/src/ray/util/temporary_directory.h
+++ b/src/ray/util/temporary_directory.h
@@ -30,7 +30,7 @@ class ScopedTemporaryDirectory {
   // If unspecified, new directory will be created under system temporary directory.
   //
   // If creation or deletion fails, the program will exit after logging error message.
-  explicit ScopedTemporaryDirectory(const std::string &dir = "");
+  ScopedTemporaryDirectory(const std::string &dir = "");
   ~ScopedTemporaryDirectory();
 
   const std::filesystem::path &GetDirectory() const { return temporary_directory_; }

--- a/src/ray/util/tests/cmd_line_utils_test.cc
+++ b/src/ray/util/tests/cmd_line_utils_test.cc
@@ -16,10 +16,6 @@
 
 #include <gtest/gtest.h>
 
-#include <cstdio>
-#include <string>
-#include <vector>
-
 namespace {
 
 const char *argv0 = nullptr;

--- a/src/ray/util/tests/compat_test.cc
+++ b/src/ray/util/tests/compat_test.cc
@@ -16,7 +16,6 @@
 
 #include <gtest/gtest.h>
 
-#include <string>
 #include <string_view>
 
 #include "ray/common/status_or.h"

--- a/src/ray/util/tests/container_util_test.cc
+++ b/src/ray/util/tests/container_util_test.cc
@@ -16,15 +16,10 @@
 
 #include <gtest/gtest.h>
 
-#include <deque>
-#include <list>
-#include <map>
 #include <optional>
 #include <sstream>
 #include <string>
 #include <tuple>
-#include <utility>
-#include <vector>
 
 namespace ray {
 

--- a/src/ray/util/tests/counter_test.cc
+++ b/src/ray/util/tests/counter_test.cc
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gtest/gtest.h>
-
-#include <string>
-
+#include "gtest/gtest.h"
 #include "ray/util/counter_map.h"
 
 namespace ray {

--- a/src/ray/util/tests/event_test.cc
+++ b/src/ray/util/tests/event_test.cc
@@ -21,13 +21,11 @@
 #include <csignal>
 #include <filesystem>
 #include <fstream>
-#include <iostream>
-#include <memory>
 #include <set>
-#include <string>
 #include <thread>
-#include <vector>
 
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "ray/common/ray_config.h"
 #include "ray/util/event_label.h"
 #include "ray/util/random.h"
@@ -40,14 +38,14 @@ namespace ray {
 
 class TestEventReporter : public BaseEventReporter {
  public:
-  void Init() override {}
-  void Report(const rpc::Event &event, const json &custom_fields) override {
+  virtual void Init() override {}
+  virtual void Report(const rpc::Event &event, const json &custom_fields) override {
     event_list.push_back(event);
   }
-  void ReportExportEvent(const rpc::ExportEvent &export_event) override {}
-  void Close() override {}
-  ~TestEventReporter() override {}
-  std::string GetReporterKey() override { return "test.event.reporter"; }
+  virtual void ReportExportEvent(const rpc::ExportEvent &export_event) override {}
+  virtual void Close() override {}
+  virtual ~TestEventReporter() {}
+  virtual std::string GetReporterKey() override { return "test.event.reporter"; }
 
  public:
   static std::vector<rpc::Event> event_list;

--- a/src/ray/util/tests/filesystem_test.cc
+++ b/src/ray/util/tests/filesystem_test.cc
@@ -15,9 +15,6 @@
 #include "ray/util/filesystem.h"
 
 #include <filesystem>
-#include <memory>
-#include <string>
-#include <vector>
 
 #include "gtest/gtest.h"
 #include "ray/common/file_system_monitor.h"
@@ -85,8 +82,8 @@ TEST(FileSystemTest, TestFileSystemMonitor) {
     FileSystemMonitor monitor({tmp_path}, 0);
     auto result = monitor.Space(tmp_path);
     ASSERT_TRUE(result.has_value());
-    ASSERT_GT(result->available, 0);
-    ASSERT_GT(result->capacity, 0);
+    ASSERT_TRUE(result->available > 0);
+    ASSERT_TRUE(result->capacity > 0);
   }
 
   auto noop_monitor = std::make_unique<ray::FileSystemMonitor>();

--- a/src/ray/util/tests/logging_test.cc
+++ b/src/ray/util/tests/logging_test.cc
@@ -18,8 +18,6 @@
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
-#include <string>
-#include <vector>
 
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_split.h"
@@ -31,7 +29,7 @@
 #include "ray/util/filesystem.h"
 #include "ray/util/util.h"
 
-using namespace testing;  // NOLINT
+using namespace testing;
 using json = nlohmann::json;
 
 namespace ray {

--- a/src/ray/util/tests/pipe_logger_test.cc
+++ b/src/ray/util/tests/pipe_logger_test.cc
@@ -20,7 +20,6 @@
 #include <cstdlib>
 #include <filesystem>
 #include <future>
-#include <string>
 #include <string_view>
 
 #include "ray/common/test/testing.h"

--- a/src/ray/util/tests/proto_schema_backward_compatibility_test.cc
+++ b/src/ray/util/tests/proto_schema_backward_compatibility_test.cc
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <string>
-
 #include "gtest/gtest.h"
 #include "src/ray/protobuf/gcs.pb.h"
 

--- a/src/ray/util/tests/sequencer_test.cc
+++ b/src/ray/util/tests/sequencer_test.cc
@@ -15,7 +15,6 @@
 #include "ray/util/sequencer.h"
 
 #include <chrono>
-#include <deque>
 #include <thread>
 
 #include "gtest/gtest.h"
@@ -37,7 +36,7 @@ TEST(SequencerTest, ExecuteOrderedTest) {
     sequencer.Post(key, operation);
   }
 
-  while (queue.size() < static_cast<size_t>(size)) {
+  while (queue.size() < (size_t)size) {
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
 

--- a/src/ray/util/tests/shared_lru_test.cc
+++ b/src/ray/util/tests/shared_lru_test.cc
@@ -17,12 +17,9 @@
 #include <gtest/gtest.h>
 
 #include <future>
-#include <memory>
 #include <string>
 #include <thread>
 #include <type_traits>
-#include <utility>
-#include <vector>
 
 namespace ray::utils::container {
 
@@ -31,7 +28,7 @@ constexpr size_t kTestCacheSz = 1;
 
 class TestClassWithHashAndEq {
  public:
-  explicit TestClassWithHashAndEq(std::string data) : data_(std::move(data)) {}
+  TestClassWithHashAndEq(std::string data) : data_(std::move(data)) {}
   bool operator==(const TestClassWithHashAndEq &rhs) const { return data_ == rhs.data_; }
   template <typename H>
   friend H AbslHashValue(H h, const TestClassWithHashAndEq &obj) {

--- a/src/ray/util/tests/signal_test.cc
+++ b/src/ray/util/tests/signal_test.cc
@@ -16,7 +16,6 @@
 
 #include <cstdlib>
 #include <iostream>
-#include <string>
 
 #include "gtest/gtest.h"
 #include "ray/util/logging.h"
@@ -31,12 +30,12 @@ void Sleep() { std::this_thread::sleep_for(std::chrono::milliseconds(100)); }
 void TestSendSignal(const std::string &test_name, int signal) {
   pid_t pid;
   pid = fork();
-  ASSERT_GE(pid, 0);
+  ASSERT_TRUE(pid >= 0);
   if (pid == 0) {
     while (true) {
       int n = 1000;
-      while (n--) {
-      }
+      while (n--)
+        ;
     }
   } else {
     Sleep();
@@ -53,7 +52,7 @@ TEST(SignalTest, SendBusSignalTest) { TestSendSignal("SendBusSignalTest", SIGBUS
 TEST(SignalTest, SIGABRT_Test) {
   pid_t pid;
   pid = fork();
-  ASSERT_GE(pid, 0);
+  ASSERT_TRUE(pid >= 0);
   if (pid == 0) {
     // This code will cause SIGABRT sent.
     std::abort();
@@ -68,7 +67,7 @@ TEST(SignalTest, SIGABRT_Test) {
 TEST(SignalTest, SIGSEGV_Test) {
   pid_t pid;
   pid = fork();
-  ASSERT_GE(pid, 0);
+  ASSERT_TRUE(pid >= 0);
   if (pid == 0) {
     int *pointer = reinterpret_cast<int *>(0x1237896);
     *pointer = 100;
@@ -83,7 +82,7 @@ TEST(SignalTest, SIGSEGV_Test) {
 TEST(SignalTest, SIGILL_Test) {
   pid_t pid;
   pid = fork();
-  ASSERT_GE(pid, 0);
+  ASSERT_TRUE(pid >= 0);
   if (pid == 0) {
     raise(SIGILL);
   } else {

--- a/src/ray/util/tests/spdlog_fd_sink_test.cc
+++ b/src/ray/util/tests/spdlog_fd_sink_test.cc
@@ -16,9 +16,6 @@
 
 #include <gtest/gtest.h>
 
-#include <memory>
-#include <string>
-
 namespace ray {
 
 namespace {
@@ -53,7 +50,7 @@ TEST(SpdlogFdSinkTest, SinkWithFd) {
   const std::string stdout_content = testing::internal::GetCapturedStdout();
 
   EXPECT_EQ(stdout_content, "helloworld");
-}
+};
 
 }  // namespace
 

--- a/src/ray/util/tests/spdlog_newliner_sink_test.cc
+++ b/src/ray/util/tests/spdlog_newliner_sink_test.cc
@@ -16,10 +16,7 @@
 
 #include <gtest/gtest.h>
 
-#include <memory>
-#include <string>
 #include <string_view>
-#include <utility>
 
 #include "ray/common/test/testing.h"
 #include "ray/util/compat.h"

--- a/src/ray/util/tests/stream_redirection_exit_test.cc
+++ b/src/ray/util/tests/stream_redirection_exit_test.cc
@@ -18,7 +18,6 @@
 
 #include <chrono>
 #include <iostream>
-#include <string>
 #include <thread>
 
 #include "ray/common/test/testing.h"

--- a/src/ray/util/tests/stream_redirection_utils_test.cc
+++ b/src/ray/util/tests/stream_redirection_utils_test.cc
@@ -18,9 +18,7 @@
 
 #include <chrono>
 #include <iostream>
-#include <string>
 #include <thread>
-#include <vector>
 
 #include "ray/common/test/testing.h"
 #include "ray/util/filesystem.h"

--- a/src/ray/util/tests/util_test.cc
+++ b/src/ray/util/tests/util_test.cc
@@ -14,20 +14,19 @@
 
 #include "ray/util/util.h"
 
+#include <stdio.h>
+
 #include <boost/asio/generic/basic_endpoint.hpp>
 #include <boost/process/child.hpp>
 #include <chrono>
-#include <cstdio>
-#include <string>
 #include <thread>
-#include <vector>
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "ray/util/logging.h"
 #include "ray/util/process.h"
 
-using namespace std::chrono_literals;  // NOLINT
+using namespace std::chrono_literals;
 
 namespace ray {
 

--- a/src/ray/util/thread_utils.h
+++ b/src/ray/util/thread_utils.h
@@ -33,9 +33,6 @@
 #endif
 #endif
 
-#include <string>
-#include <utility>
-
 #include "ray/util/thread_checker.h"
 
 // Returns the TID of the calling thread.

--- a/src/ray/util/util.cc
+++ b/src/ray/util/util.cc
@@ -22,11 +22,9 @@
 
 #include <algorithm>
 #include <boost/asio/generic/stream_protocol.hpp>
-#include <memory>
 #include <sstream>
 #include <string>
 #include <string_view>
-#include <utility>
 #include <vector>
 #ifndef _WIN32
 #include <boost/asio/local/stream_protocol.hpp>


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Reverts two commits related to Python 3.13 support:

- https://github.com/ray-project/ray/commit/ba149d9459e5b82c170e54fc399cf3dc3bd76e47
- https://github.com/ray-project/ray/commit/d2004b6353e131bb67e1bc7f771a09780ee32d2a

The cython changes appear to be causing segfault behavior observed in the release tests. Example: https://buildkite.com/ray-project/release/builds/32909

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
