### PR TITLE
[RLlib] - Add type check for 'VectorMultiAgentEnv' to `EnvRenderCallback`.

### DIFF
--- a/rllib/examples/envs/env_rendering_and_recording.py
+++ b/rllib/examples/envs/env_rendering_and_recording.py
@@ -63,6 +63,7 @@ from typing import Optional, Sequence
 
 from ray.rllib.callbacks.callbacks import RLlibCallback
 from ray.rllib.core.rl_module.default_model_config import DefaultModelConfig
+from ray.rllib.env.vector.vector_multi_agent_env import VectorMultiAgentEnv
 from ray.rllib.env.wrappers.atari_wrappers import wrap_atari_for_new_api_stack
 from ray.rllib.utils.images import resize
 from ray.rllib.utils.test_utils import (
@@ -131,7 +132,7 @@ class EnvRenderCallback(RLlibCallback):
             return
 
         # If we have a vector env, only render the sub-env at index 0.
-        if isinstance(env.unwrapped, gym.vector.VectorEnv):
+        if isinstance(env.unwrapped, (gym.vector.VectorEnv, VectorMultiAgentEnv)):
             image = env.unwrapped.envs[0].render()
         # Render the gym.Env.
         else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Due to the change from `MultiAgentEnv` to `VectorMultiAgentEnv` a check in the rendering callback was not working anymore - it tried to get an image directly from a vector env. This PR fixes this error by checking for the new `VectorMultiAgentEnv`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
