### PR TITLE
[core] Remove "serve" and "tune" dependencies from `test_runtime_env_complicated`

### DIFF
--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -923,9 +923,8 @@ def test_e2e_complex(call_ray_start, tmp_path):
 
     1.  Run a Ray Client job with both working_dir and pip specified. Check the
         environment using imports and file reads in tasks and actors.
-    2.  On the same cluster, run a job as above but using the Ray Summit
-        2021 demo's pip requirements.txt.  Also, check that per-task and
-        per-actor pip requirements work, all using the job's working_dir.
+    2.  On the same cluster, run another job with a requirements.txt file and
+        overriding per-actor and per-task pip requirements.
     """
     # Create a file to use to test working_dir
     specific_path = tmp_path / "test"
@@ -963,8 +962,6 @@ def test_e2e_complex(call_ray_start, tmp_path):
         a = TestActor.remote()
         assert ray.get(a.test.remote()) == "Hello"
 
-    # pip requirements file from Ray Summit 2021 demo; updated to be compatible with
-    # recent python versions
     requirement_path = tmp_path / "requirements.txt"
     requirement_path.write_text(
         "\n".join(
@@ -978,7 +975,7 @@ def test_e2e_complex(call_ray_start, tmp_path):
         )
     )
 
-    # Start a new job on the same cluster using the Summit 2021 requirements.
+    # Start a new job on the same cluster using the requirements file.
     with ray.client(f"localhost:{CLIENT_SERVER_PORT}").env(
         {"working_dir": str(tmp_path), "pip": str(requirement_path)}
     ).connect():

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -587,10 +587,10 @@ def test_pip_task(shutdown_only, pip_as_str, tmp_path):
     reason="This test is only run on linux CI machines.",
 )
 @pytest.mark.parametrize("option", ["conda", "pip"])
-def test_conda_pip_extras_ray_serve(shutdown_only, option):
+def test_conda_pip_extras_ray_default(shutdown_only, option):
     """Tests that ray[extras] can be included as a conda/pip dependency."""
     ray.init()
-    pip = ["pip-install-test==0.5", "ray[serve]"]
+    pip = ["pip-install-test==0.5", "ray[default]"]
     if option == "conda":
         runtime_env = {"conda": {"dependencies": ["pip", {"pip": pip}]}}
     elif option == "pip":
@@ -969,7 +969,6 @@ def test_e2e_complex(call_ray_start, tmp_path):
     requirement_path.write_text(
         "\n".join(
             [
-                "ray[serve, tune]",
                 "PyGithub",
                 "xgboost_ray",  # has Ray as a dependency
                 "pandas==1.5.3",
@@ -994,8 +993,6 @@ def test_e2e_complex(call_ray_start, tmp_path):
         @ray.remote
         def test_import():
             import ray  # noqa
-            from ray import serve  # noqa
-            from ray import tune  # noqa
             import typer  # noqa
             import xgboost_ray  # noqa
 
@@ -1008,8 +1005,6 @@ def test_e2e_complex(call_ray_start, tmp_path):
         class TestActor:
             def test(self):
                 import ray  # noqa
-                from ray import serve  # noqa
-                from ray import tune  # noqa
                 import typer  # noqa
                 import xgboost_ray  # noqa
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

- Replaced `serve` with `default` for the cause testing extra installs.
- Removed the `tune` and `serve` installs from one of the tests because it is covered by other test cases.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
