### PR TITLE
[data] fix the new dataset metrics

### DIFF
--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -468,6 +468,7 @@ class _StatsActor:
             "state": DatasetState.RUNNING.name,
             "progress": 0,
             "total": 0,
+            "total_rows": 0,
             "start_time": time.time(),
             "end_time": None,
             "operators": {
@@ -482,8 +483,10 @@ class _StatsActor:
 
     def update_dataset(self, dataset_tag: str, state: Dict[str, Any]):
         self.datasets[dataset_tag].update(state)
-        job_id = self.datasets[dataset_tag].get("job_id", None)
-        start_time = self.datasets[dataset_tag].get("start_time", None)
+        state = self.datasets[dataset_tag]
+
+        job_id = self.datasets[dataset_tag].get("job_id", "None")
+        start_time = str(int(self.datasets[dataset_tag].get("start_time", 0)))
 
         # Update dataset-level metrics
         dataset_tags = {
@@ -497,9 +500,9 @@ class _StatsActor:
         self.data_dataset_estimated_total_rows.set(
             state.get("total_rows", 0), dataset_tags
         )
-        self.data_dataset_state.set(
-            state.get("state", DatasetState.UNKNOWN.name), dataset_tags
-        )
+        state_string = state.get("state", DatasetState.UNKNOWN.name)
+        state_enum = DatasetState.from_string(state_string)
+        self.data_dataset_state.set(state_enum.value, dataset_tags)
 
         # Update operator-level metrics
         for operator, op_state in state.get("operators", {}).items():


### PR DESCRIPTION
- Need to get the `state` back after updating to get the complete data for dataset state (otherwise `start_time` and `job_id` will be missing
- Labels have to be of type str so fix them as such
- Fix dataset state

Note: we need this before the next release because otherwise dataset workload will sprew a bunch of random exception errors

Test:
- CI
- Build an image, tested in grafana