### PR TITLE
[cg] Move default device logic into channel utils

### DIFF
--- a/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
@@ -11,7 +11,6 @@ import ray.cluster_utils
 import ray.experimental.collective as collective
 import torch
 import time
-from ray.air._internal import torch_utils
 from ray.dag import InputNode
 from ray.exceptions import RayChannelError, RayTaskError
 from ray.dag.output_node import MultiOutputNode

--- a/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
@@ -19,6 +19,7 @@ from ray.experimental.channel.communicator import (
     Communicator,
     TorchTensorAllocator,
 )
+from ray.experimental.channel.utils import get_default_torch_device
 from ray.experimental.channel.torch_tensor_type import TorchTensorType
 from ray.experimental.channel.nccl_group import _NcclGroup
 from ray._private.test_utils import (
@@ -40,7 +41,7 @@ USE_GPU = bool(os.environ.get("RAY_PYTEST_USE_GPU", 0))
 @ray.remote
 class TorchTensorWorker:
     def __init__(self):
-        self.device = torch_utils.get_devices()[0]
+        self.device = get_default_torch_device(allow_cpu=True)
 
     def init_distributed(self, world_size, rank):
         torch.distributed.init_process_group(
@@ -569,7 +570,7 @@ def test_torch_tensor_custom_comm_inited(ray_start_regular):
                 rank == expected_rank
             ), f"NCCL actor's rank {rank} does not match expected rank {expected_rank}"
             self._rank = rank
-            self._device = torch_utils.get_devices()[0]
+            self._device = get_default_torch_device(allow_cpu=True)
 
         def get_rank(self, actor: ray.actor.ActorHandle) -> int:
             actor_ids = [a._ray_actor_id for a in self._actor_handles]
@@ -703,7 +704,7 @@ def test_torch_tensor_default_comm(ray_start_regular, transports):
                 rank == expected_rank
             ), f"NCCL actor's rank {rank} does not match expected rank {expected_rank}"
             self._rank = rank
-            self._device = torch_utils.get_devices()[0]
+            self._device = get_default_torch_device(allow_cpu=True)
 
         def get_rank(self, actor: ray.actor.ActorHandle) -> int:
             actor_ids = [a._ray_actor_id for a in self._actor_handles]
@@ -850,7 +851,7 @@ def test_torch_tensor_invalid_custom_comm(ray_start_regular):
                 rank == expected_rank
             ), f"NCCL actor's rank {rank} does not match expected rank {expected_rank}"
             self._rank = rank
-            self._device = torch_utils.get_devices()[0]
+            self._device = get_default_torch_device(allow_cpu=True)
 
         def get_rank(self, actor: ray.actor.ActorHandle) -> int:
             actor_ids = [a._ray_actor_id for a in self._actor_handles]

--- a/python/ray/experimental/channel/common.py
+++ b/python/ray/experimental/channel/common.py
@@ -19,6 +19,7 @@ from typing import (
 import ray
 import ray.exceptions
 from ray.experimental.channel.communicator import Communicator
+from ray.experimental.channel.utils import get_default_torch_device
 from ray.experimental.channel.serialization_context import _SerializationContext
 from ray.util.annotations import DeveloperAPI, PublicAPI
 
@@ -162,17 +163,7 @@ class ChannelContext:
     @property
     def torch_device(self) -> "torch.device":
         if self._torch_device is None:
-
-            if not ray.get_gpu_ids():
-                import torch
-
-                # torch_utils defaults to returning GPU 0 if no GPU IDs were assigned
-                # by Ray. We instead want the default to be CPU.
-                self._torch_device = torch.device("cpu")
-
-            from ray.air._internal import torch_utils
-
-            self._torch_device = torch_utils.get_devices()[0]
+            self._torch_device = get_default_torch_device(cuda_only=False)
 
         return self._torch_device
 

--- a/python/ray/experimental/channel/common.py
+++ b/python/ray/experimental/channel/common.py
@@ -163,7 +163,7 @@ class ChannelContext:
     @property
     def torch_device(self) -> "torch.device":
         if self._torch_device is None:
-            self._torch_device = get_default_torch_device(cuda_only=False)
+            self._torch_device = get_default_torch_device(allow_cpu=True)
 
         return self._torch_device
 

--- a/python/ray/experimental/channel/nccl_group.py
+++ b/python/ray/experimental/channel/nccl_group.py
@@ -6,6 +6,7 @@ import ray
 from ray.exceptions import RayChannelError
 from ray.experimental.channel.communicator import Communicator, TorchTensorAllocator
 from ray.experimental.util.types import ReduceOp
+from ray.experimental.channel.utils import get_default_torch_device
 
 if TYPE_CHECKING:
     import cupy as cp
@@ -100,10 +101,8 @@ class _NcclGroup(Communicator):
 
             import cupy as cp
 
-            from ray.air._internal import torch_utils
-
             # TODO(swang): Allow default device to be overridden.
-            device = torch_utils.get_devices()[0]
+            device = get_default_torch_device(cuda_only=True)
             self._cuda_stream = cp.cuda.ExternalStream(
                 cuda_stream, device_id=device.index
             )

--- a/python/ray/experimental/channel/nccl_group.py
+++ b/python/ray/experimental/channel/nccl_group.py
@@ -102,7 +102,7 @@ class _NcclGroup(Communicator):
             import cupy as cp
 
             # TODO(swang): Allow default device to be overridden.
-            device = get_default_torch_device(cuda_only=True)
+            device = get_default_torch_device(allow_cpu=False)
             self._cuda_stream = cp.cuda.ExternalStream(
                 cuda_stream, device_id=device.index
             )

--- a/python/ray/experimental/channel/utils.py
+++ b/python/ray/experimental/channel/utils.py
@@ -95,17 +95,17 @@ def get_actor_node(actor: Optional["ray.actor.ActorHandle"]) -> str:
         )
 
 
