### PR TITLE
[llm.serving] HF Prompt Constructor - Add tests

### DIFF
--- a/python/ray/llm/_internal/serve/configs/prompt_formats.py
+++ b/python/ray/llm/_internal/serve/configs/prompt_formats.py
@@ -140,6 +140,7 @@ class HuggingFacePromptFormat(AbstractPromptFormat):
         )
 
     def generate_prompt(self, messages: Union[Prompt, List[Message]]) -> EngineInput:
+        print(f"messages: {messages}")
         if isinstance(messages, Prompt):
             if isinstance(messages.prompt, str):
                 if not messages.use_prompt_format:

--- a/python/ray/llm/_internal/serve/configs/prompt_formats.py
+++ b/python/ray/llm/_internal/serve/configs/prompt_formats.py
@@ -140,7 +140,6 @@ class HuggingFacePromptFormat(AbstractPromptFormat):
         )
 
     def generate_prompt(self, messages: Union[Prompt, List[Message]]) -> EngineInput:
-        print(f"messages: {messages}")
         if isinstance(messages, Prompt):
             if isinstance(messages.prompt, str):
                 if not messages.use_prompt_format:

--- a/python/ray/llm/tests/serve/configs/test_prompt_formats.py
+++ b/python/ray/llm/tests/serve/configs/test_prompt_formats.py
@@ -10,6 +10,8 @@ from ray.llm._internal.serve.configs.prompt_formats import (
     Prompt,
 )
 
+from pydantic import ValidationError
+
 
 @pytest.fixture
 def hf_prompt_format(model_pixtral_12b):
@@ -25,6 +27,7 @@ def test_hf_prompt_format_on_string_message(hf_prompt_format):
 
 
 def test_hf_prompt_format_on_prompt_object(hf_prompt_format):
