### PR TITLE
[core] Preallocate instead of initialize object chunk

### DIFF
--- a/src/ray/object_manager/chunk_object_reader.cc
+++ b/src/ray/object_manager/chunk_object_reader.cc
@@ -42,17 +42,16 @@ absl::optional<std::string> ChunkObjectReader::GetChunk(uint64_t chunk_index) co
       std::min(chunk_size_,
                object_->GetDataSize() + object_->GetMetadataSize() - cur_chunk_offset);
 
-  std::string result(cur_chunk_size, '\0');
-  size_t result_offset = 0;
+  std::string result;
+  result.reserve(cur_chunk_size);
 
   if (cur_chunk_offset < object_->GetDataSize()) {
     // read from data section.
     auto offset = cur_chunk_offset;
-    auto size = std::min(object_->GetDataSize() - cur_chunk_offset, cur_chunk_size);
-    if (!object_->ReadFromDataSection(offset, size, &result[result_offset])) {
+    auto data_size = std::min(object_->GetDataSize() - cur_chunk_offset, cur_chunk_size);
+    if (!object_->ReadFromDataSection(offset, data_size, result)) {
       return absl::optional<std::string>();
     }
-    result_offset = size;
   }
 
   if (cur_chunk_offset + cur_chunk_size > object_->GetDataSize()) {
@@ -61,7 +60,7 @@ absl::optional<std::string> ChunkObjectReader::GetChunk(uint64_t chunk_index) co
         std::max(cur_chunk_offset, object_->GetDataSize()) - object_->GetDataSize();
     auto size = std::min(cur_chunk_offset + cur_chunk_size - object_->GetDataSize(),
                          cur_chunk_size);
-    if (!object_->ReadFromMetadataSection(offset, size, &result[result_offset])) {
+    if (!object_->ReadFromMetadataSection(offset, size, result)) {
       return absl::optional<std::string>();
     }
   }

--- a/src/ray/object_manager/memory_object_reader.cc
+++ b/src/ray/object_manager/memory_object_reader.cc
@@ -14,7 +14,7 @@
 
 #include "ray/object_manager/memory_object_reader.h"
 
-#include <cstring>
+#include <string>
 #include <utility>
 
 namespace ray {
@@ -34,21 +34,21 @@ const rpc::Address &MemoryObjectReader::GetOwnerAddress() const { return owner_a
 
 bool MemoryObjectReader::ReadFromDataSection(uint64_t offset,
                                              uint64_t size,
-                                             char *output) const {
+                                             std::string &output) const {
   if (offset + size > GetDataSize()) {
     return false;
   }
-  std::memcpy(output, object_buffer_.data->Data() + offset, size);
+  output.append(reinterpret_cast<char *>(object_buffer_.data->Data() + offset), size);
   return true;
 }
 
 bool MemoryObjectReader::ReadFromMetadataSection(uint64_t offset,
                                                  uint64_t size,
-                                                 char *output) const {
+                                                 std::string &output) const {
   if (offset + size > GetMetadataSize()) {
     return false;
   }
-  std::memcpy(output, object_buffer_.metadata->Data() + offset, size);
+  output.append(reinterpret_cast<char *>(object_buffer_.metadata->Data() + offset), size);
   return true;
 }
 

--- a/src/ray/object_manager/memory_object_reader.h
+++ b/src/ray/object_manager/memory_object_reader.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "ray/object_manager/object_reader.h"
 #include "ray/object_manager/plasma/client.h"
 
@@ -31,10 +33,12 @@ class MemoryObjectReader : public IObjectReader {
 
   const rpc::Address &GetOwnerAddress() const override;
 
-  bool ReadFromDataSection(uint64_t offset, uint64_t size, char *output) const override;
+  bool ReadFromDataSection(uint64_t offset,
+                           uint64_t size,
+                           std::string &output) const override;
   bool ReadFromMetadataSection(uint64_t offset,
                                uint64_t size,
-                               char *output) const override;
+                               std::string &output) const override;
 
  private:
   const plasma::ObjectBuffer object_buffer_;

--- a/src/ray/object_manager/object_reader.h
+++ b/src/ray/object_manager/object_reader.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "src/ray/protobuf/common.pb.h"
 
 namespace ray {
@@ -38,20 +40,20 @@ class IObjectReader {
   ///
   /// \param offset offset to the data section to copy from.
   /// \param size number of bytes to copy.
-  /// \param output pointer to the memory location to copy to.
+  /// \param output string to add to.
   /// \return bool.
   virtual bool ReadFromDataSection(uint64_t offset,
                                    uint64_t size,
-                                   char *output) const = 0;
+                                   std::string &output) const = 0;
   /// Read from metadata sections into output.
   /// Return false if the object is corrupted or size/offset is invalid.
   ///
   /// \param offset offset to the metadata section to copy from.
   /// \param size number of bytes to copy.
-  /// \param output pointer to the memory location to copy to.
+  /// \param output string to add to.
   /// \return bool.
   virtual bool ReadFromMetadataSection(uint64_t offset,
                                        uint64_t size,
-                                       char *output) const = 0;
+                                       std::string &output) const = 0;
 };
 }  // namespace ray

--- a/src/ray/object_manager/object_reader.h
+++ b/src/ray/object_manager/object_reader.h
@@ -40,7 +40,7 @@ class IObjectReader {
   ///
   /// \param offset offset to the data section to copy from.
   /// \param size number of bytes to copy.
-  /// \param output string to add to.
+  /// \param output string that the data will be appended to.
   /// \return bool.
   virtual bool ReadFromDataSection(uint64_t offset,
                                    uint64_t size,

--- a/src/ray/object_manager/object_reader.h
+++ b/src/ray/object_manager/object_reader.h
@@ -50,7 +50,7 @@ class IObjectReader {
   ///
   /// \param offset offset to the metadata section to copy from.
   /// \param size number of bytes to copy.
-  /// \param output string to add to.
+  /// \param output string that the metadata will be appended to.
   /// \return bool.
   virtual bool ReadFromMetadataSection(uint64_t offset,
                                        uint64_t size,

--- a/src/ray/object_manager/spilled_object_reader.cc
+++ b/src/ray/object_manager/spilled_object_reader.cc
@@ -170,15 +170,29 @@ uint64_t SpilledObjectReader::ToUINT64(const std::string &s) {
 
 bool SpilledObjectReader::ReadFromDataSection(uint64_t offset,
                                               uint64_t size,
-                                              char *output) const {
-  std::ifstream is(file_path_, std::ios::binary);
-  return is.seekg(data_offset_ + offset) && is.read(output, size);
+                                              std::string &output) const {
+  std::ifstream file(file_path_, std::ios::binary);
+  file.seekg(data_offset_ + offset);
+  std::istreambuf_iterator<char> start(file), end;
+  uint64_t size_idx = 0;
+  for (auto it = start; size_idx < size && it != end; ++it) {
+    output.push_back(*it);
+    ++size_idx;
+  }
+  return size_idx == size;
 }
 
 bool SpilledObjectReader::ReadFromMetadataSection(uint64_t offset,
                                                   uint64_t size,
-                                                  char *output) const {
-  std::ifstream is(file_path_, std::ios::binary);
-  return is.seekg(metadata_offset_ + offset) && is.read(output, size);
+                                                  std::string &output) const {
+  std::ifstream file(file_path_, std::ios::binary);
+  file.seekg(metadata_offset_ + offset);
+  std::istreambuf_iterator<char> start(file), end;
+  uint64_t size_idx = 0;
+  for (auto it = start; size_idx < size && it != end; ++it) {
+    output.push_back(*it);
+    ++size_idx;
+  }
+  return size_idx == size;
 }
 }  // namespace ray

--- a/src/ray/object_manager/spilled_object_reader.h
+++ b/src/ray/object_manager/spilled_object_reader.h
@@ -39,10 +39,12 @@ class SpilledObjectReader : public IObjectReader {
 
   const rpc::Address &GetOwnerAddress() const override;
 
-  bool ReadFromDataSection(uint64_t offset, uint64_t size, char *output) const override;
+  bool ReadFromDataSection(uint64_t offset,
+                           uint64_t size,
+                           std::string &output) const override;
   bool ReadFromMetadataSection(uint64_t offset,
                                uint64_t size,
-                               char *output) const override;
+                               std::string &output) const override;
 
  private:
   SpilledObjectReader(std::string file_path,

--- a/src/ray/object_manager/test/spilled_object_test.cc
+++ b/src/ray/object_manager/test/spilled_object_test.cc
@@ -354,24 +354,24 @@ TYPED_TEST(ObjectReaderTest, GetDataAndMetadata) {
 
       for (size_t offset = 0; offset <= data.size(); offset++) {
         for (size_t size = offset; size <= data.size() - offset; size++) {
-          std::string result(size, '\0');
+          std::string result;
           if (offset + size <= data.size()) {
-            ASSERT_TRUE(reader->ReadFromDataSection(offset, size, &result[0]));
+            ASSERT_TRUE(reader->ReadFromDataSection(offset, size, result));
             ASSERT_EQ(data.substr(offset, size), result);
           } else {
-            ASSERT_FALSE(reader->ReadFromDataSection(offset, size, &result[0]));
+            ASSERT_FALSE(reader->ReadFromDataSection(offset, size, result));
           }
         }
       }
 
       for (size_t offset = 0; offset <= metadata.size(); offset++) {
         for (size_t size = offset; size <= metadata.size() - offset; size++) {
-          std::string result(size, '\0');
+          std::string result;
           if (offset + size <= metadata.size()) {
-            ASSERT_TRUE(reader->ReadFromMetadataSection(offset, size, &result[0]));
+            ASSERT_TRUE(reader->ReadFromMetadataSection(offset, size, result));
             ASSERT_EQ(metadata.substr(offset, size), result);
           } else {
-            ASSERT_FALSE(reader->ReadFromMetadataSection(offset, size, &result[0]));
+            ASSERT_FALSE(reader->ReadFromMetadataSection(offset, size, result));
           }
         }
       }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We shouldn't create the entire (max 5mb) string to start with. We just need to allocate the memory it. This is an example benchmark showing a 50% improvement for what we're doing with things in-memory.

<img width="1512" alt="Screenshot 2025-03-13 at 1 11 20 AM" src="https://github.com/user-attachments/assets/1e3d3487-8dde-4c72-acf3-9dc9c5194a8b" />


Note: I still have yet to benchmark the changes made for the spilled object reader due to this change.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
