### PR TITLE
Fix mock dependency for mock/ray/common/ray_syncer/ray_syncer.h

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -526,7 +526,13 @@ ray_cc_library(
     name = "ray_mock",
     hdrs = glob(
         ["src/mock/**/*.h"],
+        exclude = ["src/mock/ray/common/ray_syncer/ray_syncer.h"]
     ),
+)
+
+ray_cc_library(
+    name = "ray_mock_syncer",
+    hdrs = ["src/mock/ray/common/ray_syncer/ray_syncer.h"]
 )
 
 cc_grpc_library(

--- a/src/mock/ray/common/ray_syncer/ray_syncer.h
+++ b/src/mock/ray/common/ray_syncer/ray_syncer.h
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#pragma once
+#include "gmock/gmock.h"
+#include "ray/common/ray_syncer/ray_syncer.h"
+#include "ray/common/ray_syncer/ray_syncer_bidi_reactor.h"
+#include "ray/common/ray_syncer/ray_syncer_bidi_reactor_base.h"
+
 namespace ray {
 namespace syncer {
 

--- a/src/ray/common/test/BUILD
+++ b/src/ray/common/test/BUILD
@@ -50,7 +50,7 @@ ray_cc_test(
     ],
     deps = [
         "//:grpc_common_lib",
-        "//:ray_mock",
+        "//:ray_mock_syncer",
         "//src/ray/common:ray_syncer",
         "@com_google_googletest//:gtest",
     ],

--- a/src/ray/common/test/ray_syncer_test.cc
+++ b/src/ray/common/test/ray_syncer_test.cc
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include "mock/ray/common/ray_syncer/ray_syncer.h"
 
 #include <gmock/gmock.h>
 #include <google/protobuf/util/json_util.h>
@@ -26,14 +27,11 @@
 #include <chrono>
 #include <sstream>
 
-// clang-format off
 #include "ray/common/ray_syncer/node_state.h"
 #include "ray/common/ray_syncer/ray_syncer.h"
 #include "ray/common/ray_syncer/ray_syncer_client.h"
 #include "ray/common/ray_syncer/ray_syncer_server.h"
 #include "ray/rpc/grpc_server.h"
-#include "mock/ray/common/ray_syncer/ray_syncer.h"
-// clang-format on
 
 using namespace std::chrono;
 using namespace ray::syncer;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
https://github.com/ray-project/ray/blob/master/src/mock/ray/common/ray_syncer/ray_syncer.h
should have the dependency of and  `ray_syncer`, `ray_syncer_bidi_reactor` and `ray_syncer_bidi_reactor_base` but somehow it doesn't...

As a result, we have to include ray_syncer.h before mock_ray_syncer.h and avoid linter reorder via clang-format off, otherwise build will break.

This PR add those dependecy to mock_ray_syncer.h, update use cases in unit tests, and remove clang-format off mark
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#50928
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
