### PR TITLE
[train][ci] Bump up the timeout of `test_data_parallel_trainer`

### DIFF
--- a/python/ray/train/v2/BUILD
+++ b/python/ray/train/v2/BUILD
@@ -40,7 +40,7 @@ py_test(
 )
 py_test(
     name = "test_data_parallel_trainer",
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_data_parallel_trainer.py"],
     tags = ["exclusive", "team:ml", "train_v2"],
     deps = ["//:ray_lib", ":conftest"],


### PR DESCRIPTION
## Summary

This test was flakily timing out at the last test in the suite. Bumping it up since we'll continue adding to this.