### PR TITLE
[core] Use current node id if no node id specified for ray drain-node

### DIFF
--- a/python/ray/runtime_context.py
+++ b/python/ray/runtime_context.py
@@ -546,6 +546,10 @@ def get_runtime_context() -> RuntimeContext:
     The obtained runtime context can be used to get the metadata
     of the current task and actor.
 
+    Note: For Ray Client, ray.get_runtime_context().get_node_id() should
+    point to the head node. Also, keep in mind that ray._private.worker.global_worker
+    will create a new worker object here if global_worker doesn't point to one.
+
     Example:
 
         .. testcode::

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -2345,6 +2345,8 @@ def drain_node(
 
     Manually drain a worker node.
     """
+    # This should be before get_runtime_context() so get_runtime_context()
+    # doesn't start a new worker here.
     address = services.canonicalize_bootstrap_address_or_die(address)
 
     if node_id is None:

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -2300,9 +2300,9 @@ def global_gc(address):
 )
 @click.option(
     "--node-id",
-    required=True,
+    required=False,
     type=str,
-    help="Hex ID of the worker node to be drained.",
+    help="Hex ID of the worker node to be drained. Will default to current node if not provided.",
 )
 @click.option(
     "--reason",
@@ -2345,6 +2345,8 @@ def drain_node(
 
     Manually drain a worker node.
     """
+    if node_id is None:
+        node_id = ray.get_runtime_context().get_node_id()
     deadline_timestamp_ms = 0
     if deadline_remaining_seconds is not None:
         if deadline_remaining_seconds < 0:

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -2345,6 +2345,8 @@ def drain_node(
 
     Manually drain a worker node.
     """
+    address = services.canonicalize_bootstrap_address_or_die(address)
+
     if node_id is None:
         node_id = ray.get_runtime_context().get_node_id()
     deadline_timestamp_ms = 0
@@ -2360,8 +2362,6 @@ def drain_node(
 
     if ray.NodeID.from_hex(node_id) == ray.NodeID.nil():
         raise click.BadParameter(f"Invalid hex ID of a Ray node, got {node_id}")
-
-    address = services.canonicalize_bootstrap_address_or_die(address)
 
     gcs_client = ray._raylet.GcsClient(address=address)
     _check_ray_version(gcs_client)

--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -1057,7 +1057,7 @@ def test_ray_check_open_ports(shutdown_only, start_open_port_check_server):
 
 def test_ray_drain_node(monkeypatch):
     monkeypatch.setenv("RAY_py_gcs_connect_timeout_s", "1")
-    ray._raylet.Config.initialize("")
+    ray.init()
 
     runner = CliRunner()
     result = runner.invoke(

--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -1196,6 +1196,29 @@ def test_ray_drain_node(monkeypatch):
         assert result.exit_code != 0
         assert "The drain request is not accepted: Node not idle" in result.output
 
+    # Test without node-id
+    with patch("ray._raylet.GcsClient") as MockGcsClient:
+        mock_gcs_client = MockGcsClient.return_value
+        mock_gcs_client.internal_kv_get.return_value = (
+            f'{{"ray_version": "{ray.__version__}"}}'.encode()
+        )
+        mock_gcs_client.drain_node.return_value = (True, "")
+        result = runner.invoke(
+            scripts.drain_node,
+            [
+                "--address",
+                "127.0.01:6543",
+                "--reason",
+                "DRAIN_NODE_REASON_PREEMPTION",
+                "--reason-message",
+                "spot preemption",
+            ],
+        )
+        assert result.exit_code == 0
+        assert mock_gcs_client.mock_calls[1] == mock.call.drain_node(
+            ray.get_runtime_context().get_node_id(), 2, "spot preemption", 0
+        )
+
     with patch("time.time_ns", return_value=1000000000), patch(
         "ray._raylet.GcsClient"
     ) as MockGcsClient:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
With this, users are able to call ray drain-node without a node id and it will just call the gcs drain api with its own node id.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
