### PR TITLE
[docs,tune] fix typo, and standardize equations across the two apis

### DIFF
--- a/doc/source/tune/doc_code/key_concepts.py
+++ b/doc/source/tune/doc_code/key_concepts.py
@@ -5,7 +5,7 @@ from ray import train
 
 
 def objective(x, a, b):  # Define an objective function.
-    return a * (x**0.5) + b
+    return a * (x ** 2) + b
 
 
 def trainable(config):  # Pass a "config" dictionary into your trainable.

--- a/doc/source/tune/doc_code/key_concepts.py
+++ b/doc/source/tune/doc_code/key_concepts.py
@@ -5,7 +5,7 @@ from ray import train
 
 
 def objective(x, a, b):  # Define an objective function.
-    return a * (x ** 2) + b
+    return a * (x**2) + b
 
 
 def trainable(config):  # Pass a "config" dictionary into your trainable.

--- a/doc/source/tune/key-concepts.rst
+++ b/doc/source/tune/key-concepts.rst
@@ -33,7 +33,7 @@ and the :ref:`Class API <tune-class-api>`.
 Both are valid ways of defining a `trainable`, but the Function API is generally recommended and is used
 throughout the rest of this guide.
 
-Let's say we want to optimize a simple objective function like ``a (x ** 2) + b`` in which ``a`` and ``b`` are the
+Consider an example of optimizing a simple objective function like ``a * (x ** 2) + b `` in which ``a`` and ``b`` are the
 hyperparameters we want to tune to `minimize` the objective.
 Since the objective also has a variable ``x``, we need to test for different values of ``x``.
 Given concrete choices for ``a``, ``b`` and ``x`` we can evaluate the objective function and get a `score` to minimize.


### PR DESCRIPTION
## Why are these changes needed?

fix typo, and standardize equations across the two apis

## Related issue number

supersedes #49053 which cannot be rescued because I don't have write access to the other repo

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
