### PR TITLE
[core] Checkin opentelemetry C++ sdk dependency

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -861,6 +861,15 @@ ray_cc_library(
 )
 
 ray_cc_library(
+    name = "stats_opentelemetry",
+    srcs = ["src/ray/stats/opentelemetry_metrics.cc"],
+    deps = [
+        "@io_opentelemetry_cpp//sdk/src/logs:logs",
+        "@io_opentelemetry_cpp//sdk/src/trace:trace",
+    ],
+)
+
+ray_cc_library(
     name = "stats_metric",
     srcs = [
         "src/ray/stats/metric.cc",

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -216,6 +216,12 @@ def ray_deps_setup():
         patch_args = ["-p1"],
     )
 
+    auto_http_archive(
+        name = "io_opentelemetry_cpp",
+        url = "https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.19.0.zip",
+        sha256 = "8ef0a63f4959d5dfc3d8190d62229ef018ce41eef36e1f3198312d47ab2de05a",
+    )
+
     # OpenCensus depends on Abseil so we have to explicitly pull it in.
     # This is how diamond dependencies are prevented.
     #

--- a/src/ray/stats/opentelemetry_metrics.cc
+++ b/src/ray/stats/opentelemetry_metrics.cc
@@ -1,0 +1,34 @@
+// TODO(hjiang): This is an example file which demonstrates opentelemetry dependency is
+// correct, should be replaced with real metrics exporter implementation.
+
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/sdk/version/version.h"
+#include "opentelemetry/trace/provider.h"
+#include "opentelemetry/trace/scope.h"
+#include "opentelemetry/trace/tracer.h"
+#include "opentelemetry/trace/tracer_provider.h"
+
+namespace trace = opentelemetry::trace;
+namespace nostd = opentelemetry::nostd;
+
+namespace {
+nostd::shared_ptr<trace::Tracer> get_tracer() {
+  auto provider = trace::Provider::GetTracerProvider();
+  return provider->GetTracer("foo_library", OPENTELEMETRY_SDK_VERSION);
+}
+
+void f1() { auto scoped_span = trace::Scope(get_tracer()->StartSpan("f1")); }
+
+void f2() {
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("f2"));
+
+  f1();
+  f1();
+}
+}  // namespace
+
+void foo_library() {
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("library"));
+
+  f2();
+}

--- a/src/ray/stats/opentelemetry_metrics.cc
+++ b/src/ray/stats/opentelemetry_metrics.cc
@@ -1,3 +1,17 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // TODO(hjiang): This is an example file which demonstrates opentelemetry dependency is
 // correct, should be replaced with real metrics exporter implementation.
 

--- a/src/ray/stats/tests/BUILD
+++ b/src/ray/stats/tests/BUILD
@@ -1,0 +1,12 @@
+load("//bazel:ray.bzl", "ray_cc_test")
+
+ray_cc_test(
+    name = "opentelemetry_metrics_test",
+    size = "small",
+    srcs = ["opentelemetry_metrics_test.cc"],
+    tags = ["team:core"],
+    deps = [
+        "//:stats_opentelemetry",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/src/ray/stats/tests/opentelemetry_metrics_test.cc
+++ b/src/ray/stats/tests/opentelemetry_metrics_test.cc
@@ -1,0 +1,16 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TODO(hjiang): Just a dummy test used to trigger CI, replace with real implementation
+// later.


### PR DESCRIPTION
[opencensus](https://github.com/census-instrumentation/opencensus-cpp) has been archived for ~2 years, we should upgrade to opentelemetry which is the somewhat an "improved" and maintained version.