### PR TITLE
[docs] change order of libraries based on popularity

### DIFF
--- a/doc/source/tune/examples/ml-frameworks.rst
+++ b/doc/source/tune/examples/ml-frameworks.rst
@@ -11,14 +11,14 @@ Examples using Ray Tune with ML Frameworks
 .. toctree::
     :hidden:
 
-    Keras Example <tune_mnist_keras>
     PyTorch Example <tune-pytorch-cifar>
-    PyTorch Lightning Example <tune-pytorch-lightning>
-    Ray RLlib Example <pbt_ppo_example>
+    Hugging Face Transformers Example <pbt_transformers>
     XGBoost Example <tune-xgboost>
     LightGBM Example <lightgbm_example>
+    Ray RLlib Example <pbt_ppo_example>
+    Keras Example <tune_mnist_keras>
+    PyTorch Lightning Example <tune-pytorch-lightning>
     Horovod Example <horovod_simple>
-    Hugging Face Transformers Example <pbt_transformers>
 
 
 Ray Tune integrates with many popular machine learning frameworks.

--- a/doc/source/tune/examples/ml-frameworks.rst
+++ b/doc/source/tune/examples/ml-frameworks.rst
@@ -12,12 +12,12 @@ Examples using Ray Tune with ML Frameworks
     :hidden:
 
     PyTorch Example <tune-pytorch-cifar>
-    Hugging Face Transformers Example <pbt_transformers>
+    PyTorch Lightning Example <tune-pytorch-lightning>
     XGBoost Example <tune-xgboost>
     LightGBM Example <lightgbm_example>
+    Hugging Face Transformers Example <pbt_transformers>
     Ray RLlib Example <pbt_ppo_example>
     Keras Example <tune_mnist_keras>
-    PyTorch Lightning Example <tune-pytorch-lightning>
     Horovod Example <horovod_simple>
 
 


### PR DESCRIPTION
## Why are these changes needed?

changes ordering of libraries based on popularity (pytorch first, then xgboost, then the rest)

## Related issue number

N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
