### PR TITLE
[core] Subprocess to cleanup resource for parent process

### DIFF
--- a/src/ray/common/cgroup/BUILD
+++ b/src/ray/common/cgroup/BUILD
@@ -43,15 +43,15 @@ ray_cc_library(
 
 ray_cc_library(
     name = "fake_cgroup_setup",
+    testonly = True,
     srcs = ["fake_cgroup_setup.cc"],
     hdrs = ["fake_cgroup_setup.h"],
     deps = [
         ":base_cgroup_setup",
         "//src/ray/util:logging",
         "//src/ray/util:process",
-        "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/synchronization",
     ],
-    testonly = True,
 )

--- a/src/ray/common/cgroup/test/BUILD
+++ b/src/ray/common/cgroup/test/BUILD
@@ -17,9 +17,9 @@ ray_cc_test(
 ray_cc_test(
     name = "fake_cgroup_setup_test",
     srcs = ["fake_cgroup_setup_test.cc"],
+    tags = ["team:core"],
     deps = [
         "//src/ray/common/cgroup:fake_cgroup_setup",
         "@com_google_googletest//:gtest_main",
     ],
-    tags = ["team:core"]
 )

--- a/src/ray/util/BUILD
+++ b/src/ray/util/BUILD
@@ -337,3 +337,13 @@ ray_cc_library(
         "@com_google_absl//absl/synchronization",
     ],
 )
+
+ray_cc_library(
+    name = "process_cleaner",
+    srcs = ["process_cleaner.cc"],
+    hdrs = ["process_cleaner.h"],
+    deps = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["//src/ray/util:logging"],
+    }),
+)

--- a/src/ray/util/process_cleaner.cc
+++ b/src/ray/util/process_cleaner.cc
@@ -1,0 +1,64 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/util/process_cleaner.h"
+
+#if defined(__APPLE__) || defined(__linux__)
+#include <unistd.h>
+
+#include <array>
+#include <cstring>
+
+#include "ray/util/logging.h"
+#endif
+
+namespace ray {
+
+#if defined(__APPLE__) || defined(__linux__)
+void SpawnSubprocessAndCleanup(std::function<void()> cleanup) {
+  std::array<int, 2> pipe_fd;  // Intentionally no initialization.
+  RAY_CHECK_NE(pipe(pipe_fd.data()), -1)
+      << "Fails to create pipe because " << strerror(errno);
+  pid_t pid = fork();
+  RAY_CHECK_NE(pid, -1) << "Fails to create child process because " << strerror(errno);
+
+  const int pipe_readfd = pipe_fd[0];
+  const int pipe_writefd = pipe_fd[1];
+
+  // Handle parent process.
+  if (pid > 0) {
+    RAY_CHECK_NE(close(pipe_readfd), -1)
+        << "Parent process fails to close pipe read because " << strerror(errno);
+    // Intentionally leave the pipe write fd leak, which gets closed at parent process
+    // termination.
+    return;
+  }
+
+  // Close write fd.
+  RAY_CHECK_NE(close(pipe_writefd), -1)
+      << "Child process fails to close pipe write because " << strerror(errno);
+  // Handle child process, make it owner for new session so it doesn't killed along with
+  // its parent process.
+  setsid();
+
+  // Block until parent process exits.
+  char buf = 'a';
+  [[maybe_unused]] auto x = read(pipe_readfd, &buf, /*count=*/1);
+  cleanup();
+}
+#else
+void SpawnSubprocessAndCleanup(std::function<void()> cleanup) {}
+#endif
+
+}  // namespace ray

--- a/src/ray/util/process_cleaner.h
+++ b/src/ray/util/process_cleaner.h
@@ -18,12 +18,14 @@
 
 namespace ray {
 
-// This util function implement such feature:
+// This util function implements such feature:
 // To perform certain cleanup work after main process dies (i.e. cleanup cgroup for main
 // process), it spawns a subprocess which keeps listens to pipe; child process keeps
 // listening to pipe and gets awaken when parent process exits.
 //
-// Notice it only works for unix platform.
+// Notice it only works for unix platform, and it should be called AT MOST ONCE.
+// If there're multiple cleanup functions to register, callers should wrap them all into
+// one callback.
 void SpawnSubprocessAndCleanup(std::function<void()> cleanup);
 
 }  // namespace ray

