### PR TITLE
[RLlib] Stop exposing legacy API at top level

### DIFF
--- a/rllib/__init__.py
+++ b/rllib/__init__.py
@@ -1,18 +1,6 @@
 import logging
 
 from ray._private.usage import usage_lib
-
-# Note: do not introduce unnecessary library dependencies here, e.g. gym.
-# This file is imported from the tune module in order to register RLlib agents.
-from ray.rllib.env.base_env import BaseEnv
-from ray.rllib.env.external_env import ExternalEnv
-from ray.rllib.env.multi_agent_env import MultiAgentEnv
-from ray.rllib.env.vector_env import VectorEnv
-from ray.rllib.evaluation.rollout_worker import RolloutWorker
-from ray.rllib.policy.policy import Policy
-from ray.rllib.policy.sample_batch import SampleBatch
-from ray.rllib.policy.tf_policy import TFPolicy
-from ray.rllib.policy.torch_policy import TorchPolicy
 from ray.tune.registry import register_trainable
 
 
@@ -41,15 +29,3 @@ def _register_all():
 _setup_logger()
 
 usage_lib.record_library_usage("rllib")
-
-__all__ = [
-    "Policy",
-    "TFPolicy",
-    "TorchPolicy",
-    "RolloutWorker",
-    "SampleBatch",
-    "BaseEnv",
-    "MultiAgentEnv",
-    "VectorEnv",
-    "ExternalEnv",
-]


### PR DESCRIPTION
## Why are these changes needed?

We still expose legacy components at RLlib's top level.
This promotes the wrong set of APIs.
Also, for the rest of RLlib, we don't really expose lower-level APIs at higher levels to get around circular imports and to not import libraries that are not always needed.