### PR TITLE
[core] Fix path comparison on windows

### DIFF
--- a/python/ray/tests/test_logging.py
+++ b/python/ray/tests/test_logging.py
@@ -868,7 +868,7 @@ def test_tpu_logs(tmp_path):
     log_monitor.open_closed_files()
     assert len(log_monitor.open_file_infos) == 1
     file_info = log_monitor.open_file_infos[0]
-    assert file_info.filename == str(tpu_log_dir / tpu_device_log_file)
+    assert Path(file_info.filename) == tpu_log_dir / tpu_device_log_file
 
 
 def test_log_monitor_actor_task_name_and_job_id(tmp_path):


### PR DESCRIPTION
Resolves https://github.com/ray-project/ray/issues/51135

Error message pasted here:
```
[2025-03-06T19:49:02Z] >       assert file_info.filename == str(tpu_log_dir / tpu_device_log_file)
[2025-03-06T19:49:02Z] E       AssertionError: assert 'C:\\Users\\C...pu-device.log' == 'C:\\Users\\C...pu-device.log'
[2025-03-06T19:49:02Z] E         - C:\Users\ContainerAdministrator\AppData\Local\Temp\pytest-of-ContainerAdministrator\pytest-1\test_tpu_logs0\logs\tpu_logs\tpu-device.log
[2025-03-06T19:49:02Z] E         ?                                                                                                                 ^
[2025-03-06T19:49:02Z] E         + C:\Users\ContainerAdministrator\AppData\Local\Temp\pytest-of-ContainerAdministrator\pytest-1\test_tpu_logs0\logs/tpu_logs\tpu-device.log
[2025-03-06T19:49:02Z] E         ?                                     
```