### PR TITLE
Add spellcheck precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,12 @@ repos:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]
 
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+    - id: codespell
+      args: [-w] # Fix spelling in place.
+
   - repo: https://github.com/cpplint/cpplint
     rev: 2.0.0
     hooks:


### PR DESCRIPTION
Followup on https://github.com/ray-project/ray/pull/51079, this PR adds spellcheck in precommit hook.
I intentionally don't add it into CI, because we still need some time to check how the detection and fix work.

How I tested:
- I manually mis-spell several words
- The precommit hook does fix my word spelling

```
codespell................................................................Failed
- hook id: codespell
- files were modified by this hook

FIXED: python/ray/_private/runtime_env/uv.py
```