### PR TITLE
Add linters to CI

### DIFF
--- a/ci/lint/lint.sh
+++ b/ci/lint/lint.sh
@@ -34,6 +34,9 @@ pre_commit() {
     end-of-file-fixer
     check-json
     trailing-whitespace
+    cpplint
+    buildifier
+    buildifier-lint
   )
 
   for HOOK in "${HOOKS[@]}"; do

--- a/src/ray/common/cgroup/BUILD
+++ b/src/ray/common/cgroup/BUILD
@@ -43,15 +43,15 @@ ray_cc_library(
 
 ray_cc_library(
     name = "fake_cgroup_setup",
+    testonly = True,
     srcs = ["fake_cgroup_setup.cc"],
     hdrs = ["fake_cgroup_setup.h"],
     deps = [
         ":base_cgroup_setup",
         "//src/ray/util:logging",
         "//src/ray/util:process",
-        "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/synchronization",
     ],
-    testonly = True,
 )

--- a/src/ray/common/cgroup/test/BUILD
+++ b/src/ray/common/cgroup/test/BUILD
@@ -17,9 +17,9 @@ ray_cc_test(
 ray_cc_test(
     name = "fake_cgroup_setup_test",
     srcs = ["fake_cgroup_setup_test.cc"],
+    tags = ["team:core"],
     deps = [
         "//src/ray/common/cgroup:fake_cgroup_setup",
         "@com_google_googletest//:gtest_main",
     ],
-    tags = ["team:core"]
 )

--- a/src/ray/rpc/test/grpc_bench/grpc_bench.cc
+++ b/src/ray/rpc/test/grpc_bench/grpc_bench.cc
@@ -12,15 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
+#include <utility>
+#include <vector>
+
 #include "ray/common/asio/instrumented_io_context.h"
 #include "ray/rpc/grpc_server.h"
 #include "ray/rpc/server_call.h"
 #include "src/ray/rpc/test/grpc_bench/helloworld.grpc.pb.h"
 #include "src/ray/rpc/test/grpc_bench/helloworld.pb.h"
 
-using namespace ray;
-using namespace ray::rpc;
-using namespace helloworld;
+using namespace ray;         // NOLINT
+using namespace ray::rpc;    // NOLINT
+using namespace helloworld;  // NOLINT
 
 class GreeterHandler {
  public:

--- a/src/ray/rpc/worker/test/core_worker_client_pool_test.cc
+++ b/src/ray/rpc/worker/test/core_worker_client_pool_test.cc
@@ -14,7 +14,11 @@
 
 #include "ray/rpc/worker/core_worker_client_pool.h"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
 #include "ray/rpc/worker/core_worker_client.h"
 
 namespace ray {


### PR DESCRIPTION
... otherwise linter could be broken due to people forgetting to install precommit hook.