### PR TITLE
[core] Recheckin runtime env agent rotation

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3054,6 +3054,8 @@ pyx_library(
         "//src/ray/protobuf:serialization_cc_proto",
         "//src/ray/util",
         "//src/ray/util:memory",
+        "//src/ray/util:stream_redirection_options",
+        "//src/ray/util:stream_redirection_utils",
     ],
 )
 

--- a/python/ray/_private/runtime_env/agent/main.py
+++ b/python/ray/_private/runtime_env/agent/main.py
@@ -2,19 +2,16 @@ import sys
 import os
 import argparse
 import logging
-import pathlib
 import ray._private.ray_constants as ray_constants
 from ray.core.generated import (
     runtime_env_agent_pb2,
 )
 from ray._private.utils import open_log
-from ray._private.ray_logging import (
-    configure_log_file,
-)
 from ray._private.utils import (
     get_or_create_event_loop,
 )
 from ray._private.process_watcher import create_check_raylet_task
+from ray._raylet import StreamRedirector
 
 
 def import_libs():
@@ -30,11 +27,16 @@ from runtime_env_agent import RuntimeEnvAgent  # noqa: E402
 from aiohttp import web  # noqa: E402
 
 
-def open_capture_files(log_dir):
+def get_capture_filepaths(log_dir):
+    """Get filepaths for the given [log_dir].
+
+    log_dir:
+        Logging directory to place output and error logs.
+    """
     filename = "runtime_env_agent"
     return (
-        open_log(pathlib.Path(log_dir) / f"{filename}.out"),
-        open_log(pathlib.Path(log_dir) / f"{filename}.err"),
+        f"{log_dir}/{filename}.out",
+        f"{log_dir}/{filename}.err",
     )
 
 
@@ -95,20 +97,15 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--logging-rotate-bytes",
-        required=False,
+        required=True,
         type=int,
