### PR TITLE
[RLlib] Add 'single_action_space' and 'single_observation_space' to 'VectorMultiAgentEnv`.

### DIFF
--- a/rllib/env/vector/sync_vector_multi_agent_env.py
+++ b/rllib/env/vector/sync_vector_multi_agent_env.py
@@ -37,10 +37,11 @@ class SyncVectorMultiAgentEnv(VectorMultiAgentEnv):
         self.single_action_spaces = self.envs[0].unwrapped.action_spaces or dict(
             self.envs[0].unwrapped.action_space
         )
+        self.single_action_space = gym.spaces.Dict(self.single_action_spaces)
         self.single_observation_spaces = self.envs[
             0
         ].unwrapped.observation_spaces or dict(self.envs[0].unwrapped.observation_space)
-
+        self.single_observation_space = gym.spaces.Dict(self.single_observation_spaces)
         # TODO (simon): Decide if we want to include a spaces check here.
 
         # Note, if `single_observation_spaces` are not defined, this will

--- a/rllib/env/vector/vector_multi_agent_env.py
+++ b/rllib/env/vector/vector_multi_agent_env.py
@@ -25,6 +25,9 @@ class VectorMultiAgentEnv:
     # single on that holds for all sub-envs.
     single_observation_spaces: Optional[Dict[str, gym.Space]] = None
     single_action_spaces: Optional[Dict[str, gym.Space]] = None
+    # Note, the proper `gym` spaces are needed for the connector pipeline.
+    single_observation_space: Optional[gym.spaces.Dict] = None
+    single_action_space: Optional[gym.spaces.Dict] = None
 
     num_envs: int
 


### PR DESCRIPTION
…MultiAgentEnv' o conform with 'ConnectorPipelineV2' when spaces are changed.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Connectors in the `ConnectorPipelineV2` can modify output spaces and thereby rely on the `single_action_space` and `single_observation_space` in vector environments. For the `VectorMultiAgentEnv` these spaces are not defined by default - mainly because `gym` spaces are not allowed to change during the cause of an experiment - and are deduced from the `single_observation_spaces` and `single_action_spaces` by wrapping them into a `gym.spaces.Dict`. As long as users do not have defined their `single_action_space` and `single_observation_space` this default setup works, however, if these are defined in a non-standard way, i.e. not an `gym.spaces.Dict` space exceptions can happen (specifically in connectors). 

This PR proposes to add the missing space definitions into the `VectorMultiAgentEnv` and thereby enforcing the standard space definiton by type statements.

## Related issue number


## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
