### PR TITLE
[data] Adding in `TaskDurationStats` and `on_execution_step` callback

### DIFF
--- a/python/ray/data/_internal/execution/execution_callback.py
+++ b/python/ray/data/_internal/execution/execution_callback.py
@@ -15,6 +15,10 @@ class ExecutionCallback:
         """Called before the Dataset execution starts."""
         ...
 
+    def on_execution_step(self, executor: "StreamingExecutor"):
+        """Called at each step of the Dataset execution loop."""
+        ...
+
     def after_execution_succeeds(self, executor: "StreamingExecutor"):
         """Called after the Dataset execution succeeds."""
         ...

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -243,6 +243,8 @@ class StreamingExecutor(Executor, threading.Thread):
                     self._initial_stats.streaming_exec_schedule_s.add(
                         time.process_time() - t_start
                     )
+                for callback in get_execution_callbacks(self._data_context):
+                    callback.on_execution_step(self)
                 if not continue_sched or self._shutdown:
                     break
         except Exception as e:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->
This PR does two things: 1. Adds in `TaskDurationStats` to keep track of the duration statistics for tasks in Ray Data and 2. adds in a per execution loop callback to the streaming executor, `on_execution_step`.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
