### PR TITLE
[doc] use python3 ipython in web-crawler

### DIFF
--- a/doc/source/ray-core/examples/web-crawler.ipynb
+++ b/doc/source/ray-core/examples/web-crawler.ipynb
@@ -242,8 +242,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.19"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
stop using python2
