### PR TITLE
bazel lint all cpp folder

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,9 +53,9 @@ repos:
     rev: 8.0.1
     hooks:
       - id: buildifier
-        files: ^src/ray(?:/[^/]+)*/BUILD$
+        files: ^(?:src|cpp)(?:/[^/]+)*/BUILD$
       - id: buildifier-lint
-        files: ^src/ray(?:/[^/]+)*/BUILD$
+        files: ^(?:src|cpp)(?:/[^/]+)*/BUILD$
 
   - repo: https://github.com/psf/black
     rev: 22.10.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,9 +53,9 @@ repos:
     rev: 8.0.1
     hooks:
       - id: buildifier
-        files: ^(?:src|cpp)(?:/[^/]+)*/BUILD$
+        files: ^(src|cpp)(/[^/]+)*/BUILD$
       - id: buildifier-lint
-        files: ^(?:src|cpp)(?:/[^/]+)*/BUILD$
+        files: ^(src|cpp)(/[^/]+)*/BUILD$
 
   - repo: https://github.com/psf/black
     rev: 22.10.0


### PR DESCRIPTION
As titled and suggested by Lonnie, enable bazel linter for all C++ folder.