### PR TITLE
[core] Skip kuberay "chaos tests" on premerge

### DIFF
--- a/.buildkite/kuberay.rayci.yml
+++ b/.buildkite/kuberay.rayci.yml
@@ -25,7 +25,6 @@ steps:
       - python
       - docker
       - oss
-      - skip-on-microcheck
       - skip-on-premerge
     instance_type: medium
     commands:

--- a/.buildkite/kuberay.rayci.yml
+++ b/.buildkite/kuberay.rayci.yml
@@ -26,6 +26,7 @@ steps:
       - docker
       - oss
       - skip-on-microcheck
+      - skip-on-premerge
     instance_type: medium
     commands:
       - bash ci/k8s/run-chaos-test.sh {{matrix.fault}} {{matrix.workload}}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

@dayshah is reworking the ray<>kuberay tests, we can decide if we want to keep these at all or make them release tests.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
