### PR TITLE
[doc] Update vllm example support args without values, eg --enable-lora

### DIFF
--- a/doc/source/serve/doc_code/vllm_openai_example.py
+++ b/doc/source/serve/doc_code/vllm_openai_example.py
@@ -121,7 +121,10 @@ def parse_vllm_args(cli_args: Dict[str, str]):
     parser = make_arg_parser(arg_parser)
     arg_strings = []
     for key, value in cli_args.items():
-        arg_strings.extend([f"--{key}", str(value)])
+        if value is None:  # for cases when flag without value, eg: --enable-lora
+            arg_strings.extend([f"--{key}"])
+        else:
+            arg_strings.extend([f"--{key}", str(value)])
     logger.info(arg_strings)
     parsed_args = parser.parse_args(args=arg_strings)
     return parsed_args


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
To make the example support arguments/flags that doesn't have value, eg: `--enable-lora`

arg should be declared with empty or null
```
enable-lora:
```
or
```
enable-lora: null
```


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
