### PR TITLE
Fix UV hook to support Ray Job submission

### DIFF
--- a/python/ray/_private/runtime_env/uv_runtime_env_hook.py
+++ b/python/ray/_private/runtime_env/uv_runtime_env_hook.py
@@ -8,7 +8,9 @@ from typing import Any, Dict, List, Optional
 import psutil
 
 
-def _check_working_dir_files(uv_run_args: List[str], runtime_env: Dict[str, Any]) -> None:
+def _check_working_dir_files(
+    uv_run_args: List[str], runtime_env: Dict[str, Any]
+) -> None:
     """
     Check that the files required by uv are local to the working_dir. This catches
     the most common cases of how things are different in Ray, i.e. not the whole file

--- a/python/ray/_private/runtime_env/uv_runtime_env_hook.py
+++ b/python/ray/_private/runtime_env/uv_runtime_env_hook.py
@@ -1,17 +1,21 @@
 import argparse
+import copy
 import os
 from pathlib import Path
 import sys
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import psutil
 
 
-def _check_working_dir_files(uv_run_args, runtime_env):
-    # Do error checking that should catch the most common cases of how
-    # things are different in Ray, i.e. not the whole file system will
-    # be available on the workers, only the working_dir.
+def _check_working_dir_files(uv_run_args: List[str], runtime_env: Dict[str, Any]) -> None:
+    """
+    Check that the files required by uv are local to the working_dir. This catches
+    the most common cases of how things are different in Ray, i.e. not the whole file
+    system will be available on the workers, only the working_dir.
 
