### PR TITLE
Fix editorconfig option name

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ indent_size = 4
 
 [*.{h,hpp,hxx,cpp,cxx,cc,c}]
 indent_size = 2
-wrap_width = 90
+max_line_length = 90
 
 [*.html]
 indent_size = 2
@@ -22,7 +22,7 @@ indent_size = 2
 
 [*.{py,pyx,pxd,pxi}]
 indent_size = 4
-wrap_width = 79
+max_line_length = 79
 
 [*.sh]
 indent_size = 2


### PR DESCRIPTION
wrap_width is not defined and doesn't do anything: https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [x] This PR is not tested :(
