### PR TITLE
[core] unblocking macos tests by pinning aiohappyeyeballs to version 2.4.8

### DIFF
--- a/ci/build/test-wheels.sh
+++ b/ci/build/test-wheels.sh
@@ -94,7 +94,7 @@ if [[ "$platform" == "macosx" ]]; then
     "$PIP_CMD" install -q "$PYTHON_WHEEL"
 
     # Install the dependencies to run the tests.
-    "$PIP_CMD" install -q aiohttp aiosignal numpy frozenlist 'pytest==7.0.1' requests proxy.py
+    "$PIP_CMD" install 'aiohappyeyeballs==2.4.8' aiohttp aiosignal numpy frozenlist 'pytest==7.0.1' requests proxy.py
 
     # Run a simple test script to make sure that the wheel works.
     # We set the python path to prefer the directory of the wheel content: https://github.com/ray-project/ray/pull/30090

--- a/python/setup.py
+++ b/python/setup.py
@@ -588,7 +588,7 @@ def build(build_python, build_java, build_cpp):
         )
 
         # runtime env agent dependenceis
-        runtime_env_agent_pip_packages = ["aiohttp"]
+        runtime_env_agent_pip_packages = ["aiohttp", "aiohappyeyeballs==2.4.8"]
         subprocess.check_call(
             [
                 sys.executable,


### PR DESCRIPTION
Unblocking macos tests by pinning aiohappyeyeballs to version 2.4.8 for both runtime_env_agent and dashboard agent. Removing the pip -q flag from macos tests to be able to see which versions are used

The CI failure is trivially reproducible on the following versions on MacOS:

aiohappyeyeballs==2.5.0
python 3.9.1 

I opened an issue with aiohttp to see if they're aware of the breakage. See https://github.com/aio-libs/aiohappyeyeballs/issues/150 for steps to reproduce the issue. 

This should unblock CI for now. 

Closes https://github.com/ray-project/ray/issues/51287

