### PR TITLE
[LLM Serve] Fix docs example for vision language model

### DIFF
--- a/doc/source/serve/llm/overview.rst
+++ b/doc/source/serve/llm/overview.rst
@@ -401,8 +401,8 @@ For multimodal models that can process both text and images:
             # Configure a vision model
             llm_config = LLMConfig(
                 model_loading_config=dict(
-                    model_id="qwen-vl-7b",
-                    model_source="Qwen/Qwen2.5-VL-7B-Instruct",
+                    model_id="pixtral-12b",
+                    model_source="mistral-community/pixtral-12b",
                 ),
                 deployment_config=dict(
                     autoscaling_config=dict(
@@ -429,7 +429,7 @@ For multimodal models that can process both text and images:
 
             # Create and send a request with an image
             response = client.chat.completions.create(
-                model="qwen-vl-7b",
+                model="pixtral-12b",
                 messages=[
                     {
                         "role": "user",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The LLM Serve docs example for vision language models uses Qwen, which is incompatible with the current version of vLLM. This PR switches out Qwen with Pixtral, after testing it works.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
