### PR TITLE
[data/preprocessors] feat: allow vectorizers to be executed in append mode

### DIFF
--- a/python/ray/data/tests/preprocessors/test_hasher.py
+++ b/python/ray/data/tests/preprocessors/test_hasher.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pytest
 
 import ray
-from ray.data.preprocessors import FeatureHasher, HashingVectorizer
+from ray.data.preprocessors import FeatureHasher
 
 
 def test_feature_hasher():
@@ -30,40 +30,6 @@ def test_feature_hasher():
     # indices for adequately large `num_features`.
     assert document_term_matrix.iloc[1].sum() == 3
     assert all(document_term_matrix.iloc[1] <= 1)
-
-
-def test_hashing_vectorizer():
-    """Tests basic HashingVectorizer functionality."""
-
-    col_a = ["a b b c c c", "a a a a c"]
-    col_b = ["apple", "banana banana banana"]
-    in_df = pd.DataFrame.from_dict({"A": col_a, "B": col_b})
-    ds = ray.data.from_pandas(in_df)
-
-    vectorizer = HashingVectorizer(["A", "B"], num_features=3)
-
-    transformed = vectorizer.transform(ds)
-    out_df = transformed.to_pandas()
-
-    processed_col_a_0 = [2, 0]
-    processed_col_a_1 = [1, 4]
-    processed_col_a_2 = [3, 1]
-    processed_col_b_0 = [1, 0]
-    processed_col_b_1 = [0, 3]
-    processed_col_b_2 = [0, 0]
-
-    expected_df = pd.DataFrame.from_dict(
-        {
-            "hash_A_0": processed_col_a_0,
-            "hash_A_1": processed_col_a_1,
-            "hash_A_2": processed_col_a_2,
-            "hash_B_0": processed_col_b_0,
-            "hash_B_1": processed_col_b_1,
-            "hash_B_2": processed_col_b_2,
-        }
-    )
-
-    assert out_df.equals(expected_df)
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/preprocessors/test_vectorizer.py
+++ b/python/ray/data/tests/preprocessors/test_vectorizer.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pytest
 
 import ray
-from ray.data.preprocessors import CountVectorizer
+from ray.data.preprocessors import CountVectorizer, HashingVectorizer
 
 
 def test_count_vectorizer():
@@ -33,23 +33,17 @@ def test_count_vectorizer():
     transformed = vectorizer.transform(ds)
     out_df = transformed.to_pandas(limit=float("inf"))
 
-    processed_col_a_a = [1, 4] * row_multiplier
-    processed_col_a_c = [3, 1] * row_multiplier
-    processed_col_a_b = [2, 0] * row_multiplier
-    processed_col_b_banana = [0, 3] * row_multiplier
-    processed_col_b_apple = [1, 0] * row_multiplier
+    processed_col_a = [[1, 3, 2], [4, 1, 0]] * row_multiplier
+    processed_col_b = [[0, 1], [3, 0]] * row_multiplier
 
     expected_df = pd.DataFrame.from_dict(
         {
-            "A_a": processed_col_a_a,
-            "A_c": processed_col_a_c,
-            "A_b": processed_col_a_b,
-            "B_banana": processed_col_b_banana,
-            "B_apple": processed_col_b_apple,
+            "A": processed_col_a,
+            "B": processed_col_b,
         }
     )
 
-    assert out_df.equals(expected_df)
+    pd.testing.assert_frame_equal(out_df, expected_df, check_like=True)
 
     # max_features
     vectorizer = CountVectorizer(["A", "B"], max_features=2)
@@ -65,21 +59,99 @@ def test_count_vectorizer():
     transformed = vectorizer.transform(ds)
     out_df = transformed.to_pandas(limit=float("inf"))
 
