### PR TITLE
[core] Recheckin runtime agent rotation

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3054,6 +3054,8 @@ pyx_library(
         "//src/ray/protobuf:serialization_cc_proto",
         "//src/ray/util",
         "//src/ray/util:memory",
+        "//src/ray/util:stream_redirection_options",
+        "//src/ray/util:stream_redirection_utils",
     ],
 )
 

--- a/python/ray/_private/runtime_env/agent/main.py
+++ b/python/ray/_private/runtime_env/agent/main.py
@@ -2,19 +2,16 @@ import sys
 import os
 import argparse
 import logging
-import pathlib
 import ray._private.ray_constants as ray_constants
 from ray.core.generated import (
     runtime_env_agent_pb2,
 )
 from ray._private.utils import open_log
-from ray._private.ray_logging import (
-    configure_log_file,
-)
 from ray._private.utils import (
     get_or_create_event_loop,
 )
 from ray._private.process_watcher import create_check_raylet_task
+from ray._raylet import StreamRedirector
 
 
 def import_libs():
@@ -30,11 +27,16 @@ from runtime_env_agent import RuntimeEnvAgent  # noqa: E402
 from aiohttp import web  # noqa: E402
 
 
-def open_capture_files(log_dir):
+def get_capture_filepaths(log_dir):
+    """Get filepaths for the given [log_dir].
+
+    log_dir:
+        Logging directory to place output and error logs.
+    """
     filename = "runtime_env_agent"
     return (
-        open_log(pathlib.Path(log_dir) / f"{filename}.out"),
-        open_log(pathlib.Path(log_dir) / f"{filename}.err"),
+        f"{log_dir}/{filename}.out",
+        f"{log_dir}/{filename}.err",
     )
 
 
@@ -95,20 +97,15 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--logging-rotate-bytes",
-        required=False,
+        required=True,
         type=int,