-def get_default_torch_device(*, cuda_only: bool) -> "torch.device":
+def get_default_torch_device(*, allow_cpu: bool) -> "torch.device":
     """Get the default torch device inside this actor or driver.
 
     If any GPUs are available, the default device will be cuda:0.
-    Else it will be "cpu" if cuda_only is False.
+    Else it will be "cpu" if allow_cpu is True.
     """
     accelerator_ids = ray.get_runtime_context().get_accelerator_ids()
     if not accelerator_ids.get("GPU", []):
-        if cuda_only:
-            raise RuntimeError("No CUDA device available.")
-        else:
+        if allow_cpu:
             return torch.device("cpu")
+        else:
+            raise RuntimeError("No CUDA device available.")
 
     return torch.device("cuda:0")

--- a/python/ray/experimental/channel/utils.py
+++ b/python/ray/experimental/channel/utils.py
@@ -98,8 +98,11 @@ def get_actor_node(actor: Optional["ray.actor.ActorHandle"]) -> str:
 def get_default_torch_device(*, allow_cpu: bool) -> "torch.device":
     """Get the default torch device inside this actor or driver.
 
-    If any GPUs are available, the default device will be cuda:0.
-    Else it will be "cpu" if allow_cpu is True.
+    If any GPUs are available, the default device will be cuda:0 and we will rely on
+    torch to handle mapping CUDA_VISIBLE_DEVICES to a physical device.
+
+    If no GPUs are available, a CPU device will be returned if allow_cpu is true, else
+    the function will raise a RuntimeError.
     """
     accelerator_ids = ray.get_runtime_context().get_accelerator_ids()
     if not accelerator_ids.get("GPU", []):

--- a/python/ray/experimental/channel/utils.py
+++ b/python/ray/experimental/channel/utils.py
@@ -104,6 +104,8 @@ def get_default_torch_device(*, allow_cpu: bool) -> "torch.device":
     If no GPUs are available, a CPU device will be returned if allow_cpu is true, else
     the function will raise a RuntimeError.
     """
+    import torch
+
     accelerator_ids = ray.get_runtime_context().get_accelerator_ids()
     if not accelerator_ids.get("GPU", []):
         if allow_cpu:

--- a/python/ray/experimental/channel/utils.py
+++ b/python/ray/experimental/channel/utils.py
@@ -94,6 +94,7 @@ def get_actor_node(actor: Optional["ray.actor.ActorHandle"]) -> str:
             )
         )
 
+
 def get_default_torch_device(*, cuda_only: bool) -> "torch.device":
     """Get the default torch device inside this actor or driver.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The motivation of this change is to break the dependency of compiled graphs on Ray AIR (core cannot depend on libraries).

The existing device manager logic that was being used is more complex than we need for compiled graphs. In compiled graphs, we simply want to get the default device as either `"cpu"` in the driver or a CPU-only actor or `"cuda:0"` in an actor with GPUs.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
