### PR TITLE
Remove `xgboost_ray` from `test_runtime_env_complicated`

### DIFF
--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -965,7 +965,6 @@ def test_e2e_complex(call_ray_start, tmp_path):
         "\n".join(
             [
                 "PyGithub",
-                "xgboost_ray",  # has Ray as a dependency
                 f"pandas=={pandas_version}",
                 "typer",
                 "aiofiles",
@@ -989,7 +988,6 @@ def test_e2e_complex(call_ray_start, tmp_path):
         def test_import():
             import ray  # noqa
             import typer  # noqa
-            import xgboost_ray  # noqa
 
             return Path("./test").read_text()
 
@@ -1001,7 +999,6 @@ def test_e2e_complex(call_ray_start, tmp_path):
             def test(self):
                 import ray  # noqa
                 import typer  # noqa
-                import xgboost_ray  # noqa
 
                 return Path("./test").read_text()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`xgboost_ray` depends on train which is now removed during core tests.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