-    processed_col_a_a = [1, 4] * row_multiplier
-    processed_col_a_c = [3, 1] * row_multiplier
-    processed_col_b_banana = [0, 3] * row_multiplier
-    processed_col_b_apple = [1, 0] * row_multiplier
+    processed_col_a = [[1, 3], [4, 1]] * row_multiplier
+    processed_col_b = [[0, 1], [3, 0]] * row_multiplier
 
     expected_df = pd.DataFrame.from_dict(
         {
-            "A_a": processed_col_a_a,
-            "A_c": processed_col_a_c,
-            "B_banana": processed_col_b_banana,
-            "B_apple": processed_col_b_apple,
+            "A": processed_col_a,
+            "B": processed_col_b,
         }
     )
 
-    assert out_df.equals(expected_df)
+    pd.testing.assert_frame_equal(out_df, expected_df, check_like=True)
+
+    # Test append mode
+    with pytest.raises(
+        ValueError, match="The length of columns and output_columns must match."
+    ):
+        CountVectorizer(
+            columns=["A", "B"],
+            output_columns=[
+                "A_counts"
+            ],  # Should provide same number of output columns as input
+        )
+
+    vectorizer = CountVectorizer(["A", "B"], output_columns=["A_counts", "B_counts"])
+    vectorizer.fit(ds)
+
+    transformed = vectorizer.transform(ds)
+    out_df = transformed.to_pandas()
+
+    processed_col_a = [[1, 3, 2], [4, 1, 0]] * row_multiplier
+    processed_col_b = [[0, 1], [3, 0]] * row_multiplier
+
+    expected_df = pd.DataFrame.from_dict(
+        {
+            "A": col_a,
+            "B": col_b,
+            "A_counts": processed_col_a,
+            "B_counts": processed_col_b,
+        }
+    )
+
+    pd.testing.assert_frame_equal(out_df, expected_df, check_like=True)
+
+
+def test_hashing_vectorizer():
+    """Tests basic HashingVectorizer functionality."""
+
+    col_a = ["a b b c c c", "a a a a c"]
+    col_b = ["apple", "banana banana banana"]
+    in_df = pd.DataFrame.from_dict({"A": col_a, "B": col_b})
+    ds = ray.data.from_pandas(in_df)
+
+    vectorizer = HashingVectorizer(["A", "B"], num_features=3)
+
+    transformed = vectorizer.transform(ds)
+    out_df = transformed.to_pandas()
+
+    processed_col_a = [[2, 1, 3], [0, 4, 1]]
+    processed_col_b = [[1, 0, 0], [0, 3, 0]]
+
+    expected_df = pd.DataFrame.from_dict({"A": processed_col_a, "B": processed_col_b})
+
+    pd.testing.assert_frame_equal(out_df, expected_df, check_like=True)
+
+    # Test append mode
+    with pytest.raises(
+        ValueError, match="The length of columns and output_columns must match."
+    ):
+        HashingVectorizer(
+            columns=["A", "B"],
+            num_features=3,
+            output_columns=[
+                "A_hashed"
+            ],  # Should provide same number of output columns as input
+        )
+
+    vectorizer = HashingVectorizer(
+        ["A", "B"], num_features=3, output_columns=["A_hashed", "B_hashed"]
+    )
+
+    transformed = vectorizer.transform(ds)
+    out_df = transformed.to_pandas()
+
+    expected_df = pd.DataFrame.from_dict(
+        {
+            "A": col_a,
+            "B": col_b,
+            "A_hashed": processed_col_a,
+            "B_hashed": processed_col_b,
+        }
+    )
+
+    pd.testing.assert_frame_equal(out_df, expected_df, check_like=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is part of https://github.com/ray-project/ray/issues/48133. Continuing the approach taken in https://github.com/ray-project/ray/pull/49426, make all the vectorizers work in append mode.
Took similar approach to https://github.com/ray-project/ray/pull/50632 where the vectorizers also change to output a single column instead of one column per token or per num_feature

## Related issue number

https://github.com/ray-project/ray/pull/49426

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