+    # Test if generate_prompt() can handle messages structured as a Prompt object.
     messages = Prompt(
         prompt=[
             Message(role="system", content="You are a helpful assistant."),
@@ -71,9 +74,9 @@ def test_hf_prompt_format_on_prompt_object(hf_prompt_format):
 
 
 def test_hf_prompt_format_on_prompt_dict(hf_prompt_format):
-    """Test if generate_prompt() can handle messages structured as dictionaries."""
-    messages = Prompt(
-        prompt=[
+    """Test if generate_prompt() can handle a Prompt object structured as a dictionary."""
+    messages = {
+        "prompt": [
             {"role": "system", "content": "You are a helpful assistant."},
             {
                 "role": "user",
@@ -103,13 +106,10 @@ def test_hf_prompt_format_on_prompt_dict(hf_prompt_format):
                 "role": "user",
                 "content": "So you are suggesting you can find a poppy living in the snowy mountain?",
             },
-        ]
-    )
-
-    # Generate prompt using the dictionary-structured messages
+        ],
+    }
     formated_prompt = hf_prompt_format.generate_prompt(messages=messages)
 
-    # Assertions to verify correct processing
     assert formated_prompt.text == (
         "<s>[INST]Can this animal[IMG]live here?[IMG][/INST]It looks like you've "
         "shared an image of a dog lying on a wooden floor, and another image "
@@ -123,6 +123,7 @@ def test_hf_prompt_format_on_prompt_dict(hf_prompt_format):
 
 
 def test_hf_prompt_format_on_list_of_messages(hf_prompt_format):
+    """Test if generate_prompt() can handle a list of Message objects."""
     messages = [
         Message(role="system", content="You are a helpful assistant."),
         Message(
@@ -167,13 +168,13 @@ def test_hf_prompt_format_on_list_of_messages(hf_prompt_format):
 
 
 def test_hf_prompt_format_on_list_of_messages_dict(hf_prompt_format):
-    """Test if generate_prompt() can handle a list of message dictionaries."""
+    """Test if generate_prompt() can handle a list of Message objects structured as dictionaries."""
 
     messages = [
-        Message(role="system", content="You are a helpful assistant."),
-        Message(
-            role="user",
-            content=[
+        {"role": "system", "content": "You are a helpful assistant."},
+        {
+            "role": "user",
+            "content": [
                 {"field": "text", "content": "Can this animal"},
                 {
                     "field": "image_url",
@@ -185,24 +186,23 @@ def test_hf_prompt_format_on_list_of_messages_dict(hf_prompt_format):
                     "image_url": {"url": "https://example.com/mountain.jpg"},
                 },
             ],
-        ),
-        Message(
-            role="assistant",
-            content="It looks like you've shared an image of a "
-            "dog lying on a wooden floor, and another "
-            "image depicting a serene landscape with a "
-            "sunset over a snowy hill or mountain.",
-        ),
-        Message(
-            role="user",
-            content="So you are suggesting you can find a poppy living in the snowy mountain?",
-        ),
+        },
+        {
+            "role": "assistant",
+            "content": (
+                "It looks like you've shared an image of a "
+                "dog lying on a wooden floor, and another "
+                "image depicting a serene landscape with a "
+                "sunset over a snowy hill or mountain."
+            ),
+        },
+        {
+            "role": "user",
+            "content": "So you are suggesting you can find a poppy living in the snowy mountain?",
+        },
     ]
-
-    # Generate prompt using the list of message dictionaries
     formatted_prompt = hf_prompt_format.generate_prompt(messages=messages)
 
-    # Assertions to verify correct processing
     assert formatted_prompt.text == (
         "<s>[INST]Can this animal[IMG]live here?[IMG][/INST]It looks like you've "
         "shared an image of a dog lying on a wooden floor, and another image "
@@ -213,6 +213,48 @@ def test_hf_prompt_format_on_list_of_messages_dict(hf_prompt_format):
     assert len(formatted_prompt.image) == 2
     assert formatted_prompt.image[0].image_url == "https://example.com/dog.jpg"
     assert formatted_prompt.image[1].image_url == "https://example.com/mountain.jpg"
+
+
+def test_invalid_hf_prompt_formats(hf_prompt_format):
+    """Test invalid formats for generate_prompt() to ensure validation errors are raised."""
+
+    # Invalid at initialization:
+    with pytest.raises(ValidationError):
+        # Prompt is not a list
+        Prompt(prompt=Message(role="system", content="You are a helpful assistant.")),
+
+    with pytest.raises(ValidationError):
+        # Content is None for a "user" role
+        Prompt(prompt=[Message(role="user", content=None)]),
+
+    with pytest.raises(ValidationError):
+        # Message with an invalid role
+        Prompt(prompt=[Message(role="invalid_role", content="Invalid role")]),
+
+    # Invalid at generate_prompt():
+    invalid_messages = [
+        # Empty list
+        [],
+        # List of Messages mixed with invalid strings
+        ["string_instead_of_message", Message(role="user", content="Valid message")],
+        # Prompt as a single dict instead of list of Message dicts
+        {"prompt": {"role": "system", "content": "You are a helpful assistant."}},
+        # Empty prompt list
+        {"prompt": []},
+        # Invalid role in the message
+        {"prompt": [{"role": "invalid_role", "content": "Invalid role"}]},
+        # Mixed list containing dicts and Message objects
+        [
+            {"role": "system", "content": "You are a helpful assistant."},
+            Message(role="user", content="Valid message"),
+        ],
+        # List of invalid message dict
+        [{"role": "system", "invalid_key": "Invalid structure"}],
+    ]
+    # Test all invalid cases
+    for invalid_message in invalid_messages:
+        with pytest.raises((ValidationError, ValueError)):
+            hf_prompt_format.generate_prompt(messages=invalid_message)
 
 
 def test_validation_message():

--- a/python/ray/llm/tests/serve/configs/test_prompt_formats.py
+++ b/python/ray/llm/tests/serve/configs/test_prompt_formats.py
@@ -70,6 +70,58 @@ def test_hf_prompt_format_on_prompt_object(hf_prompt_format):
     assert formated_prompt.image[1].image_url == "https://example.com/mountain.jpg"
 
 
+def test_hf_prompt_format_on_prompt_dict(hf_prompt_format):
+    """Test if generate_prompt() can handle messages structured as dictionaries."""
+    messages = Prompt(
+        prompt=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {
+                "role": "user",
+                "content": [
+                    {"field": "text", "content": "Can this animal"},
+                    {
+                        "field": "image_url",
+                        "image_url": {"url": "https://example.com/dog.jpg"},
+                    },
+                    {"field": "text", "content": "live here?"},
+                    {
+                        "field": "image_url",
+                        "image_url": {"url": "https://example.com/mountain.jpg"},
+                    },
+                ],
+            },
+            {
+                "role": "assistant",
+                "content": (
+                    "It looks like you've shared an image of a "
+                    "dog lying on a wooden floor, and another "
+                    "image depicting a serene landscape with a "
+                    "sunset over a snowy hill or mountain."
+                ),
+            },
+            {
+                "role": "user",
+                "content": "So you are suggesting you can find a poppy living in the snowy mountain?",
+            },
+        ]
+    )
+
+    # Generate prompt using the dictionary-structured messages
+    formated_prompt = hf_prompt_format.generate_prompt(messages=messages)
+
+    # Assertions to verify correct processing
+    assert formated_prompt.text == (
+        "<s>[INST]Can this animal[IMG]live here?[IMG][/INST]It looks like you've "
+        "shared an image of a dog lying on a wooden floor, and another image "
+        "depicting a serene landscape with a sunset over a snowy hill or "
+        "mountain.</s>[INST]You are a helpful assistant.\n\nSo you are suggesting "
+        "you can find a poppy living in the snowy mountain?[/INST]"
+    )
+    assert len(formated_prompt.image) == 2
+    assert formated_prompt.image[0].image_url == "https://example.com/dog.jpg"
+    assert formated_prompt.image[1].image_url == "https://example.com/mountain.jpg"
+
+
 def test_hf_prompt_format_on_list_of_messages(hf_prompt_format):
     messages = [
         Message(role="system", content="You are a helpful assistant."),
@@ -114,13 +166,14 @@ def test_hf_prompt_format_on_list_of_messages(hf_prompt_format):
     assert formated_prompt.image[1].image_url == "https://example.com/mountain.jpg"
 
 
-def test_hf_prompt_format_on_prompt_dict(hf_prompt_format):
-    """Test if generate_prompt() can handle messages structured as dictionaries."""
-    messages = {"prompt": [{"message":
-        {"role": "system", "content": "You are a helpful assistant."}}, {"message": 
-        {
-            "role": "user",
-            "content": [
+def test_hf_prompt_format_on_list_of_messages_dict(hf_prompt_format):
+    """Test if generate_prompt() can handle a list of message dictionaries."""
+
+    messages = [
+        Message(role="system", content="You are a helpful assistant."),
+        Message(
+            role="user",
+            content=[
                 {"field": "text", "content": "Can this animal"},
                 {
                     "field": "image_url",
@@ -132,37 +185,34 @@ def test_hf_prompt_format_on_prompt_dict(hf_prompt_format):
                     "image_url": {"url": "https://example.com/mountain.jpg"},
                 },
             ],
-        }}, {"message":
-        {
-            "role": "assistant",
-            "content": (
-                "It looks like you've shared an image of a "
-                "dog lying on a wooden floor, and another "
-                "image depicting a serene landscape with a "
-                "sunset over a snowy hill or mountain."
-            ),
-        }, "message":
-        {
-            "role": "user",
-                "content": "So you are suggesting you can find a poppy living in the snowy mountain?",
-            }}
-        ],
-    }
+        ),
+        Message(
+            role="assistant",
+            content="It looks like you've shared an image of a "
+            "dog lying on a wooden floor, and another "
+            "image depicting a serene landscape with a "
+            "sunset over a snowy hill or mountain.",
+        ),
+        Message(
+            role="user",
+            content="So you are suggesting you can find a poppy living in the snowy mountain?",
+        ),
+    ]
 
-    # Generate prompt using the dictionary-structured messages
-    formated_prompt = hf_prompt_format.generate_prompt(messages=messages)
+    # Generate prompt using the list of message dictionaries
+    formatted_prompt = hf_prompt_format.generate_prompt(messages=messages)
 
     # Assertions to verify correct processing
-    assert formated_prompt.text == (
+    assert formatted_prompt.text == (
         "<s>[INST]Can this animal[IMG]live here?[IMG][/INST]It looks like you've "
         "shared an image of a dog lying on a wooden floor, and another image "
         "depicting a serene landscape with a sunset over a snowy hill or "
         "mountain.</s>[INST]You are a helpful assistant.\n\nSo you are suggesting "
         "you can find a poppy living in the snowy mountain?[/INST]"
     )
-    assert len(formated_prompt.image) == 2
-    assert formated_prompt.image[0].image_url == "https://example.com/dog.jpg"
-    assert formated_prompt.image[1].image_url == "https://example.com/mountain.jpg"
+    assert len(formatted_prompt.image) == 2
+    assert formatted_prompt.image[0].image_url == "https://example.com/dog.jpg"
+    assert formatted_prompt.image[1].image_url == "https://example.com/mountain.jpg"
 
 
 def test_validation_message():

--- a/python/ray/llm/tests/serve/configs/test_prompt_formats.py
+++ b/python/ray/llm/tests/serve/configs/test_prompt_formats.py
@@ -114,6 +114,57 @@ def test_hf_prompt_format_on_list_of_messages(hf_prompt_format):
     assert formated_prompt.image[1].image_url == "https://example.com/mountain.jpg"
 
 
+def test_hf_prompt_format_on_prompt_dict(hf_prompt_format):
+    """Test if generate_prompt() can handle messages structured as dictionaries."""
+    messages = {"prompt": [{"message":
+        {"role": "system", "content": "You are a helpful assistant."}}, {"message": 
+        {
+            "role": "user",
+            "content": [
+                {"field": "text", "content": "Can this animal"},
+                {
+                    "field": "image_url",
+                    "image_url": {"url": "https://example.com/dog.jpg"},
+                },
+                {"field": "text", "content": "live here?"},
+                {
+                    "field": "image_url",
+                    "image_url": {"url": "https://example.com/mountain.jpg"},
+                },
+            ],
+        }}, {"message":
+        {
+            "role": "assistant",
+            "content": (
+                "It looks like you've shared an image of a "
+                "dog lying on a wooden floor, and another "
+                "image depicting a serene landscape with a "
+                "sunset over a snowy hill or mountain."
+            ),
+        }, "message":
+        {
+            "role": "user",
+                "content": "So you are suggesting you can find a poppy living in the snowy mountain?",
+            }}
+        ],
+    }
+
+    # Generate prompt using the dictionary-structured messages
+    formated_prompt = hf_prompt_format.generate_prompt(messages=messages)
+
+    # Assertions to verify correct processing
+    assert formated_prompt.text == (
+        "<s>[INST]Can this animal[IMG]live here?[IMG][/INST]It looks like you've "
+        "shared an image of a dog lying on a wooden floor, and another image "
+        "depicting a serene landscape with a sunset over a snowy hill or "
+        "mountain.</s>[INST]You are a helpful assistant.\n\nSo you are suggesting "
+        "you can find a poppy living in the snowy mountain?[/INST]"
+    )
+    assert len(formated_prompt.image) == 2
+    assert formated_prompt.image[0].image_url == "https://example.com/dog.jpg"
+    assert formated_prompt.image[1].image_url == "https://example.com/mountain.jpg"
+
+
 def test_validation_message():
     # check that message with assistant role can have content that
     # is a string or none, but nothing else


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The HF Prompt Constructor should be able to express messages simply as `prompt:[{"role": "system", ...}, ...]`. The Pydantic model should validate the dict structure into objects—i.e. turning the above into `Prompt(prompt=[Message(role='system', ...), ...])`. This PR increases the flexibility of `HuggingFacePromptFormat.generate_prompt()` and includes unit tests to check intended behavior.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/pull/50613/files/cd32e8c9eefaf4648262e98317ae2c55ba60390a#r1957159782
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
