### PR TITLE
[Compiled Graph] Enhance Compile Graph with Multi-Device Support

### DIFF
--- a/python/ray/dag/dag_node.py
+++ b/python/ray/dag/dag_node.py
@@ -172,9 +172,9 @@ class DAGNode(DAGNodeBase):
         try:
             device = Device(device)
         except ValueError:
+            valid_devices = ", ".join(f"'{d.value}'" for d in Device)
             raise ValueError(
-                f"Invalid device '{device}'. "
-                "Valid options are: 'default', 'cpu', 'gpu', 'cuda'."
+                f"Invalid device '{device}'. Valid options are: {valid_devices}."
             )
         if transport == "auto":
             self._type_hint = AutoTransportType(

--- a/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
@@ -18,7 +18,6 @@ from ray.experimental.channel.communicator import (
     Communicator,
     TorchTensorAllocator,
 )
-from ray.experimental.channel.utils import get_devices
 from ray.experimental.channel.torch_tensor_type import TorchTensorType
 from ray.experimental.channel.nccl_group import _NcclGroup
 from ray._private.test_utils import (
@@ -28,6 +27,7 @@ from ray._private.test_utils import (
 
 from ray.tests.conftest import *  # noqa
 from ray.experimental.util.types import ReduceOp
+from ray.experimental.channel.accelerator_context import AcceleratorContext
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ USE_GPU = bool(os.environ.get("RAY_PYTEST_USE_GPU", 0))
 @ray.remote
 class TorchTensorWorker:
     def __init__(self):
-        self.device = get_devices()[0]
+        self.device = AcceleratorContext.get().get_default_device()
 
     def init_distributed(self, world_size, rank):
         torch.distributed.init_process_group(
@@ -214,9 +214,8 @@ def test_torch_tensor_as_dag_input(ray_start_regular):
 def test_torch_tensor_nccl(
     ray_start_regular, monkeypatch, enable_profiling, overlap_gpu_communication
 ):
-    assert (
-        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
-    ), "This test requires at least 2 GPUs"
+    if sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) < 2:
+        pytest.skip("This test requires at least 2 GPUs")
 
     monkeypatch.setattr(
         ray.dag.constants, "RAY_CGRAPH_ENABLE_PROFILING", enable_profiling
@@ -316,9 +315,8 @@ def test_torch_tensor_shm(ray_start_regular):
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
 @pytest.mark.parametrize("num_gpus", [[0, 0], [1, 0], [0, 1], [1, 1], [0.5, 0.5]])
 def test_torch_tensor_auto(ray_start_regular, num_gpus):
-    assert (
-        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
-    ), "This test requires at least 2 GPUs"
+    if sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) < 2:
+        pytest.skip("This test requires at least 2 GPUs")
 
     sender = TorchTensorWorker.options(num_cpus=0, num_gpus=num_gpus[0]).remote()
     receiver = TorchTensorWorker.options(num_cpus=0, num_gpus=num_gpus[1]).remote()
@@ -376,9 +374,8 @@ def test_torch_tensor_auto(ray_start_regular, num_gpus):
     indirect=["ray_start_regular"],
 )
 def test_torch_tensor_nccl_overlap_timed(ray_start_regular, overlap_gpu_communication):
-    assert (
-        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) >= 4
-    ), "This test requires at least 4 GPUs"
+    if sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) < 4:
+        pytest.skip("This test requires at least 4 GPUs")
 
     worker_cls = TorchTensorWorker.options(num_cpus=0, num_gpus=1)
     num_senders = 3
@@ -422,9 +419,8 @@ def test_torch_tensor_nccl_disallows_driver(ray_start_regular):
     and output nodes cannot have a TorchTensorType(transport="nccl")
     annotation.
     """
-    assert (
-        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
-    ), "This test requires at least 2 GPUs"
+    if sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) < 2:
+        pytest.skip("This test requires at least 2 GPUs")
 
     actor_cls = TorchTensorWorker.options(num_cpus=0, num_gpus=1)
 
@@ -462,9 +458,8 @@ def test_torch_tensor_nccl_disallows_driver(ray_start_regular):
 @pytest.mark.skipif(not USE_GPU, reason="Skipping GPU Test")
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
 def test_torch_tensor_custom_comm(ray_start_regular):
-    assert (
-        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
-    ), "This test requires at least 2 GPUs"
+    if sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) < 2:
+        pytest.skip("This test requires at least 2 GPUs")
 
     actor_cls = TorchTensorWorker.options(num_cpus=0, num_gpus=1)
 
@@ -475,8 +470,6 @@ def test_torch_tensor_custom_comm(ray_start_regular):
         """
         A custom NCCL group for testing. This is a simple wrapper around `_NcclGroup`.
         """
-
-        import cupy as cp
 
         def __init__(self, world_size, comm_id, actor_handles):
             self._world_size = world_size
@@ -490,7 +483,7 @@ def test_torch_tensor_custom_comm(ray_start_regular):
                 self._comm_id,
                 rank,
                 self._actor_handles,
-                torch.cuda.current_stream().cuda_stream,
+                AcceleratorContext.get().current_stream(),
             )
 
         def get_rank(self, actor: ray.actor.ActorHandle) -> int:
@@ -555,11 +548,11 @@ def test_torch_tensor_custom_comm(ray_start_regular):
             recv_buf += 1
 
         @property
-        def recv_stream(self) -> Optional["cp.cuda.ExternalStream"]:
+        def recv_stream(self):
             return self._inner.recv_stream
 
         @property
-        def send_stream(self) -> Optional["cp.cuda.ExternalStream"]:
+        def send_stream(self):
             return self._inner.send_stream
 
         def destroy(self) -> None:
@@ -567,6 +560,10 @@ def test_torch_tensor_custom_comm(ray_start_regular):
 
         def get_transport_name(self) -> str:
             return "nccl"
+
+        @classmethod
+        def generate_communicator_id(self) -> str:
+            return self._inner.generate_communicator_id()
 
     from cupy.cuda import nccl
 
@@ -595,9 +592,8 @@ def test_torch_tensor_custom_comm(ray_start_regular):
 @pytest.mark.skipif(not USE_GPU, reason="Skipping GPU Test")
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
 def test_torch_tensor_custom_comm_inited(ray_start_regular):
-    assert (
-        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
-    ), "This test requires at least 2 GPUs"
+    if sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) < 2:
+        pytest.skip("This test requires at least 2 GPUs")
     runtime_env = {
         "env_vars": {
             "MASTER_ADDR": socket.gethostbyname(socket.gethostname()),
@@ -624,8 +620,6 @@ def test_torch_tensor_custom_comm_inited(ray_start_regular):
         A custom NCCL group based on existing torch.distributed setup.
         """
 
-        import cupy as cp
-
         def __init__(self, world_size, actor_handles):
             self._world_size = world_size
             self._actor_handles = actor_handles
@@ -637,7 +631,7 @@ def test_torch_tensor_custom_comm_inited(ray_start_regular):
                 rank == expected_rank
             ), f"NCCL actor's rank {rank} does not match expected rank {expected_rank}"
             self._rank = rank
-            self._device = get_devices()[0]
+            self._device = AcceleratorContext.get().get_default_device()
 
         def get_rank(self, actor: ray.actor.ActorHandle) -> int:
             actor_ids = [a._ray_actor_id for a in self._actor_handles]
