### PR TITLE
[data] fix non-unique operator id

### DIFF
--- a/python/ray/dashboard/modules/data/tests/test_data_head.py
+++ b/python/ray/dashboard/modules/data/tests/test_data_head.py
@@ -5,6 +5,7 @@ import pytest
 import requests
 
 import ray
+from ray.tests.conftest import *  # noqa
 from ray.job_submission import JobSubmissionClient
 
 # For local testing on a Macbook, set `export TEST_ON_DARWIN=1`.
@@ -40,8 +41,39 @@ OPERATOR_SCHEMA = [
 @pytest.mark.skipif(
     sys.platform == "darwin" and not TEST_ON_DARWIN, reason="Flaky on OSX."
 )
-def test_get_datasets():
-    ray.init()
+def test_unique_operator_id(ray_start_regular_shared):
+    # This regression test addresses a bug caused by using a non-unique operator ID
+    # format. Specifically, the third operator's name is limit11 with the ID limit112,
+    # while the thirteenth operator's name is limit1 with the same ID limit112, leading
+    # to a collision.
+    ds = ray.data.range(100, override_num_blocks=20).limit(11)  # 3 operators
+    for i in range(11):  # 11 more operators
+        ds = ds.limit(1)
+    ds._set_name("unique_operator_id_test")
+    ds.materialize()
+
+    client = JobSubmissionClient()
+    jobs = client.list_jobs()
+    assert len(jobs) == 1, jobs
+    job_id = jobs[0].job_id
+
+    data = requests.get(DATA_HEAD_URLS["GET"].format(job_id=job_id)).json()
+    datasets = [
+        dataset
+        for dataset in data["datasets"]
+        if dataset["dataset"].startswith("unique_operator_id_test")
+    ]
+    assert len(datasets) == 1
+    dataset = datasets[0]
+
+    operators = dataset["operators"]
+    assert len(operators) == 14
+
+
+@pytest.mark.skipif(
+    sys.platform == "darwin" and not TEST_ON_DARWIN, reason="Flaky on OSX."
+)
+def test_get_datasets(ray_start_regular_shared):
     ds = ray.data.range(100, override_num_blocks=20).map_batches(lambda x: x)
     ds._set_name("data_head_test")
     ds.materialize()
@@ -52,11 +84,16 @@ def test_get_datasets():
     job_id = jobs[0].job_id
 
     data = requests.get(DATA_HEAD_URLS["GET"].format(job_id=job_id)).json()
+    datasets = [
+        dataset
+        for dataset in data["datasets"]
+        if dataset["dataset"].startswith("data_head_test")
+    ]
 
-    assert len(data["datasets"]) == 1
-    assert sorted(data["datasets"][0].keys()) == sorted(RESPONSE_SCHEMA)
+    assert len(datasets) == 1
+    assert sorted(datasets[0].keys()) == sorted(RESPONSE_SCHEMA)
 
-    dataset = data["datasets"][0]
+    dataset = datasets[0]
     assert dataset["dataset"].startswith("data_head_test")
     assert dataset["job_id"] == job_id
     assert dataset["state"] == "FINISHED"
@@ -69,26 +106,30 @@ def test_get_datasets():
     assert sorted(op0.keys()) == sorted(OPERATOR_SCHEMA)
     assert sorted(op1.keys()) == sorted(OPERATOR_SCHEMA)
     assert {
-        "operator": "Input0",
+        "operator": "Input_0",
         "name": "Input",
         "state": "FINISHED",
         "progress": 20,
         "total": 20,
     }.items() <= op0.items()
     assert {
-        "operator": "ReadRange->MapBatches(<lambda>)1",
+        "operator": "ReadRange->MapBatches(<lambda>)_1",
         "name": "ReadRange->MapBatches(<lambda>)",
         "state": "FINISHED",
         "progress": 20,
         "total": 20,
     }.items() <= op1.items()
 
+    ds._set_name("another_data_head_test")
     ds.map_batches(lambda x: x).materialize()
     data = requests.get(DATA_HEAD_URLS["GET"].format(job_id=job_id)).json()
 
-    assert len(data["datasets"]) == 2
-    dataset = data["datasets"][1]
-    assert dataset["dataset"].startswith("data_head_test")
+    dataset = [
+        dataset
+        for dataset in data["datasets"]
+        if dataset["dataset"].startswith("another_data_head_test")
+    ][0]
+    assert dataset["dataset"].startswith("another_data_head_test")
     assert dataset["job_id"] == job_id
     assert dataset["state"] == "FINISHED"
     assert dataset["end_time"] is not None

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -399,9 +399,14 @@ class StreamingExecutor(Executor, threading.Thread):
         if self._global_info:
             self._global_info.set_description(resources_status)
 
+    def _get_operator_id(self, op: PhysicalOperator, topology_index: int) -> str:
+        return f"{op.name}_{topology_index}"
+
     def _get_operator_tags(self):
         """Returns a list of operator tags."""
-        return [f"{op.name}{i}" for i, op in enumerate(self._topology)]
+        return [
+            f"{self._get_operator_id(op, i)}" for i, op in enumerate(self._topology)
+        ]
 
     def _get_state_dict(self, state):
         last_op, last_state = list(self._topology.items())[-1]
@@ -411,7 +416,7 @@ class StreamingExecutor(Executor, threading.Thread):
             "total": last_op.num_outputs_total(),
             "end_time": time.time() if state != "RUNNING" else None,
             "operators": {
-                f"{op.name}{i}": {
+                f"{self._get_operator_id(op, i)}": {
                     "name": op.name,
                     "progress": op_state.num_completed_tasks,
                     "total": op.num_outputs_total(),

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1522,8 +1522,8 @@ def test_stats_actor_metrics():
 
     args = update_fn.call_args_list[-1].args
     assert args[0] == f"dataset_{ds._uuid}"
-    assert args[2][0] == "Input0"
-    assert args[2][1] == "ReadRange->MapBatches(<lambda>)1"
+    assert args[2][0] == "Input_0"
+    assert args[2][1] == "ReadRange->MapBatches(<lambda>)_1"
 
     def sleep_three(x):
         import time
@@ -1647,8 +1647,8 @@ def test_stats_actor_datasets(ray_start_cluster):
 
     operators = dataset["operators"]
     assert len(operators) == 2
-    assert "Input0" in operators
-    assert "ReadRange->MapBatches(<lambda>)1" in operators
+    assert "Input_0" in operators
+    assert "ReadRange->MapBatches(<lambda>)_1" in operators
     for value in operators.values():
         assert value["name"] in ["Input", "ReadRange->MapBatches(<lambda>)"]
         assert value["progress"] == 20


### PR DESCRIPTION
Fix the operator id name format. The current format causes potential collision between operator in rare cases.

Example:

```
ds = ray.data.range(100, override_num_blocks=20).limit(11)
for i in range(11):
    ds = ds.limit(1)

ds._set_name("data_head_test")
ds.materialize()
```

You would expect there will be 12 limit operators but the dashboard only shows 11 because of id collisions:

<img width="1821" alt="Screenshot 2025-03-05 at 5 34 31 PM" src="https://github.com/user-attachments/assets/1cdb2a58-eb0c-4c10-bb91-a33f6fa5e946" />

Test:
- CI