### PR TITLE
[data] mark pyarrow nightly tests as soft fail

### DIFF
--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -104,7 +104,6 @@ steps:
     tags:
       - python
       - data
-      - data_non_parallel
     instance_type: medium
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/data/... //python/ray/air/... data
@@ -116,10 +115,11 @@ steps:
         python: ["3.12"]
 
   - label: ":database: data: arrow nightly tests"
-    if: pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
     tags:
       - python
       - data
+      - skip-on-premerge
+      - oss
     instance_type: medium
     parallelism: 2
     commands:
@@ -129,19 +129,21 @@ steps:
         --build-name datanbuild
         --except-tags data_integration,doctest,data_non_parallel
     depends_on: datanbuild
+    soft_fail: true
 
   - label: ":database: data: arrow nightly tests (data_non_parallel)"
-    if: pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
     tags:
       - python
       - data
-      - data_non_parallel
+      - skip-on-premerge
+      - oss
     instance_type: medium
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/data/... //python/ray/air/... data
         --build-name datanbuild
         --only-tags data_non_parallel
     depends_on: datanbuild
+    soft_fail: true
 
   - label: ":database: data: TFRecords (tfx-bsl) tests"
     tags:


### PR DESCRIPTION
so that they are not blocking.

also marking them as oss and skip-on-premerge, so they only run on oss postmerge
