### PR TITLE
fix restore BUG "RuntimeError: Expected scalars to be on CPU, got cud…

### DIFF
--- a/rllib/core/learner/torch/torch_learner.py
+++ b/rllib/core/learner/torch/torch_learner.py
@@ -353,8 +353,10 @@ class TorchLearner(Learner):
                     config=self.config.get_config_for_module(module_id=module_id),
                 )
             if name in self._named_optimizers:
+                optim_state_dict = {"state": convert_to_torch_tensor(state_dict["state"]["state"], device=self._device),
+                                    "param_groups": state_dict["state"]["param_groups"]}
                 self._named_optimizers[name].load_state_dict(
-                    convert_to_torch_tensor(state_dict["state"], device=self._device)
+                    optim_state_dict
                 )
 
     @override(Learner)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When performing a restore, the error RuntimeError: Expected scalars to be on CPU, got cuda:0 instead occurs, similar to the situation in #34159. However, in the older version, the modification was made in the policy, while in the newer version, it needs to be adjusted in torch_learner.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Similar to  #34159
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
