### PR TITLE
[core] [easy] [noop] Move pid_t alias to compatibility header

### DIFF
--- a/src/ray/util/BUILD
+++ b/src/ray/util/BUILD
@@ -95,6 +95,7 @@ ray_cc_library(
     ],
     deps = [
         ":cmd_line_utils",
+        ":compat",
         ":filesystem",
         ":logging",
         ":macros",

--- a/src/ray/util/compat.h
+++ b/src/ray/util/compat.h
@@ -33,6 +33,12 @@
 
 #include "ray/common/status.h"
 
+#if defined(__APPLE__) || defined(__linux__)
+#include <unistd.h>
+#else
+using pid_t = int;
+#endif
+
 // Workaround for multithreading on XCode 9, see
 // https://issues.apache.org/jira/browse/ARROW-1622 and
 // https://github.com/tensorflow/tensorflow/issues/13220#issuecomment-331579775

--- a/src/ray/util/process.h
+++ b/src/ray/util/process.h
@@ -30,6 +30,8 @@
 #include <utility>
 #include <vector>
 
+#include "ray/util/compat.h"
+
 #ifndef PID_MAX_LIMIT
 // This is defined by Linux to be the maximum allowable number of processes
 // There's no guarantee for other OSes, but it's useful for testing purposes.
@@ -46,10 +48,6 @@ class EnvironmentVariableLess {
 };
 
 typedef std::map<std::string, std::string, EnvironmentVariableLess> ProcessEnvironment;
-
-#ifdef _WIN32
-using pid_t = int;
-#endif
 
 using StartupToken = int64_t;
 


### PR DESCRIPTION
`pid_t` is pretty common thing, better to move it to compatibility header, so people don't need to depend on `process` and `reaper`.