### PR TITLE
[core] Remove unnecessary `ClientHandler`

### DIFF
--- a/src/ray/common/client_connection.cc
+++ b/src/ray/common/client_connection.cc
@@ -410,21 +410,17 @@ void ServerConnection::DoAsyncWrites() {
 }
 
 std::shared_ptr<ClientConnection> ClientConnection::Create(
-    ClientHandler &client_handler,
     MessageHandler &message_handler,
     local_stream_socket &&socket,
     const std::string &debug_label,
     const std::vector<std::string> &message_type_enum_names,
     int64_t error_message_type) {
-  auto self = std::make_shared<ClientConnection>(Tag{},
-                                                 message_handler,
-                                                 std::move(socket),
-                                                 debug_label,
-                                                 message_type_enum_names,
-                                                 error_message_type);
-  // Let our manager process our new connection.
-  client_handler(*self);
-  return self;
+  return std::make_shared<ClientConnection>(Tag{},
+                                            message_handler,
+                                            std::move(socket),
+                                            debug_label,
+                                            message_type_enum_names,
+                                            error_message_type);
 }
 
 ClientConnection::ClientConnection(

--- a/src/ray/common/client_connection.h
+++ b/src/ray/common/client_connection.h
@@ -188,7 +188,6 @@ class ServerConnection : public std::enable_shared_from_this<ServerConnection> {
 
 class ClientConnection;
 
-using ClientHandler = std::function<void(ClientConnection &)>;
 using MessageHandler = std::function<void(
     std::shared_ptr<ClientConnection>, int64_t, const std::vector<uint8_t> &)>;
 
@@ -217,7 +216,6 @@ class ClientConnection : public ServerConnection {
 
   /// Allocate a new node client connection.
   ///
-  /// \param new_client_handler A reference to the client handler.
   /// \param message_handler A reference to the message handler.
   /// \param socket The client socket.
   /// \param debug_label Label that is printed in debug messages, to identify
@@ -227,7 +225,6 @@ class ClientConnection : public ServerConnection {
   /// \param error_message_type the type of error message
   /// \return std::shared_ptr<ClientConnection>.
   static std::shared_ptr<ClientConnection> Create(
-      ClientHandler &new_client_handler,
       MessageHandler &message_handler,
       local_stream_socket &&socket,
       const std::string &debug_label,

--- a/src/ray/common/test/client_connection_test.cc
+++ b/src/ray/common/test/client_connection_test.cc
@@ -69,8 +69,6 @@ TEST_F(ClientConnectionTest, SimpleSyncWrite) {
   const uint8_t arr[5] = {1, 2, 3, 4, 5};
   int num_messages = 0;
 
-  ClientHandler client_handler = [](ClientConnection &client) {};
-
   MessageHandler message_handler = [&arr, &num_messages](
                                        std::shared_ptr<ClientConnection> client,
                                        int64_t message_type,
@@ -80,10 +78,10 @@ TEST_F(ClientConnectionTest, SimpleSyncWrite) {
   };
 
   auto conn1 = ClientConnection::Create(
-      client_handler, message_handler, std::move(in_), "conn1", {}, error_message_type_);
+      message_handler, std::move(in_), "conn1", {}, error_message_type_);
 
   auto conn2 = ClientConnection::Create(
-      client_handler, message_handler, std::move(out_), "conn2", {}, error_message_type_);
+      message_handler, std::move(out_), "conn2", {}, error_message_type_);
 
   RAY_CHECK_OK(conn1->WriteMessage(0, 5, arr));
   RAY_CHECK_OK(conn2->WriteMessage(0, 5, arr));
@@ -98,8 +96,6 @@ TEST_F(ClientConnectionTest, SimpleAsyncWrite) {
   const uint8_t msg2[5] = {4, 4, 4, 4, 4};
   const uint8_t msg3[5] = {8, 8, 8, 8, 8};
   int num_messages = 0;
-
-  ClientHandler client_handler = [](ClientConnection &client) {};
 
   MessageHandler noop_handler = [](std::shared_ptr<ClientConnection> client,
                                    int64_t message_type,
@@ -125,14 +121,10 @@ TEST_F(ClientConnectionTest, SimpleAsyncWrite) {
   };
 
   auto writer = ClientConnection::Create(
-      client_handler, noop_handler, std::move(in_), "writer", {}, error_message_type_);
+      noop_handler, std::move(in_), "writer", {}, error_message_type_);
 
-  reader = ClientConnection::Create(client_handler,
-                                    message_handler,
-                                    std::move(out_),
-                                    "reader",
-                                    {},
-                                    error_message_type_);
+  reader = ClientConnection::Create(
+      message_handler, std::move(out_), "reader", {}, error_message_type_);
 
   std::function<void(const ray::Status &)> callback = [](const ray::Status &status) {
     RAY_CHECK_OK(status);
@@ -179,14 +171,12 @@ TEST_F(ClientConnectionTest, SimpleAsyncReadWriteBuffers) {
 TEST_F(ClientConnectionTest, SimpleAsyncError) {
   const uint8_t msg1[5] = {1, 2, 3, 4, 5};
 
-  ClientHandler client_handler = [](ClientConnection &client) {};
-
   MessageHandler noop_handler = [](std::shared_ptr<ClientConnection> client,
                                    int64_t message_type,
                                    const std::vector<uint8_t> &message) {};
 
   auto writer = ClientConnection::Create(
-      client_handler, noop_handler, std::move(in_), "writer", {}, error_message_type_);
+      noop_handler, std::move(in_), "writer", {}, error_message_type_);
 
   std::function<void(const ray::Status &)> callback = [](const ray::Status &status) {
     ASSERT_TRUE(!status.ok());
@@ -200,14 +190,12 @@ TEST_F(ClientConnectionTest, SimpleAsyncError) {
 TEST_F(ClientConnectionTest, CallbackWithSharedRefDoesNotLeakConnection) {
   const uint8_t msg1[5] = {1, 2, 3, 4, 5};
 
-  ClientHandler client_handler = [](ClientConnection &client) {};
-
   MessageHandler noop_handler = [](std::shared_ptr<ClientConnection> client,
                                    int64_t message_type,
                                    const std::vector<uint8_t> &message) {};
 
   auto writer = ClientConnection::Create(
-      client_handler, noop_handler, std::move(in_), "writer", {}, error_message_type_);
+      noop_handler, std::move(in_), "writer", {}, error_message_type_);
 
   std::function<void(const ray::Status &)> callback =
       [writer](const ray::Status &status) {
@@ -222,8 +210,6 @@ TEST_F(ClientConnectionTest, ProcessBadMessage) {
   const uint8_t arr[5] = {1, 2, 3, 4, 5};
   int num_messages = 0;
 
-  ClientHandler client_handler = [](ClientConnection &client) {};
-
   MessageHandler message_handler = [&arr, &num_messages](
                                        std::shared_ptr<ClientConnection> client,
                                        int64_t message_type,
@@ -233,14 +219,10 @@ TEST_F(ClientConnectionTest, ProcessBadMessage) {
   };
 
   auto writer = ClientConnection::Create(
-      client_handler, message_handler, std::move(in_), "writer", {}, error_message_type_);
+      message_handler, std::move(in_), "writer", {}, error_message_type_);
 
-  auto reader = ClientConnection::Create(client_handler,
-                                         message_handler,
-                                         std::move(out_),
-                                         "reader",
-                                         {},
-                                         error_message_type_);
+  auto reader = ClientConnection::Create(
+      message_handler, std::move(out_), "reader", {}, error_message_type_);
 
   // If client ID is set, bad message would crash the test.
   // reader->SetClientID(UniqueID::FromRandom());

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1183,11 +1183,6 @@ bool NodeManager::UpdateResourceUsage(
   return true;
 }
 
-void NodeManager::ProcessNewClient(ClientConnection &client) {
-  // The new client is a worker, so begin listening for messages.
-  client.ProcessMessages();
-}
-
 void NodeManager::ProcessClientMessage(const std::shared_ptr<ClientConnection> &client,
                                        int64_t message_type,
                                        const uint8_t *message_data) {

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -132,12 +132,6 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
               std::shared_ptr<gcs::GcsClient> gcs_client,
               std::function<void(const rpc::NodeDeathInfo &)> shutdown_raylet_gracefully);
 
-  /// Process a new client connection.
-  ///
-  /// \param client The client to process.
-  /// \return Void.
-  void ProcessNewClient(ClientConnection &client);
-
   /// Process a message from a client. This method is responsible for
   /// explicitly listening for more messages from the client if the client is
   /// still alive.

--- a/src/ray/raylet/raylet.cc
+++ b/src/ray/raylet/raylet.cc
@@ -168,7 +168,9 @@ void Raylet::HandleAccept(const boost::system::error_code &error) {
         node_manager_message_enum,
         static_cast<int64_t>(protocol::MessageType::DisconnectClient));
 
-    node_manager_.ProcessNewClient(conn);
+    // Begin processing messages. The message handler above is expected to call this to
+    // continue processing messages.
+    conn->ProcessMessages();
   } else {
     RAY_LOG(ERROR) << "Raylet failed to accept new connection: " << error.message();
     if (error == boost::asio::error::operation_aborted) {

--- a/src/ray/raylet/raylet.cc
+++ b/src/ray/raylet/raylet.cc
@@ -154,23 +154,21 @@ void Raylet::DoAccept() {
 
 void Raylet::HandleAccept(const boost::system::error_code &error) {
   if (!error) {
-    // TODO: typedef these handlers.
-    ClientHandler client_handler = [this](ClientConnection &client) {
-      node_manager_.ProcessNewClient(client);
-    };
     MessageHandler message_handler = [this](std::shared_ptr<ClientConnection> client,
                                             int64_t message_type,
                                             const std::vector<uint8_t> &message) {
       node_manager_.ProcessClientMessage(client, message_type, message.data());
     };
+
     // Accept a new local client and dispatch it to the node manager.
-    auto new_connection = ClientConnection::Create(
-        client_handler,
+    auto conn = ClientConnection::Create(
         message_handler,
         std::move(socket_),
         "worker",
         node_manager_message_enum,
         static_cast<int64_t>(protocol::MessageType::DisconnectClient));
+
+    node_manager_.ProcessNewClient(conn);
   } else {
     RAY_LOG(ERROR) << "Raylet failed to accept new connection: " << error.message();
     if (error == boost::asio::error::operation_aborted) {

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -262,16 +262,15 @@ class WorkerPoolMock : public WorkerPool {
     local_stream_socket socket(instrumented_io_service_);
     auto conn = ClientConnection::Create(
         message_handler, std::move(socket), "worker", {}, error_message_type_);
-    HandleNewClient(conn) std::shared_ptr<Worker> worker_ =
-        std::make_shared<Worker>(job_id,
-                                 runtime_env_hash,
-                                 WorkerID::FromRandom(),
-                                 language,
-                                 worker_type,
-                                 "127.0.0.1",
-                                 conn,
-                                 client_call_manager_,
-                                 worker_startup_token);
+    std::shared_ptr<Worker> worker_ = std::make_shared<Worker>(job_id,
+                                                               runtime_env_hash,
+                                                               WorkerID::FromRandom(),
+                                                               language,
+                                                               worker_type,
+                                                               "127.0.0.1",
+                                                               conn,
+                                                               client_call_manager_,
+                                                               worker_startup_token);
     std::shared_ptr<WorkerInterface> worker =
         std::dynamic_pointer_cast<WorkerInterface>(worker_);
     auto rpc_client = std::make_shared<MockWorkerClient>();
@@ -393,7 +392,6 @@ class WorkerPoolMock : public WorkerPool {
   rpc::ClientCallManager client_call_manager_;
   absl::flat_hash_map<WorkerID, std::shared_ptr<MockWorkerClient>>
       &mock_worker_rpc_clients_;
-  void HandleNewClient(ClientConnection &){};
   void HandleMessage(std::shared_ptr<ClientConnection>,
                      int64_t,
                      const std::vector<uint8_t> &){};


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The client handler was being passed into `ClientConnection::Create` just to be immediately called. Removing this unnecessary indirection and moving the registration logic to the callsites.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
