### PR TITLE
[core] Remove the unnecessary key `ActorID` of `concurrency_groups_cache_` in TaskReceiver

### DIFF
--- a/src/ray/core_worker/test/direct_actor_transport_test.cc
+++ b/src/ray/core_worker/test/direct_actor_transport_test.cc
@@ -821,11 +821,6 @@ class MockTaskReceiver : public TaskReceiver {
                      task_handler,
                      initialize_thread_callback,
                      actor_creation_task_done_) {}
-
-  void UpdateConcurrencyGroupsCache(const ActorID &actor_id,
-                                    const std::vector<ConcurrencyGroup> &cgs) {
-    concurrency_groups_cache_[actor_id] = cgs;
-  }
 };
 
 class TaskReceiverTest : public ::testing::Test {
@@ -911,7 +906,6 @@ TEST_F(TaskReceiverTest, TestNewTaskFromDifferentWorker) {
       ++callback_count;
       ASSERT_TRUE(status.ok());
     };
-    receiver_->UpdateConcurrencyGroupsCache(actor_id, {});
     receiver_->HandleTask(request, &reply, reply_callback);
   }
 

--- a/src/ray/core_worker/transport/task_receiver.h
+++ b/src/ray/core_worker/transport/task_receiver.h
@@ -113,17 +113,14 @@ class TaskReceiver {
   /// the repr name could include data only initialized during the creation task.
   void SetActorReprName(const std::string &repr_name);
 
+ protected:
+  /// Cache the concurrency groups of the actor.
+  std::vector<ConcurrencyGroup> concurrency_group_cache_;
+
  private:
   /// Set up the configs for an actor.
   /// This should be called once for the actor creation task.
   void SetupActor(bool is_asyncio, int fiber_max_concurrency, bool execute_out_of_order);
-
- protected:
-  /// Cache the concurrency groups of actors.
-  // TODO(ryw): remove the ActorID key since we only ever handle 1 actor.
-  absl::flat_hash_map<ActorID, std::vector<ConcurrencyGroup>> concurrency_groups_cache_;
-
- private:
   // Worker context.
   WorkerContext &worker_context_;
   /// The callback function to process a task.

--- a/src/ray/core_worker/transport/task_receiver.h
+++ b/src/ray/core_worker/transport/task_receiver.h
@@ -113,11 +113,9 @@ class TaskReceiver {
   /// the repr name could include data only initialized during the creation task.
   void SetActorReprName(const std::string &repr_name);
 
- protected:
+ private:
   /// Cache the concurrency groups of the actor.
   std::vector<ConcurrencyGroup> concurrency_group_cache_;
-
- private:
   /// Set up the configs for an actor.
   /// This should be called once for the actor creation task.
   void SetupActor(bool is_asyncio, int fiber_max_concurrency, bool execute_out_of_order);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

### GCS

A single-core worker process can be used by at most one Ray Actor during its lifetime. For example, if an actor goes out of scope, [GcsActorManager](https://github.com/ray-project/ray/blob/07e93dd92197ccc86c50c5c37fd6b8df526c7269/src/ray/gcs/gcs_server/gcs_actor_manager.cc#L112) calls DestroyActor, which sends an RPC `KillActor` (with `force_kill=true` [ref](https://github.com/ray-project/ray/blob/07e93dd92197ccc86c50c5c37fd6b8df526c7269/src/ray/gcs/gcs_server/gcs_actor_manager.cc#L377)) to the core worker process.

  * "The actor is dead because all references to the actor were removed." 

### Core Worker

Handle the KillActor RPC: [CoreWorker::HandleKillActor](https://github.com/ray-project/ray/blob/07e93dd92197ccc86c50c5c37fd6b8df526c7269/src/ray/core_worker/core_worker.cc#L4518) -> `CoreWorker::ForceExit` 

`ForceExit` terminates the entire process immediately rather than cleaning up and waiting for new Ray Actors.

```python
import ray
import time

@ray.remote
class SleepActor:
    def sleep(self):
        print("Sleep")
        time.sleep(5)

sa = SleepActor.remote()
ray.get(sa.sleep.remote())

print("Sleep 30s before deleing `sa`")
time.sleep(30)

del sa
print("SleepActor deleted")
# The core process of `sa` died.

# `sa2` will create a new core worker process instead of reusing the same process of `sa`.
sa2 = SleepActor.remote()
ray.get(sa2.sleep.remote())

time.sleep(1000)
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
