### PR TITLE
[docs] add missing step to install KubeRay in gke-gcs-bucket.md

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides/gke-gcs-bucket.md
+++ b/doc/source/cluster/kubernetes/user-guides/gke-gcs-bucket.md
@@ -29,6 +29,11 @@ Now get credentials for the cluster to use with `kubectl`:
 gcloud container clusters get-credentials cloud-bucket-cluster --zone us-west1-b --project my-project-id
 ```
 
+## Install the KubeRay operator
+
+Follow [Deploy a KubeRay operator](kuberay-operator-deploy) to install the latest stable KubeRay operator from the Helm repository.
+The KubeRay operator Pod must be on the CPU node if you set up the taint for the GPU node pool correctly.
+
 ## Create an IAM Service Account
 
 ```bash


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`gke-gcs-bucket.md` is missing a step to install the KubeRay operator.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
