### PR TITLE
[core] [wip attempt] StatusOr union construction sometimes breaks windows build

### DIFF
--- a/src/ray/common/status_or.h
+++ b/src/ray/common/status_or.h
@@ -46,7 +46,7 @@ namespace ray {
 template <typename T>
 class StatusOr {
  public:
-  StatusOr() noexcept = default;
+  StatusOr() = default;
   // NOLINTNEXTLINE(runtime/explicit)
   StatusOr(Status status) : status_(std::move(status)) {}
   // NOLINTNEXTLINE(runtime/explicit)

--- a/src/ray/common/status_or.h
+++ b/src/ray/common/status_or.h
@@ -277,7 +277,7 @@ class StatusOr {
   //
   // `data_` is effective iff `ok() == true`.
   union {
-    T data_;
+    T data_{};
   };
 };
 

--- a/src/ray/common/status_or.h
+++ b/src/ray/common/status_or.h
@@ -277,7 +277,7 @@ class StatusOr {
   //
   // `data_` is effective iff `ok() == true`.
   union {
-    T data_{};
+    T data_;
   };
 };
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Trying to fix windows build with no noexcept constructor.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
