### PR TITLE
[core] Add the definition of `parent_task_id` in protobuf

### DIFF
--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -460,7 +460,10 @@ message TaskSpec {
   bytes job_id = 5;
   // Task ID of the task.
   bytes task_id = 6;
-  // Task ID of the parent task.
+  // Task ID of the parent task. If the parent is a normal task, it will be the task's ID.
+  // If the parent runs in a concurrent actor (async actor or threaded actor),
+  // it will be the actor's creation task ID.
+  // See https://github.com/ray-project/ray/pull/32157 for more context.
   bytes parent_task_id = 7;
   // A count of the number of tasks submitted by the parent task before this one.
   uint64 parent_counter = 8;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In #51058, I see the following CI test failure as shown in the following screenshot. The error message looks like:

```
E       AssertionError: assert '16310a0f0a45...7dd1901000000' == 'ffffffffffff...7dd1901000000'
E         - ffffffffffffffffeec399964cc9ab32acb7dd1901000000
E         + 16310a0f0a45af5ceec399964cc9ab32acb7dd1901000000
```

`16310a0f0a45af5ceec399964cc9ab32acb7dd1901000000` is the task ID of `Actor.main_task`, and `ffffffffffffffffeec399964cc9ab32acb7dd1901000000` is the parent task ID of `thd_task`.

However, my first thought was that this is a bug, because intuitively the caller of a Ray task should be its "parent." I spent some time digging into the details and realized there is a special context behind the parent task ID (see https://github.com/ray-project/ray/pull/32157).

This PR adds a comment in the protobuf regarding the definition of "parent task id."

![image](https://github.com/user-attachments/assets/993faa6d-a93d-496a-9717-d591cea2be07)


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