@@ -694,22 +688,22 @@ def test_torch_tensor_custom_comm_inited(ray_start_regular):
             raise NotImplementedError
 
         @property
-        def recv_stream(self) -> Optional["cp.cuda.ExternalStream"]:
-            import cupy as cp
-
-            return cp.cuda.get_current_stream()
+        def recv_stream(self):
+            return AcceleratorContext.get().current_stream()
 
         @property
-        def send_stream(self) -> Optional["cp.cuda.ExternalStream"]:
-            import cupy as cp
-
-            return cp.cuda.get_current_stream()
+        def send_stream(self):
+            return AcceleratorContext.get().current_stream()
 
         def destroy(self) -> None:
             pass
 
         def get_transport_name(self) -> str:
             return "nccl"
+
+        @classmethod
+        def generate_communicator_id(self) -> str:
+            return self._inner.generate_communicator_id()
 
     nccl_group = InitedNcclGroup(2, [sender, receiver])
 
@@ -740,9 +734,8 @@ def test_torch_tensor_custom_comm_inited(ray_start_regular):
     [["auto", "nccl"], ["custom", "nccl"], ["auto", "nccl"], ["custom", "custom"]],
 )
 def test_torch_tensor_default_comm(ray_start_regular, transports):
-    assert (
-        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 2
-    ), "This test requires at least 3 GPUs"
+    if sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) < 3:
+        pytest.skip("This test requires at least 3 GPUs")
     runtime_env = {
         "env_vars": {
             "MASTER_ADDR": socket.gethostbyname(socket.gethostname()),
@@ -771,8 +764,6 @@ def test_torch_tensor_default_comm(ray_start_regular, transports):
         A custom NCCL group based on existing torch.distributed setup.
         """
 
-        import cupy as cp
-
         def __init__(self, world_size, actor_handles):
             self._world_size = world_size
             self._actor_handles = actor_handles
@@ -784,7 +775,7 @@ def test_torch_tensor_default_comm(ray_start_regular, transports):
                 rank == expected_rank
             ), f"NCCL actor's rank {rank} does not match expected rank {expected_rank}"
             self._rank = rank
-            self._device = get_devices()[0]
+            self._device = AcceleratorContext.get().get_default_device()
 
         def get_rank(self, actor: ray.actor.ActorHandle) -> int:
             actor_ids = [a._ray_actor_id for a in self._actor_handles]
@@ -841,22 +832,22 @@ def test_torch_tensor_default_comm(ray_start_regular, transports):
             raise NotImplementedError
 
         @property
-        def recv_stream(self) -> Optional["cp.cuda.ExternalStream"]:
-            import cupy as cp
-
-            return cp.cuda.get_current_stream()
+        def recv_stream(self):
+            return AcceleratorContext.get().current_stream()
 
         @property
-        def send_stream(self) -> Optional["cp.cuda.ExternalStream"]:
-            import cupy as cp
-
-            return cp.cuda.get_current_stream()
+        def send_stream(self):
+            return AcceleratorContext.get().current_stream()
 
         def destroy(self) -> None:
             pass
 
         def get_transport_name(self) -> str:
             return "nccl"
+
+        @classmethod
+        def generate_communicator_id(self) -> str:
+            return self._inner.generate_communicator_id()
 
     default_comm = InitedNcclGroup(3, [worker0, worker1, worker2])
     custom_comm = InitedNcclGroup(3, [worker0, worker1, worker2])
@@ -902,9 +893,8 @@ def test_torch_tensor_default_comm(ray_start_regular, transports):
 @pytest.mark.skipif(not USE_GPU, reason="Skipping GPU Test")
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
 def test_torch_tensor_invalid_custom_comm(ray_start_regular):
-    assert (
-        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
-    ), "This test requires at least 2 GPUs"
+    if sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) < 2:
+        pytest.skip("This test requires at least 2 GPUs")
     runtime_env = {
         "env_vars": {
             "MASTER_ADDR": socket.gethostbyname(socket.gethostname()),
@@ -931,8 +921,6 @@ def test_torch_tensor_invalid_custom_comm(ray_start_regular):
         A custom NCCL group based on existing torch.distributed setup.
         """
 
-        import cupy as cp
-
         def __init__(self, world_size, actor_handles):
             self._world_size = world_size
             self._actor_handles = actor_handles
@@ -944,7 +932,7 @@ def test_torch_tensor_invalid_custom_comm(ray_start_regular):
                 rank == expected_rank
             ), f"NCCL actor's rank {rank} does not match expected rank {expected_rank}"
             self._rank = rank
-            self._device = get_devices()[0]
+            self._device = AcceleratorContext.get().get_default_device()
 
         def get_rank(self, actor: ray.actor.ActorHandle) -> int:
             actor_ids = [a._ray_actor_id for a in self._actor_handles]
@@ -1001,22 +989,22 @@ def test_torch_tensor_invalid_custom_comm(ray_start_regular):
             raise NotImplementedError
 
         @property
-        def recv_stream(self) -> Optional["cp.cuda.ExternalStream"]:
-            import cupy as cp
-
-            return cp.cuda.get_current_stream()
+        def recv_stream(self):
+            return AcceleratorContext.get().current_stream()
 
         @property
-        def send_stream(self) -> Optional["cp.cuda.ExternalStream"]:
-            import cupy as cp
-
-            return cp.cuda.get_current_stream()
+        def send_stream(self):
+            return AcceleratorContext.get().current_stream()
 
         def destroy(self) -> None:
             pass
 
         def get_transport_name(self) -> str:
             return "nccl"
+
+        @classmethod
+        def generate_communicator_id(self) -> str:
+            return self._inner.generate_communicator_id()
 
     comm2 = UserCreatedNcclGroup(2, [sender, receiver])
     comm1 = UserCreatedNcclGroup(1, [sender])
@@ -1047,12 +1035,8 @@ def test_torch_tensor_invalid_custom_comm(ray_start_regular):
 @pytest.mark.skipif(not USE_GPU, reason="Skipping GPU Test")
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
 def test_torch_tensor_nccl_static_shape(ray_start_regular):
-    if not USE_GPU:
-        pytest.skip("NCCL tests require GPUs")
-
-    assert (
-        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
-    ), "This test requires at least 2 GPUs"
+    if sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) < 2:
+        pytest.skip("This test requires at least 2 GPUs")
 
     actor_cls = TorchTensorWorker.options(num_cpus=0, num_gpus=1)
 
@@ -1086,9 +1070,8 @@ def test_torch_tensor_nccl_static_shape(ray_start_regular):
 @pytest.mark.skipif(not USE_GPU, reason="Skipping GPU Test")
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
 def test_torch_tensor_nccl_direct_return(ray_start_regular):
-    assert (
-        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
-    ), "This test requires at least 2 GPUs"
+    if sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) < 2:
+        pytest.skip("This test requires at least 2 GPUs")
 
     actor_cls = TorchTensorWorker.options(num_gpus=1)
 
