### PR TITLE
[Data] Fixing Map Operators to avoid unconditionally overriding generator's back-pressure configuration

### DIFF
--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -100,8 +100,9 @@ class ActorPoolMapOperator(MapOperator):
         _add_system_error_to_retry_exceptions(self._ray_actor_task_remote_args)
 
         if (
-            "_generator_backpressure_num_objects" not in self._ray_actor_task_remote_args and
-            self.data_context._max_num_blocks_in_streaming_gen_buffer is not None
+            "_generator_backpressure_num_objects"
+            not in self._ray_actor_task_remote_args
+            and self.data_context._max_num_blocks_in_streaming_gen_buffer is not None
         ):
             # The `_generator_backpressure_num_objects` parameter should be
             # `2 * _max_num_blocks_in_streaming_gen_buffer` because we yield

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -98,18 +98,22 @@ class ActorPoolMapOperator(MapOperator):
         if actor_task_errors:
             self._ray_actor_task_remote_args["retry_exceptions"] = actor_task_errors
         _add_system_error_to_retry_exceptions(self._ray_actor_task_remote_args)
-        data_context = self.data_context
-        if data_context._max_num_blocks_in_streaming_gen_buffer is not None:
+
+        if (
+            "_generator_backpressure_num_objects" not in self._ray_actor_task_remote_args and
+            self.data_context._max_num_blocks_in_streaming_gen_buffer is not None
+        ):
             # The `_generator_backpressure_num_objects` parameter should be
             # `2 * _max_num_blocks_in_streaming_gen_buffer` because we yield
             # 2 objects for each block: the block and the block metadata.
             self._ray_actor_task_remote_args["_generator_backpressure_num_objects"] = (
-                2 * data_context._max_num_blocks_in_streaming_gen_buffer
+                2 * self.data_context._max_num_blocks_in_streaming_gen_buffer
             )
+
         self._min_rows_per_bundle = min_rows_per_bundle
         self._ray_remote_args_fn = ray_remote_args_fn
         self._ray_remote_args = self._apply_default_remote_args(
-            self._ray_remote_args, data_context
+            self._ray_remote_args, self.data_context
         )
 
         per_actor_resource_usage = ExecutionResources(

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -87,8 +87,8 @@ class TaskPoolMapOperator(MapOperator):
         dynamic_ray_remote_args["name"] = self.name
 
         if (
-            "_generator_backpressure_num_objects" not in dynamic_ray_remote_args and
-            self.data_context._max_num_blocks_in_streaming_gen_buffer is not None
+            "_generator_backpressure_num_objects" not in dynamic_ray_remote_args
+            and self.data_context._max_num_blocks_in_streaming_gen_buffer is not None
         ):
             # The `_generator_backpressure_num_objects` parameter should be
             # `2 * _max_num_blocks_in_streaming_gen_buffer` because we yield

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -86,14 +86,18 @@ class TaskPoolMapOperator(MapOperator):
         dynamic_ray_remote_args = self._get_runtime_ray_remote_args(input_bundle=bundle)
         dynamic_ray_remote_args["name"] = self.name
 
-        data_context = self.data_context
-        if data_context._max_num_blocks_in_streaming_gen_buffer is not None:
+        if (
+            "_generator_backpressure_num_objects" not in dynamic_ray_remote_args and
+            self.data_context._max_num_blocks_in_streaming_gen_buffer is not None
+        ):
             # The `_generator_backpressure_num_objects` parameter should be
             # `2 * _max_num_blocks_in_streaming_gen_buffer` because we yield
             # 2 objects for each block: the block and the block metadata.
             dynamic_ray_remote_args["_generator_backpressure_num_objects"] = (
-                2 * data_context._max_num_blocks_in_streaming_gen_buffer
+                2 * self.data_context._max_num_blocks_in_streaming_gen_buffer
             )
+
+        data_context = self.data_context
 
         gen = self._map_task.options(**dynamic_ray_remote_args).remote(
             self._map_transformer_ref,

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -25,6 +25,7 @@ from ray.data.exceptions import UserCodeException
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.test_util import ConcurrencyCounter  # noqa
 from ray.data.tests.util import column_udf, column_udf_class, extract_values
+from ray.exceptions import RayTaskError
 from ray.tests.conftest import *  # noqa
 
 
@@ -1735,6 +1736,55 @@ def test_map_batches_async_generator_fast_yield(shutdown_only):
     # Because all tasks are submitted almost simultaneously,
     # the output order may be different compared to the original input.
     assert len(output) == len(expected_output), (len(output), len(expected_output))
+
+
+def test_map_op_backpressure_configured_properly():
+    """This test asserts that configuration of the MapOperator generator's back-pressure is
+    propagated appropriately to the Ray Core
+    """
+
+    total = 5
+
+    def _map_raising(r):
+        if isinstance(r['item'], Exception):
+            raise r['item']
+
+        return r
+
+    # Reset this to make sure test is invariant of default value changes
+    DataContext.get_current()._max_num_blocks_in_streaming_gen_buffer = 2
+
+    # To simulate incremental iteration we are
+    #   - Aggressively applying back-pressure (allowing no more than a single block
+    #       to be in the queue)
+    #   - Restrict Map Operator concurrency to run no more than 1 task at a time
+    #
+    # At the end of the pipeline we fetch only first 4 elements (instead of 5) to prevent the last 1
+    # from executing (1 is going to be a buffered block)
+    df = ray.data.from_items(
+        [i for i in range(5)] + [ValueError('failed!')],
+        override_num_blocks=6
+    )
+
+    # NOTE: Default back-pressure configuration allows 2 blocks in the
+    #       generator's buffer, hence default execution will fail as we'd
+    #       try map all 6 elements
+    with pytest.raises(RayTaskError) as exc_info:
+        df.map(_map_raising).materialize()
+
+    assert str(ValueError('failed')) in str(exc_info.value)
+
+    # Reducing number of blocks in the generator buffer, will prevent this pipeline
+    # from throwing
+    vals = df.map(
+        _map_raising,
+        concurrency=1,
+        ray_remote_args_fn=lambda: {
+            "_generator_backpressure_num_objects": 2,  # 1 for block, 1 for metadata
+        },
+    ).limit(total - 1).take_batch()['item'].tolist()
+
+    assert list(range(5))[:-1] == vals
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently `TaskPoolMapOperator` and `ActorPoolMapOperator` both unconditionally override generator's back-pressure configuration meaning that providing this configuration as `ray_remote_args` param still gets overridden to a default value.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
