### PR TITLE
Add perf metrics for 2.43.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 444.891136,
+    "_dashboard_memory_usage_mb": 306.917376,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.82,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3469\t1.85GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5358\t0.85GiB\tpython distributed/test_many_actors.py\n2835\t0.4GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3585\t0.38GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n1099\t0.23GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n586\t0.14GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n2828\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3779\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3781\t0.07GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru\n3805\t0.07GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --",
-    "actors_per_second": 581.3621620015273,
+    "_peak_memory": 3.67,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1155\t7.68GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3574\t1.77GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5013\t0.87GiB\tpython distributed/test_many_actors.py\n2913\t0.38GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3690\t0.29GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n587\t0.17GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3171\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3881\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3883\t0.07GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru\n3905\t0.07GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --",
+    "actors_per_second": 591.3775923644333,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 581.3621620015273
+            "perf_metric_value": 591.3775923644333
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 50.674
+            "perf_metric_value": 32.123
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2727.324
+            "perf_metric_value": 2575.96
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3492.239
+            "perf_metric_value": 3067.405
         }
     ],
     "success": "1",
-    "time": 17.200981855392456
+    "time": 16.909670114517212
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 227.344384,
+    "_dashboard_memory_usage_mb": 241.967104,
     "_dashboard_test_success": true,
-    "_peak_memory": 1.67,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3423\t0.51GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2972\t0.25GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n2059\t0.24GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3539\t0.21GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n4401\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3740\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n2873\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4603\t0.08GiB\tray::StateAPIGeneratorActor.start\n3742\t0.07GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru\n4180\t0.07GiB\tray::JobSupervisor",
+    "_peak_memory": 1.7,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3418\t0.52GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2905\t0.25GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3545\t0.22GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n5388\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1085\t0.12GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3738\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n2801\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n5662\t0.08GiB\tray::StateAPIGeneratorActor.start\n3740\t0.07GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru\n3762\t0.07GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 427.6684054263659
+            "perf_metric_value": 201.69050944705367
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4.297
+            "perf_metric_value": 5.567
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 36.499
+            "perf_metric_value": 21.421
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 89.739
+            "perf_metric_value": 78.71
         }
     ],
     "success": "1",
-    "tasks_per_second": 427.6684054263659,
-    "time": 302.3382601737976,
+    "tasks_per_second": 201.69050944705367,
+    "time": 304.95809149742126,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 172.720128,
+    "_dashboard_memory_usage_mb": 195.518464,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.16,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3483\t0.96GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2824\t0.41GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4997\t0.36GiB\tpython distributed/test_many_pgs.py\n1098\t0.23GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3601\t0.13GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n583\t0.13GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n2720\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3794\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3796\t0.07GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru\n3818\t0.07GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --",
+    "_peak_memory": 2.19,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1107\t6.83GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3448\t0.96GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4572\t0.36GiB\tpython distributed/test_many_pgs.py\n2764\t0.33GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n586\t0.16GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3564\t0.15GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n2519\t0.1GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l\n2997\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3780\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3782\t0.07GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22.74259799982883
+            "perf_metric_value": 13.421786372110379
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.777
+            "perf_metric_value": 4.238
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 10.692
+            "perf_metric_value": 16.646
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 396.497
+            "perf_metric_value": 252.85
         }
     ],
-    "pgs_per_second": 22.74259799982883,
+    "pgs_per_second": 13.421786372110379,
     "success": "1",
-    "time": 43.97035026550293
+    "time": 74.50573062896729
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 741.86752,
+    "_dashboard_memory_usage_mb": 716.218368,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.58,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3537\t1.16GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3653\t0.87GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n4619\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n2985\t0.23GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1104\t0.22GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n584\t0.13GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3846\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3061\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4833\t0.08GiB\tray::DashboardTester.run\n4889\t0.08GiB\tray::StateAPIGeneratorActor.start",
+    "_peak_memory": 3.49,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3576\t1.1GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3692\t0.75GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n4569\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n2796\t0.23GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n585\t0.16GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n1118\t0.13GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3883\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3001\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4744\t0.08GiB\tray::DashboardTester.run\n4808\t0.08GiB\tray::StateAPIGeneratorActor.start",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 588.1874987887217
+            "perf_metric_value": 399.43954902981744
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 115.202
+            "perf_metric_value": 89.962
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 522.805
+            "perf_metric_value": 398.245
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 849.598
+            "perf_metric_value": 589.9
         }
     ],
     "success": "1",
