### PR TITLE
[compiled graphs] Remove unused external stream in ExecutableTask

### DIFF
--- a/python/ray/experimental/channel/communicator.py
+++ b/python/ray/experimental/channel/communicator.py
@@ -6,7 +6,6 @@ from ray.experimental.util.types import ReduceOp
 from ray.util.annotations import DeveloperAPI
 
 if TYPE_CHECKING:
-    import cupy as cp
     import torch
 
 
@@ -103,22 +102,6 @@ class Communicator(ABC):
             dtype: The dtype of the tensor to receive.
             peer_rank: The rank of the actor to receive from.
             allocator: A function to allocate the tensor to receive into.
-        """
-        raise NotImplementedError
-
-    @property
-    @abstractmethod
-    def recv_stream(self) -> Optional["cp.cuda.ExternalStream"]:
-        """
-        Return the cuda stream used for receiving tensors.
-        """
-        raise NotImplementedError
-
-    @property
-    @abstractmethod
-    def send_stream(self) -> Optional["cp.cuda.ExternalStream"]:
-        """
-        Return the cuda stream used for sending tensors.
         """
         raise NotImplementedError
 

--- a/python/ray/experimental/channel/cpu_communicator.py
+++ b/python/ray/experimental/channel/cpu_communicator.py
@@ -178,9 +178,3 @@ class CPUCommunicator(Communicator):
 
     def get_transport_name(self) -> str:
         return "cpu"
-
-    def recv_stream(self):
-        raise NotImplementedError
-
-    def send_stream(self):
-        raise NotImplementedError

--- a/python/ray/experimental/channel/nccl_group.py
+++ b/python/ray/experimental/channel/nccl_group.py
@@ -286,14 +286,6 @@ class _NcclGroup(Communicator):
                 "different ranks."
             )
 
-    @property
-    def recv_stream(self) -> Optional["cp.cuda.ExternalStream"]:
-        return self._recv_stream
-
-    @property
-    def send_stream(self) -> Optional["cp.cuda.ExternalStream"]:
-        return self._send_stream
-
     def destroy(self) -> None:
         """
         Destroy the NCCL group.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
ExecutableTask records the type_hints in its read channel and write channel. If it requires NCCL, it needs to obtain the internal send_stream and recv_stream, which are of the cupy.cuda.ExternalStream type, designed to enable overlapping communication during Task read/write. However, with cupy.cuda.ExternalStream() only records the internal current_stream of cupy, and the NCCL group does not actually use cupy.cuda.get_current_stream(). Instead, it records its own send_stream and recv_stream, so it is unnecessary to retrieve these two streams here.

**If my analysis is incorrect, please correct me. Thank you.**

Additionally, I don’t think it’s necessary to use cupy.cuda.ExternalStream in the nccl_group; we can directly store the raw stream instead.

The stream created by torch.cuda.Stream() comes from Torch’s stream pool, so the creation and destruction of the stream do not need to be handled by Ray. Therefore, directly saving and using the raw stream pointer is safe.

see also #47586 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Not exista a issue yet.

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
