### PR TITLE
Add perf metrics for 2.43.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 444.891136,
+    "_dashboard_memory_usage_mb": 334.381056,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.82,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3469\t1.85GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5358\t0.85GiB\tpython distributed/test_many_actors.py\n2835\t0.4GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3585\t0.38GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n1099\t0.23GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n586\t0.14GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n2828\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3779\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3781\t0.07GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru\n3805\t0.07GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --",
-    "actors_per_second": 581.3621620015273,
+    "_peak_memory": 3.65,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1114\t6.96GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3568\t1.75GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4622\t0.88GiB\tpython distributed/test_many_actors.py\n2921\t0.41GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml --allocation-tracing\n3684\t0.29GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n581\t0.16GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3149\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3875\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3877\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru\n4782\t0.07GiB\tray::DashboardTester.run",
+    "actors_per_second": 600.763504471919,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 581.3621620015273
+            "perf_metric_value": 600.763504471919
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 50.674
+            "perf_metric_value": 38.116
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2727.324
+            "perf_metric_value": 2859.782
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3492.239
+            "perf_metric_value": 4515.016
         }
     ],
     "success": "1",
-    "time": 17.200981855392456
+    "time": 16.645485162734985
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 227.344384,
+    "_dashboard_memory_usage_mb": 230.039552,
     "_dashboard_test_success": true,
-    "_peak_memory": 1.67,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3423\t0.51GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2972\t0.25GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n2059\t0.24GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3539\t0.21GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n4401\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3740\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n2873\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4603\t0.08GiB\tray::StateAPIGeneratorActor.start\n3742\t0.07GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru\n4180\t0.07GiB\tray::JobSupervisor",
+    "_peak_memory": 1.69,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3681\t0.51GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2654\t0.26GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml --allocation-tracing\n3797\t0.21GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n4812\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1074\t0.12GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3989\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3067\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n5042\t0.08GiB\tray::StateAPIGeneratorActor.start\n3991\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru\n4600\t0.07GiB\tray::JobSupervisor",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 427.6684054263659
+            "perf_metric_value": 223.72283336753296
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4.297
+            "perf_metric_value": 4.989
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 36.499
+            "perf_metric_value": 17.072
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 89.739
+            "perf_metric_value": 67.563
         }
     ],
     "success": "1",
-    "tasks_per_second": 427.6684054263659,
-    "time": 302.3382601737976,
+    "tasks_per_second": 223.72283336753296,
+    "time": 304.4698164463043,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 172.720128,
+    "_dashboard_memory_usage_mb": 207.0528,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.16,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3483\t0.96GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2824\t0.41GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4997\t0.36GiB\tpython distributed/test_many_pgs.py\n1098\t0.23GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3601\t0.13GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n583\t0.13GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n2720\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3794\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3796\t0.07GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru\n3818\t0.07GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --",
+    "_peak_memory": 2.26,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3565\t0.96GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4601\t0.4GiB\tpython distributed/test_many_pgs.py\n2758\t0.38GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml --allocation-tracing\n3681\t0.17GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n582\t0.16GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n1116\t0.13GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2557\t0.1GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l\n2793\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3872\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3874\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22.74259799982883
+            "perf_metric_value": 13.769920950065924
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.777
+            "perf_metric_value": 3.564
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 10.692
+            "perf_metric_value": 8.581
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 396.497
+            "perf_metric_value": 243.659
         }
     ],
-    "pgs_per_second": 22.74259799982883,
+    "pgs_per_second": 13.769920950065924,
     "success": "1",
-    "time": 43.97035026550293
+    "time": 72.62205815315247
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 741.86752,
+    "_dashboard_memory_usage_mb": 666.804224,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.58,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3537\t1.16GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3653\t0.87GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n4619\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n2985\t0.23GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1104\t0.22GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n584\t0.13GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3846\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3061\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4833\t0.08GiB\tray::DashboardTester.run\n4889\t0.08GiB\tray::StateAPIGeneratorActor.start",
+    "_peak_memory": 3.53,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1891\t7.4GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3562\t1.14GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3678\t0.79GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n4505\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3043\t0.23GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml --allocation-tracing\n589\t0.15GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n2916\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3869\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n4814\t0.08GiB\tray::StateAPIGeneratorActor.start\n3871\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 588.1874987887217
+            "perf_metric_value": 397.2166130464684
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 115.202
+            "perf_metric_value": 96.5
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 522.805
+            "perf_metric_value": 428.261
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 849.598
+            "perf_metric_value": 649.655
         }
     ],
     "success": "1",
