### PR TITLE
[ci] more project id fixes for release test launching

### DIFF
--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -141,9 +141,12 @@ def get_step(
     env_dict = load_environment(env_to_use)
     env_dict.update(env)
 
-    # Set the project id for the test
-    project_id = get_test_project_id(test)
-    env_dict["ANYSCALE_PROJECT"] = project_id
+    # Set the project id for the test, based on the follow priority:
+    #  1. Specified in the test, as "project_id" field.
+    #  2. Specified in the specific test environment, as RELEASE_DEFAULT_PROJECT env var
+    #  3. Specified in the global environment, as RELEASE_DEFAULT_PROJECT env var
+    default_project_id = env_dict.get("RELEASE_DEFAULT_PROJECT")
+    env_dict["ANYSCALE_PROJECT"] = get_test_project_id(test, default_project_id)
 
     step["env"].update(env_dict)
     step["plugins"][0][DOCKER_PLUGIN_KEY]["image"] = "python:3.9"

--- a/release/ray_release/config.py
+++ b/release/ray_release/config.py
@@ -31,7 +31,7 @@ DEFAULT_CLOUD_ID = DeferredEnvVar(
 )
 DEFAULT_ANYSCALE_PROJECT = DeferredEnvVar(
     "RELEASE_DEFAULT_PROJECT",
-    "prj_rw3kzbqsehh4a6klka7j616fgb",
+    "prj_6rfevmf12tbsbd6g3al5f6zssh",
 )
 
 RELEASE_PACKAGE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -255,6 +255,7 @@ def get_test_cloud_id(test: Test) -> str:
     return cloud_id
 
 
-def get_test_project_id(test: Test) -> str:
-    default_project_id = str(DEFAULT_ANYSCALE_PROJECT)
+def get_test_project_id(test: Test, default_project_id: Optional[str] = None) -> str:
+    if default_project_id is None:
+        default_project_id = str(DEFAULT_ANYSCALE_PROJECT)
     return test.get("cluster", {}).get("project_id", default_project_id)


### PR DESCRIPTION
Set the project id for the test, based on the follow priority:

1. Specified in the test, as "project_id" field.
2. Specified in the specific test environment, as RELEASE_DEFAULT_PROJECT env var
3. Specified in the global environment, as RELEASE_DEFAULT_PROJECT env var