### PR TITLE
[docs] Hide output of very verbose ipynb notebooks

### DIFF
--- a/doc/source/train/examples/deepspeed/gptj_deepspeed_fine_tuning.ipynb
+++ b/doc/source/train/examples/deepspeed/gptj_deepspeed_fine_tuning.ipynb
@@ -44,7 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install \"datasets\" \"evaluate\" \"accelerate==0.18.0\" \"transformers==4.26.0\" \"torch>=1.12.0\" \"deepspeed==0.12.3\""
+    "! pip install -q \"datasets\" \"evaluate\" \"accelerate==0.18.0\" \"transformers==4.26.0\" \"torch>=1.12.0\" \"deepspeed==0.12.3\""
    ]
   },
   {
@@ -626,7 +626,9 @@
    "cell_type": "code",
    "execution_count": 14,
    "metadata": {
-    "tags": []
+    "tags": [
+     "hide-output"
+    ]
    },
    "outputs": [
     {

--- a/doc/source/tune/examples/tune-pytorch-lightning.ipynb
+++ b/doc/source/tune/examples/tune-pytorch-lightning.ipynb
@@ -29,7 +29,7 @@
     "To run this example, you will need to install the following:\n",
     "\n",
     "```bash\n",
-    "$ pip install \"ray[tune]\" torch torchvision pytorch_lightning\n",
+    "$ pip install -q \"ray[tune]\" torch torchvision pytorch_lightning\n",
     "```\n",
     ":::\n",
     "\n",
@@ -415,7 +415,11 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [
     {
      "data": {


### PR DESCRIPTION
## Why are these changes needed?

Some docs were failing to index properly due to their extremely long length. I've hidden verbose cell outputs so that they index properly

## Related issue number

N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
