### PR TITLE
[CI] Use UV to compile LLM requirements

### DIFF
--- a/ci/compile_llm_requirements.sh
+++ b/ci/compile_llm_requirements.sh
@@ -9,13 +9,14 @@ for CUDA_CODE in cpu cu121 cu124 ; do
 
 	echo "--- Compile dependencies for ${PYTHON_CODE}_${CUDA_CODE}"
 
-	PIP_COMPILE=(
-		pip-compile -v --generate-hashes --strip-extras
+	UV_COMPILE=(
+		uv pip compile
+		--generate-hashes
+		--strip-extras
 		--unsafe-package ray
-		# The version we use on python 3.9 is not installable on python 3.11
 		--unsafe-package grpcio-tools
-		# setuptools should not be pinned.
-		--unsafe-package setuptools
+		--unsafe-pacage setuptools
+		--index-url "https://pypi.org/simple"
 		--extra-index-url "https://download.pytorch.org/whl/${CUDA_CODE}"
 		--find-links "https://data.pyg.org/whl/torch-2.3.0+${CUDA_CODE}.html"
 	)
@@ -32,7 +33,7 @@ for CUDA_CODE in cpu cu121 cu124 ; do
 	#
 	# Needs to use the exact torch version.
 	echo "--- Compile ray base test dependencies"
-	"${PIP_COMPILE[@]}" \
+	"${UV_COMPILE[@]}" \
 		-c "/tmp/ray-deps/requirements_compiled.txt" \
 		"python/requirements.txt" \
 		"python/requirements/cloud-requirements.txt" \
@@ -41,7 +42,7 @@ for CUDA_CODE in cpu cu121 cu124 ; do
 
 	# Second, expand it into LLM test dependencies
 	echo "--- Compile LLM test dependencies"
-	"${PIP_COMPILE[@]}" \
+	"${UV_COMPILE[@]}" \
 		-c "python/requirements_compiled_ray_test_${PYTHON_CUDA_CODE}.txt" \
 		"python/requirements.txt" \
 		"python/requirements/cloud-requirements.txt" \
@@ -53,7 +54,7 @@ for CUDA_CODE in cpu cu121 cu124 ; do
 	# Third, extract the ray base dependencies from ray base test dependencies.
 	# TODO(aslonnie): This should be used for installing ray in the container images.
 	echo "--- Compile ray base test dependencies"
-	"${PIP_COMPILE[@]}" \
+	"${UV_COMPILE[@]}" \
 		-c "python/requirements_compiled_ray_test_${PYTHON_CUDA_CODE}.txt" \
 		"python/requirements.txt" \
 		-o "python/requirements_compiled_ray_${PYTHON_CUDA_CODE}.txt"
@@ -62,7 +63,7 @@ for CUDA_CODE in cpu cu121 cu124 ; do
 	# which is also an expansion of the ray base dependencies.
 	# TODO(aslonnie): This should be used for installing ray[llm] in the container images.
 	echo "--- Compile LLM dependencies"
-	"${PIP_COMPILE[@]}" \
+	"${UV_COMPILE[@]}" \
 		-c "python/requirements_compiled_rayllm_test_${PYTHON_CUDA_CODE}.txt" \
 		"python/requirements.txt" \
 		"python/requirements/llm/llm-requirements.txt" \


### PR DESCRIPTION
- Swap all `pip-compile` with `uv pip compile`
- Also add `--index-strategy unsafe-best-match` according to what uv suggests to treat both `pypi.org/simple` and the extra index equally. It was complaining about finding a match in `pypi.org` but not in `download.pytorch.org` and couldn't install because this arg was missing.