### PR TITLE
[core] Remove test_events_with_crash

### DIFF
--- a/python/ray/workflow/BUILD
+++ b/python/ray/workflow/BUILD
@@ -28,7 +28,6 @@ LARGE_TESTS = [
 LARGE_ALL_CORE_TESTS = [
     "tests/test_http_events_2.py",
     "tests/test_events.py",
-    "tests/test_events_with_crash.py",
 ]
 
 py_test_module_list(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Ray Workflows test_events_with_crash has been consistently failing and was moved to postmerge so that it was not blocking.
Per consensus from Ray core team we would like to remove them as Ray Workflows will be deprecated.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