+    The function won't return anything, it just raises a RuntimeError if there is an error.
+    """
     # First parse the arguments we need to check
     uv_run_parser = argparse.ArgumentParser()
     uv_run_parser.add_argument("--with-requirements", nargs="?")
@@ -64,7 +68,7 @@ def _check_working_dir_files(uv_run_args, runtime_env):
 def hook(runtime_env: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     """Hook that detects if the driver is run in 'uv run' and sets the runtime environment accordingly."""
 
-    runtime_env = copy.deepcopy(runtime_env or {})
+    runtime_env = copy.deepcopy(runtime_env) or {}
 
     # uv spawns the python process as a child process, so to determine if
     # we are running under 'uv run', we check the parent process commandline.

--- a/python/ray/_private/runtime_env/uv_runtime_env_hook.py
+++ b/python/ray/_private/runtime_env/uv_runtime_env_hook.py
@@ -64,7 +64,7 @@ def _check_working_dir_files(uv_run_args, runtime_env):
 def hook(runtime_env: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     """Hook that detects if the driver is run in 'uv run' and sets the runtime environment accordingly."""
 
-    runtime_env = runtime_env or {}
+    runtime_env = copy.deepcopy(runtime_env or {})
 
     # uv spawns the python process as a child process, so to determine if
     # we are running under 'uv run', we check the parent process commandline.

--- a/python/ray/_private/runtime_env/uv_runtime_env_hook.py
+++ b/python/ray/_private/runtime_env/uv_runtime_env_hook.py
@@ -27,7 +27,7 @@ def _check_working_dir_files(uv_run_args, runtime_env):
     ).resolve().is_relative_to(working_dir):
         raise RuntimeError(
             f"You specified --with-requirements={known_args.with_requirements} but "
-            f"the requirements file is not in the working_dir {runtime_env["working_dir"]}, "
+            f"the requirements file is not in the working_dir {runtime_env['working_dir']}, "
             "so the workers will not have access to the file. Make sure "
             "the requirements file is in the working directory. "
             "You can do so by specifying --directory in 'uv run', by changing the current "

--- a/python/ray/_private/runtime_env/uv_runtime_env_hook.py
+++ b/python/ray/_private/runtime_env/uv_runtime_env_hook.py
@@ -60,6 +60,7 @@ def _check_working_dir_files(uv_run_args, runtime_env):
             "parameter of the runtime_environment."
         )
 
+
 def hook(runtime_env: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     """Hook that detects if the driver is run in 'uv run' and sets the runtime environment accordingly."""
 

--- a/python/ray/_private/runtime_env/uv_runtime_env_hook.py
+++ b/python/ray/_private/runtime_env/uv_runtime_env_hook.py
@@ -7,6 +7,59 @@ from typing import Any, Dict, Optional
 import psutil
 
 
+def _check_working_dir_files(uv_run_args, runtime_env):
+    # Do error checking that should catch the most common cases of how
+    # things are different in Ray, i.e. not the whole file system will
+    # be available on the workers, only the working_dir.
+
+    # First parse the arguments we need to check
+    uv_run_parser = argparse.ArgumentParser()
+    uv_run_parser.add_argument("--with-requirements", nargs="?")
+    uv_run_parser.add_argument("--project", nargs="?")
+    uv_run_parser.add_argument("--no-project", action="store_true")
+    known_args, _ = uv_run_parser.parse_known_args(uv_run_args)
+
+    working_dir = Path(runtime_env["working_dir"]).resolve()
+
+    # Check if the requirements.txt file is in the working_dir
+    if known_args.with_requirements and not Path(
+        known_args.with_requirements
+    ).resolve().is_relative_to(working_dir):
+        raise RuntimeError(
+            f"You specified --with-requirements={known_args.with_requirements} but "
+            f"the requirements file is not in the working_dir {runtime_env["working_dir"]}, "
+            "so the workers will not have access to the file. Make sure "
+            "the requirements file is in the working directory. "
+            "You can do so by specifying --directory in 'uv run', by changing the current "
+            "working directory before running 'uv run', or by using the 'working_dir' "
+            "parameter of the runtime_environment."
+        )
+
+    # Check if the pyproject.toml file is in the working_dir
+    pyproject = None
+    if known_args.no_project:
+        pyproject = None
+    elif known_args.project:
+        pyproject = Path(known_args.project)
+    else:
+        # Walk up the directory tree until pyproject.toml is found
+        current_path = Path.cwd().resolve()
+        while current_path != current_path.parent:
+            if (current_path / "pyproject.toml").exists():
+                pyproject = Path(current_path / "pyproject.toml")
+                break
+            current_path = current_path.parent
+
+    if pyproject and not pyproject.resolve().is_relative_to(working_dir):
+        raise RuntimeError(
+            f"Your {pyproject.resolve()} is not in the working_dir {runtime_env['working_dir']}, "
+            "so the workers will not have access to the file. Make sure "
+            "the pyproject.toml file is in the working directory. "
+            "You can do so by specifying --directory in 'uv run', by changing the current "
+            "working directory before running 'uv run', or by using the 'working_dir' "
+            "parameter of the runtime_environment."
+        )
+
 def hook(runtime_env: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     """Hook that detects if the driver is run in 'uv run' and sets the runtime environment accordingly."""
 
@@ -39,58 +92,7 @@ def hook(runtime_env: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     # use the same working_dir that uv run would use
     if "working_dir" not in runtime_env:
         runtime_env["working_dir"] = os.getcwd()
-
-    # In the last part of the function we do some error checking that should catch
-    # the most common cases of how things are different in Ray, i.e. not the whole
-    # file system will be available on the workers, only the working_dir.
-
-    # First parse the arguments we need to check
-    uv_run_parser = argparse.ArgumentParser()
-    uv_run_parser.add_argument("--with-requirements", nargs="?")
-    uv_run_parser.add_argument("--project", nargs="?")
-    uv_run_parser.add_argument("--no-project", action="store_true")
-    known_args, _ = uv_run_parser.parse_known_args(uv_run_args)
-
-    working_dir = Path(runtime_env["working_dir"]).resolve()
-
-    # Check if the requirements.txt file is in the working_dir
-    if known_args.with_requirements and not Path(
-        known_args.with_requirements
-    ).resolve().is_relative_to(working_dir):
-        raise RuntimeError(
-            f"You specified --with-requirements={known_args.with_requirements} but "
-            f"the requirements file is not in the working_dir {runtime_env['working_dir']}, "
-            "so the workers will not have access to the file. Make sure "
-            "the requirements file is in the working directory. "
-            "You can do so by specifying --directory in 'uv run', by changing the current "
-            "working directory before running 'uv run', or by using the 'working_dir' "
-            "parameter of the runtime_environment."
-        )
-
-    # Check if the pyproject.toml file is in the working_dir
-    pyproject = None
-    if known_args.no_project:
-        pyproject = None
-    elif known_args.project:
-        pyproject = Path(known_args.project)
-    else:
-        # Walk up the directory tree until pyproject.toml is found
-        current_path = Path.cwd().resolve()
-        while current_path != current_path.parent:
-            if (current_path / "pyproject.toml").exists():
-                pyproject = Path(current_path / "pyproject.toml")
-                break
-            current_path = current_path.parent
-
-    if pyproject and not pyproject.resolve().is_relative_to(working_dir):
-        raise RuntimeError(
-            f"Your {pyproject.resolve()} is not in the working_dir {runtime_env['working_dir']}, "
-            "so the workers will not have access to the file. Make sure "
-            "the pyproject.toml file is in the working directory. "
-            "You can do so by specifying --directory in 'uv run', by changing the current "
-            "working directory before running 'uv run', or by using the 'working_dir' "
-            "parameter of the runtime_environment."
-        )
+        _check_working_dir_files(uv_run_args, runtime_env)
 
     return runtime_env
 

--- a/python/ray/tests/test_runtime_env_uv_run.py
+++ b/python/ray/tests/test_runtime_env_uv_run.py
@@ -345,12 +345,18 @@ with open("{tmp_out_dir / "output.txt"}", "w") as out:
     json.dump(ray.get(f.remote()), out)
 """
 