@@ -1125,9 +1108,8 @@ def test_torch_tensor_nccl_nested_dynamic(ray_start_regular):
     Test nested torch.Tensor passed via NCCL. Its shape and dtype is
     dynamically declared, and there may be multiple tensors.
     """
-    assert (
-        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
-    ), "This test requires at least 2 GPUs"
+    if sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) < 2:
+        pytest.skip("This test requires at least 2 GPUs")
 
     actor_cls = TorchTensorWorker.options(num_gpus=1)
 
@@ -1161,9 +1143,8 @@ def test_torch_tensor_exceptions(
     """
     Test exceptions being thrown by a NCCL sending task's execution.
     """
-    assert (
-        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
-    ), "This test requires at least 2 GPUs"
+    if sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) < 2:
+        pytest.skip("This test requires at least 2 GPUs")
 
     actor_cls = TorchTensorWorker.options(num_gpus=1)
 
@@ -1244,9 +1225,8 @@ def test_torch_tensor_exceptions2(
     """
     Test exceptions being thrown by a NCCL sending task's write operation.
     """
-    assert (
-        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
-    ), "This test requires at least 2 GPUs"
+    if sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) < 2:
+        pytest.skip("This test requires at least 2 GPUs")
 
     actor_cls = TorchTensorWorker.options(num_gpus=1)
     sender = actor_cls.remote()
@@ -1280,11 +1260,44 @@ def test_torch_tensor_exceptions2(
 
 
 @pytest.mark.skipif(not USE_GPU, reason="Skipping GPU Test")
+@pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 2}], indirect=True)
+def test_torch_tensor_exceptions3(
+    ray_start_regular,
+):
+    """
+    Test exception when creating a communicator group with
+    actors using different accelerators.
+    """
+
+    sender = TorchTensorWorker.options(num_gpus=1).remote()
+    receiver = TorchTensorWorker.options(num_gpus=0).remote()
+
+    with InputNode() as inp:
+        dag = sender.send_int.bind(inp)
+        dag = dag.with_tensor_transport(
+            transport="nccl",
+            _direct_return=True,
+            _static_shape=True,
+        )
+        dag = receiver.recv.bind(dag)
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"Actor Actor\(TorchTensorWorker, .*?\) returns a tensor with type hint "
+            r'TorchTensor\(transport="nccl"\) or '
+            r"TorchTensor\(transport=nccl_group_handle\) "
+            r"but actor does not have an accelerator assigned by Ray\."
+        ),
+    ):
+        dag.experimental_compile()
+
+
+@pytest.mark.skipif(not USE_GPU, reason="Skipping GPU Test")
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
 def test_torch_tensor_explicit_communicator(ray_start_regular):
-    assert (
-        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
-    ), "This test requires at least 2 GPUs"
+    if sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) < 2:
+        pytest.skip("This test requires at least 2 GPUs")
 
     actor_cls = TorchTensorWorker.options(num_cpus=0, num_gpus=1)
 
@@ -1341,9 +1354,8 @@ def test_torch_tensor_nccl_collective_ops(ray_start_regular, operation, reduce_o
     """
     Test basic collective operations.
     """
-    assert (
-        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
-    ), "This test requires at least 2 GPUs"
+    if sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) < 2:
+        pytest.skip("This test requires at least 2 GPUs")
 
     actor_cls = TorchTensorWorker.options(num_cpus=0, num_gpus=1)
 
@@ -1441,9 +1453,8 @@ def test_torch_tensor_nccl_all_reduce_get_partial(ray_start_regular):
     """
     Test getting partial results from an all-reduce does not hang.
     """
-    assert (
-        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
-    ), "This test requires at least 2 GPUs"
+    if sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) < 2:
+        pytest.skip("This test requires at least 2 GPUs")
 
     actor_cls = TorchTensorWorker.options(num_cpus=0, num_gpus=1)
 
@@ -1484,9 +1495,8 @@ def test_torch_tensor_nccl_all_reduce_wrong_shape(ray_start_regular):
     """
     Test an error is thrown when an all-reduce takes tensors of wrong shapes.
     """
-    assert (
-        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
-    ), "This test requires at least 2 GPUs"
+    if sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) < 2:
+        pytest.skip("This test requires at least 2 GPUs")
 
     actor_cls = TorchTensorWorker.options(num_cpus=0, num_gpus=1)
 
@@ -1534,9 +1544,8 @@ def test_torch_tensor_nccl_all_reduce_custom_comm(ray_start_regular):
     """
     Test all-reduce works with a custom communicator.
     """
-    assert (
-        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
-    ), "This test requires at least 2 GPUs"
+    if sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) < 2:
+        pytest.skip("This test requires at least 2 GPUs")
 
     actor_cls = TorchTensorWorker.options(num_cpus=0, num_gpus=1)
 
@@ -1550,8 +1559,6 @@ def test_torch_tensor_nccl_all_reduce_custom_comm(ray_start_regular):
         A custom NCCL group for testing. This is a simple wrapper around `_NcclGroup`.
         """
 
-        import cupy as cp
-
         def __init__(self, world_size, comm_id, actor_handles):
             self._world_size = world_size
             self._comm_id = comm_id
@@ -1564,7 +1571,7 @@ def test_torch_tensor_nccl_all_reduce_custom_comm(ray_start_regular):
                 self._comm_id,
                 rank,
                 self._actor_handles,
-                torch.cuda.current_stream().cuda_stream,
+                AcceleratorContext.get().current_stream(),
             )
 
         def get_rank(self, actor: ray.actor.ActorHandle) -> int:
@@ -1629,11 +1636,11 @@ def test_torch_tensor_nccl_all_reduce_custom_comm(ray_start_regular):
             recv_buf += 1
 
         @property
-        def recv_stream(self) -> Optional["cp.cuda.ExternalStream"]:
+        def recv_stream(self):
             return self._inner.recv_stream
 
         @property
-        def send_stream(self) -> Optional["cp.cuda.ExternalStream"]:
+        def send_stream(self):
             return self._inner.send_stream
 
         def destroy(self) -> None:
@@ -1641,6 +1648,10 @@ def test_torch_tensor_nccl_all_reduce_custom_comm(ray_start_regular):
 
         def get_transport_name(self) -> str:
             return "nccl"
+
+        @classmethod
+        def generate_communicator_id(self) -> str:
+            return self._inner.generate_communicator_id()
 
     comm_id = nccl.get_unique_id()
     nccl_group = TestNcclGroup(2, comm_id, workers)