-    "tasks_per_second": 588.1874987887217,
-    "time": 317.0013813972473,
+    "tasks_per_second": 397.2166130464684,
+    "time": 325.17518067359924,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.42.0"}
+{"release_version": "2.43.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8107.035947364004,
-        194.70645316452402
+        8547.469123215667,
+        130.11017145942574
     ],
     "1_1_actor_calls_concurrent": [
-        5218.943213086157,
-        123.36432993082248
+        5034.662033195711,
+        119.98608600789164
     ],
     "1_1_actor_calls_sync": [
-        1985.8445748508243,
-        15.604868913363081
+        1912.6174326068551,
+        21.594021607471205
     ],
     "1_1_async_actor_calls_async": [
-        4669.450952977499,
-        320.07551524119316
+        4176.255856784519,
+        205.40764157109743
     ],
     "1_1_async_actor_calls_sync": [
-        1474.7069154202795,
-        36.43494597335915
+        1417.4714984406974,
+        28.21839396297916
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2953.9546990180343,
-        128.10840371596203
+        2710.6889492331006,
+        162.21362455298956
     ],
     "1_n_actor_calls_async": [
-        8136.711770399841,
-        99.07793497695116
+        8240.53983586463,
+        109.12913433176277
     ],
     "1_n_async_actor_calls_async": [
-        7488.95904603153,
-        32.91861129793621
+        7502.0906612607105,
+        120.39851795621024
     ],
     "client__1_1_actor_calls_async": [
-        1010.2913968814835,
-        10.885467967202615
+        1025.1921134059028,
+        45.762668338935924
     ],
     "client__1_1_actor_calls_concurrent": [
-        1005.657835173811,
-        12.425189876213183
+        1032.9858412415201,
+        19.007742815425363
     ],
     "client__1_1_actor_calls_sync": [
-        522.5361491166506,
-        6.471488244048678
+        504.79511779286827,
+        15.437312917902101
     ],
     "client__get_calls": [
-        969.0161835588581,
-        23.107992379350016
+        1124.005061067884,
+        4.863677608785879
     ],
     "client__put_calls": [
-        785.9139426536512,
-        14.074198087763435
+        818.4632760027373,
+        38.7590502342988
     ],
     "client__put_gigabytes": [
-        0.15408690555366225,
-        0.0007793485636983514
+        0.1516460375456968,
+        0.001332185981053798
     ],
     "client__tasks_and_get_batch": [
-        0.838835573987595,
-        0.050083575264214385
+        0.9124810822697493,
+        0.032434700943117685
     ],
     "client__tasks_and_put_batch": [
-        14255.363968554979,
-        77.33604494108931
+        13870.502654856362,
+        333.19517763051937
     ],
     "multi_client_put_calls_Plasma_Store": [
-        15931.811977493457,
-        203.1678701142663
+        15543.88478060201,
+        508.0802589826762
     ],
     "multi_client_put_gigabytes": [
-        47.38817873082456,
-        4.689430307355956
+        33.968763685249776,
+        2.0063210566206635
     ],
     "multi_client_tasks_async": [
-        22745.167201851888,
-        3116.4036637471227
+        21404.22305204687,
+        2785.269467503163
     ],
     "n_n_actor_calls_async": [
-        26441.672940245888,
-        632.5223605512703
+        26212.485337497925,
+        814.5964008096101
     ],
     "n_n_actor_calls_with_arg_async": [
-        2732.074477927061,
-        27.55949571801805
+        2473.163327924083,
+        76.62214616648113
     ],
     "n_n_async_actor_calls_async": [
-        23390.23156817461,
-        636.7923320872748
+        22542.16458297063,
+        1141.2477895746185
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10611.609624248378
+            "perf_metric_value": 10588.032610459411
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4866.041059585032
+            "perf_metric_value": 4780.133410691611
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 15931.811977493457
+            "perf_metric_value": 15543.88478060201
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 18.521529437957106
+            "perf_metric_value": 19.040808674555695
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7.56687497857023
+            "perf_metric_value": 5.680486486924976
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 47.38817873082456
+            "perf_metric_value": 33.968763685249776
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.987017792446045
+            "perf_metric_value": 11.349304359077122
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.424179804481537
+            "perf_metric_value": 4.568303345800756
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1013.1673399687909
+            "perf_metric_value": 927.6195505025511
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8032.409007811969
+            "perf_metric_value": 7495.427972759755
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22745.167201851888
+            "perf_metric_value": 21404.22305204687
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1985.8445748508243
+            "perf_metric_value": 1912.6174326068551
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8107.035947364004
+            "perf_metric_value": 8547.469123215667
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5218.943213086157
+            "perf_metric_value": 5034.662033195711
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8136.711770399841
+            "perf_metric_value": 8240.53983586463
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 26441.672940245888
+            "perf_metric_value": 26212.485337497925
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2732.074477927061
+            "perf_metric_value": 2473.163327924083
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1474.7069154202795
+            "perf_metric_value": 1417.4714984406974
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4669.450952977499
+            "perf_metric_value": 4176.255856784519
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2953.9546990180343
+            "perf_metric_value": 2710.6889492331006
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7488.95904603153
+            "perf_metric_value": 7502.0906612607105
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23390.23156817461
+            "perf_metric_value": 22542.16458297063
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 749.1128148700998
+            "perf_metric_value": 753.5660410727677
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 969.0161835588581
+            "perf_metric_value": 1124.005061067884
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 785.9139426536512
+            "perf_metric_value": 818.4632760027373
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.15408690555366225
+            "perf_metric_value": 0.1516460375456968
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 14255.363968554979
+            "perf_metric_value": 13870.502654856362
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 522.5361491166506
+            "perf_metric_value": 504.79511779286827
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1010.2913968814835
+            "perf_metric_value": 1025.1921134059028
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1005.657835173811
+            "perf_metric_value": 1032.9858412415201
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.838835573987595
+            "perf_metric_value": 0.9124810822697493
         }
     ],
     "placement_group_create/removal": [
-        749.1128148700998,
-        14.03142021121613
+        753.5660410727677,
+        5.91035174783976
     ],
     "single_client_get_calls_Plasma_Store": [
-        10611.609624248378,
-        213.62210043960678
+        10588.032610459411,
+        281.26729109474377
     ],
     "single_client_get_object_containing_10k_refs": [
-        12.987017792446045,
-        0.03521768912488595
+        11.349304359077122,
+        0.48361881151139474
     ],
     "single_client_put_calls_Plasma_Store": [
-        4866.041059585032,
-        52.743326922210485
+        4780.133410691611,
+        95.2511371337577
     ],
     "single_client_put_gigabytes": [
-        18.521529437957106,
-        8.62315762744488
+        19.040808674555695,
+        8.802699336952044
     ],
     "single_client_tasks_and_get_batch": [
-        7.56687497857023,
-        0.3939166243754313
+        5.680486486924976,
+        2.8520433690642717
     ],
     "single_client_tasks_async": [
-        8032.409007811969,
-        398.4370160720034
+        7495.427972759755,
+        534.4884003977728
     ],
     "single_client_tasks_sync": [
-        1013.1673399687909,
-        11.015801941113976
+        927.6195505025511,
+        18.11430240200446
     ],
     "single_client_wait_1k_refs": [
-        5.424179804481537,
-        0.07320253629955845
+        4.568303345800756,
+        0.17158620842002495
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 14.082180108999992,
+    "broadcast_time": 13.282169885999991,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 14.082180108999992
+            "perf_metric_value": 13.282169885999991
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.283816822999995,
-    "get_time": 23.877336194999998,
+    "args_time": 18.745566793000002,
+    "get_time": 24.874795295,
     "large_object_size": 107374182400,
-    "large_object_time": 30.33785850800001,
+    "large_object_time": 30.332874452999988,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.283816822999995
+            "perf_metric_value": 18.745566793000002
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.807459645999998
+            "perf_metric_value": 5.667929830000006
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.877336194999998
+            "perf_metric_value": 24.874795295
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 192.979472547
+            "perf_metric_value": 199.46889562500002
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 30.33785850800001
+            "perf_metric_value": 30.332874452999988
         }
     ],
