### PR TITLE
[core][refactor] Move `node_stats_to_dict` to `utils.py` to avoid importing unnecessary modules

### DIFF
--- a/python/ray/dashboard/memory_utils.py
+++ b/python/ray/dashboard/memory_utils.py
@@ -7,6 +7,7 @@ from typing import List
 import ray
 from ray._private.internal_api import node_stats
 from ray._raylet import ActorID, JobID, TaskID
+from ray.dashboard.utils import node_stats_to_dict
 
 logger = logging.getLogger(__name__)
 
@@ -380,8 +381,6 @@ def memory_summary(
 ) -> str:
     # Get terminal size
     import shutil
-
-    from ray.dashboard.modules.node.node_head import node_stats_to_dict
 
     size = shutil.get_terminal_size((80, 20)).columns
     line_wrap_threshold = 137

--- a/python/ray/dashboard/modules/node/node_head.py
+++ b/python/ray/dashboard/modules/node/node_head.py
@@ -59,33 +59,6 @@ def _gcs_node_info_to_dict(message: gcs_pb2.GcsNodeInfo) -> dict:
     )
 
 
-def node_stats_to_dict(message):
-    decode_keys = {
-        "actorId",
-        "jobId",
-        "taskId",
-        "parentTaskId",
-        "sourceActorId",
-        "callerId",
-        "rayletId",
-        "workerId",
-        "placementGroupId",
-    }
-    core_workers_stats = message.core_workers_stats
-    message.ClearField("core_workers_stats")
-    try:
-        result = dashboard_utils.message_to_dict(message, decode_keys)
-        result["coreWorkersStats"] = [
-            dashboard_utils.message_to_dict(
-                m, decode_keys, always_print_fields_with_no_presence=True
-            )
-            for m in core_workers_stats
-        ]
-        return result
-    finally:
-        message.core_workers_stats.extend(core_workers_stats)
-
-
 class NodeHead(dashboard_utils.DashboardHeadModule):
     def __init__(self, config: dashboard_utils.DashboardHeadModuleConfig):
         super().__init__(config)
@@ -422,7 +395,9 @@ class NodeHead(dashboard_utils.DashboardHeadModule):
                         f"Error updating node stats of {node_id}.", exc_info=response
                     )
                 else:
-                    new_node_stats[node_id] = node_stats_to_dict(response)
+                    new_node_stats[node_id] = dashboard_utils.node_stats_to_dict(
+                        response
+                    )
 
             return new_node_stats
 

--- a/python/ray/dashboard/utils.py
+++ b/python/ray/dashboard/utils.py
@@ -362,7 +362,7 @@ def address_tuple(address):
 
 
 def node_stats_to_dict(
-    message: GetNodeStatsReply,
+    message: "GetNodeStatsReply",
 ) -> Optional[Dict[str, List[Dict[str, Any]]]]:
     decode_keys = {
         "actorId",
@@ -376,16 +376,12 @@ def node_stats_to_dict(
         "placementGroupId",
     }
     core_workers_stats = message.core_workers_stats
-    message.ClearField("core_workers_stats")
-    try:
-        result = message_to_dict(message, decode_keys)
-        result["coreWorkersStats"] = [
-            message_to_dict(m, decode_keys, always_print_fields_with_no_presence=True)
-            for m in core_workers_stats
-        ]
-        return result
-    finally:
-        message.core_workers_stats.extend(core_workers_stats)
+    result = message_to_dict(message, decode_keys)
+    result["coreWorkersStats"] = [
+        message_to_dict(m, decode_keys, always_print_fields_with_no_presence=True)
+        for m in core_workers_stats
+    ]
+    return result
 
 
 class CustomEncoder(json.JSONEncoder):

--- a/python/ray/dashboard/utils.py
+++ b/python/ray/dashboard/utils.py
@@ -358,7 +358,9 @@ def address_tuple(address):
     return ip, int(port)
 
 
-def node_stats_to_dict(message):
+def node_stats_to_dict(
+    message: "ray.core.generated.node_manager_pb2.GetNodeStatsReply",
+):
     decode_keys = {
         "actorId",
         "jobId",

--- a/python/ray/dashboard/utils.py
+++ b/python/ray/dashboard/utils.py
@@ -358,6 +358,31 @@ def address_tuple(address):
     return ip, int(port)
 
 
+def node_stats_to_dict(message):
+    decode_keys = {
+        "actorId",
+        "jobId",
+        "taskId",
+        "parentTaskId",
+        "sourceActorId",
+        "callerId",
+        "rayletId",
+        "workerId",
+        "placementGroupId",
+    }
+    core_workers_stats = message.core_workers_stats
+    message.ClearField("core_workers_stats")
+    try:
+        result = message_to_dict(message, decode_keys)
+        result["coreWorkersStats"] = [
+            message_to_dict(m, decode_keys, always_print_fields_with_no_presence=True)
+            for m in core_workers_stats
+        ]
+        return result
+    finally:
+        message.core_workers_stats.extend(core_workers_stats)
+
+
 class CustomEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, bytes):

--- a/python/ray/dashboard/utils.py
+++ b/python/ray/dashboard/utils.py
@@ -12,7 +12,10 @@ from base64 import b64decode
 from collections import namedtuple
 from collections.abc import Mapping, MutableMapping, Sequence
 from dataclasses import dataclass
-from typing import Optional, Dict, List, Any
+from typing import Optional, Dict, List, Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ray.core.generated.node_manager_pb2 import GetNodeStatsReply
 
 import aiosignal  # noqa: F401
 from frozenlist import FrozenList  # noqa: F401
@@ -359,7 +362,7 @@ def address_tuple(address):
 
 
 def node_stats_to_dict(
-    message: "ray.core.generated.node_manager_pb2.GetNodeStatsReply",
+    message: GetNodeStatsReply,
 ) -> Optional[Dict[str, List[Dict[str, Any]]]]:
     decode_keys = {
         "actorId",

--- a/python/ray/dashboard/utils.py
+++ b/python/ray/dashboard/utils.py
@@ -12,7 +12,7 @@ from base64 import b64decode
 from collections import namedtuple
 from collections.abc import Mapping, MutableMapping, Sequence
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Dict, List, Any
 
 import aiosignal  # noqa: F401
 from frozenlist import FrozenList  # noqa: F401
@@ -360,7 +360,7 @@ def address_tuple(address):
 
 def node_stats_to_dict(
     message: "ray.core.generated.node_manager_pb2.GetNodeStatsReply",
-):
+) -> Optional[Dict[str, List[Dict[str, Any]]]]:
     decode_keys = {
         "actorId",
         "jobId",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`node_stats_to_dict` is used by both `memory_utils.py` and `node_head.py`, and `memory_utils.py` imports `ray.dashboard.modules.node.node_head`. It's better to avoid having a "utils" module import other internal Python modules to avoid nested import or potential circular import.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
