### PR TITLE
[train][v2] add log file paths to train state

### DIFF
--- a/python/ray/train/v2/_internal/callbacks/state_manager.py
+++ b/python/ray/train/v2/_internal/callbacks/state_manager.py
@@ -22,7 +22,9 @@ from ray.train.v2._internal.execution.worker_group import (
     WorkerGroupState,
 )
 from ray.train.v2._internal.execution.worker_group.poll import WorkerGroupPollStatus
-from ray.train.v2._internal.logging.logging import get_train_app_controller_log_path
+from ray.train.v2._internal.logging.logging import (
+    get_train_application_controller_log_path,
+)
 from ray.train.v2._internal.state.state_manager import TrainStateManager
 
 logger = logging.getLogger(__name__)
@@ -44,7 +46,7 @@ class StateManagerCallback(ControllerCallback, WorkerGroupCallback):
         core_context = ray.runtime_context.get_runtime_context()
         self._job_id = core_context.get_job_id()
         self._controller_actor_id = core_context.get_actor_id()
-        self._controller_log_file_path = get_train_app_controller_log_path()
+        self._controller_log_file_path = get_train_application_controller_log_path()
 
         self._state_manager.create_train_run(
             id=self._run_id,

--- a/python/ray/train/v2/_internal/callbacks/state_manager.py
+++ b/python/ray/train/v2/_internal/callbacks/state_manager.py
@@ -22,6 +22,7 @@ from ray.train.v2._internal.execution.worker_group import (
     WorkerGroupState,
 )
 from ray.train.v2._internal.execution.worker_group.poll import WorkerGroupPollStatus
+from ray.train.v2._internal.logging.logging import get_train_app_controller_log_path
 from ray.train.v2._internal.state.state_manager import TrainStateManager
 
 logger = logging.getLogger(__name__)
@@ -43,12 +44,14 @@ class StateManagerCallback(ControllerCallback, WorkerGroupCallback):
         core_context = ray.runtime_context.get_runtime_context()
         self._job_id = core_context.get_job_id()
         self._controller_actor_id = core_context.get_actor_id()
+        self._log_file_path = get_train_app_controller_log_path()
 
         self._state_manager.create_train_run(
             id=self._run_id,
             name=self._run_name,
             job_id=self._job_id,
             controller_actor_id=self._controller_actor_id,
+            log_file_path=self._log_file_path,
         )
 
     def after_controller_state_update(

--- a/python/ray/train/v2/_internal/callbacks/state_manager.py
+++ b/python/ray/train/v2/_internal/callbacks/state_manager.py
@@ -44,14 +44,14 @@ class StateManagerCallback(ControllerCallback, WorkerGroupCallback):
         core_context = ray.runtime_context.get_runtime_context()
         self._job_id = core_context.get_job_id()
         self._controller_actor_id = core_context.get_actor_id()
-        self._log_file_path = get_train_app_controller_log_path()
+        self._controller_log_file_path = get_train_app_controller_log_path()
 
         self._state_manager.create_train_run(
             id=self._run_id,
             name=self._run_name,
             job_id=self._job_id,
             controller_actor_id=self._controller_actor_id,
-            log_file_path=self._log_file_path,
+            controller_log_file_path=self._controller_log_file_path,
         )
 
     def after_controller_state_update(

--- a/python/ray/train/v2/_internal/callbacks/state_manager.py
+++ b/python/ray/train/v2/_internal/callbacks/state_manager.py
@@ -46,14 +46,17 @@ class StateManagerCallback(ControllerCallback, WorkerGroupCallback):
         core_context = ray.runtime_context.get_runtime_context()
         self._job_id = core_context.get_job_id()
         self._controller_actor_id = core_context.get_actor_id()
-        self._controller_log_file_path = get_train_application_controller_log_path()
+
+        controller_log_file_path = get_train_application_controller_log_path()
+        if controller_log_file_path is None:
+            raise ValueError("Controller log file path is not set.")
 
         self._state_manager.create_train_run(
             id=self._run_id,
             name=self._run_name,
             job_id=self._job_id,
             controller_actor_id=self._controller_actor_id,
-            controller_log_file_path=self._controller_log_file_path,
+            controller_log_file_path=controller_log_file_path,
         )
 
     def after_controller_state_update(

--- a/python/ray/train/v2/_internal/execution/worker_group/worker.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/worker.py
@@ -71,6 +71,7 @@ class Worker:
     metadata: ActorMetadata
     resources: Dict[str, float]
     distributed_context: Optional[DistributedContext] = None
+    log_file_path: Optional[str] = None
 
     @cached_property
     def _repr(self) -> str:
@@ -83,6 +84,7 @@ class Worker:
             f"{indent}actor={repr(self.actor)},",
             f"{indent}metadata={metadata_repr},",
             f"{indent}distributed_context={context_repr},",
+            f"{indent}log_file_path={repr(self.log_file_path)},",
             ")",
         ]
         return "\n".join(repr_lines)

--- a/python/ray/train/v2/_internal/execution/worker_group/worker.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/worker.py
@@ -70,8 +70,8 @@ class Worker:
     actor: ActorHandle
     metadata: ActorMetadata
     resources: Dict[str, float]
+    log_file_path: str
     distributed_context: Optional[DistributedContext] = None
-    log_file_path: Optional[str] = None
 
     @cached_property
     def _repr(self) -> str:
@@ -83,8 +83,8 @@ class Worker:
             "Worker(",
             f"{indent}actor={repr(self.actor)},",
             f"{indent}metadata={metadata_repr},",
-            f"{indent}distributed_context={context_repr},",
             f"{indent}log_file_path={repr(self.log_file_path)},",
+            f"{indent}distributed_context={context_repr},",
             ")",
         ]
         return "\n".join(repr_lines)

--- a/python/ray/train/v2/_internal/execution/worker_group/worker.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/worker.py
@@ -70,8 +70,8 @@ class Worker:
     actor: ActorHandle
     metadata: ActorMetadata
     resources: Dict[str, float]
-    log_file_path: str
     distributed_context: Optional[DistributedContext] = None
+    log_file_path: Optional[str] = None
 
     @cached_property
     def _repr(self) -> str:
@@ -83,8 +83,8 @@ class Worker:
             "Worker(",
             f"{indent}actor={repr(self.actor)},",
             f"{indent}metadata={metadata_repr},",
-            f"{indent}log_file_path={repr(self.log_file_path)},",
             f"{indent}distributed_context={context_repr},",
+            f"{indent}log_file_path={repr(self.log_file_path)},",
             ")",
         ]
         return "\n".join(repr_lines)

--- a/python/ray/train/v2/_internal/execution/worker_group/worker_group.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/worker_group.py
@@ -701,6 +701,8 @@ class WorkerGroup:
 
         # Assign log paths to workers
         for worker, log_path in zip(workers, log_paths):
+            if log_path is None:
+                raise ValueError("Worker log file path is not set.")
             worker.log_file_path = log_path
 
         return workers

--- a/python/ray/train/v2/_internal/execution/worker_group/worker_group.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/worker_group.py
@@ -38,7 +38,7 @@ from ray.train.v2._internal.execution.context import (
     StorageContext,
     TrainRunContext,
 )
-from ray.train.v2._internal.logging.logging import get_train_app_worker_log_path
+from ray.train.v2._internal.logging.logging import get_train_application_worker_log_path
 from ray.train.v2._internal.execution.worker_group.poll import (
     PollTask,
     WorkerGroupPollStatus,
@@ -390,7 +390,7 @@ class WorkerGroup:
         ]
         ray_get_safe(context_init_tasks)
 
-        self._assign_worker_log_file_paths(workers)
+        self._decorate_worker_log_file_paths(workers)
 
     #####################################################################################
     # Shutdown Worker Group
@@ -686,15 +686,16 @@ class WorkerGroup:
         return workers
 
     @staticmethod
-    def _assign_worker_log_file_paths(workers: List[Worker]) -> List[Worker]:
-        """Assign log file paths to workers.
+    def _decorate_worker_log_file_paths(workers: List[Worker]) -> List[Worker]:
+        """Decorate worker log file paths.
 
         Returns:
             workers: Workers with log file paths set.
         """
         # Execute all tasks in parallel and then get results
         log_path_refs = [
-            worker.execute_async(get_train_app_worker_log_path) for worker in workers
+            worker.execute_async(get_train_application_worker_log_path)
+            for worker in workers
         ]
         log_paths = ray_get_safe(log_path_refs)
 

--- a/python/ray/train/v2/_internal/logging/logging.py
+++ b/python/ray/train/v2/_internal/logging/logging.py
@@ -226,6 +226,7 @@ def configure_controller_logger(context: TrainRunContext) -> None:
     """
     config = get_controller_logger_config_dict(context)
     logging.config.dictConfig(config)
+    # TODO: Return the controller log file path.
 
 
 def configure_worker_logger(context: TrainRunContext) -> None:
@@ -235,6 +236,7 @@ def configure_worker_logger(context: TrainRunContext) -> None:
     """
     config = get_worker_logger_config_dict(context)
     logging.config.dictConfig(config)
+    # TODO: Return the controller log file path.
 
 
 def get_log_directory() -> Optional[str]:
@@ -257,6 +259,8 @@ def get_train_application_controller_log_path() -> Optional[str]:
     """
     Return the path to the file train application controller log file.
     """
+    # TODO: This is a temporary solution. We should return the log file path in
+    # the `configure_controller_logger` function.
     logger = logging.getLogger("ray.train")
     for handler in logger.handlers:
         if (
@@ -271,6 +275,8 @@ def get_train_application_worker_log_path() -> Optional[str]:
     """
     Return the path to the file train application worker log file.
     """
+    # TODO: This is a temporary solution. We should return the log file path in
+    # the `configure_worker_logger` function.
     logger = logging.getLogger("ray.train")
     for handler in logger.handlers:
         if (

--- a/python/ray/train/v2/_internal/logging/logging.py
+++ b/python/ray/train/v2/_internal/logging/logging.py
@@ -236,7 +236,7 @@ def configure_worker_logger(context: TrainRunContext) -> None:
     """
     config = get_worker_logger_config_dict(context)
     logging.config.dictConfig(config)
-    # TODO: Return the controller log file path.
+    # TODO: Return the worker log file path.
 
 
 def get_log_directory() -> Optional[str]:

--- a/python/ray/train/v2/_internal/logging/logging.py
+++ b/python/ray/train/v2/_internal/logging/logging.py
@@ -186,6 +186,8 @@ class SessionFileHandler(logging.Handler):
         self._formatter = None
         self._path = None
 
+        self._try_create_handler()
+
     def emit(self, record):
         if self._handler is None:
             self._try_create_handler()
@@ -196,6 +198,9 @@ class SessionFileHandler(logging.Handler):
         if self._handler is not None:
             self._handler.setFormatter(fmt)
         self._formatter = fmt
+
+    def get_log_file_path(self) -> Optional[str]:
+        return self._path
 
     def _try_create_handler(self):
         assert self._handler is None
@@ -246,3 +251,31 @@ def get_log_directory() -> Optional[str]:
 
     root_dir = global_node.get_session_dir_path()
     return os.path.join(root_dir, "logs", "train")
+
+
+def get_train_app_controller_log_path() -> Optional[str]:
+    """
+    Return the path to the file train app controller log file.
+    """
+    logger = logging.getLogger("ray.train")
+    for handler in logger.handlers:
+        if (
+            isinstance(handler, SessionFileHandler)
+            and "ray-train-app-controller" in handler._filename
+        ):
+            return handler.get_log_file_path()
+    return None
+
+
+def get_train_app_worker_log_path() -> Optional[str]:
+    """
+    Return the path to the file train app worker log file.
+    """
+    logger = logging.getLogger("ray.train")
+    for handler in logger.handlers:
+        if (
+            isinstance(handler, SessionFileHandler)
+            and "ray-train-app-worker" in handler._filename
+        ):
+            return handler.get_log_file_path()
+    return None

--- a/python/ray/train/v2/_internal/logging/logging.py
+++ b/python/ray/train/v2/_internal/logging/logging.py
@@ -186,8 +186,6 @@ class SessionFileHandler(logging.Handler):
         self._formatter = None
         self._path = None
 
-        self._try_create_handler()
-
     def emit(self, record):
         if self._handler is None:
             self._try_create_handler()
@@ -200,6 +198,8 @@ class SessionFileHandler(logging.Handler):
         self._formatter = fmt
 
     def get_log_file_path(self) -> Optional[str]:
+        if self._handler is None:
+            self._try_create_handler()
         return self._path
 
     def _try_create_handler(self):

--- a/python/ray/train/v2/_internal/logging/logging.py
+++ b/python/ray/train/v2/_internal/logging/logging.py
@@ -253,9 +253,9 @@ def get_log_directory() -> Optional[str]:
     return os.path.join(root_dir, "logs", "train")
 
 
-def get_train_app_controller_log_path() -> Optional[str]:
+def get_train_application_controller_log_path() -> Optional[str]:
     """
-    Return the path to the file train app controller log file.
+    Return the path to the file train application controller log file.
     """
     logger = logging.getLogger("ray.train")
     for handler in logger.handlers:
@@ -267,9 +267,9 @@ def get_train_app_controller_log_path() -> Optional[str]:
     return None
 
 
-def get_train_app_worker_log_path() -> Optional[str]:
+def get_train_application_worker_log_path() -> Optional[str]:
     """
-    Return the path to the file train app worker log file.
+    Return the path to the file train application worker log file.
     """
     logger = logging.getLogger("ray.train")
     for handler in logger.handlers:

--- a/python/ray/train/v2/_internal/state/export.py
+++ b/python/ray/train/v2/_internal/state/export.py
@@ -62,6 +62,7 @@ def _to_proto_worker(worker: TrainWorker) -> ProtoTrainRunAttempt.TrainWorker:
         gpu_ids=worker.gpu_ids,
         status=status,
         resources=_to_proto_resources(worker.resources.resources),
+        log_file_path=worker.log_file_path,
     )
 
 