-    "queued_time": 192.979472547,
-    "returns_time": 5.807459645999998,
+    "queued_time": 199.46889562500002,
+    "returns_time": 5.667929830000006,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 0.7432218527793885,
-    "max_iteration_time": 3.088859796524048,
-    "min_iteration_time": 0.06358766555786133,
+    "avg_iteration_time": 1.2191412186622619,
+    "max_iteration_time": 3.4471161365509033,
+    "min_iteration_time": 0.0545649528503418,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.7432218527793885
+            "perf_metric_value": 1.2191412186622619
         }
     ],
     "success": 1,
-    "total_time": 74.32231259346008
+    "total_time": 121.91424870491028
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4.678402662277222
+            "perf_metric_value": 7.266809701919556
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.529016280174256
+            "perf_metric_value": 12.563214778900146
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 39.98830094337463
+            "perf_metric_value": 39.41141152381897
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.1666333675384521
+            "perf_metric_value": 1.7748794555664062
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1823.5409452915192
+            "perf_metric_value": 1867.0339968204498
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.20731175121781154
+            "perf_metric_value": 0.6016603078317008
         }
     ],
-    "stage_0_time": 4.678402662277222,
-    "stage_1_avg_iteration_time": 12.529016280174256,
-    "stage_1_max_iteration_time": 13.275079488754272,
-    "stage_1_min_iteration_time": 10.937284469604492,
-    "stage_1_time": 125.29022645950317,
-    "stage_2_avg_iteration_time": 39.98830094337463,
-    "stage_2_max_iteration_time": 40.26270246505737,
-    "stage_2_min_iteration_time": 39.52923345565796,
-    "stage_2_time": 199.94206047058105,
-    "stage_3_creation_time": 1.1666333675384521,
-    "stage_3_time": 1823.5409452915192,
-    "stage_4_spread": 0.20731175121781154,
+    "stage_0_time": 7.266809701919556,
+    "stage_1_avg_iteration_time": 12.563214778900146,
+    "stage_1_max_iteration_time": 12.963716983795166,
+    "stage_1_min_iteration_time": 11.490411520004272,
+    "stage_1_time": 125.63220548629761,
+    "stage_2_avg_iteration_time": 39.41141152381897,
+    "stage_2_max_iteration_time": 39.88140296936035,
+    "stage_2_min_iteration_time": 38.912354707717896,
+    "stage_2_time": 197.05759811401367,
+    "stage_3_creation_time": 1.7748794555664062,
+    "stage_3_time": 1867.0339968204498,
+    "stage_4_spread": 0.6016603078317008,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 1.470244198198109,
-    "avg_pg_remove_time_ms": 1.2978452747749973,
+    "avg_pg_create_time_ms": 1.522115139639421,
+    "avg_pg_remove_time_ms": 1.5126715450448436,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.470244198198109
+            "perf_metric_value": 1.522115139639421
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.2978452747749973
+            "perf_metric_value": 1.5126715450448436
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 47.69%: tasks_per_second (THROUGHPUT) regresses from 427.6684054263659 to 223.72283336753296 in benchmarks/many_nodes.json
REGRESSION 39.45%: pgs_per_second (THROUGHPUT) regresses from 22.74259799982883 to 13.769920950065924 in benchmarks/many_pgs.json
REGRESSION 32.47%: tasks_per_second (THROUGHPUT) regresses from 588.1874987887217 to 397.2166130464684 in benchmarks/many_tasks.json
REGRESSION 28.32%: multi_client_put_gigabytes (THROUGHPUT) regresses from 47.38817873082456 to 33.968763685249776 in microbenchmark.json
REGRESSION 24.93%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 7.56687497857023 to 5.680486486924976 in microbenchmark.json
REGRESSION 15.78%: single_client_wait_1k_refs (THROUGHPUT) regresses from 5.424179804481537 to 4.568303345800756 in microbenchmark.json
REGRESSION 12.61%: single_client_get_object_containing_10k_refs (THROUGHPUT) regresses from 12.987017792446045 to 11.349304359077122 in microbenchmark.json
REGRESSION 10.56%: 1_1_async_actor_calls_async (THROUGHPUT) regresses from 4669.450952977499 to 4176.255856784519 in microbenchmark.json
REGRESSION 9.48%: n_n_actor_calls_with_arg_async (THROUGHPUT) regresses from 2732.074477927061 to 2473.163327924083 in microbenchmark.json
REGRESSION 8.44%: single_client_tasks_sync (THROUGHPUT) regresses from 1013.1673399687909 to 927.6195505025511 in microbenchmark.json
REGRESSION 8.24%: 1_1_async_actor_calls_with_args_async (THROUGHPUT) regresses from 2953.9546990180343 to 2710.6889492331006 in microbenchmark.json
REGRESSION 6.69%: single_client_tasks_async (THROUGHPUT) regresses from 8032.409007811969 to 7495.427972759755 in microbenchmark.json
REGRESSION 5.90%: multi_client_tasks_async (THROUGHPUT) regresses from 22745.167201851888 to 21404.22305204687 in microbenchmark.json
REGRESSION 3.88%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1474.7069154202795 to 1417.4714984406974 in microbenchmark.json
REGRESSION 3.69%: 1_1_actor_calls_sync (THROUGHPUT) regresses from 1985.8445748508243 to 1912.6174326068551 in microbenchmark.json
REGRESSION 3.63%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 23390.23156817461 to 22542.16458297063 in microbenchmark.json
REGRESSION 3.53%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 5218.943213086157 to 5034.662033195711 in microbenchmark.json
REGRESSION 3.40%: client__1_1_actor_calls_sync (THROUGHPUT) regresses from 522.5361491166506 to 504.79511779286827 in microbenchmark.json
REGRESSION 2.70%: client__tasks_and_put_batch (THROUGHPUT) regresses from 14255.363968554979 to 13870.502654856362 in microbenchmark.json
REGRESSION 2.43%: multi_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 15931.811977493457 to 15543.88478060201 in microbenchmark.json
REGRESSION 1.77%: single_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 4866.041059585032 to 4780.133410691611 in microbenchmark.json
REGRESSION 1.58%: client__put_gigabytes (THROUGHPUT) regresses from 0.15408690555366225 to 0.1516460375456968 in microbenchmark.json
REGRESSION 0.87%: n_n_actor_calls_async (THROUGHPUT) regresses from 26441.672940245888 to 26212.485337497925 in microbenchmark.json
REGRESSION 0.22%: single_client_get_calls_Plasma_Store (THROUGHPUT) regresses from 10611.609624248378 to 10588.032610459411 in microbenchmark.json
REGRESSION 190.22%: stage_4_spread (LATENCY) regresses from 0.20731175121781154 to 0.6016603078317008 in stress_tests/stress_test_many_tasks.json
REGRESSION 64.03%: avg_iteration_time (LATENCY) regresses from 0.7432218527793885 to 1.2191412186622619 in stress_tests/stress_test_dead_actors.json
REGRESSION 55.33%: stage_0_time (LATENCY) regresses from 4.678402662277222 to 7.266809701919556 in stress_tests/stress_test_many_tasks.json
REGRESSION 52.14%: stage_3_creation_time (LATENCY) regresses from 1.1666333675384521 to 1.7748794555664062 in stress_tests/stress_test_many_tasks.json
REGRESSION 29.29%: dashboard_p99_latency_ms (LATENCY) regresses from 3492.239 to 4515.016 in benchmarks/many_actors.json
REGRESSION 16.55%: avg_pg_remove_time_ms (LATENCY) regresses from 1.2978452747749973 to 1.5126715450448436 in stress_tests/stress_test_placement_group.json
REGRESSION 16.10%: dashboard_p50_latency_ms (LATENCY) regresses from 4.297 to 4.989 in benchmarks/many_nodes.json
REGRESSION 8.46%: 10000_args_time (LATENCY) regresses from 17.283816822999995 to 18.745566793000002 in scalability/single_node.json
REGRESSION 4.86%: dashboard_p95_latency_ms (LATENCY) regresses from 2727.324 to 2859.782 in benchmarks/many_actors.json
REGRESSION 4.18%: 10000_get_time (LATENCY) regresses from 23.877336194999998 to 24.874795295 in scalability/single_node.json
REGRESSION 3.53%: avg_pg_create_time_ms (LATENCY) regresses from 1.470244198198109 to 1.522115139639421 in stress_tests/stress_test_placement_group.json
REGRESSION 3.36%: 1000000_queued_time (LATENCY) regresses from 192.979472547 to 199.46889562500002 in scalability/single_node.json
REGRESSION 2.39%: stage_3_time (LATENCY) regresses from 1823.5409452915192 to 1867.0339968204498 in stress_tests/stress_test_many_tasks.json
REGRESSION 0.27%: stage_1_avg_iteration_time (LATENCY) regresses from 12.529016280174256 to 12.563214778900146 in stress_tests/stress_test_many_tasks.json
```