### PR TITLE
[Dashboard] Fix timezone_utils to deal with daylight savings

### DIFF
--- a/python/ray/dashboard/optional_deps.py
+++ b/python/ray/dashboard/optional_deps.py
@@ -7,6 +7,7 @@ import aiohttp  # noqa: F401
 import aiohttp.web  # noqa: F401
 import aiohttp_cors  # noqa: F401
 import grpc  # noqa: F401
+import tzlocal  # noqa: F401
 
 # These checks have to come first because aiohttp looks
 # for opencensus, too, and raises a different error otherwise.

--- a/python/ray/dashboard/timezone_utils.py
+++ b/python/ray/dashboard/timezone_utils.py
@@ -1,43 +1,5 @@
-import logging
 from datetime import datetime
-
-logger = logging.getLogger(__name__)
-
-timezones = [
-    {"offset": "-12:00", "value": "Etc/+12"},
-    {"offset": "-11:00", "value": "Pacific/Pago_Pago"},
-    {"offset": "-10:00", "value": "Pacific/Honolulu"},
-    {"offset": "-09:00", "value": "America/Anchorage"},
-    {"offset": "-08:00", "value": "America/Los_Angeles"},
-    {"offset": "-07:00", "value": "America/Phoenix"},
-    {"offset": "-06:00", "value": "America/Guatemala"},
-    {"offset": "-05:00", "value": "America/Bogota"},
-    {"offset": "-04:00", "value": "America/Halifax"},
-    {"offset": "-03:30", "value": "America/St_Johns"},
-    {"offset": "-03:00", "value": "America/Sao_Paulo"},
-    {"offset": "-02:00", "value": "America/Godthab"},
-    {"offset": "-01:00", "value": "Atlantic/Azores"},
-    {"offset": "+00:00", "value": "Europe/London"},
-    {"offset": "+01:00", "value": "Europe/Amsterdam"},
-    {"offset": "+02:00", "value": "Asia/Amman"},
-    {"offset": "+03:00", "value": "Asia/Baghdad"},
-    {"offset": "+03:30", "value": "Asia/Tehran"},
-    {"offset": "+04:00", "value": "Asia/Dubai"},
-    {"offset": "+04:30", "value": "Asia/Kabul"},
-    {"offset": "+05:00", "value": "Asia/Karachi"},
-    {"offset": "+05:30", "value": "Asia/Kolkata"},
-    {"offset": "+05:45", "value": "Asia/Kathmandu"},
-    {"offset": "+06:00", "value": "Asia/Almaty"},
-    {"offset": "+06:30", "value": "Asia/Yangon"},
-    {"offset": "+07:00", "value": "Asia/Bangkok"},
-    {"offset": "+08:00", "value": "Asia/Shanghai"},
-    {"offset": "+09:00", "value": "Asia/Irkutsk"},
-    {"offset": "+09:30", "value": "Australia/Adelaide"},
-    {"offset": "+10:00", "value": "Australia/Brisbane"},
-    {"offset": "+11:00", "value": "Asia/Magadan"},
-    {"offset": "+12:00", "value": "Pacific/Auckland"},
-    {"offset": "+13:00", "value": "Pacific/Tongatapu"},
-]
+import tzlocal
 
 
 def get_current_timezone_info():
@@ -48,9 +10,6 @@ def get_current_timezone_info():
     sign = "+" if hours >= 0 else "-"
     current_offset = f"{sign}{abs(int(hours)):02d}:{abs(int(minutes)):02d}"
 
-    current_timezone = next(
-        (tz for tz in timezones if tz["offset"] == current_offset),
-        {"offset": None, "value": None},
-    )
+    current_timezone = {"offset": current_offset, "value": tzlocal.get_localzone_name()}
 
     return current_timezone


### PR DESCRIPTION
The `Dashboard Server Timezone` is currently incorrect in when
running in a timezone with daylight savings. Fixing that
resolution with python `tzlocal`.


## Why are these changes needed?

See https://github.com/ray-project/ray/issues/51310

## Related issue number

Closes #51310

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

My testing was just using python code through the repl.