### PR TITLE
[core] [easy] minor fix fork test

### DIFF
--- a/src/ray/util/tests/process_cleanup_test.cc
+++ b/src/ray/util/tests/process_cleanup_test.cc
@@ -17,6 +17,7 @@
 #if defined(__APPLE__) || defined(__linux__)
 
 #include <chrono>
+#include <cstdlib>
 #include <fstream>
 #include <string>
 #include <thread>
@@ -47,7 +48,7 @@ TEST(ProcessCleanerTest, BasicTest) {
   // For child process, call [SpawnSubprocessAndCleanup] and exit.
   if (pid == 0) {
     SpawnSubprocessAndCleanup(std::move(test_func));
-    return;
+    std::_Exit(0);  // No flush stdout/stderr.
   }
 
   // For parent process, first wait until child process exits.


### PR DESCRIPTION
Before:
```
[~/ray] (master) 
ubuntu@hjiang-devbox-pg$ bazel-bin/src/ray/util/tests/process_cleanup_test
Running main() from gmock_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from ProcessCleanerTest
[ RUN      ] ProcessCleanerTest.BasicTest
[       OK ] ProcessCleanerTest.BasicTest (0 ms)
[----------] 1 test from ProcessCleanerTest (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.
[       OK ] ProcessCleanerTest.BasicTest (2 ms)
[----------] 1 test from ProcessCleanerTest (2 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.
[       OK ] ProcessCleanerTest.BasicTest (2002 ms)
[----------] 1 test from ProcessCleanerTest (2002 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (2002 ms total)
[  PASSED  ] 1 test.
```
after:
```
[~/ray] (master) 
ubuntu@hjiang-devbox-pg$ bazel-bin/src/ray/util/tests/process_cleanup_test
Running main() from gmock_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from ProcessCleanerTest
[ RUN      ] ProcessCleanerTest.BasicTest
[       OK ] ProcessCleanerTest.BasicTest (2001 ms)
[----------] 1 test from ProcessCleanerTest (2001 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (2001 ms total)
[  PASSED  ] 1 test.
```