### PR TITLE
[Data] Avoid unnecessary conversion to Numpy when creating Arrow/Pandas blocks

### DIFF
--- a/python/ray/air/BUILD
+++ b/python/ray/air/BUILD
@@ -49,7 +49,7 @@ py_test(
 py_test(
     name = "test_arrow",
     size = "small",
-    srcs = ["tests/test_arrow.py"],
+    srcs = ["tests/test_arrow.py", "conftest"],
     tags = ["team:ml", "team:data", "ray_data", "exclusive"],
     deps = [":ml_lib"]
 )

--- a/python/ray/air/tests/conftest.py
+++ b/python/ray/air/tests/conftest.py
@@ -13,3 +13,11 @@ def restore_data_context(request):
     original = copy.deepcopy(ray.data.context.DataContext.get_current())
     yield
     ray.data.context.DataContext._set_current(original)
+
+
+@pytest.fixture
+def disable_fallback_to_object_extension(request, restore_data_context):
+    """Disables fallback to ArrowPythonObjectType"""
+    ray.data.context.DataContext.get_current().enable_fallback_to_arrow_object_ext_type = (
+        False
+    )

--- a/python/ray/air/tests/test_arrow.py
+++ b/python/ray/air/tests/test_arrow.py
@@ -4,14 +4,18 @@ from dataclasses import dataclass, field
 import numpy as np
 import pyarrow as pa
 import pytest
+from packaging.version import parse as parse_version
 
+from ray._private.utils import _get_pyarrow_version
 from ray.air.util.tensor_extensions.arrow import (
     ArrowConversionError,
     _convert_to_pyarrow_native_array,
     _infer_pyarrow_type,
     convert_to_pyarrow_array,
+    ArrowTensorArray,
 )
 from ray.air.util.tensor_extensions.utils import create_ragged_ndarray
+from ray.data import DataContext
 from ray.tests.conftest import *  # noqa
 
 import psutil
@@ -23,16 +27,56 @@ class UserObj:
 
 
 @pytest.mark.parametrize(
-    "numpy_precision, expected_arrow_type",
+    "input",
+    [
+        # Python native lists
+        [
+            [1, 2],
+            [3, 4],
+        ],
+        # Python native tuples
+        [
+            (1, 2),
+            (3, 4),
+        ],
+        # Lists as PA scalars
+        [
+            pa.scalar([1, 2]),
+            pa.scalar([3, 4]),
+        ],
+    ],
+)
+def test_arrow_native_list_conversion(input, disable_fallback_to_object_extension):
+    """Test asserts that nested lists are represented as native Arrow lists
+    upon serialization into Arrow format (and are NOT converted to numpy
+    tensor using extension)"""
+
+    if isinstance(input[0], pa.Scalar) and parse_version(
+        _get_pyarrow_version()
+    ) <= parse_version("13.0.0"):
+        pytest.skip(
+            "Pyarrow < 13.0 not able to properly infer native types from its own Scalars"
+        )
+
+    pa_arr = convert_to_pyarrow_array(input, "a")
+
+    # Should be able to natively convert back to Pyarrow array,
+    # not using any extensions
+    assert pa_arr.type == pa.list_(pa.int64()), pa_arr.type
+    assert pa.array(input) == pa_arr, pa_arr
+
+
+@pytest.mark.parametrize("arg_type", ["list", "ndarray"])
+@pytest.mark.parametrize(
+    "numpy_precision, expected_arrow_timestamp_type",
     [
         ("ms", pa.timestamp("ms")),
         ("us", pa.timestamp("us")),
         ("ns", pa.timestamp("ns")),
-        # Arrow has a special date32 type for dates.
-        ("D", pa.date32()),
         # The coarsest resolution Arrow supports is seconds.
         ("Y", pa.timestamp("s")),
         ("M", pa.timestamp("s")),
+        ("D", pa.timestamp("s")),
         ("h", pa.timestamp("s")),
         ("m", pa.timestamp("s")),
         ("s", pa.timestamp("s")),
@@ -44,25 +88,60 @@ class UserObj:
 )
 def test_convert_datetime_array(
     numpy_precision: str,
-    expected_arrow_type: pa.DataType,
+    expected_arrow_timestamp_type: pa.TimestampType,
+    arg_type: str,
+    restore_data_context,
 ):
-    numpy_array = np.zeros(1, dtype=f"datetime64[{numpy_precision}]")
+    DataContext.get_current().enable_fallback_to_arrow_object_ext_type = False
 
-    pyarrow_array = _convert_to_pyarrow_native_array(numpy_array, "")
+    ndarray = np.ones(1, dtype=f"datetime64[{numpy_precision}]")
 
-    assert pyarrow_array.type == expected_arrow_type
-    assert len(numpy_array) == len(pyarrow_array)
+    if arg_type == "ndarray":
+        column_values = ndarray
+    elif arg_type == "list":
+        column_values = [ndarray]
+    else:
+        pytest.fail(f"Unknown type: {arg_type}")
+
+    # Step 1: Convert to PA array
+    converted = convert_to_pyarrow_array(column_values, "")
+
+    if arg_type == "ndarray":
+        expected = pa.array(
+            column_values.astype(f"datetime64[{expected_arrow_timestamp_type.unit}]")
+        )
+    elif arg_type == "list":
+        expected = ArrowTensorArray.from_numpy(
+            [
+                column_values[0].astype(
+                    f"datetime64[{expected_arrow_timestamp_type.unit}]"
+                )
+            ]
+        )
+    else:
+        pytest.fail(f"Unknown type: {arg_type}")
+
+    assert expected.type == converted.type
+    assert expected == converted
 
 
+@pytest.mark.parametrize("arg_type", ["list", "ndarray"])
 @pytest.mark.parametrize("dtype", ["int64", "float64", "datetime64[ns]"])
-def test_infer_type_does_not_leak_memory(dtype):
+def test_infer_type_does_not_leak_memory(arg_type, dtype):
     # Test for https://github.com/apache/arrow/issues/45493.
-    column_values = np.zeros(923040, dtype=dtype)  # A ~7 MiB column
+    ndarray = np.zeros(923040, dtype=dtype)  # A ~7 MiB column
 
     process = psutil.Process()
     gc.collect()
     pa.default_memory_pool().release_unused()
     before = process.memory_info().rss
+
+    if arg_type == "ndarray":
+        column_values = ndarray
+    elif arg_type == "list":
+        column_values = [ndarray]
+    else:
+        pytest.fail(f"Unknown type: {arg_type}")
 
     _infer_pyarrow_type(column_values)
 

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -1,4 +1,6 @@
 import abc
+from datetime import datetime
+
 import itertools
 import json
 import logging
@@ -12,17 +14,24 @@ from packaging.version import parse as parse_version
 from ray._private.utils import _get_pyarrow_version
 from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.air.util.tensor_extensions.utils import (
-    _is_ndarray_tensor,
     _is_ndarray_variable_shaped_tensor,
     create_ragged_ndarray,
+)
+from ray.data._internal.numpy_support import (
+    convert_to_numpy,
+    _is_tensor,
+    ArrayLike,
+    _convert_datetime_to_np_datetime,
 )
 from ray.data._internal.util import GiB
 from ray.util import log_once
 from ray.util.annotations import DeveloperAPI, PublicAPI
 
+
 PYARROW_VERSION = _get_pyarrow_version()
 if PYARROW_VERSION is not None:
     PYARROW_VERSION = parse_version(PYARROW_VERSION)
+
 # Minimum version of Arrow that supports ExtensionScalars.
 # TODO(Clark): Remove conditional definition once we only support Arrow 8.0.0+.
 MIN_PYARROW_VERSION_SCALAR = parse_version("8.0.0")
@@ -37,6 +46,7 @@ NUM_BYTES_PER_UNICODE_CHAR = 4
 # NOTE: Overflow threshold in bytes for most Arrow types using int32 as
 #       its offsets
 INT32_OVERFLOW_THRESHOLD = 2 * GiB
+
 
 logger = logging.getLogger(__name__)
 
@@ -96,7 +106,9 @@ def pyarrow_table_from_pydict(
 
 
 @DeveloperAPI(stability="alpha")
-def convert_to_pyarrow_array(column_values: np.ndarray, column_name: str) -> pa.Array:
+def convert_to_pyarrow_array(
+    column_values: Union[List[Any], np.ndarray, ArrayLike], column_name: str
+) -> pa.Array:
     """Converts provided NumPy `ndarray` into PyArrow's `array` while utilizing
     both Arrow's natively supported types as well as custom extension types:
 
@@ -110,10 +122,14 @@ def convert_to_pyarrow_array(column_values: np.ndarray, column_name: str) -> pa.
         # Since Arrow does NOT support tensors (aka multidimensional arrays) natively,
         # we have to make sure that we handle this case utilizing `ArrowTensorArray`
         # extension type
-        if column_name == TENSOR_COLUMN_NAME or _is_ndarray_tensor(column_values):
+        if _should_convert_to_tensor(column_values, column_name):
             from ray.data.extensions.tensor_extension import ArrowTensorArray
 
-            return ArrowTensorArray.from_numpy(column_values, column_name)
+            # Convert to Numpy before creating instance of `ArrowTensorArray` to
+            # align tensor shapes falling back to ragged ndarray only if necessary
+            np_column_values = convert_to_numpy(column_values)
+
+            return ArrowTensorArray.from_numpy(np_column_values, column_name)
         else:
             return _convert_to_pyarrow_native_array(column_values, column_name)
 
@@ -153,21 +169,23 @@ def convert_to_pyarrow_array(column_values: np.ndarray, column_name: str) -> pa.
                     "= False)"
                 )
 
-        if not object_ext_type_fallback_allowed:
-            # To avoid logging following warning for every block it's
-            # only going to be logged in following cases
-            #   - When fallback is disallowed, and
-            #   - Fallback configuration is not set or set to false, and
-            #   - It's being logged for the first time
-            if not enable_fallback_config and log_once(
-                "_fallback_to_arrow_object_extension_type_warning"
-            ):
-                logger.warning(
-                    f"Failed to convert column '{column_name}' into pyarrow "
-                    f"array due to: {ace}; {object_ext_type_detail}",
-                    exc_info=ace,
-                )
+        # To avoid logging following warning for every block it's
+        # only going to be logged in following cases
+        #   - It's being logged for the first time, and
+        #   - When config enabling fallback is not set explicitly (in this case
+        #       fallback will still occur by default for compatibility reasons), or
+        #   - Fallback is disallowed (either explicitly or due to use of incompatible
+        #       Pyarrow version)
+        if (
+            enable_fallback_config is None or not object_ext_type_fallback_allowed
+        ) and log_once("_fallback_to_arrow_object_extension_type_warning"):
+            logger.warning(
+                f"Failed to convert column '{column_name}' into pyarrow "
+                f"array due to: {ace}; {object_ext_type_detail}",
+                exc_info=ace,
+            )
 
+        if not object_ext_type_fallback_allowed:
             # If `ArrowPythonObjectType` is not supported raise original exception
             raise
 
@@ -175,49 +193,96 @@ def convert_to_pyarrow_array(column_values: np.ndarray, column_name: str) -> pa.
         return ArrowPythonObjectArray.from_objects(column_values)
 
 
+def _should_convert_to_tensor(
+    column_values: Union[List[Any], np.ndarray, ArrayLike], column_name: str
+) -> bool:
+    """We convert passed in column values into a tensor representation (involving
+    Arrow/Pandas extension types) in either of the following cases:
+
+      - Column name is `TENSOR_COLUMN_NAME` (for compatibility)
+      - Provided column values are already represented by a tensor (either
+        numpy, torch, etc)
+      - Provided column values is a list of ndarrays (we do this for compatibility
+        with previously existing behavior where all column values were blindly converted
+        to Numpy leading to list of ndarrays being converted a tensor)
+    """
+
+    return (
+        column_name == TENSOR_COLUMN_NAME
+        or _is_tensor(column_values)
+        or (len(column_values) > 0 and isinstance(column_values[0], np.ndarray))
+    )
+
+
 def _convert_to_pyarrow_native_array(
-    column_values: np.ndarray, column_name: str
+    column_values: Union[List[Any], np.ndarray], column_name: str
 ) -> pa.Array:
     """Converts provided NumPy `ndarray` into PyArrow's `array` while only utilizing
     Arrow's natively supported types (ie no custom extension types)"""
 
     try:
+        # NOTE: Python's `datetime` only supports precision up to us and could
+        #       inadvertently lose precision when handling Pandas `Timestamp` type.
+        #       To avoid that we convert provided list of `datetime` objects into
+        #       ndarray of `np.datetime64`
+        if len(column_values) > 0 and isinstance(column_values[0], datetime):
+            column_values = _convert_datetime_to_np_datetime(column_values)
+
         # NOTE: We explicitly infer PyArrow `DataType` so that
         #       we can perform upcasting to be able to accommodate
         #       blocks that are larger than 2Gb in size (limited
         #       by int32 offsets used by Arrow internally)
-        dtype = _infer_pyarrow_type(column_values)
+        pa_type = _infer_pyarrow_type(column_values)
 
-        if pa.types.is_timestamp(dtype):
-            assert np.issubdtype(column_values.dtype, np.datetime64)
-            numpy_precision, _ = np.datetime_data(column_values.dtype)
-            arrow_precision = dtype.unit
-            if arrow_precision != numpy_precision:
-                # Arrow supports fewer timestamp resolutions than NumPy. So, if Arrow
-                # doesn't support the resolution, we need to cast the NumPy array to a
-                # different type. This can be a lossy conversion.
-                column_values = column_values.astype(f"datetime64[{arrow_precision}]")
-
-                if log_once(f"column_{column_name}_timestamp_warning"):
-                    logger.warning(
-                        f"Converting a {numpy_precision!r} precision datetime NumPy "
-                        f"array to '{arrow_precision}' precision Arrow timestamp. This "
-                        "conversion occurs because Arrow supports fewer precisions "
-                        "than Arrow and might result in a loss of precision or "
-                        "unrepresentable values."
-                    )
+        if pa_type and pa.types.is_timestamp(pa_type):
+            # NOTE: Quirky Arrow behavior will coerce unsupported Numpy `datetime64`
+            #       precisions that are nested inside a list type, but won't do it,
+            #       if these are top-level ndarray. To work this around we have to cast
+            #       ndarray values manually
+            if isinstance(column_values, np.ndarray):
+                column_values = _coerce_np_datetime_to_pa_timestamp_precision(
+                    column_values, pa_type, column_name
+                )
 
         logger.log(
             logging.getLevelName("TRACE"),
-            f"Inferred dtype of '{dtype}' for column '{column_name}'",
+            f"Inferred dtype of '{pa_type}' for column '{column_name}'",
         )
 
-        return pa.array(column_values, type=dtype)
+        return pa.array(column_values, type=pa_type)
     except Exception as e:
         raise ArrowConversionError(str(column_values)) from e
 
 
-def _infer_pyarrow_type(column_values: np.ndarray) -> Optional[pa.DataType]:
+def _coerce_np_datetime_to_pa_timestamp_precision(
+    column_values: np.ndarray, dtype: pa.TimestampType, column_name: str
+):
+    assert np.issubdtype(column_values.dtype, np.datetime64)
+
+    numpy_precision, _ = np.datetime_data(column_values.dtype)
+    arrow_precision = dtype.unit
+
+    if arrow_precision != numpy_precision:
+        # Arrow supports fewer timestamp resolutions than NumPy. So, if Arrow
+        # doesn't support the resolution, we need to cast the NumPy array to a
+        # different type. This can be a lossy conversion.
+        column_values = column_values.astype(f"datetime64[{arrow_precision}]")
+
+        if log_once(f"column_{column_name}_timestamp_warning"):
+            logger.warning(
+                f"Converting a {numpy_precision!r} precision datetime NumPy "
+                f"array to '{arrow_precision}' precision Arrow timestamp. This "
+                "conversion occurs because Arrow supports fewer precisions "
+                "than Arrow and might result in a loss of precision or "
+                "unrepresentable values."
+            )
+
+    return column_values
+
+
+def _infer_pyarrow_type(
+    column_values: Union[List[Any], np.ndarray]
+) -> Optional[pa.DataType]:
     """Infers target Pyarrow `DataType` based on the provided
     columnar values.
 
@@ -246,8 +311,10 @@ def _infer_pyarrow_type(column_values: np.ndarray) -> Optional[pa.DataType]:
     # `pyarrow.infer_type` leaks memory if you pass an array with a datetime64 dtype.
     # To avoid this, we handle datetime64 dtypes separately.
     # See https://github.com/apache/arrow/issues/45493.
-    if np.issubdtype(column_values.dtype, np.datetime64):
-        return _infer_pyarrow_type_from_datetime_dtype(column_values.dtype)
+    dtype_with_timestamp_type = _try_infer_pa_timestamp_type(column_values)
+
+    if dtype_with_timestamp_type is not None:
+        return dtype_with_timestamp_type
 
     inferred_pa_dtype = pa.infer_type(column_values)
 
@@ -276,27 +343,43 @@ def _infer_pyarrow_type(column_values: np.ndarray) -> Optional[pa.DataType]:
     return inferred_pa_dtype
 
 
-def _infer_pyarrow_type_from_datetime_dtype(dtype: np.dtype) -> pa.TimestampType:
-    assert np.issubdtype(dtype, np.datetime64)
-    numpy_precision, _ = np.datetime_data(dtype)
+_NUMPY_TO_ARROW_PRECISION_MAP = {
+    # Coarsest timestamp precision in Arrow is seconds
+    "Y": "s",
+    "D": "s",
+    "M": "s",
+    "W": "s",
+    "h": "s",
+    "m": "s",
+    "s": "s",
+    "ms": "ms",
+    "us": "us",
+    "ns": "ns",
+    # Finest timestamp precision in Arrow is nanoseconds
+    "ps": "ns",
+    "fs": "ns",
+    "as": "ns",
+}
 
-    # For day precision, use Arrow's date32 type since it's optimized for dates
-    if numpy_precision == "D":
-        arrow_type = pa.date32()
-    # For precisions coarser than seconds (year, month, week, hour, minute), use Arrow
-    # seconds unit since it's the coarsest Arrow timestamp supports
-    elif numpy_precision in {"Y", "M", "W", "h", "m"}:
-        arrow_type = pa.timestamp("s")
-    # For precisions finer than nanoseconds (pico, femto, atto), use Arrow
-    # nanoseconds unit since it's the finest Arrow timestamp supports
-    elif numpy_precision in {"ps", "fs", "as"}:
-        arrow_type = pa.timestamp("ns")
-    # For second, milli, micro and nano precisions, use matching Arrow unit
-    # since they are directly supported
+
+def _try_infer_pa_timestamp_type(
+    column_values: Union[List[Any], np.ndarray]
+) -> Optional[pa.DataType]:
+    if isinstance(column_values, list) and len(column_values) > 0:
+        # In case provided column values is a list of elements, this
+        # utility assumes homogeneity (in line with the behavior of Arrow
+        # type inference utils)
+        element_type = _try_infer_pa_timestamp_type(column_values[0])
+        return pa.list_(element_type) if element_type else None
+
+    if isinstance(column_values, np.ndarray) and np.issubdtype(
+        column_values.dtype, np.datetime64
+    ):
+        np_precision, _ = np.datetime_data(column_values.dtype)
+        return pa.timestamp(_NUMPY_TO_ARROW_PRECISION_MAP[np_precision])
+
     else:
-        arrow_type = pa.timestamp(numpy_precision)
-
-    return arrow_type
+        return None
 
 
 @DeveloperAPI
@@ -488,6 +571,13 @@ class ArrowTensorType(_BaseFixedShapeArrowTensorType):
         shape = tuple(json.loads(serialized))
         return cls(shape, storage_type.value_type)
 
+    def __eq__(self, other):
+        return (
+            isinstance(other, ArrowTensorType)
+            and other.shape == self.shape
+            and other.scalar_type == self.scalar_type
+        )
+
 
 @PublicAPI(stability="alpha")
 class ArrowTensorTypeV2(_BaseFixedShapeArrowTensorType):
@@ -510,6 +600,13 @@ class ArrowTensorTypeV2(_BaseFixedShapeArrowTensorType):
     def __arrow_ext_deserialize__(cls, storage_type, serialized):
         shape = tuple(json.loads(serialized))
         return cls(shape, storage_type.value_type)
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, ArrowTensorTypeV2)
+            and other.shape == self.shape
+            and other.scalar_type == self.scalar_type
+        )
 
 
 if _arrow_extension_scalars_are_subclassable():
@@ -640,12 +737,24 @@ class ArrowTensorArray(_ArrowTensorScalarIndexingMixin, pa.ExtensionArray):
 
                 # ndarray stacking may fail if the arrays are heterogeneously-shaped.
                 arr = np.array(arr, dtype=object)
+
         if not isinstance(arr, np.ndarray):
             raise ValueError(
                 f"Must give ndarray or iterable of ndarrays, got {type(arr)} {arr}"
             )
 
         try:
+            timestamp_dtype = _try_infer_pa_timestamp_type(arr)
+
+            if timestamp_dtype:
+                # NOTE: Quirky Arrow behavior will coerce unsupported Numpy `datetime64`
+                #       precisions that are nested inside a list type, but won't do it,
+                #       if these are top-level ndarray. To work this around we have to cast
+                #       ndarray values manually
+                arr = _coerce_np_datetime_to_pa_timestamp_precision(
+                    arr, timestamp_dtype, column_name
+                )
+
             return cls._from_numpy(arr)
         except Exception as e:
             data_str = ""

--- a/python/ray/air/util/tensor_extensions/utils.py
+++ b/python/ray/air/util/tensor_extensions/utils.py
@@ -5,11 +5,13 @@ import numpy as np
 
 from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.util import PublicAPI
+from ray.util.annotations import DeveloperAPI
 
 if TYPE_CHECKING:
     from pandas.core.dtypes.generic import ABCSeries
 
 
+@DeveloperAPI(stability="beta")
 class ArrayLike(Protocol):
     """Protocol matching ndarray-like objects (like torch.Tensor)"""
 
@@ -20,6 +22,7 @@ class ArrayLike(Protocol):
         ...
 
 
+@DeveloperAPI(stability="beta")
 def is_ndarray_like(value: ArrayLike) -> bool:
     """Checks whether objects are ndarray-like (for ex, torch.Tensor)
     but NOT and ndarray itself"""

--- a/python/ray/air/util/tensor_extensions/utils.py
+++ b/python/ray/air/util/tensor_extensions/utils.py
@@ -1,12 +1,69 @@
 import warnings
-from typing import TYPE_CHECKING, Any, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence, Union, List, Protocol
 
 import numpy as np
 
+from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.util import PublicAPI
 
 if TYPE_CHECKING:
     from pandas.core.dtypes.generic import ABCSeries
+
+
+class ArrayLike(Protocol):
+    """Protocol matching ndarray-like objects (like torch.Tensor)"""
+
+    def __array__(self):
+        ...
+
+    def __len__(self):
+        ...
+
+
+def is_ndarray_like(value: ArrayLike) -> bool:
+    """Checks whether objects are ndarray-like (for ex, torch.Tensor)
+    but NOT and ndarray itself"""
+    return (
+        hasattr(value, "__array__")
+        and hasattr(value, "__len__")
+        and not isinstance(value, np.ndarray)
+    )
+
+
+def _is_arrow_array(value: ArrayLike) -> bool:
+    import pyarrow as pa
+
+    return isinstance(value, (pa.Array, pa.ChunkedArray))
+
+
+def _should_convert_to_tensor(
+    column_values: Union[List[Any], np.ndarray, ArrayLike], column_name: str
+) -> bool:
+    assert len(column_values) > 0
+
+    # We convert passed in column values into a tensor representation (involving
+    # Arrow/Pandas extension types) in either of the following cases:
+    return (
+        # - Column name is `TENSOR_COLUMN_NAME` (for compatibility)
+        column_name == TENSOR_COLUMN_NAME
+        # - Provided column values are already represented by a Numpy tensor (ie
+        #   ndarray with ndim > 1)
+        or _is_ndarray_tensor(column_values)
+        # - Provided collection is already implementing Ndarray protocol like
+        #   `torch.Tensor`, `pd.Series`, etc (but *excluding* `pyarrow.Array`,
+        #   `pyarrow.ChunkedArray`)
+        or _is_ndarray_like_not_pyarrow_array(column_values)
+        # - Provided column values is a list of a) ndarrays or b) ndarray-like objects
+        #   (excluding Pyarrow arrays). This is done for compatibility with previous
+        #   existing behavior where all column values were blindly converted to Numpy
+        #   leading to list of ndarrays being converted a tensor):
+        or isinstance(column_values[0], np.ndarray)
+        or _is_ndarray_like_not_pyarrow_array(column_values[0])
+    )
+
+
+def _is_ndarray_like_not_pyarrow_array(column_values):
+    return is_ndarray_like(column_values) and not _is_arrow_array(column_values)
 
 
 def _is_ndarray_tensor(t: Any) -> bool:

--- a/python/ray/air/util/tensor_extensions/utils.py
+++ b/python/ray/air/util/tensor_extensions/utils.py
@@ -9,20 +9,21 @@ if TYPE_CHECKING:
     from pandas.core.dtypes.generic import ABCSeries
 
 
-def _is_ndarray_tensor(arr: np.ndarray) -> bool:
-    """Return whether the provided NumPy ndarray is comprised of tensors.
+def _is_ndarray_tensor(t: Any) -> bool:
+    """Return whether provided ndarray is a tensor (ie ndim > 1).
 
     NOTE: Tensor is defined as a NumPy array such that `len(arr.shape) > 1`
     """
 
+    if not isinstance(t, np.ndarray):
+        return False
+
     # Case of uniform-shaped (ie non-ragged) tensor
-    if arr.ndim > 1:
+    if t.ndim > 1:
         return True
 
     # Case of ragged tensor (as produced by `create_ragged_ndarray` utility)
-    elif (
-        arr.dtype.type is np.object_ and len(arr) > 0 and isinstance(arr[0], np.ndarray)
-    ):
+    elif t.dtype.type is np.object_ and len(t) > 0 and isinstance(t[0], np.ndarray):
         return True
 
     return False

--- a/python/ray/data/_internal/numpy_support.py
+++ b/python/ray/data/_internal/numpy_support.py
@@ -1,47 +1,57 @@
-import collections
 import logging
+import typing
 from datetime import datetime
-from typing import Any, Dict, List, Union
+from typing import Any, List, Union
 
 import numpy as np
 
-from ray.air.util.tensor_extensions.utils import create_ragged_ndarray
+from ray.air.util.tensor_extensions.utils import (
+    create_ragged_ndarray,
+    _is_ndarray_tensor,
+)
 from ray.data._internal.util import _truncated_repr
 
 logger = logging.getLogger(__name__)
 
 
-def is_array_like(value: Any) -> bool:
-    """Checks whether objects are array-like, excluding numpy scalars."""
+class ArrayLike(typing.Protocol):
+    """Protocol matching ndarray-like objects (like torch.Tensor)"""
 
-    return hasattr(value, "__array__") and hasattr(value, "__len__")
+    def __array__(self):
+        ...
+
+    def __len__(self):
+        ...
 
 
-def is_valid_udf_return(udf_return_col: Any) -> bool:
+def _is_tensor(t: Union[List[Any], np.ndarray, ArrayLike]):
+    """Checks whether provided value is a Numpy or Array-like tensor (for ex, torch.Tensor)"""
+
+    return _is_ndarray_tensor(t) or _is_ndarray_like(t)
+
+
+def _is_ndarray_like(value: ArrayLike) -> bool:
+    """Checks whether objects are ndarray-like (for ex, torch.Tensor)
+    but NOT and ndarray itself"""
+
+    return (
+        not isinstance(value, np.ndarray)
+        and hasattr(value, "__array__")
+        and hasattr(value, "__len__")
+    )
+
+
+def _is_valid_column_values(column_values: Any) -> bool:
     """Check whether a UDF column is valid.
 
     Valid columns must either be a list of elements, or an array-like object.
     """
 
-    return isinstance(udf_return_col, list) or is_array_like(udf_return_col)
-
-
-def is_nested_list(udf_return_col: List[Any]) -> bool:
-    for e in udf_return_col:
-        if isinstance(e, list):
-            return True
-    return False
-
-
-def validate_numpy_batch(batch: Union[Dict[str, np.ndarray], Dict[str, list]]) -> None:
-    if not isinstance(batch, collections.abc.Mapping) or any(
-        not is_valid_udf_return(col) for col in batch.values()
-    ):
-        raise ValueError(
-            "Batch must be an ndarray or dictionary of ndarrays when converting "
-            f"a numpy batch to a block, got: {type(batch)} "
-            f"({_truncated_repr(batch)})"
-        )
+    return (
+        isinstance(column_values, list)
+        or isinstance(column_values, np.ndarray)
+        or _is_ndarray_like(column_values)
+    )
 
 
 def _detect_highest_datetime_precision(datetime_list: List[datetime]) -> str:
@@ -114,8 +124,8 @@ def _convert_to_datetime64(dt: datetime, precision: str) -> np.datetime64:
         return np.datetime64(dt).astype(f"datetime64[{precision}]")
 
 
-def _convert_datetime_list_to_array(datetime_list: List[datetime]) -> np.ndarray:
-    """Convert a list of datetime objects to a NumPy array of datetime64 with proper
+def _convert_datetime_to_np_datetime(datetime_list: List[datetime]) -> np.ndarray:
+    """Convert a list of datetime objects to a NumPy array of datetime64 with nanosecond
     precision.
 
     Args:
@@ -159,7 +169,7 @@ def convert_to_numpy(column_values: Any) -> np.ndarray:
             return np.expand_dims(column_values[0], axis=0)
 
         if all(isinstance(elem, datetime) for elem in column_values):
-            return _convert_datetime_list_to_array(column_values)
+            return _convert_datetime_to_np_datetime(column_values)
 
         # Try to convert list values into an numpy array via
         # np.array(), so users don't need to manually cast.
@@ -167,7 +177,7 @@ def convert_to_numpy(column_values: Any) -> np.ndarray:
         # `str` are also Iterable.
         try:
             # Convert array-like objects (like torch.Tensor) to `np.ndarray`s
-            if all(is_array_like(e) for e in column_values):
+            if all(_is_ndarray_like(e) for e in column_values):
                 # Use np.asarray() instead of np.array() to avoid copying if possible.
                 column_values = [np.asarray(e) for e in column_values]
 
@@ -212,7 +222,7 @@ def convert_to_numpy(column_values: Any) -> np.ndarray:
                 f"({_truncated_repr(column_values)}): {e}."
             ) from e
 
-    elif is_array_like(column_values):
+    elif _is_ndarray_like(column_values):
         # Converts other array-like objects such as torch.Tensor.
         try:
             # Use np.asarray() instead of np.array() to avoid copying if possible.

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.air.util.tensor_extensions.utils import _is_ndarray_tensor
-from ray.data._internal.numpy_support import convert_to_numpy, validate_numpy_batch
+from ray.data._internal.numpy_support import convert_to_numpy
 from ray.data._internal.row import TableRow
 from ray.data._internal.table_block import TableBlockAccessor, TableBlockBuilder
 from ray.data._internal.util import find_partitions
@@ -285,15 +285,6 @@ class PandasBlockAccessor(TableBlockAccessor):
         # Set `preserve_index=False` so that Arrow doesn't add a '__index_level_0__'
         # column to the resulting table.
         return pyarrow.Table.from_pandas(self._table, preserve_index=False)
-
-    @staticmethod
-    def numpy_to_block(
-        batch: Union[Dict[str, np.ndarray], Dict[str, list]],
-    ) -> "pandas.DataFrame":
-        validate_numpy_batch(batch)
-
-        block = PandasBlockBuilder._table_from_pydict(batch)
-        return block
 
     def num_rows(self) -> int:
         return self._table.shape[0]

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -36,7 +36,7 @@ from ray.data._internal.logical.operators.map_operator import (
     MapRows,
     Project,
 )
-from ray.data._internal.numpy_support import is_valid_udf_return
+from ray.data._internal.numpy_support import _is_valid_column_values
 from ray.data._internal.util import _truncated_repr
 from ray.data.block import (
     Block,
@@ -359,7 +359,7 @@ def _validate_batch_output(batch: Block) -> None:
 
     if isinstance(batch, collections.abc.Mapping):
         for key, value in list(batch.items()):
-            if not is_valid_udf_return(value):
+            if not _is_valid_column_values(value):
                 raise ValueError(
                     f"Error validating {_truncated_repr(batch)}: "
                     "The `fn` you passed to `map_batches` returned a "

--- a/python/ray/data/_internal/table_block.py
+++ b/python/ray/data/_internal/table_block.py
@@ -18,7 +18,6 @@ import numpy as np
 
 from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.data._internal.block_builder import BlockBuilder
-from ray.data._internal.numpy_support import convert_to_numpy, _is_ndarray_like
 from ray.data._internal.row import TableRow
 from ray.data._internal.size_estimator import SizeEstimator
 from ray.data._internal.util import MiB, keys_equal, NULL_SENTINEL, is_nan
@@ -92,10 +91,8 @@ class TableBlockBuilder(BlockBuilder):
             self._column_names = item_column_names
 
         for key, value in item.items():
-            # Convert passed tensor-like values into ndarrays
-            if _is_ndarray_like(value):
-                value = convert_to_numpy(value)
             self._columns[key].append(value)
+
         self._num_rows += 1
         self._compact_if_needed()
         self._uncompacted_size.add(item)

--- a/python/ray/data/_internal/table_block.py
+++ b/python/ray/data/_internal/table_block.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.data._internal.block_builder import BlockBuilder
-from ray.data._internal.numpy_support import is_array_like
+from ray.data._internal.numpy_support import convert_to_numpy, _is_ndarray_like
 from ray.data._internal.row import TableRow
 from ray.data._internal.size_estimator import SizeEstimator
 from ray.data._internal.util import MiB, keys_equal, NULL_SENTINEL, is_nan
@@ -92,8 +92,9 @@ class TableBlockBuilder(BlockBuilder):
             self._column_names = item_column_names
 
         for key, value in item.items():
-            if is_array_like(value) and not isinstance(value, np.ndarray):
-                value = np.array(value)
+            # Convert passed tensor-like values into ndarrays
+            if _is_ndarray_like(value):
+                value = convert_to_numpy(value)
             self._columns[key].append(value)
         self._num_rows += 1
         self._compact_if_needed()
@@ -191,6 +192,7 @@ class TableBlockAccessor(BlockAccessor):
         # Always promote Arrow blocks to pandas for consistency, since
         # we lazily convert pandas->Arrow internally for efficiency.
         default = self.to_pandas()
+
         return default
 
     def column_names(self) -> List[str]:

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -414,9 +414,9 @@ class BlockAccessor:
     @classmethod
     def batch_to_pandas_block(cls, batch: Dict[str, Any]) -> Block:
         """Create a Pandas block from user-facing data formats."""
-        from ray.data._internal.pandas_block import PandasBlockAccessor
+        from ray.data._internal.pandas_block import PandasBlockBuilder
 
-        return PandasBlockAccessor.numpy_to_block(batch)
+        return PandasBlockBuilder._table_from_pydict(batch)
 
     @staticmethod
     def for_block(block: Block) -> "BlockAccessor[T]":

--- a/python/ray/data/tests/test_arrow_block.py
+++ b/python/ray/data/tests/test_arrow_block.py
@@ -13,7 +13,9 @@ from pyarrow import parquet as pq
 
 import ray
 from ray._private.test_utils import run_string_as_driver
-from ray.air.util.tensor_extensions.arrow import ArrowTensorArray
+from ray.air.util.tensor_extensions.arrow import (
+    ArrowTensorArray,
+)
 from ray.data import DataContext
 from ray.data._internal.arrow_block import ArrowBlockAccessor, ArrowBlockBuilder
 from ray.data._internal.arrow_ops.transform_pyarrow import combine_chunked_array

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -110,7 +110,9 @@ def test_callable_classes(shutdown_only):
 
     # map
     actor_reuse = ds.map(StatefulFn, concurrency=1).take()
-    assert sorted(extract_values("id", actor_reuse)) == list(range(10)), actor_reuse
+    assert sorted(extract_values("id", actor_reuse)) == [
+        [v] for v in list(range(10))
+    ], actor_reuse
 
     class StatefulFn:
         def __init__(self):

--- a/python/ray/data/tests/test_numpy_support.py
+++ b/python/ray/data/tests/test_numpy_support.py
@@ -92,7 +92,10 @@ DATETIME64_NANOSEC_PRECISION = np.datetime64("2024-01-01T01:01:01.000000001", "n
 @pytest.mark.parametrize(
     "data,expected_output",
     [
-        ([DATETIME_DAY_PRECISION], np.array([DATETIME64_DAY_PRECISION])),
+        (
+            [DATETIME_DAY_PRECISION],
+            np.array([DATETIME64_DAY_PRECISION], dtype="datetime64[s]"),
+        ),
         ([DATETIME_HOUR_PRECISION], np.array([DATETIME64_HOUR_PRECISION])),
         ([DATETIME_MIN_PRECISION], np.array([DATETIME64_MIN_PRECISION])),
         ([DATETIME_SEC_PRECISION], np.array([DATETIME64_SEC_PRECISION])),
@@ -119,7 +122,10 @@ DATETIME64_NANOSEC_PRECISION = np.datetime64("2024-01-01T01:01:01.000000001", "n
                 dtype="datetime64[s]",
             ),
         ),
-        ([PANDAS_DAY_PRECISION], np.array([DATETIME64_DAY_PRECISION])),
+        (
+            [PANDAS_DAY_PRECISION],
+            np.array([DATETIME64_DAY_PRECISION], dtype="datetime64[s]"),
+        ),
         ([PANDAS_HOUR_PRECISION], np.array([DATETIME64_HOUR_PRECISION])),
         ([PANDAS_MIN_PRECISION], np.array([DATETIME64_MIN_PRECISION])),
         ([PANDAS_SEC_PRECISION], np.array([DATETIME64_SEC_PRECISION])),

--- a/python/ray/data/tests/test_strict_mode.py
+++ b/python/ray/data/tests/test_strict_mode.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 import ray
+from ray.data.context import DataContext
 from ray.data.tests.conftest import *  # noqa
 from ray.tests.conftest import *  # noqa
 
@@ -143,15 +144,18 @@ def test_strict_default_batch_format(ray_start_regular_shared):
     assert isinstance(batch["id"], np.ndarray), batch
 
 
-def test_strict_tensor_support(ray_start_regular_shared):
-    ds = ray.data.from_items([np.ones(10), np.ones(10)])
-    assert np.array_equal(ds.take()[0]["item"], np.ones(10))
+@pytest.mark.parametrize("shape", [(10,), (10, 2)])
+def test_strict_tensor_support(ray_start_regular_shared, restore_data_context, shape):
+    DataContext.get_current().enable_fallback_to_arrow_object_ext_type = False
+
+    ds = ray.data.from_items([np.ones(shape), np.ones(shape)])
+    assert np.array_equal(ds.take()[0]["item"], np.ones(shape))
 
     ds = ds.map(lambda x: {"item": x["item"] * 2})
-    assert np.array_equal(ds.take()[0]["item"], 2 * np.ones(10))
+    assert np.array_equal(ds.take()[0]["item"], 2 * np.ones(shape))
 
     ds = ds.map_batches(lambda x: {"item": x["item"] * 2})
-    assert np.array_equal(ds.take()[0]["item"], 4 * np.ones(10))
+    assert np.array_equal(ds.take()[0]["item"], 4 * np.ones(shape))
 
 
 def test_strict_value_repr(ray_start_regular_shared):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Context
---

This change skips unnecessary blanket conversion to Numpy (applied to every chunk of data) before converting to Pyarrow.

That creates challenges when batches contain Arrow native `Scalars` which because of that are ultimately being serialized as `ArrowPythonObjectType` extension.

Changes
---

We revisit following conversion aspects and convert to Numpy passed in column values only in following cases:

 - Column name is `TENSOR_COLUMN_NAME` (for compatibility)
 - Provided column values are already represented by a tensor (either numpy, torch, etc)
- Provided column values is a list of ndarrays (we do this for compatibility with previously existing behavior where all column values were blindly converted to Numpy leading to list of ndarrays being converted a tensor)
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
