### PR TITLE
[ray.llm] Refactor download utilities

### DIFF
--- a/python/ray/llm/_internal/common/utils/cloud_utils.py
+++ b/python/ray/llm/_internal/common/utils/cloud_utils.py
@@ -50,7 +50,7 @@ class CloudMirrorConfig(BaseModelExtended):
         if value is None:
             return value
 
-        if not (value.startswith("s3://") or value.startswith("gs://")):
+        if not value.startswith("s3://") and not value.startswith("gs://"):
             raise ValueError(
                 f'Got invalid value "{value}" for bucket_uri. '
                 'Expected a URI that starts with "s3://" or "gs://".'
@@ -77,11 +77,15 @@ class LoraMirrorConfig(BaseModelExtended):
 
     @field_validator("bucket_uri")
     @classmethod
-    def validate_bucket_uri(cls, value: str):
-        # TODO(tchordia): remove this. this is a short term fix.
-        # We should fix this on the LLM-forge side
+    def check_uri_format(cls, value):
+        if value is None:
+            return value
+
         if not value.startswith("s3://") and not value.startswith("gs://"):
-            value = "s3://" + value
+            raise ValueError(
+                f'Got invalid value "{value}" for bucket_uri. '
+                'Expected a URI that starts with "s3://" or "gs://".'
+            )
         return value
 
     @property

--- a/python/ray/llm/_internal/common/utils/cloud_utils.py
+++ b/python/ray/llm/_internal/common/utils/cloud_utils.py
@@ -10,6 +10,7 @@ from typing import (
     TypeVar,
     NamedTuple,
 )
+from pydantic import Field, field_validator
 import os
 import time
 import inspect
@@ -19,11 +20,84 @@ import asyncio
 import pyarrow.fs as pa_fs
 
 from ray.llm._internal.serve.observability.logging import get_logger
+from ray.llm._internal.common.base_pydantic import BaseModelExtended
 
 
 T = TypeVar("T")
 
 logger = get_logger(__name__)
+
+
+class ExtraFiles(BaseModelExtended):
+    bucket_uri: str
+    destination_path: str
+
+
+class CloudMirrorConfig(BaseModelExtended):
+    """Unified mirror config for cloud storage (S3 or GCS).
+
+    Args:
+        bucket_uri: URI of the bucket (s3:// or gs://)
+        extra_files: Additional files to download
+    """
+
+    bucket_uri: Optional[str] = None
+    extra_files: List[ExtraFiles] = Field(default_factory=list)
+
+    @field_validator("bucket_uri")
+    @classmethod
+    def check_uri_format(cls, value):
+        if value is None:
+            return value
+
+        if not (value.startswith("s3://") or value.startswith("gs://")):
+            raise ValueError(
+                f'Got invalid value "{value}" for bucket_uri. '
+                'Expected a URI that starts with "s3://" or "gs://".'
+            )
+        return value
+
+    @property
+    def storage_type(self) -> str:
+        """Returns the storage type ('s3' or 'gcs') based on the URI prefix."""
+        if self.bucket_uri is None:
+            return None
+        elif self.bucket_uri.startswith("s3://"):
+            return "s3"
+        elif self.bucket_uri.startswith("gs://"):
+            return "gcs"
+        return None
+
+
+class LoraMirrorConfig(BaseModelExtended):
+    lora_model_id: str
+    bucket_uri: str
+    max_total_tokens: Optional[int]
+    sync_args: Optional[List[str]] = None
+
+    @field_validator("bucket_uri")
+    @classmethod
+    def validate_bucket_uri(cls, value: str):
+        # TODO(tchordia): remove this. this is a short term fix.
+        # We should fix this on the LLM-forge side
+        if not value.startswith("s3://") and not value.startswith("gs://"):
+            value = "s3://" + value
+        return value
+
+    @property
+    def _bucket_name_and_path(self) -> str:
+        for prefix in ["s3://", "gs://"]:
+            if self.bucket_uri.startswith(prefix):
+                return self.bucket_uri[len(prefix) :]
+        return self.bucket_uri
+
+    @property
+    def bucket_name(self) -> str:
+        return self._bucket_name_and_path.split("/")[0]
+
+    @property
+    def bucket_path(self) -> str:
+        return "/".join(self._bucket_name_and_path.split("/")[1:])
 
 
 class CloudFileSystem:

--- a/python/ray/llm/_internal/common/utils/download_utils.py
+++ b/python/ray/llm/_internal/common/utils/download_utils.py
@@ -5,8 +5,10 @@ from typing import List
 from filelock import FileLock
 
 from ray.llm._internal.serve.observability.logging import get_logger
-from ray.llm._internal.serve.deployments.utils.cloud_utils import CloudFileSystem
-from ray.llm._internal.serve.configs.server_models import CloudMirrorConfig
+from ray.llm._internal.common.utils.cloud_utils import (
+    CloudFileSystem,
+    CloudMirrorConfig,
+)
 
 logger = get_logger(__name__)
 

--- a/python/ray/llm/_internal/serve/configs/server_models.py
+++ b/python/ray/llm/_internal/serve/configs/server_models.py
@@ -28,8 +28,8 @@ from pydantic import (
     model_validator,
 )
 
+from ray.llm._internal.common.utils.cloud_utils import CloudMirrorConfig
 from ray.llm._internal.utils import try_import
-
 
 from ray.llm._internal.serve.observability.logging import get_logger
 import ray.util.accelerators.accelerators as accelerators
@@ -59,47 +59,6 @@ ModelT = TypeVar("ModelT", bound=BaseModel)
 
 
 logger = get_logger(__name__)
-
-
-class ExtraFiles(BaseModelExtended):
-    bucket_uri: str
-    destination_path: str
-
-
-class CloudMirrorConfig(BaseModelExtended):
-    """Unified mirror config for cloud storage (S3 or GCS).
-
-    Args:
-        bucket_uri: URI of the bucket (s3:// or gs://)
-        extra_files: Additional files to download
-    """
-
-    bucket_uri: Optional[str] = None
-    extra_files: List[ExtraFiles] = Field(default_factory=list)
-
-    @field_validator("bucket_uri")
-    @classmethod
-    def check_uri_format(cls, value):
-        if value is None:
-            return value
-
-        if not (value.startswith("s3://") or value.startswith("gs://")):
-            raise ValueError(
-                f'Got invalid value "{value}" for bucket_uri. '
-                'Expected a URI that starts with "s3://" or "gs://".'
-            )
-        return value
-
-    @property
-    def storage_type(self) -> str:
-        """Returns the storage type ('s3' or 'gcs') based on the URI prefix."""
-        if self.bucket_uri is None:
-            return None
-        elif self.bucket_uri.startswith("s3://"):
-            return "s3"
-        elif self.bucket_uri.startswith("gs://"):
-            return "gcs"
-        return None
 
 
 class ServeMultiplexConfig(BaseModelExtended):
@@ -609,37 +568,6 @@ class FinishReason(str, Enum):
         if finish_reason == "abort":
             return cls.CANCELLED
         return cls.STOP
-
-
-class LoraMirrorConfig(BaseModelExtended):
-    lora_model_id: str
-    bucket_uri: str
-    max_total_tokens: Optional[int]
-    sync_args: Optional[List[str]] = None
-
-    @field_validator("bucket_uri")
-    @classmethod
-    def validate_bucket_uri(cls, value: str):
-        # TODO(tchordia): remove this. this is a short term fix.
-        # We should fix this on the LLM-forge side
-        if not value.startswith("s3://") and not value.startswith("gs://"):
-            value = "s3://" + value
-        return value
-
-    @property
-    def _bucket_name_and_path(self) -> str:
-        for prefix in ["s3://", "gs://"]:
-            if self.bucket_uri.startswith(prefix):
-                return self.bucket_uri[len(prefix) :]
-        return self.bucket_uri
-
-    @property
-    def bucket_name(self) -> str:
-        return self._bucket_name_and_path.split("/")[0]
-
-    @property
-    def bucket_path(self) -> str:
-        return "/".join(self._bucket_name_and_path.split("/")[1:])
 
 
 class DiskMultiplexConfig(BaseModelExtended):

--- a/python/ray/llm/_internal/serve/deployments/llm/multiplex/lora_model_loader.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/multiplex/lora_model_loader.py
@@ -15,8 +15,8 @@ from ray.llm._internal.serve.deployments.llm.multiplex.utils import (
 from ray.llm._internal.serve.configs.server_models import (
     DiskMultiplexConfig,
     LLMConfig,
-    LoraMirrorConfig,
 )
+from ray.llm._internal.common.utils.cloud_utils import LoraMirrorConfig
 
 logger = get_logger(__name__)
 

--- a/python/ray/llm/_internal/serve/deployments/llm/multiplex/utils.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/multiplex/utils.py
@@ -8,14 +8,12 @@ from fastapi import HTTPException
 from filelock import FileLock
 
 from ray.llm._internal.serve.observability.logging import get_logger
-from ray.llm._internal.serve.deployments.utils.cloud_utils import (
+from ray.llm._internal.common.utils.cloud_utils import (
     CloudFileSystem,
+    LoraMirrorConfig,
     remote_object_cache,
 )
-from ray.llm._internal.serve.configs.server_models import (
-    LLMConfig,
-    LoraMirrorConfig,
-)
+from ray.llm._internal.serve.configs.server_models import LLMConfig
 from ray.llm._internal.serve.configs.constants import (
     CLOUD_OBJECT_MISSING_EXPIRE_S,
     CLOUD_OBJECT_EXISTS_EXPIRE_S,

--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_models.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_models.py
@@ -13,9 +13,9 @@ from ray.llm._internal.utils import try_import
 
 from ray.llm._internal.serve.observability.logging import get_logger
 from ray.llm._internal.common.base_pydantic import BaseModelExtended
+from ray.llm._internal.common.utils.cloud_utils import CloudMirrorConfig
 from ray.llm._internal.serve.configs.server_models import (
     DiskMultiplexConfig,
-    CloudMirrorConfig,
     GenerationRequest,
     GPUType,
     LLMConfig,

--- a/python/ray/llm/_internal/serve/deployments/utils/node_initialization_utils.py
+++ b/python/ray/llm/_internal/serve/deployments/utils/node_initialization_utils.py
@@ -11,14 +11,10 @@ from ray.llm._internal.utils import try_import
 
 from ray.llm._internal.serve.observability.logging import get_logger
 
-from ray.llm._internal.serve.deployments.utils.downloader_utils import (
-    CloudModelDownloader,
-)
+from ray.llm._internal.common.utils.cloud_utils import CloudMirrorConfig
+from ray.llm._internal.common.utils.download_utils import CloudModelDownloader
 from ray.llm._internal.serve.deployments.llm.vllm.vllm_models import VLLMEngineConfig
-from ray.llm._internal.serve.configs.server_models import (
-    CloudMirrorConfig,
-    LLMConfig,
-)
+from ray.llm._internal.serve.configs.server_models import LLMConfig
 from ray.llm._internal.serve.deployments.utils.server_utils import make_async
 
 torch = try_import("torch")

--- a/python/ray/llm/tests/BUILD
+++ b/python/ray/llm/tests/BUILD
@@ -8,6 +8,14 @@ py_library(
   ],
 )
 
+# Common tests
+py_test_module_list(
+  files = glob(["common/**/test_cloud_utils.py"]),
+  size = "small",
+  tags = ["exclusive", "cpu", "team:llm"],
+  deps = ["//:ray_lib"],
+)
+
 # Batch test
 py_test_module_list(
   files = glob(["batch/cpu/**/test_*.py"]),
@@ -40,7 +48,6 @@ py_test_module_list(
     "serve/deployments/test_streaming_error_handler.py",
     "serve/observability/usage_telemetry/test_usage.py",
     "serve/deployments/llm/vllm/test_vllm_engine.py",
-    "serve/utils/test_cloud_utils.py",
   ],
   data = glob(["serve/**/*.yaml"]),
   size = "small",

--- a/python/ray/llm/tests/common/utils/test_cloud_utils.py
+++ b/python/ray/llm/tests/common/utils/test_cloud_utils.py
@@ -1,7 +1,7 @@
 import sys
 import pytest
 import asyncio
-from ray.llm._internal.serve.deployments.utils.cloud_utils import (
+from ray.llm._internal.common.utils.cloud_utils import (
     CloudFileSystem,
     CloudObjectCache,
     remote_object_cache,

--- a/python/ray/llm/tests/serve/deployments/llm/multiplex/test_lora_model_loader.py
+++ b/python/ray/llm/tests/serve/deployments/llm/multiplex/test_lora_model_loader.py
@@ -12,9 +12,9 @@ from ray.llm._internal.serve.configs.server_models import (
     LLMConfig,
     LLMEngine,
     LoraConfig,
-    LoraMirrorConfig,
     ModelLoadingConfig,
 )
+from ray.llm._internal.common.utils.cloud_utils import LoraMirrorConfig
 
 
 class TestLoRAModelLoader:


### PR DESCRIPTION
## Why are these changes needed?

Move download utilities to `_internal/common/utils` so that all LLM modules can share them.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