@@ -1688,9 +1699,8 @@ def test_torch_tensor_nccl_all_reduce_scheduling(ray_start_regular):
     actor 0 starts sending t, then actor 1 waits for actor 0 to join the all-reduce
     while actor 1 waits for actor 0 to receive t.
     """
-    assert (
-        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
-    ), "This test requires at least 2 GPUs"
+    if sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) < 2:
+        pytest.skip("This test requires at least 2 GPUs")
 
     actor_cls = TorchTensorWorker.options(num_cpus=0, num_gpus=1)
 
@@ -1730,9 +1740,8 @@ def test_nccl_all_reduce_with_class_method_output_node(ray_start_regular):
     """
     Test all-reduce with class method output node.
     """
-    assert (
-        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
-    ), "This test requires at least 2 GPUs"
+    if sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) < 2:
+        pytest.skip("This test requires at least 2 GPUs")
 
     actor_cls = TorchTensorWorker.options(num_cpus=0, num_gpus=1)
 
@@ -1799,9 +1808,8 @@ def test_tensor_writable_warning_suppressed(ray_start_regular):
 @pytest.mark.skipif(not USE_GPU, reason="Skipping GPU Test")
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
 def test_torch_nccl_channel_with_local_reader(ray_start_regular):
-    assert (
-        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
-    ), "This test requires at least 2 GPUs"
+    if sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) < 2:
+        pytest.skip("This test requires at least 2 GPUs")
 
     actor_cls = TorchTensorWorker.options(num_cpus=0, num_gpus=1)
 
@@ -1834,9 +1842,8 @@ def test_torch_nccl_channel_with_local_reader(ray_start_regular):
 @pytest.mark.skipif(not USE_GPU, reason="Skipping GPU Test")
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
 def test_torch_nccl_channel_with_two_local_readers(ray_start_regular):
-    assert (
-        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
-    ), "This test requires at least 2 GPUs"
+    if sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) < 2:
+        pytest.skip("This test requires at least 2 GPUs")
     actor_cls = TorchTensorWorker.options(num_cpus=0, num_gpus=1)
 
     w1 = actor_cls.remote()
@@ -1869,9 +1876,8 @@ def test_torch_nccl_channel_with_two_local_readers(ray_start_regular):
 @pytest.mark.skipif(not USE_GPU, reason="Skipping GPU Test")
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
 def test_torch_nccl_channel_with_all_local_readers(ray_start_regular):
-    assert (
-        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 0
-    ), "This test requires at least 1 GPU"
+    if sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) < 1:
+        pytest.skip("This test requires at least 1 GPU")
     actor_cls = TorchTensorWorker.options(num_cpus=0, num_gpus=1)
 
     worker = actor_cls.remote()

--- a/python/ray/experimental/channel/accelerator_context.py
+++ b/python/ray/experimental/channel/accelerator_context.py
@@ -1,0 +1,201 @@
+import threading
+import importlib
+import ray
+from typing import TYPE_CHECKING, Optional, Type, ContextManager
+from contextlib import nullcontext
+from ray.experimental.channel.communicator import Communicator
+
+if TYPE_CHECKING:
+    import torch
+
+# The accelerator context singleton on this process.
+_accelerator_context_lock = threading.Lock()
+_default_accelerator_context: Optional["AcceleratorContext"] = None
+_global_custom_context: Optional["AcceleratorContext"] = None
+
+
+class AcceleratorContext:
+    """
+    Provides a unified interface for managing different accelerator backends
+    This includes stream management, event creation, device context control,
+    and communicator support for distributed communication.
+    """
+
+    def __init__(self, torch_module_name: str, communicator_cls: Type[Communicator]):
+        """
+        Initializes an accelerator context with the specified torch device module
+        and communicator class.
+
+        Args:
+            torch_module_name: Name of the torch device module (e.g., "cuda", "cpu").
+            communicator_cls: Class used to handle communication.
+        """
+
+        # The name of the torch module (e.g., 'cuda', 'npu')
+        self._torch_module_name: str = torch_module_name
+        # The Communicator class used to manage communication
+        self._communicator_cls: Type[Communicator] = communicator_cls
+
+        # Save the torch module corresponding to the device module name.
+        self._torch_mod = importlib.import_module(f"torch.{torch_module_name}")
+
+    @staticmethod
+    def get() -> "AcceleratorContext":
+        """
+        Returns the singleton instance of the accelerator context.
+
+        If a custom accelerator has been registered, initializes the context
+        based on the registration. Otherwise, selects an appropriate runtime
+        based on the available device (CUDA or CPU) and registers the
+        corresponding default communicator.
+
+        Returns:
+            AcceleratorContext: A singleton instance of the appropriate
+            runtime context.
+        """
+
+        global _default_accelerator_context, _global_custom_context
+
+        with _accelerator_context_lock:
+            if _global_custom_context is not None:
+                return _global_custom_context
+
+            if _default_accelerator_context is None:
+                if len(ray.get_gpu_ids()) > 0:
+                    from ray.experimental.channel.nccl_group import _NcclGroup
+
+                    _default_accelerator_context = AcceleratorContext(
+                        "cuda", _NcclGroup
+                    )
+                else:
+                    from ray.experimental.channel.cpu_communicator import (
+                        CPUCommunicator,
+                    )
+
+                    _default_accelerator_context = AcceleratorContext(
+                        "cpu", CPUCommunicator
+                    )
+
+            return _default_accelerator_context
+
+    @staticmethod
+    def set(accelerator_context: "AcceleratorContext") -> None:
+        """
+        Overwrites the default accelerator context.
+
+        Args:
+            accelerator_context: The context to register.
+        """
+        global _global_custom_context
+
+        # Accelerator context is registered.
+        _global_custom_context = accelerator_context
+
+    def get_default_device(self) -> "torch.device":
+        """
+        Returns the default device used by the compiled graph.
+
+        Currently, the default device for the compiled graph is the first visible
+        device. By default, it returns the device with logical ID 0.
+
+        Returns:
+            torch.device: The default device.
+        """
+        import torch
+
+        if self._torch_module_name == "cpu":
+            return torch.device("cpu")
+
+        return torch.device(f"{self._torch_module_name}:0")
+
+    def get_device_context(self, device: "torch.device") -> ContextManager:
+        """
+        Retrieves the context manager for the specified accelerator device.
+        There is no device context for CPU, returning a nullcontext.
+
+        Args:
+            device: The target device for which the context manager is required.
+
+        Returns:
+            ContextManager: A context manager specific to the device type.
+        """
+        if device.type == "cpu":
+            return nullcontext()
+
+        return self._torch_mod.device(device)
+
+    def current_stream(self):
+        """
+        Retrieves the current execution stream for the accelerator device.
+        """
+        return self._torch_mod.current_stream()
+
+    def create_event(self):
+        """
+        Creates an event object for the accelerator device.
+        """
+        return self._torch_mod.Event()
+
+    def generate_communicator_id(self) -> str:
+        """
+        Generates a communication identifier for communication group.
+        """
+        return self._communicator_cls.generate_communicator_id()
+
+    def create_communicator(self, *args, **kwargs) -> Communicator:
+        """
+        Creates a communication group for collective operations.
+        """
+        return self._communicator_cls(*args, **kwargs)
+
+    @property
+    def module_name(self) -> str:
+        """
+        Gets the name of the torch module backing the accelerator.
+        """
+        return self._torch_module_name
+
+    @property
+    def communicator_cls(self) -> Optional[Type[Communicator]]:
+        """
+        Returns the communicator class.
+        """
+        return self._communicator_cls
+
+    @property
+    def accelerator_count(self) -> int:
+        """
+        Returns the number of accelerators assigned by ray.
+        """
+        if self._torch_module_name == "cuda":
+            return len(ray.get_gpu_ids())
+        else:
+            accelerator_ids = ray.get_runtime_context().get_accelerator_ids()
+            return len(accelerator_ids.get(self._torch_module_name.upper(), []))
+
+
+def register_accelerator_context(
+    torch_module_name: str, communicator_cls: Type[Communicator]
+):
+    """
+    Registers the accelerator context with the specified device type and communicator.
+
+    Args:
+        torch_module_name: The name of the device module under torch.
+        communicator_cls: The communicator class associated with the device.
+    """
+    accelerator_context = AcceleratorContext(torch_module_name, communicator_cls)
+    AcceleratorContext.set(accelerator_context)
+
+
+def is_accelerator_context_registered():
+    """
+    Checks whether a custom accelerator context has been registered.
+
+    Returns:
+        bool: True if a custom accelerator context is registered
+              (_global_custom_context is not None), False otherwise.
+    """
+    if _global_custom_context is not None:
+        return True
+    return False

--- a/python/ray/experimental/channel/common.py
+++ b/python/ray/experimental/channel/common.py
@@ -19,7 +19,8 @@ from typing import (
 import ray
 import ray.exceptions
 from ray.experimental.channel.communicator import Communicator
-from ray.experimental.channel.utils import get_devices
+from ray.experimental.channel.communicator_handle import CommunicatorHandle
+from ray.experimental.channel.accelerator_context import AcceleratorContext
 from ray.experimental.channel.serialization_context import _SerializationContext
 from ray.util.annotations import DeveloperAPI, PublicAPI
 
@@ -127,6 +128,8 @@ class ChannelContext:
     def __init__(self):
         # Used for the torch.Tensor NCCL transport.
         self.communicators: Dict[str, "Communicator"] = {}
+        # Used for driver process to store actors in the communicator.
+        self.communicator_handles: Dict[str, "CommunicatorHandle"] = {}
 
     @staticmethod
     def get_current() -> "ChannelContext":
@@ -163,7 +166,7 @@ class ChannelContext:
     @property
     def torch_device(self) -> "torch.device":
         if self._torch_device is None:
-            self._torch_device = get_devices()[0]
+            self._torch_device = AcceleratorContext.get().get_default_device()
 
         return self._torch_device
 

--- a/python/ray/experimental/channel/communicator.py
+++ b/python/ray/experimental/channel/communicator.py
@@ -6,7 +6,6 @@ from ray.experimental.util.types import ReduceOp
 from ray.util.annotations import DeveloperAPI
 
 if TYPE_CHECKING:
-    import cupy as cp
     import torch
 
 
@@ -108,17 +107,17 @@ class Communicator(ABC):
 
     @property
     @abstractmethod
-    def recv_stream(self) -> Optional["cp.cuda.ExternalStream"]:
+    def recv_stream(self):
         """
