### PR TITLE
[core] Reduce cpp tests ci time by skipping ray installation

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -287,31 +287,39 @@ steps:
     tags: core_cpp
     instance_type: medium
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --build-type clang
-        --cache-test-results --parallelism-per-worker 2
+      - bazel run //ci/ray_ci:test_in_docker -- //:all core
+        --build-type clang
+        --cache-test-results
+        --skip-ray-installation
 
   - label: ":ray: core: cpp asan tests"
     tags: core_cpp
     instance_type: medium
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --build-type asan-clang
-        --cache-test-results --parallelism-per-worker 2
+      - bazel run //ci/ray_ci:test_in_docker -- //:all core
+        --build-type asan-clang
+        --cache-test-results
+        --skip-ray-installation
 
   - label: ":ray: core: cpp ubsan tests"
     tags: core_cpp
     instance_type: large
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --build-type ubsan
+      - bazel run //ci/ray_ci:test_in_docker -- //:all core
+        --build-type ubsan
         --except-tags no_ubsan
-        --cache-test-results --parallelism-per-worker 2
+        --cache-test-results
+        --skip-ray-installation
 
   - label: ":ray: core: cpp tsan tests"
     tags: core_cpp
     instance_type: medium
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --build-type tsan-clang
+      - bazel run //ci/ray_ci:test_in_docker -- //:all core
+        --build-type tsan-clang
         --except-tags no_tsan
-        --cache-test-results --parallelism-per-worker 2
+        --cache-test-results
+        --skip-ray-installation
 
   - label: ":ray: core: flaky tests"
     key: core_flaky_tests

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -287,7 +287,7 @@ steps:
     tags: core_cpp
     instance_type: medium
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //:all core
+      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core
         --build-type clang
         --cache-test-results
         --skip-ray-installation
@@ -296,7 +296,7 @@ steps:
     tags: core_cpp
     instance_type: medium
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //:all core
+      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core
         --build-type asan-clang
         --cache-test-results
         --skip-ray-installation
@@ -305,7 +305,7 @@ steps:
     tags: core_cpp
     instance_type: large
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //:all core
+      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core
         --build-type ubsan
         --except-tags no_ubsan
         --cache-test-results
@@ -315,7 +315,7 @@ steps:
     tags: core_cpp
     instance_type: medium
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //:all core
+      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core
         --build-type tsan-clang
         --except-tags no_tsan
         --cache-test-results

--- a/.buildkite/windows.rayci.yml
+++ b/.buildkite/windows.rayci.yml
@@ -42,7 +42,7 @@ steps:
         --test-env=CI="1"
         --test-env=RAY_CI_POST_WHEEL_TESTS="1"
         --test-env=USERPROFILE
-        --parallelism-per-worker 2
+        --skip-ray-installation
     depends_on: windowsbuild
 
   - label: ":ray: core: :windows: python tests"

--- a/src/ray/common/BUILD
+++ b/src/ray/common/BUILD
@@ -206,10 +206,10 @@ ray_cc_library(
     hdrs = [
         "asio/asio_chaos.h",
         "asio/asio_util.h",
-        "asio/postable.h",
         "asio/instrumented_io_context.h",
         "asio/io_service_pool.h",
         "asio/periodical_runner.h",
+        "asio/postable.h",
     ],
     deps = [
         ":event_stats",
@@ -259,15 +259,15 @@ ray_cc_library(
 ray_cc_library(
     name = "ray_syncer",
     srcs = [
-        "ray_syncer/ray_syncer.cc",
         "ray_syncer/node_state.cc",
+        "ray_syncer/ray_syncer.cc",
         "ray_syncer/ray_syncer_client.cc",
         "ray_syncer/ray_syncer_server.cc",
     ],
     hdrs = [
-        "ray_syncer/ray_syncer.h",
-        "ray_syncer/node_state.h",
         "ray_syncer/common.h",
+        "ray_syncer/node_state.h",
+        "ray_syncer/ray_syncer.h",
         "ray_syncer/ray_syncer_bidi_reactor.h",
         "ray_syncer/ray_syncer_bidi_reactor_base.h",
         "ray_syncer/ray_syncer_client.h",
@@ -309,7 +309,7 @@ ray_cc_library(
     deps = [
         ":macros",
         ":status",
-        "@com_google_absl//absl/base:core_headers"
+        "@com_google_absl//absl/base:core_headers",
     ],
 )
 
@@ -317,15 +317,4 @@ ray_cc_library(
     name = "source_location",
     srcs = ["source_location.cc"],
     hdrs = ["source_location.h"],
-)
-
-ray_cc_test(
-    name = "source_location_test",
-    size = "small",
-    srcs = ["source_location_test.cc"],
-    tags = ["team:core"],
-    deps = [
-        ":source_location",
-        "@com_google_googletest//:gtest_main",
-    ],
 )

--- a/src/ray/common/test/BUILD
+++ b/src/ray/common/test/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:ray.bzl", "ray_cc_test", "ray_cc_library", "ray_cc_binary")
+load("//bazel:ray.bzl", "ray_cc_binary", "ray_cc_library", "ray_cc_test")
 
 ray_cc_test(
     name = "resource_request_test",
@@ -159,9 +159,9 @@ ray_cc_test(
 
 ray_cc_library(
     name = "testing",
+    testonly = True,
     hdrs = ["testing.h"],
     deps = ["//src/ray/util:macros"],
-    testonly = True,
 )
 
 ray_cc_test(
@@ -197,7 +197,10 @@ ray_cc_test(
     srcs = [
         "memory_monitor_test.cc",
     ],
-    tags = ["team:core", "no_windows"],
+    tags = [
+        "no_windows",
+        "team:core",
+    ],
     target_compatible_with = [
         "@platforms//os:linux",
     ],
@@ -234,5 +237,16 @@ ray_cc_test(
         "//src/ray/common:grpc_util",
         "//src/ray/protobuf:common_cc_proto",
         "@com_google_googletest//:gtest_main",
-    ]
+    ],
+)
+
+ray_cc_test(
+    name = "source_location_test",
+    size = "small",
+    srcs = ["source_location_test.cc"],
+    tags = ["team:core"],
+    deps = [
+        "//src/ray/common:source_location",
+        "@com_google_googletest//:gtest_main",
+    ],
 )

--- a/src/ray/common/test/source_location_test.cc
+++ b/src/ray/common/test/source_location_test.cc
@@ -35,7 +35,7 @@ TEST(SourceLocationTest, StringifyTest) {
     auto loc = RAY_LOC();
     std::stringstream ss{};
     ss << loc;
-    EXPECT_EQ(ss.str(), "src/ray/common/source_location_test.cc:35");
+    EXPECT_EQ(ss.str(), "src/ray/common/test/source_location_test.cc:35");
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We don't need to initially build/install all of ray and then build it again for the tests. The tests don't use the initial ray install anyways, we should just let bazel build whatever the tests' dependencies are
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