-    "tasks_per_second": 588.1874987887217,
-    "time": 317.0013813972473,
+    "tasks_per_second": 399.43954902981744,
+    "time": 325.0350773334503,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.42.0"}
+{"release_version": "2.43.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8107.035947364004,
-        194.70645316452402
+        8588.075503140139,
+        214.3386936008847
     ],
     "1_1_actor_calls_concurrent": [
-        5218.943213086157,
-        123.36432993082248
+        5402.532852540871,
+        165.2704589016148
     ],
     "1_1_actor_calls_sync": [
-        1985.8445748508243,
-        15.604868913363081
+        2024.9514970549762,
+        39.983445473597456
     ],
     "1_1_async_actor_calls_async": [
-        4669.450952977499,
-        320.07551524119316
+        4185.269438984466,
+        314.18852893049984
     ],
     "1_1_async_actor_calls_sync": [
-        1474.7069154202795,
-        36.43494597335915
+        1434.2085547024217,
+        19.450183004371436
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2953.9546990180343,
-        128.10840371596203
+        2740.2279840306683,
+        84.62716988857152
     ],
     "1_n_actor_calls_async": [
-        8136.711770399841,
-        99.07793497695116
+        8168.440029557936,
+        267.97497006568267
     ],
     "1_n_async_actor_calls_async": [
-        7488.95904603153,
-        32.91861129793621
+        7589.035727393511,
+        116.23965915521515
     ],
     "client__1_1_actor_calls_async": [
-        1010.2913968814835,
-        10.885467967202615
+        1057.2932167754398,
+        9.079193973373348
     ],
     "client__1_1_actor_calls_concurrent": [
-        1005.657835173811,
-        12.425189876213183
+        1056.4662855748954,
+        16.51803494485674
     ],
     "client__1_1_actor_calls_sync": [
-        522.5361491166506,
-        6.471488244048678
+        496.227853176116,
+        17.970368774601223
     ],
     "client__get_calls": [
-        969.0161835588581,
-        23.107992379350016
+        1094.7883444776185,
+        66.85851930731262
     ],
     "client__put_calls": [
-        785.9139426536512,
-        14.074198087763435
+        794.8759505022576,
+        35.39399136775509
     ],
     "client__put_gigabytes": [
-        0.15408690555366225,
-        0.0007793485636983514
+        0.14981555197949994,
+        0.0006458480382978393
     ],
     "client__tasks_and_get_batch": [
-        0.838835573987595,
-        0.050083575264214385
+        0.9551721070094008,
+        0.029983017294858607
     ],
     "client__tasks_and_put_batch": [
-        14255.363968554979,
-        77.33604494108931
+        14341.529664523765,
+        320.24662535145563
     ],
     "multi_client_put_calls_Plasma_Store": [
-        15931.811977493457,
-        203.1678701142663
+        16715.417342144425,
+        255.4664451834791
     ],
     "multi_client_put_gigabytes": [
-        47.38817873082456,
-        4.689430307355956
+        43.246981615749526,
+        4.531224086871732
     ],
     "multi_client_tasks_async": [
-        22745.167201851888,
-        3116.4036637471227
+        21682.83981428489,
+        509.23274422335606
     ],
     "n_n_actor_calls_async": [
-        26441.672940245888,
-        632.5223605512703
+        24718.441650671633,
+        1049.8923008790389
     ],
     "n_n_actor_calls_with_arg_async": [
-        2732.074477927061,
-        27.55949571801805
+        2539.21250893006,
+        11.055019340184344
     ],
     "n_n_async_actor_calls_async": [
-        23390.23156817461,
-        636.7923320872748
+        22979.306268540124,
+        350.87239640082686
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10611.609624248378
+            "perf_metric_value": 10975.200393255369
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4866.041059585032
+            "perf_metric_value": 4901.43220832959
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 15931.811977493457
+            "perf_metric_value": 16715.417342144425
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 18.521529437957106
+            "perf_metric_value": 18.30617444315663
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7.56687497857023
+            "perf_metric_value": 6.116479739439202
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 47.38817873082456
+            "perf_metric_value": 43.246981615749526
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.987017792446045
+            "perf_metric_value": 11.752691593157284
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.424179804481537
+            "perf_metric_value": 4.908150175266516
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1013.1673399687909
+            "perf_metric_value": 981.51641421362
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8032.409007811969
+            "perf_metric_value": 7784.9177487724955
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22745.167201851888
+            "perf_metric_value": 21682.83981428489
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1985.8445748508243
+            "perf_metric_value": 2024.9514970549762
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8107.035947364004
+            "perf_metric_value": 8588.075503140139
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5218.943213086157
+            "perf_metric_value": 5402.532852540871
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8136.711770399841
+            "perf_metric_value": 8168.440029557936
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 26441.672940245888
+            "perf_metric_value": 24718.441650671633
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2732.074477927061
+            "perf_metric_value": 2539.21250893006
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1474.7069154202795
+            "perf_metric_value": 1434.2085547024217
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4669.450952977499
+            "perf_metric_value": 4185.269438984466
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2953.9546990180343
+            "perf_metric_value": 2740.2279840306683
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7488.95904603153
+            "perf_metric_value": 7589.035727393511
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23390.23156817461
+            "perf_metric_value": 22979.306268540124
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 749.1128148700998
+            "perf_metric_value": 741.0897046422251
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 969.0161835588581
+            "perf_metric_value": 1094.7883444776185
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 785.9139426536512
+            "perf_metric_value": 794.8759505022576
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.15408690555366225
+            "perf_metric_value": 0.14981555197949994
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 14255.363968554979
+            "perf_metric_value": 14341.529664523765
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 522.5361491166506
+            "perf_metric_value": 496.227853176116
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1010.2913968814835
+            "perf_metric_value": 1057.2932167754398
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1005.657835173811
+            "perf_metric_value": 1056.4662855748954
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.838835573987595
+            "perf_metric_value": 0.9551721070094008
         }
     ],
     "placement_group_create/removal": [
-        749.1128148700998,
-        14.03142021121613
+        741.0897046422251,
+        11.374041408701535
     ],
     "single_client_get_calls_Plasma_Store": [
-        10611.609624248378,
-        213.62210043960678
+        10975.200393255369,
+        270.12299884478415
     ],
     "single_client_get_object_containing_10k_refs": [
-        12.987017792446045,
-        0.03521768912488595
+        11.752691593157284,
+        0.2784603975313991
     ],
     "single_client_put_calls_Plasma_Store": [
-        4866.041059585032,
-        52.743326922210485
+        4901.43220832959,
+        93.36764866781367
     ],
     "single_client_put_gigabytes": [
-        18.521529437957106,
-        8.62315762744488
+        18.30617444315663,
+        9.192049596130419
     ],
     "single_client_tasks_and_get_batch": [
-        7.56687497857023,
-        0.3939166243754313
+        6.116479739439202,
+        2.726139136686573
     ],
     "single_client_tasks_async": [
-        8032.409007811969,
-        398.4370160720034
+        7784.9177487724955,
+        305.77224857815514
     ],
     "single_client_tasks_sync": [
-        1013.1673399687909,
-        11.015801941113976
+        981.51641421362,
+        4.002662242868348
     ],
     "single_client_wait_1k_refs": [
-        5.424179804481537,
-        0.07320253629955845
+        4.908150175266516,
+        0.1479586294007533
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 14.082180108999992,
+    "broadcast_time": 17.602684142,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 14.082180108999992
+            "perf_metric_value": 17.602684142
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 17.283816822999995,
-    "get_time": 23.877336194999998,
+    "args_time": 18.656692702999997,
+    "get_time": 23.620077062999997,
     "large_object_size": 107374182400,
-    "large_object_time": 30.33785850800001,
+    "large_object_time": 29.23165342300001,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.283816822999995
+            "perf_metric_value": 18.656692702999997
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.807459645999998
+            "perf_metric_value": 5.748432768000001
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.877336194999998
+            "perf_metric_value": 23.620077062999997
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 192.979472547
+            "perf_metric_value": 191.976472028
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 30.33785850800001
+            "perf_metric_value": 29.23165342300001
         }
     ],
