### PR TITLE
[core] Cover cpplint for `ray/tree/master/src/ray/gcs`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
     hooks:
       - id: cpplint
         args: ["--filter=-whitespace/braces,-whitespace/line_length,-build/c++11,-build/c++14,-build/c++17,-readability/braces,-whitespace/indent_namespace,-runtime/int,-runtime/references,-build/include_order"]
-        files: ^src/ray/(util|raylet_client|internal|scheduling|pubsub|object_manager|gcs/gcs_server|rpc(?:/.*)?)/.*\.(h|cc)$
+        files: ^src/ray/(util|raylet_client|internal|scheduling|pubsub|object_manager|gcs|rpc(?:/.*)?)/.*\.(h|cc)$
 
   - repo: https://github.com/keith/pre-commit-buildifier
     rev: 8.0.1

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -13,6 +13,11 @@
 // limitations under the License.
 
 #pragma once
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 #include "absl/types/optional.h"
 #include "ray/common/id.h"

--- a/src/ray/gcs/gcs_client/gcs_client.cc
+++ b/src/ray/gcs/gcs_client/gcs_client.cc
@@ -15,8 +15,12 @@
 #include "ray/gcs/gcs_client/gcs_client.h"
 
 #include <chrono>
+#include <memory>
+#include <string>
 #include <thread>
+#include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include "ray/common/asio/asio_util.h"
 #include "ray/common/ray_config.h"

--- a/src/ray/gcs/gcs_client/gcs_client.h
+++ b/src/ray/gcs/gcs_client/gcs_client.h
@@ -19,10 +19,11 @@
 #include <boost/asio.hpp>
 #include <memory>
 #include <string>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "absl/strings/str_split.h"
-#include "gtest/gtest_prod.h"
 #include "ray/common/asio/instrumented_io_context.h"
 #include "ray/common/asio/periodical_runner.h"
 #include "ray/common/id.h"

--- a/src/ray/gcs/gcs_client/global_state_accessor.cc
+++ b/src/ray/gcs/gcs_client/global_state_accessor.cc
@@ -14,7 +14,13 @@
 
 #include "ray/gcs/gcs_client/global_state_accessor.h"
 
+#include <algorithm>
 #include <boost/algorithm/string.hpp>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include "ray/common/asio/instrumented_io_context.h"
 

--- a/src/ray/gcs/gcs_client/global_state_accessor.h
+++ b/src/ray/gcs/gcs_client/global_state_accessor.h
@@ -14,6 +14,12 @@
 
 #pragma once
 
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include "absl/base/thread_annotations.h"
 #include "absl/synchronization/mutex.h"
 #include "ray/common/asio/instrumented_io_context.h"

--- a/src/ray/gcs/gcs_client/python_callbacks.h
+++ b/src/ray/gcs/gcs_client/python_callbacks.h
@@ -17,6 +17,7 @@
 #include <Python.h>
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "ray/util/logging.h"

--- a/src/ray/gcs/gcs_client/test/accessor_test.cc
+++ b/src/ray/gcs/gcs_client/test/accessor_test.cc
@@ -14,12 +14,14 @@
 
 #include "ray/gcs/gcs_client/accessor.h"
 
