### PR TITLE
[Debugger] Random pick ray debugger port from range

### DIFF
--- a/python/ray/util/debugpy.py
+++ b/python/ray/util/debugpy.py
@@ -4,7 +4,6 @@ import sys
 import threading
 import importlib
 import random
-from typing import Optional
 
 import ray
 from ray.util.annotations import DeveloperAPI
@@ -95,7 +94,7 @@ def _ensure_debugger_port_open_thread_safe():
                         f"Failed to open debugger on any port in range {port_range_start}-{port_range_end}"
                     )
                 else:
-                    log.error(f"Failed to open debugger on any port")
+                    log.error("Failed to open debugger on any port")
                 return
 
             ray._private.worker.global_worker.set_debugger_port(port)

--- a/python/ray/util/debugpy.py
+++ b/python/ray/util/debugpy.py
@@ -46,7 +46,7 @@ def _override_breakpoint_hooks():
     __builtin__.breakpoint = set_trace
 
 
-def _ensure_debugger_port_open_thread_safe() -> Optional[int]:
+def _ensure_debugger_port_open_thread_safe():
     """
     This is a thread safe method that ensure that the debugger port
     is open, and if not, open it.
@@ -96,14 +96,12 @@ def _ensure_debugger_port_open_thread_safe() -> Optional[int]:
                     )
                 else:
                     log.error(f"Failed to open debugger on any port")
-                return None
+                return
 
             ray._private.worker.global_worker.set_debugger_port(port)
             log.info(f"Ray debugger is listening on {host}:{port}")
-            return port
         else:
             log.info(f"Ray debugger is already open on {debugger_port}")
-            return debugger_port
 
 
 @DeveloperAPI


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->



<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Ray distributed debugger currently picks ports randomly, making it hard to expose the ports in a cluster.
This PR limits the debugger port in a range, so users could config the cluster or firewall to allow the traffic for the port range.


## Related issue number

<!-- For example: "Closes #1234" -->
Closing https://github.com/ray-project/ray/issues/45541

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
