### PR TITLE
[Data] Make chunk combination threshold configurable for improved per…

### DIFF
--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -40,7 +40,7 @@ MIN_PYARROW_VERSION_TYPE_PROMOTION = parse_version("14.0.0")
 # See https://github.com/ray-project/ray/issues/31108 for more details.
 # TODO(jjyao): remove this once https://github.com/apache/arrow/issues/35126 is resolved
 MIN_NUM_CHUNKS_TO_TRIGGER_COMBINE_CHUNKS = env_integer(
-    'RAY_DATA_MIN_NUM_CHUNKS_TO_TRIGGER_COMBINE_CHUNKS', 10
+    "RAY_DATA_MIN_NUM_CHUNKS_TO_TRIGGER_COMBINE_CHUNKS", 10
 )
 
 logger = logging.getLogger(__name__)

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -23,9 +23,22 @@ MIN_PYARROW_VERSION_TYPE_PROMOTION = parse_version("14.0.0")
 # pyarrow.Table.slice is slow when the table has many chunks
 # so we combine chunks into a single one to make slice faster
 # with the cost of an extra copy.
+#
+# The decision to combine chunks is based on a threshold for the number
+# of chunks, set by `MIN_NUM_CHUNKS_TO_TRIGGER_COMBINE_CHUNKS`. To make
+# this more flexible, we have made this threshold configurable via the
+# `RAY_DATA_MIN_NUM_CHUNKS_TO_TRIGGER_COMBINE_CHUNKS` environment variable.
+#
+# This configurability is important because the size of each chunk can vary
+# greatly depending on the dataset and the operations performed previously.
+# A fixed threshold might not be optimal for all scenarios, as in some cases,
+# a smaller number of large chunks could behave differently from a larger
+# number of smaller chunks. By making this threshold tunable, users have
+# the ability to optimize for their specific case, adjusting based on their
+# chunk sizes and available memory.
 # See https://github.com/ray-project/ray/issues/31108 for more details.
 # TODO(jjyao): remove this once https://github.com/apache/arrow/issues/35126 is resolved
-MIN_NUM_CHUNKS_TO_TRIGGER_COMBINE_CHUNKS = 10
+MIN_NUM_CHUNKS_TO_TRIGGER_COMBINE_CHUNKS = int(os.getenv('RAY_DATA_MIN_NUM_CHUNKS_TO_TRIGGER_COMBINE_CHUNKS', 10))
 
 
 logger = logging.getLogger(__name__)

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, List, Union, Dict
 import numpy as np
 from packaging.version import parse as parse_version
 
+from ray._private.ray_constants import env_integer
 from ray._private.utils import _get_pyarrow_version
 from ray.air.util.tensor_extensions.arrow import (
     INT32_OVERFLOW_THRESHOLD,
@@ -38,8 +39,9 @@ MIN_PYARROW_VERSION_TYPE_PROMOTION = parse_version("14.0.0")
 # chunk sizes and available memory.
 # See https://github.com/ray-project/ray/issues/31108 for more details.
 # TODO(jjyao): remove this once https://github.com/apache/arrow/issues/35126 is resolved
-MIN_NUM_CHUNKS_TO_TRIGGER_COMBINE_CHUNKS = int(os.getenv('RAY_DATA_MIN_NUM_CHUNKS_TO_TRIGGER_COMBINE_CHUNKS', 10))
-
+MIN_NUM_CHUNKS_TO_TRIGGER_COMBINE_CHUNKS = env_integer(
+    'RAY_DATA_MIN_NUM_CHUNKS_TO_TRIGGER_COMBINE_CHUNKS', 10
+)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The decision to combine chunks is based on a threshold for the number of chunks, set by MIN_NUM_CHUNKS_TO_TRIGGER_COMBINE_CHUNKS. To make this more flexible, we have made this threshold configurable via the RAY_DATA_MIN_NUM_CHUNKS_TO_TRIGGER_COMBINE_CHUNKS environment variable. This configurability is important because the size of each chunk can vary greatly depending on the dataset and the operations performed previously. A fixed threshold might not be optimal for all scenarios, as in some cases, a smaller number of large chunks could behave differently from a larger number of smaller chunks. By making this threshold tunable, users have the ability to optimize for their specific case, adjusting based on their chunk sizes and available memory.

<!-- Please give a short summary of the change and the problem this solves. -->

made this threshold configurable via the RAY_DATA_MIN_NUM_CHUNKS_TO_TRIGGER_COMBINE_CHUNKS environment variable. 

## Related issue number
N/A, I can create one if needed
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
