### PR TITLE
make latency buckets configurable

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -95,7 +95,7 @@ def parse_latency_buckets(bucket_str: str, default_buckets: list) -> list:
         if any(x <= 0 for x in buckets):
             raise ValueError("Bucket values must be positive")
         if sorted(set(buckets)) != buckets:
-            raise ValueError("Bucket values must be in ascending order and unique")
+            raise ValueError("Bucket values must be in strictly ascending order")
         return buckets
     except Exception as e:
         raise ValueError(

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -84,9 +84,9 @@ DEFAULT_LATENCY_BUCKET_MS = [
 ]
 
 
-def _parse_latency_buckets(bucket_str: str) -> list:
-    if not bucket_str.strip():
-        return DEFAULT_LATENCY_BUCKET_MS
+def parse_latency_buckets(bucket_str: str, default_buckets: list) -> list:
+    if bucket_str.strip() == "":
+        return default_buckets
     try:
         # Convert string to list of floats
         buckets = [float(x.strip()) for x in bucket_str.split(",")]
@@ -108,12 +108,12 @@ def _parse_latency_buckets(bucket_str: str) -> list:
 # RAY_SERVE_REQUEST_LATENCY_BUCKET_MS="1,2,3,4"
 # RAY_SERVE_MODEL_LOAD_LATENCY_BUCKET_MS="1,2,3,4"
 #: Histogram buckets for request latency.
-REQUEST_LATENCY_BUCKET_MS = _parse_latency_buckets(
-    os.getenv("REQUEST_LATENCY_BUCKET_MS", "")
+REQUEST_LATENCY_BUCKETS_MS = parse_latency_buckets(
+    os.getenv("REQUEST_LATENCY_BUCKETS_MS", ""), DEFAULT_LATENCY_BUCKET_MS
 )
 #: Histogram buckets for model load/unload latency.
-MODEL_LOAD_LATENCY_BUCKET_MS = _parse_latency_buckets(
-    os.getenv("MODEL_LOAD_LATENCY_BUCKET_MS", "")
+MODEL_LOAD_LATENCY_BUCKETS_MS = parse_latency_buckets(
+    os.getenv("MODEL_LOAD_LATENCY_BUCKETS_MS", ""), DEFAULT_LATENCY_BUCKET_MS
 )
 
 #: Name of deployment health check method implemented by user.

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -49,6 +49,11 @@ MAX_DEPLOYMENT_CONSTRUCTOR_RETRY_COUNT = int(
     os.environ.get("MAX_DEPLOYMENT_CONSTRUCTOR_RETRY_COUNT", "20")
 )
 
+# If you are wondering why we are using histogram buckets, please refer to
+# https://prometheus.io/docs/practices/histograms/
+# short answer is that its cheaper to calculate percentiles on the histogram
+# than to calculate them on raw data, both in terms of time and space.
+
 #: Default histogram buckets for latency tracker.
 DEFAULT_LATENCY_BUCKET_MS = [
     1,
@@ -77,6 +82,39 @@ DEFAULT_LATENCY_BUCKET_MS = [
     # 10 min
     600000,
 ]
+
+
+def _parse_latency_buckets(bucket_str: str) -> list:
+    if not bucket_str.strip():
+        return DEFAULT_LATENCY_BUCKET_MS
+    try:
+        # Convert string to list of floats
+        buckets = [float(x.strip()) for x in bucket_str.split(",")]
+        if not buckets:
+            raise ValueError("Empty bucket list")
+        if any(x <= 0 for x in buckets):
+            raise ValueError("Bucket values must be positive")
+        if sorted(set(buckets)) != buckets:
+            raise ValueError("Bucket values must be in ascending order and unique")
+        return buckets
+    except Exception as e:
+        raise ValueError(
+            f"Invalid format for {bucket_str}. "
+            f"Expected comma-separated positive numbers in ascending order. Error: {str(e)}"
+        )
+
+
+# Example usage:
+# RAY_SERVE_REQUEST_LATENCY_BUCKET_MS="1,2,3,4"
+# RAY_SERVE_MODEL_LOAD_LATENCY_BUCKET_MS="1,2,3,4"
+#: Histogram buckets for request latency.
+REQUEST_LATENCY_BUCKET_MS = _parse_latency_buckets(
+    os.getenv("REQUEST_LATENCY_BUCKET_MS", "")
+)
+#: Histogram buckets for model load/unload latency.
+MODEL_LOAD_LATENCY_BUCKET_MS = _parse_latency_buckets(
+    os.getenv("MODEL_LOAD_LATENCY_BUCKET_MS", "")
+)
 
 #: Name of deployment health check method implemented by user.
 HEALTH_CHECK_METHOD = "check_health"

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -31,7 +31,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_ENABLE_PROXY_GC_OPTIMIZATIONS,
     RAY_SERVE_HTTP_PROXY_CALLBACK_IMPORT_PATH,
     RAY_SERVE_PROXY_GC_THRESHOLD,
-    REQUEST_LATENCY_BUCKET_MS,
+    REQUEST_LATENCY_BUCKETS_MS,
     SERVE_CONTROLLER_NAME,
     SERVE_LOGGER_NAME,
     SERVE_MULTIPLEXED_MODEL_ID,
@@ -183,14 +183,14 @@ class GenericProxy(ABC):
         )
 
         # log REQUEST_LATENCY_BUCKET_MS
-        logger.debug(f"REQUEST_LATENCY_BUCKET_MS: {REQUEST_LATENCY_BUCKET_MS}")
+        logger.debug(f"REQUEST_LATENCY_BUCKET_MS: {REQUEST_LATENCY_BUCKETS_MS}")
         self.processing_latency_tracker = metrics.Histogram(
             f"serve_{self.protocol.lower()}_request_latency_ms",
             description=(
                 f"The end-to-end latency of {self.protocol} requests "
                 f"(measured from the Serve {self.protocol} proxy)."
             ),
-            boundaries=REQUEST_LATENCY_BUCKET_MS,
+            boundaries=REQUEST_LATENCY_BUCKETS_MS,
             tag_keys=(
                 "method",
                 "route",

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -27,11 +27,11 @@ from ray.serve._private.common import (
     RequestProtocol,
 )
 from ray.serve._private.constants import (
-    DEFAULT_LATENCY_BUCKET_MS,
     PROXY_MIN_DRAINING_PERIOD_S,
     RAY_SERVE_ENABLE_PROXY_GC_OPTIMIZATIONS,
     RAY_SERVE_HTTP_PROXY_CALLBACK_IMPORT_PATH,
     RAY_SERVE_PROXY_GC_THRESHOLD,
+    REQUEST_LATENCY_BUCKET_MS,
     SERVE_CONTROLLER_NAME,
     SERVE_LOGGER_NAME,
     SERVE_MULTIPLEXED_MODEL_ID,
@@ -182,13 +182,15 @@ class GenericProxy(ABC):
             ),
         )
 
+        # log REQUEST_LATENCY_BUCKET_MS
+        logger.debug(f"REQUEST_LATENCY_BUCKET_MS: {REQUEST_LATENCY_BUCKET_MS}")
         self.processing_latency_tracker = metrics.Histogram(
             f"serve_{self.protocol.lower()}_request_latency_ms",
             description=(
                 f"The end-to-end latency of {self.protocol} requests "
                 f"(measured from the Serve {self.protocol} proxy)."
             ),
-            boundaries=DEFAULT_LATENCY_BUCKET_MS,
+            boundaries=REQUEST_LATENCY_BUCKET_MS,
             tag_keys=(
                 "method",
                 "route",

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -54,7 +54,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_RUN_SYNC_IN_THREADPOOL,
     RAY_SERVE_RUN_SYNC_IN_THREADPOOL_WARNING,
     RECONFIGURE_METHOD,
-    REQUEST_LATENCY_BUCKET_MS,
+    REQUEST_LATENCY_BUCKETS_MS,
     SERVE_CONTROLLER_NAME,
     SERVE_LOGGER_NAME,
     SERVE_NAMESPACE,
@@ -175,11 +175,11 @@ class ReplicaMetricsManager:
             self._cached_error_counter = defaultdict(int)
 
         # log REQUEST_LATENCY_BUCKET_MS
-        logger.debug(f"REQUEST_LATENCY_BUCKET_MS: {REQUEST_LATENCY_BUCKET_MS}")
+        logger.debug(f"REQUEST_LATENCY_BUCKETS_MS: {REQUEST_LATENCY_BUCKETS_MS}")
         self._processing_latency_tracker = metrics.Histogram(
             "serve_deployment_processing_latency_ms",
             description="The latency for queries to be processed.",
-            boundaries=REQUEST_LATENCY_BUCKET_MS,
+            boundaries=REQUEST_LATENCY_BUCKETS_MS,
             tag_keys=("route",),
         )
         if self._cached_metrics_enabled:

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -46,7 +46,6 @@ from ray.serve._private.common import (
 )
 from ray.serve._private.config import DeploymentConfig
 from ray.serve._private.constants import (
-    DEFAULT_LATENCY_BUCKET_MS,
     GRPC_CONTEXT_ARG_NAME,
     HEALTH_CHECK_METHOD,
     RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE,
@@ -55,6 +54,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_RUN_SYNC_IN_THREADPOOL,
     RAY_SERVE_RUN_SYNC_IN_THREADPOOL_WARNING,
     RECONFIGURE_METHOD,
+    REQUEST_LATENCY_BUCKET_MS,
     SERVE_CONTROLLER_NAME,
     SERVE_LOGGER_NAME,
     SERVE_NAMESPACE,
@@ -174,10 +174,12 @@ class ReplicaMetricsManager:
         if self._cached_metrics_enabled:
             self._cached_error_counter = defaultdict(int)
 
+        # log REQUEST_LATENCY_BUCKET_MS
+        logger.debug(f"REQUEST_LATENCY_BUCKET_MS: {REQUEST_LATENCY_BUCKET_MS}")
         self._processing_latency_tracker = metrics.Histogram(
             "serve_deployment_processing_latency_ms",
             description="The latency for queries to be processed.",
-            boundaries=DEFAULT_LATENCY_BUCKET_MS,
+            boundaries=REQUEST_LATENCY_BUCKET_MS,
             tag_keys=("route",),
         )
         if self._cached_metrics_enabled:

--- a/python/ray/serve/multiplex.py
+++ b/python/ray/serve/multiplex.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, List, Set
 from ray.serve import metrics
 from ray.serve._private.common import MultiplexedReplicaInfo
 from ray.serve._private.constants import (
-    MODEL_LOAD_LATENCY_BUCKET_MS,
+    MODEL_LOAD_LATENCY_BUCKETS_MS,
     PUSH_MULTIPLEXED_MODEL_IDS_INTERVAL_S,
     SERVE_LOGGER_NAME,
 )
@@ -59,16 +59,16 @@ class _ModelMultiplexWrapper:
         self.max_num_models_per_replica: int = max_num_models_per_replica
 
         # log MODEL_LOAD_LATENCY_BUCKET_MS
-        logger.debug(f"MODEL_LOAD_LATENCY_BUCKET_MS: {MODEL_LOAD_LATENCY_BUCKET_MS}")
+        logger.debug(f"MODEL_LOAD_LATENCY_BUCKET_MS: {MODEL_LOAD_LATENCY_BUCKETS_MS}")
         self.model_load_latency_ms = metrics.Histogram(
             "serve_multiplexed_model_load_latency_ms",
             description="The time it takes to load a model.",
-            boundaries=MODEL_LOAD_LATENCY_BUCKET_MS,
+            boundaries=MODEL_LOAD_LATENCY_BUCKETS_MS,
         )
         self.model_unload_latency_ms = metrics.Histogram(
             "serve_multiplexed_model_unload_latency_ms",
             description="The time it takes to unload a model.",
-            boundaries=MODEL_LOAD_LATENCY_BUCKET_MS,
+            boundaries=MODEL_LOAD_LATENCY_BUCKETS_MS,
         )
         self.num_models_gauge = metrics.Gauge(
             "serve_num_multiplexed_models",

--- a/python/ray/serve/multiplex.py
+++ b/python/ray/serve/multiplex.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, List, Set
 from ray.serve import metrics
 from ray.serve._private.common import MultiplexedReplicaInfo
 from ray.serve._private.constants import (
-    DEFAULT_LATENCY_BUCKET_MS,
+    MODEL_LOAD_LATENCY_BUCKET_MS,
     PUSH_MULTIPLEXED_MODEL_IDS_INTERVAL_S,
     SERVE_LOGGER_NAME,
 )
@@ -58,15 +58,17 @@ class _ModelMultiplexWrapper:
         self.self_arg: Any = self_arg
         self.max_num_models_per_replica: int = max_num_models_per_replica
 
+        # log MODEL_LOAD_LATENCY_BUCKET_MS
+        logger.debug(f"MODEL_LOAD_LATENCY_BUCKET_MS: {MODEL_LOAD_LATENCY_BUCKET_MS}")
         self.model_load_latency_ms = metrics.Histogram(
             "serve_multiplexed_model_load_latency_ms",
             description="The time it takes to load a model.",
-            boundaries=DEFAULT_LATENCY_BUCKET_MS,
+            boundaries=MODEL_LOAD_LATENCY_BUCKET_MS,
         )
         self.model_unload_latency_ms = metrics.Histogram(
             "serve_multiplexed_model_unload_latency_ms",
             description="The time it takes to unload a model.",
-            boundaries=DEFAULT_LATENCY_BUCKET_MS,
+            boundaries=MODEL_LOAD_LATENCY_BUCKET_MS,
         )
         self.num_models_gauge = metrics.Gauge(
             "serve_num_multiplexed_models",

--- a/python/ray/serve/tests/test_constants.py
+++ b/python/ray/serve/tests/test_constants.py
@@ -1,0 +1,45 @@
+import pytest
+from ray.serve._private.constants import (
+    DEFAULT_LATENCY_BUCKET_MS,
+    _parse_latency_buckets,
+)
+
+
+def test_parse_latency_buckets():
+    # Test empty string returns default buckets
+    assert _parse_latency_buckets("") == DEFAULT_LATENCY_BUCKET_MS
+
+    # Test valid inputs with different formats
+    assert _parse_latency_buckets("1,2,3") == [1.0, 2.0, 3.0]
+    assert _parse_latency_buckets("1,2,3,4 ") == [1.0, 2.0, 3.0, 4.0]
+    assert _parse_latency_buckets("  1,2,3,4,5") == [1.0, 2.0, 3.0, 4.0, 5.0]
+    assert _parse_latency_buckets(" 1, 2,3  ,4,5 ,6 ") == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+
+    # Test decimal numbers
+    assert _parse_latency_buckets("0.5,1.5,2.5") == [0.5, 1.5, 2.5]
+
+
+def test_parse_latency_buckets_invalid():
+    # Test negative numbers
+    with pytest.raises(ValueError, match=".*must be positive.*"):
+        _parse_latency_buckets("-1,1,2,3,4")
+
+    # Test non-ascending order
+    with pytest.raises(ValueError, match=".*must be in ascending order.*"):
+        _parse_latency_buckets("4,3,2,1")
+
+    # Test duplicate values
+    with pytest.raises(ValueError, match=".*must be in ascending order.*"):
+        _parse_latency_buckets("1,2,2,3,4")
+
+    # Test invalid number format
+    with pytest.raises(ValueError, match=".*Invalid.*format.*"):
+        _parse_latency_buckets("1,2,3,4,a")
+
+    # Test empty list
+    with pytest.raises(ValueError, match=".*could not convert.*"):
+        _parse_latency_buckets(",,,")
+
+    # Test invalid separators
+    with pytest.raises(ValueError, match=".*could not convert.*"):
+        _parse_latency_buckets("1;2;3;4")

--- a/python/ray/serve/tests/test_constants.py
+++ b/python/ray/serve/tests/test_constants.py
@@ -1,45 +1,55 @@
 import pytest
 from ray.serve._private.constants import (
     DEFAULT_LATENCY_BUCKET_MS,
-    _parse_latency_buckets,
+    parse_latency_buckets,
 )
 
 
 def test_parse_latency_buckets():
     # Test empty string returns default buckets
-    assert _parse_latency_buckets("") == DEFAULT_LATENCY_BUCKET_MS
+    assert (
+        parse_latency_buckets("", DEFAULT_LATENCY_BUCKET_MS)
+        == DEFAULT_LATENCY_BUCKET_MS
+    )
 
     # Test valid inputs with different formats
-    assert _parse_latency_buckets("1,2,3") == [1.0, 2.0, 3.0]
-    assert _parse_latency_buckets("1,2,3,4 ") == [1.0, 2.0, 3.0, 4.0]
-    assert _parse_latency_buckets("  1,2,3,4,5") == [1.0, 2.0, 3.0, 4.0, 5.0]
-    assert _parse_latency_buckets(" 1, 2,3  ,4,5 ,6 ") == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    assert parse_latency_buckets("1,2,3", []) == [1.0, 2.0, 3.0]
+    assert parse_latency_buckets("1,2,3,4 ", []) == [1.0, 2.0, 3.0, 4.0]
+    assert parse_latency_buckets("  1,2,3,4,5", []) == [1.0, 2.0, 3.0, 4.0, 5.0]
+    assert parse_latency_buckets(" 1, 2,3  ,4,5 ,6 ", []) == [
+        1.0,
+        2.0,
+        3.0,
+        4.0,
+        5.0,
+        6.0,
+    ]
 
     # Test decimal numbers
-    assert _parse_latency_buckets("0.5,1.5,2.5") == [0.5, 1.5, 2.5]
+    assert parse_latency_buckets("0.5,1.5,2.5", []) == [0.5, 1.5, 2.5]
 
 
 def test_parse_latency_buckets_invalid():
     # Test negative numbers
     with pytest.raises(ValueError, match=".*must be positive.*"):
-        _parse_latency_buckets("-1,1,2,3,4")
+        parse_latency_buckets("-1,1,2,3,4", [])
 
     # Test non-ascending order
     with pytest.raises(ValueError, match=".*must be in ascending order.*"):
-        _parse_latency_buckets("4,3,2,1")
+        parse_latency_buckets("4,3,2,1", [])
 
     # Test duplicate values
     with pytest.raises(ValueError, match=".*must be in ascending order.*"):
-        _parse_latency_buckets("1,2,2,3,4")
+        parse_latency_buckets("1,2,2,3,4", [])
 
     # Test invalid number format
     with pytest.raises(ValueError, match=".*Invalid.*format.*"):
-        _parse_latency_buckets("1,2,3,4,a")
+        parse_latency_buckets("1,2,3,4,a", [])
 
     # Test empty list
     with pytest.raises(ValueError, match=".*could not convert.*"):
-        _parse_latency_buckets(",,,")
+        parse_latency_buckets(",,,", [])
 
     # Test invalid separators
     with pytest.raises(ValueError, match=".*could not convert.*"):
-        _parse_latency_buckets("1;2;3;4")
+        parse_latency_buckets("1;2;3;4", [])

--- a/python/ray/serve/tests/unit/test_constants.py
+++ b/python/ray/serve/tests/unit/test_constants.py
@@ -53,3 +53,9 @@ def test_parse_latency_buckets_invalid():
     # Test invalid separators
     with pytest.raises(ValueError, match=".*could not convert.*"):
         parse_latency_buckets("1;2;3;4", [])
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/unit/test_constants.py
+++ b/python/ray/serve/tests/unit/test_constants.py
@@ -35,11 +35,11 @@ def test_parse_latency_buckets_invalid():
         parse_latency_buckets("-1,1,2,3,4", [])
 
     # Test non-ascending order
-    with pytest.raises(ValueError, match=".*must be in ascending order.*"):
+    with pytest.raises(ValueError, match=".*be in strictly ascending order*"):
         parse_latency_buckets("4,3,2,1", [])
 
     # Test duplicate values
-    with pytest.raises(ValueError, match=".*must be in ascending order.*"):
+    with pytest.raises(ValueError, match=".*be in strictly ascending order.*"):
         parse_latency_buckets("1,2,2,3,4", [])
 
     # Test invalid number format


### PR DESCRIPTION
## Why are these changes needed?

The choice of bucket boundaries in Prometheus is an application-level decision. Well-defined boundaries lead to more accurate quantile calculations, while poor choices can result in less precise estimates. 

This PR exposes bucket boundary configuration to users via two environment variables:  
- `REQUEST_LATENCY_BUCKET_MS`  
- `MODEL_LOAD_LATENCY_BUCKET_MS`  

This allows users to fine-tune latency measurement based on their needs.

Change is backwards compatible

See #38223 for a more detailed rationale.  

## Related Issue

Fixes #38223  

## Checks

- Added unit tests.  
