### PR TITLE
Fix minor typo in ray-client.rst

### DIFF
--- a/doc/source/cluster/running-applications/job-submission/ray-client.rst
+++ b/doc/source/cluster/running-applications/job-submission/ray-client.rst
@@ -178,7 +178,8 @@ this can be done by modifying the security group to allow inbound access from yo
 
 
 .. warning::
-   Anyone with Ray Client access can execute arbitrary code on the Ray Cluster.\n
+   Anyone with Ray Client access can execute arbitrary code on the Ray Cluster.
+
    **Do not expose this to `0.0.0.0/0`.**
 
 Connect to multiple Ray clusters (Experimental)


### PR DESCRIPTION
## Why are these changes needed?

Fixes typo in ray client docs. See screenshot.

<img width="835" alt="image" src="https://github.com/user-attachments/assets/7f5330f0-4c10-411e-bda8-b33a61f0df56" />

## Related issue number

NA

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
