### PR TITLE
[core] Fix file not found error

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -684,14 +684,22 @@ class Worker:
 
     def get_current_out_offset(self) -> int:
         """Get the current offset of the out file if seekable, else 0"""
-        if self._out_filepath is not None:
-            return os.path.getsize(self._out_filepath)
+        try:
+            if self._out_filepath is not None:
+                return os.path.getsize(self._out_filepath)
+        # When rotation enabled, C++ spdlog deletes file before rename.
+        except FileNotFoundError:
+            return 0
         return 0
 
     def get_current_err_offset(self) -> int:
         """Get the current offset of the err file if seekable, else 0"""
-        if self._err_filepath is not None:
-            return os.path.getsize(self._err_filepath)
+        try:
+            if self._err_filepath is not None:
+                return os.path.getsize(self._err_filepath)
+        # When rotation enabled, C++ spdlog deletes file before rename.
+        except FileNotFoundError:
+            return 0
         return 0
 
     def get_serialization_context(self):


### PR DESCRIPTION
Checking the implementation for spdlog, it found rotation is implemented via deletion then rename, so it's possible in certain window we don't have the log file, this PR tolerates by capturing the exact exception.

https://github.com/gabime/spdlog/blob/3335c380a08c5e0f5117a66622df6afdb3d74959/include/spdlog/sinks/rotating_file_sink-inl.h#L139-L147