-        default=ray_constants.LOGGING_ROTATE_BYTES,
-        help="Specify the max bytes for rotating "
-        "log file, default is {} bytes.".format(ray_constants.LOGGING_ROTATE_BYTES),
+        help="Specify the max bytes for rotating log file",
     )
     parser.add_argument(
         "--logging-rotate-backup-count",
-        required=False,
+        required=True,
         type=int,
-        default=ray_constants.LOGGING_ROTATE_BACKUP_COUNT,
-        help="Specify the backup count of rotated log file, default is {}.".format(
-            ray_constants.LOGGING_ROTATE_BACKUP_COUNT
-        ),
+        help="Specify the backup count of rotated log file",
     )
     parser.add_argument(
         "--log-dir",
@@ -127,18 +124,50 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
+    # Disable log rotation for windows platform.
+    logging_rotation_bytes = (
+        args.logging_rotate_bytes if sys.platform != "win32" else sys.maxsize
+    )
+    logging_rotation_backup_count = (
+        args.logging_rotate_backup_count if sys.platform != "win32" else 1
+    )
+
     logging_params = dict(
         logging_level=args.logging_level,
         logging_format=args.logging_format,
         log_dir=args.log_dir,
         filename=args.logging_filename,
-        max_bytes=args.logging_rotate_bytes,
-        backup_count=args.logging_rotate_backup_count,
+        max_bytes=logging_rotation_bytes,
+        backup_count=logging_rotation_backup_count,
     )
 
     # Setup stdout/stderr redirect files
-    out_file, err_file = open_capture_files(args.log_dir)
-    configure_log_file(out_file, err_file)
+    out_filepath, err_filepath = get_capture_filepaths(args.log_dir)
+    StreamRedirector.redirect_stdout(
+        out_filepath,
+        logging_rotation_bytes,
+        logging_rotation_backup_count,
+        False,
+        False,
+    )
+    StreamRedirector.redirect_stderr(
+        err_filepath,
+        logging_rotation_bytes,
+        logging_rotation_backup_count,
+        False,
+        False,
+    )
+
+    # Setup python stdout/stderr stream.
+    stdout_fileno = sys.stdout.fileno()
+    stderr_fileno = sys.stderr.fileno()
+    # We also manually set sys.stdout and sys.stderr because that seems to
+    # have an effect on the output buffering. Without doing this, stdout
+    # and stderr are heavily buffered resulting in seemingly lost logging
+    # statements. We never want to close the stdout file descriptor, dup2 will
+    # close it when necessary and we don't want python's GC to close it.
+    sys.stdout = open_log(stdout_fileno, unbuffered=True, closefd=False)
+    sys.stderr = open_log(stderr_fileno, unbuffered=True, closefd=False)
 
     agent = RuntimeEnvAgent(
         runtime_env_dir=args.runtime_env_dir,

--- a/python/ray/_private/runtime_env/agent/main.py
+++ b/python/ray/_private/runtime_env/agent/main.py
@@ -125,9 +125,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # Disable log rotation for windows platform.
-    logging_rotation_bytes = (
-        args.logging_rotate_bytes if sys.platform != "win32" else sys.maxsize
-    )
+    logging_rotation_bytes = args.logging_rotate_bytes if sys.platform != "win32" else 0
     logging_rotation_backup_count = (
         args.logging_rotate_backup_count if sys.platform != "win32" else 1
     )

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -158,6 +158,11 @@ from ray.includes.libcoreworker cimport (
     CGeneratorBackpressureWaiter,
     CReaderRefInfo,
 )
+from ray.includes.stream_redirection cimport (
+    CStreamRedirectionOptions,
+    RedirectStdout,
+    RedirectStderr,
+)
 
 from ray.includes.ray_config cimport RayConfig
 from ray.includes.global_state_accessor cimport CGlobalStateAccessor
@@ -2651,6 +2656,26 @@ cdef void terminate_asyncio_thread() nogil:
         core_worker = ray._private.worker.global_worker.core_worker
         core_worker.stop_and_join_asyncio_threads_if_exist()
 
+cdef class StreamRedirector:
+    @staticmethod
+    def redirect_stdout(const c_string &file_path, uint64_t rotation_max_size, uint64_t rotation_max_file_count, c_bool tee_to_stdout, c_bool tee_to_stderr):
+        cdef CStreamRedirectionOptions opt = CStreamRedirectionOptions()
+        opt.file_path = file_path
+        opt.rotation_max_size = rotation_max_size
+        opt.rotation_max_file_count = rotation_max_file_count
+        opt.tee_to_stdout = tee_to_stdout
+        opt.tee_to_stderr = tee_to_stderr
+        RedirectStdout(opt)
+
+    @staticmethod
+    def redirect_stderr(const c_string &file_path, uint64_t rotation_max_size, uint64_t rotation_max_file_count, c_bool tee_to_stdout, c_bool tee_to_stderr):
+        cdef CStreamRedirectionOptions opt = CStreamRedirectionOptions()
+        opt.file_path = file_path
+        opt.rotation_max_size = rotation_max_size
+        opt.rotation_max_file_count = rotation_max_file_count
+        opt.tee_to_stdout = tee_to_stdout
+        opt.tee_to_stderr = tee_to_stderr
+        RedirectStderr(opt)
 
 # An empty profile event context to be used when the timeline is disabled.
 cdef class EmptyProfileEvent:

--- a/python/ray/includes/stream_redirection.pxd
+++ b/python/ray/includes/stream_redirection.pxd
@@ -1,0 +1,16 @@
+from libcpp.string cimport string as c_string
+from libc.stdint cimport uint64_t
+from libcpp cimport bool as c_bool
+
+cdef extern from "ray/util/stream_redirection_options.h" nogil:
+    cdef cppclass CStreamRedirectionOptions "ray::StreamRedirectionOption":
+        CStreamRedirectionOptions()
+        c_string file_path
+        uint64_t rotation_max_size
+        uint64_t rotation_max_file_count
+        c_bool tee_to_stdout
+        c_bool tee_to_stderr
+
+cdef extern from "ray/util/stream_redirection_utils.h" namespace "ray" nogil:
+    void RedirectStdout(const CStreamRedirectionOptions& opt)
+    void RedirectStderr(const CStreamRedirectionOptions& opt)

--- a/python/ray/tests/test_logging.py
+++ b/python/ray/tests/test_logging.py
@@ -269,7 +269,8 @@ def test_log_rotation(shutdown_only, monkeypatch):
         parts = filename.split(".")
         if len(parts) == 3:
             filename_without_suffix = parts[0]
-            file_cnts[filename_without_suffix] += 1
+            file_type = parts[1]  # eg. err, log, out
+            file_cnts[f"{filename_without_suffix}.{file_type}"] += 1
     for filename, file_cnt in file_cnts.items():
         assert file_cnt <= backup_count, (
             f"{filename} has files that are more than "

--- a/python/ray/tests/test_logging.py
+++ b/python/ray/tests/test_logging.py
@@ -189,6 +189,94 @@ def test_log_file_exists(shutdown_only):
 @pytest.mark.skipif(
     sys.platform == "win32", reason="Log rotation is disable on windows platform."
 )
+def test_log_rotation_invalid_rotation_params(shutdown_only, monkeypatch):
+    max_bytes = 0  # Invalid value, should sanitize to sys.maxsize
+    backup_count = 0  # Invalid value, should sanitize to 1
+    set_logging_config(monkeypatch, max_bytes, backup_count)
+    ray.init(num_cpus=1)
+    session_dir = ray._private.worker.global_worker.node.address_info["session_dir"]
+    session_path = Path(session_dir)
+    log_dir_path = session_path / "logs"
+
+    # NOTICE: There's no ray_constants.PROCESS_TYPE_WORKER because "worker" is a
+    # substring of "python-core-worker".
+    log_rotating_component = [
+        ray_constants.PROCESS_TYPE_DASHBOARD,
+        ray_constants.PROCESS_TYPE_DASHBOARD_AGENT,
+        ray_constants.PROCESS_TYPE_LOG_MONITOR,
+        ray_constants.PROCESS_TYPE_MONITOR,
+        ray_constants.PROCESS_TYPE_PYTHON_CORE_WORKER_DRIVER,
+        ray_constants.PROCESS_TYPE_PYTHON_CORE_WORKER,
+        ray_constants.PROCESS_TYPE_RAYLET,
+        ray_constants.PROCESS_TYPE_GCS_SERVER,
+    ]
+
+    # Run the basic workload.
+    @ray.remote
+    def f():
+        for i in range(10):
+            print(f"test {i}")
+
+    # Create a runtime env to make sure dashboard agent is alive.
+    ray.get(f.options(runtime_env={"env_vars": {"A": "a", "B": "b"}}).remote())
+
+    # Filter out only paths that end in .log, .log.1, (which is produced by python
+    # rotating log handler) and .out.1 and so on (which is produced by C++ spdlog
+    # rotation handler) . etc. These paths are handled by the logger; the others (.err)
+    # are not.
+    paths = []
+    for path in log_dir_path.iterdir():
+        # Match all rotated files, which suffixes with `log.x` or `log.x.out`.
+        if re.search(r".*\.log(\.\d+)?", str(path)):
+            paths.append(path)
+        elif re.search(r".*\.out(\.\d+)?", str(path)):
+            paths.append(path)
+
+    def component_exist(component, paths):
+        """Return whether there's at least one log file path is for the given
+        [component]."""
+        for path in paths:
+            filename = path.stem
+            if component in filename:
+                return True
+        return False
+
+    for component in log_rotating_component:
+        assert component_exist(component, paths), paths
+
+    # Check if the backup count is respected.
+    file_cnts = defaultdict(int)
+    for path in paths:
+        filename = path.name
+        parts = filename.split(".")
+        if len(parts) == 3:
+            filename_without_suffix = parts[0]
+            file_type = parts[1]  # eg. err, log, out
+            file_cnts[f"{filename_without_suffix}.{file_type}"] += 1
+    for filename, file_cnt in file_cnts.items():
+        assert file_cnt == backup_count, (
+            f"{filename} has files that are more than "
+            f"backup count {backup_count}, file count: {file_cnt}"
+        )
+
+    # Test application log, which starts with `worker-`.
+    # Should be tested separately with other components since "worker" is a substring of "python-core-worker".
+    #
+    # Check file count.
+    application_stdout_paths = []
+    for path in paths:
+        if (
+            path.stem.startswith("worker-")
+            and re.search(r".*\.out(\.\d+)?", str(path))
+            and path.stat().st_size > 0
+        ):
+            application_stdout_paths.append(path)
+    assert len(application_stdout_paths) == 1, application_stdout_paths
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Log rotation is disable on windows platform."
+)
 def test_log_rotation(shutdown_only, monkeypatch):
     max_bytes = 1
     backup_count = 3

--- a/python/ray/tests/test_logging.py
+++ b/python/ray/tests/test_logging.py
@@ -186,12 +186,10 @@ def test_log_file_exists(shutdown_only):
             return suffix in appplication_log_suffixes
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="Log rotation is disable on windows platform."
-)
-def test_log_rotation_invalid_rotation_params(shutdown_only, monkeypatch):
-    max_bytes = 0  # Invalid value, should sanitize to sys.maxsize
-    backup_count = 0  # Invalid value, should sanitize to 1
+# Rotation is disable in the unit test.
+def test_log_rotation_disable_rotation_params(shutdown_only, monkeypatch):
+    max_bytes = 0
+    backup_count = 1
     set_logging_config(monkeypatch, max_bytes, backup_count)
     ray.init(num_cpus=1)
     session_dir = ray._private.worker.global_worker.node.address_info["session_dir"]

--- a/src/ray/gcs/gcs_server/gcs_server_main.cc
+++ b/src/ray/gcs/gcs_server/gcs_server_main.cc
@@ -80,15 +80,14 @@ int main(int argc, char *argv[]) {
 
   // For compatibility, by default GCS server dumps logging into a single file with no
   // rotation.
-  InitShutdownRAII ray_log_shutdown_raii(
-      ray::RayLog::StartRayLog,
-      ray::RayLog::ShutDownRayLog,
-      argv[0],
-      ray::RayLogLevel::INFO,
-      /*log_filepath=*/"",
-      /*err_log_filepath=*/"",
-      /*log_rotation_max_size=*/std::numeric_limits<size_t>::max(),
-      /*log_rotation_file_num=*/1);
+  InitShutdownRAII ray_log_shutdown_raii(ray::RayLog::StartRayLog,
+                                         ray::RayLog::ShutDownRayLog,
+                                         argv[0],
+                                         ray::RayLogLevel::INFO,
+                                         /*log_filepath=*/"",
+                                         /*err_log_filepath=*/"",
+                                         /*log_rotation_max_size=*/0,
+                                         /*log_rotation_file_num=*/1);
   ray::RayLog::InstallFailureSignalHandler(argv[0]);
   ray::RayLog::InstallTerminateHandler();
 

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -163,15 +163,14 @@ int main(int argc, char *argv[]) {
 
   // For compatibility, by default GCS server dumps logging into a single file with no
   // rotation.
-  InitShutdownRAII ray_log_shutdown_raii(
-      ray::RayLog::StartRayLog,
-      ray::RayLog::ShutDownRayLog,
-      /*app_name=*/argv[0],
-      ray::RayLogLevel::INFO,
-      /*ray_log_filepath=*/"",
-      /*ray_err_log_filepath=*/"",
-      /*log_rotation_max_size=*/std::numeric_limits<size_t>::max(),
-      /*log_rotation_file_num=*/1);
+  InitShutdownRAII ray_log_shutdown_raii(ray::RayLog::StartRayLog,
+                                         ray::RayLog::ShutDownRayLog,
+                                         /*app_name=*/argv[0],
+                                         ray::RayLogLevel::INFO,
+                                         /*ray_log_filepath=*/"",
+                                         /*ray_err_log_filepath=*/"",
+                                         /*log_rotation_max_size=*/0,
+                                         /*log_rotation_file_num=*/1);
 
   ray::RayLog::InstallFailureSignalHandler(argv[0]);
   ray::RayLog::InstallTerminateHandler();

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -408,16 +408,15 @@ void RayLog::InitLogFormat() {
       spdlog::drop(RayLog::GetLoggerName());
     }
 
+    spdlog::sink_ptr file_sink;
     if (log_rotation_max_size_ == 0) {
-      auto file_sink = std::make_shared<spdlog::sinks::basic_file_sink_st>(log_filepath);
-      file_sink->set_level(level);
-      sinks[0] = std::move(file_sink);
+      file_sink = std::make_shared<spdlog::sinks::basic_file_sink_st>(log_filepath);
     } else {
-      auto file_sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
+      file_sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
           log_filepath, log_rotation_max_size_, log_rotation_file_num_);
-      file_sink->set_level(level);
-      sinks[0] = std::move(file_sink);
     }
+    file_sink->set_level(level);
+    sinks[0] = std::move(file_sink);
   } else {
     component_name_ = app_name_without_path;
     auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
@@ -427,8 +426,13 @@ void RayLog::InitLogFormat() {
 
   // Set sink for stderr.
   if (!err_log_filepath.empty()) {
-    auto err_sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
-        err_log_filepath, log_rotation_max_size_, log_rotation_file_num_);
+    spdlog::sink_ptr err_sink;
+    if (log_rotation_max_size_ == 0) {
+      err_sink = std::make_shared<spdlog::sinks::basic_file_sink_st>(err_log_filepath);
+    } else {
+      err_sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
+          err_log_filepath, log_rotation_max_size_, log_rotation_file_num_);
+    }
     err_sink->set_level(spdlog::level::err);
     sinks[1] = std::move(err_sink);
   } else {

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -280,15 +280,14 @@ class RayLog {
   /// Example: if log_filepath is /my/path/raylet.out, the output can be
   /// /my/path/raylet.out, /my/path/raylet.out.1 and /my/path/raylet.out.2
   ///
-  /// \param log_rotation_max_size max bytes for of log rotation.
+  /// \param log_rotation_max_size max bytes for of log rotation. 0 means no rotation.
   /// \param log_rotation_file_num max number of rotating log files.
-  static void StartRayLog(
-      const std::string &app_name,
-      RayLogLevel severity_threshold = RayLogLevel::INFO,
-      const std::string &log_filepath = "",
-      const std::string &err_log_filepath = "",
-      size_t log_rotation_max_size = std::numeric_limits<size_t>::max(),
-      size_t log_rotation_file_num = 1);
+  static void StartRayLog(const std::string &app_name,
+                          RayLogLevel severity_threshold = RayLogLevel::INFO,
+                          const std::string &log_filepath = "",
+                          const std::string &err_log_filepath = "",
+                          size_t log_rotation_max_size = 0,
+                          size_t log_rotation_file_num = 1);
 
   /// The shutdown function of ray log which should be used with StartRayLog as a pair.
   /// If `StartRayLog` wasn't called before, it will be no-op.
@@ -296,14 +295,14 @@ class RayLog {
 
   /// Get max bytes value from env variable.
   /// Return default value, which indicates no rotation, if env not set, parse failure or
-  /// value 0.
+  /// return value 0.
   ///
   /// Log rotation is disable on windows platform.
   static size_t GetRayLogRotationMaxBytesOrDefault();
 
   /// Get log rotation backup count.
   /// Return default value, which indicates no rotation, if env not set, parse failure or
-  /// value 0.
+  /// return value 1.
   ///
   /// Log rotation is disabled on windows platform.
   static size_t GetRayLogRotationBackupCountOrDefault();

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -424,7 +424,7 @@ class RayLog {
   // Log format pattern.
   static std::string log_format_pattern_;
   // Log rotation file size limitation.
-  inline static size_t log_rotation_max_size_ = std::numeric_limits<size_t>::max();
+  inline static size_t log_rotation_max_size_ = 0;
   // Log rotation file number.
   inline static size_t log_rotation_file_num_ = 1;
   // Ray default logger name.

--- a/src/ray/util/pipe_logger.cc
+++ b/src/ray/util/pipe_logger.cc
@@ -216,8 +216,7 @@ std::shared_ptr<spdlog::logger> CreateLogger(
 // 1. Log roration is requested;
 // 2. Multiple sinks are involved.
 bool ShouldUsePipeStream(const StreamRedirectionOption &stream_redirect_opt) {
-  const bool need_rotation =
-      stream_redirect_opt.rotation_max_size != std::numeric_limits<size_t>::max();
+  const bool need_rotation = stream_redirect_opt.rotation_max_size != 0;
   return need_rotation || stream_redirect_opt.tee_to_stdout ||
          stream_redirect_opt.tee_to_stderr;
 }

--- a/src/ray/util/pipe_logger.cc
+++ b/src/ray/util/pipe_logger.cc
@@ -138,7 +138,7 @@ std::shared_ptr<spdlog::logger> CreateLogger(
 
   // Setup file sink.
   spdlog::sink_ptr file_sink = nullptr;
-  if (stream_redirect_opt.rotation_max_size != std::numeric_limits<size_t>::max()) {
+  if (stream_redirect_opt.rotation_max_size != 0) {
     file_sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
         stream_redirect_opt.file_path,
         stream_redirect_opt.rotation_max_size,

--- a/src/ray/util/stream_redirection_options.h
+++ b/src/ray/util/stream_redirection_options.h
@@ -25,6 +25,8 @@ namespace ray {
 // For example, if redirection file set and `tee_to_stdout` both set to true, the stream
 // content is written to both sinks.
 struct StreamRedirectionOption {
+  StreamRedirectionOption() = default;
+
   // Redirected file path on local filesystem.
   std::string file_path;
   // Max number of bytes in a rotated file.

--- a/src/ray/util/stream_redirection_options.h
+++ b/src/ray/util/stream_redirection_options.h
@@ -30,7 +30,8 @@ struct StreamRedirectionOption {
   // Redirected file path on local filesystem.
   std::string file_path;
   // Max number of bytes in a rotated file.
-  size_t rotation_max_size = std::numeric_limits<size_t>::max();
+  // 0 means rotation not enabled, by default 0.
+  size_t rotation_max_size = 0;
   // Max number of files for all rotated files.
   size_t rotation_max_file_count = 1;
   // Whether to tee to stdout.


### PR DESCRIPTION
A redo for https://github.com/ray-project/ray/pull/50974

The biggest change is to align C++ implementation with python's, to use 0 as the default value and disable rotation.