### PR TITLE
[core] Fix double checked locking

### DIFF
--- a/src/ray/stats/metric.cc
+++ b/src/ray/stats/metric.cc
@@ -22,8 +22,6 @@ namespace ray {
 
 namespace stats {
 
-absl::Mutex Metric::registration_mutex_;
-
 namespace internal {
 
 void RegisterAsView(opencensus::stats::ViewDescriptor view_descriptor,
@@ -114,25 +112,20 @@ void Metric::Record(double value, const TagsType &tags) {
   if (StatsConfig::instance().IsStatsDisabled()) {
     return;
   }
-  // NOTE(lingxuan.zlx): Double check for recording performance while
-  // processing in multithread and avoid race since metrics may invoke
-  // record in different threads or code pathes.
-  if (measure_ == nullptr) {
-    absl::MutexLock lock(&registration_mutex_);
-    if (measure_ == nullptr) {
-      // Measure could be registered before, so we try to get it first.
-      MeasureDouble registered_measure =
-          opencensus::stats::MeasureRegistry::GetMeasureDoubleByName(name_);
 
-      if (registered_measure.IsValid()) {
-        measure_.reset(new MeasureDouble(registered_measure));
-      } else {
-        measure_.reset(
-            new MeasureDouble(MeasureDouble::Register(name_, description_, unit_)));
-      }
-      RegisterView();
+  std::call_once(measure_init_flag_, [this]() {
+    // Measure could be registered before, so we try to get it first.
+    MeasureDouble registered_measure =
+        opencensus::stats::MeasureRegistry::GetMeasureDoubleByName(name_);
+
+    if (registered_measure.IsValid()) {
+      measure_ = std::make_unique<MeasureDouble>(registered_measure);
+    } else {
+      measure_ = std::make_unique<MeasureDouble>(
+          MeasureDouble::Register(name_, description_, unit_));
     }
-  }
+    RegisterView();
+  });
 
   // Do record.
   TagsType combined_tags(tags);

--- a/src/ray/stats/metric.h
+++ b/src/ray/stats/metric.h
@@ -145,7 +145,9 @@ class Metric {
 
  private:
   const std::regex &name_regex_;
-  std::once_flag measure_init_flag_;
+
+  // For making sure thread-safe to all of metric registrations.
+  inline static absl::Mutex registration_mutex_;
 };  // class Metric
 
 class Gauge : public Metric {

--- a/src/ray/stats/metric.h
+++ b/src/ray/stats/metric.h
@@ -18,6 +18,7 @@
 
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <regex>
 #include <tuple>
 #include <unordered_map>
@@ -142,11 +143,9 @@ class Metric {
   std::vector<opencensus::tags::TagKey> tag_keys_;
   std::unique_ptr<opencensus::stats::Measure<double>> measure_;
 
-  // For making sure thread-safe to all of metric registrations.
-  static absl::Mutex registration_mutex_;
-
  private:
   const std::regex &name_regex_;
+  std::once_flag measure_init_flag_;
 };  // class Metric
 
 class Gauge : public Metric {


### PR DESCRIPTION
Double checked locking is known to be buggy (check if null and update pointer leads to data race), `std::once_flag` is the solution.