-        Return the cuda stream used for receiving tensors.
+        Return the torch stream context used for receiving tensors.
         """
         raise NotImplementedError
 
     @property
     @abstractmethod
-    def send_stream(self) -> Optional["cp.cuda.ExternalStream"]:
+    def send_stream(self):
         """
-        Return the cuda stream used for sending tensors.
+        Return the torch stream context used for sending tensors.
         """
         raise NotImplementedError
 
@@ -188,5 +187,13 @@ class Communicator(ABC):
     def get_transport_name(self) -> str:
         """
         Return the type of the communicator (gpu or cpu).
+        """
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def generate_communicator_id(cls) -> str:
+        """
+        Return the unique id of the communicator.
         """
         raise NotImplementedError

--- a/python/ray/experimental/channel/communicator_handle.py
+++ b/python/ray/experimental/channel/communicator_handle.py
@@ -1,0 +1,27 @@
+from typing import List
+import ray
+
+
+class CommunicatorHandle:
+    """
+    A lightweight communicator handle used by the driver to store handles to
+    the actors in the communicator.
+    """
+
+    def __init__(
+        self,
+        actor_handles: List["ray.actor.ActorHandle"],
+    ):
+        """
+        Initializes the CommunicatorHandle with the given actor handles.
+
+        Args:
+            actor_handles: A list of actor handles to be stored.
+        """
+        self._actor_handles = actor_handles
+
+    def get_actor_handles(self) -> List["ray.actor.ActorHandle"]:
+        """
+        Retuan all actor handles in this communicator.
+        """
+        return self._actor_handles

--- a/python/ray/experimental/channel/conftest.py
+++ b/python/ray/experimental/channel/conftest.py
@@ -8,6 +8,7 @@ import torch
 import ray
 import ray.dag
 import ray.experimental.channel as ray_channel
+from ray.experimental.channel import nccl_group
 from ray.experimental.channel.communicator import TorchTensorAllocator
 from ray.experimental.util.types import Device
 
@@ -66,8 +67,11 @@ class MockCudaStream:
     def __init__(self):
         self.cuda_stream = 0
 
+    def synchronize(self):
+        pass
 
-class MockNcclGroup(ray_channel.nccl_group._NcclGroup):
+
+class MockNcclGroup(nccl_group._NcclGroup):
     """
     Mock the internal _NcclGroup to use a barrier actor instead of a NCCL group
     for communication.
@@ -133,7 +137,7 @@ def start_nccl_mock():
     cp_patcher.start()
 
     # Mock send/recv ops to use an actor instead of NCCL.
-    ray.experimental.channel.torch_tensor_nccl_channel._NcclGroup = MockNcclGroup
+    ray.experimental.channel.nccl_group._NcclGroup = MockNcclGroup
 
     # PyTorch mocks.
     stream_patcher = mock.patch(

--- a/python/ray/experimental/channel/cpu_communicator.py
+++ b/python/ray/experimental/channel/cpu_communicator.py
@@ -199,3 +199,9 @@ class CPUCommunicator(Communicator):
 
     def send_stream(self):
         raise NotImplementedError
+
+    @classmethod
+    def generate_communicator_id(cls) -> str:
+        import uuid
+
+        return str(uuid.uuid4())

--- a/python/ray/experimental/channel/nccl_group.py
+++ b/python/ray/experimental/channel/nccl_group.py
@@ -6,10 +6,9 @@ import ray
 from ray.exceptions import RayChannelError
 from ray.experimental.channel.communicator import Communicator, TorchTensorAllocator
 from ray.experimental.util.types import ReduceOp
-from ray.experimental.channel.utils import get_devices
+from ray.experimental.channel.accelerator_context import AcceleratorContext
 
 if TYPE_CHECKING:
-    import cupy as cp
     import torch
 
 
@@ -33,7 +32,7 @@ class _NcclGroup(Communicator):
         comm_id: tuple,
         rank: Optional[int],
         actor_handles: List["ray.actor.ActorHandle"],
-        cuda_stream: Optional[int],
+        cuda_stream: Optional["torch.cuda.Stream"],
         use_communication_streams: bool = False,
     ):
         """
@@ -93,29 +92,21 @@ class _NcclGroup(Communicator):
             # Driver does not have a rank.
             self._comm = None
 
-        self._cuda_stream: Optional["cp.cuda.ExternalStream"] = None
-        self._send_stream: Optional["cp.cuda.ExternalStream"] = None
-        self._recv_stream: Optional["cp.cuda.ExternalStream"] = None
+        self._cuda_stream: Optional["torch.cuda.Stream"] = None
+        self._send_stream: Optional["torch.cuda.Stream"] = None
+        self._recv_stream: Optional["torch.cuda.Stream"] = None
         if cuda_stream is not None:
             assert rank is not None, "NCCL actor has no rank assigned"
-
-            import cupy as cp
-
-            # TODO(swang): Allow default device to be overridden.
-            device = get_devices()[0]
-            self._cuda_stream = cp.cuda.ExternalStream(
-                cuda_stream, device_id=device.index
-            )
+            self._cuda_stream = cuda_stream
 
             if use_communication_streams:
                 import torch
 
-                self._send_stream = cp.cuda.ExternalStream(
-                    torch.cuda.Stream().cuda_stream, device_id=device.index
-                )
-                self._recv_stream = cp.cuda.ExternalStream(
-                    torch.cuda.Stream().cuda_stream, device_id=device.index
-                )
+                # TODO(swang): Allow default device to be overridden.
+                device = AcceleratorContext.get().get_default_device()
+
+                self._send_stream = torch.cuda.Stream(device=device)
+                self._recv_stream = torch.cuda.Stream(device=device)
             else:
                 self._send_stream = self._cuda_stream
                 self._recv_stream = self._cuda_stream
@@ -189,7 +180,7 @@ class _NcclGroup(Communicator):
             buf.numel(),
             self.nccl_util.get_nccl_tensor_dtype(buf),
             peer_rank,
-            self._send_stream.ptr,
+            self._send_stream.cuda_stream,
         )
 
     def recv(
@@ -228,7 +219,7 @@ class _NcclGroup(Communicator):
                 buf.numel(),
                 self.nccl_util.get_nccl_tensor_dtype(buf),
                 peer_rank,
-                self._recv_stream.ptr,
+                self._recv_stream.cuda_stream,
             )
         else:
             self._comm.recv(
@@ -236,7 +227,7 @@ class _NcclGroup(Communicator):
                 buf.numel(),
                 self.nccl_util.get_nccl_tensor_dtype(buf),
                 peer_rank,
-                self._recv_stream.ptr,
+                self._recv_stream.cuda_stream,
             )
 
             # Buffer values are undefined if NCCL ops are aborted. Therefore, we
@@ -290,7 +281,7 @@ class _NcclGroup(Communicator):
             self.nccl_util.get_tensor_ptr(recv_buf),
             send_buf.numel(),
             self.nccl_util.get_nccl_tensor_dtype(send_buf),
-            self._cuda_stream.ptr,
+            self._cuda_stream.cuda_stream,
         ]
         self._exec_collective(
             send_buf,
@@ -311,7 +302,7 @@ class _NcclGroup(Communicator):
             send_buf.numel(),
             self.nccl_util.get_nccl_tensor_dtype(send_buf),
             op.value,
-            self._cuda_stream.ptr,
+            self._cuda_stream.cuda_stream,
         ]
         self._exec_collective(
             send_buf,
@@ -332,7 +323,7 @@ class _NcclGroup(Communicator):
             recv_buf.numel(),
             self.nccl_util.get_nccl_tensor_dtype(send_buf),
             op.value,
-            self._cuda_stream.ptr,
+            self._cuda_stream.cuda_stream,
         ]
         self._exec_collective(
             send_buf,
@@ -342,12 +333,16 @@ class _NcclGroup(Communicator):
         )
 
     @property
-    def recv_stream(self) -> Optional["cp.cuda.ExternalStream"]:
-        return self._recv_stream
+    def recv_stream(self):
+        import torch
+
+        return torch.cuda.StreamContext(self._recv_stream)
 
     @property
-    def send_stream(self) -> Optional["cp.cuda.ExternalStream"]:
-        return self._send_stream
+    def send_stream(self):
+        import torch
+
+        return torch.cuda.StreamContext(self._send_stream)
 
     def destroy(self) -> None:
         """
