### PR TITLE
[core][1/N] Remove the use of `redis_max_memory`

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -194,7 +194,6 @@ def start_redis_instance(
     stdout_file: Optional[str] = None,
     stderr_file: Optional[str] = None,
     password: Optional[str] = None,
-    redis_max_memory: Optional[int] = None,
     fate_share: Optional[bool] = None,
     port_denylist: Optional[List[int]] = None,
     listen_to_localhost_only: bool = False,
@@ -225,9 +224,6 @@ def start_redis_instance(
             no redirection should happen, then this should be None.
         password: Prevents external clients without the password
             from connecting to Redis if provided.
-        redis_max_memory: The max amount of memory (in bytes) to allow redis
-            to use, or None for no limit. Once the limit is exceeded, redis
-            will start LRU eviction of entries.
         port_denylist: A set of denylist ports that shouldn't
             be used when allocating a new port.
         listen_to_localhost_only: Redis server only listens to

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -747,14 +747,12 @@ import ray
 from ray.tune import run_experiments
 from ray.tune.utils.release_test_util import ProgressCallback
 
-num_redis_shards = 5
-redis_max_memory = 10**8
 object_store_memory = 10**9
 num_nodes = 3
 
 message = ("Make sure there is enough memory on this machine to run this "
            "workload. We divide the system memory by 2 to provide a buffer.")
-assert (num_nodes * object_store_memory + num_redis_shards * redis_max_memory <
+assert (num_nodes * object_store_memory <
         ray._private.utils.get_system_memory() / 2), message
 
 # Simulate a cluster on one machine.

--- a/python/ray/tests/test_stress.py
+++ b/python/ray/tests/test_stress.py
@@ -14,7 +14,7 @@ def ray_start_combination(request):
     # Start the Ray processes.
     cluster = Cluster(
         initialize_head=True,
-        head_node_args={"num_cpus": 10, "redis_max_memory": 10**8},
+        head_node_args={"num_cpus": 10},
     )
     for i in range(num_nodes - 1):
         cluster.add_node(num_cpus=10)

--- a/python/ray/tests/test_stress_failure.py
+++ b/python/ray/tests/test_stress_failure.py
@@ -22,7 +22,6 @@ def ray_start_reconstruction(request):
         head_node_args={
             "num_cpus": 1,
             "object_store_memory": plasma_store_memory // num_nodes,
-            "redis_max_memory": 10**8,
             "_system_config": {"object_timeout_milliseconds": 200},
         },
     )

--- a/python/ray/tests/test_stress_sharded.py
+++ b/python/ray/tests/test_stress_sharded.py
@@ -6,15 +6,10 @@ import ray
 
 @pytest.fixture(params=[1])
 def ray_start_sharded(request):
-    # TODO(ekl) enable this again once GCS supports sharding.
-    # num_redis_shards = request.param
-
     # Start the Ray processes.
     ray.init(
         object_store_memory=int(0.5 * 10**9),
         num_cpus=10,
-        # _num_redis_shards=num_redis_shards,
-        _redis_max_memory=10**8,
     )
 
     yield None

--- a/release/long_running_tests/workloads/actor_deaths.py
+++ b/release/long_running_tests/workloads/actor_deaths.py
@@ -21,8 +21,7 @@ message = (
     "workload. We divide the system memory by 2 to provide a buffer."
 )
 assert (
-    num_nodes * object_store_memory
-    < ray._private.utils.get_system_memory() / 2
+    num_nodes * object_store_memory < ray._private.utils.get_system_memory() / 2
 ), message
 
 # Simulate a cluster on one machine.

--- a/release/long_running_tests/workloads/actor_deaths.py
+++ b/release/long_running_tests/workloads/actor_deaths.py
@@ -13,8 +13,6 @@ def update_progress(result):
     safe_write_to_results_json(result)
 
 
-num_redis_shards = 1
-redis_max_memory = 10**8
 object_store_memory = 10**8
 num_nodes = 2
 
@@ -23,7 +21,7 @@ message = (
     "workload. We divide the system memory by 2 to provide a buffer."
 )
 assert (
-    num_nodes * object_store_memory + num_redis_shards * redis_max_memory
+    num_nodes * object_store_memory
     < ray._private.utils.get_system_memory() / 2
 ), message
 
@@ -33,12 +31,10 @@ cluster = Cluster()
 for i in range(num_nodes):
     cluster.add_node(
         redis_port=6379 if i == 0 else None,
-        num_redis_shards=num_redis_shards if i == 0 else None,
         num_cpus=8,
         num_gpus=0,
         resources={str(i): 2},
         object_store_memory=object_store_memory,
-        redis_max_memory=redis_max_memory,
         dashboard_host="0.0.0.0",
     )
 ray.init(address=cluster.address)

--- a/release/long_running_tests/workloads/apex.py
+++ b/release/long_running_tests/workloads/apex.py
@@ -12,8 +12,7 @@ message = (
     "workload. We divide the system memory by 2 to provide a buffer."
 )
 assert (
-    num_nodes * object_store_memory
-    < ray._private.utils.get_system_memory() / 2
+    num_nodes * object_store_memory < ray._private.utils.get_system_memory() / 2
 ), message
 
 # Simulate a cluster on one machine.

--- a/release/long_running_tests/workloads/apex.py
+++ b/release/long_running_tests/workloads/apex.py
@@ -4,8 +4,6 @@ import ray
 from ray.tune import run_experiments
 from ray.tune.utils.release_test_util import ProgressCallback
 
-num_redis_shards = 5
-redis_max_memory = 10**8
 object_store_memory = 10**9
 num_nodes = 3
 
@@ -14,23 +12,12 @@ message = (
     "workload. We divide the system memory by 2 to provide a buffer."
 )
 assert (
-    num_nodes * object_store_memory + num_redis_shards * redis_max_memory
+    num_nodes * object_store_memory
     < ray._private.utils.get_system_memory() / 2
 ), message
 
 # Simulate a cluster on one machine.
 
-# cluster = Cluster()
-# for i in range(num_nodes):
-#     cluster.add_node(redis_port=6379 if i == 0 else None,
-#                      num_redis_shards=num_redis_shards if i == 0 else None,
-#                      num_cpus=20,
-#                      num_gpus=0,
-#                      resources={str(i): 2},
-#                      object_store_memory=object_store_memory,
-#                      redis_max_memory=redis_max_memory,
-#                      dashboard_host="0.0.0.0")
-# ray.init(address=cluster.address)
 ray.init()
 
 # Run the workload.

--- a/release/long_running_tests/workloads/impala.py
+++ b/release/long_running_tests/workloads/impala.py
@@ -14,8 +14,7 @@ message = (
     "workload. We divide the system memory by 2 to provide a buffer."
 )
 assert (
-    num_nodes * object_store_memory
-    < ray._private.utils.get_system_memory() / 2
+    num_nodes * object_store_memory < ray._private.utils.get_system_memory() / 2
 ), message
 
 # Simulate a cluster on one machine.

--- a/release/long_running_tests/workloads/impala.py
+++ b/release/long_running_tests/workloads/impala.py
@@ -6,8 +6,6 @@ import os
 
 from ray.tune.utils.release_test_util import ProgressCallback
 
-num_redis_shards = 5
-redis_max_memory = 10**8
 object_store_memory = 10**8
 num_nodes = 1
 
@@ -16,24 +14,11 @@ message = (
     "workload. We divide the system memory by 2 to provide a buffer."
 )
 assert (
-    num_nodes * object_store_memory + num_redis_shards * redis_max_memory
+    num_nodes * object_store_memory
     < ray._private.utils.get_system_memory() / 2
 ), message
 
 # Simulate a cluster on one machine.
-
-# cluster = Cluster()
-# for i in range(num_nodes):
-#     cluster.add_node(
-#         redis_port=6379 if i == 0 else None,
-#         num_redis_shards=num_redis_shards if i == 0 else None,
-#         num_cpus=10,
-#         num_gpus=0,
-#         resources={str(i): 2},
-#         object_store_memory=object_store_memory,
-#         redis_max_memory=redis_max_memory,
-#         dashboard_host="0.0.0.0")
-# ray.init(address=cluster.address)
 
 if "RAY_ADDRESS" in os.environ:
     del os.environ["RAY_ADDRESS"]

--- a/release/long_running_tests/workloads/many_actor_tasks.py
+++ b/release/long_running_tests/workloads/many_actor_tasks.py
@@ -21,8 +21,7 @@ message = (
     "workload. We divide the system memory by 2 to provide a buffer."
 )
 assert (
-    num_nodes * object_store_memory
-    < ray._private.utils.get_system_memory() / 2
+    num_nodes * object_store_memory < ray._private.utils.get_system_memory() / 2
 ), message
 
 # Simulate a cluster on one machine.

--- a/release/long_running_tests/workloads/many_actor_tasks.py
+++ b/release/long_running_tests/workloads/many_actor_tasks.py
@@ -13,8 +13,6 @@ def update_progress(result):
     safe_write_to_results_json(result)
 
 
-num_redis_shards = 5
-redis_max_memory = 10**8
 object_store_memory = 10**8
 num_nodes = 10
 
@@ -23,7 +21,7 @@ message = (
     "workload. We divide the system memory by 2 to provide a buffer."
 )
 assert (
-    num_nodes * object_store_memory + num_redis_shards * redis_max_memory
+    num_nodes * object_store_memory
     < ray._private.utils.get_system_memory() / 2
 ), message
 
@@ -33,12 +31,10 @@ cluster = Cluster()
 for i in range(num_nodes):
     cluster.add_node(
         redis_port=6379 if i == 0 else None,
-        num_redis_shards=num_redis_shards if i == 0 else None,
         num_cpus=5,
         num_gpus=0,
         resources={str(i): 2},
         object_store_memory=object_store_memory,
-        redis_max_memory=redis_max_memory,
         dashboard_host="0.0.0.0",
     )
 ray.init(address=cluster.address)

--- a/release/long_running_tests/workloads/many_ppo.py
+++ b/release/long_running_tests/workloads/many_ppo.py
@@ -7,8 +7,6 @@ from ray.tune import run_experiments
 from ray.tune.utils.release_test_util import ProgressCallback
 from ray._private.test_utils import monitor_memory_usage
 
-num_redis_shards = 5
-redis_max_memory = 10**8
 object_store_memory = 10**9
 num_nodes = 3
 
@@ -17,7 +15,7 @@ message = (
     "workload. We divide the system memory by 2 to provide a buffer."
 )
 assert (
-    num_nodes * object_store_memory + num_redis_shards * redis_max_memory
+    num_nodes * object_store_memory
     < ray._private.utils.get_system_memory() / 2
 ), message
 

--- a/release/long_running_tests/workloads/many_ppo.py
+++ b/release/long_running_tests/workloads/many_ppo.py
@@ -15,8 +15,7 @@ message = (
     "workload. We divide the system memory by 2 to provide a buffer."
 )
 assert (
-    num_nodes * object_store_memory
-    < ray._private.utils.get_system_memory() / 2
+    num_nodes * object_store_memory < ray._private.utils.get_system_memory() / 2
 ), message
 
 # Simulate a cluster on one machine.

--- a/release/long_running_tests/workloads/many_tasks.py
+++ b/release/long_running_tests/workloads/many_tasks.py
@@ -21,8 +21,7 @@ message = (
     "workload. We divide the system memory by 2 to provide a buffer."
 )
 assert (
-    num_nodes * object_store_memory
-    < ray._private.utils.get_system_memory() / 2
+    num_nodes * object_store_memory < ray._private.utils.get_system_memory() / 2
 ), message
 
 # Simulate a cluster on one machine.

--- a/release/long_running_tests/workloads/many_tasks.py
+++ b/release/long_running_tests/workloads/many_tasks.py
@@ -13,8 +13,6 @@ def update_progress(result):
     safe_write_to_results_json(result)
 
 
-num_redis_shards = 5
-redis_max_memory = 10**8
 object_store_memory = 10**8
 num_nodes = 10
 
@@ -23,7 +21,7 @@ message = (
     "workload. We divide the system memory by 2 to provide a buffer."
 )
 assert (
-    num_nodes * object_store_memory + num_redis_shards * redis_max_memory
+    num_nodes * object_store_memory
     < ray._private.utils.get_system_memory() / 2
 ), message
 
@@ -33,12 +31,10 @@ cluster = Cluster()
 for i in range(num_nodes):
     cluster.add_node(
         redis_port=6379 if i == 0 else None,
-        num_redis_shards=num_redis_shards if i == 0 else None,
         num_cpus=2,
         num_gpus=0,
         resources={str(i): 2},
         object_store_memory=object_store_memory,
-        redis_max_memory=redis_max_memory,
         dashboard_host="0.0.0.0",
     )
 ray.init(address=cluster.address)

--- a/release/long_running_tests/workloads/many_tasks_serialized_ids.py
+++ b/release/long_running_tests/workloads/many_tasks_serialized_ids.py
@@ -23,8 +23,7 @@ message = (
     "workload. We divide the system memory by 2 to provide a buffer."
 )
 assert (
-    num_nodes * object_store_memory
-    < ray._private.utils.get_system_memory() / 2
+    num_nodes * object_store_memory < ray._private.utils.get_system_memory() / 2
 ), message
 
 # Simulate a cluster on one machine.

--- a/release/long_running_tests/workloads/many_tasks_serialized_ids.py
+++ b/release/long_running_tests/workloads/many_tasks_serialized_ids.py
@@ -15,8 +15,6 @@ def update_progress(result):
     safe_write_to_results_json(result)
 
 
-num_redis_shards = 5
-redis_max_memory = 10**8
 object_store_memory = 10**8
 num_nodes = 10
 
@@ -25,7 +23,7 @@ message = (
     "workload. We divide the system memory by 2 to provide a buffer."
 )
 assert (
-    num_nodes * object_store_memory + num_redis_shards * redis_max_memory
+    num_nodes * object_store_memory
     < ray._private.utils.get_system_memory() / 2
 ), message
 
@@ -35,12 +33,10 @@ cluster = Cluster()
 for i in range(num_nodes):
     cluster.add_node(
         redis_port=6379 if i == 0 else None,
-        num_redis_shards=num_redis_shards if i == 0 else None,
         num_cpus=2,
         num_gpus=0,
         resources={str(i): 2},
         object_store_memory=object_store_memory,
-        redis_max_memory=redis_max_memory,
         dashboard_host="0.0.0.0",
     )
 ray.init(address=cluster.address)

--- a/release/long_running_tests/workloads/node_failures.py
+++ b/release/long_running_tests/workloads/node_failures.py
@@ -19,8 +19,7 @@ message = (
     "workload. We divide the system memory by 2 to provide a buffer."
 )
 assert (
-    num_nodes * object_store_memory
-    < ray._private.utils.get_system_memory() / 2
+    num_nodes * object_store_memory < ray._private.utils.get_system_memory() / 2
 ), message
 
 # Simulate a cluster on one machine.

--- a/release/long_running_tests/workloads/node_failures.py
+++ b/release/long_running_tests/workloads/node_failures.py
@@ -11,8 +11,6 @@ def update_progress(result):
     safe_write_to_results_json(result)
 
 
-num_redis_shards = 5
-redis_max_memory = 10**8
 object_store_memory = 10**8
 num_nodes = 10
 
@@ -21,7 +19,7 @@ message = (
     "workload. We divide the system memory by 2 to provide a buffer."
 )
 assert (
-    num_nodes * object_store_memory + num_redis_shards * redis_max_memory
+    num_nodes * object_store_memory
     < ray._private.utils.get_system_memory() / 2
 ), message
 
@@ -31,12 +29,10 @@ cluster = Cluster()
 for i in range(num_nodes):
     cluster.add_node(
         redis_port=6379 if i == 0 else None,
-        num_redis_shards=num_redis_shards if i == 0 else None,
         num_cpus=2,
         num_gpus=0,
         resources={str(i): 2},
         object_store_memory=object_store_memory,
-        redis_max_memory=redis_max_memory,
         dashboard_host="0.0.0.0",
     )
 ray.init(address=cluster.address)

--- a/release/long_running_tests/workloads/serve.py
+++ b/release/long_running_tests/workloads/serve.py
@@ -16,8 +16,6 @@ NUM_REPLICAS = 7
 MAX_BATCH_SIZE = 16
 
 # Cluster setup constants
-NUM_REDIS_SHARDS = 1
-REDIS_MAX_MEMORY = 10**8
 OBJECT_STORE_MEMORY = 10**8
 NUM_NODES = 4
 
@@ -42,13 +40,11 @@ cluster = Cluster()
 for i in range(NUM_NODES):
     cluster.add_node(
         redis_port=6379 if i == 0 else None,
-        num_redis_shards=NUM_REDIS_SHARDS if i == 0 else None,
         dashboard_agent_listen_port=(52365 + i),
         num_cpus=8,
         num_gpus=0,
         resources={str(i): 2},
         object_store_memory=OBJECT_STORE_MEMORY,
-        redis_max_memory=REDIS_MAX_MEMORY,
         dashboard_host="0.0.0.0",
     )
 

--- a/release/long_running_tests/workloads/serve_failure.py
+++ b/release/long_running_tests/workloads/serve_failure.py
@@ -20,8 +20,6 @@ NUM_REPLICAS = 7
 MAX_BATCH_SIZE = 16
 
 # Cluster setup constants
-NUM_REDIS_SHARDS = 1
-REDIS_MAX_MEMORY = 10**8
 OBJECT_STORE_MEMORY = 10**8
 NUM_NODES = 4
 
@@ -51,12 +49,10 @@ cluster = Cluster()
 for i in range(NUM_NODES):
     cluster.add_node(
         redis_port=6379 if i == 0 else None,
-        num_redis_shards=NUM_REDIS_SHARDS if i == 0 else None,
         num_cpus=16,
         num_gpus=0,
         resources={str(i): 2},
         object_store_memory=OBJECT_STORE_MEMORY,
-        redis_max_memory=REDIS_MAX_MEMORY,
         dashboard_host="0.0.0.0",
     )
 

--- a/rllib/algorithms/tests/test_node_failures.py
+++ b/rllib/algorithms/tests/test_node_failures.py
@@ -16,10 +16,7 @@ from ray.rllib.utils.metrics import (
 object_store_memory = 10**8
 num_nodes = 3
 
-assert (
-    num_nodes * object_store_memory
-    < ray._private.utils.get_system_memory() / 2
-), (
+assert num_nodes * object_store_memory < ray._private.utils.get_system_memory() / 2, (
     "Make sure there is enough memory on this machine to run this "
     "workload. We divide the system memory by 2 to provide a buffer."
 )

--- a/rllib/algorithms/tests/test_node_failures.py
+++ b/rllib/algorithms/tests/test_node_failures.py
@@ -13,13 +13,11 @@ from ray.rllib.utils.metrics import (
 )
 
 
-num_redis_shards = 5
-redis_max_memory = 10**8
 object_store_memory = 10**8
 num_nodes = 3
 
 assert (
-    num_nodes * object_store_memory + num_redis_shards * redis_max_memory
+    num_nodes * object_store_memory
     < ray._private.utils.get_system_memory() / 2
 ), (
     "Make sure there is enough memory on this machine to run this "
@@ -35,11 +33,9 @@ class TestNodeFailures(unittest.TestCase):
         for i in range(num_nodes):
             self.cluster.add_node(
                 redis_port=6379 if i == 0 else None,
-                num_redis_shards=num_redis_shards if i == 0 else None,
                 num_cpus=2,
                 num_gpus=0,
                 object_store_memory=object_store_memory,
-                redis_max_memory=redis_max_memory,
                 dashboard_host="0.0.0.0",
             )
         self.cluster.wait_for_nodes()
@@ -183,11 +179,9 @@ class TestNodeFailures(unittest.TestCase):
                 print("Bringing back node ...")
                 self.cluster.add_node(
                     redis_port=None,
-                    num_redis_shards=None,
                     num_cpus=2,
                     num_gpus=0,
                     object_store_memory=object_store_memory,
-                    redis_max_memory=redis_max_memory,
                     dashboard_host="0.0.0.0",
                 )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Redis was removed from Ray's dependencies more than 2.5 years ago. However, some Redis-related parameters remain in the Ray codebase, such as `redis_max_memory`.

This PR deletes the use of `redis_max_memory` in all tests. The next step is removed `redis_max_memory` from the Ray codebase.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
