### PR TITLE
Avoid `setup-dev.py` writing to `generated/`

### DIFF
--- a/python/ray/setup-dev.py
+++ b/python/ray/setup-dev.py
@@ -90,9 +90,10 @@ def do_link(package, force=False, skip_list=None, local_path=None):
         if package == "serve":
             tmp_generated_folder = os.path.join(temp_dir, "generated")
             package_generated_folder = os.path.join(package_home, "generated")
-            subprocess.check_call(
-                ["mv", tmp_generated_folder, package_generated_folder]
-            )
+            if not os.path.exists(package_generated_folder):
+                subprocess.check_call(
+                    ["mv", tmp_generated_folder, package_generated_folder]
+                )
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/kuberay/rune2e.sh
+++ b/python/ray/tests/kuberay/rune2e.sh
@@ -6,7 +6,7 @@ kind delete cluster
 docker image rm $RAY_IMAGE
 
 pushd ../../../..
-docker build --build-arg BUILD_DATE="$(date +%Y-%m-%d:%H:%M:%S)" -t $RAY_IMAGE -f ./python/ray/tests/kuberay/Dockerfile . || exit
+docker build --progress=plain --build-arg BUILD_DATE="$(date +%Y-%m-%d:%H:%M:%S)" -t $RAY_IMAGE -f ./python/ray/tests/kuberay/Dockerfile . || exit
 popd || exit
 
 kind create cluster || exit


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

```bash
docker build --progress=plain --build-arg BUILD_DATE="$(date +%Y-%m-%d:%H:%M:%S)" -t $RAY_IMAGE -f ./python/ray/tests/kuberay/Dockerfile . || exit
```

<img width="1280" alt="image" src="https://github.com/user-attachments/assets/2a0e1842-59f3-42c8-b58c-1fadaba7cb85" />

https://github.com/ray-project/ray/pull/48793 assumes that the `ray/serve/generated` directory does not exist in the Ray directory, which means that users have not compiled Ray in that directory.

However, this approach is incorrect for developers who want to test code changes in KubeRay. The workflow is like:

* Develop Ray locally, meaning you continuously update the code and compile it as needed. The directory `ray/serve/generated` should be created after compilation.
* After finishing development, the developer wants to build a Docker image using this [Dockerfile](https://github.com/ray-project/ray/blob/master/python/ray/tests/kuberay/Dockerfile) and then test it with KubeRay. The Dockerfile copies the local Ray directory into the image and runs `python3 setup-dev.py -y` to replace the Ray package with your local Ray code.
* #48793 will move the existing `.../site-packages/ray/serve/generated` directory to a temporary directory, and then move it back after the soft link is created. However, in this case, `ray/serve/generated` directory has already existed.

In addition, in the [Dockerfile](https://github.com/ray-project/ray/blob/master/python/ray/tests/kuberay/Dockerfile), the `ray` directory is added by the command `ADD . ray`, so the owner is `root` instead of `ray`. That's why we see the permission error above.

<img width="947" alt="image" src="https://github.com/user-attachments/assets/da852337-4c12-4bcd-a724-4ab38abcfd88" />



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
