### PR TITLE
[core][autoscaler] Add Pod names to the output of `ray status -v`

### DIFF
--- a/python/ray/autoscaler/v2/tests/test_utils.py
+++ b/python/ray/autoscaler/v2/tests/test_utils.py
@@ -579,17 +579,23 @@ Node: instance1 (head_node)
   0.5/1.0 CPU
   0.0/2.0 GPU
   5.42KiB/10.04KiB object_store_memory
+ Activity:
+  (no activity)
 
 Node: instance2 (worker_node)
  Id: fffffffffffffffffffffffffffffffffffffffffffffffffff00002
  Usage:
   0/1.0 CPU
   0/2.0 GPU
+ Activity:
+  (no activity)
 
 Node: instance3 (worker_node)
  Id: fffffffffffffffffffffffffffffffffffffffffffffffffff00003
  Usage:
-  0.0/1.0 CPU"""
+  0.0/1.0 CPU
+ Activity:
+  (no activity)"""
     assert actual == expected
 
 

--- a/python/ray/autoscaler/v2/tests/test_utils.py
+++ b/python/ray/autoscaler/v2/tests/test_utils.py
@@ -573,18 +573,21 @@ Total Demands:
  {'GPU': 2} * 1 (STRICT_PACK): 2+ pending placement groups
  {'GPU': 2, 'CPU': 100}: 2+ from request_resources()
 
-Node: fffffffffffffffffffffffffffffffffffffffffffffffffff00001 (head_node)
+Node: instance1 (head_node)
+ Id: fffffffffffffffffffffffffffffffffffffffffffffffffff00001
  Usage:
   0.5/1.0 CPU
   0.0/2.0 GPU
   5.42KiB/10.04KiB object_store_memory
 
-Node: fffffffffffffffffffffffffffffffffffffffffffffffffff00002 (worker_node)
+Node: instance2 (worker_node)
+ Id: fffffffffffffffffffffffffffffffffffffffffffffffffff00002
  Usage:
   0/1.0 CPU
   0/2.0 GPU
 
