### PR TITLE
[tune] Fix `RunConfig` deprecation message in Tune being emitted in `trainer.fit` usage

### DIFF
--- a/python/ray/train/tests/test_api_migrations.py
+++ b/python/ray/train/tests/test_api_migrations.py
@@ -31,8 +31,9 @@ def test_trainer_restore():
             pass
 
 
-def test_trainer_valid_configs(tmp_path):
-    with warnings.catch_warnings():
+def test_trainer_valid_configs(ray_start_4_cpus, tmp_path):
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
         DataParallelTrainer(
             lambda _: None,
             scaling_config=ray.train.ScalingConfig(num_workers=1),
@@ -40,6 +41,13 @@ def test_trainer_valid_configs(tmp_path):
                 storage_path=tmp_path,
                 failure_config=ray.train.FailureConfig(max_failures=1),
             ),
+        ).fit()
+
+    for warning in w:
+        assert not (
+            warning.category == RayDeprecationWarning
+            and "`RunConfig` class should be imported from `ray.tune`"
+            in str(warning.message)
         )
 
 


### PR DESCRIPTION
## Summary

Train V1 creates a `Tuner` when calling `trainer.fit()`. The `Trainer` instance passes its own `ray.train.RunConfig` to Tune, which now emits a deprecation warning message about how the Tuner should take in a `ray.tune.RunConfig`. This warning should not be emitted in this case.
