### PR TITLE
[core] [easy] [no-op] Remove unused function argument

### DIFF
--- a/python/ray/_private/function_manager.py
+++ b/python/ray/_private/function_manager.py
@@ -665,9 +665,7 @@ class FunctionActorManager:
         actor_class.__module__ = module_name
         return actor_class
 
-    def _make_actor_method_executor(
-        self, method_name: str, method, actor_imported: bool
-    ):
+    def _make_actor_method_executor(self, method_name: str, method):
         """Make an executor that wraps a user-defined actor method.
         The wrapped method updates the worker's internal state and performs any
         necessary checkpointing operations.
@@ -676,9 +674,6 @@ class FunctionActorManager:
             method: The actor method to wrap. This should be a
                 method defined on the actor class and should therefore take an
                 instance of the actor as the first argument.
-            actor_imported: Whether the actor has been imported.
-                Checkpointing operations will not be run if this is set to
-                False.
         Returns:
             A function that executes the given actor method on the worker's
                 stored instance of the actor. The function also updates the

--- a/python/ray/_private/function_manager.py
+++ b/python/ray/_private/function_manager.py
@@ -568,9 +568,7 @@ class FunctionActorManager:
                     )
                 method_id = method_descriptor.function_id
                 executor = self._make_actor_method_executor(
-                    actor_method_name,
-                    actor_method,
-                    actor_imported=True,
+                    actor_method_name, actor_method
                 )
                 self._function_execution_info[method_id] = FunctionExecutionInfo(
                     function=executor,


### PR DESCRIPTION
Function argument not used anywhere:
```
[~/ray] (master) 
ubuntu@hjiang-devbox-pg$ git grep "_make_actor_method_executor"
python/ray/_private/function_manager.py:                executor = self._make_actor_method_executor(
python/ray/_private/function_manager.py:    def _make_actor_method_executor(
```