### PR TITLE
[core] Acquire GIL before calling PyGILState_Release

### DIFF
--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -1046,6 +1046,7 @@ def test_actor_creation_latency(ray_start_regular_shared):
     )
 
 
+@pytest.mark.parametrize("enable_concurrency_group", [True, False])
 @pytest.mark.parametrize(
     "exit_condition",
     [
@@ -1055,13 +1056,17 @@ def test_actor_creation_latency(ray_start_regular_shared):
         "ray.kill",
     ],
 )
-def test_atexit_handler(ray_start_regular_shared, exit_condition):
-    @ray.remote
+def test_atexit_handler(
+    ray_start_regular_shared, exit_condition, enable_concurrency_group
+):
+    concurrency_groups = {"io": 1} if enable_concurrency_group else None
+
+    @ray.remote(concurrency_groups=concurrency_groups)
     class A:
         def __init__(self, tmpfile, data):
             import atexit
 
-            def f(*args, **kwargs):
+            def f():
                 with open(tmpfile, "w") as f:
                     f.write(data)
                     f.flush()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

For Python/CPython, the GIL should be automatically released and reacquired at every [switch interval](https://docs.python.org/3/library/sys.html#sys.setswitchinterval). However, Cython somehow interferes with the GIL, so when we try to call `PyGILState_Release` to release a thread, the following error message is displayed:

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/9f138859-ba9e-445a-94ee-02a5fa60f922" />

The error message shows that the current thread (which holds the GIL) is the main thread, but we are trying to release another thread (i.e. default executor). The [CPython source code](https://github.com/python/cpython/blob/475f933ed8b1c9546f1b5497a2241140c7065b5f/Python/pystate.c#L2862) shows that this means that the default executor doesn't hold GIL at that time.

In this PR, we explicitly acquire GIL when we call `PyGILState_Release`.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
