### PR TITLE
[core] Use the correct way to check whether an actor task is running or not

### DIFF
--- a/python/ray/_private/state_api_test_utils.py
+++ b/python/ray/_private/state_api_test_utils.py
@@ -418,6 +418,12 @@ def _is_actor_task_running(actor_pid: int, task_name: str):
 
     Returns:
       True if the actor task is running, False otherwise.
+
+    Limitation:
+        If the actor task name is set using options.name and is a substring of
+        the actor name, this function may return true even if the task is not
+        running on the actor process. To resolve this issue, we can possibly
+        pass in the actor name.
     """
     if not psutil.pid_exists(actor_pid):
         return False

--- a/python/ray/tests/test_task_events_2.py
+++ b/python/ray/tests/test_task_events_2.py
@@ -14,6 +14,7 @@ from ray._private.state_api_test_utils import (
     get_state_api_manager,
     verify_tasks_running_or_terminated,
     verify_failed_task,
+    _is_actor_task_running,
 )
 from ray.util.state.common import ListApiOptions, StateResource
 from ray._private.test_utils import (
@@ -28,6 +29,7 @@ from ray.util.state import (
     list_jobs,
     list_tasks,
 )
+import psutil
 
 _SYSTEM_CONFIG = {
     "task_events_report_interval_ms": 100,
@@ -1109,6 +1111,167 @@ def test_task_events_gc_default_policy(shutdown_only):
     [error_task.remote() for _ in range(5)]
 
     wait_for_condition(verify_tasks, expected_tasks_cnt={"error_task": 5})
+
+
+class TestIsActorTaskRunning:
+    def test_main_thread_short_comm(self, ray_start_regular):
+        """
+        Test that the main thread's comm is not truncated.
+        """
+
+        @ray.remote
+        class A:
+            def check(self):
+                pid = os.getpid()
+                assert _is_actor_task_running(pid, "check")
+                assert psutil.Process(pid).name() == "ray::A.check"
+                assert psutil.Process(pid).cmdline()[0] == "ray::A.check"
+
+        a = A.remote()
+        ray.get(a.check.remote())
+
+    def test_main_thread_long_comm(self, ray_start_regular):
+        """
+        In this case, the process comm should be truncated because of the
+        name is more than 15 characters ("ray::Actor.check_long_comm"). Hence,
+        `psutil.Process.name()` will return `cmdline()[0]` instead.
+        """
+
+        @ray.remote
+        class Actor:
+            def check_long_comm(self):
+                pid = os.getpid()
+                assert _is_actor_task_running(pid, "check_long_comm")
+                assert psutil.Process(pid).name() == "ray::Actor.check_long_comm"
+                assert psutil.Process(pid).cmdline()[0] == "ray::Actor.check_long_comm"
+
+        a = Actor.remote()
+        ray.get(a.check_long_comm.remote())
+
+    def test_main_thread_options_name_short_comm(self, ray_start_regular):
+        """
+        The task name is passed in as `options.name`.
+        """
+        task_name = "hello"
+
+        @ray.remote
+        class A:
+            def check(self):
+                pid = os.getpid()
+                assert _is_actor_task_running(pid, task_name)
+                assert psutil.Process(pid).name() == f"ray::{task_name}"
+                assert psutil.Process(pid).cmdline()[0] == f"ray::{task_name}"
+
+        a = A.remote()
+        ray.get(a.check.options(name=task_name).remote())
+
+    def test_main_thread_options_name_long_comm(self, ray_start_regular):
+        """
+        The task name is passed in as `options.name`, and it's longer than 15
+        characters. `psutil.Process.name()` will return `cmdline()[0]` instead.
+        """
+        task_name = "very_long_task_name_1234567890"
+
+        @ray.remote
+        class A:
+            def check(self):
+                pid = os.getpid()
+                assert _is_actor_task_running(pid, task_name)
+                assert psutil.Process(pid).name() == f"ray::{task_name}"
+                assert psutil.Process(pid).cmdline()[0] == f"ray::{task_name}"
+
+        a = A.remote()
+        ray.get(a.check.options(name=task_name).remote())
+
+    def test_default_thread_short_comm(self, ray_start_regular):
+        """
+        `check` is not running in the main thread, so `/proc/pid/comm` will
+        not be updated but `/proc/pid/cmdline` will still be updated.
+        """
+
+        @ray.remote(concurrency_groups={"io": 1})
+        class A:
+            def check(self):
+                pid = os.getpid()
+                assert _is_actor_task_running(pid, "check")
+                assert psutil.Process(pid).name() == "ray::A"
+                assert psutil.Process(pid).cmdline()[0] == "ray::A.check"
+
+        a = A.remote()
+        ray.get(a.check.remote())
+
+    def test_default_thread_long_comm(self, ray_start_regular):
+        """
+        `check` is not running in the main thread, so `/proc/pid/comm` will
+        not be updated but `/proc/pid/cmdline` will still be updated.
+
+        In this example, because `ray::VeryLongCommActor` is longer than 15
+        characters, `psutil.Process.name()` will return `cmdline()[0]` instead.
+        """
+
+        @ray.remote(concurrency_groups={"io": 1})
+        class VeryLongCommActor:
+            def check_long_comm(self):
+                pid = os.getpid()
+                assert _is_actor_task_running(pid, "check_long_comm")
+                assert (
+                    psutil.Process(pid).name()
+                    == "ray::VeryLongCommActor.check_long_comm"
+                )
+                assert (
+                    psutil.Process(pid).cmdline()[0]
+                    == "ray::VeryLongCommActor.check_long_comm"
+                )
+
+        a = VeryLongCommActor.remote()
+        ray.get(a.check_long_comm.remote())
+
+    def test_default_thread_options_name_short_comm(self, ray_start_regular):
+        """
+        `check` is not running in the main thread, so `/proc/pid/comm` will
+        not be updated but `/proc/pid/cmdline` will still be updated.
+        """
+        task_name = "hello"
+
+        @ray.remote(concurrency_groups={"io": 1})
+        class A:
+            def check(self):
+                pid = os.getpid()
+                assert _is_actor_task_running(pid, task_name)
+                assert psutil.Process(pid).name() == "ray::A"
+                assert psutil.Process(pid).cmdline()[0] == f"ray::{task_name}"
+
+        a = A.remote()
+        ray.get(a.check.options(name=task_name).remote())
+
+    def test_default_thread_options_name_long_comm(self, ray_start_regular):
+        task_name = "hello"
+
+        @ray.remote(concurrency_groups={"io": 1})
+        class Actor:
+            def check_long_comm(self):
+                pid = os.getpid()
+                assert _is_actor_task_running(pid, task_name)
+                assert psutil.Process(pid).name() == "ray::Actor"
+                assert psutil.Process(pid).cmdline()[0] == f"ray::{task_name}"
+
+        a = Actor.remote()
+        ray.get(a.check_long_comm.options(name=task_name).remote())
+
+    def test_default_thread_options_name_long_comm_2(self, ray_start_regular):
+        task_name = "hello"
+
+        @ray.remote(concurrency_groups={"io": 1})
+        class VeryLongCommActor:
+            def check_long_comm(self):
+                pid = os.getpid()
+                assert _is_actor_task_running(pid, task_name)
+                # The first 15 characters of "ray::VeryLongCommActor"
+                assert psutil.Process(pid).name() == "ray::VeryLongCo"
+                assert psutil.Process(pid).cmdline()[0] == f"ray::{task_name}"
+
+        a = VeryLongCommActor.remote()
+        ray.get(a.check_long_comm.options(name=task_name).remote())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Ray core worker processes change the process title by calling `setproctitle` before and after executing tasks. Then, `verify_tasks_running_or_terminated` uses the following logic to check whether the Ray actor task is running or not:

```python
if psutil.pid_exists(pid) and task_name in psutil.Process(pid).name():
```

However, the logic is not correct in some cases. To understand the issue, we need to understand the behavior of `setproctitle` and `psutil.Process(pid).name()`.

* `setproctitle`:
  * It calls functions like [prctl](https://github.com/dvarrazzo/py-setproctitle/blob/cacf96fafa3da1cd1a5b131b4f8b9997c01518d5/src/spt_status.c#L390) based on the OS and arch under the hood. It updates `/proc/pid/task/tid/comm` of the calling thread.
  * If the thread is the leader thread (i.e. main thread in Python), `/proc/pid/comm` will also be updated.
  * `/proc/pid/cmdline` and `/proc/pid/task/tid/cmdline` will always be updated based on my observation.
  * Note that `comm` has a length limitation (15 chars)

* `psutil.Process(pid).name()`
  *  https://github.com/giampaolo/psutil/blob/a17550784b0d3175da01cdb02cee1bc6b61637dc/psutil/__init__.py#L664-L693
  * Try to retrieve `/proc/pid/comm`.
  * If `/proc/pid/comm` is truncated, attempt to retrieve the first element of `/proc/pid/cmdline`; otherwise, return `/proc/pid/comm`.
  * If `cmdline[0]` begins with the contents of `/proc/pid/comm`, return `cmdline[0]`; otherwise, return the truncated `/proc/pid/comm`.

If the actor task is not running on the main thread (in which case `setproctitle` will not update `/proc/pid/comm`), and if users pass an `options.name` to the actor that doesn't start with `/proc/pid/comm`, then `task_name in psutil.Process(pid).name()` will evaluate to false, which is incorrect.

```python
def test_default_thread_options_name_long_comm_2(self, ray_start_regular):
    """
    `/proc/PID/comm` is truncated to 15 characters, so the process title
    is "ray::VeryLongCo". `psutil.Process.name()` doesn't return `cmdline()[0]`
    because `cmdline()[0]` doesn't start with "ray::VeryLongCo". This is the
    implementation detail of `psutil`.
    """
    task_name = "hello"

    @ray.remote(concurrency_groups={"io": 1})
    class VeryLongCommActor:
        def check_long_comm(self):
            pid = os.getpid()
            assert _is_actor_task_running(pid, task_name)
            # The first 15 characters of "ray::VeryLongCommActor"
            assert psutil.Process(pid).name() == "ray::VeryLongCo"
            assert psutil.Process(pid).cmdline()[0] == f"ray::{task_name}"
            return pid

    a = VeryLongCommActor.remote()
    pid = ray.get(a.check_long_comm.options(name=task_name).remote())
    wait_for_condition(lambda: not _is_actor_task_running(pid, task_name))
```


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
