### PR TITLE
[POC] Run arbitrary bash commands in doc as test

### DIFF
--- a/doc/source/cluster/kubernetes/getting-started.md
+++ b/doc/source/cluster/kubernetes/getting-started.md
@@ -8,6 +8,7 @@
 getting-started/raycluster-quick-start
 getting-started/rayjob-quick-start
 getting-started/rayservice-quick-start
+getting-started/notebook
 ```
 
 

--- a/doc/source/cluster/kubernetes/getting-started/doc_sanitize.cfg
+++ b/doc/source/cluster/kubernetes/getting-started/doc_sanitize.cfg
@@ -1,0 +1,3 @@
+[regex1]
+regex: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z
+replace: DATETIME

--- a/doc/source/cluster/kubernetes/getting-started/notebook.ipynb
+++ b/doc/source/cluster/kubernetes/getting-started/notebook.ipynb
@@ -1,0 +1,322 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "9efb4aca",
+      "metadata": {},
+      "source": [
+        "(bash-notebook-poc)=\n",
+        "\n",
+        "# Jupyter Notebook"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "a3410414-a4f6-474f-a265-84aa08bce7b8",
+      "metadata": {},
+      "source": [
+        "## Step 1"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "id": "dc64b552-2601-4bed-b7c6-eb9a600583ec",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": [
+          "nbval-ignore-output",
+          "remove-output"
+        ]
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Creating cluster \"kind\" ...\n",
+            " \u001b[32m✓\u001b[0m Ensuring node image (kindest/node:v1.26.0) 🖼\n",
+            " \u001b[32m✓\u001b[0m Preparing nodes 📦 7l\n",
+            " \u001b[32m✓\u001b[0m Writing configuration 📜7l\n",
+            " \u001b[32m✓\u001b[0m Starting control-plane 🕹️7l\n",
+            " \u001b[32m✓\u001b[0m Installing CNI 🔌7l\n",
+            " \u001b[32m✓\u001b[0m Installing StorageClass 💾7l\n",
+            "Set kubectl context to \"kind-kind\"\n",
+            "You can now use your cluster with:\n",
+            "\n",
+            "kubectl cluster-info --context kind-kind\n",
+            "\n",
+            "Thanks for using kind! 😊\n"
+          ]
+        }
+      ],
+      "source": [
+        "kind create cluster --image=kindest/node:v1.26.0"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "7fa05d63-cc4b-43d6-bc66-ef7c4d77d969",
+      "metadata": {},
+      "source": [
+        "## Step 2"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "id": "799442de-7fac-42b2-8175-6578d3a537a6",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": [
+          "nbval-ignore-output",
+          "remove-output"
+        ]
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "NAME: kuberay-operator\n",
+            "LAST DEPLOYED: Fri Feb 28 19:31:25 2025\n",
+            "NAMESPACE: default\n",
+            "STATUS: deployed\n",
+            "REVISION: 1\n",
+            "TEST SUITE: None\n"
+          ]
+        }
+      ],
+      "source": [
+        "helm install kuberay-operator kuberay/kuberay-operator --version 1.3.0"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "id": "03446987-ec21-4f6d-98e9-774fe57cd473",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": [
+          "nbval-ignore-output",
+          "remove-cell"
+        ]
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "deployment.apps/kuberay-operator condition met\n"
+          ]
+        }
+      ],
+      "source": [
+        "kubectl wait --for=condition=available deployment/kuberay-operator --timeout=120s"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "id": "6999ac1e-bfa7-4e0c-bbb9-c79f7959346b",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": []
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "rayservice.ray.io/rayservice-mobilenet created\n"
+          ]
+        }
+      ],
+      "source": [
+        "kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/v1.3.0/ray-operator/config/samples/ray-service.mobilenet.yaml"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "id": "5375dd03-3beb-4c98-8c0e-c5618f2693d0",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": []
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "rayservice.ray.io/rayservice-mobilenet condition met\n"
+          ]
+        }
+      ],
+      "source": [
+        "kubectl wait --for=condition=ready rayservice/rayservice-mobilenet --timeout=500s"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "id": "9c6cd34e-1d58-4079-aef1-8ca373f8af6d",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": []
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[\n",
+            "    {\n",
+            "        \"lastTransitionTime\": \"2025-02-28T11:35:55Z\",\n",
+            "        \"message\": \"Number of serve endpoints is greater than 0\",\n",
+            "        \"observedGeneration\": 1,\n",
+            "        \"reason\": \"NonZeroServeEndpoints\",\n",
+            "        \"status\": \"True\",\n",
+            "        \"type\": \"Ready\"\n",
+            "    }\n",
+            "]\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Or use kubectl describe rayservice/rayservice-mobilenet\n",
+        "kubectl get rayservice/rayservice-mobilenet -o jsonpath-as-json='{.status.conditions[?(@.type==\"Ready\")]}'"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "id": "931378a1-8bc8-45c2-8a2f-fd3c0c197190",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": [
+          "nbval-ignore-output",
+          "remove-output"
+        ]
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[1] 1596457\n"
+          ]
+        }
+      ],
+      "source": [
+        "kubectl port-forward svc/rayservice-mobilenet-serve-svc 8000 > /dev/null &"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "id": "f9be8e69-9a27-4e8f-8736-c686ead7f649",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": [
+          "nbval-ignore-output"
+        ]
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "{\"prediction\":[\"n02892201\",\"brass\",0.0880170688033104]}\n"
+          ]
+        }
+      ],
+      "source": [
+        "python mobilenet_req.py"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "5d610ed8-6cdc-4326-b06f-5690d405f2c1",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": []
+      },
+      "source": [
+        "## Cleanup"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "id": "2f2e77ec-6a3b-402b-98cd-0a53637deed1",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": [
+          "nbval-ignore-output",
+          "remove-output"
+        ]
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Deleting cluster \"kind\" ...\n",
+            "Deleted nodes: [\"kind-control-plane\"]\n",
+            "[1]+  Terminated              kubectl port-forward svc/rayservice-mobilenet-serve-svc 8000 > /dev/null\n"
+          ]
+        }
+      ],
+      "source": [
+        "killall kubectl\n",
+        "kind delete cluster"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Bash",
+      "language": "bash",
+      "name": "bash"
+    },
+    "language_info": {
+      "codemirror_mode": "shell",
+      "file_extension": ".sh",
+      "mimetype": "text/x-sh",
+      "name": "bash"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
This is a POC to automate the docs that requires manual testing by running arbitrary bash commands in doc as test using Jupyter notebooks.

This PR tries to convert [KubeRay MobileNet example](https://docs.ray.io/en/releases-2.43.0/cluster/kubernetes/examples/mobilenet-rayservice.html) to automated test.

# Doc link

https://anyscale-ray--50988.com.readthedocs.build/en/50988/cluster/kubernetes/getting-started/notebook.html

# Run this PR

## Prerequisites

- `kind`, `helm`, `kubectl`, `python`
- `cd doc/source/cluster/kubernetes/getting-started`
- `pip install pytest nbval bash_kernel jupyterlab requests`
- `python -m bash_kernel.install`
- `wget https://raw.githubusercontent.com/ray-project/serve_config_examples/607d1264c2c998e4a85eaf5403efcd3bc9ed3039/mobilenet/mobilenet_req.py`
- Prepare an image. And edit line 4 of the downloaded `mobilenet_req.py` to the path of your image.

Note: This is only a POC, so I didn't handle the automation for `mobilenet_req.py`. In the formal PR I'll handle it.

## Run test

`py.test --nbval notebook.ipynb --nbval-kernel-name bash --sanitize-with doc_sanitize.cfg`

## Limitations

We cannot use `tab-set` containing code blocks in Jupyter notebooks. For example, the following snippet does not work.

<pre>
::::{tab-set}

:::{tab-item} ARM64 (Apple silicon)
```sh
curl -s https://raw.githubusercontent.com/ray-project/kuberay/v1.3.0/ray-operator/config/samples/ray-job.sample.yaml | sed 's/2.41.0/2.41.0-aarch64/g' | kubectl apply -f -
```
:::

:::{tab-item} x86-64 (Intel/Linux)
```sh
kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/v1.3.0/ray-operator/config/samples/ray-job.sample.yaml
```
:::

::::
</pre>

## Discussions

- Whether to create a kind cluster for each test? Or should we use a shared k8s cluster?

## References

- https://nbval.readthedocs.io/en/latest/