### PR TITLE
Fix argument going into bigquery_datasource._create_client 

### DIFF
--- a/python/ray/data/_internal/datasource/bigquery_datasink.py
+++ b/python/ray/data/_internal/datasource/bigquery_datasink.py
@@ -77,7 +77,7 @@ class BigQueryDatasink(Datasink[None]):
 
             block = BlockAccessor.for_block(block).to_arrow()
 
-            client = bigquery_datasource._create_client(project=project_id)
+            client = bigquery_datasource._create_client(project_id=project_id)
             job_config = bigquery.LoadJobConfig(autodetect=True)
             job_config.source_format = bigquery.SourceFormat.PARQUET
             job_config.write_disposition = bigquery.WriteDisposition.WRITE_APPEND


### PR DESCRIPTION
When trying to write to bigquery with `dataset.write_bigquery(...)``, I get the exception `TypeError: _create_client() got an unexpected keyword argument 'project'`

This seems to be a slight mismatch in function signatures and was unfortunately not picked up by tests due to the level at which mocking was applied 

Fixes: https://github.com/ray-project/ray/issues/50991

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
