### PR TITLE
[data] Pass along kwargs to prevent breaking `ArrowPythonObjectScalar`

### DIFF
--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -118,7 +118,7 @@ steps:
     tags:
       - python
       - data
-      # - skip-on-premerge
+      - skip-on-premerge
       - oss
     instance_type: medium
     parallelism: 2
@@ -135,7 +135,7 @@ steps:
     tags:
       - python
       - data
-      # - skip-on-premerge
+      - skip-on-premerge
       - oss
     instance_type: medium
     commands:

--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -118,7 +118,7 @@ steps:
     tags:
       - python
       - data
-      - skip-on-premerge
+      # - skip-on-premerge
       - oss
     instance_type: medium
     parallelism: 2
@@ -135,7 +135,7 @@ steps:
     tags:
       - python
       - data
-      - skip-on-premerge
+      # - skip-on-premerge
       - oss
     instance_type: medium
     commands:

--- a/python/ray/air/util/object_extensions/arrow.py
+++ b/python/ray/air/util/object_extensions/arrow.py
@@ -77,7 +77,7 @@ class ArrowPythonObjectType(pa.ExtensionType):
 class ArrowPythonObjectScalar(pa.ExtensionScalar):
     """Scalar class for ArrowPythonObjectType"""
 
-    def as_py(self) -> typing.Any:
+    def as_py(self, **kwargs) -> typing.Any:
         if not isinstance(self.value, pa.LargeBinaryScalar):
             raise RuntimeError(
                 f"{type(self.value)} is not the expected LargeBinaryScalar"


### PR DESCRIPTION
## Why are these changes needed?
Our tests with pyarrow nightly caught a backwards incompatibility bug with a [recent pyarrow change](https://github.com/apache/arrow/pull/45471). To fix this we simply need to pass along kwargs in our `as_py` method as suggested by the pyarrow team [here](https://github.com/apache/arrow/pull/45471#issuecomment-2683130901).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
