### PR TITLE
Revert "add __name__ guard to testing script for pytest_format check"

### DIFF
--- a/python/ray/tune/tests/_test_multi_tenancy_run.py
+++ b/python/ray/tune/tests/_test_multi_tenancy_run.py
@@ -51,38 +51,37 @@ def train_func(config):
     train.report({"param": config["param"], "fixed": config["fixed"]})
 
 
-if __name__ == "__main__":
-    trainer = DataParallelTrainer(
-        train_loop_per_worker=train_func,
-        train_loop_config={
-            "fixed": FIXED_VAL,
-        },
-        scaling_config=train.ScalingConfig(
-            num_workers=1, trainer_resources={"CPU": 0}, resources_per_worker={"CPU": 2}
-        ),
-    )
+trainer = DataParallelTrainer(
+    train_loop_per_worker=train_func,
+    train_loop_config={
+        "fixed": FIXED_VAL,
+    },
+    scaling_config=train.ScalingConfig(
+        num_workers=1, trainer_resources={"CPU": 0}, resources_per_worker={"CPU": 2}
+    ),
+)
 
-    tuner = tune.Tuner(
-        trainer,
-        param_space={
-            "train_loop_config": {
-                "param": tune.grid_search(VALS),
-                "delete_marker": DELETE_TRIAL_MARKER,
-                "hang_marker": HANG_TRIAL_MARKER,
-            }
-        },
-        tune_config=tune.TuneConfig(search_alg=BasicVariantGenerator(max_concurrent=1)),
-    )
-    results = tuner.fit()
+tuner = tune.Tuner(
+    trainer,
+    param_space={
+        "train_loop_config": {
+            "param": tune.grid_search(VALS),
+            "delete_marker": DELETE_TRIAL_MARKER,
+            "hang_marker": HANG_TRIAL_MARKER,
+        }
+    },
+    tune_config=tune.TuneConfig(search_alg=BasicVariantGenerator(max_concurrent=1)),
+)
+results = tuner.fit()
 
-    # Delete DELETE_RUN_MARKER
-    if DELETE_RUN_MARKER and Path(DELETE_RUN_MARKER).exists():
-        Path(DELETE_RUN_MARKER).unlink()
+# Delete DELETE_RUN_MARKER
+if DELETE_RUN_MARKER and Path(DELETE_RUN_MARKER).exists():
+    Path(DELETE_RUN_MARKER).unlink()
 
-    # Wait for HANG_END_MARKER
-    while HANG_END_MARKER and Path(HANG_END_MARKER).exists():
-        time.sleep(0.1)
+# Wait for HANG_END_MARKER
+while HANG_END_MARKER and Path(HANG_END_MARKER).exists():
+    time.sleep(0.1)
 
-    # Put assertions last, so we don't finish early because of failures
-    assert sorted([result.metrics["param"] for result in results]) == VALS
-    assert [result.metrics["fixed"] for result in results] == [FIXED_VAL, FIXED_VAL]
+# Put assertions last, so we don't finish early because of failures
+assert sorted([result.metrics["param"] for result in results]) == VALS
+assert [result.metrics["fixed"] for result in results] == [FIXED_VAL, FIXED_VAL]


### PR DESCRIPTION
This reverts commit f98b7e45475f4fe837867e84d8c80e746f5e70b4 made in #51092. 

## Why are these changes needed?

It is an unrelated change which could be introduced in a separate PR. We can revert and then reintroduce.

## Related issue number

Originally introduced change in PR for #51091. No issue currently open since this is just reverting a change.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
