### PR TITLE
[core][dashboard] Return the correct error message when trying to kill non-existent actors

### DIFF
--- a/python/ray/dashboard/modules/snapshot/snapshot_head.py
+++ b/python/ray/dashboard/modules/snapshot/snapshot_head.py
@@ -89,21 +89,31 @@ class APIHead(dashboard_utils.DashboardHeadModule):
                 success=False, message="actor_id is required."
             )
 
-        await self.gcs_aio_client.kill_actor(
+        status_code = await self.gcs_aio_client.kill_actor(
             ActorID.from_hex(actor_id),
             force_kill,
             no_restart,
             timeout=SNAPSHOT_API_TIMEOUT_SECONDS,
         )
 
-        message = (
-            f"Force killed actor with id {actor_id}"
-            if force_kill
-            else f"Requested actor with id {actor_id} to terminate. "
-            + "It will exit once running tasks complete"
-        )
+        success = status_code == 200
+        if status_code == 404:
+            message = f"Actor with id {actor_id} not found."
+        elif status_code == 500:
+            message = f"Failed to kill actor with id {actor_id}."
+        elif status_code == 200:
+            message = (
+                f"Force killed actor with id {actor_id}"
+                if force_kill
+                else f"Requested actor with id {actor_id} to terminate. "
+                + "It will exit once running tasks complete"
+            )
+        else:
+            message = f"Unknown status code: {status_code}. Please open a bug report in the Ray repository."
 
-        return dashboard_optional_utils.rest_response(success=True, message=message)
+        # TODO(kevin85421): The utility function needs to be refactored to handle
+        # different status codes. Currently, it only returns 200 and 500.
+        return dashboard_optional_utils.rest_response(success=success, message=message)
 
     @routes.get("/api/component_activities")
     async def get_component_activities(self, req) -> aiohttp.web.Response:

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -673,7 +673,7 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   /// messages come from a Driver/Worker caused by some network problems.
   absl::flat_hash_map<ActorID, std::vector<CreateActorCallback>>
       actor_to_create_callbacks_;
-  /// All registered actors (unresoved and pending actors are also included).
+  /// All registered actors (unresolved and pending actors are also included).
   /// TODO(swang): Use unique_ptr instead of shared_ptr.
   absl::flat_hash_map<ActorID, std::shared_ptr<GcsActor>> registered_actors_;
   /// All destroyed actors.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

```sh
# Launch a Ray cluster with Ray dashboard
ray start --head --include-dashboard=True

# Use `/api/actors/kill` to kill an non-existent actor
curl -X GET -w "%{http_code}" "http://localhost:8265/api/actors/kill?actor_id=abc&force_kill=false"

# [response of the curl command]
# The error code is 200, and the msg is wrong.
{"result": true, "msg": "Requested actor with id abc to terminate. It will exit once running tasks complete", "data": {}}200%
```

This PR corrects the error message, and the fix of status code is a follow up.

With this PR, the status code changes from 200 to 500. It should be 404. This will be fixed in a follow up PR.

<img width="1317" alt="image" src="https://github.com/user-attachments/assets/eaef961b-4229-4c92-9168-f2eb69434d85" />


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