@@ -371,3 +366,9 @@ class _NcclGroup(Communicator):
 
     def get_transport_name(self) -> str:
         return "nccl"
+
+    @classmethod
+    def generate_communicator_id(cls) -> str:
+        from cupy.cuda import nccl
+
+        return nccl.get_unique_id()

--- a/python/ray/experimental/channel/serialization_context.py
+++ b/python/ray/experimental/channel/serialization_context.py
@@ -2,6 +2,7 @@ import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Set, Tuple, Union
 
 from ray.experimental.util.types import Device
+from ray.experimental.channel.accelerator_context import AcceleratorContext
 
 if TYPE_CHECKING:
     import numpy as np
@@ -120,7 +121,7 @@ class _SerializationContext:
         # CPU and another from CPU to shared memory. Ideally we should elide
         # the first copy and memcpy directly from GPU to the shared memory
         # buffer.
-        if tensor_device_type == "cuda":
+        if tensor_device_type != "cpu":
             tensor = tensor.to("cpu")
 
         # Numpy does not have an equivalent dtype for all torch dtypes, so
@@ -169,12 +170,12 @@ class _SerializationContext:
         if target_device == Device.DEFAULT:
             target_device_type = tensor_device_type
         elif target_device in [Device.GPU, Device.CUDA]:
-            target_device_type = "cuda"
+            target_device_type = AcceleratorContext.get().module_name
         else:
-            target_device_type = "cpu"
+            target_device_type = target_device.value
 
         # TODO(swang): Support local P2P transfers if available.
-        if target_device_type == "cuda":
+        if target_device_type != "cpu":
 
             def convert_numpy_to_tensor(np_array):
                 if not isinstance(np_array, np.ndarray):

--- a/python/ray/experimental/channel/torch_tensor_nccl_channel.py
+++ b/python/ray/experimental/channel/torch_tensor_nccl_channel.py
@@ -3,7 +3,7 @@ import logging
 import uuid
 from dataclasses import dataclass
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union, Type
 
 import ray
 import ray.util.serialization
@@ -12,10 +12,15 @@ from ray.experimental.channel.common import ChannelInterface
 from ray.experimental.channel.communicator import Communicator
 from ray.experimental.channel.cpu_communicator import CPUCommunicator
 from ray.experimental.channel.intra_process_channel import IntraProcessChannel
-from ray.experimental.channel.nccl_group import _NcclGroup
+from ray.experimental.channel.communicator_handle import CommunicatorHandle
 from ray.experimental.channel.shared_memory_channel import SharedMemoryType
 from ray.experimental.channel.torch_tensor_type import TorchTensorType
 from ray.util.annotations import DeveloperAPI
+from ray.experimental.channel.accelerator_context import (
+    AcceleratorContext,
+    register_accelerator_context,
+    is_accelerator_context_registered,
+)
 
 if TYPE_CHECKING:
     import torch
@@ -399,32 +404,38 @@ class _TorchTensorNcclChannel(ChannelInterface):
         ), f"NCCL group ID ({typ.communicator_id}) must be a str."
         self._typ = typ
 
-        assert self._typ.communicator_id is not None, "No NCCL group specified."
-        self._nccl_group_id: str = self._typ.communicator_id
-        self._nccl_group: "Communicator" = ctx.communicators[self._typ.communicator_id]
-        assert (
-            self._nccl_group is not None
-        ), "ChannelContext.nccl_group is not initialized."
-
         self._static_shape = typ.static_shape
 
-        self._writer_rank = self._nccl_group.get_rank(self._writer)
-        self._reader_ranks = [
-            self._nccl_group.get_rank(reader)
-            for reader, _ in self._reader_and_node_list
-        ]
+        assert self._typ.communicator_id is not None, "No NCCL group specified."
+        self._nccl_group_id: str = self._typ.communicator_id
 
-        if (
-            self._writer_rank is not None
-            and self._writer_rank == self._nccl_group.get_self_rank()
-        ):
-            self._writer_registered = True
+        # If the communicators does not contain the group_id, it means the current
+        # process is the driver, and there’s no need to fetch the nccl_group.
+        if self._typ.communicator_id in ctx.communicators:
+            self._nccl_group: "Communicator" = ctx.communicators[
+                self._typ.communicator_id
+            ]
+            assert (
+                self._nccl_group is not None
+            ), "ChannelContext.nccl_group is not initialized."
 