@@ -95,6 +96,7 @@ def train_run_to_proto(run: TrainRun) -> ProtoTrainRun:
         status_detail=run.status_detail,
         start_time_ns=run.start_time_ns,
         end_time_ns=run.end_time_ns,
+        log_file_path=run.log_file_path,
     )
 
     return proto_run

--- a/python/ray/train/v2/_internal/state/export.py
+++ b/python/ray/train/v2/_internal/state/export.py
@@ -96,7 +96,7 @@ def train_run_to_proto(run: TrainRun) -> ProtoTrainRun:
         status_detail=run.status_detail,
         start_time_ns=run.start_time_ns,
         end_time_ns=run.end_time_ns,
-        log_file_path=run.log_file_path,
+        controller_log_file_path=run.controller_log_file_path,
     )
 
     return proto_run

--- a/python/ray/train/v2/_internal/state/schema.py
+++ b/python/ray/train/v2/_internal/state/schema.py
@@ -96,6 +96,9 @@ class TrainWorker(BaseModel):
     resources: TrainResources = Field(
         description="The resources allocated to this Train worker."
     )
+    log_file_path: Optional[str] = Field(
+        description="The path to the log file for the Train worker."
+    )
 
 
 @DeveloperAPI
@@ -224,6 +227,9 @@ class TrainRun(BaseModel):
     end_time_ns: Optional[int] = Field(
         description="The UNIX timestamp (in nanoseconds) when the Train run ended. "
         "If null, the run is still in progress."
+    )
+    log_file_path: Optional[str] = Field(
+        description="The path to the log file for the Train run."
     )
 
 

