### PR TITLE
fix restore Bug

### DIFF
--- a/rllib/core/learner/torch/torch_learner.py
+++ b/rllib/core/learner/torch/torch_learner.py
@@ -353,8 +353,10 @@ class TorchLearner(Learner):
                     config=self.config.get_config_for_module(module_id=module_id),
                 )
             if name in self._named_optimizers:
+                optim_state_dict = {"state": convert_to_torch_tensor(state_dict["state"]["state"], device=self._device),
+                                    "param_groups": state_dict["state"]["param_groups"]}
                 self._named_optimizers[name].load_state_dict(
-                    convert_to_torch_tensor(state_dict["state"], device=self._device)
+                    optim_state_dict
                 )
 
     @override(Learner)


### PR DESCRIPTION
Why are these changes needed?
When performing a restore, the error RuntimeError: Expected scalars to be on CPU, got cuda:0 instead occurs, similar to the situation in https://github.com/ray-project/ray/issues/34159. However, in the older version, the modification was made in the policy, while in the newer version, it needs to be adjusted in torch_learner.

Related issue number
similar to the situation in https://github.com/ray-project/ray/issues/34159 in old

Checks
 I've signed off every commit(by using the -s flag, i.e., git commit -s) in this PR.
 I've run scripts/format.sh to lint the changes in this PR.
 I've included any doc changes needed for https://docs.ray.io/en/master/.
 I've added any new APIs to the API Reference. For example, if I added a
method in Tune, I've added it in doc/source/tune/api/ under the
corresponding .rst file.
 I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
Testing Strategy
 Unit tests
 Release tests
 This PR is not tested :(













Why are these changes needed?
When performing a restore, the error RuntimeError: Expected scalars to be on CPU, got cuda:0 instead occurs, similar to the situation in https://github.com/ray-project/ray/issues/34159. However, in the older version, the modification was made in the policy, while in the newer version, it needs to be adjusted in torch_learner.

Related issue number
similar to the situation in https://github.com/ray-project/ray/issues/34159 in old

Checks
 I've signed off every commit(by using the -s flag, i.e., git commit -s) in this PR.
 I've run scripts/format.sh to lint the changes in this PR.
 I've included any doc changes needed for https://docs.ray.io/en/master/.
 I've added any new APIs to the API Reference. For example, if I added a
method in Tune, I've added it in doc/source/tune/api/ under the
corresponding .rst file.
 I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
Testing Strategy
 Unit tests
 Release tests
 This PR is not tested :(