### PR TITLE
[llm.serving] validate null response content

### DIFF
--- a/python/ray/llm/_internal/serve/configs/openai_api_models.py
+++ b/python/ray/llm/_internal/serve/configs/openai_api_models.py
@@ -33,6 +33,7 @@ from openai.types.chat import (
 from pydantic import (
     BaseModel,
     Field,
+    model_validator,
 )
 from ray.serve._private.utils import (
     generate_request_id,
@@ -546,6 +547,11 @@ class DeltaMessage(BaseModel):
     content: Optional[str] = None
     reasoning_content: Optional[str] = None
     tool_calls: List[DeltaToolCall] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _non_null_content(self):
+        self.content = self.content or ""
+        return self
 
 
 class ChatCompletionResponseStreamChoice(BaseModel):

--- a/python/ray/llm/tests/serve/configs/test_openai_api_models.py
+++ b/python/ray/llm/tests/serve/configs/test_openai_api_models.py
@@ -1,0 +1,29 @@
+from ray.llm._internal.serve.configs.openai_api_models import DeltaMessage
+
+
+def test_delta_message_null_content():
+    """Test that the DeltaMessage class is correctly constructed.
+
+    When the content is passed as None, it should be set to an empty string.
+    """
+    role = "user"
+    delta_message_implicitly_null_content = DeltaMessage(
+        role=role,
+    )
+
+    delta_message_explicitly_null_content = DeltaMessage(
+        role=role,
+        content=None,
+    )
+
+    delta_message_empty_string_content = DeltaMessage(
+        role=role,
+        content="",
+    )
+
+    assert delta_message_implicitly_null_content.role == role
+    assert delta_message_explicitly_null_content.role == role
+    assert delta_message_empty_string_content.role == role
+    assert delta_message_implicitly_null_content.content == ""
+    assert delta_message_explicitly_null_content.content == ""
+    assert delta_message_empty_string_content.content == ""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The response content type should never be null when there is no content. It should be empty string instead. TDD add a test case to capture this and add a validation fix the issue.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
