### PR TITLE
[core][dashboard] Return status code other than 200 and 500

### DIFF
--- a/python/ray/dashboard/modules/actor/actor_head.py
+++ b/python/ray/dashboard/modules/actor/actor_head.py
@@ -264,7 +264,7 @@ class ActorHead(dashboard_utils.DashboardHeadModule):
     async def get_all_actors(self, req) -> aiohttp.web.Response:
         actors = await DataOrganizer.get_actor_infos()
         return dashboard_optional_utils.rest_response(
-            success=True,
+            status_code=dashboard_utils.HTTPStatusCode.OK,
             message="All actors fetched.",
             actors=actors,
             # False to avoid converting Ray resource name to google style.
@@ -279,7 +279,9 @@ class ActorHead(dashboard_utils.DashboardHeadModule):
         actor_id = req.match_info.get("actor_id")
         actors = await DataOrganizer.get_actor_infos(actor_ids=[actor_id])
         return dashboard_optional_utils.rest_response(
-            success=True, message="Actor details fetched.", detail=actors[actor_id]
+            status_code=dashboard_utils.HTTPStatusCode.OK,
+            message="Actor details fetched.",
+            detail=actors[actor_id],
         )
 
     async def run(self, server):

--- a/python/ray/dashboard/modules/event/event_head.py
+++ b/python/ray/dashboard/modules/event/event_head.py
@@ -109,7 +109,7 @@ class EventHead(
 
     async def limit_handler_(self):
         return dashboard_optional_utils.rest_response(
-            success=False,
+            status_code=dashboard_utils.HTTPStatusCode.INTERNAL_ERROR,
             error_message=(
                 "Max number of in-progress requests="
                 f"{self.max_num_call_} reached. "
@@ -174,12 +174,14 @@ class EventHead(
                 for job_id, job_events in self.events.items()
             }
             return dashboard_optional_utils.rest_response(
-                success=True, message="All events fetched.", events=all_events
+                status_code=dashboard_utils.HTTPStatusCode.OK,
+                message="All events fetched.",
+                events=all_events,
             )
 
         job_events = self.events[job_id]
         return dashboard_optional_utils.rest_response(
-            success=True,
+            status_code=dashboard_utils.HTTPStatusCode.OK,
             message="Job events fetched.",
             job_id=job_id,
             events=list(job_events.values()),

--- a/python/ray/dashboard/modules/metrics/metrics_head.py
+++ b/python/ray/dashboard/modules/metrics/metrics_head.py
@@ -143,7 +143,7 @@ class MetricsHead(dashboard_utils.DashboardHeadModule):
         # If disabled, we don't want to show the metrics tab at all.
         if self.grafana_host == GRAFANA_HOST_DISABLED_VALUE:
             return dashboard_optional_utils.rest_response(
-                success=True,
+                status_code=dashboard_utils.HTTPStatusCode.OK,
                 message="Grafana disabled",
                 grafana_host=GRAFANA_HOST_DISABLED_VALUE,
             )
@@ -156,7 +156,7 @@ class MetricsHead(dashboard_utils.DashboardHeadModule):
             async with self.http_session.get(path) as resp:
                 if resp.status != 200:
                     return dashboard_optional_utils.rest_response(
-                        success=False,
+                        status_code=dashboard_utils.HTTPStatusCode.INTERNAL_ERROR,
                         message="Grafana healtcheck failed",
                         status=resp.status,
                     )
@@ -164,14 +164,14 @@ class MetricsHead(dashboard_utils.DashboardHeadModule):
                 # Check if the required Grafana services are running.
                 if json["database"] != "ok":
                     return dashboard_optional_utils.rest_response(
-                        success=False,
+                        status_code=dashboard_utils.HTTPStatusCode.INTERNAL_ERROR,
                         message="Grafana healtcheck failed. Database not ok.",
                         status=resp.status,
                         json=json,
                     )
 
                 return dashboard_optional_utils.rest_response(
-                    success=True,
+                    status_code=dashboard_utils.HTTPStatusCode.OK,
                     message="Grafana running",
                     grafana_host=grafana_iframe_host,
                     session_name=self.session_name,
@@ -185,7 +185,9 @@ class MetricsHead(dashboard_utils.DashboardHeadModule):
             )
 
             return dashboard_optional_utils.rest_response(
-                success=False, message="Grafana healtcheck failed", exception=str(e)
+                status_code=dashboard_utils.HTTPStatusCode.INTERNAL_ERROR,
+                message="Grafana healtcheck failed",
+                exception=str(e),
             )
 
     @routes.get("/api/prometheus_health")
@@ -198,13 +200,13 @@ class MetricsHead(dashboard_utils.DashboardHeadModule):
             ) as resp:
                 if resp.status != 200:
                     return dashboard_optional_utils.rest_response(
-                        success=False,
+                        status_code=dashboard_utils.HTTPStatusCode.INTERNAL_ERROR,
                         message="prometheus healthcheck failed.",
                         status=resp.status,
                     )
 
                 return dashboard_optional_utils.rest_response(
-                    success=True,
+                    status_code=dashboard_utils.HTTPStatusCode.OK,
                     message="prometheus running",
                 )
         except Exception as e:
@@ -212,7 +214,9 @@ class MetricsHead(dashboard_utils.DashboardHeadModule):
                 "Error fetching prometheus endpoint. Is prometheus running?", exc_info=e
             )
             return dashboard_optional_utils.rest_response(
-                success=False, message="prometheus healthcheck failed.", reason=str(e)
+                status_code=dashboard_utils.HTTPStatusCode.INTERNAL_ERROR,
+                message="prometheus healthcheck failed.",
+                reason=str(e),
             )
 
     @staticmethod

--- a/python/ray/dashboard/modules/node/node_head.py
+++ b/python/ray/dashboard/modules/node/node_head.py
@@ -292,7 +292,7 @@ class NodeHead(dashboard_utils.DashboardHeadModule):
             )
 
             return dashboard_optional_utils.rest_response(
-                success=True,
+                status_code=dashboard_utils.HTTPStatusCode.OK,
                 message="Node summary fetched.",
                 summary=all_node_summary,
                 node_logical_resources=nodes_logical_resources,
@@ -303,13 +303,14 @@ class NodeHead(dashboard_utils.DashboardHeadModule):
                 if node["state"] == "ALIVE":
                     alive_hostnames.add(node["nodeManagerHostname"])
             return dashboard_optional_utils.rest_response(
-                success=True,
+                status_code=dashboard_utils.HTTPStatusCode.OK,
                 message="Node hostname list fetched.",
                 host_name_list=list(alive_hostnames),
             )
         else:
             return dashboard_optional_utils.rest_response(
-                success=False, message=f"Unknown view {view}"
+                status_code=dashboard_utils.HTTPStatusCode.INTERNAL_ERROR,
+                message=f"Unknown view {view}",
             )
 
     @routes.get("/nodes/{node_id}")
@@ -318,7 +319,9 @@ class NodeHead(dashboard_utils.DashboardHeadModule):
         node_id = req.match_info.get("node_id")
         node_info = await DataOrganizer.get_node_info(node_id)
         return dashboard_optional_utils.rest_response(
-            success=True, message="Node details fetched.", detail=node_info
+            status_code=dashboard_utils.HTTPStatusCode.OK,
+            message="Node details fetched.",
+            detail=node_info,
         )
 
     @async_loop_forever(node_consts.NODE_STATS_UPDATE_INTERVAL_SECONDS)

--- a/python/ray/dashboard/modules/reporter/reporter_head.py
+++ b/python/ray/dashboard/modules/reporter/reporter_head.py
@@ -78,7 +78,9 @@ class ReportHead(dashboard_utils.DashboardHeadModule):
     @routes.get("/api/v0/cluster_metadata")
     async def get_cluster_metadata(self, req):
         return dashboard_optional_utils.rest_response(
-            success=True, message="", **self.cluster_metadata
+            status_code=dashboard_utils.HTTPStatusCode.OK,
+            message="",
+            **self.cluster_metadata,
         )
 
     @routes.get("/api/cluster_status")
@@ -120,7 +122,7 @@ class ReportHead(dashboard_utils.DashboardHeadModule):
 
         if not return_formatted_output:
             return dashboard_optional_utils.rest_response(
-                success=True,
+                status_code=dashboard_utils.HTTPStatusCode.OK,
                 message="Got cluster status.",
                 autoscaling_status=legacy_status.decode() if legacy_status else None,
                 autoscaling_error=error.decode() if error else None,
@@ -128,7 +130,7 @@ class ReportHead(dashboard_utils.DashboardHeadModule):
             )
         else:
             return dashboard_optional_utils.rest_response(
-                success=True,
+                status_code=dashboard_utils.HTTPStatusCode.OK,
                 message="Got formatted cluster status.",
                 cluster_status=debug_status(
                     formatted_status_string, error, address=self.gcs_address

--- a/python/ray/dashboard/modules/snapshot/tests/test_actors.py
+++ b/python/ray/dashboard/modules/snapshot/tests/test_actors.py
@@ -73,12 +73,11 @@ def test_kill_actor_gcs(ray_start_with_dashboard):
     actor_id = a._ray_actor_id.hex()
 
     OK = 200
-    INTERNAL_ERROR = 500
+    NOT_FOUND = 404
 
     # Kill an non-existent actor
-    # TODO(kevin85421): It should return 404 instead of 500.
     resp = _kill_actor_using_dashboard_gcs(
-        webui_url, "non-existent-actor-id", INTERNAL_ERROR
+        webui_url, "non-existent-actor-id", NOT_FOUND
     )
     assert "not found" in resp["msg"]
 

--- a/python/ray/dashboard/modules/tests/test_head.py
+++ b/python/ray/dashboard/modules/tests/test_head.py
@@ -51,14 +51,14 @@ class TestHead(dashboard_utils.DashboardHeadModule):
                 if not k.startswith("_")
             }
             return dashboard_optional_utils.rest_response(
-                success=True,
+                status_code=dashboard_utils.HTTPStatusCode.OK,
                 message="Fetch all data from datacenter success.",
                 **all_data,
             )
         else:
             data = dict(DataSource.__dict__.get(key))
             return dashboard_optional_utils.rest_response(
-                success=True,
+                status_code=dashboard_utils.HTTPStatusCode.OK,
                 message=f"Fetch {key} from datacenter success.",
                 **{key: data},
             )
@@ -74,7 +74,10 @@ class TestHead(dashboard_utils.DashboardHeadModule):
     async def test_aiohttp_cache(self, req) -> aiohttp.web.Response:
         value = req.query["value"]
         return dashboard_optional_utils.rest_response(
-            success=True, message="OK", value=value, timestamp=time.time()
+            status_code=dashboard_utils.HTTPStatusCode.OK,
+            message="OK",
+            value=value,
+            timestamp=time.time(),
         )
 
     @routes.get("/test/aiohttp_cache_lru/{sub_path}")
@@ -82,7 +85,10 @@ class TestHead(dashboard_utils.DashboardHeadModule):
     async def test_aiohttp_cache_lru(self, req) -> aiohttp.web.Response:
         value = req.query.get("value")
         return dashboard_optional_utils.rest_response(
-            success=True, message="OK", value=value, timestamp=time.time()
+            status_code=dashboard_utils.HTTPStatusCode.OK,
+            message="OK",
+            value=value,
+            timestamp=time.time(),
         )
 
     @routes.get("/test/file")
@@ -101,7 +107,7 @@ class TestHead(dashboard_utils.DashboardHeadModule):
         time.sleep(seconds)
 
         return dashboard_optional_utils.rest_response(
-            success=True,
+            status_code=dashboard_utils.HTTPStatusCode.OK,
             message=f"Blocked event loop for {seconds} seconds",
             timestamp=time.time(),
         )

--- a/python/ray/dashboard/modules/usage_stats/usage_stats_head.py
+++ b/python/ray/dashboard/modules/usage_stats/usage_stats_head.py
@@ -45,7 +45,7 @@ class UsageStatsHead(dashboard_utils.DashboardHeadModule):
         @routes.get("/usage_stats_enabled")
         async def get_usage_stats_enabled(self, req) -> aiohttp.web.Response:
             return ray.dashboard.optional_utils.rest_response(
-                success=True,
+                status_code=dashboard_utils.HTTPStatusCode.OK,
                 message="Fetched usage stats enabled",
                 usage_stats_enabled=self.usage_stats_enabled,
                 usage_stats_prompt_enabled=self.usage_stats_prompt_enabled,
@@ -54,7 +54,7 @@ class UsageStatsHead(dashboard_utils.DashboardHeadModule):
         @routes.get("/cluster_id")
         async def get_cluster_id(self, req) -> aiohttp.web.Response:
             return ray.dashboard.optional_utils.rest_response(
-                success=True,
+                status_code=dashboard_utils.HTTPStatusCode.OK,
                 message="Fetched cluster id",
                 cluster_id=self.gcs_client.cluster_id.hex(),
             )

--- a/python/ray/dashboard/optional_utils.py
+++ b/python/ray/dashboard/optional_utils.py
@@ -17,6 +17,7 @@ from aiohttp.web import Request, Response
 
 import ray
 import ray.dashboard.consts as dashboard_consts
+import ray.dashboard.utils as dashboard_utils
 from ray._private.ray_constants import RAY_INTERNAL_DASHBOARD_NAMESPACE, env_bool
 
 # All third-party dependencies that are not included in the minimal Ray
@@ -83,7 +84,8 @@ def aiohttp_cache(
                         response = task.result()
                     except Exception:
                         response = rest_response(
-                            success=False, message=traceback.format_exc()
+                            status_code=dashboard_utils.HTTPStatusCode.INTERNAL_ERROR,
+                            message=traceback.format_exc(),
                         )
                     data = {
                         "status": response.status,

--- a/python/ray/dashboard/routes.py
+++ b/python/ray/dashboard/routes.py
@@ -174,14 +174,14 @@ def method_route_table_factory():
 
 
 def rest_response(
-    status_code: int,
+    status_code: HTTPStatusCode,
     message: str,
     convert_google_style: bool = True,
     **kwargs,
 ) -> aiohttp.web.Response:
     """
     Args:
-        status_code: int
+        status_code: HTTPStatusCode
             The HTTP status code of the response.
         message: str
             The message of the response.

--- a/python/ray/dashboard/routes.py
+++ b/python/ray/dashboard/routes.py
@@ -9,7 +9,7 @@ import traceback
 from typing import Any
 
 from ray.dashboard.optional_deps import PathLike, RouteDef, aiohttp, hdrs
-from ray.dashboard.utils import CustomEncoder, to_google_style
+from ray.dashboard.utils import CustomEncoder, HTTPStatusCode, to_google_style
 
 logger = logging.getLogger(__name__)
 
@@ -144,7 +144,8 @@ def method_route_table_factory():
                     except Exception:
                         logger.exception("Handle %s %s failed.", method, path)
                         return rest_response(
-                            success=False, message=traceback.format_exc()
+                            status_code=HTTPStatusCode.INTERNAL_ERROR,
+                            message=traceback.format_exc(),
                         )
 
                 cls._bind_map[method][path] = bind_info
@@ -173,8 +174,23 @@ def method_route_table_factory():
 
 
 def rest_response(
-    success, message, convert_google_style=True, **kwargs
+    status_code: int,
+    message: str,
+    convert_google_style: bool = True,
+    **kwargs,
 ) -> aiohttp.web.Response:
+    """
+    Args:
+        status_code: int
+            The HTTP status code of the response.
+        message: str
+            The message of the response.
+        convert_google_style: bool
+            Whether to convert the response to google style.
+
+    Returns:
+        aiohttp.web.Response
+    """
     # In the dev context we allow a dev server running on a
     # different port to consume the API, meaning we need to allow
     # cross-origin access
@@ -182,6 +198,8 @@ def rest_response(
         headers = {"Access-Control-Allow-Origin": "*"}
     else:
         headers = {}
+
+    success = status_code == HTTPStatusCode.OK
     return aiohttp.web.json_response(
         {
             "result": success,
@@ -190,5 +208,5 @@ def rest_response(
         },
         dumps=functools.partial(json.dumps, cls=CustomEncoder),
         headers=headers,
-        status=200 if success else 500,
+        status=status_code,
     )

--- a/python/ray/dashboard/state_api_utils.py
+++ b/python/ray/dashboard/state_api_utils.py
@@ -5,6 +5,7 @@ from typing import Awaitable, Callable, List, Tuple
 import aiohttp.web
 
 from ray.dashboard.optional_utils import rest_response
+from ray.dashboard.utils import HTTPStatusCode
 from ray.util.state.common import (
     DEFAULT_LIMIT,
     DEFAULT_RPC_TIMEOUT,
@@ -24,7 +25,7 @@ from ray.util.state.util import convert_string_to_type
 
 def do_reply(success: bool, error_message: str, result: ListApiResponse, **kwargs):
     return rest_response(
-        success=success,
+        status_code=HTTPStatusCode.OK if success else HTTPStatusCode.INTERNAL_ERROR,
         message=error_message,
         result=result,
         convert_google_style=False,

--- a/python/ray/dashboard/tests/test_dashboard.py
+++ b/python/ray/dashboard/tests/test_dashboard.py
@@ -812,8 +812,12 @@ def test_immutable_types():
     assert type(deserialized_immutable_dict) is dict
     assert type(deserialized_immutable_dict["list"]) is list
     assert immutable_dict.mutable() == deserialized_immutable_dict
-    dashboard_optional_utils.rest_response(True, "OK", data=immutable_dict)
-    dashboard_optional_utils.rest_response(True, "OK", **immutable_dict)
+    dashboard_optional_utils.rest_response(
+        dashboard_utils.HTTPStatusCode.OK, "OK", data=immutable_dict
+    )
+    dashboard_optional_utils.rest_response(
+        dashboard_utils.HTTPStatusCode.OK, "OK", **immutable_dict
+    )
 
     # Test copy
     copy_of_immutable = copy.copy(immutable_dict)

--- a/python/ray/dashboard/utils.py
+++ b/python/ray/dashboard/utils.py
@@ -13,6 +13,7 @@ from collections import namedtuple
 from collections.abc import Mapping, MutableMapping, Sequence
 from dataclasses import dataclass
 from typing import Optional, Dict, List, Any, TYPE_CHECKING
+from enum import IntEnum
 
 if TYPE_CHECKING:
     from ray.core.generated.node_manager_pb2 import GetNodeStatsReply
@@ -42,6 +43,17 @@ except AttributeError:
     create_task = asyncio.ensure_future
 
 logger = logging.getLogger(__name__)
+
+
+class HTTPStatusCode(IntEnum):
+    # 2xx Success
+    OK = 200
+
+    # 4xx Client Errors
+    NOT_FOUND = 404
+
+    # 5xx Server Errors
+    INTERNAL_ERROR = 500
 
 
 class FrontendNotFoundError(OSError):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The utility function `rest_response` takes a boolean parameter, `success`, to generate an HTTP response. It returns 200 when `success` is true, and 500 otherwise. However, it's not enough.

For example, if users try to kill a non-existent actor via `/api/actors/kill`, 404 should be returned. Revisiting status code of each API endpoint can be good first issues.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
