### PR TITLE
[llm] ray.llm support custom accelerators

### DIFF
--- a/python/ray/data/llm.py
+++ b/python/ray/data/llm.py
@@ -19,6 +19,9 @@ class ProcessorConfig(_ProcessorConfig):
             On the other hand, small batch sizes are more fault-tolerant and could
             reduce bubbles in the data pipeline. You can tune the batch size to balance
             the throughput and fault-tolerance based on your use case.
+        resources_per_bundle: The resource bundles for placement groups.
+            You can specify a custom device label e.g. {'NPU': 1}.
+            The default resource bundle for LLM Stage is always a GPU resource i.e. {'GPU': 1}.
         accelerator_type: The accelerator type used by the LLM stage in a processor.
             Default to None, meaning that only the CPU will be used.
         concurrency: The number of workers for data parallelism. Default to 1.

--- a/python/ray/llm/_internal/batch/processor/base.py
+++ b/python/ray/llm/_internal/batch/processor/base.py
@@ -26,6 +26,11 @@ class ProcessorConfig(BaseModelExtended):
         "You can tune the batch size to balance the throughput and fault-tolerance "
         "based on your use case. Defaults to 64.",
     )
+    resources_per_worker: Optional[Dict[str, float]] = Field(
+        default=None,
+        description="This will override the default resources config for actors/workers, "
+        "the default resource config for LLM Stage may be something like {'GPU': 1}."
+    )
     accelerator_type: Optional[str] = Field(
         default=None,
         description="The accelerator type used by the LLM stage in a processor. "

--- a/python/ray/llm/_internal/batch/processor/base.py
+++ b/python/ray/llm/_internal/batch/processor/base.py
@@ -29,7 +29,7 @@ class ProcessorConfig(BaseModelExtended):
     resources_per_worker: Optional[Dict[str, float]] = Field(
         default=None,
         description="This will override the default resources config for actors/workers, "
-        "the default resource config for LLM Stage may be something like {'GPU': 1}."
+        "the default resource config for LLM Stage may be something like {'GPU': 1}.",
     )
     accelerator_type: Optional[str] = Field(
         default=None,

--- a/python/ray/llm/_internal/batch/processor/base.py
+++ b/python/ray/llm/_internal/batch/processor/base.py
@@ -26,10 +26,11 @@ class ProcessorConfig(BaseModelExtended):
         "You can tune the batch size to balance the throughput and fault-tolerance "
         "based on your use case. Defaults to 64.",
     )
-    resources_per_worker: Optional[Dict[str, float]] = Field(
+    resources_per_bundle: Optional[Dict[str, float]] = Field(
         default=None,
-        description="This will override the default resources config for actors/workers, "
-        "the default resource config for LLM Stage may be something like {'GPU': 1}.",
+        description="This will override the default resource bundles for placement groups. "
+        "You can specify a custom device label e.g. {'NPU': 1}. "
+        "The default resource bundle for LLM Stage is always a GPU resource i.e. {'GPU': 1}.",
     )
     accelerator_type: Optional[str] = Field(
         default=None,

--- a/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
@@ -190,7 +190,7 @@ def build_vllm_engine_processor(
                 # This is used to make sure we overlap batches to avoid the tail
                 # latency of each batch.
                 max_concurrency=config.max_concurrent_batches,
-                resources_per_bundle=config.resources_per_bundle,
+                resources=config.resources_per_bundle,
                 accelerator_type=config.accelerator_type,
                 runtime_env=config.runtime_env,
             ),

--- a/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
@@ -190,6 +190,7 @@ def build_vllm_engine_processor(
                 # This is used to make sure we overlap batches to avoid the tail
                 # latency of each batch.
                 max_concurrency=config.max_concurrent_batches,
+                resources=config.resources_per_worker,
                 accelerator_type=config.accelerator_type,
                 runtime_env=config.runtime_env,
             ),

--- a/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
@@ -190,7 +190,7 @@ def build_vllm_engine_processor(
                 # This is used to make sure we overlap batches to avoid the tail
                 # latency of each batch.
                 max_concurrency=config.max_concurrent_batches,
-                resources=config.resources_per_worker,
+                resources_per_bundle=config.resources_per_bundle,
                 accelerator_type=config.accelerator_type,
                 runtime_env=config.runtime_env,
             ),

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -574,7 +574,9 @@ class vLLMEngineStageUDF(StatefulStageUDF):
 
 
 def _ray_scheduling_strategy_fn(
-    num_workers_per_instance: int, accelerator_type: str, resources: Optional[Dict[str, float]] = None
+    num_workers_per_instance: int,
+    accelerator_type: str,
+    resources: Optional[Dict[str, float]] = None,
 ):
     """
     Create a Ray scheduling strategy for vLLM engine.
@@ -660,7 +662,8 @@ class vLLMEngineStage(StatefulStage):
             map_batches_kwargs["num_gpus"] = num_mp_workers
         else:
             ray_remote_args["resources"] = {
-                key: value * num_mp_workers for key, value in resources_per_worker.items()
+                key: value * num_mp_workers
+                for key, value in resources_per_worker.items()
             }
 
         map_batches_kwargs.update(ray_remote_args)

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -668,15 +668,16 @@ class vLLMEngineStage(StatefulStage):
                 accelerator_type,
                 resources_per_bundle,
             )
-
-        if not resources_per_bundle:
-            # Default to GPUs per bundle if custom resources are not specified.
-            ray_remote_args["num_gpus"] = num_bundles_per_replica
+            ray_remote_args["num_gpus"] = 0
         else:
-            ray_remote_args["resources"] = {
-                resource_key: resource_count * num_bundles_per_replica
-                for resource_key, resource_count in resources_per_bundle.items()
-            }
+            if not resources_per_bundle:
+                # Default to GPUs per bundle if custom resources are not specified.
+                ray_remote_args["num_gpus"] = num_bundles_per_replica
+            else:
+                ray_remote_args["resources"] = {
+                    resource_key: resource_count * num_bundles_per_replica
+                    for resource_key, resource_count in resources_per_bundle.items()
+                }
 
         map_batches_kwargs.update(ray_remote_args)
         return values

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -637,7 +637,7 @@ class vLLMEngineStage(StatefulStage):
             The updated values.
         """
         map_batches_kwargs = values["map_batches_kwargs"]
-        resources_per_bundle = map_batches_kwargs.get("resources_per_bundle")
+        resources_per_bundle = map_batches_kwargs.get("resources")
         accelerator_type = map_batches_kwargs.get("accelerator_type", "")
         fn_constructor_kwargs = values["fn_constructor_kwargs"]
         engine_kwargs = fn_constructor_kwargs.get("engine_kwargs", {})

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -655,6 +655,7 @@ class vLLMEngineStage(StatefulStage):
                 _ray_scheduling_strategy_fn,
                 num_workers,
                 accelerator_type,
+                resources_per_worker,
             )
             num_mp_workers = 0
 

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -637,7 +637,6 @@ class vLLMEngineStage(StatefulStage):
             The updated values.
         """
         map_batches_kwargs = values["map_batches_kwargs"]
-        resources_per_bundle = map_batches_kwargs.get("resources")
         accelerator_type = map_batches_kwargs.get("accelerator_type", "")
         fn_constructor_kwargs = values["fn_constructor_kwargs"]
         engine_kwargs = fn_constructor_kwargs.get("engine_kwargs", {})
@@ -659,6 +658,7 @@ class vLLMEngineStage(StatefulStage):
         # Ray Data won't reserve GPUs in advance. Instead, we specify scheduling
         # strategy in .map_batches() arguments and let vLLM Ray executor to
         # create placement groups for each TP/PP worker.
+        resources_per_bundle = map_batches_kwargs.pop("resources", None)
         if executor_backend == "ray" and num_bundles_per_replica > 1:
             # Note that we have to use partial() to pass a function
             # instead of an object.

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -573,12 +573,14 @@ class vLLMEngineStageUDF(StatefulStageUDF):
             self.llm.shutdown()
 
 
-def _ray_scheduling_strategy_fn(num_gpus_per_instance: int, accelerator_type: str):
+def _ray_scheduling_strategy_fn(
+    num_workers_per_instance: int, accelerator_type: str, resources: Optional[Dict[str, float]] = None
+):
     """
     Create a Ray scheduling strategy for vLLM engine.
 
     Args:
-        num_gpus_per_instance: The number of GPUs per instance.
+        num_workers_per_instance: The number of workers per instance.
         accelerator_type: The accelerator type.
 
     Returns:
@@ -586,13 +588,13 @@ def _ray_scheduling_strategy_fn(num_gpus_per_instance: int, accelerator_type: st
     """
 
     def _get_bundle() -> Dict[str, float]:
-        bundle: Dict[str, float] = {"GPU": 1, "CPU": 1}
+        bundle: Dict[str, float] = resources if resources else {"GPU": 1, "CPU": 1}
         if accelerator_type:
             bundle[f"accelerator_type:{accelerator_type}"] = 0.001
         return bundle
 
     pg = ray.util.placement_group(
-        [_get_bundle()] * num_gpus_per_instance,
+        [_get_bundle()] * num_workers_per_instance,
         strategy="STRICT_PACK",
     )
     return dict(
@@ -621,6 +623,7 @@ class vLLMEngineStage(StatefulStage):
             The updated values.
         """
         map_batches_kwargs = values["map_batches_kwargs"]
+        resources_per_worker = map_batches_kwargs.get("resources")
         accelerator_type = map_batches_kwargs.get("accelerator_type", "")
         fn_constructor_kwargs = values["fn_constructor_kwargs"]
         engine_kwargs = fn_constructor_kwargs.get("engine_kwargs", {})
@@ -629,29 +632,36 @@ class vLLMEngineStage(StatefulStage):
         if accelerator_type:
             ray_remote_args["accelerator_type"] = accelerator_type
 
-        # Setup num_gpus required per vLLM engine.
+        # Setup num_workers required per vLLM engine.
         tp_size = engine_kwargs.get("tensor_parallel_size", 1)
         pp_size = engine_kwargs.get("pipeline_parallel_size", 1)
-        num_gpus = tp_size * pp_size
+        num_workers = tp_size * pp_size
 
         # Use the MP backend by default.
         engine_kwargs.setdefault("distributed_executor_backend", "mp")
         executor_backend = engine_kwargs.get("distributed_executor_backend")
 
-        # When Ray is used in the vLLM engine, we set num_gpus to 0 so that
+        # When Ray is used in the vLLM engine, we set num_devices to 0 so that
         # Ray Data won't reserve GPUs in advance. Instead, we specify scheduling
         # strategy in .map_batches() arguments and let vLLM Ray executor to
         # create placement groups for each TP/PP worker.
-        if executor_backend == "ray" and num_gpus > 1:
+        num_mp_workers = num_workers
+        if executor_backend == "ray" and num_workers > 1:
             # Note that we have to use partial() to pass a function
             # instead of an object.
             map_batches_kwargs["ray_remote_args_fn"] = partial(
                 _ray_scheduling_strategy_fn,
-                num_gpus,
+                num_workers,
                 accelerator_type,
             )
-            num_gpus = 0
+            num_mp_workers = 0
 
-        map_batches_kwargs["num_gpus"] = num_gpus
+        if not resources_per_worker:
+            map_batches_kwargs["num_gpus"] = num_mp_workers
+        else:
+            ray_remote_args["resources"] = {
+                key: value * num_mp_workers for key, value in resources_per_worker.items()
+            }
+
         map_batches_kwargs.update(ray_remote_args)
         return values

--- a/python/ray/llm/_internal/serve/configs/server_models.py
+++ b/python/ray/llm/_internal/serve/configs/server_models.py
@@ -193,7 +193,7 @@ class LLMConfig(BaseModelExtended):
     resources_per_worker: Optional[Dict[str, float]] = Field(
         default=None,
         description="This will pass to config like `VLLMEngineConfig` and override "
-        "the resources config for the workers in vLLM engine."
+        "the resources config for the workers in vLLM engine.",
     )
 
     accelerator_type: Optional[str] = Field(

--- a/python/ray/llm/_internal/serve/configs/server_models.py
+++ b/python/ray/llm/_internal/serve/configs/server_models.py
@@ -190,10 +190,11 @@ class LLMConfig(BaseModelExtended):
         ),
     )
 
-    resources_per_worker: Optional[Dict[str, float]] = Field(
+    resources_per_bundle: Optional[Dict[str, float]] = Field(
         default=None,
-        description="This will pass to config like `VLLMEngineConfig` and override "
-        "the resources config for the workers in vLLM engine.",
+        description="This will override the default resource bundles for placement groups. "
+        "You can specify a custom device label e.g. {'NPU': 1}. "
+        "The default resource bundle for LLM Stage is always a GPU resource i.e. {'GPU': 1}.",
     )
 
     accelerator_type: Optional[str] = Field(

--- a/python/ray/llm/_internal/serve/configs/server_models.py
+++ b/python/ray/llm/_internal/serve/configs/server_models.py
@@ -190,6 +190,12 @@ class LLMConfig(BaseModelExtended):
         ),
     )
 
+    resources_per_worker: Optional[Dict[str, float]] = Field(
+        default=None,
+        description="This will pass to config like `VLLMEngineConfig` and override "
+        "the resources config for the workers in vLLM engine."
+    )
+
     accelerator_type: Optional[str] = Field(
         default=None,
         description=f"The type of accelerator runs the model on. Only the following values are supported: {str([t.value for t in GPUType])}",

--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_models.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_models.py
@@ -54,7 +54,7 @@ class VLLMEngineConfig(BaseModelExtended):
     resources_per_worker: Optional[Dict[str, float]] = Field(
         default=None,
         description="This overrides the vLLM engine worker's default resource configuration, "
-        "the number of resources returned by `placement_bundles`."
+        "the number of resources returned by `placement_bundles`.",
     )
     accelerator_type: Optional[GPUType] = Field(
         None,

--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_models.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_models.py
@@ -51,6 +51,11 @@ class VLLMEngineConfig(BaseModelExtended):
         None,
         description="Configuration for cloud storage mirror. This is for where the weights are downloaded from.",
     )
+    resources_per_worker: Optional[Dict[str, float]] = Field(
+        default=None,
+        description="This overrides the vLLM engine worker's default resource configuration, "
+        "the number of resources returned by `placement_bundles`."
+    )
     accelerator_type: Optional[GPUType] = Field(
         None,
         description="The type of accelerator to use. This is used to determine the placement group strategy.",
@@ -104,6 +109,7 @@ class VLLMEngineConfig(BaseModelExtended):
             model_id=llm_config.model_id,
             hf_model_id=hf_model_id,
             mirror_config=mirror_config,
+            accelerator_name=llm_config.resources_per_worker,
             accelerator_type=llm_config.accelerator_type,
             engine_kwargs=llm_config.engine_kwargs,
             runtime_env=llm_config.runtime_env,
@@ -134,7 +140,10 @@ class VLLMEngineConfig(BaseModelExtended):
 
     @property
     def placement_bundles(self) -> List[Dict[str, float]]:
-        bundle = {"GPU": 1}
+        if not self.resources_per_worker:
+            bundle = {"GPU": 1}
+        else:
+            bundle = self.resources_per_worker
         if self.accelerator_type:
             bundle[self.ray_accelerator_type()] = 0.001
         bundles = [bundle for _ in range(self.num_gpu_workers)]

--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_models.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_models.py
@@ -51,7 +51,7 @@ class VLLMEngineConfig(BaseModelExtended):
         None,
         description="Configuration for cloud storage mirror. This is for where the weights are downloaded from.",
     )
-    resources_per_worker: Optional[Dict[str, float]] = Field(
+    resources_per_bundle: Optional[Dict[str, float]] = Field(
         default=None,
         description="This overrides the vLLM engine worker's default resource configuration, "
         "the number of resources returned by `placement_bundles`.",
@@ -109,7 +109,7 @@ class VLLMEngineConfig(BaseModelExtended):
             model_id=llm_config.model_id,
             hf_model_id=hf_model_id,
             mirror_config=mirror_config,
-            resources_per_worker=llm_config.resources_per_worker,
+            resources_per_bundle=llm_config.resources_per_bundle,
             accelerator_type=llm_config.accelerator_type,
             engine_kwargs=llm_config.engine_kwargs,
             runtime_env=llm_config.runtime_env,
@@ -128,7 +128,7 @@ class VLLMEngineConfig(BaseModelExtended):
         return self.engine_kwargs.get("pipeline_parallel_size", 1)
 
     @property
-    def num_gpu_workers(self) -> int:
+    def num_devices(self) -> int:
         return self.tensor_parallel_degree * self.pipeline_parallel_degree
 
     @property
@@ -140,13 +140,13 @@ class VLLMEngineConfig(BaseModelExtended):
 
     @property
     def placement_bundles(self) -> List[Dict[str, float]]:
-        if not self.resources_per_worker:
-            bundle = {"GPU": 1}
+        if self.resources_per_bundle:
+            bundle = self.resources_per_bundle
         else:
-            bundle = self.resources_per_worker
+            bundle = {"GPU": 1, "CPU": 1}
         if self.accelerator_type:
             bundle[self.ray_accelerator_type()] = 0.001
-        bundles = [bundle for _ in range(self.num_gpu_workers)]
+        bundles = [bundle for _ in range(self.num_devices)]
 
         return bundles
 

--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_models.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_models.py
@@ -143,7 +143,7 @@ class VLLMEngineConfig(BaseModelExtended):
         if self.resources_per_bundle:
             bundle = self.resources_per_bundle
         else:
-            bundle = {"GPU": 1, "CPU": 1}
+            bundle = {"GPU": 1}
         if self.accelerator_type:
             bundle[self.ray_accelerator_type()] = 0.001
         bundles = [bundle for _ in range(self.num_devices)]

--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_models.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_models.py
@@ -109,7 +109,7 @@ class VLLMEngineConfig(BaseModelExtended):
             model_id=llm_config.model_id,
             hf_model_id=hf_model_id,
             mirror_config=mirror_config,
-            accelerator_name=llm_config.resources_per_worker,
+            resources_per_worker=llm_config.resources_per_worker,
             accelerator_type=llm_config.accelerator_type,
             engine_kwargs=llm_config.engine_kwargs,
             runtime_env=llm_config.runtime_env,

--- a/python/ray/llm/_internal/serve/observability/usage_telemetry/usage.py
+++ b/python/ray/llm/_internal/serve/observability/usage_telemetry/usage.py
@@ -266,6 +266,6 @@ def push_telemetry_report_for_all_models(
             max_replicas=max_replicas,
             tensor_parallel_degree=engine_config.tensor_parallel_degree,
             gpu_type=model.accelerator_type or DEFAULT_GPU_TYPE,
-            num_gpus=engine_config.num_gpu_workers,
+            num_gpus=engine_config.num_devices,
         )
         _push_telemetry_report(telemetry_model)

--- a/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
+++ b/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
@@ -91,7 +91,7 @@ def test_vllm_engine_stage_post_init(gpu_type, model_llama_3_2_216M):
         "concurrency": 1,
         "max_concurrency": 4,
         "accelerator_type": gpu_type,
-        "num_gpus": 8,
+        "num_gpus": 0,
     }
     scheduling_strategy = ray_remote_args_fn()["scheduling_strategy"]
     assert isinstance(scheduling_strategy, PlacementGroupSchedulingStrategy)

--- a/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
+++ b/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
@@ -91,7 +91,7 @@ def test_vllm_engine_stage_post_init(gpu_type, model_llama_3_2_216M):
         "concurrency": 1,
         "max_concurrency": 4,
         "accelerator_type": gpu_type,
-        "num_gpus": 0,
+        "num_gpus": 8,
     }
     scheduling_strategy = ray_remote_args_fn()["scheduling_strategy"]
     assert isinstance(scheduling_strategy, PlacementGroupSchedulingStrategy)

--- a/python/ray/llm/tests/serve/configs/test_models.py
+++ b/python/ray/llm/tests/serve/configs/test_models.py
@@ -220,7 +220,7 @@ class TestModelConfig:
             model_loading_config=dict(model_id="test_model"),
             engine_kwargs=dict(tensor_parallel_size=3, pipeline_parallel_size=2),
         ).get_serve_options(name_prefix="Test:")
-        assert serve_options["placement_group_bundles"] == [{'CPU': 1, 'GPU': 0}] + [
+        assert serve_options["placement_group_bundles"] == [{"CPU": 1, "GPU": 0}] + [
             {"GPU": 1} for _ in range(6)
         ]
 
@@ -230,7 +230,7 @@ class TestModelConfig:
             engine_kwargs=dict(tensor_parallel_size=3, pipeline_parallel_size=2),
             resources_per_bundle={"XPU": 1},
         ).get_serve_options(name_prefix="Test:")
-        assert serve_options["placement_group_bundles"] == [{'CPU': 1, 'GPU': 0}] + [
+        assert serve_options["placement_group_bundles"] == [{"CPU": 1, "GPU": 0}] + [
             {"XPU": 1} for _ in range(6)
         ]
 

--- a/python/ray/llm/tests/serve/configs/test_models.py
+++ b/python/ray/llm/tests/serve/configs/test_models.py
@@ -220,7 +220,7 @@ class TestModelConfig:
             model_loading_config=dict(model_id="test_model"),
             engine_kwargs=dict(tensor_parallel_size=3, pipeline_parallel_size=2),
         ).get_serve_options(name_prefix="Test:")
-        assert serve_options["placement_group_bundles"] == [
+        assert serve_options["placement_group_bundles"] == [{'CPU': 1, 'GPU': 0}] + [
             {"GPU": 1} for _ in range(6)
         ]
 
@@ -230,7 +230,7 @@ class TestModelConfig:
             engine_kwargs=dict(tensor_parallel_size=3, pipeline_parallel_size=2),
             resources_per_bundle={"XPU": 1},
         ).get_serve_options(name_prefix="Test:")
-        assert serve_options["placement_group_bundles"] == [
+        assert serve_options["placement_group_bundles"] == [{'CPU': 1, 'GPU': 0}] + [
             {"XPU": 1} for _ in range(6)
         ]
 

--- a/python/ray/llm/tests/serve/configs/test_models.py
+++ b/python/ray/llm/tests/serve/configs/test_models.py
@@ -211,11 +211,10 @@ class TestModelConfig:
             "name": "Test:test_model",
         }
         assert serve_options == expected_options
-        
-        
+
     def test_resources_per_bundle(self):
         """Test that resources_per_bundle is correctly parsed."""
-        
+
         # Test the default resource bundle
         serve_options = LLMConfig(
             model_loading_config=dict(model_id="test_model"),

--- a/python/ray/llm/tests/serve/configs/test_models.py
+++ b/python/ray/llm/tests/serve/configs/test_models.py
@@ -211,6 +211,29 @@ class TestModelConfig:
             "name": "Test:test_model",
         }
         assert serve_options == expected_options
+        
+        
+    def test_resources_per_bundle(self):
+        """Test that resources_per_bundle is correctly parsed."""
+        
+        # Test the default resource bundle
+        serve_options = LLMConfig(
+            model_loading_config=dict(model_id="test_model"),
+            engine_kwargs=dict(tensor_parallel_size=3, pipeline_parallel_size=2),
+        ).get_serve_options(name_prefix="Test:")
+        assert serve_options["placement_group_bundles"] == [
+            {"GPU": 1} for _ in range(6)
+        ]
+
+        # Test the custom resource bundle
+        serve_options = LLMConfig(
+            model_loading_config=dict(model_id="test_model"),
+            engine_kwargs=dict(tensor_parallel_size=3, pipeline_parallel_size=2),
+            resources_per_bundle={"XPU": 1},
+        ).get_serve_options(name_prefix="Test:")
+        assert serve_options["placement_group_bundles"] == [
+            {"XPU": 1} for _ in range(6)
+        ]
 
 
 if __name__ == "__main__":

--- a/python/ray/util/accelerators/accelerators.py
+++ b/python/ray/util/accelerators/accelerators.py
@@ -26,6 +26,8 @@ GOOGLE_TPU_V4 = "TPU-V4"
 GOOGLE_TPU_V5P = "TPU-V5P"
 GOOGLE_TPU_V5LITEPOD = "TPU-V5LITEPOD"
 GOOGLE_TPU_V6E = "TPU-V6E"
+HUAWEI_NPU_910B = "Ascend910B"
+HUAWEI_NPU_910B4 = "Ascend910B4"
 
 # Use these instead of NVIDIA_A100 if you need a specific accelerator size. Note that
 # these labels are not auto-added to nodes, you'll have to add them manually in


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Support the usage of `ray.data.llm` and `ray.serve.llm` on custom accelerators beyond just GPU.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

[Roadmap for Data and Serve LLM APIs](https://github.com/ray-project/ray/issues/51313)

This PR should contribute to advancing the implementation of TPU support as outlined in the Roadmap.

<!-- For example: "Closes #1234" -->

## Usage Example

Users should install the corresponding vllm platform plugin. For example, the installation process for [vllm-ascend](https://github.com/vllm-project/vllm-ascend) is as follows:

```
# Install vllm main branch according:
git clone --depth 1 https://github.com/vllm-project/vllm.git
cd vllm
pip install -r requirements/build.txt
VLLM_TARGET_DEVICE=empty pip install .

# Install vllm-ascend main branch
git clone https://github.com/vllm-project/vllm-ascend.git
cd vllm-ascend
pip install -e .
```

Then users can utilize the NPU (and other accelerators) through `ray.data.llm`, 

```python
from ray.data.llm import vLLMEngineProcessorConfig, build_llm_processor

config = vLLMEngineProcessorConfig(
    model="unsloth/Llama-3.1-8B-Instruct",
    engine_kwargs={},
    concurrency=1,
    batch_size=64,
    # an additional line of code compare to default GPU
    accelerator_name="NPU",
)
```

and similarly for `ray.serve.llm`

```python
from ray import serve
from ray.serve.llm.configs import LLMConfig
from ray.serve.llm.deployments import VLLMService, LLMRouter

llm_config = LLMConfig(
    model_loading_config=dict(
        model_id="qwen-0.5b",
        model_source="Qwen/Qwen2.5-0.5B-Instruct",
    ),
    deployment_config=dict(
        autoscaling_config=dict(
            min_replicas=1, max_replicas=2,
        )
    ),
    # An additional line of code compare to default GPU.
    accelerator_name="NPU",
    # If you want to specify more precise resource types.
    accelerator_type="910B4",
    # You can customize the engine arguments (e.g. vLLM engine kwargs)
    engine_kwargs=dict(),
)

# Deploy the application
deployment = VLLMService.as_deployment(llm_config.get_serve_options(name_prefix="VLLM:")).bind(llm_config)
llm_app = LLMRouter.as_deployment().bind([deployment])
serve.run(llm_app)
```

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(