--- a/python/ray/train/v2/_internal/state/schema.py
+++ b/python/ray/train/v2/_internal/state/schema.py
@@ -96,7 +96,7 @@ class TrainWorker(BaseModel):
     resources: TrainResources = Field(
         description="The resources allocated to this Train worker."
     )
-    log_file_path: Optional[str] = Field(
+    log_file_path: str = Field(
         description="The path to the log file for the Train worker."
     )
 
@@ -228,8 +228,8 @@ class TrainRun(BaseModel):
         description="The UNIX timestamp (in nanoseconds) when the Train run ended. "
         "If null, the run is still in progress."
     )
-    log_file_path: Optional[str] = Field(
-        description="The path to the log file for the Train run."
+    controller_log_file_path: str = Field(
+        description="The path to the log file for the Train run controller."
     )
 
 

--- a/python/ray/train/v2/_internal/state/state_manager.py
+++ b/python/ray/train/v2/_internal/state/state_manager.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from collections import defaultdict
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from ray.actor import ActorHandle
 from ray.train.v2._internal.execution.context import DistributedContext
@@ -41,7 +41,7 @@ class TrainStateManager:
         name: str,
         job_id: str,
         controller_actor_id: str,
-        log_file_path: Optional[str] = None,
+        controller_log_file_path: str,
     ) -> None:
         run = TrainRun(
             id=id,
@@ -51,7 +51,7 @@ class TrainStateManager:
             status_detail=None,
             controller_actor_id=controller_actor_id,
             start_time_ns=_current_time_ns(),
-            log_file_path=log_file_path,
+            controller_log_file_path=controller_log_file_path,
         )
         self._runs[run.id] = run
         self._create_or_update_train_run(run)

