### PR TITLE
[core][compiled graphs] Controllably destroy CUDA events in `GPUFuture`s

### DIFF
--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -542,9 +542,9 @@ class ExecutableTask:
 
     def destroy_cuda_event(self):
         """
-        If this executable task has produced a GPU future that is not yet waited,
-        that future is in the channel context cache. Pop the future from the cache
-        and destroy the CUDA event it contains.
+        If this executable task has created a GPU future that is not yet waited on,
+        that future is in the channel context cache. Remove the future from the cache
+        and destroy its CUDA event.
         """
         from ray.experimental.channel.common import ChannelContext
 

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -546,10 +546,7 @@ class ExecutableTask:
         that future is in the channel context cache. Remove the future from the cache
         and destroy its CUDA event.
         """
-        from ray.experimental.channel.common import ChannelContext
-
-        ctx = ChannelContext.get_current().serialization_context
-        ctx.remove_gpu_future(self.task_idx)
+        GPUFuture.remove_gpu_future(self.task_idx)
 
     def prepare(self, overlap_gpu_communication: bool = False):
         """

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -610,7 +610,7 @@ class ExecutableTask:
         assert self._intermediate_future is None
 
         if wrap_in_gpu_future:
-            future = GPUFuture(val)
+            future = GPUFuture(val, self.task_idx)
         else:
             future = ResolvedFuture(val)
         self._intermediate_future = future

--- a/python/ray/dag/dag_operation_future.py
+++ b/python/ray/dag/dag_operation_future.py
@@ -113,7 +113,6 @@ class GPUFuture(DAGOperationFuture[Any]):
                 on when the future is resolved. If None, the current stream is used.
         """
         import cupy as cp
-        from ray.experimental.channel.common import ChannelContext
 
         if stream is None:
             stream = cp.cuda.get_current_stream()
@@ -133,7 +132,6 @@ class GPUFuture(DAGOperationFuture[Any]):
         the GPU operation. This operation does not block CPU.
         """
         import cupy as cp
-        from ray.experimental.channel.common import ChannelContext
 
         current_stream = cp.cuda.get_current_stream()
         if not self._waited:

--- a/python/ray/experimental/channel/serialization_context.py
+++ b/python/ray/experimental/channel/serialization_context.py
@@ -5,6 +5,8 @@ if TYPE_CHECKING:
     import numpy as np
     import torch
 
+from ray.dag.dag_operation_future import GPUFuture
+
 
 _TORCH_WARNING_FILTER_ACTIVATE = True
 
@@ -31,6 +33,9 @@ class _SerializationContext:
         # The number of readers for each channel. When the number of readers
         # reaches 0, remove the data from the buffer.
         self.channel_id_to_num_readers: Dict[str, int] = {}
+        # Caching GPU futures ensures CUDA events associated with futures are propoerly
+        # destroyed instead of relying on garbage collection.
+        self.gpu_futures: Dict[int, "GPUFuture"] = {}
 
     def set_data(self, channel_id: str, value: Any, num_readers: int) -> None:
         assert num_readers > 0, "num_readers must be greater than 0."
@@ -65,6 +70,27 @@ class _SerializationContext:
     def reset_data(self, channel_id: str) -> None:
         self.intra_process_channel_buffers.pop(channel_id, None)
         self.channel_id_to_num_readers.pop(channel_id, None)
+
+    def add_gpu_future(self, fut_id: int, fut: "GPUFuture") -> None:
+        """
+        Cache the GPU future.
+        Args:
+            fut_id: GPU future ID.
+            fut: GPU future to be cached.
+        """
+        assert (
+            fut_id not in self.gpu_futures
+        ), f"GPUFuture with id {fut_id} is already cached"
+        self.gpu_futures[fut_id] = fut
+
+    def remove_gpu_future(self, fut_id: int) -> None:
+        """
+        Remove the cached GPU future and destroy its CUDA event.
+        Args:
+            fut_id: GPU future ID.
+        """
+        if fut_id in self.gpu_futures:
+            self.gpu_futures.pop(fut_id).destroy_event()
 
     def set_use_external_transport(self, use_external_transport: bool) -> None:
         self._use_external_transport = use_external_transport

--- a/python/ray/experimental/channel/serialization_context.py
+++ b/python/ray/experimental/channel/serialization_context.py
@@ -5,8 +5,6 @@ if TYPE_CHECKING:
     import numpy as np
     import torch
 
-from ray.dag.dag_operation_future import GPUFuture
-
 
 _TORCH_WARNING_FILTER_ACTIVATE = True
 

--- a/python/ray/experimental/channel/serialization_context.py
+++ b/python/ray/experimental/channel/serialization_context.py
@@ -76,9 +76,8 @@ class _SerializationContext:
             fut_id: GPU future ID.
             fut: GPU future to be cached.
         """
-        assert (
-            fut_id not in self.gpu_futures
-        ), f"GPUFuture with id {fut_id} is already cached"
+        if fut_id in self.gpu_futures:
+            self.gpu_futures.pop(fut_id).destroy_event()
         self.gpu_futures[fut_id] = fut
 
     def remove_gpu_future(self, fut_id: int) -> None:

--- a/python/ray/experimental/channel/serialization_context.py
+++ b/python/ray/experimental/channel/serialization_context.py
@@ -80,8 +80,7 @@ class _SerializationContext:
             fut: GPU future to be cached.
         """
         if fut_id in self.gpu_futures:
-            # Old future from a previous execution was not waited
-            # because of an exception.
+            # The old future was not waited on because of an execution exception.
             self.gpu_futures.pop(fut_id).destroy_event()
         self.gpu_futures[fut_id] = fut
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, a `GPUFuture` contains a recorded CUDA event. When the `GPUFuture` is garbage-collected, its event is also garbage-collected, at which point `cupy` destroys that CUDA event.

This is problematic because the event might be destroyed after other CUDA resources. In particular, we found that the overlapping test in `test_torch_tensor_dag.py` consistently prints out an invalid cuda memory error that occurs during dag teardown. Our hypothesis is that: For an event, CUDA likely stores a pointer to the stream it recorded. Since the CUDA streams are destroyed before the events, the stream pointer is no longer valid when the event is destroyed.

This PR fixes the issue by caching an actor's unresolved `GPUFuture`s in its serialization context. After the `GPUFuture` has been waited on, its event is manually destroyed. During teardown, the events inside all unresolved `GPUFuture`s are destroyed before other CUDA resources.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
