### PR TITLE
Fixed grammar of OOM error message

### DIFF
--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -558,10 +558,11 @@ void ClientConnection::ProcessMessage(const boost::system::error_code &error) {
         error.value(),
         ". ",
         error.message(),
-        ". There are some potential root causes. (1) The process is killed by "
-        "SIGKILL by OOM killer due to high memory usage. (2) ray stop --force is "
-        "called. (3) The worker is crashed unexpectedly due to SIGSEGV or other "
-        "unexpected errors."));
+        ". There are several potential root causes. (1) The process is killed by"
+        " SIGKILL due to the OOM killer triggering from high high memory usage."
+        " (2) ray stop --force was called."
+        " (3) The worker crashed unexpectedly due to SIGSEGV or other unforseen"
+        " errors."));
     protocol::DisconnectClientBuilder builder(fbb);
     builder.add_disconnect_type(static_cast<int>(ray::rpc::WorkerExitType::SYSTEM_ERROR));
     builder.add_disconnect_detail(disconnect_detail);


### PR DESCRIPTION
## Why are these changes needed?

Fixes the grammar of the crashed worker error message.

## Related issue number

Replaces https://github.com/ray-project/ray/pull/51049

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