--- a/src/ray/util/process_cleaner.h
+++ b/src/ray/util/process_cleaner.h
@@ -1,0 +1,29 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <functional>
+
+namespace ray {
+
+// This util function implement such feature:
+// To perform certain cleanup work after main process dies (i.e. cleanup cgroup for main
+// process), it spawns a subprocess which keeps listens to pipe; child process keeps
+// listening to pipe and gets awaken when parent process exits.
+//
+// Notice it only works for unix platform.
+void SpawnSubprocessAndCleanup(std::function<void()> cleanup);
+
+}  // namespace ray

--- a/src/ray/util/tests/BUILD
+++ b/src/ray/util/tests/BUILD
@@ -343,3 +343,16 @@ ray_cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+ray_cc_test(
+    name = "process_cleanup_test",
+    srcs = ["process_cleanup_test.cc"],
+    tags = ["team:core"],
+    deps = [
+        "//src/ray/common/test:testing",
+        "//src/ray/util",
+        "//src/ray/util:filesystem",
+        "//src/ray/util:process_cleaner",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/src/ray/util/tests/process_cleanup_test.cc
+++ b/src/ray/util/tests/process_cleanup_test.cc
@@ -1,0 +1,74 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#if defined(__APPLE__) || defined(__linux__)
+
+#include <chrono>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <utility>
+
+#include "ray/common/test/testing.h"
+#include "ray/util/filesystem.h"
+#include "ray/util/process_cleaner.h"
+#include "ray/util/util.h"
+
+namespace ray {
+
+namespace {
+
+TEST(ProcessCleanerTest, BasicTest) {
+  const std::string kTestFname =
+      absl::StrFormat("/tmp/process_cleanup_%s", GenerateUUIDV4());
+  auto test_func = [fname = kTestFname]() {
+    std::fstream f{fname, std::ios::app | std::ios::out};
+    f << "helloworld";
+    f.flush();
+    f.close();
+  };
+
+  pid_t pid = fork();
+  ASSERT_NE(pid, -1);
+
+  // For child process, call [SpawnSubprocessAndCleanup] and exit.
+  if (pid == 0) {
+    SpawnSubprocessAndCleanup(std::move(test_func));
+    return;
+  }
+
+  // For parent process, first wait until child process exits.
+  int status = 0;
+  ASSERT_NE(waitpid(pid, &status, 0), -1);
+
+  // Wait for a while for grand child to execute cleanup function.
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+
+  // Check whether expected file has been generated (by child process).
+  auto content = ReadEntireFile(kTestFname);
+  RAY_ASSERT_OK(content);
+  EXPECT_EQ(*content, "helloworld");
+
+  // Remove test file. Here we cannot use `ScopedTemporaryDirectory` because destructor
+  // will be invoked in child process, thus double delete and crash.
+  std::filesystem::remove(kTestFname);
+}
+
+}  // namespace
+
+}  // namespace ray
+
+#endif


### PR DESCRIPTION
A util function used in cgroup project, the overall idea is:
- raylet is the component to create and cleanup cgroup folders / resources;
- system components (i.e. GCS, raylet, etc) will be placed at system cgroup folder; while worker (aka, user application) will be placed at application cgroup;
- the issue is raylet needs to cleanup its own from its cgroup folder, but cgroup doesn't allow to remove a folder when there're still process inside of it;
- this PR implement the solution: raylet spawn its subprocess, which re-parents to init process; when raylet exits, child process awaken and delete the corresponding cgroup folder;
- it's worth noting there's no need to place the cleanup child process in that cgroup, since its behavior and resource consumption is confined.