### PR TITLE
Sync (most) CI linters to precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -146,6 +146,37 @@ repos:
 
   - repo: local
     hooks:
+      - id: bazel_team_owner_check
+        name: Check for bazel team owner tagging violations
+        entry: python ci/lint/check_bazel_team_owner.py
+        language: python
+        types: [python]
+
+  - repo: local
+    hooks:
+      - id: copyright_format_check
+        name: Check for file copyright format violations
+        entry: ci/lint/copyright-format.sh
+        language: system
+        args: ["-c"]
+        pass_filenames: false
+
+  - repo: local
+    hooks:
+      - id: code_format_check
+        name: Check for code format violations
+        entry: ci/lint/format.sh
+        language: system
+
+  - repo: local
+    hooks:
+      - id: documentation_style_check
+        name: Check for documentation style violations
+        entry: ci/lint/check-documentation-style.sh
+        language: system
+
+  - repo: local
+    hooks:
       - id: check-import-order
         name: Check for Ray import order violations
         entry: python ci/lint/check_import_order.py


### PR DESCRIPTION
I sometimes met inconsistency among (1) CI linter check; (2) local format script; (3) precommit check.
For example, certain linter check and fix only exists in (1) but not (2), which means I have to fix it manually via the CI command.

Related issue: https://github.com/ray-project/ray/issues/50694

This PR adds most of the CI linter commands to precommit check, with a few disabled (reason illustrated below).

I did't put pytest check in precommit, because it produces a lot of error message which I cannot fix myself.
```sh
+ python ci/lint/pytest_checker.py
Traceback (most recent call last):
  File "/home/ubuntu/.local/bin/xq", line 5, in <module>
    from yq import xq_cli
  File "/home/ubuntu/.local/lib/python3.9/site-packages/yq/__init__.py", line 19, in <module>
    import yaml
<omit>
```

I didn't put API documentation in precommit, because it produces a lot of error message which I cannot fix myself.
```sh
[INFO 2025-03-08 11:12:08,317] cmd_check_api_discrepancy.py: 85  Validating that public core APIs should be documented...
[INFO 2025-03-08 11:12:08,317] cmd_check_api_discrepancy.py: 96  Public APIs that are NOT documented:
[INFO 2025-03-08 11:12:08,317] cmd_check_api_discrepancy.py: 98         ray._private.ray_logging.logging_config.LoggingConfig
[INFO 2025-03-08 11:12:08,318] cmd_check_api_discrepancy.py: 98         ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy
[INFO 2025-03-08 11:12:08,318] cmd_check_api_discrepancy.py: 98         ray.util.placement_group.PlacementGroup
[INFO 2025-03-08 11:12:08,318] cmd_check_api_discrepancy.py: 98         ray.util.scheduling_strategies.PlacementGroupSchedulingStrategy
[INFO 2025-03-08 11:12:08,318] cmd_check_api_discrepancy.py: 98         ray.exceptions.RuntimeEnvSetupError
[INFO 2025-03-08 11:12:08,318] cmd_check_api_discrepancy.py: 98         ray.runtime_env.runtime_env.RuntimeEnv
```

I didn't put dashboard format check into precommit because it's SUPER SLOW.

I didn't place banned words check into precommit check, because it produces lots of error that I myself hard to fix.
```sh
Check for banned words violations........................................Failed
- hook id: banned_words_check
- exit code: 1

Checking for common mis-spellings...
./bazel-ray/bazel-out/k8-opt/bin/ci/ray_ci/doc/cmd_check_api_discrepancy.runfiles/py_deps_buildkite_botocore/botocore/utils.py:        self._session = botocore.httpsession.URLLib3Session(
./bazel-ray/bazel-out/k8-opt/bin/ci/ray_ci/doc/cmd_check_api_discrepancy.runfiles/py_deps_buildkite_botocore/botocore/utils.py:            session = botocore.httpsession.URLLib3Session(
<omit others>
```