-    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as f:
+    requirements_content = """
+emoji
+"""
+
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as f, tempfile.NamedTemporaryFile("w", delete=False) as requirements:
         f.write(script)
         f.close()
+        requirements.write(requirements_content)
+        requirements.close()
         # Test job submission
         subprocess.run(
-            ["ray", "job", "submit", "--working-dir", ".", "--", uv, "run", f.name],
+            ["ray", "job", "submit", "--working-dir", ".", "--", uv, "run", "--with-requirements", requirements.name, f.name],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/python/ray/tests/test_runtime_env_uv_run.py
+++ b/python/ray/tests/test_runtime_env_uv_run.py
@@ -312,19 +312,22 @@ with open("{tmp_out_dir / "output.txt"}", "w") as out:
             }
 
 
-
 @pytest.mark.skipif(sys.platform == "win32", reason="Not ported to Windows yet.")
 @pytest.mark.parametrize(
     "ray_start_cluster_head_with_env_vars",
     [
         {
-            "env_vars": {"RAY_RUNTIME_ENV_HOOK": "ray._private.runtime_env.uv_runtime_env_hook.hook"},
+            "env_vars": {
+                "RAY_RUNTIME_ENV_HOOK": "ray._private.runtime_env.uv_runtime_env_hook.hook"
+            },
             "include_dashboard": True,
         }
     ],
     indirect=True,
 )
-def test_uv_run_runtime_env_hook_e2e_job(ray_start_cluster_head_with_env_vars, with_uv, temp_dir):
+def test_uv_run_runtime_env_hook_e2e_job(
+    ray_start_cluster_head_with_env_vars, with_uv, temp_dir
+):
     cluster = ray_start_cluster_head_with_env_vars
     assert wait_until_server_available(cluster.webui_url) is True
     webui_url = format_web_url(cluster.webui_url)
@@ -347,14 +350,18 @@ with open("{tmp_out_dir / "output.txt"}", "w") as out:
 """
 
     with tempfile.NamedTemporaryFile(
-            "w", suffix=".py", delete=False
+        "w", suffix=".py", delete=False
     ) as f, tempfile.NamedTemporaryFile("w", delete=False) as requirements:
         f.write(script)
         f.close()
         requirements.write("emoji\n")
         requirements.close()
         # Test job submission
-        runtime_env_json = '{"env_vars": {"PYTHONPATH": "' + ":".join(sys.path) + '"}, "working_dir": "."}'
+        runtime_env_json = (
+            '{"env_vars": {"PYTHONPATH": "'
+            + ":".join(sys.path)
+            + '"}, "working_dir": "."}'
+        )
         subprocess.run(
             [
                 "ray",
@@ -368,7 +375,7 @@ with open("{tmp_out_dir / "output.txt"}", "w") as out:
                 "--with-requirements",
                 requirements.name,
                 "--no-project",
-                f.name
+                f.name,
             ],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,

--- a/python/ray/tests/test_runtime_env_uv_run.py
+++ b/python/ray/tests/test_runtime_env_uv_run.py
@@ -346,7 +346,9 @@ with open("{tmp_out_dir / "output.txt"}", "w") as out:
     json.dump(ray.get(f.remote()), out)
 """
 
