### PR TITLE
[core][autoscaler][v1] fix crashes by infeasible strict spread placement groups

### DIFF
--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -568,7 +568,7 @@ class ResourceDemandScheduler:
         for bundles in strict_spreads:
             # Try to pack as many bundles of this group as possible on existing
             # nodes. The remaining will be allocated on new nodes.
-            unfulfilled, node_resources = get_bin_pack_residual(
+            unfulfilled, updated_node_resources = get_bin_pack_residual(
                 node_resources, bundles, strict_spread=True
             )
             max_to_add = self.max_workers + 1 - sum(node_type_counts.values())
@@ -582,8 +582,6 @@ class ResourceDemandScheduler:
                 utilization_scorer=utilization_scorer,
                 strict_spread=True,
             )
-            _inplace_add(node_type_counts, to_launch)
-            _inplace_add(to_add, to_launch)
             new_node_resources = _node_type_counts_to_node_resources(
                 self.node_types, to_launch
             )
@@ -592,8 +590,12 @@ class ResourceDemandScheduler:
             unfulfilled, including_reserved = get_bin_pack_residual(
                 new_node_resources, unfulfilled, strict_spread=True
             )
-            assert not unfulfilled
-            node_resources += including_reserved
+            if unfulfilled:
+                logger.debug("Unfulfilled strict placement group: {}".format(bundles))
+                continue
+            _inplace_add(node_type_counts, to_launch)
+            _inplace_add(to_add, to_launch)
+            node_resources = updated_node_resources + including_reserved
         return to_add, node_resources, node_type_counts
 
     def debug_string(

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -591,7 +591,7 @@ class ResourceDemandScheduler:
                 new_node_resources, unfulfilled, strict_spread=True
             )
             if unfulfilled:
-                logger.debug("Unfulfilled strict placement group: {}".format(bundles))
+                logger.debug("Unfulfilled strict spread placement group: {}".format(bundles))
                 continue
             _inplace_add(node_type_counts, to_launch)
             _inplace_add(to_add, to_launch)

--- a/python/ray/autoscaler/_private/resource_demand_scheduler.py
+++ b/python/ray/autoscaler/_private/resource_demand_scheduler.py
@@ -591,7 +591,9 @@ class ResourceDemandScheduler:
                 new_node_resources, unfulfilled, strict_spread=True
             )
             if unfulfilled:
-                logger.debug("Unfulfilled strict spread placement group: {}".format(bundles))
+                logger.debug(
+                    "Unfulfilled strict spread placement group: {}".format(bundles)
+                )
                 continue
             _inplace_add(node_type_counts, to_launch)
             _inplace_add(to_add, to_launch)


### PR DESCRIPTION
## Why are these changes needed?

As the issue https://github.com/ray-project/ray/issues/39691 describes, the autoscaler v1 will **crash intentionally** on any infeasible strict spread placement group. This PR changes the behavior to **skipping** such groups.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes https://github.com/ray-project/ray/issues/39691
Related to https://github.com/ray-project/kuberay/issues/2385

## Manual Test

Use the following script locally:

```python
import ray
from ray.cluster_utils import AutoscalingCluster
from ray.util.placement_group import placement_group

cluster = AutoscalingCluster(
    head_resources={"CPU": 1},
    worker_node_types={
        "type-1": {
            "resources": {"CPU": 2},
            "node_config": {},
            "min_workers": 0,
            "max_workers": 2,
        },
    },
    max_workers=2,
)

cluster.start()
ray.init("auto")

pg1 = placement_group([{"CPU": 2}] * 3, strategy="STRICT_SPREAD")
pg2 = placement_group([{"CPU": 2}] * 2, strategy="STRICT_SPREAD")

ray.get(pg2.ready())
```

Without this fix, the `pg2` never gets ready because the autoscaler keeps crashing on `assert not unfulfilled` caused by `pg1`.
However, with this fix, `pg1` keeps pending and the `pg2` will get ready.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