-    "queued_time": 192.979472547,
-    "returns_time": 5.807459645999998,
+    "queued_time": 191.976472028,
+    "returns_time": 5.748432768000001,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 0.7432218527793885,
-    "max_iteration_time": 3.088859796524048,
-    "min_iteration_time": 0.06358766555786133,
+    "avg_iteration_time": 1.1939783954620362,
+    "max_iteration_time": 4.9624292850494385,
+    "min_iteration_time": 0.0681600570678711,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.7432218527793885
+            "perf_metric_value": 1.1939783954620362
         }
     ],
     "success": 1,
-    "total_time": 74.32231259346008
+    "total_time": 119.39797282218933
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4.678402662277222
+            "perf_metric_value": 6.343268156051636
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.529016280174256
+            "perf_metric_value": 12.727009963989257
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 39.98830094337463
+            "perf_metric_value": 39.46649179458618
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.1666333675384521
+            "perf_metric_value": 1.6967883110046387
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1823.5409452915192
+            "perf_metric_value": 1829.902144908905
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.20731175121781154
+            "perf_metric_value": 0.6171852602079066
         }
     ],
-    "stage_0_time": 4.678402662277222,
-    "stage_1_avg_iteration_time": 12.529016280174256,
-    "stage_1_max_iteration_time": 13.275079488754272,
-    "stage_1_min_iteration_time": 10.937284469604492,
-    "stage_1_time": 125.29022645950317,
-    "stage_2_avg_iteration_time": 39.98830094337463,
-    "stage_2_max_iteration_time": 40.26270246505737,
-    "stage_2_min_iteration_time": 39.52923345565796,
-    "stage_2_time": 199.94206047058105,
-    "stage_3_creation_time": 1.1666333675384521,
-    "stage_3_time": 1823.5409452915192,
-    "stage_4_spread": 0.20731175121781154,
+    "stage_0_time": 6.343268156051636,
+    "stage_1_avg_iteration_time": 12.727009963989257,
+    "stage_1_max_iteration_time": 13.265979766845703,
+    "stage_1_min_iteration_time": 11.543980360031128,
+    "stage_1_time": 127.27016830444336,
+    "stage_2_avg_iteration_time": 39.46649179458618,
+    "stage_2_max_iteration_time": 40.12660527229309,
+    "stage_2_min_iteration_time": 38.797585010528564,
+    "stage_2_time": 197.33301377296448,
+    "stage_3_creation_time": 1.6967883110046387,
+    "stage_3_time": 1829.902144908905,
+    "stage_4_spread": 0.6171852602079066,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 1.470244198198109,
-    "avg_pg_remove_time_ms": 1.2978452747749973,
+    "avg_pg_create_time_ms": 1.5345107927928425,
+    "avg_pg_remove_time_ms": 1.4037860555554367,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.470244198198109
+            "perf_metric_value": 1.5345107927928425
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.2978452747749973
+            "perf_metric_value": 1.4037860555554367
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 52.84%: tasks_per_second (THROUGHPUT) regresses from 427.6684054263659 to 201.69050944705367 in benchmarks/many_nodes.json
REGRESSION 40.98%: pgs_per_second (THROUGHPUT) regresses from 22.74259799982883 to 13.421786372110379 in benchmarks/many_pgs.json
REGRESSION 32.09%: tasks_per_second (THROUGHPUT) regresses from 588.1874987887217 to 399.43954902981744 in benchmarks/many_tasks.json
REGRESSION 19.17%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 7.56687497857023 to 6.116479739439202 in microbenchmark.json
REGRESSION 10.37%: 1_1_async_actor_calls_async (THROUGHPUT) regresses from 4669.450952977499 to 4185.269438984466 in microbenchmark.json
REGRESSION 9.51%: single_client_wait_1k_refs (THROUGHPUT) regresses from 5.424179804481537 to 4.908150175266516 in microbenchmark.json
REGRESSION 9.50%: single_client_get_object_containing_10k_refs (THROUGHPUT) regresses from 12.987017792446045 to 11.752691593157284 in microbenchmark.json
REGRESSION 8.74%: multi_client_put_gigabytes (THROUGHPUT) regresses from 47.38817873082456 to 43.246981615749526 in microbenchmark.json
REGRESSION 7.24%: 1_1_async_actor_calls_with_args_async (THROUGHPUT) regresses from 2953.9546990180343 to 2740.2279840306683 in microbenchmark.json
REGRESSION 7.06%: n_n_actor_calls_with_arg_async (THROUGHPUT) regresses from 2732.074477927061 to 2539.21250893006 in microbenchmark.json
REGRESSION 6.52%: n_n_actor_calls_async (THROUGHPUT) regresses from 26441.672940245888 to 24718.441650671633 in microbenchmark.json
REGRESSION 5.03%: client__1_1_actor_calls_sync (THROUGHPUT) regresses from 522.5361491166506 to 496.227853176116 in microbenchmark.json
REGRESSION 4.67%: multi_client_tasks_async (THROUGHPUT) regresses from 22745.167201851888 to 21682.83981428489 in microbenchmark.json
REGRESSION 3.12%: single_client_tasks_sync (THROUGHPUT) regresses from 1013.1673399687909 to 981.51641421362 in microbenchmark.json
REGRESSION 3.08%: single_client_tasks_async (THROUGHPUT) regresses from 8032.409007811969 to 7784.9177487724955 in microbenchmark.json
REGRESSION 2.77%: client__put_gigabytes (THROUGHPUT) regresses from 0.15408690555366225 to 0.14981555197949994 in microbenchmark.json
REGRESSION 2.75%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1474.7069154202795 to 1434.2085547024217 in microbenchmark.json
REGRESSION 1.76%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 23390.23156817461 to 22979.306268540124 in microbenchmark.json
REGRESSION 1.16%: single_client_put_gigabytes (THROUGHPUT) regresses from 18.521529437957106 to 18.30617444315663 in microbenchmark.json
REGRESSION 1.07%: placement_group_create/removal (THROUGHPUT) regresses from 749.1128148700998 to 741.0897046422251 in microbenchmark.json
REGRESSION 197.71%: stage_4_spread (LATENCY) regresses from 0.20731175121781154 to 0.6171852602079066 in stress_tests/stress_test_many_tasks.json
REGRESSION 60.65%: avg_iteration_time (LATENCY) regresses from 0.7432218527793885 to 1.1939783954620362 in stress_tests/stress_test_dead_actors.json
REGRESSION 55.69%: dashboard_p95_latency_ms (LATENCY) regresses from 10.692 to 16.646 in benchmarks/many_pgs.json
REGRESSION 45.44%: stage_3_creation_time (LATENCY) regresses from 1.1666333675384521 to 1.6967883110046387 in stress_tests/stress_test_many_tasks.json
REGRESSION 35.59%: stage_0_time (LATENCY) regresses from 4.678402662277222 to 6.343268156051636 in stress_tests/stress_test_many_tasks.json
REGRESSION 29.56%: dashboard_p50_latency_ms (LATENCY) regresses from 4.297 to 5.567 in benchmarks/many_nodes.json
REGRESSION 25.00%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 14.082180108999992 to 17.602684142 in scalability/object_store.json
REGRESSION 12.21%: dashboard_p50_latency_ms (LATENCY) regresses from 3.777 to 4.238 in benchmarks/many_pgs.json
REGRESSION 8.16%: avg_pg_remove_time_ms (LATENCY) regresses from 1.2978452747749973 to 1.4037860555554367 in stress_tests/stress_test_placement_group.json
REGRESSION 7.94%: 10000_args_time (LATENCY) regresses from 17.283816822999995 to 18.656692702999997 in scalability/single_node.json
REGRESSION 4.37%: avg_pg_create_time_ms (LATENCY) regresses from 1.470244198198109 to 1.5345107927928425 in stress_tests/stress_test_placement_group.json
REGRESSION 1.58%: stage_1_avg_iteration_time (LATENCY) regresses from 12.529016280174256 to 12.727009963989257 in stress_tests/stress_test_many_tasks.json
REGRESSION 0.35%: stage_3_time (LATENCY) regresses from 1823.5409452915192 to 1829.902144908905 in stress_tests/stress_test_many_tasks.json
```