-Node: fffffffffffffffffffffffffffffffffffffffffffffffffff00003 (worker_node)
+Node: instance3 (worker_node)
+ Id: fffffffffffffffffffffffffffffffffffffffffffffffffff00003
  Usage:
   0.0/1.0 CPU"""
     assert actual == expected

--- a/python/ray/autoscaler/v2/utils.py
+++ b/python/ray/autoscaler/v2/utils.py
@@ -356,6 +356,17 @@ class ClusterStatusFormatter:
     def _node_usage_report(
         active_nodes: List[NodeInfo], idle_nodes: List[NodeInfo]
     ) -> str:
+        """[Example]:
+        Node: raycluster-autoscaler-small-group-worker-n8hrw (small-group)
+         Id: cc22041297e5fc153b5357e41f184c8000869e8de97252cc0291fd17
+         Usage:
+          1.0/1.0 CPU
+          0B/953.67MiB memory
+          0B/251.76MiB object_store_memory
+         Activity:
+          Resource: CPU currently in use.
+          Busy workers on node.
+        """
         node_id_to_usage = {}
         node_id_to_type = {}
         node_id_to_idle_time = {}

--- a/python/ray/autoscaler/v2/utils.py
+++ b/python/ray/autoscaler/v2/utils.py
@@ -320,7 +320,11 @@ class ClusterStatusFormatter:
         failure_report = cls._failed_node_report(data, verbose)
         cluster_usage_report = cls._cluster_usage_report(data, verbose)
         demand_report = cls._demand_report(data)
-        node_usage_report = cls._node_usage_report(data, verbose)
+        node_usage_report = (
+            ""
+            if not verbose
+            else cls._node_usage_report(data.active_nodes, data.idle_nodes)
+        )
 
         # Format Cluster Status reports into one output
         formatted_output_lines = [
@@ -349,58 +353,56 @@ class ClusterStatusFormatter:
         return formatted_output.strip()
 
     @staticmethod
-    def _node_usage_report(data: ClusterStatus, verbose: bool) -> str:
-        usage_by_node = {}
-        node_type_mapping = {}
-        idle_time_map = {}
+    def _node_usage_report(
+        active_nodes: List[NodeInfo], idle_nodes: List[NodeInfo]
+    ) -> str:
+        node_id_to_usage = {}
+        node_id_to_type = {}
+        node_id_to_idle_time = {}
+        node_id_to_instance_id = {}
 
         # Populate mappings for usage, node types, and idle times
-        for node in chain(data.active_nodes, data.idle_nodes):
-            usage_by_node[node.node_id] = {
+        for node in chain(active_nodes, idle_nodes):
+            node_id_to_usage[node.node_id] = {
                 u.resource_name: (u.used, u.total) for u in node.resource_usage.usage
             }
-            node_type_mapping[node.node_id] = node.ray_node_type_name
-            idle_time_map[node.node_id] = node.resource_usage.idle_time_ms
-
+            node_id_to_type[node.node_id] = node.ray_node_type_name
+            node_id_to_idle_time[node.node_id] = node.resource_usage.idle_time_ms
+            node_id_to_instance_id[node.node_id] = node.instance_id
         # Create a dictionary for node activities
-        node_activities = {
-            node.node_id: node.node_activity for node in data.active_nodes
-        }
+        node_activities = {node.node_id: node.node_activity for node in active_nodes}
 
         node_usage_report_lines = []
-        if verbose:
-            if usage_by_node:
-                for node_id, usage in usage_by_node.items():
-                    node_usage_report_lines.append("")  # Add a blank line between nodes
+        for node_id, usage in node_id_to_usage.items():
+            node_usage_report_lines.append("")  # Add a blank line between nodes
 
-                    # Node type line
-                    node_type_line = f"Node: {node_id}"
-                    if node_id in node_type_mapping:
-                        node_type = node_type_mapping[node_id]
-                        node_type_line += f" ({node_type})"
-                    node_usage_report_lines.append(node_type_line)
+            # Node type line
+            node_type_line = f"Node: {node_id_to_instance_id[node_id]}"
+            if node_id in node_id_to_type:
+                node_type = node_id_to_type[node_id]
+                node_type_line += f" ({node_type})"
+            node_usage_report_lines.append(node_type_line)
+            node_usage_report_lines.append(f" Id: {node_id}")
 
-                    # Idle time for the node
-                    if idle_time_map.get(node_id, 0) > 0:
-                        node_usage_report_lines.append(
-                            f" Idle: {idle_time_map[node_id]} ms"
-                        )
+            # Idle time for the node
+            if node_id_to_idle_time.get(node_id, 0) > 0:
+                node_usage_report_lines.append(
+                    f" Idle: {node_id_to_idle_time[node_id]} ms"
+                )
 
-                    # Add resource usage information
-                    node_usage_report_lines.append(" Usage:")
-                    for line in parse_usage(usage, verbose):
-                        node_usage_report_lines.append(f"  {line}")
+            # Add resource usage information
+            node_usage_report_lines.append(" Usage:")
+            for line in parse_usage(usage, verbose=True):
+                node_usage_report_lines.append(f"  {line}")
 
-                    # Add node activity, if any
-                    if node_activities:
-                        node_usage_report_lines.append(" Activity:")
-                        if node_id not in node_activities:
-                            node_usage_report_lines.append("  (no activity)")
-                        else:
-                            for reason in node_activities[node_id]:
-                                node_usage_report_lines.append(f"  {reason}")
-        else:
-            node_usage_report_lines.append("")  # For the non-verbose case
+            # Add node activity, if any
+            if node_activities:
+                node_usage_report_lines.append(" Activity:")
+                if node_id not in node_activities:
+                    node_usage_report_lines.append("  (no activity)")
+                else:
+                    for reason in node_activities[node_id]:
+                        node_usage_report_lines.append(f"  {reason}")
 
         # Join the list into a single string with new lines
         return "\n".join(node_usage_report_lines)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

1. Currently, the output of `ray status -v` only includes information on node types (i.e., group names in KubeRay) and Ray node IDs. However, it is not easy to map a Ray node ID to the name of the corresponding Ray Pod (i.e. instance id in Autoscaler).

<img width="496" alt="Screenshot 2025-03-08 at 11 50 43 PM" src="https://github.com/user-attachments/assets/89c66096-88c2-47fb-80d6-08067c7b9d90" />

2. Refactor


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
