### PR TITLE
[Serve] Fix multiplex fallback logic during burst requests

### DIFF
--- a/python/ray/serve/_private/replica_scheduler/pow_2_scheduler.py
+++ b/python/ray/serve/_private/replica_scheduler/pow_2_scheduler.py
@@ -423,7 +423,8 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
                             and request_metadata.multiplexed_model_id
                             not in self._multiplexed_model_id_fallback_match
                         ) or tried_first_multiplexed_models:
-                            # When there is no match for a multiplexed model id,
+                            # When there is no match for a multiplexed model id
+                            # or when the replica(s) with the matching model id is busy,
                             # first try to fall back to replicas with the fewest models.
                             candidate_replica_ids = (
                                 self._get_replica_ids_with_fewest_multiplexed_models()

--- a/python/ray/serve/_private/replica_scheduler/pow_2_scheduler.py
+++ b/python/ray/serve/_private/replica_scheduler/pow_2_scheduler.py
@@ -382,6 +382,7 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
                 RAY_SERVE_MULTIPLEXED_MODEL_ID_MATCHING_TIMEOUT_S * 2,
             )
             tried_fewest_multiplexed_models = False
+            tried_first_multiplexed_models = False
 
             while True:
                 # If no replicas are available, wait until `update_replicas` is called.
@@ -421,7 +422,7 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
                             not candidate_replica_ids
                             and request_metadata.multiplexed_model_id
                             not in self._multiplexed_model_id_fallback_match
-                        ):
+                        ) or tried_first_multiplexed_models:
                             # When there is no match for a multiplexed model id,
                             # first try to fall back to replicas with the fewest models.
                             candidate_replica_ids = (
@@ -434,6 +435,7 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
                             self._multiplexed_model_id_fallback_match.discard(
                                 request_metadata.multiplexed_model_id
                             )
+                        tried_first_multiplexed_models = True
                     elif not tried_fewest_multiplexed_models:
                         # After the `multiplexed_matching_timeout` is up, first try
                         # routing to replicas that have the fewest models loaded.

--- a/python/ray/serve/tests/unit/test_pow_2_replica_scheduler.py
+++ b/python/ray/serve/tests/unit/test_pow_2_replica_scheduler.py
@@ -1391,7 +1391,7 @@ class TestModelMultiplexing:
         # multiplexed_matching_timeout to expire then to go to other replicas. This
         # timeout ensures that the request is scheduled to other replicas right away
         # after first try.
-        done, _ = await asyncio.wait(tasks, timeout=0.01)
+        done, _ = await asyncio.wait(tasks, timeout=0.1)
         assert len(done) == 100
         for task in done:
             assert task.result() in {r2, r3}

--- a/python/ray/serve/tests/unit/test_pow_2_replica_scheduler.py
+++ b/python/ray/serve/tests/unit/test_pow_2_replica_scheduler.py
@@ -1386,6 +1386,11 @@ class TestModelMultiplexing:
         ]
 
         # Ensure that all tasks are scheduled to r2 and r3 right away, since r1 is busy.
+        #
+        # The timeout is important in this test, else the request can still wait for the
+        # multiplexed_matching_timeout to expire then to go to other replicas. This
+        # timeout ensures that the request is scheduled to other replicas right away
+        # after first try.
         done, _ = await asyncio.wait(tasks, timeout=0.01)
         assert len(done) == 100
         for task in done:

--- a/python/ray/serve/tests/unit/test_pow_2_replica_scheduler.py
+++ b/python/ray/serve/tests/unit/test_pow_2_replica_scheduler.py
@@ -1361,6 +1361,36 @@ class TestModelMultiplexing:
             assert done.pop() == m2_tasks[0]
             m2_tasks = m2_tasks[1:]
 
+    async def test_replicas_with_model_id_not_chosen_when_busy(self, pow_2_scheduler):
+        """
+        Setup 3 replicas, one of which has the model ID, the other two do not. Verifies
+        that when the replica with the model ID is busy, the other replicas are chosen.
+        """
+        s = pow_2_scheduler
+        loop = get_or_create_event_loop()
+
+        r1 = FakeRunningReplica("r1", model_ids={"m1"})
+        r1.set_queue_len_response(DEFAULT_MAX_ONGOING_REQUESTS)
+        r2 = FakeRunningReplica("r2", model_ids={})
+        r2.set_queue_len_response(0)
+        r3 = FakeRunningReplica("r3", model_ids={})
+        r3.set_queue_len_response(0)
+        s.update_replicas([r1, r2, r3])
+
+        # Sending burst of requests with model_id=m1.
+        tasks = [
+            loop.create_task(
+                s.choose_replica_for_request(fake_pending_request(model_id="m1"))
+            )
+            for _ in range(100)
+        ]
+
+        # Ensure that all tasks are scheduled to r2 and r3 right away, since r1 is busy.
+        done, _ = await asyncio.wait(tasks, timeout=0.01)
+        assert len(done) == 100
+        for task in done:
+            assert task.result() in {r2, r3}
+
 
 @pytest.mark.asyncio
 async def test_get_queue_len_cancelled_on_timeout(pow_2_scheduler):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When there are burst of requests, our existing implementation will send all of them to the replica that has the loaded model in every scheduling loop until the multiplex timeout expired. This is undesirable when there are other replicas that can handle the request immediately. This PR addressed the case by keeping a flag to check whether it's the first time checking multiplex replicas. Then it goes into the multiplex fallback logic since the second loop. Did this in TDD way to write a test that fails then add the logics to fix it.

## Related issue number

Closes https://anyscaleteam.slack.com/archives/C011RJWAV08/p1741987056393629

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
