### PR TITLE
[llm.serving] Fix using uni executor when world size == 1

### DIFF
--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
@@ -191,24 +191,18 @@ class _EngineBackgroundProcess:
         # Adapted from vllm.engine.multiprocessing.engine.MQLLMEngine.from_engine_args
         vllm.plugins.load_general_plugins()
 
-        # Note (genesu): This is a temporary fix to avoid vllm 0.7.2 forced the use of
-        # uni processing executor when world_size is 1. This is a bug in vllm 0.7.2 and
+        # Note (genesu): There is a bug in vllm 0.7.2 forced the use of uni processing
+        # executor when world_size is 1. This is a bug in vllm 0.7.2 and
         # is fixed by https://github.com/vllm-project/vllm/pull/12934 which is shipped
-        # with vllm 0.7.3.
-        if engine_config.parallel_config.world_size == 1:
-            from vllm.executor.ray_distributed_executor import RayDistributedExecutor
-
-            executor_class = RayDistributedExecutor
-        else:
-            executor_class = vllm.engine.llm_engine.LLMEngine._get_executor_cls(
-                engine_config
-            )
+        # with vllm 0.7.3. However, in Ray's llm package, we will enforce the use of
+        # ray distributed executor for all cases so it's always compatible with Ray.
+        from vllm.executor.ray_distributed_executor import RayDistributedExecutor
 
         self.engine = MQLLMEngine(
             ipc_path=ipc_path,
             use_async_sockets=engine_config.model_config.use_async_output_proc,
             vllm_config=engine_config,
-            executor_class=executor_class,
+            executor_class=RayDistributedExecutor,
             log_requests=not engine_args.disable_log_requests,
             log_stats=not engine_args.disable_log_stats,
             usage_context=vllm.usage.usage_lib.UsageContext.API_SERVER,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When using vllm 0.7.2 with world size 1 (tp=1 and pp=1), vllm will force to use `UniProcExecutor` and cause `No CUDA GPUs are available` error. This PR forces to uses `RayDistributedExecutor` for any case so it will always be compatible with Ray.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