-    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as f, tempfile.NamedTemporaryFile("w", delete=False) as requirements:
+    with tempfile.NamedTemporaryFile(
+            "w", suffix=".py", delete=False
+    ) as f, tempfile.NamedTemporaryFile("w", delete=False) as requirements:
         f.write(script)
         f.close()
         requirements.write("emoji\n")
@@ -354,7 +356,20 @@ with open("{tmp_out_dir / "output.txt"}", "w") as out:
         # Test job submission
         runtime_env_json = '{"env_vars": {"PYTHONPATH": "' + ":".join(sys.path) + '"}, "working_dir": "."}'
         subprocess.run(
-            ["ray", "job", "submit", "--runtime-env-json", runtime_env_json, "--", "uv", "run", "--with-requirements", requirements.name, "--no-project", f.name],
+            [
+                "ray",
+                "job",
+                "submit",
+                "--runtime-env-json",
+                runtime_env_json,
+                "--",
+                uv,
+                "run",
+                "--with-requirements",
+                requirements.name,
+                "--no-project",
+                f.name
+            ],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/python/ray/tests/test_runtime_env_uv_run.py
+++ b/python/ray/tests/test_runtime_env_uv_run.py
@@ -10,6 +10,7 @@ import tempfile
 
 import ray
 from ray._private.test_utils import (
+    format_web_url,
     wait_until_server_available,
 )
 
@@ -314,18 +315,18 @@ with open("{tmp_out_dir / "output.txt"}", "w") as out:
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Not ported to Windows yet.")
 @pytest.mark.parametrize(
-    "ray_start_cluster_head_with_env_vars",
+    "ray_start_cluster_head",
     [
         {
             "include_dashboard": True,
-            "env_vars": {},
         }
     ],
     indirect=True,
 )
-def test_uv_run_runtime_env_hook_e2e_job(ray_start_cluster_head_with_env_vars, with_uv, temp_dir):
-    cluster = ray_start_cluster_head_with_env_vars
+def test_uv_run_runtime_env_hook_e2e_job(ray_start_cluster_head, with_uv, temp_dir):
+    cluster = ray_start_cluster_head
     assert wait_until_server_available(cluster.webui_url) is True
+    webui_url = format_web_url(cluster.webui_url)
 
     uv = with_uv
     tmp_out_dir = Path(temp_dir)
@@ -357,7 +358,7 @@ with open("{tmp_out_dir / "output.txt"}", "w") as out:
                 "RAY_RUNTIME_ENV_HOOK": "ray._private.runtime_env.uv_runtime_env_hook.hook",
                 "PYTHONPATH": ":".join(sys.path),
                 "PATH": os.environ["PATH"],
-                "RAY_ADDRESS": cluster.webui_url,
+                "RAY_ADDRESS": webui_url,
             },
             cwd=os.path.dirname(uv),
             check=True,

--- a/python/ray/tests/test_runtime_env_uv_run.py
+++ b/python/ray/tests/test_runtime_env_uv_run.py
@@ -339,6 +339,7 @@ import os
 def f():
     import emoji
     return {{"working_dir_files": os.listdir(os.getcwd())}}
+
 with open("{tmp_out_dir / "output.txt"}", "w") as out:
     json.dump(ray.get(f.remote()), out)
 """


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR moves the checking logic for whether the pyproject.toml etc. are inside the working directory. The checks are now only done if the working_dir is not explicitly set by the user. This is to make sure the checks are not happening on the job submission codepath, since in that case the working_dir could have been zipped up by the user / on the client side, so the files are not available in the runtime environment hook.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
