### PR TITLE
Remove unused "nums_reconnect_retry" argument from GCS clients

### DIFF
--- a/python/ray/_private/gcs_aio_client.py
+++ b/python/ray/_private/gcs_aio_client.py
@@ -20,7 +20,6 @@ class GcsAioClient:
         address: str = None,
         loop=None,
         executor=None,
-        nums_reconnect_retry: int = 5,
         cluster_id: Optional[str] = None,
     ):
         # This must be consistent with GcsClient.__cinit__ in _raylet.pyx

--- a/python/ray/_private/usage/usage_lib.py
+++ b/python/ray/_private/usage/usage_lib.py
@@ -854,9 +854,7 @@ def generate_report_data(
     """
     assert cluster_id
 
-    gcs_client = ray._raylet.GcsClient(
-        address=gcs_address, nums_reconnect_retry=20, cluster_id=cluster_id
-    )
+    gcs_client = ray._raylet.GcsClient(address=gcs_address, cluster_id=cluster_id)
 
     cluster_metadata = get_cluster_metadata(gcs_client)
     cluster_status_to_report = get_cluster_status_to_report(gcs_client)

--- a/python/ray/dashboard/agent.py
+++ b/python/ray/dashboard/agent.py
@@ -77,7 +77,6 @@ class DashboardAgent:
         # Used by the agent and sub-modules.
         self.gcs_aio_client = GcsAioClient(
             address=self.gcs_address,
-            nums_reconnect_retry=ray._config.gcs_rpc_server_reconnect_timeout_s(),
             cluster_id=self.cluster_id_hex,
         )
 

--- a/python/ray/dashboard/head.py
+++ b/python/ray/dashboard/head.py
@@ -257,11 +257,9 @@ class DashboardHead:
         gcs_address = self.gcs_address
 
         # Dashboard will handle connection failure automatically
-        self.gcs_client = GcsClient(
-            address=gcs_address, nums_reconnect_retry=0, cluster_id=self.cluster_id_hex
-        )
+        self.gcs_client = GcsClient(address=gcs_address, cluster_id=self.cluster_id_hex)
         self.gcs_aio_client = GcsAioClient(
-            address=gcs_address, nums_reconnect_retry=0, cluster_id=self.cluster_id_hex
+            address=gcs_address, cluster_id=self.cluster_id_hex
         )
         internal_kv._initialize_internal_kv(self.gcs_client)
 

--- a/python/ray/dashboard/modules/event/tests/test_generate_export_events.py
+++ b/python/ray/dashboard/modules/event/tests/test_generate_export_events.py
@@ -163,9 +163,7 @@ async def test_submission_job_export_events(call_ray_start, tmp_path):  # noqa: 
     """
 
     address_info = ray.init(address=call_ray_start)
-    gcs_aio_client = GcsAioClient(
-        address=address_info["gcs_address"], nums_reconnect_retry=0
-    )
+    gcs_aio_client = GcsAioClient(address=address_info["gcs_address"])
     job_manager = JobManager(gcs_aio_client, tmp_path)
 
     # Submit a job.

--- a/python/ray/dashboard/modules/job/tests/conftest.py
+++ b/python/ray/dashboard/modules/job/tests/conftest.py
@@ -20,9 +20,7 @@ def create_ray_cluster(_tracing_startup_hook=None):
 
 def create_job_manager(ray_cluster, tmp_path):
     address_info = ray_cluster
-    gcs_aio_client = GcsAioClient(
-        address=address_info["gcs_address"], nums_reconnect_retry=0
-    )
+    gcs_aio_client = GcsAioClient(address=address_info["gcs_address"])
     return JobManager(gcs_aio_client, tmp_path)
 
 

--- a/python/ray/dashboard/modules/job/tests/test_job_manager.py
+++ b/python/ray/dashboard/modules/job/tests/test_job_manager.py
@@ -58,9 +58,7 @@ async def test_get_scheduling_strategy(
 ):
     monkeypatch.setenv(RAY_JOB_ALLOW_DRIVER_ON_WORKER_NODES_ENV_VAR, "0")
     address_info = ray.init(address=call_ray_start)
-    gcs_aio_client = GcsAioClient(
-        address=address_info["gcs_address"], nums_reconnect_retry=0
-    )
+    gcs_aio_client = GcsAioClient(address=address_info["gcs_address"])
 
     job_manager = JobManager(gcs_aio_client, tmp_path)
 
@@ -104,9 +102,7 @@ async def test_submit_no_ray_address(call_ray_start, tmp_path):  # noqa: F811
     """Test that a job script with an unspecified Ray address works."""
 
     address_info = ray.init(address=call_ray_start)
-    gcs_aio_client = GcsAioClient(
-        address=address_info["gcs_address"], nums_reconnect_retry=0
-    )
+    gcs_aio_client = GcsAioClient(address=address_info["gcs_address"])
     job_manager = JobManager(gcs_aio_client, tmp_path)
 
     init_ray_no_address_script = """
@@ -141,9 +137,7 @@ assert ray.cluster_resources().get('TestResourceKey') == 123
 async def test_get_all_job_info(call_ray_start, tmp_path):  # noqa: F811
     """Test that JobInfo is correctly populated in the GCS get_all_job_info API."""
     address_info = ray.init(address=call_ray_start)
-    gcs_aio_client = GcsAioClient(
-        address=address_info["gcs_address"], nums_reconnect_retry=0
-    )
+    gcs_aio_client = GcsAioClient(address=address_info["gcs_address"])
     job_manager = JobManager(gcs_aio_client, tmp_path)
 
     # Submit a job.
@@ -190,9 +184,7 @@ async def test_get_all_job_info_with_is_running_tasks(call_ray_start):  # noqa: 
     """Test the is_running_tasks bit in the GCS get_all_job_info API."""
 
     address_info = ray.init(address=call_ray_start)
-    gcs_aio_client = GcsAioClient(
-        address=address_info["gcs_address"], nums_reconnect_retry=0
-    )
+    gcs_aio_client = GcsAioClient(address=address_info["gcs_address"])
 
     @ray.remote
     def sleep_forever():
@@ -271,9 +263,7 @@ async def test_get_all_job_info_with_is_running_tasks(call_ray_start):  # noqa: 
 async def test_job_supervisor_log_json(call_ray_start, tmp_path):  # noqa: F811
     """Test JobSupervisor logs are structured JSON logs"""
     address_info = ray.init(address=call_ray_start)
-    gcs_aio_client = GcsAioClient(
-        address=address_info["gcs_address"], nums_reconnect_retry=0
-    )
+    gcs_aio_client = GcsAioClient(address=address_info["gcs_address"])
     job_manager = JobManager(gcs_aio_client, tmp_path)
     job_id = await job_manager.submit_job(
         entrypoint="echo hello 1", submission_id="job_1"
@@ -304,9 +294,7 @@ async def test_job_supervisor_logs_saved(
 ):
     """Test JobSupervisor logs are saved to jobs/supervisor-{submission_id}.log"""
     address_info = ray.init(address=call_ray_start)
-    gcs_aio_client = GcsAioClient(
-        address=address_info["gcs_address"], nums_reconnect_retry=0
-    )
+    gcs_aio_client = GcsAioClient(address=address_info["gcs_address"])
     job_manager = JobManager(gcs_aio_client, tmp_path)
     job_id = await job_manager.submit_job(
         entrypoint="echo hello 1", submission_id="job_1"
@@ -342,9 +330,7 @@ async def test_runtime_env_setup_logged_to_job_driver_logs(
 ):
     """Test runtime env setup messages are logged to jobs driver log"""
     address_info = ray.init(address=call_ray_start)
-    gcs_aio_client = GcsAioClient(
-        address=address_info["gcs_address"], nums_reconnect_retry=0
-    )
+    gcs_aio_client = GcsAioClient(address=address_info["gcs_address"])
     job_manager = JobManager(gcs_aio_client, tmp_path)
 
     job_id = await job_manager.submit_job(

--- a/python/ray/dashboard/utils.py
+++ b/python/ray/dashboard/utils.py
@@ -169,7 +169,6 @@ class DashboardHeadModule(abc.ABC):
         if self._gcs_client is None:
             self._gcs_client = GcsClient(
                 address=self._config.gcs_address,
-                nums_reconnect_retry=0,
                 cluster_id=self._config.cluster_id_hex,
             )
         return self._gcs_client
@@ -179,7 +178,6 @@ class DashboardHeadModule(abc.ABC):
         if self._gcs_aio_client is None:
             self._gcs_aio_client = GcsAioClient(
                 address=self._config.gcs_address,
-                nums_reconnect_retry=0,
                 cluster_id=self._config.cluster_id_hex,
             )
             if not internal_kv._internal_kv_initialized():
@@ -835,7 +833,7 @@ def ray_address_to_api_server_url(address: Optional[str]) -> str:
     """
 
     address = services.canonicalize_bootstrap_address_or_die(address)
-    gcs_client = GcsClient(address=address, nums_reconnect_retry=0)
+    gcs_client = GcsClient(address=address)
 
     ray.experimental.internal_kv._initialize_internal_kv(gcs_client)
     api_server_url = ray._private.utils.internal_kv_get_with_retry(

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -437,7 +437,7 @@ def test_detached_actor_restarts(ray_start_regular_with_external_redis):
 
 def test_gcs_client_reconnect(ray_start_regular_with_external_redis):
     gcs_address = ray._private.worker.global_worker.gcs_client.address
-    gcs_client = ray._raylet.GcsClient(address=gcs_address, nums_reconnect_retry=20)
+    gcs_client = ray._raylet.GcsClient(address=gcs_address)
 
     gcs_client.internal_kv_put(b"a", b"b", True, None)
     assert gcs_client.internal_kv_get(b"a", None) == b"b"
@@ -467,9 +467,7 @@ def test_gcs_aio_client_reconnect(ray_start_regular_with_external_redis):
     passed = [False]
 
     async def async_kv_get():
-        gcs_aio_client = gcs_utils.GcsAioClient(
-            address=gcs_address, nums_reconnect_retry=20
-        )
+        gcs_aio_client = gcs_utils.GcsAioClient(address=gcs_address)
         assert await gcs_aio_client.internal_kv_get(b"a", None) == b"b"
         return True
 

--- a/python/ray/tests/test_gcs_utils.py
+++ b/python/ray/tests/test_gcs_utils.py
@@ -36,7 +36,7 @@ def stop_gcs_server():
 def test_kv_basic(ray_start_regular, monkeypatch):
     monkeypatch.setenv("TEST_RAY_COLLECT_KV_FREQUENCY", "1")
     gcs_address = ray._private.worker.global_worker.gcs_client.address
-    gcs_client = ray._raylet.GcsClient(address=gcs_address, nums_reconnect_retry=0)
+    gcs_client = ray._raylet.GcsClient(address=gcs_address)
     # Wait until all other calls finished
     time.sleep(2)
     # reset the counter
@@ -82,7 +82,7 @@ def test_kv_basic(ray_start_regular, monkeypatch):
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't have signals.")
 def test_kv_timeout(ray_start_regular):
     gcs_address = ray._private.worker.global_worker.gcs_client.address
-    gcs_client = ray._raylet.GcsClient(address=gcs_address, nums_reconnect_retry=0)
+    gcs_client = ray._raylet.GcsClient(address=gcs_address)
 
     assert gcs_client.internal_kv_put(b"A", b"", False, b"") == 1
 
@@ -108,7 +108,7 @@ def test_kv_transient_network_error(shutdown_only, monkeypatch):
     )
     ray.init()
     gcs_address = ray._private.worker.global_worker.gcs_client.address
-    gcs_client = ray._raylet.GcsClient(address=gcs_address, nums_reconnect_retry=0)
+    gcs_client = ray._raylet.GcsClient(address=gcs_address)
 
     gcs_client.internal_kv_put(b"A", b"Hello", True, b"")
     assert gcs_client.internal_kv_get(b"A", b"") == b"Hello"
@@ -161,7 +161,7 @@ async def test_kv_basic_aio(ray_start_regular):
 @pytest.mark.asyncio
 async def test_kv_timeout_aio(ray_start_regular):
     gcs_address = ray._private.worker.global_worker.gcs_client.address
-    gcs_client = gcs_utils.GcsAioClient(address=gcs_address, nums_reconnect_retry=0)
+    gcs_client = gcs_utils.GcsAioClient(address=gcs_address)
 
     with stop_gcs_server():
         with pytest.raises(ray.exceptions.RpcError, match="Deadline Exceeded"):
@@ -264,7 +264,7 @@ async def test_check_liveness(monkeypatch, ray_start_cluster):
 @pytest.mark.asyncio
 async def test_gcs_aio_client_is_async(ray_start_regular):
     gcs_address = ray._private.worker.global_worker.gcs_client.address
-    gcs_client = gcs_utils.GcsAioClient(address=gcs_address, nums_reconnect_retry=0)
+    gcs_client = gcs_utils.GcsAioClient(address=gcs_address)
 
     await gcs_client.internal_kv_put(b"A", b"B", False, b"NS", timeout=2)
     async with async_timeout.timeout(3):

--- a/python/ray/tests/test_memory_pressure.py
+++ b/python/ray/tests/test_memory_pressure.py
@@ -34,7 +34,7 @@ def get_local_state_client():
         hostname, ray_constants.GLOBAL_GRPC_OPTIONS, asynchronous=True
     )
 
