### PR TITLE
[core] Avoid creating a boost::asio::thread_pool with 0 threads

### DIFF
--- a/python/ray/tests/test_concurrency_group.py
+++ b/python/ray/tests/test_concurrency_group.py
@@ -7,6 +7,7 @@ import ray
 import time
 
 from ray._private.utils import get_or_create_event_loop
+from ray._private.test_utils import run_string_as_driver
 
 
 # This tests the methods are executed in the correct eventloop.
@@ -177,6 +178,28 @@ def test_system_concurrency_group(ray_start_regular_shared):
     n = NormalActor.remote()
     n.block_forever.options(concurrency_group="_ray_system").remote()
     print(ray.get(n.ping.remote()))
+
+
+def test_invalid_concurrency_group():
+    """Verify that when a concurrency group has max concurrency set to 0,
+    an error is raised when the actor is created.
+    """
+
+    script = """
+import ray
+
+ray.init()
+
+@ray.remote(concurrency_groups={"io": 0, "compute": 0})
+class A:
+    def __init__(self):
+        pass
+
+actor = A.remote()
+    """
+
+    output = run_string_as_driver(script)
+    assert "max_concurrency must be greater than 0" in output
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_concurrency_group.py
+++ b/python/ray/tests/test_concurrency_group.py
@@ -182,7 +182,11 @@ def test_system_concurrency_group(ray_start_regular_shared):
 
 def test_invalid_concurrency_group():
     """Verify that when a concurrency group has max concurrency set to 0,
-    an error is raised when the actor is created.
+    an error is raised when the actor is created. This test uses
+    `run_string_as_driver` and checks whether the error message appears in the
+    driver's stdout. Since the error in the core worker process does not raise
+    an exception in the driver process, we need to check the driver process's
+    stdout.
     """
 
     script = """

--- a/src/ray/core_worker/fiber.h
+++ b/src/ray/core_worker/fiber.h
@@ -91,9 +91,11 @@ using FiberChannel = boost::fibers::unbuffered_channel<std::function<void()>>;
 
 class FiberState {
  public:
-  static bool NeedDefaultExecutor(int32_t max_concurrency_in_default_group) {
+  static bool NeedDefaultExecutor(int32_t max_concurrency_in_default_group,
+                                  bool has_other_concurrency_groups) {
     RAY_UNUSED(max_concurrency_in_default_group);
-    /// asycio mode always need a default executor.
+    RAY_UNUSED(has_other_concurrency_groups);
+    /// asyncio mode always need a default executor.
     return true;
   }
 

--- a/src/ray/core_worker/transport/concurrency_group_manager.cc
+++ b/src/ray/core_worker/transport/concurrency_group_manager.cc
@@ -39,8 +39,8 @@ ConcurrencyGroupManager<ExecutorType>::ConcurrencyGroupManager(
   // this actor, the tasks of default group will be performed in main thread instead of
   // any executor pool, otherwise tasks in any concurrency group should be performed in
   // the thread pools instead of main thread.
-  if (ExecutorType::NeedDefaultExecutor(max_concurrency_for_default_concurrency_group) ||
-      !concurrency_groups.empty()) {
+  if (ExecutorType::NeedDefaultExecutor(max_concurrency_for_default_concurrency_group,
+                                        !concurrency_groups.empty())) {
     default_executor_ =
         std::make_shared<ExecutorType>(max_concurrency_for_default_concurrency_group);
   }

--- a/src/ray/core_worker/transport/thread_pool.cc
+++ b/src/ray/core_worker/transport/thread_pool.cc
@@ -19,13 +19,16 @@
 namespace ray {
 namespace core {
 
-BoundedExecutor::BoundedExecutor(int max_concurrency) : pool_(max_concurrency){};
+BoundedExecutor::BoundedExecutor(int max_concurrency) {
+  RAY_CHECK(max_concurrency > 0) << "max_concurrency must be greater than 0";
+  pool_ = std::make_unique<boost::asio::thread_pool>(max_concurrency);
+}
 
 /// Stop the thread pool.
-void BoundedExecutor::Stop() { pool_.stop(); }
+void BoundedExecutor::Stop() { pool_->stop(); }
 
 /// Join the thread pool.
-void BoundedExecutor::Join() { pool_.join(); }
+void BoundedExecutor::Join() { pool_->join(); }
 
 }  // namespace core
 }  // namespace ray

--- a/src/ray/core_worker/transport/thread_pool.h
+++ b/src/ray/core_worker/transport/thread_pool.h
@@ -35,15 +35,18 @@ namespace core {
 /// by the SchedulingQueue to provide backpressure to clients.
 class BoundedExecutor {
  public:
-  static bool NeedDefaultExecutor(int32_t max_concurrency_in_default_group) {
-    //  Threaded actor mode only need a default executor when max_concurrency > 1.
-    return max_concurrency_in_default_group > 1;
+  static bool NeedDefaultExecutor(int32_t max_concurrency_in_default_group,
+                                  bool has_other_concurrency_groups) {
+    if (max_concurrency_in_default_group == 0) {
+      return false;
+    }
+    return max_concurrency_in_default_group > 1 || has_other_concurrency_groups;
   }
 
   explicit BoundedExecutor(int max_concurrency);
 
   /// Posts work to the pool
-  void Post(std::function<void()> fn) { boost::asio::post(pool_, std::move(fn)); }
+  void Post(std::function<void()> fn) { boost::asio::post(*pool_, std::move(fn)); }
 
   /// Stop the thread pool.
   void Stop();
@@ -53,7 +56,7 @@ class BoundedExecutor {
 
  private:
   /// The underlying thread pool for running tasks.
-  boost::asio::thread_pool pool_;
+  std::unique_ptr<boost::asio::thread_pool> pool_;
 };
 
 }  // namespace core


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

* Change 1: Unify the logic for determining whether a default executor is needed
  * Currently, there are two conditions that determine whether to create a default executor. That is, if `NeedDefaultExecutor` is false, a default executor may still be created, which is a bit odd.
    ```cpp
      if (ExecutorType::NeedDefaultExecutor(max_concurrency_for_default_concurrency_group) ||
          !concurrency_groups.empty()) {
        default_executor_ =
            std::make_shared<ExecutorType>(max_concurrency_for_default_concurrency_group);
      }
    ```
  * With this PR, we only need to call `NeedDefaultExecutor` to determine whether to create a default executor or not. That is, none of the tasks submitted to the group will be executed.

* Change 2: Avoid creating a thread pool with 0 thread. Currently, if an actor is async, the `default_executor` will be a thread pool with 0 thread.
   https://github.com/ray-project/ray/blob/fd328d7dc2544e78ded68dfc600daf4a79500a4d/src/ray/core_worker/transport/task_receiver.cc#L174-L177

Note that if users create worker groups with 0 threads, the original behavior is that no error is thrown when an actor is created, but tasks submitted to the group will get stuck forever without any error message. In this PR, an error will be thrown when the actor is created.

```python
import ray

ray.init()

@ray.remote(concurrency_groups={"io": 0, "compute": 0})
class A:
  def __init__(self):
    pass

  @ray.method(concurrency_group="io")
  def f(self, value):
    return value

actor = A.remote()
ray.get(actor.f.remote(1))
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
