### PR TITLE
[train] fix serialize import test for py3.12

### DIFF
--- a/python/ray/train/v2/tests/test_v2_api.py
+++ b/python/ray/train/v2/tests/test_v2_api.py
@@ -1,6 +1,7 @@
 import importlib
 
 import pytest
+import sys
 
 import ray.train
 from ray.train import FailureConfig, RunConfig, ScalingConfig

--- a/python/ray/train/v2/tests/test_v2_api.py
+++ b/python/ray/train/v2/tests/test_v2_api.py
@@ -58,9 +58,13 @@ def test_serialized_imports(ray_start_4_cpus):
     """Check that captured imports are deserialized properly without circular imports."""
 
     from ray.train.torch import TorchTrainer
-    from ray.train.tensorflow import TensorflowTrainer
     from ray.train.xgboost import XGBoostTrainer
     from ray.train.lightgbm import LightGBMTrainer
+
+    if sys.version_info < (3, 12):
+        from ray.train.tensorflow import TensorflowTrainer
+    else:
+        TensorflowTrainer = None
 
     @ray.remote
     def dummy_task():


### PR DESCRIPTION
## Why are these changes needed?

Test fails in python 3.12 because TensorFlow is not installed.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
