### PR TITLE
[core] `BoundedExecutor` is never used when an actor is async

### DIFF
--- a/src/ray/core_worker/transport/task_receiver.cc
+++ b/src/ray/core_worker/transport/task_receiver.cc
@@ -169,18 +169,16 @@ void TaskReceiver::HandleTask(const rpc::PushTaskRequest &request,
       }
 
       if (task_spec.IsActorCreationTask()) {
-        /// The default max concurrency for creating PoolManager should
-        /// be 0 if this is an asyncio actor.
-        const int default_max_concurrency =
-            task_spec.IsAsyncioActor() ? 0 : task_spec.MaxActorConcurrency();
-        pool_manager_ = std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(
-            task_spec.ConcurrencyGroups(),
-            default_max_concurrency,
-            initialize_thread_callback_);
         if (task_spec.IsAsyncioActor()) {
           fiber_state_manager_ = std::make_shared<ConcurrencyGroupManager<FiberState>>(
               task_spec.ConcurrencyGroups(),
               fiber_max_concurrency_,
+              initialize_thread_callback_);
+        } else {
+          const int default_max_concurrency = task_spec.MaxActorConcurrency();
+          pool_manager_ = std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(
+              task_spec.ConcurrencyGroups(),
+              default_max_concurrency,
               initialize_thread_callback_);
         }
         concurrency_groups_cache_[task_spec.TaskId().ActorId()] =

--- a/src/ray/core_worker/transport/task_receiver.cc
+++ b/src/ray/core_worker/transport/task_receiver.cc
@@ -175,6 +175,8 @@ void TaskReceiver::HandleTask(const rpc::PushTaskRequest &request,
               fiber_max_concurrency_,
               initialize_thread_callback_);
         } else {
+          // If the actor is an asyncio actor, then this concurrency group manager
+          // for BoundedExecutor will never be used, so we don't need to initialize it.
           const int default_max_concurrency = task_spec.MaxActorConcurrency();
           pool_manager_ = std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(
               task_spec.ConcurrencyGroups(),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If an actor is async, `pool_manager_` will never be used. Hence, some threads are created but are never used.

https://github.com/ray-project/ray/blob/584d826fda984bf46fe74a69d577e68d6ddfb852/src/ray/core_worker/transport/actor_scheduling_queue.cc#L175-L194

### Experiment

```sh
# Download https://gist.github.com/kevin85421/bfe6a12e8ce743442e6285e2a9dbc564
python3 test.py
```

* Without this PR, we can see 9 "Python" threads when all Ray tasks are running.
  * 1 main thread
  * 2 threads * 3 async groups 
  * `pool_manager_`: A thread in each concurrency group executes `PyGILState_Ensure()`, and we have two concurrency groups in this example, so we can see two Python threads (2128795, 2128799). These threads are never used. We should revisit how to handle scenarios involving multiple threads in the same thread pool, but this is beyond the scope of this PR.
    <img width="464" alt="Screenshot 2025-03-04 at 1 34 39 PM" src="https://github.com/user-attachments/assets/697c7295-fea7-43e2-9e7d-750f4990afd2" />

* With this PR, we can see only 7 "Python" threads when all Ray tasks are running.
  * 1 main thread
  * 2 threads * 3 async groups 
    <img width="527" alt="Screenshot 2025-03-04 at 11 12 10 AM" src="https://github.com/user-attachments/assets/326cef5d-c794-49f7-acc5-61d464c08d82" />






## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