-        default=ray_constants.LOGGING_ROTATE_BYTES,
-        help="Specify the max bytes for rotating "
-        "log file, default is {} bytes.".format(ray_constants.LOGGING_ROTATE_BYTES),
+        help="Specify the max bytes for rotating log file",
     )
     parser.add_argument(
         "--logging-rotate-backup-count",
-        required=False,
+        required=True,
         type=int,
-        default=ray_constants.LOGGING_ROTATE_BACKUP_COUNT,
-        help="Specify the backup count of rotated log file, default is {}.".format(
-            ray_constants.LOGGING_ROTATE_BACKUP_COUNT
-        ),
+        help="Specify the backup count of rotated log file",
     )
     parser.add_argument(
         "--log-dir",
@@ -127,18 +124,50 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
+    # Disable log rotation for windows platform.
+    logging_rotation_bytes = (
+        args.logging_rotate_bytes if sys.platform != "win32" else sys.maxsize
+    )
+    logging_rotation_backup_count = (
+        args.logging_rotate_backup_count if sys.platform != "win32" else 1
+    )
+
     logging_params = dict(
         logging_level=args.logging_level,
         logging_format=args.logging_format,
         log_dir=args.log_dir,
         filename=args.logging_filename,
-        max_bytes=args.logging_rotate_bytes,
-        backup_count=args.logging_rotate_backup_count,
+        max_bytes=logging_rotation_bytes,
+        backup_count=logging_rotation_backup_count,
     )
 
     # Setup stdout/stderr redirect files
-    out_file, err_file = open_capture_files(args.log_dir)
-    configure_log_file(out_file, err_file)
+    out_filepath, err_filepath = get_capture_filepaths(args.log_dir)
+    StreamRedirector.redirect_stdout(
+        out_filepath,
+        logging_rotation_bytes,
+        logging_rotation_backup_count,
+        False,
+        False,
+    )
+    StreamRedirector.redirect_stderr(
+        err_filepath,
+        logging_rotation_bytes,
+        logging_rotation_backup_count,
+        False,
+        False,
+    )
+
+    # Setup python stdout/stderr stream.
+    stdout_fileno = sys.stdout.fileno()
+    stderr_fileno = sys.stderr.fileno()
+    # We also manually set sys.stdout and sys.stderr because that seems to
+    # have an effect on the output buffering. Without doing this, stdout
+    # and stderr are heavily buffered resulting in seemingly lost logging
+    # statements. We never want to close the stdout file descriptor, dup2 will
+    # close it when necessary and we don't want python's GC to close it.
+    sys.stdout = open_log(stdout_fileno, unbuffered=True, closefd=False)
+    sys.stderr = open_log(stderr_fileno, unbuffered=True, closefd=False)
 
     agent = RuntimeEnvAgent(
         runtime_env_dir=args.runtime_env_dir,

--- a/python/ray/_private/runtime_env/agent/main.py
+++ b/python/ray/_private/runtime_env/agent/main.py
@@ -6,9 +6,11 @@ import ray._private.ray_constants as ray_constants
 from ray.core.generated import (
     runtime_env_agent_pb2,
 )
-from ray._private.utils import open_log
 from ray._private.utils import (
+    open_log,
     get_or_create_event_loop,
+    get_logging_rotation_bytes,
+    get_logging_rotation_backup_count,
 )
 from ray._private.process_watcher import create_check_raylet_task
 from ray._raylet import StreamRedirector
@@ -125,11 +127,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # Disable log rotation for windows platform.
-    logging_rotation_bytes = (
-        args.logging_rotate_bytes if sys.platform != "win32" else sys.maxsize
-    )
-    logging_rotation_backup_count = (
-        args.logging_rotate_backup_count if sys.platform != "win32" else 1
+    logging_rotation_bytes = get_logging_rotation_bytes(args.logging_rotate_bytes)
+    logging_rotation_backup_count = get_logging_rotation_backup_count(
+        args.logging_rotate_backup_count
     )
 
     logging_params = dict(

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -434,6 +434,30 @@ class Unbuffered(object):
         return getattr(self.stream, attr)
 
 
+def get_logging_rotation_bytes(logging_rotation_bytes: int):
+    """Sanitize logging rotation bytes based on platform and value."""
+    # Disable log rotation for windows platform, which is hard to perform because windows doesn't allow deletion when file used by two processes.
+    if sys.platform == "win32":
+        return sys.maxsize
+    # Invalid input, ignore and emit max value of uint64 (which is the value to skip rotation in C++ stream redirection).
+    if logging_rotation_bytes <= 0:
+        return (1 << 64) - 1
+
+    return logging_rotation_bytes
+
+
+def get_logging_rotation_backup_count(logging_rotation_backup_count: int):
+    """Sanitize logging rotation backup cout based on platform and value."""
+    # Disable log rotation for windows platform, which is hard to perform because windows doesn't allow deletion when file used by two processes.
+    if sys.platform == "win32":
+        return 1
+    # Invalid input, ignore and emit 1.
+    if logging_rotation_backup_count <= 0:
+        return 1
+
+    return logging_rotation_backup_count
+
+
 def open_log(path, unbuffered=False, **kwargs):
     """
     Opens the log file at `path`, with the provided kwargs being given to

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -158,6 +158,11 @@ from ray.includes.libcoreworker cimport (
     CGeneratorBackpressureWaiter,
     CReaderRefInfo,
 )
+from ray.includes.stream_redirection cimport (
+    CStreamRedirectionOptions,
+    RedirectStdout,
+    RedirectStderr,
+)
 
 from ray.includes.ray_config cimport RayConfig
 from ray.includes.global_state_accessor cimport CGlobalStateAccessor
@@ -2651,6 +2656,26 @@ cdef void terminate_asyncio_thread() nogil:
         core_worker = ray._private.worker.global_worker.core_worker
         core_worker.stop_and_join_asyncio_threads_if_exist()
 
+cdef class StreamRedirector:
+    @staticmethod
+    def redirect_stdout(const c_string &file_path, uint64_t rotation_max_size, uint64_t rotation_max_file_count, c_bool tee_to_stdout, c_bool tee_to_stderr):
+        cdef CStreamRedirectionOptions opt = CStreamRedirectionOptions()
+        opt.file_path = file_path
+        opt.rotation_max_size = rotation_max_size
+        opt.rotation_max_file_count = rotation_max_file_count
+        opt.tee_to_stdout = tee_to_stdout
+        opt.tee_to_stderr = tee_to_stderr
+        RedirectStdout(opt)
+
+    @staticmethod
+    def redirect_stderr(const c_string &file_path, uint64_t rotation_max_size, uint64_t rotation_max_file_count, c_bool tee_to_stdout, c_bool tee_to_stderr):
+        cdef CStreamRedirectionOptions opt = CStreamRedirectionOptions()
+        opt.file_path = file_path
+        opt.rotation_max_size = rotation_max_size
+        opt.rotation_max_file_count = rotation_max_file_count
+        opt.tee_to_stdout = tee_to_stdout
+        opt.tee_to_stderr = tee_to_stderr
+        RedirectStderr(opt)
 
 # An empty profile event context to be used when the timeline is disabled.
 cdef class EmptyProfileEvent:

--- a/python/ray/includes/stream_redirection.pxd
+++ b/python/ray/includes/stream_redirection.pxd
@@ -1,0 +1,16 @@
+from libcpp.string cimport string as c_string
+from libc.stdint cimport uint64_t
+from libcpp cimport bool as c_bool
+
+cdef extern from "ray/util/stream_redirection_options.h" nogil:
+    cdef cppclass CStreamRedirectionOptions "ray::StreamRedirectionOption":
+        CStreamRedirectionOptions()
+        c_string file_path
+        uint64_t rotation_max_size
+        uint64_t rotation_max_file_count
+        c_bool tee_to_stdout
+        c_bool tee_to_stderr
+
+cdef extern from "ray/util/stream_redirection_utils.h" namespace "ray" nogil:
+    void RedirectStdout(const CStreamRedirectionOptions& opt)
+    void RedirectStderr(const CStreamRedirectionOptions& opt)

--- a/python/ray/tests/test_logging.py
+++ b/python/ray/tests/test_logging.py
@@ -269,7 +269,8 @@ def test_log_rotation(shutdown_only, monkeypatch):
         parts = filename.split(".")
         if len(parts) == 3:
             filename_without_suffix = parts[0]
-            file_cnts[filename_without_suffix] += 1
+            file_type = parts[1]  # eg. err, log, out
+            file_cnts[f"{filename_without_suffix}.{file_type}"] += 1
     for filename, file_cnt in file_cnts.items():
         assert file_cnt <= backup_count, (
             f"{filename} has files that are more than "

--- a/python/ray/tests/test_logging.py
+++ b/python/ray/tests/test_logging.py
@@ -189,6 +189,94 @@ def test_log_file_exists(shutdown_only):
 @pytest.mark.skipif(
     sys.platform == "win32", reason="Log rotation is disable on windows platform."
 )
+def test_log_rotation_invalid_rotation_params(shutdown_only, monkeypatch):
+    max_bytes = 0  # Invalid value, should sanitize to sys.maxsize
+    backup_count = 0  # Invalid value, should sanitize to 1
+    set_logging_config(monkeypatch, max_bytes, backup_count)
+    ray.init(num_cpus=1)
+    session_dir = ray._private.worker.global_worker.node.address_info["session_dir"]
+    session_path = Path(session_dir)
+    log_dir_path = session_path / "logs"
+
+    # NOTICE: There's no ray_constants.PROCESS_TYPE_WORKER because "worker" is a
+    # substring of "python-core-worker".
+    log_rotating_component = [
+        ray_constants.PROCESS_TYPE_DASHBOARD,
+        ray_constants.PROCESS_TYPE_DASHBOARD_AGENT,
+        ray_constants.PROCESS_TYPE_LOG_MONITOR,
+        ray_constants.PROCESS_TYPE_MONITOR,
+        ray_constants.PROCESS_TYPE_PYTHON_CORE_WORKER_DRIVER,
+        ray_constants.PROCESS_TYPE_PYTHON_CORE_WORKER,
+        ray_constants.PROCESS_TYPE_RAYLET,
+        ray_constants.PROCESS_TYPE_GCS_SERVER,
+    ]
+
+    # Run the basic workload.
+    @ray.remote
+    def f():
+        for i in range(10):
+            print(f"test {i}")
+
+    # Create a runtime env to make sure dashboard agent is alive.
+    ray.get(f.options(runtime_env={"env_vars": {"A": "a", "B": "b"}}).remote())
+
+    # Filter out only paths that end in .log, .log.1, (which is produced by python
+    # rotating log handler) and .out.1 and so on (which is produced by C++ spdlog
+    # rotation handler) . etc. These paths are handled by the logger; the others (.err)
+    # are not.
+    paths = []
+    for path in log_dir_path.iterdir():
+        # Match all rotated files, which suffixes with `log.x` or `log.x.out`.
+        if re.search(r".*\.log(\.\d+)?", str(path)):
+            paths.append(path)
+        elif re.search(r".*\.out(\.\d+)?", str(path)):
+            paths.append(path)
+
+    def component_exist(component, paths):
+        """Return whether there's at least one log file path is for the given
+        [component]."""
+        for path in paths:
+            filename = path.stem
+            if component in filename:
+                return True
+        return False
+
+    for component in log_rotating_component:
+        assert component_exist(component, paths), paths
+
+    # Check if the backup count is respected.
+    file_cnts = defaultdict(int)
+    for path in paths:
+        filename = path.name
+        parts = filename.split(".")
+        if len(parts) == 3:
+            filename_without_suffix = parts[0]
+            file_type = parts[1]  # eg. err, log, out
+            file_cnts[f"{filename_without_suffix}.{file_type}"] += 1
+    for filename, file_cnt in file_cnts.items():
+        assert file_cnt == backup_count, (
+            f"{filename} has files that are more than "
+            f"backup count {backup_count}, file count: {file_cnt}"
+        )
+
+    # Test application log, which starts with `worker-`.
+    # Should be tested separately with other components since "worker" is a substring of "python-core-worker".
+    #
+    # Check file count.
+    application_stdout_paths = []
+    for path in paths:
+        if (
+            path.stem.startswith("worker-")
+            and re.search(r".*\.out(\.\d+)?", str(path))
+            and path.stat().st_size > 0
+        ):
+            application_stdout_paths.append(path)
+    assert len(application_stdout_paths) == 1, application_stdout_paths
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Log rotation is disable on windows platform."
+)
 def test_log_rotation(shutdown_only, monkeypatch):
     max_bytes = 1
     backup_count = 3

--- a/src/ray/util/stream_redirection_options.h
+++ b/src/ray/util/stream_redirection_options.h
@@ -25,6 +25,8 @@ namespace ray {
 // For example, if redirection file set and `tee_to_stdout` both set to true, the stream
 // content is written to both sinks.
 struct StreamRedirectionOption {
+  StreamRedirectionOption() = default;
+
   // Redirected file path on local filesystem.
   std::string file_path;
   // Max number of bytes in a rotated file.


### PR DESCRIPTION
The issue is, when rotation size is 0, we should sanitize it first to disable rotation.