### PR TITLE
cord benchmark

### DIFF
--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -377,3 +377,9 @@ def ray_deps_setup():
         sha256 = "2db82d1e7119df3e71b7640219b6dfe84789bc0537983c3b7ac4f7189aecfeaa",
         strip_prefix = "jemalloc-5.3.0",
     )
+
+    git_repository(
+        name = "benchmark",
+        remote = "https://github.com/google/benchmark",
+        tag = "v1.9.1", # Release date: 2024/Nov/28
+    )

--- a/src/ray/util/benchmark/BUILD
+++ b/src/ray/util/benchmark/BUILD
@@ -1,0 +1,10 @@
+load("//bazel:ray.bzl", "ray_cc_binary")
+
+ray_cc_binary(
+    name = "cord_benchmark",
+    srcs = ["cord_benchmark.cc"],
+    deps = [
+        "@benchmark",
+        "@com_google_absl//absl/strings:cord",
+    ],
+)

--- a/src/ray/util/benchmark/cord_benchmark.cc
+++ b/src/ray/util/benchmark/cord_benchmark.cc
@@ -1,0 +1,49 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <benchmark/benchmark.h>
+
+#include <algorithm>
+#include <string>
+
+#include "absl/strings/cord.h"
+
+static void UseCord(benchmark::State &state) {
+  // Code inside this loop is measured repeatedly
+  std::string created_string(5000, 'h');
+  for (auto _ : state) {
+    auto cord = absl::MakeCordFromExternal(absl::string_view(created_string), []() {});
+    // absl::string_view cord(created_string);
+    // Make sure the variable is not optimized away by compiler
+    benchmark::DoNotOptimize(cord);
+  }
+}
+// Register the function as a benchmark
+BENCHMARK(UseCord);
+
+static void UseMemcpy(benchmark::State &state) {
+  // Code before the loop is not measured
+  std::string created_string(5000, 'h');
+  for (auto _ : state) {
+    std::string copy(created_string);
+    benchmark::DoNotOptimize(copy);
+  }
+}
+BENCHMARK(UseMemcpy);
+
+int main(int argc, char **argv) {
+  ::benchmark::Initialize(&argc, argv);
+  ::benchmark::RunSpecifiedBenchmarks();
+  return 0;
+}


### PR DESCRIPTION
```sh
Running bazel-bin/src/ray/util/benchmark/cord_benchmark
Run on (32 X 2500 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x16)
  L1 Instruction 32 KiB (x16)
  L2 Unified 1024 KiB (x16)
  L3 Unified 33792 KiB (x1)
Load Average: 2.46, 0.81, 0.46
-----------------------------------------------------
Benchmark           Time             CPU   Iterations
-----------------------------------------------------
UseCord          25.5 ns         25.5 ns     27482419
UseMemcpy        85.1 ns         85.1 ns      8245821
```