### PR TITLE
[core] Move asyncio-related utils to `_common/`

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -52,7 +52,7 @@ steps:
     instance_type: large
     parallelism: 4
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... //python/ray/autoscaler/v2/... core
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/_common/tests/... //python/ray/dag/... //python/ray/autoscaler/v2/... core
         --install-mask llm,rllib,serve,train,tune,workflow
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual,use_all_core,multi_gpu

--- a/python/ray/_common/tests/BUILD
+++ b/python/ray/_common/tests/BUILD
@@ -1,0 +1,16 @@
+load("//bazel:python.bzl", "py_test_module_list")
+
+# Small tests.
+py_test_module_list(
+    size = "small",
+    files = [
+        "test_utils.py",
+    ],
+    tags = [
+        "exclusive",
+        "team:core",
+    ],
+    deps = [
+        "//:ray_lib",
+    ],
+)

--- a/python/ray/_common/tests/test_utils.py
+++ b/python/ray/_common/tests/test_utils.py
@@ -6,29 +6,59 @@ import pytest
 
 from ray._common.utils import (
     get_or_create_event_loop,
+    run_background_task,
+    _BACKGROUND_TASKS,
 )
 
 
-def test_get_or_create_event_loop_existing_event_loop():
-    # With running event loop
-    expect_loop = asyncio.new_event_loop()
-    expect_loop.set_debug(True)
-    asyncio.set_event_loop(expect_loop)
-    with warnings.catch_warnings():
-        # Assert no deprecating warnings raised for python>=3.10.
-        warnings.simplefilter("error")
-        actual_loop = get_or_create_event_loop()
+class TestGetOrCreateEventLoop:
+    def test_existing_event_loop(self):
+        # With running event loop
+        expect_loop = asyncio.new_event_loop()
+        expect_loop.set_debug(True)
+        asyncio.set_event_loop(expect_loop)
+        with warnings.catch_warnings():
+            # Assert no deprecating warnings raised for python>=3.10.
+            warnings.simplefilter("error")
+            actual_loop = get_or_create_event_loop()
 
-        assert actual_loop == expect_loop, "Loop should not be recreated."
+            assert actual_loop == expect_loop, "Loop should not be recreated."
 
 
-def test_get_or_create_event_loop_new_event_loop():
-    with warnings.catch_warnings():
-        # Assert no deprecating warnings raised for python>=3.10.
-        warnings.simplefilter("error")
-        loop = get_or_create_event_loop()
-        assert loop is not None, "new event loop should be created."
+    def test_new_event_loop(self):
+        with warnings.catch_warnings():
+            # Assert no deprecating warnings raised for python>=3.10.
+            warnings.simplefilter("error")
+            loop = get_or_create_event_loop()
+            assert loop is not None, "new event loop should be created."
 
+
+
+
+@pytest.mark.asyncio
+async def test_run_background_task():
+    result = {}
+
+    async def co():
+        result["start"] = 1
+        await asyncio.sleep(0)
+        result["end"] = 1
+
+    run_background_task(co())
+
+    # Background task is running.
+    assert len(_BACKGROUND_TASKS) == 1
+    # co executed.
+    await asyncio.sleep(0)
+    # await asyncio.sleep(0) from co is reached.
+    await asyncio.sleep(0)
+    # co finished and callback called.
+    await asyncio.sleep(0)
+    # The task should be removed from the set once it finishes.
+    assert len(_BACKGROUND_TASKS) == 0
+
+    assert result.get("start") == 1
+    assert result.get("end") == 1
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/_common/tests/test_utils.py
+++ b/python/ray/_common/tests/test_utils.py
@@ -29,5 +29,6 @@ def test_get_or_create_event_loop_new_event_loop():
         loop = get_or_create_event_loop()
         assert loop is not None, "new event loop should be created."
 
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/_common/tests/test_utils.py
+++ b/python/ray/_common/tests/test_utils.py
@@ -1,0 +1,33 @@
+import asyncio
+import warnings
+import sys
+
+import pytest
+
+from ray._common.utils import (
+    get_or_create_event_loop,
+)
+
+
+def test_get_or_create_event_loop_existing_event_loop():
+    # With running event loop
+    expect_loop = asyncio.new_event_loop()
+    expect_loop.set_debug(True)
+    asyncio.set_event_loop(expect_loop)
+    with warnings.catch_warnings():
+        # Assert no deprecating warnings raised for python>=3.10.
+        warnings.simplefilter("error")
+        actual_loop = get_or_create_event_loop()
+
+        assert actual_loop == expect_loop, "Loop should not be recreated."
+
+
+def test_get_or_create_event_loop_new_event_loop():
+    with warnings.catch_warnings():
+        # Assert no deprecating warnings raised for python>=3.10.
+        warnings.simplefilter("error")
+        loop = get_or_create_event_loop()
+        assert loop is not None, "new event loop should be created."
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/_common/tests/test_utils.py
+++ b/python/ray/_common/tests/test_utils.py
@@ -24,15 +24,12 @@ class TestGetOrCreateEventLoop:
 
             assert actual_loop == expect_loop, "Loop should not be recreated."
 
-
     def test_new_event_loop(self):
         with warnings.catch_warnings():
             # Assert no deprecating warnings raised for python>=3.10.
             warnings.simplefilter("error")
             loop = get_or_create_event_loop()
             assert loop is not None, "new event loop should be created."
-
-
 
 
 @pytest.mark.asyncio