+#include <utility>
+
 #include "gtest/gtest.h"
 #include "src/ray/protobuf/gcs.pb.h"
 
 namespace ray {
-using namespace ray::gcs;
-using namespace ray::rpc;
+using namespace ray::gcs;  // NOLINT
+using namespace ray::rpc;  // NOLINT
 
 TEST(NodeInfoAccessorTest, TestHandleNotification) {
   NodeInfoAccessor accessor;

--- a/src/ray/gcs/gcs_client/test/gcs_client_reconnection_test.cc
+++ b/src/ray/gcs/gcs_client/test/gcs_client_reconnection_test.cc
@@ -15,6 +15,9 @@
 #include <boost/asio/ip/tcp.hpp>
 #include <chrono>
 #include <future>
+#include <memory>
+#include <string>
+#include <vector>
 
 #include "absl/strings/substitute.h"
 #include "gtest/gtest.h"
@@ -27,9 +30,9 @@
 #include "ray/rpc/gcs_server/gcs_rpc_client.h"
 #include "ray/util/util.h"
 
-using namespace std::chrono_literals;
-using namespace ray;
-using namespace std::chrono;
+using namespace std::chrono_literals;  // NOLINT
+using namespace ray;                   // NOLINT
+using namespace std::chrono;           // NOLINT
 
 class GcsClientReconnectionTest : public ::testing::Test {
  public:
@@ -127,7 +130,7 @@ class GcsClientReconnectionTest : public ::testing::Test {
 
  protected:
   unsigned short GetFreePort() {
-    using namespace boost::asio;
+    using namespace boost::asio;  // NOLINT
     io_service service;
     ip::tcp::acceptor acceptor(service, ip::tcp::endpoint(ip::tcp::v4(), 0));
     unsigned short port = acceptor.local_endpoint().port();

--- a/src/ray/gcs/gcs_client/test/gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/gcs_client_test.cc
@@ -14,6 +14,11 @@
 
 #include "ray/gcs/gcs_client/gcs_client.h"
 
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "absl/strings/substitute.h"
 #include "gtest/gtest.h"
 #include "ray/common/asio/instrumented_io_context.h"
@@ -24,7 +29,7 @@
 #include "ray/rpc/gcs_server/gcs_rpc_client.h"
 #include "ray/util/util.h"
 
-using namespace std::chrono_literals;
+using namespace std::chrono_literals;  // NOLINT
 
 namespace ray {
 
@@ -660,7 +665,7 @@ TEST_P(GcsClientTest, TestErrorInfo) {
 }
 
 TEST_P(GcsClientTest, TestJobTableResubscribe) {
-  // TODO: Support resubscribing with GCS pubsub.
+  // TODO(mwtian): Support resubscribing with GCS pubsub.
   GTEST_SKIP();
 
   // Test that subscription of the job table can still work when GCS server restarts.
@@ -687,7 +692,7 @@ TEST_P(GcsClientTest, TestJobTableResubscribe) {
 }
 
 TEST_P(GcsClientTest, TestActorTableResubscribe) {
-  // TODO: Support resubscribing with GCS pubsub.
+  // TODO(mwtian): Support resubscribing with GCS pubsub.
   GTEST_SKIP();
 
   // Test that subscription of the actor table can still work when GCS server restarts.
@@ -744,7 +749,7 @@ TEST_P(GcsClientTest, TestActorTableResubscribe) {
 }
 
 TEST_P(GcsClientTest, TestNodeTableResubscribe) {
-  // TODO: Support resubscribing with GCS pubsub.
+  // TODO(mwtian): Support resubscribing with GCS pubsub.
   GTEST_SKIP();
 
   // Test that subscription of the node table can still work when GCS server restarts.
@@ -774,7 +779,7 @@ TEST_P(GcsClientTest, TestNodeTableResubscribe) {
 }
 
 TEST_P(GcsClientTest, TestWorkerTableResubscribe) {
-  // TODO: Support resubscribing with GCS pubsub.
+  // TODO(mwtian): Support resubscribing with GCS pubsub.
   GTEST_SKIP();
 
   // Subscribe to all unexpected failure of workers from GCS.
@@ -876,7 +881,7 @@ TEST_P(GcsClientTest, DISABLED_TestGetActorPerf) {
 
   // Get all actors.
   auto condition = [this, actor_count]() {
-    return (int)GetAllActors().size() == actor_count;
+    return static_cast<int>(GetAllActors().size()) == actor_count;
   };
   EXPECT_TRUE(WaitForCondition(condition, timeout_ms_.count()));
 

--- a/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
+++ b/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
@@ -14,6 +14,10 @@
 
 #include "ray/gcs/gcs_client/global_state_accessor.h"
 
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "gtest/gtest.h"
 #include "ray/common/asio/instrumented_io_context.h"
 #include "ray/common/test_util.h"

--- a/src/ray/gcs/pb_util.h
+++ b/src/ray/gcs/pb_util.h
@@ -15,6 +15,8 @@
 #pragma once
 
 #include <memory>
+#include <string>
+#include <utility>
 
 #include "absl/time/time.h"
 #include "ray/common/constants.h"
@@ -340,8 +342,8 @@ inline size_t NumProfileEvents(const rpc::TaskEvents &task_event) {
 }
 
 inline TaskAttempt GetTaskAttempt(const rpc::TaskEvents &task_event) {
-  return std::make_pair<>(TaskID::FromBinary(task_event.task_id()),
-                          task_event.attempt_number());
+  return std::make_pair(TaskID::FromBinary(task_event.task_id()),
+                        task_event.attempt_number());
 }
 
 inline bool IsActorTask(const rpc::TaskEvents &task_event) {

--- a/src/ray/gcs/pb_utils.cc
+++ b/src/ray/gcs/pb_utils.cc
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 // TODO(hjiang): Move all functions from `pb_utils.h` to this implementation file.
-
+#include <memory>
+#include <string>
 #include <string_view>
+#include <utility>
 
 #include "absl/strings/str_format.h"
 #include "ray/gcs/pb_util.h"

--- a/src/ray/gcs/pubsub/gcs_pub_sub.cc
+++ b/src/ray/gcs/pubsub/gcs_pub_sub.cc
@@ -14,6 +14,11 @@
 
 #include "ray/gcs/pubsub/gcs_pub_sub.h"
 
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "ray/rpc/gcs_server/gcs_rpc_client.h"
 
 namespace ray {

--- a/src/ray/gcs/pubsub/gcs_pub_sub.h
+++ b/src/ray/gcs/pubsub/gcs_pub_sub.h
@@ -14,9 +14,13 @@
 
 #pragma once
 
+#include <deque>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
+#include <vector>
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/synchronization/mutex.h"
@@ -39,7 +43,7 @@ class GcsPublisher {
   /// Initializes GcsPublisher with GCS based publishers.
   /// Publish*() member functions below would be incrementally converted to use the GCS
   /// based publisher, if available.
-  GcsPublisher(std::unique_ptr<pubsub::Publisher> publisher)
+  explicit GcsPublisher(std::unique_ptr<pubsub::Publisher> publisher)
       : publisher_(std::move(publisher)) {
     RAY_CHECK(publisher_);
   }
@@ -63,7 +67,7 @@ class GcsPublisher {
                       rpc::ActorTableData message,
                       const StatusCallback &done);
 
-  // TODO (dayshah): Look at possibility of moving all of these rpc messages
+  // TODO(dayshah): Look at possibility of moving all of these rpc messages
 
   Status PublishJob(const JobID &id,
                     const rpc::JobTableData &message,
@@ -99,7 +103,7 @@ class GcsPublisher {
 class GcsSubscriber {
  public:
   /// Initializes GcsSubscriber with GCS based GcsSubscribers.
-  // TODO: Support restarted GCS publisher, at the same or a different address.
+  // TODO(mwtian): Support restarted GCS publisher, at the same or a different address.
   GcsSubscriber(const rpc::Address &gcs_address,
                 std::unique_ptr<pubsub::Subscriber> subscriber)
       : gcs_address_(gcs_address), subscriber_(std::move(subscriber)) {}

--- a/src/ray/gcs/redis_async_context.cc
+++ b/src/ray/gcs/redis_async_context.cc
@@ -14,6 +14,10 @@
 
 #include "ray/gcs/redis_async_context.h"
 
+#include <memory>
+#include <string>
+#include <utility>
+
 extern "C" {
 #include "hiredis/async.h"
 #include "hiredis/hiredis.h"

--- a/src/ray/gcs/redis_async_context.h
+++ b/src/ray/gcs/redis_async_context.h
@@ -19,6 +19,7 @@
 #include <boost/asio.hpp>
 #include <boost/asio/error.hpp>
 #include <boost/bind/bind.hpp>
+#include <memory>
 #include <mutex>
 
 #include "ray/common/asio/instrumented_io_context.h"

--- a/src/ray/gcs/redis_client.cc
+++ b/src/ray/gcs/redis_client.cc
@@ -14,6 +14,8 @@
 
 #include "ray/gcs/redis_client.h"
 
+#include <memory>
+
 #include "ray/common/ray_config.h"
 #include "ray/gcs/redis_context.h"
 

--- a/src/ray/gcs/redis_client.h
+++ b/src/ray/gcs/redis_client.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <map>
+#include <memory>
 #include <string>
 
 #include "ray/common/asio/instrumented_io_context.h"
@@ -55,7 +56,7 @@ class RedisClientOptions {
 /// This class is used to send commands to Redis.
 class RedisClient {
  public:
-  RedisClient(const RedisClientOptions &options);
+  explicit RedisClient(const RedisClientOptions &options);
 
   /// Connect to Redis. Non-thread safe.
   /// Call this function before calling other functions.

--- a/src/ray/gcs/redis_context.cc
+++ b/src/ray/gcs/redis_context.cc
@@ -14,7 +14,11 @@
 
 #include "ray/gcs/redis_context.h"
 
+#include <memory>
 #include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "ray/common/asio/asio_util.h"
 #include "ray/stats/metric_defs.h"
@@ -563,7 +567,7 @@ Status ConnectRedisSentinel(RedisContext &context,
 std::vector<std::string> ResolveDNS(instrumented_io_context &io_service,
                                     const std::string &address,
                                     int port) {
-  using namespace boost::asio;
+  using namespace boost::asio;  // NOLINT
   ip::tcp::resolver resolver(io_service);
   ip::tcp::resolver::iterator iter = resolver.resolve(address, std::to_string(port));
   ip::tcp::resolver::iterator end;

--- a/src/ray/gcs/redis_context.h
+++ b/src/ray/gcs/redis_context.h
@@ -18,6 +18,8 @@
 #include <boost/bind/bind.hpp>
 #include <functional>
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "ray/common/asio/instrumented_io_context.h"
 #include "ray/common/status.h"

--- a/src/ray/gcs/store_client/in_memory_store_client.cc
+++ b/src/ray/gcs/store_client/in_memory_store_client.cc
@@ -14,6 +14,10 @@
 
 #include "ray/gcs/store_client/in_memory_store_client.h"
 
+#include <string>
+#include <utility>
+#include <vector>
+
 namespace ray::gcs {
 
 Status InMemoryStoreClient::AsyncPut(const std::string &table_name,

--- a/src/ray/gcs/store_client/observable_store_client.cc
+++ b/src/ray/gcs/store_client/observable_store_client.cc
@@ -14,13 +14,15 @@
 
 #include "ray/gcs/store_client/observable_store_client.h"
 
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "absl/time/time.h"
 #include "ray/stats/metric_defs.h"
 
 namespace ray {
 namespace gcs {
-
-using namespace ray::stats;
 
 Status ObservableStoreClient::AsyncPut(const std::string &table_name,
                                        const std::string &key,
@@ -28,11 +30,11 @@ Status ObservableStoreClient::AsyncPut(const std::string &table_name,
                                        bool overwrite,
                                        Postable<void(bool)> callback) {
   auto start = absl::GetCurrentTimeNanos();
-  STATS_gcs_storage_operation_count.Record(1, "Put");
+  ray::stats::STATS_gcs_storage_operation_count.Record(1, "Put");
   return delegate_->AsyncPut(
       table_name, key, data, overwrite, std::move(callback).OnInvocation([start]() {
         auto end = absl::GetCurrentTimeNanos();
-        STATS_gcs_storage_operation_latency_ms.Record(
+        ray::stats::STATS_gcs_storage_operation_latency_ms.Record(
             absl::ToDoubleMilliseconds(absl::Nanoseconds(end - start)), "Put");
       }));
 }
@@ -42,10 +44,10 @@ Status ObservableStoreClient::AsyncGet(
     const std::string &key,
     ToPostable<OptionalItemCallback<std::string>> callback) {
   auto start = absl::GetCurrentTimeNanos();
-  STATS_gcs_storage_operation_count.Record(1, "Get");
+  ray::stats::STATS_gcs_storage_operation_count.Record(1, "Get");
   return delegate_->AsyncGet(table_name, key, std::move(callback).OnInvocation([start]() {
     auto end = absl::GetCurrentTimeNanos();
-    STATS_gcs_storage_operation_latency_ms.Record(
+    ray::stats::STATS_gcs_storage_operation_latency_ms.Record(
         absl::ToDoubleMilliseconds(absl::Nanoseconds(end - start)), "Get");
   }));
 }
@@ -54,10 +56,10 @@ Status ObservableStoreClient::AsyncGetAll(
     const std::string &table_name,
     Postable<void(absl::flat_hash_map<std::string, std::string>)> callback) {
   auto start = absl::GetCurrentTimeNanos();
-  STATS_gcs_storage_operation_count.Record(1, "GetAll");
+  ray::stats::STATS_gcs_storage_operation_count.Record(1, "GetAll");
   return delegate_->AsyncGetAll(table_name, std::move(callback).OnInvocation([start]() {
     auto end = absl::GetCurrentTimeNanos();
-    STATS_gcs_storage_operation_latency_ms.Record(
+    ray::stats::STATS_gcs_storage_operation_latency_ms.Record(
         absl::ToDoubleMilliseconds(absl::Nanoseconds(end - start)), "GetAll");
   }));
 }
@@ -67,11 +69,11 @@ Status ObservableStoreClient::AsyncMultiGet(
     const std::vector<std::string> &keys,
     Postable<void(absl::flat_hash_map<std::string, std::string>)> callback) {
   auto start = absl::GetCurrentTimeNanos();
-  STATS_gcs_storage_operation_count.Record(1, "MultiGet");
+  ray::stats::STATS_gcs_storage_operation_count.Record(1, "MultiGet");
   return delegate_->AsyncMultiGet(
       table_name, keys, std::move(callback).OnInvocation([start]() {
         auto end = absl::GetCurrentTimeNanos();
-        STATS_gcs_storage_operation_latency_ms.Record(
+        ray::stats::STATS_gcs_storage_operation_latency_ms.Record(
             absl::ToDoubleMilliseconds(absl::Nanoseconds(end - start)), "MultiGet");
       }));
 }
@@ -80,11 +82,11 @@ Status ObservableStoreClient::AsyncDelete(const std::string &table_name,
                                           const std::string &key,
                                           Postable<void(bool)> callback) {
   auto start = absl::GetCurrentTimeNanos();
-  STATS_gcs_storage_operation_count.Record(1, "Delete");
+  ray::stats::STATS_gcs_storage_operation_count.Record(1, "Delete");
   return delegate_->AsyncDelete(
       table_name, key, std::move(callback).OnInvocation([start]() {
         auto end = absl::GetCurrentTimeNanos();
-        STATS_gcs_storage_operation_latency_ms.Record(
+        ray::stats::STATS_gcs_storage_operation_latency_ms.Record(
             absl::ToDoubleMilliseconds(absl::Nanoseconds(end - start)), "Delete");
       }));
 }
@@ -93,11 +95,11 @@ Status ObservableStoreClient::AsyncBatchDelete(const std::string &table_name,
                                                const std::vector<std::string> &keys,
                                                Postable<void(int64_t)> callback) {
   auto start = absl::GetCurrentTimeNanos();
-  STATS_gcs_storage_operation_count.Record(1, "BatchDelete");
+  ray::stats::STATS_gcs_storage_operation_count.Record(1, "BatchDelete");
   return delegate_->AsyncBatchDelete(
       table_name, keys, std::move(callback).OnInvocation([start]() {
         auto end = absl::GetCurrentTimeNanos();
-        STATS_gcs_storage_operation_latency_ms.Record(
+        ray::stats::STATS_gcs_storage_operation_latency_ms.Record(
             absl::ToDoubleMilliseconds(absl::Nanoseconds(end - start)), "BatchDelete");
       }));
 }
@@ -111,11 +113,11 @@ Status ObservableStoreClient::AsyncGetKeys(
     const std::string &prefix,
     Postable<void(std::vector<std::string>)> callback) {
   auto start = absl::GetCurrentTimeNanos();
-  STATS_gcs_storage_operation_count.Record(1, "GetKeys");
+  ray::stats::STATS_gcs_storage_operation_count.Record(1, "GetKeys");
   return delegate_->AsyncGetKeys(
       table_name, prefix, std::move(callback).OnInvocation([start]() {
         auto end = absl::GetCurrentTimeNanos();
-        STATS_gcs_storage_operation_latency_ms.Record(
+        ray::stats::STATS_gcs_storage_operation_latency_ms.Record(
             absl::ToDoubleMilliseconds(absl::Nanoseconds(end - start)), "GetKeys");
       }));
 }
@@ -124,11 +126,11 @@ Status ObservableStoreClient::AsyncExists(const std::string &table_name,
                                           const std::string &key,
                                           Postable<void(bool)> callback) {
   auto start = absl::GetCurrentTimeNanos();
-  STATS_gcs_storage_operation_count.Record(1, "Exists");
+  ray::stats::STATS_gcs_storage_operation_count.Record(1, "Exists");
   return delegate_->AsyncExists(
       table_name, key, std::move(callback).OnInvocation([start]() {
         auto end = absl::GetCurrentTimeNanos();
-        STATS_gcs_storage_operation_latency_ms.Record(
+        ray::stats::STATS_gcs_storage_operation_latency_ms.Record(
             absl::ToDoubleMilliseconds(absl::Nanoseconds(end - start)), "Exists");
       }));
 }

--- a/src/ray/gcs/store_client/observable_store_client.h
+++ b/src/ray/gcs/store_client/observable_store_client.h
@@ -15,7 +15,9 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include "ray/gcs/store_client/store_client.h"
 

--- a/src/ray/gcs/store_client/redis_store_client.cc
+++ b/src/ray/gcs/store_client/redis_store_client.cc
@@ -15,9 +15,13 @@
 #include "ray/gcs/store_client/redis_store_client.h"
 
 #include <functional>
+#include <memory>
+#include <queue>
 #include <regex>
+#include <string>
 #include <thread>
 #include <utility>
+#include <vector>
 
 #include "absl/cleanup/cleanup.h"
 #include "absl/strings/match.h"

--- a/src/ray/gcs/store_client/redis_store_client.h
+++ b/src/ray/gcs/store_client/redis_store_client.h
@@ -16,7 +16,11 @@
 
 #include <gtest/gtest_prod.h>
 
+#include <memory>
 #include <queue>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "absl/container/flat_hash_set.h"
 #include "absl/synchronization/mutex.h"

--- a/src/ray/gcs/store_client/store_client.h
+++ b/src/ray/gcs/store_client/store_client.h
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "ray/common/asio/io_service_pool.h"
 #include "ray/common/asio/postable.h"

--- a/src/ray/gcs/store_client/test/in_memory_store_client_test.cc
+++ b/src/ray/gcs/store_client/test/in_memory_store_client_test.cc
@@ -14,6 +14,8 @@
 
 #include "ray/gcs/store_client/in_memory_store_client.h"
 
+#include <memory>
+
 #include "ray/gcs/store_client/test/store_client_test_base.h"
 
 namespace ray {

--- a/src/ray/gcs/store_client/test/observable_store_client_test.cc
+++ b/src/ray/gcs/store_client/test/observable_store_client_test.cc
@@ -14,6 +14,8 @@
 
 #include "ray/gcs/store_client/observable_store_client.h"
 
+#include <memory>
+
 #include "ray/gcs/store_client/in_memory_store_client.h"
 #include "ray/gcs/store_client/test/store_client_test_base.h"
 

--- a/src/ray/gcs/store_client/test/redis_store_client_test.cc
+++ b/src/ray/gcs/store_client/test/redis_store_client_test.cc
@@ -16,12 +16,17 @@
 
 #include <boost/optional/optional_io.hpp>
 #include <chrono>
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <vector>
 
 #include "ray/common/test_util.h"
 #include "ray/gcs/redis_client.h"
 #include "ray/gcs/store_client/test/store_client_test_base.h"
 
-using namespace std::chrono_literals;
+using namespace std::chrono_literals;  // NOLINT
 namespace ray {
 
 namespace gcs {
@@ -393,7 +398,8 @@ TEST_F(RedisStoreClientTest, Random) {
     ops[idx](i);
   }
   EXPECT_TRUE(WaitForCondition([&counter]() { return *counter == 0; }, 10000));
-  auto redis_store_client_raw_ptr = (RedisStoreClient *)store_client_.get();
+  auto redis_store_client_raw_ptr =
+      reinterpret_cast<RedisStoreClient *>(store_client_.get());
   absl::MutexLock lock(&redis_store_client_raw_ptr->mu_);
   ASSERT_TRUE(redis_store_client_raw_ptr->pending_redis_request_by_key_.empty());
 }

--- a/src/ray/gcs/test/callback_reply_test.cc
+++ b/src/ray/gcs/test/callback_reply_test.cc
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <string>
+#include <vector>
+
 #include "gtest/gtest.h"
 #include "ray/gcs/redis_context.h"
 

--- a/src/ray/gcs/test/gcs_test_util.h
+++ b/src/ray/gcs/test/gcs_test_util.h
@@ -17,7 +17,10 @@
 #include <filesystem>
 #include <fstream>
 #include <memory>
+#include <string>
+#include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include "gmock/gmock.h"
 #include "ray/common/asio/instrumented_io_context.h"

--- a/src/ray/gcs/test/redis_async_context_test.cc
+++ b/src/ray/gcs/test/redis_async_context_test.cc
@@ -15,6 +15,8 @@
 #include "ray/gcs/redis_async_context.h"
 
 #include <iostream>
+#include <memory>
+#include <string>
 
 #include "gtest/gtest.h"
 #include "ray/common/asio/instrumented_io_context.h"
@@ -42,7 +44,7 @@ void DisconnectCallback(const redisAsyncContext *c, int status) {
 void GetCallback(redisAsyncContext *c, void *r, void *privdata) {
   redisReply *reply = reinterpret_cast<redisReply *>(r);
   ASSERT_TRUE(reply != nullptr);
-  ASSERT_TRUE(std::string(reinterpret_cast<char *>(reply->str)) == "test");
+  ASSERT_EQ(std::string(reinterpret_cast<char *>(reply->str)), "test");
   io_service.stop();
 }
 
@@ -55,7 +57,7 @@ class RedisAsyncContextTest : public ::testing::Test {
 
 TEST_F(RedisAsyncContextTest, TestRedisCommands) {
   redisAsyncContext *ac = redisAsyncConnect("127.0.0.1", TEST_REDIS_SERVER_PORTS.front());
-  ASSERT_TRUE(ac->err == 0);
+  ASSERT_EQ(ac->err, 0);
   ray::gcs::RedisAsyncContext redis_async_context(
       io_service,
       std::unique_ptr<redisAsyncContext, RedisContextDeleter>(ac, RedisContextDeleter()));


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Ensure all .h and .cc files in `src/ray/gcs` comply with cpplint rules.

This is the command that I had ran and the console output

```
/home/simple/code/py/ray/src/ray/gcs/gcs_client/accessor.cc:27:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
/home/simple/code/py/ray/src/ray/gcs/gcs_client/accessor.cc:1163:  Using C-style cast.  Use static_cast<int>(...) instead  [readability/casting] [4]
/home/simple/code/py/ray/src/ray/gcs/gcs_client/accessor.cc:997:  Add #include <memory> for shared_ptr<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/gcs_client/accessor.cc:1345:  Add #include <unordered_map> for unordered_map<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/gcs_client/accessor.cc:1433:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/gcs_client/accessor.cc:1494:  Add #include <utility> for move  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/gcs_client/accessor.cc:1531:  Add #include <string> for string  [build/include_what_you_use] [4]
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_client/accessor.cc
/home/simple/code/py/ray/src/ray/gcs/gcs_client/accessor.h:486:  Add #include <unordered_set> for unordered_set<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/gcs_client/accessor.h:655:  Add #include <memory> for shared_ptr<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/gcs_client/accessor.h:903:  Add #include <unordered_map> for unordered_map<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/gcs_client/accessor.h:978:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/gcs_client/accessor.h:1001:  Add #include <string> for string  [build/include_what_you_use] [4]
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_client/accessor.h
/home/simple/code/py/ray/src/ray/gcs/gcs_client/gcs_client.cc:133:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/gcs_client/gcs_client.cc:157:  Add #include <memory> for make_unique<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/gcs_client/gcs_client.cc:212:  Add #include <string> for string  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/gcs_client/gcs_client.cc:212:  Add #include <unordered_map> for unordered_map<>  [build/include_what_you_use] [4]
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_client/gcs_client.cc
/home/simple/code/py/ray/src/ray/gcs/gcs_client/gcs_client.h:25:  "gtest/gtest_prod.h" already included at /home/simple/code/py/ray/src/ray/gcs/gcs_client/gcs_client.h:17  [build/include] [4]
/home/simple/code/py/ray/src/ray/gcs/gcs_client/gcs_client.h:136:  Add #include <utility> for pair<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/gcs_client/gcs_client.h:262:  Add #include <unordered_map> for unordered_map<>  [build/include_what_you_use] [4]
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_client/gcs_client.h
/home/simple/code/py/ray/src/ray/gcs/gcs_client/global_state_accessor.cc:148:  Add #include <unordered_map> for unordered_map<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/gcs_client/global_state_accessor.cc:376:  Add #include <memory> for make_unique<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/gcs_client/global_state_accessor.cc:440:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/gcs_client/global_state_accessor.cc:457:  Add #include <string> for string  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/gcs_client/global_state_accessor.cc:461:  Add #include <utility> for move  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/gcs_client/global_state_accessor.cc:475:  Add #include <algorithm> for max  [build/include_what_you_use] [4]
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_client/global_state_accessor.cc
/home/simple/code/py/ray/src/ray/gcs/gcs_client/global_state_accessor.h:88:  Add #include <unordered_map> for unordered_map<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/gcs_client/global_state_accessor.h:232:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/gcs_client/global_state_accessor.h:234:  Add #include <algorithm> for transform  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/gcs_client/global_state_accessor.h:270:  Add #include <string> for string  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/gcs_client/global_state_accessor.h:286:  Add #include <memory> for unique_ptr<>  [build/include_what_you_use] [4]
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_client/global_state_accessor.h
/home/simple/code/py/ray/src/ray/gcs/gcs_client/python_callbacks.h:92:  Add #include <utility> for forward  [build/include_what_you_use] [4]
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_client/python_callbacks.h
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_actor_manager.cc
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_actor_manager.h
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_actor_scheduler.h
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.cc
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.h
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_function_manager.h
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_health_check_manager.cc
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_health_check_manager.h
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_init_data.cc
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_init_data.h
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_job_manager.cc
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_job_manager.h
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_kv_manager.cc
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_kv_manager.h
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_node_manager.cc
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_node_manager.h
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_placement_group_manager.h
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_redis_failure_detector.cc
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_redis_failure_detector.h
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_resource_manager.cc
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_resource_manager.h
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_server.cc
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_server.h
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_server_io_context_policy.h
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_server_main.cc
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_table_storage.cc
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_table_storage.h
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_task_manager.cc
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_task_manager.h
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_worker_manager.cc
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/gcs_worker_manager.h
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/pubsub_handler.cc
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/pubsub_handler.h
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/runtime_env_handler.cc
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/runtime_env_handler.h
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/state_util.cc
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/state_util.h
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/store_client_kv.cc
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/store_client_kv.h
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/usage_stats_client.cc
Done processing /home/simple/code/py/ray/src/ray/gcs/gcs_server/usage_stats_client.h
/home/simple/code/py/ray/src/ray/gcs/pubsub/gcs_pub_sub.cc:220:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/pubsub/gcs_pub_sub.cc:385:  Add #include <utility> for move  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/pubsub/gcs_pub_sub.cc:415:  Add #include <string> for string  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/pubsub/gcs_pub_sub.cc:426:  Add #include <memory> for shared_ptr<>  [build/include_what_you_use] [4]
Done processing /home/simple/code/py/ray/src/ray/gcs/pubsub/gcs_pub_sub.cc
/home/simple/code/py/ray/src/ray/gcs/pubsub/gcs_pub_sub.h:42:  Single-parameter constructors should be marked explicit.  [runtime/explicit] [4]
/home/simple/code/py/ray/src/ray/gcs/pubsub/gcs_pub_sub.h:66:  Missing username in TODO; it should look like "// TODO(my_username): Stuff."  [readability/todo] [2]
/home/simple/code/py/ray/src/ray/gcs/pubsub/gcs_pub_sub.h:102:  Missing username in TODO; it should look like "// TODO(my_username): Stuff."  [readability/todo] [2]
/home/simple/code/py/ray/src/ray/gcs/pubsub/gcs_pub_sub.h:105:  Add #include <utility> for move  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/pubsub/gcs_pub_sub.h:209:  Add #include <deque> for deque<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/pubsub/gcs_pub_sub.h:211:  Add #include <memory> for shared_ptr<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/pubsub/gcs_pub_sub.h:216:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
Done processing /home/simple/code/py/ray/src/ray/gcs/pubsub/gcs_pub_sub.h
/home/simple/code/py/ray/src/ray/gcs/store_client/in_memory_store_client.cc:143:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/store_client/in_memory_store_client.cc:159:  Add #include <string> for string  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/store_client/in_memory_store_client.cc:167:  Add #include <utility> for move  [build/include_what_you_use] [4]
Done processing /home/simple/code/py/ray/src/ray/gcs/store_client/in_memory_store_client.cc
Done processing /home/simple/code/py/ray/src/ray/gcs/store_client/in_memory_store_client.h
/home/simple/code/py/ray/src/ray/gcs/store_client/observable_store_client.cc:23:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
/home/simple/code/py/ray/src/ray/gcs/store_client/observable_store_client.cc:93:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/store_client/observable_store_client.cc:124:  Add #include <string> for string  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/store_client/observable_store_client.cc:129:  Add #include <utility> for move  [build/include_what_you_use] [4]
Done processing /home/simple/code/py/ray/src/ray/gcs/store_client/observable_store_client.cc
/home/simple/code/py/ray/src/ray/gcs/store_client/observable_store_client.h:56:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/store_client/observable_store_client.h:66:  Add #include <string> for string  [build/include_what_you_use] [4]
Done processing /home/simple/code/py/ray/src/ray/gcs/store_client/observable_store_client.h
/home/simple/code/py/ray/src/ray/gcs/store_client/redis_store_client.cc:239:  Add #include <queue> for queue<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/store_client/redis_store_client.cc:538:  Add #include <string> for string  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/store_client/redis_store_client.cc:538:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/store_client/redis_store_client.cc:541:  Add #include <memory> for shared_ptr<>  [build/include_what_you_use] [4]
Done processing /home/simple/code/py/ray/src/ray/gcs/store_client/redis_store_client.cc
/home/simple/code/py/ray/src/ray/gcs/store_client/redis_store_client.h:77:  Add #include <utility> for move  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/store_client/redis_store_client.h:256:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/store_client/redis_store_client.h:260:  Add #include <memory> for shared_ptr<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/store_client/redis_store_client.h:276:  Add #include <string> for string  [build/include_what_you_use] [4]
Done processing /home/simple/code/py/ray/src/ray/gcs/store_client/redis_store_client.h
/home/simple/code/py/ray/src/ray/gcs/store_client/store_client.h:99:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
Done processing /home/simple/code/py/ray/src/ray/gcs/store_client/store_client.h
/home/simple/code/py/ray/src/ray/gcs/test/callback_reply_test.cc:99:  Add #include <string> for string  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/test/callback_reply_test.cc:99:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
Done processing /home/simple/code/py/ray/src/ray/gcs/test/callback_reply_test.cc
/home/simple/code/py/ray/src/ray/gcs/test/gcs_test_util.h:191:  Add #include <unordered_map> for unordered_map<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/test/gcs_test_util.h:419:  Add #include <vector> for vector<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/test/gcs_test_util.h:434:  Add #include <string> for string  [build/include_what_you_use] [4]
Done processing /home/simple/code/py/ray/src/ray/gcs/test/gcs_test_util.h
/home/simple/code/py/ray/src/ray/gcs/test/redis_async_context_test.cc:45:  Consider using ASSERT_EQ instead of ASSERT_TRUE(a == b)  [readability/check] [2]
/home/simple/code/py/ray/src/ray/gcs/test/redis_async_context_test.cc:58:  Consider using ASSERT_EQ instead of ASSERT_TRUE(a == b)  [readability/check] [2]
/home/simple/code/py/ray/src/ray/gcs/test/redis_async_context_test.cc:70:  Add #include <memory> for make_shared<>  [build/include_what_you_use] [4]
/home/simple/code/py/ray/src/ray/gcs/test/redis_async_context_test.cc:75:  Add #include <string> for string  [build/include_what_you_use] [4]
Done processing /home/simple/code/py/ray/src/ray/gcs/test/redis_async_context_test.cc
Total errors found: 69
```


## Related issue number

Closes #51405 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