-        if (
-            self._reader_ranks
-            and self._nccl_group.get_self_rank() in self._reader_ranks
-        ):
-            self._reader_registered = True
+            self._writer_rank = self._nccl_group.get_rank(self._writer)
+            self._reader_ranks = [
+                self._nccl_group.get_rank(reader)
+                for reader, _ in self._reader_and_node_list
+            ]
+
+            if (
+                self._writer_rank is not None
+                and self._writer_rank == self._nccl_group.get_self_rank()
+            ):
+                self._writer_registered = True
+
+            if (
+                self._reader_ranks
+                and self._nccl_group.get_self_rank() in self._reader_ranks
+            ):
+                self._reader_registered = True
 
         # If the channel type specifies that the tensor shape is static, then the
         # receiver can allocate buffers without needing to coordinate with the
@@ -448,13 +459,13 @@ class _TorchTensorNcclChannel(ChannelInterface):
         assert self._nccl_group is not None, "Actor is not part of a NCCL group"
         assert self._writer_registered
         ctx = ChannelContext.get_current()
-        assert ctx.torch_device.type == "cuda"
+        assert ctx.torch_device.type != "cpu"
 
     def ensure_registered_as_reader(self) -> bool:
         assert self._nccl_group is not None, "Actor is not part of a NCCL group"
         assert self._reader_registered
         ctx = ChannelContext.get_current()
-        assert ctx.torch_device.type == "cuda"
+        assert ctx.torch_device.type != "cpu"
 
     def __reduce__(self):
         return (
@@ -642,12 +653,10 @@ def _do_init_communicator(
     use_communication_streams,
     custom_communicator: Optional[Communicator] = None,
 ):
-    import torch
-
     if not custom_communicator:
         assert (
-            ray.get_gpu_ids()
-        ), "Actors participating in NCCL group must have at least one GPU assigned"
+            AcceleratorContext.get().accelerator_count > 0
+        ), "Actors participating in Communication group must have at least one Accelerator assigned"
 
     ctx = ChannelContext.get_current()
     if custom_communicator is not None:
@@ -655,12 +664,12 @@ def _do_init_communicator(
         ctx.communicators[group_id] = custom_communicator
     else:
         # default to NcclGroup
-        ctx.communicators[group_id] = _NcclGroup(
+        ctx.communicators[group_id] = AcceleratorContext.get().create_communicator(
             world_size,
             comm_id,
             rank,
             actor_handles,
-            torch.cuda.current_stream().cuda_stream,
+            AcceleratorContext.get().current_stream(),
             use_communication_streams,
         )
 
@@ -675,14 +684,16 @@ def _do_destroy_communicator(self, group_id):
     # task loop running.
 
 
-def _do_check_has_gpu(self) -> bool:
-    return bool(ray.get_gpu_ids())
+def _do_check_has_accelerators(self) -> str:
+    return AcceleratorContext.get().accelerator_count > 0
 
 
-def _do_get_unique_nccl_id(self) -> tuple:
-    from cupy.cuda import nccl
+def do_register_accelerator_context(self, name: str, communicator: Type[Communicator]):
+    register_accelerator_context(name, communicator)
 
-    return nccl.get_unique_id()
+
+def _do_get_unique_communication_id(self) -> bool:
+    return AcceleratorContext.get().generate_communicator_id()
 
 
 def _get_ranks(
@@ -722,6 +733,8 @@ def _init_communicator(
     actors: List[ray.actor.ActorHandle],
     custom_communicator: Optional[Communicator] = None,
     use_communication_streams: bool = False,
+    accelerator_module_name: Optional[str] = None,
+    accelerator_communicator_cls: Optional[Type[Communicator]] = None,
 ) -> str:
     """
     Initialize a NCCL group with the given actors. If a custom NCCL group is
@@ -733,6 +746,8 @@ def _init_communicator(
         use_communication_streams: Whether to use dedicated send and recv
                 streams for communication. If True, communication and computation
                 can be overlapped to improve performance.
+        accelerator_module_name: Optional name of the accelerator module to use.
+        accelerator_communicator_cls: Optional communicator class for the accelerator.
     """
     ctx = ChannelContext.get_current()
 
@@ -740,16 +755,30 @@ def _init_communicator(
         custom_communicator, CPUCommunicator
     )
 
-    has_gpus = ray.get(
-        [actor.__ray_call__.remote(_do_check_has_gpu) for actor in actors]
+    # Register accelerator context for all actors if accelerator is not default
+    if accelerator_module_name and accelerator_communicator_cls:
+        if is_accelerator_context_registered():
+            ray.get(
+                [
+                    actor.__ray_call__.remote(
+                        do_register_accelerator_context,
+                        accelerator_module_name,
+                        accelerator_communicator_cls,
+                    )
+                    for actor in actors
+                ]
+            )
+
+    has_accelerators = ray.get(
+        [actor.__ray_call__.remote(_do_check_has_accelerators) for actor in actors]
     )
-    for has_gpu, actor in zip(has_gpus, actors):
-        if not has_gpu and not is_cpu_communicator:
+    for has_accelerator, actor in zip(has_accelerators, actors):
+        if not has_accelerator and not is_cpu_communicator:
             raise ValueError(
                 f"Actor {actor} returns a tensor with type hint "
                 'TorchTensor(transport="nccl") or '
-                "TorchTensor(transport=nccl_group_handle)"
-                "but actor does not have a GPU assigned by Ray."
+                "TorchTensor(transport=nccl_group_handle) "
+                "but actor does not have an accelerator assigned by Ray."
             )
 
     actor_ids = {actor._ray_actor_id for actor in actors}
@@ -758,11 +787,8 @@ def _init_communicator(
     # Allocate a communicator ID on one of the actors that will participate in
     # the group. This is in case the driver is not on the same node as one of
     # the NCCL actors.
-    nccl_comm_id = (
-        ray.get(actors[0].__ray_call__.remote(_do_get_unique_nccl_id))
-        if not is_cpu_communicator
-        else str(uuid.uuid4())
-    )
+    comm_id = ray.get(actors[0].__ray_call__.remote(_do_get_unique_communication_id))
+
     # Used to uniquely identify this NCCL group.
     group_id = str(uuid.uuid4())
 
@@ -778,7 +804,7 @@ def _init_communicator(
             _do_init_communicator,
             group_id,
             world_size,
-            nccl_comm_id,
+            comm_id,
             rank,
             actors,
             use_communication_streams,
@@ -797,15 +823,14 @@ def _init_communicator(
     logger.info("NCCL group initialized.")
 
     if custom_communicator is not None:
-        ctx.communicators[group_id] = custom_communicator
-    else:
-        ctx.communicators[group_id] = _NcclGroup(
-            world_size,
-            nccl_comm_id,
-            rank=None,
-            actor_handles=actors,
-            cuda_stream=None,
+        ctx.communicator_handles[group_id] = CommunicatorHandle(
+            actor_handles=custom_communicator.get_actor_handles(),
         )
+    else:
+        ctx.communicator_handles[group_id] = CommunicatorHandle(
+            actor_handles=actors,
+        )
+
     return group_id
 
 
@@ -814,10 +839,10 @@ def _destroy_communicator(group_id: str) -> None:
     Destroy the NCCL group with the given ID.
     """
     ctx = ChannelContext.get_current()
-    if group_id not in ctx.communicators:
+    if group_id not in ctx.communicator_handles:
         return
 
-    group = ctx.communicators[group_id]
+    group = ctx.communicator_handles[group_id]
     actors = group.get_actor_handles()
     destroy_tasks = [
         actor.__ray_call__.remote(
@@ -834,4 +859,4 @@ def _destroy_communicator(group_id: str) -> None:
             "may be hung."
         )
 
-    del ctx.communicators[group_id]
+    del ctx.communicator_handles[group_id]

--- a/python/ray/experimental/channel/utils.py
+++ b/python/ray/experimental/channel/utils.py
@@ -1,10 +1,6 @@
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 import ray
-import os
-
-if TYPE_CHECKING:
-    import torch
 
 
 def get_self_actor() -> Optional["ray.actor.ActorHandle"]:
@@ -94,68 +90,3 @@ def get_actor_node(actor: Optional["ray.actor.ActorHandle"]) -> str:
                 lambda self: ray.get_runtime_context().get_node_id()
             )
         )
-
-
-def get_cuda_devices() -> List["torch.device"]:
-    """Gets the correct torch cuda device list configured for this process.
-
-    Assumes that `CUDA_VISIBLE_DEVICES` is set and is a
-    superset of the `ray.get_gpu_ids()`.
-    """
-    # Note: currently this method replicates the logic from
-    # `CUDATorchDeviceManager.get_devices()`.
-    # TODO(rui): tailor and clean up the logic for proper use in
-    # Compiled Graphs.
-    import torch
-
-    # GPU IDs are assigned by Ray after you specify "use_gpu"
-    # GPU `ray.get_gpu_ids()` may return ints or may return strings.
-    # We should always convert to strings.
-    gpu_ids = [str(id) for id in ray.get_gpu_ids()]
-
-    device_ids = []
-
-    if len(gpu_ids) > 0:
-        cuda_visible_str = os.environ.get("CUDA_VISIBLE_DEVICES", "")
-        if cuda_visible_str and cuda_visible_str != "NoDevFiles":
-            cuda_visible_list = cuda_visible_str.split(",")
-        else:
-            cuda_visible_list = []
-
-        # By default, there should only be one GPU ID if `use_gpu=True`.
-        # If there are multiple GPUs, return a list of devices.
-        # If using fractional GPUs, these IDs are not guaranteed
-        # to be unique across different processes.
-        for gpu_id in gpu_ids:
-            try:
-                device_ids.append(cuda_visible_list.index(gpu_id))
-            except IndexError:
-                raise RuntimeError(
-                    "CUDA_VISIBLE_DEVICES set incorrectly. "
-                    f"Got {cuda_visible_str}, expected to include {gpu_id}. "
-                    "Did you override the `CUDA_VISIBLE_DEVICES` environment"
-                    " variable? If not, please help file an issue on Github."
-                )
-
-    else:
-        # If called on the driver or outside of Ray Train, return the
-        # 0th device.
-        device_ids.append(0)
-
-    return [torch.device(f"cuda:{device_id}") for device_id in device_ids]
-
-
-def get_devices() -> List["torch.device"]:
-    """Gets the correct torch device list configured for this process.
-
-    Returns a list of torch devices allocated for the current worker.
-    If no devices are assigned, then it returns a list with a single CPU device.
-    """
-
-    import torch
-
-    gpu_ids = [str(id) for id in ray.get_gpu_ids()]
-    if len(gpu_ids) > 0:
-        return get_cuda_devices()
-    else:
-        return [torch.device("cpu")]

--- a/python/ray/experimental/collective/conftest.py
+++ b/python/ray/experimental/collective/conftest.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Dict, FrozenSet, List, Optional, Set, Tuple
+from typing import Dict, FrozenSet, List, Optional, Set, Tuple, Type
 
 import torch
 
@@ -16,8 +16,6 @@ class AbstractNcclGroup(Communicator):
     """
     A dummy NCCL group for testing.
     """
-
-    import cupy as cp
 
     def __init__(self, actor_handles: List[ray.actor.ActorHandle]):
         self._actor_handles = actor_handles
@@ -74,11 +72,11 @@ class AbstractNcclGroup(Communicator):
         raise NotImplementedError
 
     @property
-    def recv_stream(self) -> Optional["cp.cuda.ExternalStream"]:
+    def recv_stream(self):
         return None
 
     @property
-    def send_stream(self) -> Optional["cp.cuda.ExternalStream"]:
+    def send_stream(self):
         return None
 
     def destroy(self) -> None:
@@ -86,6 +84,10 @@ class AbstractNcclGroup(Communicator):
 
     def get_transport_name(self) -> str:
         return "nccl"
+
+    @classmethod
+    def generate_communicator_id(cls) -> str:
+        pass
 
 
 class MockNcclGroupSet:
@@ -101,6 +103,8 @@ class MockNcclGroupSet:
         actors: List["ray.actor.ActorHandle"],
         custom_nccl_group: Optional[Communicator] = None,
         use_communication_streams: bool = False,
+        accelerator_module_name: Optional[str] = None,
+        accelerator_communicator_cls: Optional[Type[Communicator]] = None,
     ) -> str:
         group_id = str(uuid.uuid4())
         self.ids_to_actors_and_custom_comms[group_id] = (

--- a/python/ray/util/collective/util.py
+++ b/python/ray/util/collective/util.py
@@ -26,7 +26,7 @@ class NCCLUniqueIDStore:
         Initialize the NCCL unique ID for this store.
 
         Args:
-            uid: the unique ID generated via the NCCL get_unique_id API.
+            uid: the unique ID generated via the NCCL generate_communicator_id API.
 
         Returns:
             None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR improves multi-device support in Compile Graph, which significantly reduces Tensor transmission latency by utilizing out-of-band communication. Currently, this feature only supports CUDA’s NCCL. Since Ray already supports multiple accelerators, it is necessary to extend Compile Graph to support multi-device as well.

This PR mainly introduces two key changes:
	1.	Removed dependency on cupy.cuda.ExternalStream – Since this library only supports CUDA devices, we replaced it with a more general stream context manager to accommodate various accelerators. The new implementation uses torch.{device}.StreamContext.
	2.	Replaced hardcoded torch.cuda.xxx calls with AcceleratorRuntime – This allows automatic detection of the accelerator type and invokes the appropriate device-specific functions.

### How to add a new backend for CG? here's an example for Ascend NPU:
```python
import ray
import torch
import torch_npu
from ray.dag import InputNode
# implement customer Communicator class
from ray.experimental.channel.hccl_group import _HcclGroup
from ray.experimental.channel.accelerator_context import register_accelerator_context

@ray.remote
class TorchTensorWorker:
    def __init__(self):
        self.device = torch.device('npu:0')
        torch.npu.set_device(self.device)

    def send(self, shape, dtype, value: int):
        return torch.ones(shape, dtype=dtype, device=self.device) * value

    def recv(self, tensor):
        return (tensor[0].item(), tensor.shape, tensor.dtype)

# global register accelerator context
register_accelerator_context('npu', _HcclGroup)

actor_cls = TorchTensorWorker.options(num_cpus=0, resources={'NPU': 1})

sender = actor_cls.remote()
receiver = actor_cls.remote()

with InputNode() as inp:
    dag = sender.send.bind(inp.shape, inp.dtype, inp[0])
    dag = dag.with_tensor_transport(transport='nccl')
    dag = receiver.recv.bind(dag)

shape = (10,)
dtype = torch.float16

compiled_dag = dag.experimental_compile()
for i in range(3):
    ref = compiled_dag.execute(i, shape=shape, dtype=dtype)
    assert ray.get(ref) == (i, shape, dtype)

print("Success")
```


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
This PR is the main part of Task 2 in #51574 
It would better to set the function name more general, such as changing requires_nccl to require_communicator. This is implemented in #51061.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
