### PR TITLE
[core][1/N] Make executor to be a long-running Python thread

### DIFF
--- a/python/ray/_raylet.pxd
+++ b/python/ray/_raylet.pxd
@@ -76,6 +76,16 @@ cdef extern from "Python.h":
     int Py_GetRecursionLimit()
     void Py_SetRecursionLimit(int)
 
+# Note that `functional.pxd` in the Cython repository supports only a limited subset of
+# <functional>. Therefore, `from libcpp.functional cimport function` is not enough, and we
+# still need to expose some functions here.
+cdef extern from "<functional>" namespace "std" nogil:
+    T bind[T, Args](T callable, Args args)
+    # Reference: https://github.com/scipy/scipy/blob/6b56162fa6880b0182faea44af88d6a1587f35a8/scipy/stats/_qmc_cy.pyx#L31-L34
+    cdef cppclass reference_wrapper[T]:
+        pass
+    cdef reference_wrapper[T] ref[T](T&)
+
 cdef class Buffer:
     cdef:
         shared_ptr[CBuffer] buffer

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -61,6 +61,7 @@ from ray.includes.optional cimport (
     make_optional,
 )
 
+from libcpp.functional cimport function
 from libcpp.string cimport string as c_string
 from libcpp.utility cimport pair
 from libcpp.unordered_map cimport unordered_map
@@ -68,6 +69,10 @@ from libcpp.vector cimport vector as c_vector
 from libcpp.pair cimport pair as c_pair
 
 from cython.operator import dereference, postincrement
