### PR TITLE
ensure deployment name does not contain #

### DIFF
--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -127,7 +127,7 @@ class Deployment:
         # name does not contain #
         if "#" in name:
             warnings.warn(
-                f"Deployment names cannot contain '#' character, this will raise an error in a future release. "
+                f"Deployment names should not contain the '#' character, this will raise an error after 3 releases. "
                 f"Current name: {name}."
             )
 

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -2,6 +2,7 @@ import inspect
 import logging
 from copy import deepcopy
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+import warnings
 
 from ray.serve._private.config import (
     DeploymentConfig,
@@ -125,7 +126,10 @@ class Deployment:
 
         # name does not contain #
         if "#" in name:
-            raise ValueError("name cannot contain #")
+            warnings.warn(
+                f"Name cannot contain '#' character, it will be removed in future releases. "
+                f"Current name: {name}."
+            )
 
     @property
     def name(self) -> str:

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -101,8 +101,7 @@ class Deployment:
                 "The Deployment constructor should not be called "
                 "directly. Use `@serve.deployment` instead."
             )
-        if not isinstance(name, str):
-            raise TypeError("name must be a string.")
+        self._validate_name(name)
         if not (version is None or isinstance(version, str)):
             raise TypeError("version must be a string.")
         docs_path = None
@@ -119,6 +118,14 @@ class Deployment:
         self._deployment_config = deployment_config
         self._replica_config = replica_config
         self._docs_path = docs_path
+
+    def _validate_name(self, name: str):
+        if not isinstance(name, str):
+            raise TypeError("name must be a string.")
+
+        # name does not contain #
+        if "#" in name:
+            raise ValueError("name cannot contain #")
 
     @property
     def name(self) -> str:

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -127,7 +127,7 @@ class Deployment:
         # name does not contain #
         if "#" in name:
             warnings.warn(
-                f"Name cannot contain '#' character, it will be removed in future releases. "
+                f"Deployment names cannot contain '#' character, this will raise an error in a future release. "
                 f"Current name: {name}."
             )
 

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -127,7 +127,7 @@ class Deployment:
         # name does not contain #
         if "#" in name:
             warnings.warn(
-                f"Deployment names should not contain the '#' character, this will raise an error after 3 releases. "
+                f"Deployment names should not contain the '#' character, this will raise an error starting in Ray 2.46.0. "
                 f"Current name: {name}."
             )
 

--- a/python/ray/serve/tests/unit/test_build_app.py
+++ b/python/ray/serve/tests/unit/test_build_app.py
@@ -130,6 +130,20 @@ def test_single_deployment_custom_name():
         ],
     )
 
+    with pytest.raises(ValueError):
+
+        @serve.deployment(name="test#deployment")
+        def my_deployment():
+            return "Hello!"
+
+    with pytest.raises(ValueError):
+
+        @serve.deployment()
+        def my_deployment():
+            return "Hello!"
+
+        my_deployment.options(name="test#deployment")
+
 
 def test_multi_deployment_basic():
     @serve.deployment(num_replicas=3)

--- a/python/ray/serve/tests/unit/test_build_app.py
+++ b/python/ray/serve/tests/unit/test_build_app.py
@@ -130,13 +130,14 @@ def test_single_deployment_custom_name():
         ],
     )
 
-    with pytest.raises(ValueError):
+    # Change to `with pytest.raises(ValueError)` when the warning is removed.
+    with pytest.warns(UserWarning):
 
         @serve.deployment(name="test#deployment")
         def my_deployment():
             return "Hello!"
 
-    with pytest.raises(ValueError):
+    with pytest.warns(UserWarning):
 
         @serve.deployment()
         def my_deployment():


### PR DESCRIPTION
## Why are these changes needed?

Currently, `#` is allowed in deployment names, but it is also used as a delimiter when recovering from a checkpoint to infer the app, deployment, and replica. This leads to ambiguity and potential issues during recovery.

To resolve this, we are now prohibiting `#` in deployment names.

This change introduces an incompatibility for users who have already used `#` in their deployment names but do not use the checkpointing feature. I suspect this group is mostly tinkerers rather than production users, but I'm interested in hearing the reviewers' thoughts.

An alternative approach would be to escape `#` during checkpoint serialization and unescape it during deserialization. However, this felt like unnecessary complexity for limited benefit. That said, I'm open to revisiting this if reviewers prefer that approach.

## Related Issue

Fixes #48260  

## Checks

- Added unit tests.
