### PR TITLE
[CI] Replace `black` with `ruff format`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,16 @@ repos:
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]
+      - id: ruff-format
+        files: |
+            (?x)^(
+              bazel/|
+              cpp/|
+              doc/|
+              docker/|
+              java/|
+              python/ray/_private/
+            )
 
   - repo: https://github.com/cpplint/cpplint
     rev: 2.0.0
@@ -70,7 +80,8 @@ repos:
             python/ray/_private/thirdparty/|
             python/ray/serve/tests/test_config_files/syntax_error\.py|
             python/ray/serve/_private/benchmarks/streaming/_grpc/test_server_pb2_grpc\.py|
-            doc/external/
+            doc/external/|
+            python/ray/_private/
           )
         types_or: [python]
 

--- a/ci/lint/lint.sh
+++ b/ci/lint/lint.sh
@@ -18,6 +18,7 @@ pre_commit() {
   HOOKS=(
     python-no-log-warn
     ruff
+    ruff-format
     check-added-large-files
     check-ast
     check-toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,10 @@ ignore = [
 
 [tool.ruff.lint.flake8-quotes]
 avoid-escape = false
+
+[tool.ruff.format]
+exclude = [
+    "python/ray/core/src/ray/gcs/",
+    "python/ray/serve/_private/benchmarks/streaming/_grpc/test_server_pb2_grpc.py",
+    "doc/external/",
+]

--- a/python/ray/_private/accelerators/amd_gpu.py
+++ b/python/ray/_private/accelerators/amd_gpu.py
@@ -102,9 +102,9 @@ class AMDGPUAcceleratorManager(AcceleratorManager):
         if os.environ.get(NOSET_ROCR_VISIBLE_DEVICES_ENV_VAR):
             return
 
-        os.environ[
-            AMDGPUAcceleratorManager.get_visible_accelerator_ids_env_var()
-        ] = ",".join([str(i) for i in visible_amd_devices])
+        os.environ[AMDGPUAcceleratorManager.get_visible_accelerator_ids_env_var()] = (
+            ",".join([str(i) for i in visible_amd_devices])
+        )
 
     @staticmethod
     def _get_amd_device_ids() -> List[str]:

--- a/python/ray/_private/accelerators/hpu.py
+++ b/python/ray/_private/accelerators/hpu.py
@@ -116,6 +116,6 @@ class HPUAcceleratorManager(AcceleratorManager):
         if os.environ.get(NOSET_HABANA_VISIBLE_MODULES_ENV_VAR):
             return
 
-        os.environ[
-            HPUAcceleratorManager.get_visible_accelerator_ids_env_var()
-        ] = ",".join([str(i) for i in visible_hpu_devices])
+        os.environ[HPUAcceleratorManager.get_visible_accelerator_ids_env_var()] = (
+            ",".join([str(i) for i in visible_hpu_devices])
+        )

--- a/python/ray/_private/accelerators/intel_gpu.py
+++ b/python/ray/_private/accelerators/intel_gpu.py
@@ -98,6 +98,6 @@ class IntelGPUAcceleratorManager(AcceleratorManager):
             return
 
         prefix = ONEAPI_DEVICE_BACKEND_TYPE + ":"
-        os.environ[
-            IntelGPUAcceleratorManager.get_visible_accelerator_ids_env_var()
-        ] = prefix + ",".join([str(i) for i in visible_xpu_devices])
+        os.environ[IntelGPUAcceleratorManager.get_visible_accelerator_ids_env_var()] = (
+            prefix + ",".join([str(i) for i in visible_xpu_devices])
+        )

--- a/python/ray/_private/accelerators/neuron.py
+++ b/python/ray/_private/accelerators/neuron.py
@@ -108,9 +108,9 @@ class NeuronAcceleratorManager(AcceleratorManager):
         if os.environ.get(NOSET_AWS_NEURON_RT_VISIBLE_CORES_ENV_VAR):
             return
 
-        os.environ[
-            NeuronAcceleratorManager.get_visible_accelerator_ids_env_var()
-        ] = ",".join([str(i) for i in visible_neuron_core_ids])
+        os.environ[NeuronAcceleratorManager.get_visible_accelerator_ids_env_var()] = (
+            ",".join([str(i) for i in visible_neuron_core_ids])
+        )
 
     @staticmethod
     def get_ec2_instance_num_accelerators(

--- a/python/ray/_private/accelerators/npu.py
+++ b/python/ray/_private/accelerators/npu.py
@@ -94,6 +94,6 @@ class NPUAcceleratorManager(AcceleratorManager):
         if os.environ.get(NOSET_ASCEND_RT_VISIBLE_DEVICES_ENV_VAR):
             return
 
-        os.environ[
-            NPUAcceleratorManager.get_visible_accelerator_ids_env_var()
-        ] = ",".join([str(i) for i in visible_npu_devices])
+        os.environ[NPUAcceleratorManager.get_visible_accelerator_ids_env_var()] = (
+            ",".join([str(i) for i in visible_npu_devices])
+        )

--- a/python/ray/_private/accelerators/tpu.py
+++ b/python/ray/_private/accelerators/tpu.py
@@ -218,18 +218,18 @@ class TPUAcceleratorManager(AcceleratorManager):
             os.environ.pop(TPU_CHIPS_PER_HOST_BOUNDS_ENV_VAR, None)
             os.environ.pop(TPU_HOST_BOUNDS_ENV_VAR, None)
             return
-        os.environ[
-            TPUAcceleratorManager.get_visible_accelerator_ids_env_var()
-        ] = ",".join([str(i) for i in visible_tpu_chips])
+        os.environ[TPUAcceleratorManager.get_visible_accelerator_ids_env_var()] = (
+            ",".join([str(i) for i in visible_tpu_chips])
+        )
         if num_visible_tpu_chips == 1:
-            os.environ[
-                TPU_CHIPS_PER_HOST_BOUNDS_ENV_VAR
-            ] = TPU_CHIPS_PER_HOST_BOUNDS_1_CHIP_CONFIG
+            os.environ[TPU_CHIPS_PER_HOST_BOUNDS_ENV_VAR] = (
+                TPU_CHIPS_PER_HOST_BOUNDS_1_CHIP_CONFIG
+            )
             os.environ[TPU_HOST_BOUNDS_ENV_VAR] = TPU_SINGLE_HOST_BOUNDS
         elif num_visible_tpu_chips == 2:
-            os.environ[
-                TPU_CHIPS_PER_HOST_BOUNDS_ENV_VAR
-            ] = TPU_CHIPS_PER_HOST_BOUNDS_2_CHIP_CONFIG
+            os.environ[TPU_CHIPS_PER_HOST_BOUNDS_ENV_VAR] = (
+                TPU_CHIPS_PER_HOST_BOUNDS_2_CHIP_CONFIG
+            )
             os.environ[TPU_HOST_BOUNDS_ENV_VAR] = TPU_SINGLE_HOST_BOUNDS
 
     @staticmethod

--- a/python/ray/_private/async_compat.py
+++ b/python/ray/_private/async_compat.py
@@ -2,6 +2,7 @@
 This file should only be imported from Python 3.
 It will raise SyntaxError when importing from Python 2.
 """
+
 import asyncio
 import inspect
 from functools import lru_cache

--- a/python/ray/_private/custom_types.py
+++ b/python/ray/_private/custom_types.py
@@ -125,9 +125,7 @@ def validate_protobuf_enum(grpc_enum, custom_enum):
     # Sometimes, the grpc enum is mocked, and it
     # doesn't include any values in that case.
     if len(enum_vals) > 0:
-        assert enum_vals == set(
-            custom_enum
-        ), """Literals and protos out of sync,\
+        assert enum_vals == set(custom_enum), """Literals and protos out of sync,\
 consider building //:install_py_proto with bazel?"""
 
 

--- a/python/ray/_private/external_storage.py
+++ b/python/ray/_private/external_storage.py
@@ -383,7 +383,7 @@ class FileSystemStorage(ExternalStorage):
         while os.path.isdir(directory_path):
             try:
                 shutil.rmtree(directory_path)
-            except (FileNotFoundError):
+            except FileNotFoundError:
                 # If exception occurs when other IO workers are
                 # deleting the file at the same time.
                 pass

--- a/python/ray/_private/internal_api.py
+++ b/python/ray/_private/internal_api.py
@@ -121,8 +121,7 @@ def store_stats_summary(reply):
     # TODO(ekl) it would be nice if we could provide a full memory usage
     # breakdown by type (e.g., pinned by worker, primary, etc.)
     store_summary += (
-        "Plasma memory usage {} MiB, {} objects, {}% full, {}% "
-        "needed\n".format(
+        "Plasma memory usage {} MiB, {} objects, {}% full, {}% " "needed\n".format(
             int(reply.store_stats.object_store_bytes_used / (1024 * 1024)),
             reply.store_stats.num_local_objects,
             round(
@@ -235,9 +234,9 @@ def free(object_refs: list, local_only: bool = False):
         worker.core_worker.free_objects(object_refs, local_only)
 
 
-def get_local_ongoing_lineage_reconstruction_tasks() -> List[
-    Tuple[common_pb2.LineageReconstructionTask, int]
-]:
+def get_local_ongoing_lineage_reconstruction_tasks() -> (
+    List[Tuple[common_pb2.LineageReconstructionTask, int]]
+):
     """Return the locally submitted ongoing retry tasks
        triggered by lineage reconstruction.
 

--- a/python/ray/_private/metrics_agent.py
+++ b/python/ray/_private/metrics_agent.py
@@ -414,7 +414,6 @@ class OpenCensusProxyCollector:
             return
 
         elif isinstance(agg_data, DistributionAggregationData):
-
             assert agg_data.bounds == sorted(agg_data.bounds)
             # buckets are a list of buckets. Each bucket is another list with
             # a pair of bucket name and value, or a triple of bucket name,
@@ -676,8 +675,9 @@ class PrometheusServiceDiscoveryWriter(threading.Thread):
                 self.write()
             except Exception as e:
                 logger.warning(
-                    "Writing a service discovery file, {},"
-                    "failed.".format(self.get_target_file_name())
+                    "Writing a service discovery file, {}," "failed.".format(
+                        self.get_target_file_name()
+                    )
                 )
                 logger.warning(traceback.format_exc())
                 logger.warning(f"Error message: {e}")

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -1803,15 +1803,15 @@ class Node:
         # We need to set both ray param's system config and self._config
         # because they could've been diverged at this point.
         deserialized_config = json.loads(object_spilling_config)
-        self._ray_params._system_config[
-            "object_spilling_config"
-        ] = object_spilling_config
+        self._ray_params._system_config["object_spilling_config"] = (
+            object_spilling_config
+        )
         self._config["object_spilling_config"] = object_spilling_config
 
         is_external_storage_type_fs = deserialized_config["type"] == "filesystem"
-        self._ray_params._system_config[
-            "is_external_storage_type_fs"
-        ] = is_external_storage_type_fs
+        self._ray_params._system_config["is_external_storage_type_fs"] = (
+            is_external_storage_type_fs
+        )
         self._config["is_external_storage_type_fs"] = is_external_storage_type_fs
 
         # Validate external storage usage.

--- a/python/ray/_private/profiling.py
+++ b/python/ray/_private/profiling.py
@@ -186,9 +186,9 @@ def chrome_tracing_dump(
                     node_to_index[node_ip_address],
                     component_id,
                 ) not in worker_to_index:  # noqa
-                    worker_to_index[
-                        (node_to_index[node_ip_address], component_id)
-                    ] = worker_idx  # noqa
+                    worker_to_index[(node_to_index[node_ip_address], component_id)] = (
+                        worker_idx  # noqa
+                    )
                     worker_idx += 1
 
                 # Modify the name with the additional user-defined extra data.

--- a/python/ray/_private/prometheus_exporter.py
+++ b/python/ray/_private/prometheus_exporter.py
@@ -162,7 +162,6 @@ class Collector(object):
             return
 
         elif isinstance(agg_data, aggregation_data_module.DistributionAggregationData):
-
             assert agg_data.bounds == sorted(agg_data.bounds)
             # buckets are a list of buckets. Each bucket is another list with
             # a pair of bucket name and value, or a triple of bucket name,

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -70,7 +70,8 @@ ID_SIZE = 28
 # The default maximum number of bytes to allocate to the object store unless
 # overridden by the user.
 DEFAULT_OBJECT_STORE_MAX_MEMORY_BYTES = env_integer(
-    "RAY_DEFAULT_OBJECT_STORE_MAX_MEMORY_BYTES", 200 * 10**9  # 200 GB
+    "RAY_DEFAULT_OBJECT_STORE_MAX_MEMORY_BYTES",
+    200 * 10**9,  # 200 GB
 )
 # The default proportion of available memory allocated to the object store
 DEFAULT_OBJECT_STORE_MEMORY_PROPORTION = env_float(
@@ -392,7 +393,8 @@ GRPC_CPP_MAX_MESSAGE_SIZE = 512 * 1024 * 1024
 #       and HAVE TO STAY IN SYNC with it (ie, meaning that both of these values
 #       have to be set at the same time)
 AGENT_GRPC_MAX_MESSAGE_LENGTH = env_integer(
-    "AGENT_GRPC_MAX_MESSAGE_LENGTH", 20 * 1024 * 1024  # 20MB
+    "AGENT_GRPC_MAX_MESSAGE_LENGTH",
+    20 * 1024 * 1024,  # 20MB
 )
 
 

--- a/python/ray/_private/ray_logging/__init__.py
+++ b/python/ray/_private/ray_logging/__init__.py
@@ -124,6 +124,7 @@ def run_callback_on_events_in_ipython(event: str, cb: Callable):
 All components underneath here is used specifically for the default_worker.py.
 """
 
+
 # It's worth noticing that filepath format should be kept in sync with function
 # `GetWorkerOutputFilepath` under file "src/ray/core_worker/core_worker_process.cc".
 def get_worker_log_file_name(worker_type, job_id=None):

--- a/python/ray/_private/ray_option_utils.py
+++ b/python/ray/_private/ray_option_utils.py
@@ -1,4 +1,5 @@
 """Manage, parse and validate options for Ray tasks, actors and actor methods."""
+
 import warnings
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional, Tuple, Union
@@ -84,9 +85,7 @@ def _validate_resource_quantity(name, quantity):
             error_message,
         ) = ray._private.accelerators.get_accelerator_manager_for_resource(
             resource_name
-        ).validate_resource_request_quantity(
-            quantity
-        )
+        ).validate_resource_request_quantity(quantity)
         if not valid:
             return error_message
     return None

--- a/python/ray/_private/resource_spec.py
+++ b/python/ray/_private/resource_spec.py
@@ -94,9 +94,7 @@ class ResourceSpec(
         for resource_label, resource_quantity in resources.items():
             assert isinstance(resource_quantity, int) or isinstance(
                 resource_quantity, float
-            ), (
-                f"{resource_label} ({type(resource_quantity)}): " f"{resource_quantity}"
-            )
+            ), f"{resource_label} ({type(resource_quantity)}): " f"{resource_quantity}"
             if (
                 isinstance(resource_quantity, float)
                 and not resource_quantity.is_integer()

--- a/python/ray/_private/runtime_env/conda.py
+++ b/python/ray/_private/runtime_env/conda.py
@@ -257,7 +257,6 @@ def _get_conda_dict_with_ray_inserted(
 
 
 class CondaPlugin(RuntimeEnvPlugin):
-
     name = "conda"
 
     def __init__(self, resources_dir: str):

--- a/python/ray/_private/runtime_env/dependency_utils.py
+++ b/python/ray/_private/runtime_env/dependency_utils.py
@@ -43,9 +43,7 @@ with open(r"{ray_version_path}", "wt") as f:
     f.write(ray.__version__)
     f.write(" ")
     f.write(ray.__path__[0])
-                """.format(
-                    ray_version_path=ray_version_path
-                ),
+                """.format(ray_version_path=ray_version_path),
             ]
             if virtualenv_utils._WIN32:
                 env = os.environ.copy()

--- a/python/ray/_private/runtime_env/java_jars.py
+++ b/python/ray/_private/runtime_env/java_jars.py
@@ -18,7 +18,6 @@ default_logger = logging.getLogger(__name__)
 
 
 class JavaJarsPlugin(RuntimeEnvPlugin):
-
     name = "java_jars"
 
     def __init__(self, resources_dir: str, gcs_aio_client: GcsAioClient):

--- a/python/ray/_private/runtime_env/py_modules.py
+++ b/python/ray/_private/runtime_env/py_modules.py
@@ -161,11 +161,12 @@ def upload_py_modules_if_needed(
 
 
 class PyModulesPlugin(RuntimeEnvPlugin):
-
     name = "py_modules"
 
     def __init__(
-        self, resources_dir: str, gcs_aio_client: "GcsAioClient"  # noqa: F821
+        self,
+        resources_dir: str,
+        gcs_aio_client: "GcsAioClient",  # noqa: F821
     ):
         self._resources_dir = os.path.join(resources_dir, "py_modules_files")
         self._gcs_aio_client = gcs_aio_client
@@ -199,7 +200,6 @@ class PyModulesPlugin(RuntimeEnvPlugin):
         context: RuntimeEnvContext,
         logger: Optional[logging.Logger] = default_logger,
     ) -> int:
-
         module_dir = await download_and_unpack_package(
             uri, self._resources_dir, self._gcs_aio_client, logger=logger
         )

--- a/python/ray/_private/runtime_env/uv.py
+++ b/python/ray/_private/runtime_env/uv.py
@@ -1,5 +1,4 @@
-"""Util class to install packages via uv.
-"""
+"""Util class to install packages via uv."""
 
 from typing import Dict, List, Optional
 import os

--- a/python/ray/_private/runtime_env/working_dir.py
+++ b/python/ray/_private/runtime_env/working_dir.py
@@ -118,7 +118,6 @@ def set_pythonpath_in_context(python_path: str, context: RuntimeEnvContext):
 
 
 class WorkingDirPlugin(RuntimeEnvPlugin):
-
     name = "working_dir"
 
     # Note working_dir is not following the priority order of other plugins. Instead
@@ -126,7 +125,9 @@ class WorkingDirPlugin(RuntimeEnvPlugin):
     priority = 5
 
     def __init__(
-        self, resources_dir: str, gcs_aio_client: "GcsAioClient"  # noqa: F821
+        self,
+        resources_dir: str,
+        gcs_aio_client: "GcsAioClient",  # noqa: F821
     ):
         self._resources_dir = os.path.join(resources_dir, "working_dir_files")
         self._gcs_aio_client = gcs_aio_client

--- a/python/ray/_private/state.py
+++ b/python/ray/_private/state.py
@@ -121,9 +121,9 @@ class GlobalState:
             results = {}
             for i in range(len(actor_table)):
                 actor_table_data = gcs_pb2.ActorTableData.FromString(actor_table[i])
-                results[
-                    binary_to_hex(actor_table_data.actor_id)
-                ] = self._gen_actor_info(actor_table_data)
+                results[binary_to_hex(actor_table_data.actor_id)] = (
+                    self._gen_actor_info(actor_table_data)
+                )
 
             return results
 

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -63,7 +63,6 @@ REDIS_EXECUTABLE = os.path.join(
 try:
     from prometheus_client.parser import text_string_to_metric_families, Sample
 except (ImportError, ModuleNotFoundError):
-
     Sample = None
 
     def text_string_to_metric_families(*args, **kwargs):

--- a/python/ray/_private/usage/usage_lib.py
+++ b/python/ray/_private/usage/usage_lib.py
@@ -41,6 +41,7 @@ Note that it is also possible to configure the interval using the environment va
 To see collected/reported data, see `usage_stats.json` inside a temp
 folder (e.g., /tmp/ray/session_[id]/*).
 """
+
 import json
 import logging
 import threading
@@ -660,7 +661,6 @@ def get_cluster_status_to_report(gcs_client) -> ClusterStatusToReport:
         The current cluster status or empty if it fails to get that information.
     """
     try:
-
         from ray.autoscaler.v2.utils import is_autoscaler_v2
 
         if is_autoscaler_v2():

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -403,9 +403,9 @@ def resources_from_ray_options(options_dict: Dict[str, Any]) -> Dict[str, Any]:
     if object_store_memory is not None:
         resources["object_store_memory"] = object_store_memory
     if accelerator_type is not None:
-        resources[
-            f"{ray_constants.RESOURCE_CONSTRAINT_PREFIX}{accelerator_type}"
-        ] = 0.001
+        resources[f"{ray_constants.RESOURCE_CONSTRAINT_PREFIX}{accelerator_type}"] = (
+            0.001
+        )
 
     return resources
 
@@ -509,9 +509,10 @@ def _get_docker_cpus(
     # See: https://bugs.openjdk.java.net/browse/JDK-8146115
     if os.path.exists(cpu_quota_file_name) and os.path.exists(cpu_period_file_name):
         try:
-            with open(cpu_quota_file_name, "r") as quota_file, open(
-                cpu_period_file_name, "r"
-            ) as period_file:
+            with (
+                open(cpu_quota_file_name, "r") as quota_file,
+                open(cpu_period_file_name, "r") as period_file,
+            ):
                 cpu_quota = float(quota_file.read()) / float(period_file.read())
         except Exception:
             logger.exception("Unexpected error calculating docker cpu quota.")
@@ -1908,7 +1909,7 @@ def validate_node_labels(labels: Dict[str, str]):
 
 
 def parse_pg_formatted_resources_to_original(
-    pg_formatted_resources: Dict[str, float]
+    pg_formatted_resources: Dict[str, float],
 ) -> Dict[str, float]:
     original_resources = {}
 

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -132,8 +132,7 @@ RF = TypeVar("RF", bound="HasOptions")
 
 
 class HasOptions(Protocol):
-    def options(self: RF, **task_options) -> RF:
-        ...
+    def options(self: RF, **task_options) -> RF: ...
 
 
 class RemoteFunctionNoArgs(HasOptions, Generic[R]):
@@ -142,13 +141,11 @@ class RemoteFunctionNoArgs(HasOptions, Generic[R]):
 
     def remote(
         self,
-    ) -> "ObjectRef[R]":
-        ...
+    ) -> "ObjectRef[R]": ...
 
     def bind(
         self,
-    ) -> "DAGNode[R]":
-        ...
+    ) -> "DAGNode[R]": ...
 
 
 class RemoteFunction0(HasOptions, Generic[R, T0]):
@@ -158,14 +155,12 @@ class RemoteFunction0(HasOptions, Generic[R, T0]):
     def remote(
         self,
         __arg0: "Union[T0, ObjectRef[T0]]",
-    ) -> "ObjectRef[R]":
-        ...
+    ) -> "ObjectRef[R]": ...
 
     def bind(
         self,
         __arg0: "Union[T0, DAGNode[T0]]",
-    ) -> "DAGNode[R]":
-        ...
+    ) -> "DAGNode[R]": ...
 
 
 class RemoteFunction1(HasOptions, Generic[R, T0, T1]):
@@ -176,15 +171,13 @@ class RemoteFunction1(HasOptions, Generic[R, T0, T1]):
         self,
         __arg0: "Union[T0, ObjectRef[T0]]",
         __arg1: "Union[T1, ObjectRef[T1]]",
-    ) -> "ObjectRef[R]":
-        ...
+    ) -> "ObjectRef[R]": ...
 
     def bind(
         self,
         __arg0: "Union[T0, DAGNode[T0]]",
         __arg1: "Union[T1, DAGNode[T1]]",
-    ) -> "DAGNode[R]":
-        ...
+    ) -> "DAGNode[R]": ...
 
 
 class RemoteFunction2(HasOptions, Generic[R, T0, T1, T2]):
@@ -196,16 +189,14 @@ class RemoteFunction2(HasOptions, Generic[R, T0, T1, T2]):
         __arg0: "Union[T0, ObjectRef[T0]]",
         __arg1: "Union[T1, ObjectRef[T1]]",
         __arg2: "Union[T2, ObjectRef[T2]]",
-    ) -> "ObjectRef[R]":
-        ...
+    ) -> "ObjectRef[R]": ...
 
     def bind(
         self,
         __arg0: "Union[T0, DAGNode[T0]]",
         __arg1: "Union[T1, DAGNode[T1]]",
         __arg2: "Union[T2, DAGNode[T2]]",
-    ) -> "DAGNode[R]":
-        ...
+    ) -> "DAGNode[R]": ...
 
 
 class RemoteFunction3(HasOptions, Generic[R, T0, T1, T2, T3]):
@@ -218,8 +209,7 @@ class RemoteFunction3(HasOptions, Generic[R, T0, T1, T2, T3]):
         __arg1: "Union[T1, ObjectRef[T1]]",
         __arg2: "Union[T2, ObjectRef[T2]]",
         __arg3: "Union[T3, ObjectRef[T3]]",
-    ) -> "ObjectRef[R]":
-        ...
+    ) -> "ObjectRef[R]": ...
 
     def bind(
         self,
@@ -227,8 +217,7 @@ class RemoteFunction3(HasOptions, Generic[R, T0, T1, T2, T3]):
         __arg1: "Union[T1, DAGNode[T1]]",
         __arg2: "Union[T2, DAGNode[T2]]",
         __arg3: "Union[T3, DAGNode[T3]]",
-    ) -> "DAGNode[R]":
-        ...
+    ) -> "DAGNode[R]": ...
 
 
 class RemoteFunction4(HasOptions, Generic[R, T0, T1, T2, T3, T4]):
@@ -242,8 +231,7 @@ class RemoteFunction4(HasOptions, Generic[R, T0, T1, T2, T3, T4]):
         __arg2: "Union[T2, ObjectRef[T2]]",
         __arg3: "Union[T3, ObjectRef[T3]]",
         __arg4: "Union[T4, ObjectRef[T4]]",
-    ) -> "ObjectRef[R]":
-        ...
+    ) -> "ObjectRef[R]": ...
 
     def bind(
         self,
@@ -252,8 +240,7 @@ class RemoteFunction4(HasOptions, Generic[R, T0, T1, T2, T3, T4]):
         __arg2: "Union[T2, DAGNode[T2]]",
         __arg3: "Union[T3, DAGNode[T3]]",
         __arg4: "Union[T4, DAGNode[T4]]",
-    ) -> "DAGNode[R]":
-        ...
+    ) -> "DAGNode[R]": ...
 
 
 class RemoteFunction5(HasOptions, Generic[R, T0, T1, T2, T3, T4, T5]):
@@ -268,8 +255,7 @@ class RemoteFunction5(HasOptions, Generic[R, T0, T1, T2, T3, T4, T5]):
         __arg3: "Union[T3, ObjectRef[T3]]",
         __arg4: "Union[T4, ObjectRef[T4]]",
         __arg5: "Union[T5, ObjectRef[T5]]",
-    ) -> "ObjectRef[R]":
-        ...
+    ) -> "ObjectRef[R]": ...
 
     def bind(
         self,
@@ -279,8 +265,7 @@ class RemoteFunction5(HasOptions, Generic[R, T0, T1, T2, T3, T4, T5]):
         __arg3: "Union[T3, DAGNode[T3]]",
         __arg4: "Union[T4, DAGNode[T4]]",
         __arg5: "Union[T5, DAGNode[T5]]",
-    ) -> "DAGNode[R]":
-        ...
+    ) -> "DAGNode[R]": ...
 
 
 class RemoteFunction6(HasOptions, Generic[R, T0, T1, T2, T3, T4, T5, T6]):
@@ -296,8 +281,7 @@ class RemoteFunction6(HasOptions, Generic[R, T0, T1, T2, T3, T4, T5, T6]):
         __arg4: "Union[T4, ObjectRef[T4]]",
         __arg5: "Union[T5, ObjectRef[T5]]",
         __arg6: "Union[T6, ObjectRef[T6]]",
-    ) -> "ObjectRef[R]":
-        ...
+    ) -> "ObjectRef[R]": ...
 
     def bind(
         self,
@@ -308,8 +292,7 @@ class RemoteFunction6(HasOptions, Generic[R, T0, T1, T2, T3, T4, T5, T6]):
         __arg4: "Union[T4, DAGNode[T4]]",
         __arg5: "Union[T5, DAGNode[T5]]",
         __arg6: "Union[T6, DAGNode[T6]]",
-    ) -> "DAGNode[R]":
-        ...
+    ) -> "DAGNode[R]": ...
 
 
 class RemoteFunction7(HasOptions, Generic[R, T0, T1, T2, T3, T4, T5, T6, T7]):
@@ -326,8 +309,7 @@ class RemoteFunction7(HasOptions, Generic[R, T0, T1, T2, T3, T4, T5, T6, T7]):
         __arg5: "Union[T5, ObjectRef[T5]]",
         __arg6: "Union[T6, ObjectRef[T6]]",
         __arg7: "Union[T7, ObjectRef[T7]]",
-    ) -> "ObjectRef[R]":
-        ...
+    ) -> "ObjectRef[R]": ...
 
     def bind(
         self,
@@ -339,8 +321,7 @@ class RemoteFunction7(HasOptions, Generic[R, T0, T1, T2, T3, T4, T5, T6, T7]):
         __arg5: "Union[T5, DAGNode[T5]]",
         __arg6: "Union[T6, DAGNode[T6]]",
         __arg7: "Union[T7, DAGNode[T7]]",
-    ) -> "DAGNode[R]":
-        ...
+    ) -> "DAGNode[R]": ...
 
 
 class RemoteFunction8(HasOptions, Generic[R, T0, T1, T2, T3, T4, T5, T6, T7, T8]):
@@ -360,8 +341,7 @@ class RemoteFunction8(HasOptions, Generic[R, T0, T1, T2, T3, T4, T5, T6, T7, T8]
         __arg6: "Union[T6, ObjectRef[T6]]",
         __arg7: "Union[T7, ObjectRef[T7]]",
         __arg8: "Union[T8, ObjectRef[T8]]",
-    ) -> "ObjectRef[R]":
-        ...
+    ) -> "ObjectRef[R]": ...
 
     def bind(
         self,
@@ -374,8 +354,7 @@ class RemoteFunction8(HasOptions, Generic[R, T0, T1, T2, T3, T4, T5, T6, T7, T8]
         __arg6: "Union[T6, DAGNode[T6]]",
         __arg7: "Union[T7, DAGNode[T7]]",
         __arg8: "Union[T8, DAGNode[T8]]",
-    ) -> "DAGNode[R]":
-        ...
+    ) -> "DAGNode[R]": ...
 
 
 class RemoteFunction9(HasOptions, Generic[R, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9]):
@@ -396,8 +375,7 @@ class RemoteFunction9(HasOptions, Generic[R, T0, T1, T2, T3, T4, T5, T6, T7, T8,
         __arg7: "Union[T7, ObjectRef[T7]]",
         __arg8: "Union[T8, ObjectRef[T8]]",
         __arg9: "Union[T9, ObjectRef[T9]]",
-    ) -> "ObjectRef[R]":
-        ...
+    ) -> "ObjectRef[R]": ...
 
     def bind(
         self,
@@ -411,8 +389,7 @@ class RemoteFunction9(HasOptions, Generic[R, T0, T1, T2, T3, T4, T5, T6, T7, T8,
         __arg7: "Union[T7, DAGNode[T7]]",
         __arg8: "Union[T8, DAGNode[T8]]",
         __arg9: "Union[T9, DAGNode[T9]]",
-    ) -> "DAGNode[R]":
-        ...
+    ) -> "DAGNode[R]": ...
 
 
 # Visible for testing.
@@ -898,11 +875,11 @@ class Worker:
         timeout_ms = (
             int(timeout * 1000) if timeout is not None and timeout != -1 else -1
         )
-        data_metadata_pairs: List[
-            Tuple[ray._raylet.Buffer, bytes]
-        ] = self.core_worker.get_objects(
-            object_refs,
-            timeout_ms,
+        data_metadata_pairs: List[Tuple[ray._raylet.Buffer, bytes]] = (
+            self.core_worker.get_objects(
+                object_refs,
+                timeout_ms,
+            )
         )
 
         debugger_breakpoint = b""
@@ -2645,32 +2622,27 @@ blocking_get_inside_async_warned = False
 @overload
 def get(
     object_refs: "Sequence[ObjectRef[Any]]", *, timeout: Optional[float] = None
-) -> List[Any]:
-    ...
+) -> List[Any]: ...
 
 
 @overload
 def get(
     object_refs: "Sequence[ObjectRef[R]]", *, timeout: Optional[float] = None
-) -> List[R]:
-    ...
+) -> List[R]: ...
 
 
 @overload
-def get(object_refs: "ObjectRef[R]", *, timeout: Optional[float] = None) -> R:
-    ...
+def get(object_refs: "ObjectRef[R]", *, timeout: Optional[float] = None) -> R: ...
 
 
 @overload
 def get(
     object_refs: Sequence[CompiledDAGRef], *, timeout: Optional[float] = None
-) -> List[Any]:
-    ...
+) -> List[Any]: ...
 
 
 @overload
-def get(object_refs: CompiledDAGRef, *, timeout: Optional[float] = None) -> Any:
-    ...
+def get(object_refs: CompiledDAGRef, *, timeout: Optional[float] = None) -> Any: ...
 
 
 @PublicAPI
@@ -3197,146 +3169,124 @@ def _make_remote(function_or_class, options):
 
 class RemoteDecorator(Protocol):
     @overload
-    def __call__(self, __function: Callable[[], R]) -> RemoteFunctionNoArgs[R]:
-        ...
+    def __call__(self, __function: Callable[[], R]) -> RemoteFunctionNoArgs[R]: ...
 
     @overload
-    def __call__(self, __function: Callable[[T0], R]) -> RemoteFunction0[R, T0]:
-        ...
+    def __call__(self, __function: Callable[[T0], R]) -> RemoteFunction0[R, T0]: ...
 
     @overload
-    def __call__(self, __function: Callable[[T0, T1], R]) -> RemoteFunction1[R, T0, T1]:
-        ...
+    def __call__(
+        self, __function: Callable[[T0, T1], R]
+    ) -> RemoteFunction1[R, T0, T1]: ...
 
     @overload
     def __call__(
         self, __function: Callable[[T0, T1, T2], R]
-    ) -> RemoteFunction2[R, T0, T1, T2]:
-        ...
+    ) -> RemoteFunction2[R, T0, T1, T2]: ...
 
     @overload
     def __call__(
         self, __function: Callable[[T0, T1, T2, T3], R]
-    ) -> RemoteFunction3[R, T0, T1, T2, T3]:
-        ...
+    ) -> RemoteFunction3[R, T0, T1, T2, T3]: ...
 
     @overload
     def __call__(
         self, __function: Callable[[T0, T1, T2, T3, T4], R]
-    ) -> RemoteFunction4[R, T0, T1, T2, T3, T4]:
-        ...
+    ) -> RemoteFunction4[R, T0, T1, T2, T3, T4]: ...
 
     @overload
     def __call__(
         self, __function: Callable[[T0, T1, T2, T3, T4, T5], R]
-    ) -> RemoteFunction5[R, T0, T1, T2, T3, T4, T5]:
-        ...
+    ) -> RemoteFunction5[R, T0, T1, T2, T3, T4, T5]: ...
 
     @overload
     def __call__(
         self, __function: Callable[[T0, T1, T2, T3, T4, T5, T6], R]
-    ) -> RemoteFunction6[R, T0, T1, T2, T3, T4, T5, T6]:
-        ...
+    ) -> RemoteFunction6[R, T0, T1, T2, T3, T4, T5, T6]: ...
 
     @overload
     def __call__(
         self, __function: Callable[[T0, T1, T2, T3, T4, T5, T6, T7], R]
-    ) -> RemoteFunction7[R, T0, T1, T2, T3, T4, T5, T6, T7]:
-        ...
+    ) -> RemoteFunction7[R, T0, T1, T2, T3, T4, T5, T6, T7]: ...
 
     @overload
     def __call__(
         self, __function: Callable[[T0, T1, T2, T3, T4, T5, T6, T7, T8], R]
-    ) -> RemoteFunction8[R, T0, T1, T2, T3, T4, T5, T6, T7, T8]:
-        ...
+    ) -> RemoteFunction8[R, T0, T1, T2, T3, T4, T5, T6, T7, T8]: ...
 
     @overload
     def __call__(
         self, __function: Callable[[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9], R]
-    ) -> RemoteFunction9[R, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9]:
-        ...
+    ) -> RemoteFunction9[R, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9]: ...
 
     # Pass on typing actors for now. The following makes it so no type errors
     # are generated for actors.
     @overload
-    def __call__(self, __t: type) -> Any:
-        ...
+    def __call__(self, __t: type) -> Any: ...
 
 
 @overload
-def remote(__function: Callable[[], R]) -> RemoteFunctionNoArgs[R]:
-    ...
+def remote(__function: Callable[[], R]) -> RemoteFunctionNoArgs[R]: ...
 
 
 @overload
-def remote(__function: Callable[[T0], R]) -> RemoteFunction0[R, T0]:
-    ...
+def remote(__function: Callable[[T0], R]) -> RemoteFunction0[R, T0]: ...
 
 
 @overload
-def remote(__function: Callable[[T0, T1], R]) -> RemoteFunction1[R, T0, T1]:
-    ...
+def remote(__function: Callable[[T0, T1], R]) -> RemoteFunction1[R, T0, T1]: ...
 
 
 @overload
-def remote(__function: Callable[[T0, T1, T2], R]) -> RemoteFunction2[R, T0, T1, T2]:
-    ...
+def remote(__function: Callable[[T0, T1, T2], R]) -> RemoteFunction2[R, T0, T1, T2]: ...
 
 
 @overload
 def remote(
-    __function: Callable[[T0, T1, T2, T3], R]
-) -> RemoteFunction3[R, T0, T1, T2, T3]:
-    ...
+    __function: Callable[[T0, T1, T2, T3], R],
+) -> RemoteFunction3[R, T0, T1, T2, T3]: ...
 
 
 @overload
 def remote(
-    __function: Callable[[T0, T1, T2, T3, T4], R]
-) -> RemoteFunction4[R, T0, T1, T2, T3, T4]:
-    ...
+    __function: Callable[[T0, T1, T2, T3, T4], R],
+) -> RemoteFunction4[R, T0, T1, T2, T3, T4]: ...
 
 
 @overload
 def remote(
-    __function: Callable[[T0, T1, T2, T3, T4, T5], R]
-) -> RemoteFunction5[R, T0, T1, T2, T3, T4, T5]:
-    ...
+    __function: Callable[[T0, T1, T2, T3, T4, T5], R],
+) -> RemoteFunction5[R, T0, T1, T2, T3, T4, T5]: ...
 
 
 @overload
 def remote(
-    __function: Callable[[T0, T1, T2, T3, T4, T5, T6], R]
-) -> RemoteFunction6[R, T0, T1, T2, T3, T4, T5, T6]:
-    ...
+    __function: Callable[[T0, T1, T2, T3, T4, T5, T6], R],
+) -> RemoteFunction6[R, T0, T1, T2, T3, T4, T5, T6]: ...
 
 
 @overload
 def remote(
-    __function: Callable[[T0, T1, T2, T3, T4, T5, T6, T7], R]
-) -> RemoteFunction7[R, T0, T1, T2, T3, T4, T5, T6, T7]:
-    ...
+    __function: Callable[[T0, T1, T2, T3, T4, T5, T6, T7], R],
+) -> RemoteFunction7[R, T0, T1, T2, T3, T4, T5, T6, T7]: ...
 
 
 @overload
 def remote(
-    __function: Callable[[T0, T1, T2, T3, T4, T5, T6, T7, T8], R]
-) -> RemoteFunction8[R, T0, T1, T2, T3, T4, T5, T6, T7, T8]:
-    ...
+    __function: Callable[[T0, T1, T2, T3, T4, T5, T6, T7, T8], R],
+) -> RemoteFunction8[R, T0, T1, T2, T3, T4, T5, T6, T7, T8]: ...
 
 
 @overload
 def remote(
-    __function: Callable[[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9], R]
-) -> RemoteFunction9[R, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9]:
-    ...
+    __function: Callable[[T0, T1, T2, T3, T4, T5, T6, T7, T8, T9], R],
+) -> RemoteFunction9[R, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9]: ...
 
 
 # Pass on typing actors for now. The following makes it so no type errors
 # are generated for actors.
 @overload
-def remote(__t: type) -> Any:
-    ...
+def remote(__t: type) -> Any: ...
 
 
 # Passing options
@@ -3358,8 +3308,7 @@ def remote(
     scheduling_strategy: Union[
         None, Literal["DEFAULT"], Literal["SPREAD"], PlacementGroupSchedulingStrategy
     ] = Undefined,
-) -> RemoteDecorator:
-    ...
+) -> RemoteDecorator: ...
 
 
 @PublicAPI


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
As title.

Note: `ruff format` also supports `fmt: on/off` like `black`, so we don't need to change them. See https://docs.astral.sh/ruff/formatter/#format-suppression

This PR removes `black` in `format.sh` and runs `ruff format` in both the `pre-commit` hook and CI. Note that `black` is removed from `format.sh` because it is already run in `pre-commit` in CI, so there is no need to run it again in `format.sh`.  

After an offline discussion, we decided to migrate gradually, excluding `black` and including `ruff format` piece by piece. This PR only migrates the `python/ray/_private/` folder.

## Related issue number

<!-- For example: "Closes #1234" -->
ray-project/ray#49436

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
