### PR TITLE
[core] Use cord for sending objects

### DIFF
--- a/src/ray/object_manager/chunk_object_reader.cc
+++ b/src/ray/object_manager/chunk_object_reader.cc
@@ -41,16 +41,13 @@ absl::Cord ChunkObjectReader::GetChunk(uint64_t chunk_index) const {
   const auto cur_chunk_size =
       std::min(chunk_size_,
                object_->GetDataSize() + object_->GetMetadataSize() - cur_chunk_offset);
-
   absl::Cord cord;
-  size_t result_offset = 0;
 
   if (cur_chunk_offset < object_->GetDataSize()) {
     // read from data section.
     auto offset = cur_chunk_offset;
     auto size = std::min(object_->GetDataSize() - cur_chunk_offset, cur_chunk_size);
     cord.Append(object_->ReadFromDataSection(offset, size));
-    result_offset = size;
   }
 
   if (cur_chunk_offset + cur_chunk_size > object_->GetDataSize()) {
@@ -60,8 +57,8 @@ absl::Cord ChunkObjectReader::GetChunk(uint64_t chunk_index) const {
     auto size = std::min(cur_chunk_offset + cur_chunk_size - object_->GetDataSize(),
                          cur_chunk_size);
     std::string result;
-    result.reserve(size);
-    if (!object_->ReadFromMetadataSection(offset, size, &result[result_offset])) {
+    result.resize(size, '\0');
+    if (!object_->ReadFromMetadataSection(offset, size, result.data())) {
       RAY_LOG(ERROR) << "Failed to read metadata section for object "
                      << object_->GetOwnerAddress().worker_id();
     }

--- a/src/ray/object_manager/chunk_object_reader.cc
+++ b/src/ray/object_manager/chunk_object_reader.cc
@@ -56,13 +56,7 @@ absl::Cord ChunkObjectReader::GetChunk(uint64_t chunk_index) const {
         std::max(cur_chunk_offset, object_->GetDataSize()) - object_->GetDataSize();
     auto size = std::min(cur_chunk_offset + cur_chunk_size - object_->GetDataSize(),
                          cur_chunk_size);
-    std::string result;
-    result.resize(size, '\0');
-    if (!object_->ReadFromMetadataSection(offset, size, result.data())) {
-      RAY_LOG(ERROR) << "Failed to read metadata section for object "
-                     << object_->GetOwnerAddress().worker_id();
-    }
-    cord.Append(std::move(result));
+    cord.Append(object_->ReadFromMetadataSection(offset, size));
   }
   return cord;
 }

--- a/src/ray/object_manager/chunk_object_reader.h
+++ b/src/ray/object_manager/chunk_object_reader.h
@@ -33,11 +33,12 @@ class ChunkObjectReader {
   uint64_t GetNumChunks() const;
 
   /// Return the value in a given chunk, identified by chunk_index.
-  /// It migh return an empty optional if the file is deleted.
+  /// It migh return an empty optional if we can't read the correct amount from the file
+  /// or shm.
   ///
   /// \param chunk_index the index of chunk to return. index greater or
   ///                    equal to GetNumChunks() yields undefined behavior.
-  absl::Cord GetChunk(uint64_t chunk_index) const;
+  std::optional<absl::Cord> GetChunk(uint64_t chunk_index) const;
 
   const IObjectReader &GetObject() const { return *object_; }
 

--- a/src/ray/object_manager/chunk_object_reader.h
+++ b/src/ray/object_manager/chunk_object_reader.h
@@ -33,7 +33,7 @@ class ChunkObjectReader {
   uint64_t GetNumChunks() const;
 
   /// Return the value in a given chunk, identified by chunk_index.
-  /// It migh return an empty optional if we can't read the correct amount from the file
+  /// It might return an empty optional if we can't read the correct amount from the file
   /// or shm.
   ///
   /// \param chunk_index the index of chunk to return. index greater or

--- a/src/ray/object_manager/chunk_object_reader.h
+++ b/src/ray/object_manager/chunk_object_reader.h
@@ -37,7 +37,7 @@ class ChunkObjectReader {
   ///
   /// \param chunk_index the index of chunk to return. index greater or
   ///                    equal to GetNumChunks() yields undefined behavior.
-  absl::optional<std::string> GetChunk(uint64_t chunk_index) const;
+  absl::Cord GetChunk(uint64_t chunk_index) const;
 
   const IObjectReader &GetObject() const { return *object_; }
 

--- a/src/ray/object_manager/memory_object_reader.cc
+++ b/src/ray/object_manager/memory_object_reader.cc
@@ -33,7 +33,7 @@ uint64_t MemoryObjectReader::GetMetadataSize() const {
 const rpc::Address &MemoryObjectReader::GetOwnerAddress() const { return owner_address_; }
 
 absl::Cord MemoryObjectReader::ReadFromDataSection(uint64_t offset, uint64_t size) const {
-  RAY_CHECK_GT(offset + size, GetDataSize());
+  RAY_CHECK_LE(offset + size, GetDataSize());
   return absl::MakeCordFromExternal(
       absl::string_view{reinterpret_cast<char *>(object_buffer_.data->Data() + offset),
                         size},
@@ -42,7 +42,7 @@ absl::Cord MemoryObjectReader::ReadFromDataSection(uint64_t offset, uint64_t siz
 
 absl::Cord MemoryObjectReader::ReadFromMetadataSection(uint64_t offset,
                                                        uint64_t size) const {
-  RAY_CHECK_GT(offset + size, GetMetadataSize());
+  RAY_CHECK_LE(offset + size, GetMetadataSize());
   return absl::MakeCordFromExternal(
       absl::string_view{
           reinterpret_cast<char *>(object_buffer_.metadata->Data() + offset), size},

--- a/src/ray/object_manager/memory_object_reader.cc
+++ b/src/ray/object_manager/memory_object_reader.cc
@@ -46,7 +46,7 @@ std::optional<absl::Cord> MemoryObjectReader::ReadFromDataSection(uint64_t offse
 
 std::optional<absl::Cord> MemoryObjectReader::ReadFromMetadataSection(
     uint64_t offset, uint64_t size) const {
-  if (offset + size > GetDataSize()) {
+  if (offset + size > GetMetadataSize()) {
     RAY_LOG(WARNING) << "Failed to read from metadata section in shared memory.";
     return std::nullopt;
   }

--- a/src/ray/object_manager/memory_object_reader.cc
+++ b/src/ray/object_manager/memory_object_reader.cc
@@ -32,14 +32,10 @@ uint64_t MemoryObjectReader::GetMetadataSize() const {
 
 const rpc::Address &MemoryObjectReader::GetOwnerAddress() const { return owner_address_; }
 
-bool MemoryObjectReader::ReadFromDataSection(uint64_t offset,
-                                             uint64_t size,
-                                             std::string &output) const {
-  if (offset + size > GetDataSize()) {
-    return false;
-  }
-  output.append(reinterpret_cast<char *>(object_buffer_.data->Data() + offset), size);
-  return true;
+absl::Cord MemoryObjectReader::ReadFromDataSection(uint64_t offset, uint64_t size) const {
+  return absl::MakeCordFromExternal(
+      absl::string_view{reinterpret_cast<char *>(object_buffer_.data->Data()), size},
+      [](absl::string_view) {});
 }
 
 bool MemoryObjectReader::ReadFromMetadataSection(uint64_t offset,

--- a/src/ray/object_manager/memory_object_reader.h
+++ b/src/ray/object_manager/memory_object_reader.h
@@ -33,8 +33,10 @@ class MemoryObjectReader : public IObjectReader {
 
   const rpc::Address &GetOwnerAddress() const override;
 
-  absl::Cord ReadFromDataSection(uint64_t offset, uint64_t size) const override;
-  absl::Cord ReadFromMetadataSection(uint64_t offset, uint64_t size) const override;
+  std::optional<absl::Cord> ReadFromDataSection(uint64_t offset,
+                                                uint64_t size) const override;
+  std::optional<absl::Cord> ReadFromMetadataSection(uint64_t offset,
+                                                    uint64_t size) const override;
 
  private:
   const plasma::ObjectBuffer object_buffer_;

--- a/src/ray/object_manager/memory_object_reader.h
+++ b/src/ray/object_manager/memory_object_reader.h
@@ -33,9 +33,7 @@ class MemoryObjectReader : public IObjectReader {
 
   const rpc::Address &GetOwnerAddress() const override;
 
-  bool ReadFromDataSection(uint64_t offset,
-                           uint64_t size,
-                           std::string &output) const override;
+  absl::Cord ReadFromDataSection(uint64_t offset, uint64_t size) const override;
   bool ReadFromMetadataSection(uint64_t offset,
                                uint64_t size,
                                std::string &output) const override;

--- a/src/ray/object_manager/memory_object_reader.h
+++ b/src/ray/object_manager/memory_object_reader.h
@@ -34,9 +34,7 @@ class MemoryObjectReader : public IObjectReader {
   const rpc::Address &GetOwnerAddress() const override;
 
   absl::Cord ReadFromDataSection(uint64_t offset, uint64_t size) const override;
-  bool ReadFromMetadataSection(uint64_t offset,
-                               uint64_t size,
-                               std::string &output) const override;
+  absl::Cord ReadFromMetadataSection(uint64_t offset, uint64_t size) const override;
 
  private:
   const plasma::ObjectBuffer object_buffer_;

--- a/src/ray/object_manager/object_buffer_pool.cc
+++ b/src/ray/object_manager/object_buffer_pool.cc
@@ -157,9 +157,11 @@ void ObjectBufferPool::WriteChunk(const ObjectID &object_id,
   RAY_CHECK(chunk_info.has_value()) << "chunk_info is not set";
   // The num_inflight_copies is used to ensure that another thread cannot call Release
   // on the object_id, which makes the unguarded copy call safe.
-  std::memcpy(chunk_info->data,
-              reinterpret_cast<const uint8_t *>(&(*data.Chars().begin())),
-              chunk_info->buffer_length);
+  size_t offset = 0;
+  for (absl::string_view cord_chunk : data.Chunks()) {
+    std::memcpy(chunk_info->data + offset, cord_chunk.data(), cord_chunk.size());
+    offset += cord_chunk.size();
+  }
 
   {
     // Ensure the process of object_id Seal and Release is mutex guarded.

--- a/src/ray/object_manager/object_buffer_pool.h
+++ b/src/ray/object_manager/object_buffer_pool.h
@@ -130,7 +130,7 @@ class ObjectBufferPool {
                   uint64_t data_size,
                   uint64_t metadata_size,
                   uint64_t chunk_index,
-                  const std::string &data) ABSL_LOCKS_EXCLUDED(pool_mutex_);
+                  const absl::Cord &data) ABSL_LOCKS_EXCLUDED(pool_mutex_);
 
   /// Free a list of objects from object store.
   ///

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -381,7 +381,7 @@ class ObjectManager : public ObjectManagerInterface,
                           uint64_t data_size,
                           uint64_t metadata_size,
                           uint64_t chunk_index,
-                          const std::string &data);
+                          const absl::Cord &data);
 
   /// Send pull request
   ///

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -314,7 +314,7 @@ class ObjectManager : public ObjectManagerInterface,
                        const NodeID &node_id,
                        uint64_t chunk_index,
                        std::shared_ptr<rpc::ObjectManagerClient> rpc_client,
-                       std::function<void(const Status &)> on_complete,
+                       std::function<void()> on_complete,
                        std::shared_ptr<ChunkObjectReader> chunk_reader,
                        bool from_disk);
 

--- a/src/ray/object_manager/object_reader.h
+++ b/src/ray/object_manager/object_reader.h
@@ -42,9 +42,7 @@ class IObjectReader {
   /// \param size number of bytes to copy.
   /// \param output string that the data will be appended to.
   /// \return bool.
-  virtual bool ReadFromDataSection(uint64_t offset,
-                                   uint64_t size,
-                                   std::string &output) const = 0;
+  virtual absl::Cord ReadFromDataSection(uint64_t offset, uint64_t size) const = 0;
   /// Read from metadata sections into output.
   /// Return false if the object is corrupted or size/offset is invalid.
   ///

--- a/src/ray/object_manager/object_reader.h
+++ b/src/ray/object_manager/object_reader.h
@@ -50,8 +50,6 @@ class IObjectReader {
   /// \param size number of bytes to copy.
   /// \param output string that the metadata will be appended to.
   /// \return bool.
-  virtual bool ReadFromMetadataSection(uint64_t offset,
-                                       uint64_t size,
-                                       std::string &output) const = 0;
+  virtual absl::Cord ReadFromMetadataSection(uint64_t offset, uint64_t size) const = 0;
 };
 }  // namespace ray

--- a/src/ray/object_manager/object_reader.h
+++ b/src/ray/object_manager/object_reader.h
@@ -40,16 +40,16 @@ class IObjectReader {
   ///
   /// \param offset offset to the data section to copy from.
   /// \param size number of bytes to copy.
-  /// \param output string that the data will be appended to.
-  /// \return bool.
-  virtual absl::Cord ReadFromDataSection(uint64_t offset, uint64_t size) const = 0;
+  /// \return optional cord that will hold view or copy of data section
+  virtual std::optional<absl::Cord> ReadFromDataSection(uint64_t offset,
+                                                        uint64_t size) const = 0;
   /// Read from metadata sections into output.
   /// Return false if the object is corrupted or size/offset is invalid.
   ///
   /// \param offset offset to the metadata section to copy from.
   /// \param size number of bytes to copy.
-  /// \param output string that the metadata will be appended to.
-  /// \return bool.
-  virtual absl::Cord ReadFromMetadataSection(uint64_t offset, uint64_t size) const = 0;
+  /// \return optional cord that will hold view or copy of metadata section
+  virtual std::optional<absl::Cord> ReadFromMetadataSection(uint64_t offset,
+                                                            uint64_t size) const = 0;
 };
 }  // namespace ray

--- a/src/ray/object_manager/spilled_object_reader.cc
+++ b/src/ray/object_manager/spilled_object_reader.cc
@@ -178,7 +178,7 @@ std::optional<absl::Cord> SpilledObjectReader::ReadFromDataSection(uint64_t offs
     absl::Span<char> span = buffer.available_up_to(size);
     is.read(span.data(), span.size());
     // We reached the end of the file before reading the expected number of bytes.
-    if (is.gcount() != span.size()) {
+    if (static_cast<size_t>(is.gcount()) != span.size()) {
       RAY_LOG(WARNING) << "Failed to read from data section in spilled file";
       return std::nullopt;
     }
@@ -199,7 +199,7 @@ std::optional<absl::Cord> SpilledObjectReader::ReadFromMetadataSection(
     absl::Span<char> span = buffer.available_up_to(size);
     is.read(span.data(), span.size());
     // We reached the end of the file before reading the expected number of bytes.
-    if (is.gcount() != span.size()) {
+    if (static_cast<size_t>(is.gcount()) != span.size()) {
       RAY_LOG(WARNING) << "Failed to read from metadata section in spilled file";
       return std::nullopt;
     }

--- a/src/ray/object_manager/spilled_object_reader.cc
+++ b/src/ray/object_manager/spilled_object_reader.cc
@@ -169,11 +169,9 @@ uint64_t SpilledObjectReader::ToUINT64(const std::string &s) {
 }
 
 absl::Cord SpilledObjectReader::ReadFromDataSection(uint64_t offset,
-                                                    uint64_t size,
-                                                    char *output) const {
+                                                    uint64_t size) const {
   std::ifstream is(file_path_, std::ios::binary);
   absl::Cord cord;
-  uint64_t read_size = 0;
   is.seekg(data_offset_ + offset);
   while (size > 0) {
     auto buffer = cord.GetAppendBuffer(size);

--- a/src/ray/object_manager/spilled_object_reader.cc
+++ b/src/ray/object_manager/spilled_object_reader.cc
@@ -177,6 +177,9 @@ absl::Cord SpilledObjectReader::ReadFromDataSection(uint64_t offset,
     auto buffer = cord.GetAppendBuffer(size);
     absl::Span<char> span = buffer.available_up_to(size);
     is.read(span.data(), span.size());
+    // Read will only read up to end of file, so we need to check if we read the expected
+    // number of bytes.
+    RAY_CHECK_EQ(span.size(), is.gcount());
     buffer.IncreaseLengthBy(span.size());
     cord.Append(std::move(buffer));
     size -= span.size();

--- a/src/ray/object_manager/spilled_object_reader.cc
+++ b/src/ray/object_manager/spilled_object_reader.cc
@@ -184,17 +184,19 @@ absl::Cord SpilledObjectReader::ReadFromDataSection(uint64_t offset,
   return cord;
 }
 
-bool SpilledObjectReader::ReadFromMetadataSection(uint64_t offset,
-                                                  uint64_t size,
-                                                  std::string &output) const {
-  std::ifstream file(file_path_, std::ios::binary);
-  file.seekg(metadata_offset_ + offset);
-  std::istreambuf_iterator<char> start(file), end;
-  uint64_t size_idx = 0;
-  for (auto it = start; size_idx < size && it != end; ++it) {
-    output.push_back(*it);
-    ++size_idx;
+absl::Cord SpilledObjectReader::ReadFromMetadataSection(uint64_t offset,
+                                                        uint64_t size) const {
+  std::ifstream is(file_path_, std::ios::binary);
+  absl::Cord cord;
+  is.seekg(metadata_offset_ + offset);
+  while (size > 0) {
+    auto buffer = cord.GetAppendBuffer(size);
+    absl::Span<char> span = buffer.available_up_to(size);
+    is.read(span.data(), span.size());
+    buffer.IncreaseLengthBy(span.size());
+    cord.Append(std::move(buffer));
+    size -= span.size();
   }
-  return size_idx == size;
+  return cord;
 }
 }  // namespace ray

--- a/src/ray/object_manager/spilled_object_reader.h
+++ b/src/ray/object_manager/spilled_object_reader.h
@@ -39,8 +39,10 @@ class SpilledObjectReader : public IObjectReader {
 
   const rpc::Address &GetOwnerAddress() const override;
 
-  absl::Cord ReadFromDataSection(uint64_t offset, uint64_t size) const override;
-  absl::Cord ReadFromMetadataSection(uint64_t offset, uint64_t size) const override;
+  std::optional<absl::Cord> ReadFromDataSection(uint64_t offset,
+                                                uint64_t size) const override;
+  std::optional<absl::Cord> ReadFromMetadataSection(uint64_t offset,
+                                                    uint64_t size) const override;
 
  private:
   SpilledObjectReader(std::string file_path,

--- a/src/ray/object_manager/spilled_object_reader.h
+++ b/src/ray/object_manager/spilled_object_reader.h
@@ -40,9 +40,7 @@ class SpilledObjectReader : public IObjectReader {
   const rpc::Address &GetOwnerAddress() const override;
 
   absl::Cord ReadFromDataSection(uint64_t offset, uint64_t size) const override;
-  bool ReadFromMetadataSection(uint64_t offset,
-                               uint64_t size,
-                               std::string &output) const override;
+  absl::Cord ReadFromMetadataSection(uint64_t offset, uint64_t size) const override;
 
  private:
   SpilledObjectReader(std::string file_path,

--- a/src/ray/object_manager/spilled_object_reader.h
+++ b/src/ray/object_manager/spilled_object_reader.h
@@ -39,9 +39,7 @@ class SpilledObjectReader : public IObjectReader {
 
   const rpc::Address &GetOwnerAddress() const override;
 
-  bool ReadFromDataSection(uint64_t offset,
-                           uint64_t size,
-                           std::string &output) const override;
+  absl::Cord ReadFromDataSection(uint64_t offset, uint64_t size) const override;
   bool ReadFromMetadataSection(uint64_t offset,
                                uint64_t size,
                                std::string &output) const override;

--- a/src/ray/object_manager/test/object_buffer_pool_test.cc
+++ b/src/ray/object_manager/test/object_buffer_pool_test.cc
@@ -75,7 +75,7 @@ class ObjectBufferPoolTest : public ::testing::Test {
       : chunk_size_(1000),
         mock_plasma_client_(std::make_shared<MockPlasmaClient>()),
         object_buffer_pool_(mock_plasma_client_, chunk_size_),
-        mock_data_(chunk_size_, 'x') {}
+        mock_data_(std::string(chunk_size_, 'x')) {}
 
   void AssertNoLeaks() {
     absl::MutexLock lock(&object_buffer_pool_.pool_mutex_);
@@ -86,7 +86,7 @@ class ObjectBufferPoolTest : public ::testing::Test {
   uint64_t chunk_size_;
   std::shared_ptr<MockPlasmaClient> mock_plasma_client_;
   ObjectBufferPool object_buffer_pool_;
-  std::string mock_data_;
+  absl::Cord mock_data_;
 };
 
 TEST_F(ObjectBufferPoolTest, TestBasic) {

--- a/src/ray/object_manager/test/spilled_object_test.cc
+++ b/src/ray/object_manager/test/spilled_object_test.cc
@@ -355,6 +355,7 @@ TYPED_TEST(ObjectReaderTest, GetDataAndMetadata) {
       for (size_t offset = 0; offset <= data.size(); offset++) {
         for (size_t size = offset; size <= data.size() - offset; size++) {
           auto cord = reader->ReadFromDataSection(offset, size);
+          ASSERT_TRUE(cord.has_value());
           std::string result(cord->char_begin(), cord->char_end());
           ASSERT_EQ(data.substr(offset, size), result);
         }
@@ -363,6 +364,7 @@ TYPED_TEST(ObjectReaderTest, GetDataAndMetadata) {
       for (size_t offset = 0; offset <= metadata.size(); offset++) {
         for (size_t size = offset; size <= metadata.size() - offset; size++) {
           auto cord = reader->ReadFromMetadataSection(offset, size);
+          ASSERT_TRUE(cord.has_value());
           std::string result(cord->char_begin(), cord->char_end());
           ASSERT_EQ(metadata.substr(offset, size), result);
         }
@@ -394,12 +396,13 @@ TYPED_TEST(ObjectReaderTest, GetChunk) {
         std::string actual_output_by_chunks;
         for (uint64_t i = 0; i < reader.GetNumChunks(); i++) {
           auto chunk = reader.GetChunk(i);
-          ASSERT_GE(chunk_size, chunk.size());
+          ASSERT_TRUE(chunk.has_value());
+          ASSERT_GE(chunk_size, chunk->size());
           if (i + 1 != reader.GetNumChunks()) {
-            ASSERT_EQ(chunk_size, chunk.size());
+            ASSERT_EQ(chunk_size, chunk->size());
           }
           actual_output_by_chunks.append(
-              std::string(chunk.char_begin(), chunk.char_end()));
+              std::string(chunk->char_begin(), chunk->char_end()));
         }
         ASSERT_EQ(expected_output, actual_output_by_chunks);
       }

--- a/src/ray/object_manager/test/spilled_object_test.cc
+++ b/src/ray/object_manager/test/spilled_object_test.cc
@@ -355,7 +355,7 @@ TYPED_TEST(ObjectReaderTest, GetDataAndMetadata) {
       for (size_t offset = 0; offset <= data.size(); offset++) {
         for (size_t size = offset; size <= data.size() - offset; size++) {
           auto cord = reader->ReadFromDataSection(offset, size);
-          std::string result(cord.char_begin(), cord.char_end());
+          std::string result(cord->char_begin(), cord->char_end());
           ASSERT_EQ(data.substr(offset, size), result);
         }
       }
@@ -363,7 +363,7 @@ TYPED_TEST(ObjectReaderTest, GetDataAndMetadata) {
       for (size_t offset = 0; offset <= metadata.size(); offset++) {
         for (size_t size = offset; size <= metadata.size() - offset; size++) {
           auto cord = reader->ReadFromMetadataSection(offset, size);
-          std::string result(cord.char_begin(), cord.char_end());
+          std::string result(cord->char_begin(), cord->char_end());
           ASSERT_EQ(metadata.substr(offset, size), result);
         }
       }

--- a/src/ray/object_manager/test/spilled_object_test.cc
+++ b/src/ray/object_manager/test/spilled_object_test.cc
@@ -356,10 +356,9 @@ TYPED_TEST(ObjectReaderTest, GetDataAndMetadata) {
         for (size_t size = offset; size <= data.size() - offset; size++) {
           std::string result;
           if (offset + size <= data.size()) {
-            ASSERT_TRUE(reader->ReadFromDataSection(offset, size, result));
+            auto cord = reader->ReadFromDataSection(offset, size);
+            std::string result(cord.char_begin(), cord.char_end());
             ASSERT_EQ(data.substr(offset, size), result);
-          } else {
-            ASSERT_FALSE(reader->ReadFromDataSection(offset, size, result));
           }
         }
       }
@@ -368,10 +367,9 @@ TYPED_TEST(ObjectReaderTest, GetDataAndMetadata) {
         for (size_t size = offset; size <= metadata.size() - offset; size++) {
           std::string result;
           if (offset + size <= metadata.size()) {
-            ASSERT_TRUE(reader->ReadFromMetadataSection(offset, size, result));
+            auto cord = reader->ReadFromMetadataSection(offset, size);
+            std::string result(cord.char_begin(), cord.char_end());
             ASSERT_EQ(metadata.substr(offset, size), result);
-          } else {
-            ASSERT_FALSE(reader->ReadFromMetadataSection(offset, size, result));
           }
         }
       }
@@ -402,12 +400,12 @@ TYPED_TEST(ObjectReaderTest, GetChunk) {
         std::string actual_output_by_chunks;
         for (uint64_t i = 0; i < reader.GetNumChunks(); i++) {
           auto chunk = reader.GetChunk(i);
-          ASSERT_TRUE(chunk.has_value());
-          ASSERT_GE(chunk_size, chunk->size());
+          ASSERT_GE(chunk_size, chunk.size());
           if (i + 1 != reader.GetNumChunks()) {
-            ASSERT_EQ(chunk_size, chunk->size());
+            ASSERT_EQ(chunk_size, chunk.size());
           }
-          actual_output_by_chunks.append(chunk.value());
+          actual_output_by_chunks.append(
+              std::string(chunk.char_begin(), chunk.char_end()));
         }
         ASSERT_EQ(expected_output, actual_output_by_chunks);
       }

--- a/src/ray/object_manager/test/spilled_object_test.cc
+++ b/src/ray/object_manager/test/spilled_object_test.cc
@@ -354,23 +354,17 @@ TYPED_TEST(ObjectReaderTest, GetDataAndMetadata) {
 
       for (size_t offset = 0; offset <= data.size(); offset++) {
         for (size_t size = offset; size <= data.size() - offset; size++) {
-          std::string result;
-          if (offset + size <= data.size()) {
-            auto cord = reader->ReadFromDataSection(offset, size);
-            std::string result(cord.char_begin(), cord.char_end());
-            ASSERT_EQ(data.substr(offset, size), result);
-          }
+          auto cord = reader->ReadFromDataSection(offset, size);
+          std::string result(cord.char_begin(), cord.char_end());
+          ASSERT_EQ(data.substr(offset, size), result);
         }
       }
 
       for (size_t offset = 0; offset <= metadata.size(); offset++) {
         for (size_t size = offset; size <= metadata.size() - offset; size++) {
-          std::string result;
-          if (offset + size <= metadata.size()) {
-            auto cord = reader->ReadFromMetadataSection(offset, size);
-            std::string result(cord.char_begin(), cord.char_end());
-            ASSERT_EQ(metadata.substr(offset, size), result);
-          }
+          auto cord = reader->ReadFromMetadataSection(offset, size);
+          std::string result(cord.char_begin(), cord.char_end());
+          ASSERT_EQ(metadata.substr(offset, size), result);
         }
       }
     }

--- a/src/ray/protobuf/object_manager.proto
+++ b/src/ray/protobuf/object_manager.proto
@@ -35,6 +35,8 @@ message PushRequest {
   // The metadata size.
   uint64 metadata_size = 7;
   // The chunk data
+  // CORD allows us to create pass a view of the data to the protobuf message instead of
+  // a string we have to copy into.
   bytes data = 8 [ctype = CORD];
 }
 

--- a/src/ray/protobuf/object_manager.proto
+++ b/src/ray/protobuf/object_manager.proto
@@ -35,8 +35,8 @@ message PushRequest {
   // The metadata size.
   uint64 metadata_size = 7;
   // The chunk data
-  // CORD allows us to create pass a view of the data to the protobuf message instead of
-  // a string we have to copy into.
+  // absl::Cord allows us to pass a view of the data to the protobuf message instead
+  // of copying into a string
   bytes data = 8 [ctype = CORD];
 }
 

--- a/src/ray/protobuf/object_manager.proto
+++ b/src/ray/protobuf/object_manager.proto
@@ -35,7 +35,7 @@ message PushRequest {
   // The metadata size.
   uint64 metadata_size = 7;
   // The chunk data
-  bytes data = 8;
+  bytes data = 8 [ctype = CORD];
 }
 
 message PullRequest {
@@ -50,12 +50,9 @@ message FreeObjectsRequest {
 }
 
 // Reply for request
-message PushReply {
-}
-message PullReply {
-}
-message FreeObjectsReply {
-}
+message PushReply {}
+message PullReply {}
+message FreeObjectsReply {}
 
 service ObjectManagerService {
   // Push service used to send object chunks


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
By giving the cord just a view of the data we don't have to copy it into the protobuf and we can remove all the overhead that comes from copying into the string.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
