### PR TITLE
Handle offset overflow case in take_table

### DIFF
--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -78,11 +78,18 @@ def take_table(
             # .take() will concatenate internally, which currently breaks for
             # extension arrays.
             col = combine_chunked_array(col)
-        elif (
-            sum(chunk.length for chunk in col.chunks) > MAX_INT32 and col.num_chunks > 1
-        ):
-            # .take() breaks when offset > MAX_INT32
-            col = combine_chunked_array(col)
+        elif col.num_chunks > 1:
+            total_length = sum(chunk.length for chunk in col.chunks)
+            if total_length > MAX_INT32:
+                # .take() breaks when offset > MAX_INT32
+                col = combine_chunked_array(col)
+            else:
+                # Check individual chunk size in case any single chunk is larger than MAX_INT32
+                for chunk in col.chunks:
+                    if chunk.length > MAX_INT32:
+                        col = combine_chunked_array(col)
+                        break
+
         new_cols.append(col.take(indices))
     table = pyarrow.Table.from_arrays(new_cols, schema=table.schema)
     return table

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -78,10 +78,9 @@ def take_table(
             # .take() will concatenate internally, which currently breaks for
             # extension arrays.
             col = combine_chunked_array(col)
-        elif col.num_chunks > 1:
-            if col.nbytes > MAX_INT32:
-                # .take() breaks when offset > MAX_INT32
-                col = combine_chunked_array(col)
+        elif col.nbytes > MAX_INT32 and col.num_chunks > 1:
+            # .take() breaks when offset > MAX_INT32
+            col = combine_chunked_array(col)
         new_cols.append(col.take(indices))
     table = pyarrow.Table.from_arrays(new_cols, schema=table.schema)
     return table

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -79,7 +79,7 @@ def take_table(
             # extension arrays.
             col = combine_chunked_array(col)
         elif col.num_chunks > 1:
-            if col.length() > MAX_INT32:
+            if col.nbytes > MAX_INT32:
                 # .take() breaks when offset > MAX_INT32
                 col = combine_chunked_array(col)
         new_cols.append(col.take(indices))

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -82,7 +82,6 @@ def take_table(
             if col.length() > MAX_INT32:
                 # .take() breaks when offset > MAX_INT32
                 col = combine_chunked_array(col)
- 
         new_cols.append(col.take(indices))
     table = pyarrow.Table.from_arrays(new_cols, schema=table.schema)
     return table

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -79,17 +79,10 @@ def take_table(
             # extension arrays.
             col = combine_chunked_array(col)
         elif col.num_chunks > 1:
-            total_length = sum(chunk.length for chunk in col.chunks)
-            if total_length > MAX_INT32:
+            if col.length() > MAX_INT32:
                 # .take() breaks when offset > MAX_INT32
                 col = combine_chunked_array(col)
-            else:
-                # Check individual chunk size in case any single chunk is larger than MAX_INT32
-                for chunk in col.chunks:
-                    if chunk.length > MAX_INT32:
-                        col = combine_chunked_array(col)
-                        break
-
+ 
         new_cols.append(col.take(indices))
     table = pyarrow.Table.from_arrays(new_cols, schema=table.schema)
     return table

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -92,9 +92,9 @@ def _take_chunked(
         A new Arrow array containing the selected elements
     """
     if isinstance(idx_chunk, np.ndarray):
-        return col.take(idx_chunk)
+        return pc.take(col, idx_chunk)
     else:
-        return col.take(idx_chunk.slice(0, chunk_size))
+        return pc.take(col, idx_chunk.slice(0, chunk_size))
 
 
 def _process_large_indices(
@@ -214,7 +214,7 @@ def take_table(
         if needs_chunking:
             new_col = _process_large_indices(col, indices, indices_len)
         else:
-            new_col = col.take(indices)
+            new_col = pc.take(col, indices)
 
         new_cols.append(new_col)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Fix `table_take` for case when offset can overflow max 32 bit int. Here to avoid overflow,
* Combine chunks when there are Multiple chunks and Arrow extension types. 
* Check for max offset from indices. If overflow possibility exists, just do batching.
* Use `pc.take` instead of `table.take`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