+from cpython.pystate cimport (
+    PyGILState_Ensure,
+    PyGILState_Release,
+)
 
 from ray.includes.common cimport (
     CBuffer,
@@ -2241,6 +2246,23 @@ cdef shared_ptr[LocalMemoryBuffer] ray_error_to_memory_buf(ray_error):
     return make_shared[LocalMemoryBuffer](
         <uint8_t*>py_bytes, len(py_bytes), True)
 
+cdef function[void()] initialize_pygilstate_for_thread() nogil:
+    """
+    This function initializes a C++ thread to make it be considered as a
+    Python thread from the Python interpreter's perspective, regardless of whether
+    it is executing Python code or not. This function must be called in a thread
+    before executing any Ray tasks on that thread.
+    Returns:
+        A function that calls `PyGILState_Release` to release the GIL state.
+        This function should be called in a thread before the thread exits.
+    Reference: https://docs.python.org/3/c-api/init.html#non-python-created-threads
+    """
+    cdef function[void()] callback
+    with gil:
+        gstate = PyGILState_Ensure()
+        callback = bind(PyGILState_Release, ref(gstate))
+    return callback
+
 cdef CRayStatus task_execution_handler(
         const CAddress &caller_address,
         CTaskType task_type,
@@ -2990,6 +3012,7 @@ cdef class CoreWorker:
         options.node_manager_port = node_manager_port
         options.raylet_ip_address = raylet_ip_address.encode("utf-8")
         options.driver_name = driver_name
+        options.initialize_thread_callback = initialize_pygilstate_for_thread
         options.task_execution_callback = task_execution_handler
         options.check_signals = check_signals
         options.gc_collect = gc_collect

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2252,9 +2252,11 @@ cdef function[void()] initialize_pygilstate_for_thread() nogil:
     Python thread from the Python interpreter's perspective, regardless of whether
     it is executing Python code or not. This function must be called in a thread
     before executing any Ray tasks on that thread.
+
     Returns:
         A function that calls `PyGILState_Release` to release the GIL state.
         This function should be called in a thread before the thread exits.
+
     Reference: https://docs.python.org/3/c-api/init.html#non-python-created-threads
     """
     cdef function[void()] callback

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -4,6 +4,7 @@
 
 from libc.stdint cimport int64_t, uint64_t
 from libcpp cimport bool as c_bool
+from libcpp.functional cimport function
 from libcpp.memory cimport shared_ptr, unique_ptr
 from libcpp.pair cimport pair as c_pair
 from libcpp.string cimport string as c_string
@@ -69,7 +70,6 @@ ctypedef void (*plasma_callback_function) \
 # "pair[shared_ptr[const CActorHandle], CRayStatus]".
 # This is a bug of cython: https://github.com/cython/cython/issues/3967.
 ctypedef shared_ptr[const CActorHandle] ActorHandleSharedPtr
-
 
 cdef extern from "ray/core_worker/profile_event.h" nogil:
     cdef cppclass CProfileEvent "ray::core::worker::ProfileEvent":
@@ -404,6 +404,7 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
             int64_t generator_backpressure_num_objects
         ) nogil) task_execution_callback
         (void(const CWorkerID &) nogil) on_worker_shutdown
+        (function[void()]() nogil) initialize_thread_callback
         (CRayStatus() nogil) check_signals
         (void(c_bool) nogil) gc_collect
         (c_vector[c_string](

--- a/python/ray/tests/test_concurrency_group.py
+++ b/python/ray/tests/test_concurrency_group.py
@@ -6,6 +6,7 @@ import pytest
 import ray
 import time
 
+from typing import Any, Tuple
 from ray._private.utils import get_or_create_event_loop
 from ray._private.test_utils import run_string_as_driver
 
@@ -178,6 +179,60 @@ def test_system_concurrency_group(ray_start_regular_shared):
     n = NormalActor.remote()
     n.block_forever.options(concurrency_group="_ray_system").remote()
     print(ray.get(n.ping.remote()))
+
+
+@ray.remote(concurrency_groups={"io": 1, "compute": 1})
+class Actor:
+    def __init__(self):
+        self._thread_local_data = threading.local()
+
+    def set_thread_local(self, value: Any) -> int:
+        self._thread_local_data.value = value
+        return threading.current_thread().ident
+
+    def get_thread_local(self) -> Tuple[Any, int]:
+        return self._thread_local_data.value, threading.current_thread().ident
+
+
+class TestThreadingLocalData:
+    """
+    This test verifies that synchronous tasks can access thread local data
+    that was set by previous synchronous tasks.
+    """
+
+    def test_tasks_on_default_executor(self, ray_start_regular_shared):
+        a = Actor.remote()
+        tid_1 = ray.get(a.set_thread_local.remote("f1"))
+        value, tid_2 = ray.get(a.get_thread_local.remote())
+        assert tid_1 == tid_2
+        assert value == "f1"
+
+    def test_tasks_on_specific_executor(self, ray_start_regular_shared):
+        a = Actor.remote()
+        tid_1 = ray.get(a.set_thread_local.options(concurrency_group="io").remote("f1"))
+        value, tid_2 = ray.get(
+            a.get_thread_local.options(concurrency_group="io").remote()
+        )
+        assert tid_1 == tid_2
+        assert value == "f1"
+
+    def test_tasks_on_different_executors(self, ray_start_regular_shared):
+        a = Actor.remote()
+        tid_1 = ray.get(a.set_thread_local.options(concurrency_group="io").remote("f1"))
+        tid_3 = ray.get(
+            a.set_thread_local.options(concurrency_group="compute").remote("f2")
+        )
+        value, tid_2 = ray.get(
+            a.get_thread_local.options(concurrency_group="io").remote()
+        )
+        assert tid_1 == tid_2
+        assert value == "f1"
+
+        value, tid_4 = ray.get(
+            a.get_thread_local.options(concurrency_group="compute").remote()
+        )
+        assert tid_3 == tid_4
+        assert value == "f2"
 
 
 def test_invalid_concurrency_group():

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -422,6 +422,7 @@ CoreWorker::CoreWorker(CoreWorkerOptions options, const WorkerID &worker_id)
         task_execution_service_,
         *task_event_buffer_,
         execute_task,
+        options_.initialize_thread_callback,
         [this] { return local_raylet_client_->ActorCreationTaskDone(); });
   }
 

--- a/src/ray/core_worker/core_worker_options.h
+++ b/src/ray/core_worker/core_worker_options.h
@@ -82,6 +82,7 @@ struct CoreWorkerOptions {
         driver_name(""),
         task_execution_callback(nullptr),
         check_signals(nullptr),
+        initialize_thread_callback(nullptr),
         gc_collect(nullptr),
         spill_objects(nullptr),
         restore_spilled_objects(nullptr),
@@ -136,7 +137,7 @@ struct CoreWorkerOptions {
   std::string raylet_ip_address;
   /// The name of the driver.
   std::string driver_name;
-  /// Language worker callback to execute tasks.
+  /// Application-language worker callback to execute tasks.
   TaskExecutionCallback task_execution_callback;
   /// The callback to be called when shutting down a `CoreWorker` instance.
   std::function<void(const WorkerID &)> on_worker_shutdown;
@@ -146,6 +147,9 @@ struct CoreWorkerOptions {
   /// any long-running operations in the core worker will short circuit and return that
   /// status.
   std::function<Status()> check_signals;
+  /// Application-language callback that initializes a thread and returns a function to
+  /// be called when the thread is destroyed.
+  std::function<std::function<void()>()> initialize_thread_callback;
   /// Application-language callback to trigger garbage collection in the language
   /// runtime. This is required to free distributed references that may otherwise
   /// be held up in garbage objects.

--- a/src/ray/core_worker/test/concurrency_group_manager_test.cc
+++ b/src/ray/core_worker/test/concurrency_group_manager_test.cc
@@ -41,6 +41,42 @@ TEST(ConcurrencyGroupManagerTest, TestEmptyConcurrencyGroupManager) {
 #endif
 }
 
+TEST(ConcurrencyGroupManagerTest, TestInitializeThreadCallback) {
+  /*
+  This test creates a ConcurrencyGroupManager with two threads: one for the default
+  concurrency group and one for the IO concurrency group. Then, it verifies that the
+  initialize_thread_callback is called for both default and IO executors after the
+  constructor is called. It also verifies that the release_callback is called for both
+  executors after the Stop method is called.
+  */
+
+  std::vector<ConcurrencyGroup> concurrency_groups{ConcurrencyGroup{"io", 1, {}}};
+  int init_count = 0;
+  int release_count = 0;
+
+  ConcurrencyGroupManager<BoundedExecutor> manager(
+      /* concurrency_groups= */ concurrency_groups,
+      /* max_concurrency_for_default_concurrency_group= */ 1,
+      /* initialize_thread_callback= */ [&init_count, &release_count]() {
+        init_count++;
+        return [&release_count]() { release_count++; };
+      });
+
+  // Verify initialize_thread_callback was called for both default and io executors
+  ASSERT_EQ(init_count, 2);
+  ASSERT_EQ(release_count, 0);
+
+  auto default_executor = manager.GetDefaultExecutor();
+  ASSERT_NE(default_executor, nullptr);
+
+  auto io_executor = manager.GetExecutor("io", {});
+  ASSERT_NE(io_executor, nullptr);
+
+  manager.Stop();
+  // Verify release callbacks were called for both executors
+  ASSERT_EQ(release_count, 2);
+}
+
 }  // namespace core
 }  // namespace ray
 

--- a/src/ray/core_worker/test/direct_actor_transport_test.cc
+++ b/src/ray/core_worker/test/direct_actor_transport_test.cc
@@ -813,11 +813,13 @@ class MockTaskReceiver : public TaskReceiver {
                    instrumented_io_context &main_io_service,
                    worker::TaskEventBuffer &task_event_buffer,
                    const TaskHandler &task_handler,
+                   std::function<std::function<void()>()> initialize_thread_callback,
                    const OnActorCreationTaskDone &actor_creation_task_done_)
       : TaskReceiver(worker_context,
                      main_io_service,
                      task_event_buffer,
                      task_handler,
+                     initialize_thread_callback,
                      actor_creation_task_done_) {}
 
   void UpdateConcurrencyGroupsCache(const ActorID &actor_id,
@@ -841,9 +843,12 @@ class TaskReceiverTest : public ::testing::Test {
                                   std::placeholders::_5,
                                   std::placeholders::_6);
     receiver_ = std::make_unique<MockTaskReceiver>(
-        worker_context_, main_io_service_, task_event_buffer_, execute_task, [] {
-          return Status::OK();
-        });
+        worker_context_,
+        main_io_service_,
+        task_event_buffer_,
+        execute_task,
+        /* intiialize_thread_callback= */ []() { return []() { return; }; },
+        /* actor_creation_task_done= */ []() { return Status::OK(); });
     receiver_->Init(std::make_shared<rpc::CoreWorkerClientPool>(
                         [&](const rpc::Address &addr) { return worker_client_; }),
                     rpc_address_,

--- a/src/ray/core_worker/transport/concurrency_group_manager.cc
+++ b/src/ray/core_worker/transport/concurrency_group_manager.cc
@@ -14,6 +14,8 @@
 
 #include "ray/core_worker/transport/concurrency_group_manager.h"
 
+#include <optional>
+
 #include "ray/core_worker/fiber.h"
 #include "ray/core_worker/transport/thread_pool.h"
 
@@ -23,11 +25,14 @@ namespace core {
 template <typename ExecutorType>
 ConcurrencyGroupManager<ExecutorType>::ConcurrencyGroupManager(
     const std::vector<ConcurrencyGroup> &concurrency_groups,
-    const int32_t max_concurrency_for_default_concurrency_group) {
+    const int32_t max_concurrency_for_default_concurrency_group,
+    std::function<std::function<void()>()> initialize_thread_callback)
+    : initialize_thread_callback_(std::move(initialize_thread_callback)) {
   for (auto &group : concurrency_groups) {
     const auto name = group.name;
     const auto max_concurrency = group.max_concurrency;
     auto executor = std::make_shared<ExecutorType>(max_concurrency);
+    executor_releasers_.push_back(InitializeExecutor(executor));
     auto &fds = group.function_descriptors;
     for (auto fd : fds) {
       functions_to_executor_index_[fd->ToString()] = executor;
@@ -43,6 +48,7 @@ ConcurrencyGroupManager<ExecutorType>::ConcurrencyGroupManager(
                                         !concurrency_groups.empty())) {
     default_executor_ =
         std::make_shared<ExecutorType>(max_concurrency_for_default_concurrency_group);
+    executor_releasers_.push_back(InitializeExecutor(default_executor_));
   }
 }
 
@@ -81,9 +87,50 @@ std::shared_ptr<ExecutorType> ConcurrencyGroupManager<ExecutorType>::GetDefaultE
   return default_executor_;
 }
 
+template <typename ExecutorType>
+std::optional<std::function<void()>>
+ConcurrencyGroupManager<ExecutorType>::InitializeExecutor(
+    std::shared_ptr<ExecutorType> executor) {
+  if (!initialize_thread_callback_) {
+    return std::nullopt;
+  }
+
+  if constexpr (std::is_same<ExecutorType, BoundedExecutor>::value) {
+    std::promise<void> init_promise;
+    auto init_future = init_promise.get_future();
+    auto initializer = initialize_thread_callback_;
+    std::function<void()> releaser;
+
+    executor->Post([&initializer, &init_promise, &releaser]() {
+      releaser = initializer();
+      init_promise.set_value();
+    });
+
+    // Wait for thread initialization to complete before executing any tasks in the
+    // executor.
+    init_future.wait();
+
+    return [executor, releaser]() {
+      std::promise<void> release_promise;
+      auto release_future = release_promise.get_future();
+      executor->Post([releaser, &release_promise]() {
+        releaser();
+        release_promise.set_value();
+      });
+      release_future.wait();
+    };
+  }
+  return std::nullopt;
+}
+
 /// Stop and join the executors that the this manager owns.
 template <typename ExecutorType>
 void ConcurrencyGroupManager<ExecutorType>::Stop() {
+  for (const auto &releaser : executor_releasers_) {
+    if (releaser.has_value()) {
+      releaser.value()();
+    }
+  }
   if (default_executor_) {
     RAY_LOG(DEBUG) << "Default executor is stopping.";
     default_executor_->Stop();

--- a/src/ray/core_worker/transport/task_receiver.cc
+++ b/src/ray/core_worker/transport/task_receiver.cc
@@ -174,10 +174,14 @@ void TaskReceiver::HandleTask(const rpc::PushTaskRequest &request,
         const int default_max_concurrency =
             task_spec.IsAsyncioActor() ? 0 : task_spec.MaxActorConcurrency();
         pool_manager_ = std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(
-            task_spec.ConcurrencyGroups(), default_max_concurrency);
+            task_spec.ConcurrencyGroups(),
+            default_max_concurrency,
+            initialize_thread_callback_);
         if (task_spec.IsAsyncioActor()) {
           fiber_state_manager_ = std::make_shared<ConcurrencyGroupManager<FiberState>>(
-              task_spec.ConcurrencyGroups(), fiber_max_concurrency_);
+              task_spec.ConcurrencyGroups(),
+              fiber_max_concurrency_,
+              initialize_thread_callback_);
         }
         concurrency_groups_cache_[task_spec.TaskId().ActorId()] =
             task_spec.ConcurrencyGroups();

--- a/src/ray/core_worker/transport/task_receiver.h
+++ b/src/ray/core_worker/transport/task_receiver.h
@@ -67,11 +67,13 @@ class TaskReceiver {
                instrumented_io_context &main_io_service,
                worker::TaskEventBuffer &task_event_buffer,
                TaskHandler task_handler,
+               std::function<std::function<void()>()> initialize_thread_callback,
                const OnActorCreationTaskDone &actor_creation_task_done_)
       : worker_context_(worker_context),
         task_handler_(std::move(task_handler)),
         task_main_io_service_(main_io_service),
         task_event_buffer_(task_event_buffer),
+        initialize_thread_callback_(std::move(initialize_thread_callback)),
         actor_creation_task_done_(actor_creation_task_done_),
         pool_manager_(std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>()),
         fiber_state_manager_(nullptr) {}
@@ -129,6 +131,8 @@ class TaskReceiver {
   /// The IO event loop for running tasks on.
   instrumented_io_context &task_main_io_service_;
   worker::TaskEventBuffer &task_event_buffer_;
+  /// The language-specific callback function that initializes threads.
+  std::function<std::function<void()>()> initialize_thread_callback_;
   /// The callback function to be invoked when finishing a task.
   OnActorCreationTaskDone actor_creation_task_done_;
   /// Shared pool for producing new core worker clients.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is the same as https://github.com/ray-project/ray/pull/50644

Currently, tasks are sometimes executed on the main thread and sometimes on other threads which is created by C++. However, C++ threads are only considered Python threads when they execute Python functions. Hence, when a task finishes, the thread-local state will be garbage-collected. See https://github.com/ray-project/ray/issues/46336#issuecomment-2613167049 for more details.

This PR uses the CPython API to treat C++ threads as Python threads, even if they do not execute Python functions.
https://docs.python.org/3/c-api/init.html#non-python-created-threads

This PR handles synchronous tasks. After this PR is merged, the follow-up tasks are:
* Always create a default executor.
* Move the constructor to the default executor.
* Support asynchronous tasks.

## Related issue number

Part of #46336 

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
