### PR TITLE
[Refactor]Rename NCCL-related items to comm_backend

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1493,8 +1493,8 @@ python/ray/experimental/channel/shared_memory_channel.py
     DOC101: Method `CompositeChannel.__init__`: Docstring contains fewer arguments than in function signature.
     DOC103: Method `CompositeChannel.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_channel_dict: Optional[Dict[ray.ActorID, ChannelInterface]], _channels: Optional[Set[ChannelInterface]], _reader_registered: bool, _writer_registered: bool].
 --------------------
-python/ray/experimental/channel/torch_tensor_nccl_channel.py
-    DOC201: Method `TorchTensorNcclChannel._recv_cpu_and_gpu_data` does not have a return section in docstring
+python/ray/experimental/channel/torch_tensor_accelerator_channel.py
+    DOC201: Method `TorchTensorAcceleratorChannel._recv_cpu_and_gpu_data` does not have a return section in docstring
     DOC201: Function `_get_ranks` does not have a return section in docstring
     DOC201: Function `_init_communicator` does not have a return section in docstring
 --------------------

--- a/python/ray/dag/collective_node.py
+++ b/python/ray/dag/collective_node.py
@@ -22,7 +22,7 @@ from ray.util.annotations import DeveloperAPI
 
 class _CollectiveOperation:
     """
-    Represent metadata for a NCCL collective operation.
+    Represent metadata for a communicator collective operation.
 
     Args:
         input_nodes: A list of input nodes to the collective operation.
@@ -32,7 +32,7 @@ class _CollectiveOperation:
     Requirements:
     1. Input nodes are unique.
     2. Actor handles are unique.
-    3. Actor handles match the custom NCCL group if specified.
+    3. Actor handles match the custom communicator group if specified.
     """
 
     def __init__(
@@ -66,12 +66,12 @@ class _CollectiveOperation:
 
         self._op = op
         if transport is None:
-            transport = TorchTensorType.NCCL
+            transport = TorchTensorType.ACCELERATOR
         self._type_hint = TorchTensorType(transport=transport, _direct_return=True)
         if isinstance(transport, Communicator):
             if set(transport.get_actor_handles()) != set(self._actor_handles):
                 raise ValueError(
-                    "Expected actor handles to match the custom NCCL group"
+                    "Expected actor handles to match the custom communicator group"
                 )
 
     def __str__(self) -> str:
@@ -97,7 +97,7 @@ class _CollectiveOperation:
         elif self._type_hint.get_custom_communicator() is not None:
             communicator = self._type_hint.get_custom_communicator()
         else:
-            raise ValueError("Expected a NCCL group")
+            raise ValueError("Expected a communicator group")
         return communicator
 
     def execute(self, send_buf: "torch.Tensor") -> "torch.Tensor":
@@ -142,14 +142,12 @@ class _CollectiveOperation:
 
 @DeveloperAPI
 class CollectiveOutputNode(ClassMethodNode):
-    """Represent an output node from a NCCL collective operation in a Ray DAG."""
+    """Represent an output node from a communicator collective operation in a Ray DAG."""
 
     def __init__(
         self,
         method_name: str,
-        method_args: Tuple[
-            DAGNode,
-        ],
+        method_args: Tuple[DAGNode,],
         method_kwargs: Dict[str, Any],
         method_options: Dict[str, Any],
         other_args_to_resolve: Dict[str, Any],

--- a/python/ray/dag/collective_node.py
+++ b/python/ray/dag/collective_node.py
@@ -22,7 +22,7 @@ from ray.util.annotations import DeveloperAPI
 
 class _CollectiveOperation:
     """
-    Represent metadata for a communicator collective operation.
+    Represent metadata for a collective communicator collective operation.
 
     Args:
         input_nodes: A list of input nodes to the collective operation.

--- a/python/ray/dag/collective_node.py
+++ b/python/ray/dag/collective_node.py
@@ -147,7 +147,9 @@ class CollectiveOutputNode(ClassMethodNode):
     def __init__(
         self,
         method_name: str,
-        method_args: Tuple[DAGNode,],
+        method_args: Tuple[
+            DAGNode,
+        ],
         method_kwargs: Dict[str, Any],
         method_options: Dict[str, Any],
         other_args_to_resolve: Dict[str, Any],

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -723,7 +723,7 @@ class ExecutableTask:
             resolved_inputs.append(task_input.resolve(input_data))
 
         if self.collective_op is not None:
-            # Run a accelerator collective operation.
+            # Run an accelerator collective operation.
             method = self.collective_op.execute
         else:
             # Run an actor method.

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -948,13 +948,13 @@ class CompiledDAG:
         ] = {}
 
         # Set of actors involved in P2P communication using an unresolved communicator.
-        self._p2p_actors_with_unresolved_communicators: Set["ray.actor.ActorHandle"] = (
-            set()
-        )
+        self._p2p_actors_with_unresolved_communicators: Set[
+            "ray.actor.ActorHandle"
+        ] = set()
         # Set of DAG nodes involved in P2P communication using an unresolved communicator.
-        self._p2p_dag_nodes_with_unresolved_communicators: Set["ray.dag.DAGNode"] = (
-            set()
-        )
+        self._p2p_dag_nodes_with_unresolved_communicators: Set[
+            "ray.dag.DAGNode"
+        ] = set()
         # Set of collective operations using an unresolved communicator.
         self._collective_ops_with_unresolved_communicators: Set[
             "ray.dag.collective_node._CollectiveOperation"
@@ -1008,9 +1008,9 @@ class CompiledDAG:
         # ObjectRef for each worker's task. The task is an infinite loop that
         # repeatedly executes the method specified in the DAG.
         self.worker_task_refs: Dict["ray.actor.ActorHandle", "ray.ObjectRef"] = {}
-        self.actor_to_tasks: Dict["ray.actor.ActorHandle", List["CompiledTask"]] = (
-            defaultdict(list)
-        )
+        self.actor_to_tasks: Dict[
+            "ray.actor.ActorHandle", List["CompiledTask"]
+        ] = defaultdict(list)
         # Mapping from actor handle to its GPU IDs.
         # This is used for type hint resolution for with_tensor_transport("auto").
         self.actor_to_gpu_ids: Dict["ray.actor.ActorHandle", List[str]] = {}

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -64,7 +64,7 @@ from ray.experimental.channel.shared_memory_channel import (
 )
 from ray.experimental.channel.torch_tensor_type import TorchTensorType
 
-from ray.experimental.channel.torch_tensor_nccl_channel import (
+from ray.experimental.channel.torch_tensor_accelerator_channel import (
     _init_communicator,
     _destroy_communicator,
 )
@@ -341,18 +341,19 @@ def _wrap_exception(exc):
     return wrapped
 
 
-def _get_nccl_group_id(type_hint: ChannelOutputType) -> Optional[str]:
+def _get_comm_group_id(type_hint: ChannelOutputType) -> Optional[str]:
     """
-    Get the NCCL group ID from the type hint. If the type hint does not
-    require NCCL, return None.
+    Get the communicator group ID from the type hint. If the type hint does not
+    require communicator, return None.
 
     Args:
         type_hint: The type hint of the channel.
 
     Returns:
-        The NCCL group ID if the type hint requires NCCL, otherwise None.
+        The communicator group ID if the type hint requires communicator,
+        otherwise None.
     """
-    if type_hint.requires_nccl():
+    if type_hint.requires_accelerator():
         assert isinstance(type_hint, TorchTensorType)
         return type_hint.communicator_id
     return None
@@ -361,7 +362,7 @@ def _get_nccl_group_id(type_hint: ChannelOutputType) -> Optional[str]:
 def _device_context_manager():
     """
     Return a context manager for executing communication operations
-    (i.e., READ and WRITE). For NCCL operations, the context manager
+    (i.e., READ and WRITE). For accelerator operations, the context manager
     uses the proper cuda device from channel context, otherwise,
     nullcontext will be returned.
     """
@@ -509,7 +510,7 @@ class ExecutableTask:
         self.input_type_hints: List[ChannelOutputType] = task.arg_type_hints
         self.output_type_hint: ChannelOutputType = task.dag_node.type_hint
 
-        # The NCCL collective operation.
+        # The accelerator collective operation.
         self.collective_op: Optional["ray.dag.CollectiveOperation"] = None
         if isinstance(task.dag_node, CollectiveOutputNode):
             self.collective_op = task.dag_node.collective_op
@@ -599,25 +600,25 @@ class ExecutableTask:
 
         # Set up send_stream and recv_stream when overlap_gpu_communication
         # is configured
-        if self.output_type_hint.requires_nccl():
-            nccl_group_id = _get_nccl_group_id(self.output_type_hint)
-            nccl_group = ChannelContext.get_current().communicators.get(nccl_group_id)
-            assert nccl_group is not None
-            self._send_stream = nccl_group.send_stream
+        if self.output_type_hint.requires_accelerator():
+            comm_group_id = _get_comm_group_id(self.output_type_hint)
+            comm_group = ChannelContext.get_current().communicators.get(comm_group_id)
+            assert comm_group is not None
+            self._send_stream = comm_group.send_stream
         if self.input_type_hints:
             for type_hint in self.input_type_hints:
-                if type_hint.requires_nccl():
-                    nccl_group_id = _get_nccl_group_id(type_hint)
-                    nccl_group = ChannelContext.get_current().communicators.get(
-                        nccl_group_id
+                if type_hint.requires_accelerator():
+                    comm_group_id = _get_comm_group_id(type_hint)
+                    comm_group = ChannelContext.get_current().communicators.get(
+                        comm_group_id
                     )
-                    assert nccl_group is not None
+                    assert comm_group is not None
                     if not isinstance(self._recv_stream, nullcontext):
-                        assert self._recv_stream == nccl_group.recv_stream, (
+                        assert self._recv_stream == comm_group.recv_stream, (
                             "Currently all torch tensor input channels of a "
                             "Compiled Graph task should use the same recv cuda stream."
                         )
-                    self._recv_stream = nccl_group.recv_stream
+                    self._recv_stream = comm_group.recv_stream
 
     def wrap_and_set_intermediate_future(
         self, val: Any, wrap_in_gpu_future: bool
@@ -722,7 +723,7 @@ class ExecutableTask:
             resolved_inputs.append(task_input.resolve(input_data))
 
         if self.collective_op is not None:
-            # Run a NCCL collective operation.
+            # Run a accelerator collective operation.
             method = self.collective_op.execute
         else:
             # Run an actor method.
@@ -877,7 +878,7 @@ class CompiledDAG:
                 tensors. Three types of values are valid. (1) Communicator:
                 For p2p operations, this is the default communicator
                 to use for nodes annotated with `with_tensor_transport()` and when
-                shared memory is not the desired option (e.g., when transport="nccl",
+                shared memory is not the desired option (e.g., when transport="accelerator",
                 or when transport="auto" for communication between two different GPUs).
                 For collective operations, this is the default communicator to use
                 when a custom communicator is not specified.
@@ -947,13 +948,13 @@ class CompiledDAG:
         ] = {}
 
         # Set of actors involved in P2P communication using an unresolved communicator.
-        self._p2p_actors_with_unresolved_communicators: Set[
-            "ray.actor.ActorHandle"
-        ] = set()
+        self._p2p_actors_with_unresolved_communicators: Set["ray.actor.ActorHandle"] = (
+            set()
+        )
         # Set of DAG nodes involved in P2P communication using an unresolved communicator.
-        self._p2p_dag_nodes_with_unresolved_communicators: Set[
-            "ray.dag.DAGNode"
-        ] = set()
+        self._p2p_dag_nodes_with_unresolved_communicators: Set["ray.dag.DAGNode"] = (
+            set()
+        )
         # Set of collective operations using an unresolved communicator.
         self._collective_ops_with_unresolved_communicators: Set[
             "ray.dag.collective_node._CollectiveOperation"
@@ -1007,9 +1008,9 @@ class CompiledDAG:
         # ObjectRef for each worker's task. The task is an infinite loop that
         # repeatedly executes the method specified in the DAG.
         self.worker_task_refs: Dict["ray.actor.ActorHandle", "ray.ObjectRef"] = {}
-        self.actor_to_tasks: Dict[
-            "ray.actor.ActorHandle", List["CompiledTask"]
-        ] = defaultdict(list)
+        self.actor_to_tasks: Dict["ray.actor.ActorHandle", List["CompiledTask"]] = (
+            defaultdict(list)
+        )
         # Mapping from actor handle to its GPU IDs.
         # This is used for type hint resolution for with_tensor_transport("auto").
         self.actor_to_gpu_ids: Dict["ray.actor.ActorHandle", List[str]] = {}
@@ -1189,10 +1190,10 @@ class CompiledDAG:
                 if isinstance(dag_node.type_hint, AutoTransportType):
                     auto_transport_tasks.add(task)
 
-                # Collect actors for NCCL P2P methods.
-                if dag_node.type_hint.requires_nccl():
+                # Collect actors for accelerator P2P methods.
+                if dag_node.type_hint.requires_accelerator():
                     self._track_communicator_usage(dag_node, {actor_handle})
-                # Collect NCCL collective operations.
+                # Collect accelerator collective operations.
                 if isinstance(dag_node, CollectiveOutputNode):
                     self._track_communicator_usage(
                         dag_node,
@@ -1201,16 +1202,16 @@ class CompiledDAG:
                     )
                     assert not self._overlap_gpu_communication, (
                         "Currently, the overlap_gpu_communication option is not "
-                        "supported for NCCL collective operations. Please set "
+                        "supported for accelerator collective operations. Please set "
                         "overlap_gpu_communication=False."
                     )
             elif isinstance(dag_node, InputNode) or isinstance(
                 dag_node, InputAttributeNode
             ):
-                if dag_node.type_hint.requires_nccl():
+                if dag_node.type_hint.requires_accelerator():
                     raise ValueError(
-                        "DAG inputs cannot be transferred via NCCL because "
-                        "the driver cannot participate in the NCCL group"
+                        "DAG inputs cannot be transferred via accelerator because "
+                        "the driver cannot participate in the communicator group"
                     )
                 if isinstance(dag_node.type_hint, AutoTransportType):
                     # Currently driver on GPU is not supported, so we always
@@ -1283,7 +1284,7 @@ class CompiledDAG:
 
                 upstream_task.downstream_task_idxs[task_idx] = downstream_actor_handle
 
-                if upstream_task.dag_node.type_hint.requires_nccl():
+                if upstream_task.dag_node.type_hint.requires_accelerator():
                     # Here we are processing the args of the DAGNode, so track
                     # downstream actors only, upstream actor is already tracked
                     # when processing the DAGNode itself.
@@ -1399,7 +1400,7 @@ class CompiledDAG:
             collective_op: Whether the communicator is used for a collective operation.
         """
         if None in actors:
-            raise ValueError("Driver cannot participate in the NCCL group.")
+            raise ValueError("Driver cannot participate in the communicator group.")
         if collective_op:
             type_hint = dag_node._collective_op.type_hint
         else:
@@ -1461,9 +1462,9 @@ class CompiledDAG:
         Resolve the auto transport type hint for the DAG.
         """
         type_hint_resolver = TypeHintResolver(self.actor_to_gpu_ids)
-        # Resolve AutoChannelType type hints and track the actors that use NCCL.
-        # This is needed so that the NCCL group can be initialized for these
-        # actors that use NCCL.
+        # Resolve AutoChannelType type hints and track the actors that use accelerator.
+        # This is needed so that the communicator group can be initialized for
+        # these actors that use accelerator.
         for task in auto_transport_tasks:
             writer = task.dag_node._get_actor_handle()
             readers = task.downstream_task_idxs.values()
@@ -1479,7 +1480,7 @@ class CompiledDAG:
                 writer_and_node,
                 reader_and_node_list,
             )
-            if task.dag_node.type_hint.requires_nccl():
+            if task.dag_node.type_hint.requires_accelerator():
                 self._track_communicator_usage(
                     task.dag_node,
                     set(readers).union({writer}),
@@ -1776,7 +1777,7 @@ class CompiledDAG:
 
         if RAY_CGRAPH_ENABLE_DETECT_DEADLOCK and self._detect_deadlock():
             raise ValueError(
-                "This DAG cannot be compiled because it will deadlock on NCCL "
+                "This DAG cannot be compiled because it will deadlock on accelerator "
                 "calls. If you believe this is a false positive, please disable "
                 "the graph verification by setting the environment variable "
                 "RAY_CGRAPH_ENABLE_DETECT_DEADLOCK to 0 and file an issue at "
@@ -1961,13 +1962,15 @@ class CompiledDAG:
                 dag_node = self.idx_to_task[task_idx].dag_node
                 method_name = exec_task.method_name
                 actor_handle = dag_node._get_actor_handle()
-                requires_nccl_read = False
+                requires_accelerator_read = False
                 for upstream_node in dag_node._upstream_nodes:
-                    if upstream_node.type_hint.requires_nccl():
-                        requires_nccl_read = True
+                    if upstream_node.type_hint.requires_accelerator():
+                        requires_accelerator_read = True
                         break
-                requires_nccl_compute = isinstance(dag_node, CollectiveOutputNode)
-                requires_nccl_write = dag_node.type_hint.requires_nccl()
+                requires_accelerator_compute = isinstance(
+                    dag_node, CollectiveOutputNode
+                )
+                requires_accelerator_write = dag_node.type_hint.requires_accelerator()
 
                 read_node = _DAGOperationGraphNode(
                     _DAGNodeOperation(
@@ -1975,7 +1978,7 @@ class CompiledDAG:
                     ),
                     task_idx,
                     actor_handle,
-                    requires_nccl_read,
+                    requires_accelerator_read,
                 )
                 compute_node = _DAGOperationGraphNode(
                     _DAGNodeOperation(
@@ -1983,7 +1986,7 @@ class CompiledDAG:
                     ),
                     task_idx,
                     actor_handle,
-                    requires_nccl_compute,
+                    requires_accelerator_compute,
                 )
                 write_node = _DAGOperationGraphNode(
                     _DAGNodeOperation(
@@ -1991,7 +1994,7 @@ class CompiledDAG:
                     ),
                     task_idx,
                     actor_handle,
-                    requires_nccl_write,
+                    requires_accelerator_write,
                 )
 
                 actor_to_operation_nodes[actor_handle].append(
@@ -2058,8 +2061,8 @@ class CompiledDAG:
         """
         TODO (kevin85421): Avoid false negatives.
 
-        Currently, a compiled graph may deadlock if there are NCCL channels, and the
-        readers have control dependencies on the same actor. For example:
+        Currently, a compiled graph may deadlock if there are accelerator channels,
+        and the readers have control dependencies on the same actor. For example:
 
         actor1.a ---> actor2.f1
                  |
@@ -2860,8 +2863,8 @@ class CompiledDAG:
 
                     # Get the type hint for this argument
                     if arg_index < len(task.arg_type_hints):
-                        if task.arg_type_hints[arg_index].requires_nccl():
-                            type_hint = "Nccl"
+                        if task.arg_type_hints[arg_index].requires_accelerator():
+                            type_hint = "Accelerator"
                         else:
                             type_hint = type(task.arg_type_hints[arg_index]).__name__
                     else:
@@ -2905,7 +2908,7 @@ class CompiledDAG:
         # Print edges
         ascii_visualization += "\nEdges Information:\n"
         for upstream_task, downstream_task, type_hint in edge_info:
-            if type_hint == "Nccl":
+            if type_hint == "Accelerator":
                 edgs_channel = "+++"
             else:
                 edgs_channel = "---"
@@ -2915,7 +2918,7 @@ class CompiledDAG:
 
         # Add the legend to the output
         ascii_visualization += "\nLegend:\n"
-        ascii_visualization += "+++> : Represents Nccl-type data channels\n"
+        ascii_visualization += "+++> : Represents Accelerator-type data channels\n"
         ascii_visualization += "---> : Represents Shared Memory data channels\n"
 
         # Find the maximum width (number of nodes in any layer)

--- a/python/ray/dag/dag_node.py
+++ b/python/ray/dag/dag_node.py
@@ -151,12 +151,18 @@ class DAGNode(DAGNodeBase):
         Configure the torch tensor transport for this node.
 
         Args:
-            transport: "nccl" means that tensors will be passed via NCCL.
-                "shm" means that tensors will be passed via host shared memory and gRPC.
-                "accelerator" means that tensors are communicated using accelerator-specific backends.
-                "auto" (default) means that tensor transport will be
-                automatically determined based on the sender and receiver,
-                either through NCCL or host memory.
+            transport: Specifies the tensor transport mechanism.
+                - "accelerator": Tensors are communicated using accelerator-specific backends
+                (e.g., NCCL, XLA, or vendor-provided transport). This is the recommended option
+                for most use cases, as it supports extensibility and future hardware backends.
+                - "nccl": Tensors are passed explicitly via NCCL. This option is kept for
+                backwards compatibility and may be removed in the future. Use "accelerator"
+                instead unless you have legacy requirements.
+                - "shm": Tensors are passed via host shared memory and gRPC. Typically used
+                when accelerator-based transport is unavailable or not suitable.
+                - "auto" (default): The system automatically selects the appropriate transport
+                mechanism based on the sender and receiver, usually preferring accelerator-based
+                transport when available.
             device: The target device to use for the tensor transport.
                 "default": The tensor will maintain its original device placement from the sender
                 "cpu": The tensor will be explicitly moved to CPU device in the receiver

--- a/python/ray/dag/dag_node.py
+++ b/python/ray/dag/dag_node.py
@@ -153,7 +153,7 @@ class DAGNode(DAGNodeBase):
         Args:
             transport: "nccl" means that tensors will be passed via NCCL.
                 "shm" means that tensors will be passed via host shared memory and gRPC.
-                "accelerator" means that tensors will be passed via their accelerator like NCCL.
+                "accelerator" means that tensors are communicated using accelerator-specific backends.
                 "auto" (default) means that tensor transport will be
                 automatically determined based on the sender and receiver,
                 either through NCCL or host memory.

--- a/python/ray/dag/dag_node.py
+++ b/python/ray/dag/dag_node.py
@@ -153,6 +153,7 @@ class DAGNode(DAGNodeBase):
         Args:
             transport: "nccl" means that tensors will be passed via NCCL.
                 "shm" means that tensors will be passed via host shared memory and gRPC.
+                "accelerator" means that tensors will be passed via their accelerator like NCCL.
                 "auto" (default) means that tensor transport will be
                 automatically determined based on the sender and receiver,
                 either through NCCL or host memory.
@@ -184,7 +185,14 @@ class DAGNode(DAGNodeBase):
             )
         elif transport == "nccl":
             self._type_hint = TorchTensorType(
-                transport=transport,
+                transport="accelerator",
+                device=device,
+                _static_shape=_static_shape,
+                _direct_return=_direct_return,
+            )
+        elif transport == "accelerator":
+            self._type_hint = TorchTensorType(
+                transport == "accelerator",
                 device=device,
                 _static_shape=_static_shape,
                 _direct_return=_direct_return,
@@ -198,7 +206,8 @@ class DAGNode(DAGNodeBase):
         else:
             if not isinstance(transport, Communicator):
                 raise ValueError(
-                    "transport must be 'auto', 'nccl', 'shm' or a Communicator type"
+                    "transport must be 'auto', 'nccl', 'shm', 'accelerator' or "
+                    "a Communicator type"
                 )
             self._type_hint = TorchTensorType(
                 transport=transport,

--- a/python/ray/dag/dag_node_operation.py
+++ b/python/ray/dag/dag_node_operation.py
@@ -89,7 +89,7 @@ class _DAGOperationGraphNode:
         operation: _DAGNodeOperation,
         task_idx: int,
         actor_handle: "ray.actor.ActorHandle",
-        requires_nccl: bool,
+        requires_accelerator: bool,
     ):
         """
         _DAGOperationGraphNode represents a node in the DAG operation graph.
@@ -102,12 +102,12 @@ class _DAGOperationGraphNode:
             task_idx: A unique index which can be used to index into
                 `CompiledDAG.idx_to_task` to get the corresponding task.
             actor_handle: The actor handle to which this operation belongs.
-            requires_nccl: Whether this operation requires NCCL.
+            requires_accelerator: Whether this operation requires accelerator.
         """
         self.operation = operation
         self.task_idx = task_idx
         self.actor_handle = actor_handle
-        self.requires_nccl = requires_nccl
+        self.requires_accelerator = requires_accelerator
         # The in_edges and out_edges are dicts of tuples to strings.
         # Each tuple (the key) contains an integer `task_idx`, which can be
         # used to index into `idx_to_task` to get the corresponding task,
@@ -117,13 +117,13 @@ class _DAGOperationGraphNode:
         # the edge is a control dependency.
         self.in_edges: Dict[Tuple[int, _DAGNodeOperationType], Tuple[str, bool]] = {}
         self.out_edges: Dict[Tuple[int, _DAGNodeOperationType], Tuple[str, bool]] = {}
-        # The synchronous nodes are all the nodes that belong to the same NCCL
+        # The synchronous nodes are all the nodes that belong to the same accelerator
         # operation. Each node is represented by a tuple of its task idx and type.
         self.sync_idxs: Set[Tuple[int, _DAGNodeOperationType]] = set()
         # The pending synchronous nodes are the nodes that are pending to be executed,
         # i.e., their in-degrees are zero. When a synchronous node is pending, it
         # will be added to the pending synchronous nodes of all the nodes in the
-        # NCCL operation.
+        # accelerator operation.
         self.pending_sync_idxs: Set[Tuple[int, _DAGNodeOperationType]] = set()
 
     def __repr__(self):
@@ -132,7 +132,7 @@ class _DAGOperationGraphNode:
             f"operation: {self.operation}, "
             f"task_idx: {self.task_idx}, "
             f"actor_id: {self.actor_handle._ray_actor_id}, "
-            f"requires_nccl: {self.requires_nccl})"
+            f"requires_accelerator: {self.requires_accelerator})"
         )
 
     def __lt__(self, other: "_DAGOperationGraphNode"):
@@ -141,14 +141,15 @@ class _DAGOperationGraphNode:
         `_select_next_nodes`. The priority queue is a min-heap, so the node with
         higher priority is considered "less than" the other node.
         """
-        if self.is_nccl_op != other.is_nccl_op:
-            # When one node is a NCCL operation and the other is not, prioritize
-            # the NCCL operation.
-            return self.is_nccl_op
+        if self.is_accelerator_op != other.is_accelerator_op:
+            # When one node is a accelerator operation and the other is not,
+            # prioritize the accelerator operation.
+            return self.is_accelerator_op
         else:
-            # When either both nodes are NCCL operations or both nodes are not NCCL
-            # operations, prioritize the earlier task within the same actor and load
-            # balance tasks across actors. The tie is broken by the `task_idx`.
+            # When either both nodes are accelerator operations or both nodes
+            # are not accelerator operations, prioritize the earlier task within
+            # the same actor and load balance tasks across actors. The tie is
+            # broken by the `task_idx`.
             return (self.operation.exec_task_idx, self.task_idx) < (
                 other.operation.exec_task_idx,
                 other.task_idx,
@@ -178,9 +179,10 @@ class _DAGOperationGraphNode:
     @property
     def is_ready(self) -> bool:
         """
-        If a node is not a NCCL operation, it is ready when it has a zero in-degree.
-        If it is a NCCL operation, it is ready when all the nodes in the operation
-        have zero in-degrees.
+        If a node is not a accelerator operation, it is ready when it has a zero
+        in-degree.
+        If it is a accelerator operation, it is ready when all the nodes in the
+        operation have zero in-degrees.
         """
         return self.in_degree == 0 and (
             len(self.pending_sync_idxs) == len(self.sync_idxs)
@@ -191,31 +193,42 @@ class _DAGOperationGraphNode:
         return self.operation.type == _DAGNodeOperationType.READ
 
     @property
-    def is_nccl_read(self) -> bool:
+    def is_accelerator_read(self) -> bool:
         """
-        A node is a NCCL read if it is a read node and requires NCCL.
-        """
-        return self.operation.type == _DAGNodeOperationType.READ and self.requires_nccl
-
-    @property
-    def is_nccl_compute(self) -> bool:
-        """
-        A node is a NCCL compute if it is a compute node and requires NCCL.
+        A node is a accelerator read if it is a read node and requires accelerator.
         """
         return (
-            self.operation.type == _DAGNodeOperationType.COMPUTE and self.requires_nccl
+            self.operation.type == _DAGNodeOperationType.READ
+            and self.requires_accelerator
         )
 
     @property
-    def is_nccl_write(self) -> bool:
+    def is_accelerator_compute(self) -> bool:
         """
-        A node is a NCCL write if it is a write node and requires NCCL.
+        A node is a accelerator compute if it is a compute node and requires accelerator.
         """
-        return self.operation.type == _DAGNodeOperationType.WRITE and self.requires_nccl
+        return (
+            self.operation.type == _DAGNodeOperationType.COMPUTE
+            and self.requires_accelerator
+        )
 
     @property
-    def is_nccl_op(self) -> bool:
-        return self.is_nccl_read or self.is_nccl_compute or self.is_nccl_write
+    def is_accelerator_write(self) -> bool:
+        """
+        A node is a accelerator write if it is a write node and requires accelerator.
+        """
+        return (
+            self.operation.type == _DAGNodeOperationType.WRITE
+            and self.requires_accelerator
+        )
+
+    @property
+    def is_accelerator_op(self) -> bool:
+        return (
+            self.is_accelerator_read
+            or self.is_accelerator_compute
+            or self.is_accelerator_write
+        )
 
     def viz_str(self):
         """
@@ -273,25 +286,27 @@ def _push_candidate_node_if_ready(
 ) -> None:
     """
     Push the node with a zero in-degree to the candidates if its operation is ready.
-    If it has synchronous nodes, its NCCL operation is not ready until all the nodes
-    are pending, then all the nodes will be pushed to the candidates.
+    If it has synchronous nodes, its accelerator operation is not ready until all
+    the nodes are pending, then all the nodes will be pushed to the candidates.
     """
     assert node.in_degree == 0, "Expected to have a zero in-degree"
-    # For the NCCL write node, update the in-degrees of the downstream NCCL read nodes
-    # and update them as pending. This is necessary because the data dependency edges
-    # between NCCL write and read nodes are only updated here. The NCCL P2P operation
-    # becomes ready after both the write and read nodes are marked as pending.
-    if node.is_nccl_write:
+    # For the accelerator write node, update the in-degrees of the downstream
+    # accelerator read nodes and update them as pending. This is necessary because
+    # the data dependency edges between accelerator write and read nodes are only
+    # updated here. The accelerator P2P operation becomes ready after both the write
+    # and read nodes are marked as pending.
+    if node.is_accelerator_write:
         for task_idx, op_type in node.out_edges:
             read_node = graph[task_idx][op_type]
             read_node.in_edges.pop((node.task_idx, node.operation.type))
-            assert read_node.is_nccl_read and len(read_node.in_edges) == 0
+            assert read_node.is_accelerator_read and len(read_node.in_edges) == 0
             _update_pending_sync_idxs(graph, read_node)
-    # For the NCCL operation node, update it as pending.
+    # For the accelerator operation node, update it as pending.
     if len(node.sync_idxs) != 0:
         _update_pending_sync_idxs(graph, node)
-    # The NCCL operation is ready when all the nodes have zero in-degrees. When the last
-    # node in the operation is updated as pending, push all the nodes to the candidates.
+    # The accelerator operation is ready when all the nodes have zero in-degrees.
+    # When the last node in the operation is updated as pending, push all the nodes
+    # to the candidates.
     if node.is_ready:
         if len(node.sync_idxs) == 0:
             heapq.heappush(
@@ -320,18 +335,18 @@ def _select_next_nodes(
     For the implementation details, we maintain a priority queue for each actor,
     where the head of the priority queue is the node with the smallest `exec_task_idx`.
     When a node has a zero in-degree, it is added to the corresponding actor's
-    priority queue. For a node other than a NCCL collective node, it is ready to be
-    executed if it has a zero in-degree. For a NCCL collective node, it is ready to
+    priority queue. For a node other than a accelerator collective node, it is ready to be
+    executed if it has a zero in-degree. For a accelerator collective node, it is ready to
     be executed when all the nodes in its collective operation have zero in-degrees.
 
-    If a node is a NCCL collective node, it updates the `ready_collective_nodes` of
+    If a node is a accelerator collective node, it updates the `ready_collective_nodes` of
     all the nodes in its collective operation. Unless all the nodes in its collective
     group have zero in-degrees, this node is removed from the candidate list.
-    Eventually, exactly one NCCL collective node from its collective operation is
+    Eventually, exactly one accelerator collective node from its collective operation is
     selected from the candidate list.
 
-    If the selected node is a NCCL write node, select all the downstream NCCL
-    read nodes. If the selected node is a NCCL collective node, select all the NCCL
+    If the selected node is a accelerator write node, select all the downstream accelerator
+    read nodes. If the selected node is a accelerator collective node, select all the accelerator
     compute nodes in its collective operation.
 
     Args:
@@ -357,7 +372,7 @@ def _select_next_nodes(
         return None
     next_nodes = [top_priority_node]
 
-    # Select all the synchronous nodes in the NCCL operation.
+    # Select all the synchronous nodes in the accelerator operation.
     if len(top_priority_node.sync_idxs) != 0:
         for task_idx, op_type in top_priority_node.sync_idxs:
             node = graph[task_idx][op_type]
@@ -373,7 +388,7 @@ def _select_next_nodes(
     # Remove the selected nodes from the candidates.
     for node in next_nodes:
         candidates = actor_to_candidates[node.actor_handle._actor_id]
-        #  The NCCL read nodes are not added to the candidates.
+        #  The accelerator read nodes are not added to the candidates.
         if node in candidates:
             candidates.remove(node)
             heapq.heapify(candidates)
@@ -449,7 +464,7 @@ def _build_dag_node_operation_graph(
     from ray.dag.collective_node import _CollectiveOperation
 
     # Add an edge from WRITE of the writer task to READ of the reader task.
-    # Set synchronous nodes for NCCL P2P operations.
+    # Set synchronous nodes for accelerator P2P operations.
     for task_idx, task in idx_to_task.items():
         if not (
             isinstance(task.dag_node, ClassMethodNode)
@@ -482,9 +497,9 @@ def _build_dag_node_operation_graph(
                         _add_edge(
                             write_node,
                             read_node,
-                            "nccl" if write_node.requires_nccl else "shm",
+                            "accelerator" if write_node.requires_accelerator else "shm",
                         )
-                        if write_node.requires_nccl:
+                        if write_node.requires_accelerator:
                             idxs = {
                                 (task_idx, _DAGNodeOperationType.WRITE),
                                 (consumer_idx, _DAGNodeOperationType.READ),
@@ -496,9 +511,9 @@ def _build_dag_node_operation_graph(
             _add_edge(
                 write_node,
                 read_node,
-                "nccl" if write_node.requires_nccl else "shm",
+                "accelerator" if write_node.requires_accelerator else "shm",
             )
-            if write_node.requires_nccl:
+            if write_node.requires_accelerator:
                 idxs = {
                     (task_idx, _DAGNodeOperationType.WRITE),
                     (downstream_task_idx, _DAGNodeOperationType.READ),
@@ -506,7 +521,7 @@ def _build_dag_node_operation_graph(
                 for node in [write_node, read_node]:
                     node.sync_idxs.update(idxs)
 
-    # Set synchronous nodes for NCCL collective operations.
+    # Set synchronous nodes for accelerator collective operations.
     collective_op_to_idxs: Dict[
         _CollectiveOperation, Set[Tuple[int, _DAGNodeOperationType]]
     ] = defaultdict(set)
@@ -582,7 +597,7 @@ def _visualize_execution_schedule(
         Edges:
             black color (without label): data dependency
             black color (annotated with "shm"): shared memory channel
-            blue color (annotated with "nccl): NCCL channel
+            blue color (annotated with "accelerator): accelerator channel
             dashed edge: control dependency between compute operations
 
     Args:
@@ -638,7 +653,7 @@ def _visualize_execution_schedule(
                 out_task_idx, out_op_type = out_edge
                 out_node = graph[out_task_idx][out_op_type]
                 out_node_viz_id = node_to_viz_id[out_node]
-                color = "blue" if label == "nccl" else "black"
+                color = "blue" if label == "accelerator" else "black"
                 style = "dashed" if control_dependency else "solid"
                 dot.edge(
                     node_viz_id, out_node_viz_id, label=label, color=color, style=style
@@ -668,7 +683,7 @@ def _visualize_execution_schedule(
             '<TR><TD ALIGN="LEFT"><B>Edges:</B></TD></TR>'
             '<TR><TD ALIGN="LEFT">black color (without label): data dependency</TD></TR>'  # noqa
             '<TR><TD ALIGN="LEFT">black color (annotated with "shm"): shared memory channel</TD></TR>'  # noqa
-            '<TR><TD ALIGN="LEFT"><FONT COLOR="blue">blue color</FONT> (annotated with "nccl): NCCL channel</TD></TR>'  # noqa
+            '<TR><TD ALIGN="LEFT"><FONT COLOR="blue">blue color</FONT> (annotated with "accelerator): accelerator channel</TD></TR>'  # noqa
             '<TR><TD ALIGN="LEFT">dashed edge: control dependency between compute operations</TD></TR>'  # noqa
             "</TABLE>>"
         )
@@ -713,9 +728,9 @@ def _generate_actor_to_execution_schedule(
     # A dictionary mapping an actor id to a list of candidate nodes. The list
     # is maintained as a priority queue, so the head of the queue, i.e.,
     # `candidates[0]`, is the node with the smallest `bind_index`.
-    actor_to_candidates: Dict[
-        "ray._raylet.ActorID", List[_DAGOperationGraphNode]
-    ] = defaultdict(list)
+    actor_to_candidates: Dict["ray._raylet.ActorID", List[_DAGOperationGraphNode]] = (
+        defaultdict(list)
+    )
     for _, node_dict in graph.items():
         for _, node in node_dict.items():
             # A node with a zero in-degree edge means all of its dependencies
@@ -729,10 +744,10 @@ def _generate_actor_to_execution_schedule(
     # Use topological sort algorithm to generate the execution schedule.
     while True:
         # Select a list of nodes to be executed. There are three cases:
-        # 1. If a selected node is not a NCCL operation, only itself is returned.
-        # 2. If a selected node is a NCCL write operation, the corresponding NCCL
+        # 1. If a selected node is not a accelerator operation, only itself is returned.
+        # 2. If a selected node is a accelerator write operation, the corresponding accelerator
         #    read operations are also returned.
-        # 3. If a selected node is a NCCL collective operation, all the nodes in
+        # 3. If a selected node is a accelerator collective operation, all the nodes in
         #    its collective operation are returned.
         nodes = _select_next_nodes(actor_to_candidates, graph)
         if nodes is None:
@@ -748,7 +763,7 @@ def _generate_actor_to_execution_schedule(
                 out_node = graph[out_node_task_idx][out_node_type]
                 if out_node in visited_nodes:
                     # If the downstream node is already visited, it has been added
-                    # to the execution schedule. They are the NCCL read nodes in
+                    # to the execution schedule. They are the accelerator read nodes in
                     # case 2.
                     continue
                 out_node.in_edges.pop((node.task_idx, node.operation.type))
@@ -769,8 +784,8 @@ def _generate_overlapped_execution_schedule(
     computation and communication.
 
     Currently, the algorithm generates a new schedule for each actor as follows:
-    For each NCCL read operation (i.e., recv), scan backwards to find the nearest
-    compute node to swap with so that the NCCL read operation can be overlapped
+    For each accelerator read operation (i.e., recv), scan backwards to find the nearest
+    compute node to swap with so that the accelerator read operation can be overlapped
     with computation.
 
     Collective operations are not yet supported.
@@ -792,30 +807,30 @@ def _generate_overlapped_execution_schedule(
         for i in range(len(overlapped_schedule)):
             if (
                 overlapped_schedule[i].operation.type == _DAGNodeOperationType.READ
-                and overlapped_schedule[i].requires_nccl
+                and overlapped_schedule[i].requires_accelerator
             ):
-                # For each NCCL read operation (i.e., recv), scan backwards
+                # For each accelerator read operation (i.e., recv), scan backwards
                 # to find the nearest compute node to swap with so that
-                # the NCCL read operation can be overlapped with computation.
+                # the accelerator read operation can be overlapped with computation.
                 for j in range(i - 1, -1, -1):
                     if (
                         overlapped_schedule[j].operation.type
                         == _DAGNodeOperationType.COMPUTE
                     ):
                         # Found a desired compute operation, make the swap
-                        nccl_read_op = overlapped_schedule[i]
+                        accelerator_read_op = overlapped_schedule[i]
                         prev_ops = overlapped_schedule[j:i]
                         overlapped_schedule[j + 1 : i + 1] = prev_ops
-                        overlapped_schedule[j] = nccl_read_op
+                        overlapped_schedule[j] = accelerator_read_op
                         break
                     if (
                         overlapped_schedule[j].operation.type
                         == _DAGNodeOperationType.READ
                         or overlapped_schedule[j].operation.type
                         == _DAGNodeOperationType.WRITE
-                    ) and overlapped_schedule[j].requires_nccl:
-                        # Found a NCCL read/write operation, skip the overlap
-                        # optimization to keep relative order of NCCL operations
+                    ) and overlapped_schedule[j].requires_accelerator:
+                        # Found a accelerator read/write operation, skip the overlap
+                        # optimization to keep relative order of accelerator operations
                         break
     return actor_to_overlapped_schedule
 

--- a/python/ray/dag/dag_node_operation.py
+++ b/python/ray/dag/dag_node_operation.py
@@ -728,9 +728,9 @@ def _generate_actor_to_execution_schedule(
     # A dictionary mapping an actor id to a list of candidate nodes. The list
     # is maintained as a priority queue, so the head of the queue, i.e.,
     # `candidates[0]`, is the node with the smallest `bind_index`.
-    actor_to_candidates: Dict["ray._raylet.ActorID", List[_DAGOperationGraphNode]] = (
-        defaultdict(list)
-    )
+    actor_to_candidates: Dict[
+        "ray._raylet.ActorID", List[_DAGOperationGraphNode]
+    ] = defaultdict(list)
     for _, node_dict in graph.items():
         for _, node in node_dict.items():
             # A node with a zero in-degree edge means all of its dependencies

--- a/python/ray/dag/dag_node_operation.py
+++ b/python/ray/dag/dag_node_operation.py
@@ -142,7 +142,7 @@ class _DAGOperationGraphNode:
         higher priority is considered "less than" the other node.
         """
         if self.is_accelerator_op != other.is_accelerator_op:
-            # When one node is a accelerator operation and the other is not,
+            # When one node is an accelerator operation and the other is not,
             # prioritize the accelerator operation.
             return self.is_accelerator_op
         else:
@@ -179,9 +179,9 @@ class _DAGOperationGraphNode:
     @property
     def is_ready(self) -> bool:
         """
-        If a node is not a accelerator operation, it is ready when it has a zero
+        If a node is not an accelerator operation, it is ready when it has a zero
         in-degree.
-        If it is a accelerator operation, it is ready when all the nodes in the
+        If it is an accelerator operation, it is ready when all the nodes in the
         operation have zero in-degrees.
         """
         return self.in_degree == 0 and (
@@ -195,7 +195,7 @@ class _DAGOperationGraphNode:
     @property
     def is_accelerator_read(self) -> bool:
         """
-        A node is a accelerator read if it is a read node and requires accelerator.
+        A node is an accelerator read if it is a read node and requires accelerator.
         """
         return (
             self.operation.type == _DAGNodeOperationType.READ
@@ -205,7 +205,7 @@ class _DAGOperationGraphNode:
     @property
     def is_accelerator_compute(self) -> bool:
         """
-        A node is a accelerator compute if it is a compute node and requires accelerator.
+        A node is an accelerator compute if it is a compute node and requires accelerator.
         """
         return (
             self.operation.type == _DAGNodeOperationType.COMPUTE
@@ -215,7 +215,7 @@ class _DAGOperationGraphNode:
     @property
     def is_accelerator_write(self) -> bool:
         """
-        A node is a accelerator write if it is a write node and requires accelerator.
+        A node is an accelerator write if it is a write node and requires accelerator.
         """
         return (
             self.operation.type == _DAGNodeOperationType.WRITE
@@ -335,18 +335,18 @@ def _select_next_nodes(
     For the implementation details, we maintain a priority queue for each actor,
     where the head of the priority queue is the node with the smallest `exec_task_idx`.
     When a node has a zero in-degree, it is added to the corresponding actor's
-    priority queue. For a node other than a accelerator collective node, it is ready to be
-    executed if it has a zero in-degree. For a accelerator collective node, it is ready to
+    priority queue. For a node other than an accelerator collective node, it is ready to be
+    executed if it has a zero in-degree. For an accelerator collective node, it is ready to
     be executed when all the nodes in its collective operation have zero in-degrees.
 
-    If a node is a accelerator collective node, it updates the `ready_collective_nodes` of
+    If a node is an accelerator collective node, it updates the `ready_collective_nodes` of
     all the nodes in its collective operation. Unless all the nodes in its collective
     group have zero in-degrees, this node is removed from the candidate list.
     Eventually, exactly one accelerator collective node from its collective operation is
     selected from the candidate list.
 
-    If the selected node is a accelerator write node, select all the downstream accelerator
-    read nodes. If the selected node is a accelerator collective node, select all the accelerator
+    If the selected node is an accelerator write node, select all the downstream accelerator
+    read nodes. If the selected node is an accelerator collective node, select all the accelerator
     compute nodes in its collective operation.
 
     Args:
@@ -744,10 +744,10 @@ def _generate_actor_to_execution_schedule(
     # Use topological sort algorithm to generate the execution schedule.
     while True:
         # Select a list of nodes to be executed. There are three cases:
-        # 1. If a selected node is not a accelerator operation, only itself is returned.
-        # 2. If a selected node is a accelerator write operation, the corresponding accelerator
+        # 1. If a selected node is not an accelerator operation, only itself is returned.
+        # 2. If a selected node is an accelerator write operation, the corresponding accelerator
         #    read operations are also returned.
-        # 3. If a selected node is a accelerator collective operation, all the nodes in
+        # 3. If a selected node is an accelerator collective operation, all the nodes in
         #    its collective operation are returned.
         nodes = _select_next_nodes(actor_to_candidates, graph)
         if nodes is None:
@@ -829,7 +829,7 @@ def _generate_overlapped_execution_schedule(
                         or overlapped_schedule[j].operation.type
                         == _DAGNodeOperationType.WRITE
                     ) and overlapped_schedule[j].requires_accelerator:
-                        # Found a accelerator read/write operation, skip the overlap
+                        # Found an accelerator read/write operation, skip the overlap
                         # optimization to keep relative order of accelerator operations
                         break
     return actor_to_overlapped_schedule

--- a/python/ray/dag/tests/experimental/test_collective_dag.py
+++ b/python/ray/dag/tests/experimental/test_collective_dag.py
@@ -139,7 +139,7 @@ def test_all_reduce_custom_comm_wrong_actors(ray_start_regular):
         computes = [worker.return_tensor.bind(inp) for worker in workers]
         with pytest.raises(
             ValueError,
-            match="Expected actor handles to match the custom NCCL group",
+            match="Expected actor handles to match the custom communicator group",
         ):
             collective.allreduce.bind(computes, transport=nccl_group)
 

--- a/python/ray/dag/tests/experimental/test_cpu_communicator_dag.py
+++ b/python/ray/dag/tests/experimental/test_cpu_communicator_dag.py
@@ -355,7 +355,7 @@ def test_allreduce_wrong_actors(ray_start_cluster):
         computes = [worker.return_tensor.bind(inp) for worker in workers[2:]]
         with pytest.raises(
             ValueError,
-            match="Expected actor handles to match the custom NCCL group",
+            match="Expected actor handles to match the custom communicator group",
         ):
             collective.allreduce.bind(computes, transport=cpu_group)
 

--- a/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
@@ -323,7 +323,7 @@ def test_torch_tensor_auto(ray_start_regular, num_gpus):
     # Use NCCL only when sender and receiver are on different GPUs.
     # When each actor has 0.5 GPU, sender and receiver are allocated
     # on the same GPU, so we use auto.
-    expected_transport = "nccl" if num_gpus == [1, 1] else "auto"
+    expected_transport = "accelerator" if num_gpus == [1, 1] else "auto"
 
     shape = (10,)
     dtype = torch.float16
@@ -438,7 +438,7 @@ def test_torch_tensor_nccl_disallows_driver(ray_start_regular):
         ValueError,
         match=(
             r"DAG inputs cannot be transferred "
-            "via NCCL because the driver cannot participate in the NCCL group"
+            "via accelerator because the driver cannot participate in the communicator group"
         ),
     ):
         dag.experimental_compile()
@@ -450,7 +450,7 @@ def test_torch_tensor_nccl_disallows_driver(ray_start_regular):
 
     with pytest.raises(
         ValueError,
-        match=(r"Driver cannot participate in the NCCL group\."),
+        match=(r"Driver cannot participate in the communicator group\."),
     ):
         dag.experimental_compile()
 
@@ -559,7 +559,7 @@ def test_torch_tensor_custom_comm(ray_start_regular):
             return self._inner.destroy()
 
         def get_transport_name(self) -> str:
-            return "nccl"
+            return "accelerator"
 
         @classmethod
         def generate_communicator_id(self) -> str:
@@ -699,7 +699,7 @@ def test_torch_tensor_custom_comm_inited(ray_start_regular):
             pass
 
         def get_transport_name(self) -> str:
-            return "nccl"
+            return "accelerator"
 
         @classmethod
         def generate_communicator_id(self) -> str:
@@ -843,7 +843,7 @@ def test_torch_tensor_default_comm(ray_start_regular, transports):
             pass
 
         def get_transport_name(self) -> str:
-            return "nccl"
+            return "accelerator"
 
         @classmethod
         def generate_communicator_id(self) -> str:
@@ -1000,7 +1000,7 @@ def test_torch_tensor_invalid_custom_comm(ray_start_regular):
             pass
 
         def get_transport_name(self) -> str:
-            return "nccl"
+            return "accelerator"
 
         @classmethod
         def generate_communicator_id(self) -> str:
@@ -1285,8 +1285,8 @@ def test_torch_tensor_exceptions3(
         ValueError,
         match=(
             r"Actor Actor\(TorchTensorWorker, .*?\) returns a tensor with type hint "
-            r'TorchTensor\(transport="nccl"\) or '
-            r"TorchTensor\(transport=nccl_group_handle\) "
+            r'TorchTensor\(transport="accelerator"\) or '
+            r"TorchTensor\(transport=accelerator_group_handle\) "
             r"but actor does not have an accelerator assigned by Ray\."
         ),
     ):
@@ -1647,7 +1647,7 @@ def test_torch_tensor_nccl_all_reduce_custom_comm(ray_start_regular):
             return self._inner.destroy()
 
         def get_transport_name(self) -> str:
-            return "nccl"
+            return "accelerator"
 
         @classmethod
         def generate_communicator_id(self) -> str:
@@ -1890,7 +1890,7 @@ def test_torch_nccl_channel_with_all_local_readers(ray_start_regular):
         AssertionError,
         match=(
             "All readers are from the same actor. The TorchTensorType type hint "
-            "is not needed. No NCCL channel will be created."
+            "is not needed. No accelerator channel will be created."
         ),
     ):
         dag.experimental_compile()

--- a/python/ray/dag/tests/experimental/test_torch_tensor_transport.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_transport.py
@@ -319,7 +319,8 @@ class TestWorkerToWorkerDeviceCPU:
         receiver = Actor.options(num_gpus=1).remote()
 
         with pytest.raises(
-            ValueError, match="NCCL transport is not supported with CPU target device."
+            ValueError,
+            match="accelerator transport is not supported with CPU target device.",
         ):
             run_worker_to_worker_dag(sender, receiver, "cpu", "cpu")
 
@@ -343,7 +344,8 @@ class TestWorkerToWorkerDeviceCPU:
         receiver = Actor.options(num_gpus=1).remote()
 
         with pytest.raises(
-            ValueError, match="NCCL transport is not supported with CPU target device."
+            ValueError,
+            match="accelerator transport is not supported with CPU target device.",
         ):
             run_worker_to_worker_dag(
                 sender,
@@ -391,7 +393,8 @@ class TestWorkerToWorkerDeviceGPU:
         receiver = Actor.options(num_gpus=1).remote()
 
         with pytest.raises(
-            ValueError, match="NCCL transport is not supported with CPU target device."
+            ValueError,
+            match="accelerator transport is not supported with CPU target device.",
         ):
             run_worker_to_worker_dag(sender, receiver, "cpu", "cpu")
 
@@ -461,7 +464,8 @@ class TestWorkerToWorkerDeviceDefault:
         receiver = Actor.options(num_gpus=1).remote()
 
         with pytest.raises(
-            ValueError, match="NCCL transport is not supported with CPU target device."
+            ValueError,
+            match="accelerator transport is not supported with CPU target device.",
         ):
             run_worker_to_worker_dag(sender, receiver, "cpu", "cpu")
 

--- a/python/ray/experimental/channel/__init__.py
+++ b/python/ray/experimental/channel/__init__.py
@@ -19,7 +19,9 @@ from ray.experimental.channel.shared_memory_channel import (
     Channel,
     CompositeChannel,
 )
-from ray.experimental.channel.torch_tensor_nccl_channel import TorchTensorNcclChannel
+from ray.experimental.channel.torch_tensor_accelerator_channel import (
+    TorchTensorAcceleratorChannel,
+)
 
 __all__ = [
     "AwaitableBackgroundReader",
@@ -33,7 +35,7 @@ __all__ = [
     "SynchronousWriter",
     "WriterInterface",
     "ChannelContext",
-    "TorchTensorNcclChannel",
+    "TorchTensorAcceleratorChannel",
     "IntraProcessChannel",
     "CompositeChannel",
     "BufferedSharedMemoryChannel",

--- a/python/ray/experimental/channel/auto_transport_type.py
+++ b/python/ray/experimental/channel/auto_transport_type.py
@@ -11,8 +11,8 @@ class AutoTransportType(ChannelOutputType):
     Type hint for automatic transport selection for tensors.
 
     With this type hint Compiled Graphs automatically decide the best transport
-    to use (e.g., NCCL or shared memory) based on the node locations and GPU IDs
-    of the readers and writers.
+    to use (e.g., Accellerator or shared memory) based on the node locations and
+    GPU IDs of the readers and writers.
     """
 
     def __init__(
@@ -172,10 +172,10 @@ class TypeHintResolver:
                 _direct_return=auto_transport_type._direct_return,
             )
 
-        # Case 3: writer and readers use different GPUs, use NCCL to transport
+        # Case 3: writer and readers use different GPUs, use accelerator to transport
         # the tensors
         return TorchTensorType(
-            transport="nccl",
+            transport="accelerator",
             device=auto_transport_type.device,
             _static_shape=auto_transport_type._static_shape,
             _direct_return=auto_transport_type._direct_return,

--- a/python/ray/experimental/channel/auto_transport_type.py
+++ b/python/ray/experimental/channel/auto_transport_type.py
@@ -11,7 +11,7 @@ class AutoTransportType(ChannelOutputType):
     Type hint for automatic transport selection for tensors.
 
     With this type hint Compiled Graphs automatically decide the best transport
-    to use (e.g., Accellerator or shared memory) based on the node locations and
+    to use (e.g., accellerator or shared memory) based on the node locations and
     GPU IDs of the readers and writers.
     """
 

--- a/python/ray/experimental/channel/common.py
+++ b/python/ray/experimental/channel/common.py
@@ -103,13 +103,13 @@ class ChannelOutputType:
         """
         raise NotImplementedError
 
-    def requires_nccl(self) -> bool:
-        # By default, channels do not require NCCL.
+    def requires_accelerator(self) -> bool:
+        # By default, channels do not require accelerator.
         return False
 
     def get_custom_communicator(self) -> Optional[Communicator]:
         """
-        Return the custom NCCL group if one is specified.
+        Return the custom communicator group if one is specified.
         """
         return None
 
@@ -126,7 +126,7 @@ class ChannelContext:
     _current_stream: Optional["torch.cuda.Stream"] = None
 
     def __init__(self):
-        # Used for the torch.Tensor NCCL transport.
+        # Used for the torch.Tensor accelerator transport.
         self.communicators: Dict[str, "Communicator"] = {}
         # Used for driver process to store actors in the communicator.
         self.communicator_handles: Dict[str, "CommunicatorHandle"] = {}

--- a/python/ray/experimental/channel/conftest.py
+++ b/python/ray/experimental/channel/conftest.py
@@ -153,7 +153,7 @@ def start_nccl_mock():
     tensor_patcher = mock.patch("torch.Tensor.is_cuda", True)
     tensor_patcher.start()
     tensor_allocator_patcher = mock.patch(
-        "ray.experimental.channel.torch_tensor_nccl_channel._torch_zeros_allocator",
+        "ray.experimental.channel.torch_tensor_accelerator_channel._torch_zeros_allocator",
         lambda shape, dtype: torch.zeros(shape, dtype=dtype),
     )
     tensor_allocator_patcher.start()

--- a/python/ray/experimental/channel/cpu_communicator.py
+++ b/python/ray/experimental/channel/cpu_communicator.py
@@ -91,7 +91,7 @@ class CPUCommBarrier:
 
 class CPUCommunicator(Communicator):
     """
-    Uses a CPU-based communicator actor instead of a NCCL group.
+    Uses a CPU-based communicator actor instead of a communicator group like NCCL.
     """
 
     def __init__(self, world_size: int, actor_handles: List["ray.actor.ActorHandle"]):

--- a/python/ray/experimental/channel/cpu_communicator.py
+++ b/python/ray/experimental/channel/cpu_communicator.py
@@ -91,7 +91,7 @@ class CPUCommBarrier:
 
 class CPUCommunicator(Communicator):
     """
-    Uses a CPU-based communicator actor instead of a communicator group like NCCL.
+    Uses a CPU-based communicator actor instead of an accelerator group like NCCL.
     """
 
     def __init__(self, world_size: int, actor_handles: List["ray.actor.ActorHandle"]):

--- a/python/ray/experimental/channel/nccl_group.py
+++ b/python/ray/experimental/channel/nccl_group.py
@@ -365,7 +365,7 @@ class _NcclGroup(Communicator):
             self._comm.destroy()
 
     def get_transport_name(self) -> str:
-        return "nccl"
+        return "accelerator"
 
     @classmethod
     def generate_communicator_id(cls) -> str:

--- a/python/ray/experimental/channel/serialization_context.py
+++ b/python/ray/experimental/channel/serialization_context.py
@@ -144,7 +144,7 @@ class _SerializationContext:
         target_device: Device,
     ):
 
-        # Found a placeholder for a tensor that was serialized via NCCL.
+        # Found a placeholder for a tensor that was serialized via accelerator.
         # Replace it with the corresponding deserialized tensor.
         if isinstance(val, int):
             placeholder = val

--- a/python/ray/experimental/channel/torch_tensor_accelerator_channel.py
+++ b/python/ray/experimental/channel/torch_tensor_accelerator_channel.py
@@ -458,13 +458,17 @@ class _TorchTensorAcceleratorChannel(ChannelInterface):
             )
 
     def ensure_registered_as_writer(self):
-        assert self._accelerator_group is not None, "Actor is not part of an accelerator group"
+        assert (
+            self._accelerator_group is not None
+        ), "Actor is not part of an accelerator group"
         assert self._writer_registered
         ctx = ChannelContext.get_current()
         assert ctx.torch_device.type != "cpu"
 
     def ensure_registered_as_reader(self) -> bool:
-        assert self._accelerator_group is not None, "Actor is not part of an accelerator group"
+        assert (
+            self._accelerator_group is not None
+        ), "Actor is not part of an accelerator group"
         assert self._reader_registered
         ctx = ChannelContext.get_current()
         assert ctx.torch_device.type != "cpu"

--- a/python/ray/experimental/channel/torch_tensor_accelerator_channel.py
+++ b/python/ray/experimental/channel/torch_tensor_accelerator_channel.py
@@ -59,9 +59,9 @@ class TorchTensorAcceleratorChannel(ChannelInterface):
         _local_channel: Optional["IntraProcessChannel"] = None,
     ):
         """
-        Can be used to send GPU tensors nested inside other data. The data is
-        sent via shared memory while the GPU tensors are sent through a P2P
-        transport (e.g., NCCL).
+        Can be used to send accelerator tensors nested inside other data. The data is
+        sent via shared memory while the accelerator tensors are sent through a P2P
+        transport (e.g., NCCL for GPU).
 
         NOTE: This class is currently not thread-safe because it reads and
         writes the worker-local

--- a/python/ray/experimental/channel/torch_tensor_accelerator_channel.py
+++ b/python/ray/experimental/channel/torch_tensor_accelerator_channel.py
@@ -46,7 +46,7 @@ class _TorchTensorMetadata:
 
 
 @DeveloperAPI
-class TorchTensorNcclChannel(ChannelInterface):
+class TorchTensorAcceleratorChannel(ChannelInterface):
     def __init__(
         self,
         writer: ray.actor.ActorHandle,
@@ -55,13 +55,13 @@ class TorchTensorNcclChannel(ChannelInterface):
         driver_actor_id: str,
         tensor_metadata_channel: Optional["Channel"] = None,
         _cpu_data_channel: Optional["Channel"] = None,
-        _gpu_data_channel: Optional["_TorchTensorNcclChannel"] = None,
+        _gpu_data_channel: Optional["_TorchTensorAcceleratorChannel"] = None,
         _local_channel: Optional["IntraProcessChannel"] = None,
     ):
         """
         Can be used to send GPU tensors nested inside other data. The data is
         sent via shared memory while the GPU tensors are sent through a P2P
-        transport (NCCL).
+        transport (e.g., NCCL).
 
         NOTE: This class is currently not thread-safe because it reads and
         writes the worker-local
@@ -82,7 +82,7 @@ class TorchTensorNcclChannel(ChannelInterface):
                 writer and readers. If None is provided, then we assume that
                 there is no CPU-specific data, i.e. the task directly returned
                 a CUDA torch.Tensor.
-            _gpu_data_channel: A channel for sending torch.Tensors via NCCL.
+            _gpu_data_channel: A channel for sending torch.Tensors via accelerator.
             _local_channel: A channel for sending data between the writer and
                 local readers.
 
@@ -113,15 +113,17 @@ class TorchTensorNcclChannel(ChannelInterface):
         assert len(remote_reader_and_node_list) > 0, (
             "All readers are from the same actor. "
             "The TorchTensorType type hint is not needed. "
-            "No NCCL channel will be created."
+            "No accelerator channel will be created."
         )
         self._gpu_data_channel = _gpu_data_channel
         if self._gpu_data_channel is None:
-            self._gpu_data_channel: _TorchTensorNcclChannel = _TorchTensorNcclChannel(
-                writer,
-                remote_reader_and_node_list,
-                typ,
-                _meta_channel=tensor_metadata_channel,
+            self._gpu_data_channel: _TorchTensorAcceleratorChannel = (
+                _TorchTensorAcceleratorChannel(
+                    writer,
+                    remote_reader_and_node_list,
+                    typ,
+                    _meta_channel=tensor_metadata_channel,
+                )
             )
 
         self._cpu_data_channel: Optional["Channel"] = _cpu_data_channel
@@ -146,7 +148,7 @@ class TorchTensorNcclChannel(ChannelInterface):
 
     def __reduce__(self):
         return (
-            TorchTensorNcclChannel,
+            TorchTensorAcceleratorChannel,
             (
                 self._writer,
                 self._reader_and_node_list,
@@ -180,7 +182,7 @@ class TorchTensorNcclChannel(ChannelInterface):
 
     def _send_cpu_and_gpu_data(self, value: Any, timeout: Optional[float]):
         self.serialization_ctx.reset_out_of_band_tensors([])
-        # All tensors found in `value` will be transferred via NCCL.
+        # All tensors found in `value` will be transferred via accelerator.
         self.serialization_ctx.set_use_external_transport(True)
 
         try:
@@ -363,7 +365,7 @@ def _torch_zeros_allocator(
     return torch.zeros(shape, dtype=dtype, device=ctx.torch_device)
 
 
-class _TorchTensorNcclChannel(ChannelInterface):
+class _TorchTensorAcceleratorChannel(ChannelInterface):
     def __init__(
         self,
         writer: ray.actor.ActorHandle,
@@ -372,8 +374,8 @@ class _TorchTensorNcclChannel(ChannelInterface):
         _meta_channel: Optional["Channel"] = None,
     ):
         """
-        A helper channel for TorchTensorNcclChannel that is used to transfer
-        lists of torch.Tensors via NCCL. This class can only transfer
+        A helper channel for TorchTensorAcceleratorChannel that is used to transfer
+        lists of torch.Tensors via accelerator. This class can only transfer
         torch.Tensors and cannot transfer other CPU data, such as Exception
         objects or tensors nested inside of a dictionary.
 
@@ -401,39 +403,39 @@ class _TorchTensorNcclChannel(ChannelInterface):
         ctx = ChannelContext.get_current()
         assert isinstance(
             typ.communicator_id, str
-        ), f"NCCL group ID ({typ.communicator_id}) must be a str."
+        ), f"communicator group ID ({typ.communicator_id}) must be a str."
         self._typ = typ
 
         self._static_shape = typ.static_shape
 
-        assert self._typ.communicator_id is not None, "No NCCL group specified."
-        self._nccl_group_id: str = self._typ.communicator_id
+        assert self._typ.communicator_id is not None, "No communicator group specified."
+        self._comm_group_id: str = self._typ.communicator_id
 
         # If the communicators does not contain the group_id, it means the current
-        # process is the driver, and there’s no need to fetch the nccl_group.
+        # process is the driver, and there’s no need to fetch the comm_group.
         if self._typ.communicator_id in ctx.communicators:
-            self._nccl_group: "Communicator" = ctx.communicators[
+            self._comm_group: "Communicator" = ctx.communicators[
                 self._typ.communicator_id
             ]
             assert (
-                self._nccl_group is not None
-            ), "ChannelContext.nccl_group is not initialized."
+                self._comm_group is not None
+            ), "ChannelContext.comm_group is not initialized."
 
-            self._writer_rank = self._nccl_group.get_rank(self._writer)
+            self._writer_rank = self._comm_group.get_rank(self._writer)
             self._reader_ranks = [
-                self._nccl_group.get_rank(reader)
+                self._comm_group.get_rank(reader)
                 for reader, _ in self._reader_and_node_list
             ]
 
             if (
                 self._writer_rank is not None
-                and self._writer_rank == self._nccl_group.get_self_rank()
+                and self._writer_rank == self._comm_group.get_self_rank()
             ):
                 self._writer_registered = True
 
             if (
                 self._reader_ranks
-                and self._nccl_group.get_self_rank() in self._reader_ranks
+                and self._comm_group.get_self_rank() in self._reader_ranks
             ):
                 self._reader_registered = True
 
@@ -456,13 +458,13 @@ class _TorchTensorNcclChannel(ChannelInterface):
             )
 
     def ensure_registered_as_writer(self):
-        assert self._nccl_group is not None, "Actor is not part of a NCCL group"
+        assert self._comm_group is not None, "Actor is not part of a comm group"
         assert self._writer_registered
         ctx = ChannelContext.get_current()
         assert ctx.torch_device.type != "cpu"
 
     def ensure_registered_as_reader(self) -> bool:
-        assert self._nccl_group is not None, "Actor is not part of a NCCL group"
+        assert self._comm_group is not None, "Actor is not part of a comm group"
         assert self._reader_registered
         ctx = ChannelContext.get_current()
         assert ctx.torch_device.type != "cpu"
@@ -546,11 +548,11 @@ class _TorchTensorNcclChannel(ChannelInterface):
         timeout: Optional[float] = None,
     ):
         """
-        Write a list of tensors via NCCL:
+        Write a list of tensors via accelerator:
 
         1) Send the tensor metadata, i.e. the shape and dtypes of all tensors
         via the shared-memory metadata channel.
-        2) Send the tensor data via NCCL.
+        2) Send the tensor data via accelerator.
 
         If static_shape=True was set, then we only perform step (1) on the
         first message. The reader is expected to reuse the sent metadata for
@@ -571,17 +573,17 @@ class _TorchTensorNcclChannel(ChannelInterface):
         if metadata is not None:
             self._meta_channel.write(metadata)
 
-        # NOTE(swang): We must send the metadata *before* launching the NCCL
-        # send. We are using blocking NCCL ops, so the following calls will
+        # NOTE(swang): We must send the metadata *before* launching the accelerator
+        # send. We are using blocking accelerator ops, so the following calls will
         # block until the kernel has been enqueued. Also, peers must launch the
         # kernel together before either can proceed. Therefore, we send the
         # metadata first so that the receiver can read the metadata and then
-        # launch the same NCCL op.
+        # launch the same accelerator op.
         for tensor in tensors:
             # TODO: If there are multiple readers, can replace with a
             # broadcast.
             for rank in self._reader_ranks:
-                self._nccl_group.send(tensor, rank)
+                self._comm_group.send(tensor, rank)
 
     def _get_recv_tensors_metadata(
         self, timeout: Optional[float] = None
@@ -611,7 +613,7 @@ class _TorchTensorNcclChannel(ChannelInterface):
         (1) Receive the tensor metadata via the shared-memory metadata channel.
         (2) Allocate buffers on our default device according to the received
         tensor metadata.
-        (3) Receive the tensor data via NCCL.
+        (3) Receive the tensor data via accelerator.
 
         If static_data=True was set, then we only perform step (1) on the first
         message. Subsequent messages reuse the same metadata.
@@ -626,7 +628,7 @@ class _TorchTensorNcclChannel(ChannelInterface):
 
         bufs: List["torch.Tensor"] = []
         for meta in meta_list:
-            buf = self._nccl_group.recv(
+            buf = self._comm_group.recv(
                 meta.shape, meta.dtype, self._writer_rank, _torch_zeros_allocator
             )
             bufs.append(buf)
@@ -637,10 +639,10 @@ class _TorchTensorNcclChannel(ChannelInterface):
     def close(self) -> None:
         self._meta_channel.close()
 
-        self._nccl_group.destroy()
+        self._comm_group.destroy()
         ctx = ChannelContext.get_current()
-        if self._nccl_group_id in ctx.communicators:
-            del ctx.communicators[self._nccl_group_id]
+        if self._comm_group_id in ctx.communicators:
+            del ctx.communicators[self._comm_group_id]
 
 
 def _do_init_communicator(
@@ -663,7 +665,7 @@ def _do_init_communicator(
         custom_communicator.initialize(rank)
         ctx.communicators[group_id] = custom_communicator
     else:
-        # default to NcclGroup
+        # default to CommGroup
         ctx.communicators[group_id] = AcceleratorContext.get().create_communicator(
             world_size,
             comm_id,
@@ -680,8 +682,8 @@ def _do_destroy_communicator(self, group_id):
         return
     ctx.communicators[group_id].destroy()
 
-    # Keep the NCCL group in the map after destruction in case there is still a
-    # task loop running.
+    # Keep the communicator group in the map after destruction in case there is
+    # still a task loop running.
 
 
 def _do_check_has_accelerators(self) -> str:
@@ -697,32 +699,32 @@ def _do_get_unique_communication_id(self) -> bool:
 
 
 def _get_ranks(
-    actors: List[ray.actor.ActorHandle], custom_nccl_group: Optional[Communicator]
+    actors: List[ray.actor.ActorHandle], custom_comm_group: Optional[Communicator]
 ) -> List[int]:
     """
-    Get ranks for the NCCL group to use. If custom_nccl_group is specified,
-    return the ranks of the actors in the custom NCCL group, in the same
+    Get ranks for the communicator group to use. If custom_comm_group is specified,
+    return the ranks of the actors in the custom communicator group, in the same
     order of the actors; otherwise, return list(range(len(actors))).
 
     Args:
-        actors: A list of actors that participate in the NCCL group.
-        custom_nccl_group: The custom NCCL group to use.
+        actors: A list of actors that participate in the communicator group.
+        custom_comm_group: The custom communicator group to use.
     """
-    if custom_nccl_group is None:
+    if custom_comm_group is None:
         return list(range(len(actors)))
 
-    assert len(actors) == custom_nccl_group.get_world_size(), (
-        "The world size of the custom NCCL group does not match the number "
-        "of actors."
+    assert len(actors) == custom_comm_group.get_world_size(), (
+        "The world size of the custom communicator group does not match the "
+        "number of actors."
     )
     ranks = []
     for actor in actors:
-        rank = custom_nccl_group.get_rank(actor)
-        assert rank not in ranks, "Duplicate rank in custom NCCL group"
+        rank = custom_comm_group.get_rank(actor)
+        assert rank not in ranks, "Duplicate rank in custom communicator group"
         ranks.append(rank)
-    assert custom_nccl_group.get_world_size() == len(actors), (
-        "The world size of the custom NCCL group "
-        f"({custom_nccl_group.get_world_size()}) "
+    assert custom_comm_group.get_world_size() == len(actors), (
+        "The world size of the custom communicator group "
+        f"({custom_comm_group.get_world_size()}) "
         "does not match the number of actors "
         f"({len(actors)})."
     )
@@ -737,12 +739,13 @@ def _init_communicator(
     accelerator_communicator_cls: Optional[Type[Communicator]] = None,
 ) -> str:
     """
-    Initialize a NCCL group with the given actors. If a custom NCCL group is
-    provided, then it will be used, otherwise a new NCCL group will be created.
+    Initialize a communicator group with the given actors. If a custom communicator
+    group is provided, then it will be used, otherwise a new communicator group
+    will be created.
 
     Args:
-        actors: A list of actors that participate in the NCCL group.
-        custom_communicator: A custom NCCL group to initialize.
+        actors: A list of actors that participate in the communicator group.
+        custom_communicator: A custom communicator group to initialize.
         use_communication_streams: Whether to use dedicated send and recv
                 streams for communication. If True, communication and computation
                 can be overlapped to improve performance.
@@ -776,8 +779,8 @@ def _init_communicator(
         if not has_accelerator and not is_cpu_communicator:
             raise ValueError(
                 f"Actor {actor} returns a tensor with type hint "
-                'TorchTensor(transport="nccl") or '
-                "TorchTensor(transport=nccl_group_handle) "
+                'TorchTensor(transport="accelerator") or '
+                "TorchTensor(transport=accelerator_group_handle) "
                 "but actor does not have an accelerator assigned by Ray."
             )
 
@@ -786,16 +789,18 @@ def _init_communicator(
 
     # Allocate a communicator ID on one of the actors that will participate in
     # the group. This is in case the driver is not on the same node as one of
-    # the NCCL actors.
+    # the communicator actors.
     comm_id = ray.get(actors[0].__ray_call__.remote(_do_get_unique_communication_id))
 
-    # Used to uniquely identify this NCCL group.
+    # Used to uniquely identify this communicator group.
     group_id = str(uuid.uuid4())
 
     if custom_communicator is not None:
-        logger.info(f"Initializing custom NCCL group {group_id} on actors: {actors}")
+        logger.info(
+            f"Initializing custom communicator group {group_id} on actors: {actors}"
+        )
     else:
-        logger.info(f"Creating NCCL group {group_id} on actors: {actors}")
+        logger.info(f"Creating communicator group {group_id} on actors: {actors}")
 
     world_size = len(actors)
     ranks = _get_ranks(actors, custom_communicator)
@@ -816,11 +821,12 @@ def _init_communicator(
         ray.get(init_tasks, timeout=30)
     except ray.exceptions.GetTimeoutError:
         logger.warning(
-            "NCCL group creation not done after 30s. NCCL group creation may be hung."
+            "Communicator group creation not done after 30s. communicator group"
+            "creation may be hung."
         )
         ray.get(init_tasks)
 
-    logger.info("NCCL group initialized.")
+    logger.info("Communicator group initialized.")
 
     if custom_communicator is not None:
         ctx.communicator_handles[group_id] = CommunicatorHandle(
@@ -836,7 +842,7 @@ def _init_communicator(
 
 def _destroy_communicator(group_id: str) -> None:
     """
-    Destroy the NCCL group with the given ID.
+    Destroy the communicator group with the given ID.
     """
     ctx = ChannelContext.get_current()
     if group_id not in ctx.communicator_handles:
@@ -855,8 +861,8 @@ def _destroy_communicator(group_id: str) -> None:
     _, unready = ray.wait(destroy_tasks, timeout=30, num_returns=len(destroy_tasks))
     if unready:
         logger.warning(
-            "NCCL group destruction not done after 30s. NCCL group destruction "
-            "may be hung."
+            "Communicator group destruction not done after 30s. Communicator"
+            "group destruction may be hung."
         )
 
     del ctx.communicator_handles[group_id]

--- a/python/ray/experimental/channel/torch_tensor_type.py
+++ b/python/ray/experimental/channel/torch_tensor_type.py
@@ -142,7 +142,7 @@ class TorchTensorType(ChannelOutputType):
         _tensor_metadata_channel: Optional["Channel"] = None,
     ) -> type:
         if self.requires_accelerator():
-            from python.ray.experimental.channel.torch_tensor_accelerator_channel import (
+            from ray.experimental.channel.torch_tensor_accelerator_channel import (
                 TorchTensorAcceleratorChannel,
             )
 

--- a/python/ray/experimental/channel/torch_tensor_type.py
+++ b/python/ray/experimental/channel/torch_tensor_type.py
@@ -79,8 +79,9 @@ class TorchTensorType(ChannelOutputType):
             transport = transport.get_transport_name()
 
         if transport not in [self.AUTO, self.CPU, self.ACCELERATOR]:
+            print(f"lcg ====>{transport=}")
             raise ValueError(
-                "`transport` must be TorchTensorType.AUTO, TorchTensorType.ACCELERATOR"
+                "`transport` must be TorchTensorType.AUTO, TorchTensorType.ACCELERATOR "
                 "or TorchTensorType.CPU"
             )
         if device == Device.CPU and transport == self.ACCELERATOR:

--- a/python/ray/experimental/channel/torch_tensor_type.py
+++ b/python/ray/experimental/channel/torch_tensor_type.py
@@ -79,14 +79,13 @@ class TorchTensorType(ChannelOutputType):
             transport = transport.get_transport_name()
 
         if transport not in [self.AUTO, self.CPU, self.ACCELERATOR]:
-            print(f"lcg ====>{transport=}")
             raise ValueError(
                 "`transport` must be TorchTensorType.AUTO, TorchTensorType.ACCELERATOR "
                 "or TorchTensorType.CPU"
             )
         if device == Device.CPU and transport == self.ACCELERATOR:
             raise ValueError(
-                "accelerator transport is not supported with CPU " "target device."
+                "accelerator transport is not supported with CPU target device."
             )
         self.transport = transport
 

--- a/python/ray/experimental/channel/torch_tensor_type.py
+++ b/python/ray/experimental/channel/torch_tensor_type.py
@@ -17,8 +17,8 @@ logger = logging.getLogger(__name__)
 @PublicAPI(stability="alpha")
 class TorchTensorType(ChannelOutputType):
     AUTO = "auto"
-    NCCL = "nccl"
     CPU = "cpu"
+    ACCELERATOR = "accelerator"
 
     def __init__(
         self,
@@ -40,11 +40,12 @@ class TorchTensorType(ChannelOutputType):
         Args:
             transport: "auto" (default) means that tensors will be passed via
                 host memory, using numpy as the serialization format. Pass
-                TorchTensorType.NCCL or "nccl" to use NCCL instead, avoiding
-                the host memory copy.
+                TorchTensorType.ACCELERATOR or "accelerator" to use accelerator
+                instead, avoiding the host memory copy.
             device: Target device for tensor transport. Options:
                 - "default": Retains the same device type as the sender.
-                - "cpu": Moves tensor to CPU on the receiver. Not compatible with NCCL transport.
+                - "cpu": Moves tensor to CPU on the receiver. Not compatible
+                  with accelerator transport.
                 - "gpu" or "cuda": Moves tensor to GPU on the receiver.
             _static_shape: A hint indicating whether the shape(s) and dtype(s)
                 of tensor(s) contained in this value always remain the same
@@ -77,13 +78,15 @@ class TorchTensorType(ChannelOutputType):
             self._communicator = transport
             transport = transport.get_transport_name()
 
-        if transport not in [self.AUTO, self.NCCL, self.CPU]:
+        if transport not in [self.AUTO, self.CPU, self.ACCELERATOR]:
             raise ValueError(
-                "`transport` must be TorchTensorType.AUTO, TorchTensorType.NCCL, "
+                "`transport` must be TorchTensorType.AUTO, TorchTensorType.ACCELERATOR"
                 "or TorchTensorType.CPU"
             )
-        if device == Device.CPU and transport == self.NCCL:
-            raise ValueError("NCCL transport is not supported with CPU target device.")
+        if device == Device.CPU and transport == self.ACCELERATOR:
+            raise ValueError(
+                "accelerator transport is not supported with CPU " "target device."
+            )
         self.transport = transport
 
         self._communicator_id: Optional[str] = None
@@ -138,12 +141,12 @@ class TorchTensorType(ChannelOutputType):
         _cpu_data_channel: Optional["Channel"] = None,
         _tensor_metadata_channel: Optional["Channel"] = None,
     ) -> type:
-        if self.requires_nccl():
-            from ray.experimental.channel.torch_tensor_nccl_channel import (
-                TorchTensorNcclChannel,
+        if self.requires_accelerator():
+            from python.ray.experimental.channel.torch_tensor_accelerator_channel import (
+                TorchTensorAcceleratorChannel,
             )
 
-            return TorchTensorNcclChannel(
+            return TorchTensorAcceleratorChannel(
                 writer,
                 reader_and_node_list,
                 self,
@@ -152,18 +155,18 @@ class TorchTensorType(ChannelOutputType):
                 _cpu_data_channel,
             )
 
-        # Data does not require NCCL. Transfer via host memory using a
+        # Data does not require accelerator. Transfer via host memory using a
         # shared-memory channel.
         # TODO(swang): Allow the initial max buffer size to be overridden.
         typ = SharedMemoryType()
         return typ.create_channel(writer, reader_and_node_list, driver_actor_id)
 
-    def requires_nccl(self) -> bool:
-        return self.transport == self.NCCL
+    def requires_accelerator(self) -> bool:
+        return self.transport == self.ACCELERATOR
 
     def get_custom_communicator(self) -> Optional[Communicator]:
         """
-        Return the NCCL group if one is specified.
+        Return the communicator group if one is specified.
         """
         return self._communicator
 
@@ -176,9 +179,9 @@ class TorchTensorType(ChannelOutputType):
 
     def __deepcopy__(self, memo):
         """
-        Deep copy all the fields except for the NCCL group. The NCCL group
-        should not be deep copied because it can be shared across
-        `TorchTensorType` instances.
+        Deep copy all the fields except for the communicator group. The communicator
+        group should not be deep copied because it can be shared across `TorchTensorType`
+        instances.
         """
         copy = TorchTensorType(
             transport=self.transport,

--- a/python/ray/experimental/collective/conftest.py
+++ b/python/ray/experimental/collective/conftest.py
@@ -83,7 +83,7 @@ class AbstractNcclGroup(Communicator):
         pass
 
     def get_transport_name(self) -> str:
-        return "nccl"
+        return "accelerator"
 
     @classmethod
     def generate_communicator_id(cls) -> str:

--- a/python/ray/experimental/collective/operations.py
+++ b/python/ray/experimental/collective/operations.py
@@ -51,7 +51,7 @@ def _bind(
         A list of collective output nodes.
     """
     if transport is None:
-        transport = TorchTensorType.NCCL
+        transport = TorchTensorType.ACCELERATOR
     collective_op = _CollectiveOperation(input_nodes, op, transport)
     collective_output_nodes: List[CollectiveOutputNode] = []
 

--- a/python/ray/tests/test_nccl_channel.py
+++ b/python/ray/tests/test_nccl_channel.py
@@ -14,7 +14,7 @@ from ray.experimental.channel.conftest import (
     TracedChannel,
 )
 from ray.experimental.channel.torch_tensor_type import TorchTensorType
-from ray.experimental.channel.torch_tensor_nccl_channel import (
+from ray.experimental.channel.torch_tensor_accelerator_channel import (
     _init_communicator,
 )
 from ray._private.test_utils import get_actor_node_id
@@ -127,7 +127,7 @@ def test_p2p(ray_start_cluster):
 
     nccl_id = _init_communicator([sender, receiver])
 
-    chan_typ = TorchTensorType(transport="nccl")
+    chan_typ = TorchTensorType(transport="accelerator")
     chan_typ.set_communicator_id(nccl_id)
     chan_ref = sender.create_nccl_channel.remote(chan_typ, [(receiver, receiver_node)])
     receiver_ready = receiver.set_nccl_channel.remote(chan_typ, chan_ref)
@@ -186,7 +186,7 @@ def test_multiple_receivers(ray_start_cluster):
 
     nccl_id = _init_communicator(workers)
 
-    chan_typ = TorchTensorType(transport="nccl")
+    chan_typ = TorchTensorType(transport="accelerator")
     chan_typ.set_communicator_id(nccl_id)
     chan_ref = sender.create_nccl_channel.remote(chan_typ, receiver_to_node)
     receiver_ready = [
@@ -241,7 +241,7 @@ def test_static_shape(ray_start_cluster):
     nccl_id = _init_communicator([sender, receiver])
 
     chan_typ = TorchTensorType(
-        transport="nccl",
+        transport="accelerator",
         _static_shape=True,
     )
     chan_typ.set_communicator_id(nccl_id)
@@ -330,7 +330,7 @@ def test_direct_return(ray_start_cluster):
     nccl_id = _init_communicator([sender, receiver])
 
     chan_typ = TorchTensorType(
-        transport="nccl",
+        transport="accelerator",
         _direct_return=True,
     )
     chan_typ.set_communicator_id(nccl_id)
@@ -413,7 +413,7 @@ def test_static_shape_and_direct_return(ray_start_cluster):
     nccl_id = _init_communicator([sender, receiver])
 
     chan_typ = TorchTensorType(
-        transport="nccl",
+        transport="accelerator",
         _static_shape=True,
         _direct_return=True,
     )
@@ -498,7 +498,7 @@ def test_direct_return_with_cpu_data_channel(ray_start_cluster):
 
     nccl_id = _init_communicator([sender, receiver])
     chan_typ = TorchTensorType(
-        transport="nccl",
+        transport="accelerator",
         _direct_return=True,
     )
     chan_typ.set_communicator_id(nccl_id)


### PR DESCRIPTION
## Why are these changes needed?

### Background
This PR is a follow-up to [#51032](https://github.com/ray-project/ray/pull/51032), which introduced multi-device support in the Compiled Graph by leveraging CUDA's NCCL backend for efficient out-of-band tensor communication.

While the current implementation is tightly coupled with NCCL and CUDA, the Compiled Graph runtime is now ready to support a broader spectrum of device types and collective communication backends (e.g., HCCL, RCCL).

### What This PR Does?
To enable extensibility and backend-agnostic design, this PR introduces the following core changes:

Refactored NCCL-specific naming and APIs
NCCL-related modules, classes, and function names have been generalized to eliminate hardcoded CUDA/NCCL assumptions.

Introduced a pluggable communication backend interface
A unified abstraction layer is added to decouple collective communication logic from any specific implementation. This makes it easier to support alternative collective libraries and device types in the future.

This refactor does not alter the existing behavior of NCCL-based Compiled Graph execution. All current workflows using CUDA+NCCL continue to function as before.


## Related issue number
https://github.com/ray-project/ray/issues/51574

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