-    gcs_aio_client = gcs_utils.GcsAioClient(address=hostname, nums_reconnect_retry=0)
+    gcs_aio_client = gcs_utils.GcsAioClient(address=hostname)
     client = StateDataSourceClient(gcs_channel, gcs_aio_client)
 
     return client

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -148,7 +148,7 @@ def state_source_client(gcs_address):
     gcs_channel = ray._private.utils.init_grpc_channel(
         gcs_address, GRPC_CHANNEL_OPTIONS, asynchronous=True
     )
-    gcs_aio_client = GcsAioClient(address=gcs_address, nums_reconnect_retry=0)
+    gcs_aio_client = GcsAioClient(address=gcs_address)
     client = StateDataSourceClient(
         gcs_channel=gcs_channel, gcs_aio_client=gcs_aio_client
     )

--- a/python/ray/util/collective/collective_group/gloo_util.py
+++ b/python/ray/util/collective/collective_group/gloo_util.py
@@ -273,7 +273,7 @@ class RayInternalKvStore:
         self._group_name = group_name
         self._job_id = ray.get_runtime_context().get_job_id()
         gcs_address = ray._private.worker._global_node.gcs_address
-        self._gcs_client = GcsClient(address=gcs_address, nums_reconnect_retry=10)
+        self._gcs_client = GcsClient(address=gcs_address)
         internal_kv._initialize_internal_kv(self._gcs_client)
 
     def set(self, key: str, data: bytes) -> bool:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This had no effect...

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
