### PR TITLE
[core] Add comments explaining why `unique_ptr::release()` is used.

### DIFF
--- a/src/ray/common/test/ray_syncer_test.cc
+++ b/src/ray/common/test/ray_syncer_test.cc
@@ -860,6 +860,9 @@ class SyncerReactorTest : public ::testing::Test {
     client_node_id = NodeID::FromRandom();
     cli_channel = MakeChannel("18990");
     auto cli_stub = ray::rpc::syncer::RaySyncer::NewStub(cli_channel);
+
+    // `cli_reactor` will be deleted by `RayClientBidiReactor::OnDone`, so we need to use
+    // `release()` to release ownership.
     cli_reactor =
         std::make_unique<RayClientBidiReactor>(
             rpc_service_->node_id.Binary(),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It's not common to call `unique_ptr::release()` because it can easily lead to memory leaks. However, `ray_syncer_test.cc` is a special case.

I tried to change `cli_reactor` to `unique_ptr`, and then the tests will fail with double free. I use ASAN to check:
 
1. `RayClientBidiReactor::OnDone` calls `delete this;`.
2. Unique pointer goes out of scope.

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/5f807a16-2633-4576-b057-d34dd1aaa546" />


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
