### PR TITLE
[serve.llm][bugfix] Fix the wrong device_capability issue in vllm on quantized models.

### DIFF
--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
@@ -115,8 +115,11 @@ def clear_current_platform_cache():
     """
     from vllm.platforms import current_platform
 
-    if hasattr(current_platform.get_device_compatibility, "clear_cache"):
-        current_platform.get_device_compatibility.clear_cache()
+    # This check is just to future proof this implementation 
+    # in case vllm removes their lru_cache decorator
+    if hasattr(current_platform.get_device_capability, "cache_clear"):
+        logger.info("Clearing the current platform cache ...")
+        current_platform.get_device_capability.cache_clear()
 
 
 class BatchLLMRawResponses:

--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
@@ -97,7 +97,7 @@ def _get_vllm_engine_config(
     return async_engine_args, vllm_config
 
 
-def clear_current_platform_cache():
+def _clear_current_platform_cache():
     """Clear the cache of the current platform.
 
     vllm current has an lru cache for getting device compatibility
@@ -221,7 +221,7 @@ class _EngineBackgroundProcess:
         from vllm.executor.ray_distributed_executor import RayDistributedExecutor
 
         # Clear the cache of the current platform.
-        clear_current_platform_cache()
+        _clear_current_platform_cache()
 
         self.engine = MQLLMEngine(
             ipc_path=ipc_path,
@@ -389,7 +389,7 @@ class VLLMEngine:
 
         vllm_config.parallel_config.placement_group = placement_group
 
-        clear_current_platform_cache()
+        _clear_current_platform_cache()
 
         return vllm.engine.async_llm_engine.AsyncLLMEngine(
             vllm_config=vllm_config,

--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
@@ -97,6 +97,28 @@ def _get_vllm_engine_config(
     return async_engine_args, vllm_config
 
 
+def clear_current_platform_cache():
+    """Clear the cache of the current platform.
+
+    vllm current has an lru cache for getting device compatibility
+    that will not have the correct returned value if
+    CUDA_VISIBLE_DEVICES is not set properly. In RayLLM eventually
+    when we want to create the engine the env will be set properly,
+    but till then, upon the import of vllm somewhere
+    (which is a mystery) the lru cache will have the wrong value.
+    This function will clear the cache so that the next time the
+    cache is accessed, it will be re-evaluated.
+
+    Related issues:
+    https://github.com/vllm-project/vllm/issues/8402
+    https://github.com/vllm-project/vllm/issues/7890
+    """
+    from vllm.platforms import current_platform
+
+    if hasattr(current_platform.get_device_compatibility, "clear_cache"):
+        current_platform.get_device_compatibility.clear_cache()
+
+
 class BatchLLMRawResponses:
     """This class batches multiple LLMRawResponses from a generator into a
     single response, at some time interval.
@@ -197,6 +219,9 @@ class _EngineBackgroundProcess:
         # with vllm 0.7.3. However, in Ray's llm package, we will enforce the use of
         # ray distributed executor for all cases so it's always compatible with Ray.
         from vllm.executor.ray_distributed_executor import RayDistributedExecutor
+
+        # Clear the cache of the current platform.
+        clear_current_platform_cache()
 
         self.engine = MQLLMEngine(
             ipc_path=ipc_path,
@@ -360,12 +385,15 @@ class VLLMEngine:
         placement_group: PlacementGroup,
     ) -> "EngineClient":
         """Creates an async LLM engine from the engine arguments."""
+        from vllm.executor.ray_distributed_executor import RayDistributedExecutor
 
         vllm_config.parallel_config.placement_group = placement_group
 
+        clear_current_platform_cache()
+
         return vllm.engine.async_llm_engine.AsyncLLMEngine(
             vllm_config=vllm_config,
-            executor_class=vllm.executor.ray_distributed_executor.RayDistributedExecutor,
+            executor_class=RayDistributedExecutor,
             log_stats=not engine_args.disable_log_stats,
         )
 

--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
@@ -115,7 +115,7 @@ def clear_current_platform_cache():
     """
     from vllm.platforms import current_platform
 
-    # This check is just to future proof this implementation 
+    # This check is just to future proof this implementation
     # in case vllm removes their lru_cache decorator
     if hasattr(current_platform.get_device_capability, "cache_clear"):
         logger.info("Clearing the current platform cache ...")


### PR DESCRIPTION
Fixes a bug where get_device_capability() was getting cached based on the wrong environment variables. `vllm` assumes that upon import the `CUDA_AVAILABLE_DEVICES` will have their final values and will cache some attributes like cuda device compatibility. 


If later we use ray actors to serialize the modules over the cache apparently also gets serialized with the wrong values. This PR clears the cache before creating engine so the values will be recomputed based on the right env variables. 