### PR TITLE
[serve] Fix bad `mock` import

### DIFF
--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -368,9 +368,7 @@ def mock_deployment_state_manager(
 
 @pytest.fixture
 def mock_max_per_replica_retry_count():
-    with patch(
-        "ray.serve._private.deployment_state.MAX_PER_REPLICA_RETRY_COUNT", 2
-    ):
+    with patch("ray.serve._private.deployment_state.MAX_PER_REPLICA_RETRY_COUNT", 2):
         yield 2
 
 

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -3,7 +3,6 @@ from copy import deepcopy
 from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import Mock, patch
 
-import mock
 import pytest
 
 from ray._private.ray_constants import DEFAULT_MAX_CONCURRENCY_ASYNC
@@ -369,7 +368,7 @@ def mock_deployment_state_manager(
 
 @pytest.fixture
 def mock_max_per_replica_retry_count():
-    with mock.patch(
+    with patch(
         "ray.serve._private.deployment_state.MAX_PER_REPLICA_RETRY_COUNT", 2
     ):
         yield 2


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Somehow a bad import snuck in...

## Related issue number

Closes https://github.com/ray-project/ray/issues/49634
Closes https://github.com/ray-project/ray/issues/49632
Closes https://github.com/ray-project/ray/issues/49638
Closes https://github.com/ray-project/ray/issues/49642

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