--- a/python/ray/train/v2/_internal/state/state_manager.py
+++ b/python/ray/train/v2/_internal/state/state_manager.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from collections import defaultdict
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from ray.actor import ActorHandle
 from ray.train.v2._internal.execution.context import DistributedContext
@@ -41,6 +41,7 @@ class TrainStateManager:
         name: str,
         job_id: str,
         controller_actor_id: str,
+        log_file_path: Optional[str] = None,
     ) -> None:
         run = TrainRun(
             id=id,
@@ -50,6 +51,7 @@ class TrainStateManager:
             status_detail=None,
             controller_actor_id=controller_actor_id,
             start_time_ns=_current_time_ns(),
+            log_file_path=log_file_path,
         )
         self._runs[run.id] = run
         self._create_or_update_train_run(run)
@@ -167,6 +169,7 @@ class TrainStateManager:
                 gpu_ids=actor_metadata.gpu_ids,
                 status=ActorStatus.ALIVE,
                 resources=TrainResources(resources=worker.resources),
+                log_file_path=worker.log_file_path,
             )
 
         workers: List[TrainWorker] = [_convert_worker(worker) for worker in workers]

--- a/python/ray/train/v2/tests/test_state.py
+++ b/python/ray/train/v2/tests/test_state.py
@@ -415,6 +415,68 @@ def test_callback_worker_group_error(
     assert attempt.end_time_ns is not None
 
 
+def test_callback_log_file_paths(
+    ray_start_regular, monkeypatch, mock_worker_group_context, mock_worker
+):
+    """Test that StateManagerCallback correctly captures and propagates log file paths."""
+
+    # Mock the runtime context
+    mock_runtime_context = MagicMock()
+    mock_runtime_context.get_job_id.return_value = "test_job_id"
+    mock_runtime_context.get_actor_id.return_value = "test_controller_id"
+    monkeypatch.setattr(
+        ray.runtime_context, "get_runtime_context", lambda: mock_runtime_context
+    )
+
+    # Mock the log path function
+    expected_controller_log_path = (
+        "/tmp/ray/session_xxx/logs/train/ray-train-app-controller.log"
+    )
+    monkeypatch.setattr(
+        ray.train.v2._internal.callbacks.state_manager,
+        "get_train_app_controller_log_path",
+        lambda: expected_controller_log_path,
+    )
+
+    # Create the callback
+    train_run_context = TrainRunContext(RunConfig(name="test_run"))
+    callback = StateManagerCallback(train_run_context)
+
+    # Initialize the callback
+    callback.after_controller_start()
+
+    # Verify the log path was set in the state actor
+    state_actor = get_state_actor()
+    runs = ray.get(state_actor.get_train_runs.remote())
+    run = runs[callback._run_id]
+    assert run.log_file_path == expected_controller_log_path
+
+    # Now test worker log paths
+    # Create a mock worker with a log file path
+    mock_worker = mock_worker
+    mock_worker.log_file_path = (
+        "/tmp/ray/session_xxx/logs/train/ray-train-app-worker.log"
+    )
+
+    # Create a mock worker group
+    mock_worker_group = MagicMock(spec=WorkerGroup)
+    mock_worker_group.get_worker_group_context.return_value = mock_worker_group_context
+    mock_worker_group.get_worker_group_state.return_value = MagicMock(
+        workers=[mock_worker]
+    )
+    mock_worker_group.get_latest_poll_status.return_value = None
+
+    # Start the worker group
+    callback.before_worker_group_start(mock_worker_group_context)
+    callback.after_worker_group_start(mock_worker_group)
+
+    # Verify the worker log path was set in the state actor
+    attempts = ray.get(state_actor.get_train_run_attempts.remote())
+    attempt = list(attempts.values())[0][mock_worker_group_context.run_attempt_id]
+    assert len(attempt.workers) == 1
+    assert attempt.workers[0].log_file_path == mock_worker.log_file_path
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/train/v2/tests/test_state.py
+++ b/python/ray/train/v2/tests/test_state.py
@@ -434,7 +434,7 @@ def test_callback_log_file_paths(
     )
     monkeypatch.setattr(
         ray.train.v2._internal.callbacks.state_manager,
-        "get_train_app_controller_log_path",
+        "get_train_application_controller_log_path",
         lambda: expected_controller_log_path,
     )
 

--- a/python/ray/train/v2/tests/test_state_export.py
+++ b/python/ray/train/v2/tests/test_state_export.py
@@ -271,6 +271,46 @@ def test_export_optional_fields(enable_export_api_write):
     assert "end_time_ns" in attempt_data["event_data"]
 
 
+def test_export_log_file_paths(enable_export_api_write):
+    """Test that log file paths are correctly exported."""
+    state_actor = get_or_create_state_actor()
+
+    # Create a run with a log file path
+    run = _create_mock_train_run(RunStatus.RUNNING)
+    run.log_file_path = "/tmp/ray/session_xxx/logs/train/ray-train-app-controller.log"
+    ray.get(state_actor.create_or_update_train_run.remote(run))
+
+    # Create an attempt with a worker that has a log file path
+    attempt = _create_mock_train_run_attempt(
+        attempt_id="attempt_with_log_path",
+        status=RunAttemptStatus.RUNNING,
+    )
+    attempt.workers[
+        0
+    ].log_file_path = "/tmp/ray/session_xxx/logs/train/ray-train-app-worker.log"
+    ray.get(state_actor.create_or_update_train_run_attempt.remote(attempt))
+
+    # Check that export files were created with log paths
+    data = _get_exported_data()
+    assert len(data) == 2
+
+    # Verify run log path was exported
+    run_data = data[0]
+    assert run_data["source_type"] == "EXPORT_TRAIN_RUN"
+    assert (
+        run_data["event_data"]["log_file_path"]
+        == "/tmp/ray/session_xxx/logs/train/ray-train-app-controller.log"
+    )
+
+    # Verify worker log path was exported
+    attempt_data = data[1]
+    assert attempt_data["source_type"] == "EXPORT_TRAIN_RUN_ATTEMPT"
+    assert (
+        attempt_data["event_data"]["workers"][0]["log_file_path"]
+        == "/tmp/ray/session_xxx/logs/train/ray-train-app-worker.log"
+    )
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/train/v2/tests/test_worker_group.py
+++ b/python/ray/train/v2/tests/test_worker_group.py
@@ -451,6 +451,20 @@ def test_worker_group_callback():
     assert hooks.shutdown_hook_called
 
 
+def test_worker_log_file_paths():
+    """Test that log file paths are correctly assigned to workers."""
+    wg = _default_inactive_worker_group()
+    wg._start()
+
+    # Check that all workers have log file paths assigned
+    workers = wg.get_workers()
+    for worker in workers:
+        assert worker.log_file_path is not None
+        assert "ray-train-app-worker" in worker.log_file_path
+
+    wg.shutdown()
+
+
 def test_shutdown_hook_with_dead_actors():
     """Check that the shutdown hook raises correctly if run
     on a mix of alive and dead actors."""

--- a/src/ray/protobuf/export_api/export_train_state.proto
+++ b/src/ray/protobuf/export_api/export_train_state.proto
@@ -58,6 +58,8 @@ message ExportTrainRunEventData {
   // The timestamp when the Train run ended in ns. If not set, the run is still
   // in progress
   optional uint64 end_time_ns = 9;
+  // The path to the log file for the Train run.
+  optional string log_file_path = 10;
 }
 
 // Metadata for an individual attempt to execute a Train run
@@ -120,6 +122,8 @@ message ExportTrainRunAttemptEventData {
     optional ActorStatus status = 9;
     // The resources allocated to this Train worker
     TrainResources resources = 10;
+    // The path to the log file for the Train worker
+    optional string log_file_path = 11;
   }
 
   // Unique identifier for the parent Train run

--- a/src/ray/protobuf/export_api/export_train_state.proto
+++ b/src/ray/protobuf/export_api/export_train_state.proto
@@ -58,8 +58,8 @@ message ExportTrainRunEventData {
   // The timestamp when the Train run ended in ns. If not set, the run is still
   // in progress
   optional uint64 end_time_ns = 9;
-  // The path to the log file for the Train run.
-  optional string log_file_path = 10;
+  // The path to the log file for the Train run controller.
+  string controller_log_file_path = 10;
 }
 
 // Metadata for an individual attempt to execute a Train run
@@ -123,7 +123,7 @@ message ExportTrainRunAttemptEventData {
     // The resources allocated to this Train worker
     TrainResources resources = 10;
     // The path to the log file for the Train worker
-    optional string log_file_path = 11;
+    string log_file_path = 11;
   }
 
   // Unique identifier for the parent Train run


### PR DESCRIPTION
This PR adds log file paths to the Train state schema, for both the controller and workers. These will be user facing application logs.

## Changes

- Added `controller_log_file_path` field to `TrainRun` and `log_file_path` to `TrainWorker` schema classes
- Added corresponding fields to protobuf messages for state export API
- Implemented utility methods to retrieve log file paths for controller and workers
   - Note that these should be called after the loggers are initialized
- Added functionality to assign log file paths to workers in the worker group

## Example

```bash
curl http://localhost:8265/api/train/v2/runs/v1 | jq '{train_runs: [.train_runs[] | {controller_log_file_path: .controller_log_file_path, attempts: [.attempts[] | {workers: [.workers[] | {log_file_path: .log_file_path}]}]}]}'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2150  100  2150    0     0   6014      0 --:--:-- --:--:-- --:--:--  6073
{
  "train_runs": [
    {
      "controller_log_file_path": "/tmp/ray/session_2025-03-06_17-49-54_391760_49580/logs/train/ray-train-app-controller-f646cf91eef6c94d621624c8f25c6da3b3fbab430384dbc5eac72d44.log",
      "attempts": [
        {
          "workers": [
            {
              "log_file_path": "/tmp/ray/session_2025-03-06_17-49-54_391760_49580/logs/train/ray-train-app-worker-31f6c027fbfd7e50e10a264c598b51e84c678c7a25914e20caeea0fb.log"
            },
            {
              "log_file_path": "/tmp/ray/session_2025-03-06_17-49-54_391760_49580/logs/train/ray-train-app-worker-8bfc009ec92c4f983365a4d603b894e8335db764d8734bde90b3cee7.log"
            }
          ]
        }
      ]
    }
  ]
}
```

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