@@ -59,6 +56,7 @@ async def test_run_background_task():
 
     assert result.get("start") == 1
     assert result.get("end") == 1
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/_common/utils.py
+++ b/python/ray/_common/utils.py
@@ -2,6 +2,8 @@ import asyncio
 import importlib
 import sys
 
+from typing import Coroutine
+
 
 def import_attr(full_path: str, *, reload_module: bool = False):
     """Given a full import path to a module attr, return the imported attr.

--- a/python/ray/_common/utils.py
+++ b/python/ray/_common/utils.py
@@ -1,4 +1,6 @@
+import asyncio
 import importlib
+import sys
 
 
 def import_attr(full_path: str, *, reload_module: bool = False):
@@ -33,3 +35,68 @@ def import_attr(full_path: str, *, reload_module: bool = False):
     if reload_module:
         importlib.reload(module)
     return getattr(module, attr_name)
+
+
+def get_or_create_event_loop() -> asyncio.AbstractEventLoop:
+    """Get a running async event loop if one exists, otherwise create one.
+
+    This function serves as a proxy for the deprecating get_event_loop().
+    It tries to get the running loop first, and if no running loop
+    could be retrieved:
+    - For python version <3.10: it falls back to the get_event_loop
+        call.
+    - For python version >= 3.10: it uses the same python implementation
+        of _get_event_loop() at asyncio/events.py.
+
+    Ideally, one should use high level APIs like asyncio.run() with python
+    version >= 3.7, if not possible, one should create and manage the event
+    loops explicitly.
+    """
+    vers_info = sys.version_info
+    if vers_info.major >= 3 and vers_info.minor >= 10:
+        # This follows the implementation of the deprecating `get_event_loop`
+        # in python3.10's asyncio. See python3.10/asyncio/events.py
+        # _get_event_loop()
+        try:
+            loop = asyncio.get_running_loop()
+            assert loop is not None
+            return loop
+        except RuntimeError as e:
+            # No running loop, relying on the error message as for now to
+            # differentiate runtime errors.
+            assert "no running event loop" in str(e)
+            return asyncio.get_event_loop_policy().get_event_loop()
+
+    return asyncio.get_event_loop()
+
+
+_BACKGROUND_TASKS = set()
+
+
+def run_background_task(coroutine: Coroutine) -> asyncio.Task:
+    """Schedule a task reliably to the event loop.
+
+    This API is used when you don't want to cache the reference of `asyncio.Task`.
+    For example,
+
+    ```
+    get_event_loop().create_task(coroutine(*args))
+    ```
+
+    The above code doesn't guarantee to schedule the coroutine to the event loops
+
+    When using create_task in a  "fire and forget" way, we should keep the references
+    alive for the reliable execution. This API is used to fire and forget
+    asynchronous execution.
+
+    https://docs.python.org/3/library/asyncio-task.html#creating-tasks
+    """
+    task = get_or_create_event_loop().create_task(coroutine)
+    # Add task to the set. This creates a strong reference.
+    _BACKGROUND_TASKS.add(task)
+
+    # To prevent keeping references to finished tasks forever,
+    # make each task remove its own reference from the set after
+    # completion:
+    task.add_done_callback(_BACKGROUND_TASKS.discard)
+    return task

--- a/python/ray/_private/gcs_pubsub.py
+++ b/python/ray/_private/gcs_pubsub.py
@@ -5,7 +5,7 @@ import random
 from typing import Tuple, List
 
 import grpc
-from ray._private.utils import get_or_create_event_loop
+from ray._common.utils import get_or_create_event_loop
 
 from grpc import aio as aiogrpc
 import ray._private.gcs_utils as gcs_utils

--- a/python/ray/_private/process_watcher.py
+++ b/python/ray/_private/process_watcher.py
@@ -9,8 +9,8 @@ from concurrent.futures import ThreadPoolExecutor
 import ray
 from ray.dashboard.consts import _PARENT_DEATH_THREASHOLD
 import ray.dashboard.consts as dashboard_consts
+from ray._common.utils import run_background_task
 import ray._private.ray_constants as ray_constants
-from ray._private.utils import run_background_task
 
 # Import psutil after ray so the packaged version is used.
 import psutil

--- a/python/ray/_private/ray_experimental_perf.py
+++ b/python/ray/_private/ray_experimental_perf.py
@@ -10,7 +10,7 @@ from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 import ray.experimental.channel as ray_channel
 from ray.dag import InputNode, MultiOutputNode
-from ray._private.utils import (
+from ray._common.utils import (
     get_or_create_event_loop,
 )
 from ray._private.test_utils import get_actor_node_id

--- a/python/ray/_private/runtime_env/agent/main.py
+++ b/python/ray/_private/runtime_env/agent/main.py
@@ -1,15 +1,16 @@
-import sys
-import os
 import argparse
 import logging
+import os
+import sys
+
 import ray._private.ray_constants as ray_constants
 from ray.core.generated import (
     runtime_env_agent_pb2,
 )
-from ray._private.utils import open_log
-from ray._private.utils import (
+from ray._common.utils import (
     get_or_create_event_loop,
 )
+from ray._private.utils import open_log
 from ray._private.process_watcher import create_check_raylet_task
 from ray._raylet import StreamRedirector
 

--- a/python/ray/_private/runtime_env/agent/runtime_env_agent.py
+++ b/python/ray/_private/runtime_env/agent/runtime_env_agent.py
@@ -24,7 +24,7 @@ from ray._private.runtime_env.plugin import (
     RuntimeEnvPlugin,
     create_for_plugin_if_needed,
 )
-from ray._private.utils import get_or_create_event_loop
+from ray._common.utils import get_or_create_event_loop
 from ray._private.runtime_env.plugin import RuntimeEnvPluginManager
 from ray._private.runtime_env.py_modules import PyModulesPlugin
 from ray._private.runtime_env.working_dir import WorkingDirPlugin

--- a/python/ray/_private/runtime_env/conda.py
+++ b/python/ray/_private/runtime_env/conda.py
@@ -14,6 +14,9 @@ import yaml
 from filelock import FileLock
 
 import ray
+from ray._common.utils import (
+    get_or_create_event_loop,
+)
 from ray._private.runtime_env.conda_utils import (
     create_conda_env_if_needed,
     delete_conda_env,
@@ -27,7 +30,6 @@ from ray._private.runtime_env.validation import parse_and_validate_conda
 from ray._private.utils import (
     get_directory_size_bytes,
     get_master_wheel_url,
-    get_or_create_event_loop,
     get_release_wheel_url,
     get_wheel_filename,
     try_to_create_directory,

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -41,6 +41,7 @@ import ray._private.memory_monitor as memory_monitor
 import ray._private.services
 import ray._private.usage.usage_lib as ray_usage_lib
 import ray._private.utils
+from ray._common.utils import get_or_create_event_loop
 from ray._private.internal_api import memory_summary
 from ray._private.tls_utils import generate_self_signed_tls_certs
 from ray._raylet import GcsClientOptions, GlobalStateAccessor
@@ -1529,7 +1530,7 @@ class ResourceKillerActor:
         self.is_running = False
         self.head_node_id = head_node_id
         self.killed = set()
-        self.done = ray._private.utils.get_or_create_event_loop().create_future()
+        self.done = get_or_create_event_loop().create_future()
         self.max_to_kill = max_to_kill
         self.batch_size_to_kill = batch_size_to_kill
         self.kill_filter_fn = kill_filter_fn

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1687,39 +1687,6 @@ def split_address(address: str) -> Tuple[str, str]:
     return (module_string, inner_address)
 
 
-def get_or_create_event_loop() -> asyncio.AbstractEventLoop:
-    """Get a running async event loop if one exists, otherwise create one.
-
-    This function serves as a proxy for the deprecating get_event_loop().
-    It tries to get the running loop first, and if no running loop
-    could be retrieved:
-    - For python version <3.10: it falls back to the get_event_loop
-        call.
-    - For python version >= 3.10: it uses the same python implementation
-        of _get_event_loop() at asyncio/events.py.
-
-    Ideally, one should use high level APIs like asyncio.run() with python
-    version >= 3.7, if not possible, one should create and manage the event
-    loops explicitly.
-    """
-    vers_info = sys.version_info
-    if vers_info.major >= 3 and vers_info.minor >= 10:
-        # This follows the implementation of the deprecating `get_event_loop`
-        # in python3.10's asyncio. See python3.10/asyncio/events.py
-        # _get_event_loop()
-        try:
-            loop = asyncio.get_running_loop()
-            assert loop is not None
-            return loop
-        except RuntimeError as e:
-            # No running loop, relying on the error message as for now to
-            # differentiate runtime errors.
-            assert "no running event loop" in str(e)
-            return asyncio.get_event_loop_policy().get_event_loop()
-
-    return asyncio.get_event_loop()
-
-
 def get_entrypoint_name():
     """Get the entrypoint of the current script."""
     prefix = ""
@@ -1886,38 +1853,6 @@ class DeferSigint(contextlib.AbstractContextManager):
             # If exception was raised in context, returning False will cause it to be
             # reraised.
             return False
-
-
-background_tasks = set()
-
-
-def run_background_task(coroutine: Coroutine) -> asyncio.Task:
-    """Schedule a task reliably to the event loop.
-
-    This API is used when you don't want to cache the reference of `asyncio.Task`.
-    For example,
-
-    ```
-    get_event_loop().create_task(coroutine(*args))
-    ```
-
-    The above code doesn't guarantee to schedule the coroutine to the event loops
-
-    When using create_task in a  "fire and forget" way, we should keep the references
-    alive for the reliable execution. This API is used to fire and forget
-    asynchronous execution.
-
-    https://docs.python.org/3/library/asyncio-task.html#creating-tasks
-    """
-    task = get_or_create_event_loop().create_task(coroutine)
-    # Add task to the set. This creates a strong reference.
-    background_tasks.add(task)
-
-    # To prevent keeping references to finished tasks forever,
-    # make each task remove its own reference from the set after
-    # completion:
-    task.add_done_callback(background_tasks.discard)
-    return task
 
 
 def try_import_each_module(module_names_to_import: List[str]) -> None:

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1,4 +1,3 @@
-import asyncio
 import binascii
 import random
 import string
@@ -33,7 +32,6 @@ from typing import (
     Sequence,
     Tuple,
     Union,
-    Coroutine,
     List,
     Mapping,
 )

--- a/python/ray/dag/tests/experimental/test_accelerated_dag.py
+++ b/python/ray/dag/tests/experimental/test_accelerated_dag.py
@@ -19,12 +19,11 @@ from ray.exceptions import ActorDiedError, RayChannelError, RayChannelTimeoutErr
 import ray
 import ray._private
 import ray.cluster_utils
-from ray.dag import InputNode, MultiOutputNode
+from ray.dag import DAGContext, InputNode, MultiOutputNode
 from ray.tests.conftest import *  # noqa
-from ray._private.utils import (
+from ray._common.utils import (
     get_or_create_event_loop,
 )
-from ray.dag import DAGContext
 from ray._private.test_utils import (
     run_string_as_driver_nonblocking,
     wait_for_pid_to_exit,

--- a/python/ray/dashboard/agent.py
+++ b/python/ray/dashboard/agent.py
@@ -13,6 +13,7 @@ import ray._private.services
 import ray._private.utils
 import ray.dashboard.consts as dashboard_consts
 import ray.dashboard.utils as dashboard_utils
+from ray._common.utils import get_or_create_event_loop
 from ray._private.gcs_utils import GcsAioClient
 from ray._private.process_watcher import create_check_raylet_task
 from ray._private.ray_constants import AGENT_GRPC_MAX_MESSAGE_LENGTH
@@ -422,7 +423,7 @@ if __name__ == "__main__":
 
         # Initialize event loop, see Dashboard init code for caveat
         # w.r.t grpc server init in the DashboardAgent initializer.
-        loop = ray._private.utils.get_or_create_event_loop()
+        loop = get_or_create_event_loop()
 
         # Setup stdout/stderr redirect files
         out_filepath, err_filepath = get_capture_filepaths(args.log_dir)

--- a/python/ray/dashboard/datacenter.py
+++ b/python/ray/dashboard/datacenter.py
@@ -2,8 +2,10 @@ import logging
 from typing import List, Optional
 
 import ray.dashboard.consts as dashboard_consts
-from ray._private.utils import (
+from ray._common.utils import (
     get_or_create_event_loop,
+)
+from ray._private.utils import (
     parse_pg_formatted_resources_to_original,
 )
 from ray.dashboard.utils import (

--- a/python/ray/dashboard/http_server_agent.py
+++ b/python/ray/dashboard/http_server_agent.py
@@ -3,8 +3,8 @@ import logging
 from packaging.version import Version
 
 import ray.dashboard.optional_utils as dashboard_optional_utils
-from ray._private.utils import get_or_create_event_loop
 from ray.dashboard.optional_deps import aiohttp, aiohttp_cors, hdrs
+from ray._common.utils import get_or_create_event_loop
 
 logger = logging.getLogger(__name__)
 routes = dashboard_optional_utils.DashboardAgentRouteTable

--- a/python/ray/dashboard/http_server_head.py
+++ b/python/ray/dashboard/http_server_head.py
@@ -14,8 +14,8 @@ import ray
 import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.timezone_utils as timezone_utils
 import ray.dashboard.utils as dashboard_utils
+from ray._common.utils import get_or_create_event_loop
 from ray._private.usage.usage_lib import TagKey, record_extra_usage_tag
-from ray._private.utils import get_or_create_event_loop
 from ray.dashboard.dashboard_metrics import DashboardPrometheusMetrics
 
 # All third-party dependencies that are not included in the minimal Ray

--- a/python/ray/dashboard/modules/actor/actor_head.py
+++ b/python/ray/dashboard/modules/actor/actor_head.py
@@ -9,8 +9,8 @@ import aiohttp.web
 import ray
 import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.utils as dashboard_utils
+from ray._common.utils import get_or_create_event_loop
 from ray._private.gcs_pubsub import GcsAioActorSubscriber
-from ray._private.utils import get_or_create_event_loop
 from ray.dashboard.consts import GCS_RPC_TIMEOUT_SECONDS
 from ray.dashboard.datacenter import DataOrganizer, DataSource
 from ray.dashboard.modules.actor import actor_consts

--- a/python/ray/dashboard/modules/event/event_head.py
+++ b/python/ray/dashboard/modules/event/event_head.py
@@ -12,9 +12,9 @@ import aiohttp.web
 
 import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.utils as dashboard_utils
+from ray._common.utils import get_or_create_event_loop
 from ray._private.ray_constants import env_integer
 from ray._private.usage.usage_lib import TagKey, record_extra_usage_tag
-from ray._private.utils import get_or_create_event_loop
 from ray.core.generated import event_pb2, event_pb2_grpc
 from ray.dashboard.consts import (
     RAY_STATE_SERVER_MAX_HTTP_REQUEST,

--- a/python/ray/dashboard/modules/event/event_utils.py
+++ b/python/ray/dashboard/modules/event/event_utils.py
@@ -9,7 +9,7 @@ import os
 import time
 from concurrent.futures import ThreadPoolExecutor
 
-from ray._private.utils import get_or_create_event_loop, run_background_task
+from ray._common.utils import get_or_create_event_loop, run_background_task
 from ray.dashboard.modules.event import event_consts
 from ray.dashboard.utils import async_loop_forever
 

--- a/python/ray/dashboard/modules/job/cli.py
+++ b/python/ray/dashboard/modules/job/cli.py
@@ -9,8 +9,10 @@ from typing import Any, Dict, Optional, Tuple, Union
 import click
 
 import ray._private.ray_constants as ray_constants
-from ray._private.utils import (
+from ray._common.utils import (
     get_or_create_event_loop,
+)
+from ray._private.utils import (
     load_class,
     parse_metadata_json,
     parse_resources_json,

--- a/python/ray/dashboard/modules/job/job_head.py
+++ b/python/ray/dashboard/modules/job/job_head.py
@@ -21,13 +21,13 @@ from ray.dashboard.consts import (
 )
 import ray.dashboard.optional_utils as optional_utils
 import ray.dashboard.utils as dashboard_utils
+from ray._common.utils import get_or_create_event_loop
 from ray._private.ray_constants import env_bool, KV_NAMESPACE_DASHBOARD
 from ray._private.runtime_env.packaging import (
     package_exists,
     pin_runtime_env_uri,
     upload_package_to_gcs,
 )
-from ray._private.utils import get_or_create_event_loop
 from ray.dashboard.modules.job.common import (
     JobDeleteResponse,
     JobInfoStorageClient,

--- a/python/ray/dashboard/modules/job/job_manager.py
+++ b/python/ray/dashboard/modules/job/job_manager.py
@@ -10,9 +10,9 @@ from typing import Any, AsyncIterator, Dict, Optional, Union
 
 import ray
 import ray._private.ray_constants as ray_constants
+from ray._common.utils import run_background_task
 from ray._private.event.event_logger import get_event_logger
 from ray._private.gcs_utils import GcsAioClient
-from ray._private.utils import run_background_task
 from ray._private.accelerators.nvidia_gpu import NOSET_CUDA_VISIBLE_DEVICES_ENV_VAR
 from ray.actor import ActorHandle
 from ray.core.generated.event_pb2 import Event

--- a/python/ray/dashboard/modules/job/tests/test_job_agent.py
+++ b/python/ray/dashboard/modules/job/tests/test_job_agent.py
@@ -13,6 +13,7 @@ import requests
 import yaml
 
 import ray
+from ray._common.utils import get_or_create_event_loop
 from ray._private.ray_constants import DEFAULT_DASHBOARD_AGENT_LISTEN_PORT
 from ray._private.runtime_env.py_modules import upload_py_modules_if_needed
 from ray._private.runtime_env.working_dir import upload_working_dir_if_needed
@@ -25,7 +26,6 @@ from ray._private.test_utils import (
     wait_for_condition,
     wait_until_server_available,
 )
-from ray._private.utils import get_or_create_event_loop
 from ray.dashboard.modules.job.common import (
     JOB_ACTOR_NAME_TEMPLATE,
     SUPERVISOR_ACTOR_RAY_NAMESPACE,

--- a/python/ray/dashboard/modules/metrics/metrics_head.py
+++ b/python/ray/dashboard/modules/metrics/metrics_head.py
@@ -11,13 +11,13 @@ import aiohttp
 import ray
 import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.utils as dashboard_utils
+from ray._common.utils import get_or_create_event_loop
 from ray._private.async_utils import enable_monitor_loop_lag
 from ray._private.ray_constants import (
     PROMETHEUS_SERVICE_DISCOVERY_FILE,
     SESSION_LATEST,
     env_integer,
 )
-from ray._private.utils import get_or_create_event_loop
 from ray.dashboard.consts import AVAILABLE_COMPONENT_NAMES_FOR_METRICS
 from ray.dashboard.modules.metrics.grafana_dashboard_factory import (
     generate_data_grafana_dashboard,

--- a/python/ray/dashboard/modules/node/node_head.py
+++ b/python/ray/dashboard/modules/node/node_head.py
@@ -14,6 +14,7 @@ import ray._private.utils
 import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.utils as dashboard_utils
 from ray._private import ray_constants
+from ray._common.utils import get_or_create_event_loop
 from ray._private.collections_utils import split
 from ray._private.gcs_pubsub import GcsAioNodeInfoSubscriber
 from ray._private.ray_constants import (
@@ -22,7 +23,6 @@ from ray._private.ray_constants import (
     env_integer,
 )
 from ray._private.gcs_pubsub import GcsAioResourceUsageSubscriber
-from ray._private.utils import get_or_create_event_loop
 from ray.autoscaler._private.util import (
     LoadMetricsSummary,
     get_per_node_breakdown_as_dict,

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -18,6 +18,7 @@ import ray._private.prometheus_exporter as prometheus_exporter
 import ray._private.services
 import ray.dashboard.modules.reporter.reporter_consts as reporter_consts
 import ray.dashboard.utils as dashboard_utils
+from ray._common.utils import get_or_create_event_loop
 from ray._private import utils
 from ray._private.metrics_agent import Gauge, MetricsAgent, Record
 from ray._private.ray_constants import DEBUG_AUTOSCALING_STATUS, env_integer
@@ -1236,7 +1237,7 @@ class ReporterAgent(
 
     async def _run_loop(self, publisher):
         """Get any changes to the log files and push updates to kv."""
-        loop = utils.get_or_create_event_loop()
+        loop = get_or_create_event_loop()
 
         while True:
             try:

--- a/python/ray/dashboard/modules/usage_stats/usage_stats_head.py
+++ b/python/ray/dashboard/modules/usage_stats/usage_stats_head.py
@@ -9,7 +9,7 @@ import requests
 import ray
 import ray._private.usage.usage_lib as ray_usage_lib
 import ray.dashboard.utils as dashboard_utils
-from ray._private.utils import get_or_create_event_loop
+from ray._common.utils import get_or_create_event_loop
 from ray.dashboard.utils import async_loop_forever
 
 logger = logging.getLogger(__name__)

--- a/python/ray/dashboard/state_aggregator.py
+++ b/python/ray/dashboard/state_aggregator.py
@@ -6,9 +6,9 @@ from typing import List, Optional
 
 from ray import NodeID
 import ray.dashboard.memory_utils as memory_utils
+from ray._common.utils import get_or_create_event_loop
 from ray._private.profiling import chrome_tracing_dump
 from ray._private.ray_constants import env_integer
-from ray._private.utils import get_or_create_event_loop
 from ray.dashboard.state_api_utils import do_filter
 from ray.dashboard.utils import compose_state_message
 from ray.runtime_env import RuntimeEnv

--- a/python/ray/dashboard/tests/test_dashboard.py
+++ b/python/ray/dashboard/tests/test_dashboard.py
@@ -23,6 +23,7 @@ import ray.dashboard.consts as dashboard_consts
 import ray.dashboard.modules
 import ray.dashboard.utils as dashboard_utils
 import ray.scripts.scripts as scripts
+from ray._common.utils import get_or_create_event_loop
 from ray._private import ray_constants
 from ray._private.ray_constants import (
     DEBUG_AUTOSCALING_ERROR,
@@ -38,7 +39,6 @@ from ray._private.test_utils import (
     wait_until_server_available,
     wait_until_succeeded_without_exception,
 )
-from ray._private.utils import get_or_create_event_loop
 from ray.core.generated import common_pb2
 from ray.dashboard import dashboard
 from ray.dashboard.head import DashboardHead

--- a/python/ray/dashboard/utils.py
+++ b/python/ray/dashboard/utils.py
@@ -26,11 +26,11 @@ import ray._private.protobuf_compat
 import ray._private.ray_constants as ray_constants
 import ray._private.services as services
 import ray.experimental.internal_kv as internal_kv
+from ray._common.utils import get_or_create_event_loop
 from ray._private.gcs_utils import GcsAioClient, GcsChannel
 from ray._private.utils import (
     binary_to_hex,
     check_dashboard_dependencies_installed,
-    get_or_create_event_loop,
     split_address,
 )
 from ray._raylet import GcsClient

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -11,7 +11,7 @@ import pandas as pd
 import pyarrow as pa
 
 import ray
-from ray._private.utils import get_or_create_event_loop
+from ray._common.utils import get_or_create_event_loop
 from ray.data._internal.compute import get_compute
 from ray.data._internal.execution.interfaces import PhysicalOperator
 from ray.data._internal.execution.interfaces.task_context import TaskContext

--- a/python/ray/llm/_internal/serve/deployments/routers/router.py
+++ b/python/ray/llm/_internal/serve/deployments/routers/router.py
@@ -18,7 +18,7 @@ from typing import (
 from fastapi import FastAPI, HTTPException, status
 from fastapi.middleware.cors import CORSMiddleware
 from ray import serve
-from ray._private.utils import get_or_create_event_loop
+from ray._common.utils import get_or_create_event_loop
 from ray.serve.handle import DeploymentHandle
 from starlette.responses import JSONResponse, Response, StreamingResponse
 

--- a/python/ray/llm/_internal/serve/observability/usage_telemetry/usage.py
+++ b/python/ray/llm/_internal/serve/observability/usage_telemetry/usage.py
@@ -7,8 +7,7 @@ import ray
 from botocore.exceptions import ClientError
 from ray import serve
 
-from ray._private.usage.usage_lib import record_extra_usage_tag, TagKey
-
+from ray._private.usage.usage_lib import record_extra_usage_tag
 
 from ray.llm._internal.serve.observability.logging import get_logger
 from ray.llm._internal.serve.deployments.llm.multiplex.utils import get_lora_model_ids
@@ -173,6 +172,8 @@ class TelemetryAgent:
 
     def record(self, model: Optional[TelemetryModel] = None) -> None:
         """Record telemetry model."""
+        from ray._private.usage.usage_lib import TagKey
+
         if model:
             self.models.append(model)
 

--- a/python/ray/llm/_internal/serve/observability/usage_telemetry/usage.py
+++ b/python/ray/llm/_internal/serve/observability/usage_telemetry/usage.py
@@ -7,7 +7,8 @@ import ray
 from botocore.exceptions import ClientError
 from ray import serve
 
-from ray._private.usage.usage_lib import record_extra_usage_tag
+from ray._private.usage.usage_lib import record_extra_usage_tag, TagKey
+
 
 from ray.llm._internal.serve.observability.logging import get_logger
 from ray.llm._internal.serve.deployments.llm.multiplex.utils import get_lora_model_ids
@@ -172,8 +173,6 @@ class TelemetryAgent:
 
     def record(self, model: Optional[TelemetryModel] = None) -> None:
         """Record telemetry model."""
-        from ray._private.usage.usage_lib import TagKey
-
         if model:
             self.models.append(model)
 

--- a/python/ray/llm/tests/serve/observability/usage_telemetry/test_usage.py
+++ b/python/ray/llm/tests/serve/observability/usage_telemetry/test_usage.py
@@ -1,8 +1,8 @@
 import ray
-from ray._private.usage.usage_lib import TagKey
 import pytest
 import sys
 
+from ray._private.usage.usage_lib import TagKey
 from ray.llm._internal.serve.observability.usage_telemetry.usage import (
     _get_or_create_telemetry_agent,
     push_telemetry_report_for_all_models,

--- a/python/ray/llm/tests/serve/observability/usage_telemetry/test_usage.py
+++ b/python/ray/llm/tests/serve/observability/usage_telemetry/test_usage.py
@@ -1,8 +1,8 @@
 import ray
+from ray._private.usage.usage_lib import TagKey
 import pytest
 import sys
 
-from ray._private.usage.usage_lib import TagKey
 from ray.llm._internal.serve.observability.usage_telemetry.usage import (
     _get_or_create_telemetry_agent,
     push_telemetry_report_for_all_models,

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -7,8 +7,8 @@ import time
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import ray
+from ray._common.utils import run_background_task
 from ray._private.resource_spec import HEAD_NODE_RESOURCE_NAME
-from ray._private.utils import run_background_task
 from ray._raylet import GcsClient
 from ray.actor import ActorHandle
 from ray.serve._private.application_state import ApplicationStateManager, StatusOverview

--- a/python/ray/serve/_private/long_poll.py
+++ b/python/ray/serve/_private/long_poll.py
@@ -11,7 +11,7 @@ from enum import Enum, auto
 from typing import Any, Callable, DefaultDict, Dict, Optional, Set, Tuple, Union
 
 import ray
-from ray._private.utils import get_or_create_event_loop
+from ray._common.utils import get_or_create_event_loop
 from ray.serve._private.constants import SERVE_LOGGER_NAME
 from ray.serve.generated.serve_pb2 import DeploymentTargetInfo
 from ray.serve.generated.serve_pb2 import EndpointInfo as EndpointInfoProto

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -16,7 +16,7 @@ from packaging import version
 from starlette.types import Receive
 
 import ray
-from ray._private.utils import get_or_create_event_loop
+from ray._common.utils import get_or_create_event_loop
 from ray.exceptions import RayActorError, RayTaskError
 from ray.serve._private.common import (
     DeploymentID,

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -31,7 +31,7 @@ from starlette.types import ASGIApp, Message
 
 import ray
 from ray import cloudpickle
-from ray._private.utils import get_or_create_event_loop
+from ray._common.utils import get_or_create_event_loop
 from ray.actor import ActorClass, ActorHandle
 from ray.remote_function import RemoteFunction
 from ray.serve import metrics

--- a/python/ray/serve/batching.py
+++ b/python/ray/serve/batching.py
@@ -25,7 +25,7 @@ from typing import (
 
 from ray import serve
 from ray._private.signature import extract_signature, flatten_args, recover_args
-from ray._private.utils import get_or_create_event_loop
+from ray._common.utils import get_or_create_event_loop
 from ray.serve._private.constants import SERVE_LOGGER_NAME
 from ray.serve._private.utils import extract_self_if_method_call
 from ray.serve.exceptions import RayServeException

--- a/python/ray/serve/tests/test_actor_replica_wrapper.py
+++ b/python/ray/serve/tests/test_actor_replica_wrapper.py
@@ -8,7 +8,7 @@ import pytest
 import ray
 from ray import ObjectRef, ObjectRefGenerator
 from ray._private.test_utils import SignalActor
-from ray._private.utils import get_or_create_event_loop
+from ray._common.utils import get_or_create_event_loop
 from ray.serve._private.common import (
     DeploymentID,
     ReplicaID,

--- a/python/ray/serve/tests/test_handle_2.py
+++ b/python/ray/serve/tests/test_handle_2.py
@@ -7,7 +7,7 @@ import pytest
 import ray
 from ray import serve
 from ray._private.test_utils import SignalActor, async_wait_for_condition
-from ray._private.utils import get_or_create_event_loop
+from ray._common.utils import get_or_create_event_loop
 from ray.serve._private.constants import (
     RAY_SERVE_ENABLE_STRICT_MAX_ONGOING_REQUESTS,
     RAY_SERVE_FORCE_LOCAL_TESTING_MODE,

--- a/python/ray/serve/tests/test_long_poll.py
+++ b/python/ray/serve/tests/test_long_poll.py
@@ -8,7 +8,7 @@ import pytest
 
 import ray
 from ray._private.test_utils import async_wait_for_condition
-from ray._private.utils import get_or_create_event_loop
+from ray._common.utils import get_or_create_event_loop
 from ray.serve._private.common import (
     DeploymentID,
     DeploymentTargetInfo,

--- a/python/ray/serve/tests/test_multiplex.py
+++ b/python/ray/serve/tests/test_multiplex.py
@@ -8,7 +8,7 @@ import requests
 import ray
 from ray import serve
 from ray._private.test_utils import SignalActor, wait_for_condition
-from ray._private.utils import get_or_create_event_loop
+from ray._common.utils import get_or_create_event_loop
 from ray.serve._private.common import DeploymentID, ReplicaID
 from ray.serve._private.config import DeploymentConfig
 from ray.serve._private.constants import SERVE_MULTIPLEXED_MODEL_ID

--- a/python/ray/serve/tests/unit/test_batching.py
+++ b/python/ray/serve/tests/unit/test_batching.py
@@ -7,7 +7,7 @@ import pytest
 
 import ray
 from ray import serve
-from ray._private.utils import get_or_create_event_loop
+from ray._common.utils import get_or_create_event_loop
 from ray.serve._private.common import DeploymentID, ReplicaID
 from ray.serve._private.config import DeploymentConfig
 from ray.serve._private.constants import SERVE_LOGGER_NAME

--- a/python/ray/serve/tests/unit/test_http_util.py
+++ b/python/ray/serve/tests/unit/test_http_util.py
@@ -5,7 +5,7 @@ from typing import Generator, Tuple
 
 import pytest
 
-from ray._private.utils import get_or_create_event_loop
+from ray._common.utils import get_or_create_event_loop
 from ray.serve._private.http_util import ASGIReceiveProxy, MessageQueue
 
 

--- a/python/ray/serve/tests/unit/test_pow_2_replica_scheduler.py
+++ b/python/ray/serve/tests/unit/test_pow_2_replica_scheduler.py
@@ -10,7 +10,7 @@ import pytest
 
 import ray
 from ray._private.test_utils import async_wait_for_condition
-from ray._private.utils import get_or_create_event_loop
+from ray._common.utils import get_or_create_event_loop
 from ray.actor import ActorHandle
 from ray.exceptions import ActorDiedError, ActorUnavailableError
 from ray.serve._private.common import (

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -9,7 +9,7 @@ import pytest
 
 import ray
 from ray._private.test_utils import async_wait_for_condition
-from ray._private.utils import get_or_create_event_loop
+from ray._common.utils import get_or_create_event_loop
 from ray.exceptions import ActorDiedError, ActorUnavailableError
 from ray.serve._private.common import (
     DeploymentHandleSource,

--- a/python/ray/tests/test_async.py
+++ b/python/ray/tests/test_async.py
@@ -12,10 +12,6 @@ from ray._common.utils import (
     get_or_create_event_loop,
 )
 from ray._private.test_utils import wait_for_condition
-from ray._private.utils import (
-    run_background_task,
-    background_tasks,
-)
 
 
 @pytest.fixture
@@ -164,33 +160,6 @@ def test_concurrent_future_many(ray_start_regular_shared):
         assert fut.done()
         result.add(fut.result())
     assert result == set(range(100))
-
-
-@pytest.mark.asyncio
-async def test_run_backgroun_job():
-    """Test `run_backgroun_job` works as expected."""
-    result = {}
-
-    async def co():
-        result["start"] = 1
-        await asyncio.sleep(0)
-        result["end"] = 1
-
-    run_background_task(co())
-
-    # Backgroun job is registered.
-    assert len(background_tasks) == 1
-    # co executed.
-    await asyncio.sleep(0)
-    # await asyncio.sleep(0) from co is reached.
-    await asyncio.sleep(0)
-    # co finished and callback called.
-    await asyncio.sleep(0)
-    # The callback should be cleaned.
-    assert len(background_tasks) == 0
-
-    assert result.get("start") == 1
-    assert result.get("end") == 1
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_async.py
+++ b/python/ray/tests/test_async.py
@@ -8,9 +8,11 @@ import numpy as np
 import pytest
 
 import ray
+from ray._common.utils import (
+    get_or_create_event_loop,
+)
 from ray._private.test_utils import wait_for_condition
 from ray._private.utils import (
-    get_or_create_event_loop,
     run_background_task,
     background_tasks,
 )

--- a/python/ray/tests/test_client_reconnect.py
+++ b/python/ray/tests/test_client_reconnect.py
@@ -13,7 +13,7 @@ from typing import Any, Callable, Optional
 from unittest.mock import patch, Mock
 
 import ray
-from ray._private.utils import get_or_create_event_loop
+from ray._common.utils import get_or_create_event_loop
 import ray.core.generated.ray_client_pb2 as ray_client_pb2
 import ray.core.generated.ray_client_pb2_grpc as ray_client_pb2_grpc
 from ray.tests.conftest import call_ray_start_context

--- a/python/ray/tests/test_concurrency_group.py
+++ b/python/ray/tests/test_concurrency_group.py
@@ -1,13 +1,13 @@
 # coding: utf-8
 import asyncio
+import pytest
 import sys
 import threading
-import pytest
-import ray
 import time
-
 from typing import Any, Tuple
-from ray._private.utils import get_or_create_event_loop
+
+import ray
+from ray._common.utils import get_or_create_event_loop
 from ray._private.test_utils import run_string_as_driver
 
 

--- a/python/ray/tests/test_concurrency_group.py
+++ b/python/ray/tests/test_concurrency_group.py
@@ -1,10 +1,11 @@
 # coding: utf-8
 import asyncio
-import pytest
 import sys
 import threading
 import time
 from typing import Any, Tuple
+
+import pytest
 
 import ray
 from ray._common.utils import get_or_create_event_loop

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -8,7 +8,7 @@ import signal
 import pytest
 
 import ray
-from ray._private.utils import get_or_create_event_loop
+from ray._common.utils import get_or_create_event_loop
 from ray.util.placement_group import placement_group
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 import ray._private.gcs_utils as gcs_utils

--- a/python/ray/tests/test_utils.py
+++ b/python/ray/tests/test_utils.py
@@ -8,7 +8,6 @@ This currently expects to work for minimal installs.
 import pytest
 import logging
 from ray._private.utils import (
-    get_or_create_event_loop,
     parse_pg_formatted_resources_to_original,
     try_import_each_module,
     get_current_node_cpu_model_name,
@@ -17,32 +16,6 @@ from unittest.mock import patch, mock_open
 import sys
 
 logger = logging.getLogger(__name__)
-
-
-def test_get_or_create_event_loop_existing_event_loop():
-    import asyncio
-    import warnings
-
-    # With running event loop
-    expect_loop = asyncio.new_event_loop()
-    expect_loop.set_debug(True)
-    asyncio.set_event_loop(expect_loop)
-    with warnings.catch_warnings():
-        # Assert no deprecating warnings raised for python>=3.10
-        warnings.simplefilter("error")
-        actual_loop = get_or_create_event_loop()
-
-        assert actual_loop == expect_loop, "Loop should not be recreated."
-
-
-def test_get_or_create_event_loop_new_event_loop():
-    import warnings
-
-    with warnings.catch_warnings():
-        # Assert no deprecating warnings raised for python>=3.10
-        warnings.simplefilter("error")
-        loop = get_or_create_event_loop()
-        assert loop is not None, "new event loop should be created."
 
 
 def test_try_import_each_module():

--- a/python/ray/workflow/common.py
+++ b/python/ray/workflow/common.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 
 import ray
 from ray import ObjectRef
-from ray._private.utils import get_or_create_event_loop
+from ray._common.utils import get_or_create_event_loop
 from ray.util.annotations import PublicAPI
 
 # Alias types


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

- Moves two utils to `_common/`: `get_or_create_event_loop` and `run_background_task`
- Adds tests and a `BUILD` file to the `_common/` directory.
- Adds `python/ray/_common/tests/` to Ray Core CI tests

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
