### PR TITLE
[deps] explicitly add dl-cpu requirements in ray-ml docker build file

### DIFF
--- a/docker/ray-ml/install-ml-docker-requirements.sh
+++ b/docker/ray-ml/install-ml-docker-requirements.sh
@@ -28,6 +28,7 @@ pip --no-cache-dir install -U -r requirements.txt
 pip --no-cache-dir install -U \
            -c requirements.txt \
            -c requirements_compiled.txt \
+           -r dl-cpu-requirements.txt \
            -r core-requirements.txt \
            -r data-requirements.txt \
            -r rllib-requirements.txt \


### PR DESCRIPTION
it is current already indirectly being referenced in other requirement files now
