### PR TITLE
[core][dashboard] Lazy init `NotifyQueue`

### DIFF
--- a/python/ray/dashboard/utils.py
+++ b/python/ray/dashboard/utils.py
@@ -479,15 +479,23 @@ class Change:
 class NotifyQueue:
     """Asyncio notify queue for Dict signal."""
 
-    _queue = asyncio.Queue()
+    _queue = None
+
+    @classmethod
+    def queue(cls):
+        # Lazy initialization to avoid creating a asyncio.Queue
+        # whenever this Python file is imported.
+        if cls._queue is None:
+            cls._queue = asyncio.Queue()
+        return cls._queue
 
     @classmethod
     def put(cls, co):
-        cls._queue.put_nowait(co)
+        cls.queue().put_nowait(co)
 
     @classmethod
     async def get(cls):
-        return await cls._queue.get()
+        return await cls.queue().get()
 
 
 """


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, the class variable `_queue` calls `asyncio.Queue()`. This means that whenever this Python file is imported, `asyncio.Queue()` is invoked, and an error will be thrown if the thread does not have an event loop set.

This PR is a blocker of #51058. 

<img width="1496" alt="image" src="https://github.com/user-attachments/assets/cfb894c0-456f-4e08-8054-294249d615b6" />


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
