### PR TITLE
[serve] Exclude redirects from request error count

### DIFF
--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -984,7 +984,7 @@ class HTTPProxy(GenericProxy):
                         status_code = str(asgi_message["status"])
                         status = ResponseStatus(
                             code=status_code,
-                            is_error=not status_code.startswith("2"),
+                            is_error=status_code.startswith(("4", "5")),
                         )
                         expecting_trailers = asgi_message.get("trailers", False)
                     elif asgi_message["type"] == "websocket.accept":

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -588,7 +588,7 @@ def test_proxy_metrics_fields_internal_error(serve_start_shutdown):
 
 
 def test_proxy_metrics_http_status_code_is_error(serve_start_shutdown):
-    """Verify that 2xx status codes aren't errors, others are."""
+    """Verify that 2xx and 3xx status codes aren't errors, others are."""
 
     def check_request_count_metrics(
         expected_error_count: int,
@@ -632,12 +632,12 @@ def test_proxy_metrics_http_status_code_is_error(serve_start_shutdown):
         expected_success_count=2,
     )
 
-    # 3xx is an error.
+    # 3xx is not an error.
     r = requests.get("http://127.0.0.1:8000/", data=b"300")
     assert r.status_code == 300
     wait_for_condition(
         check_request_count_metrics,
-        expected_error_count=1,
+        expected_error_count=0,
         expected_success_count=3,
     )
 
@@ -646,7 +646,7 @@ def test_proxy_metrics_http_status_code_is_error(serve_start_shutdown):
     assert r.status_code == 400
     wait_for_condition(
         check_request_count_metrics,
-        expected_error_count=2,
+        expected_error_count=1,
         expected_success_count=4,
     )
 
@@ -655,7 +655,7 @@ def test_proxy_metrics_http_status_code_is_error(serve_start_shutdown):
     assert r.status_code == 500
     wait_for_condition(
         check_request_count_metrics,
-        expected_error_count=3,
+        expected_error_count=2,
         expected_success_count=5,
     )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The proxy currently includes http redirects as http errors, which are emitted to metrics. 3xx shouldn't be an error. This PR excludes 3xx responses from the error count, and updates the relevant test case.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
