### PR TITLE
Add perf metrics for 2.44.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 306.917376,
+    "_dashboard_memory_usage_mb": 428.52352,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.67,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1155\t7.68GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3574\t1.77GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5013\t0.87GiB\tpython distributed/test_many_actors.py\n2913\t0.38GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3690\t0.29GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n587\t0.17GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3171\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3881\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3883\t0.07GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru\n3905\t0.07GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --",
-    "actors_per_second": 591.3775923644333,
+    "_peak_memory": 3.76,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1169\t6.63GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3583\t1.81GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4580\t0.86GiB\tpython distributed/test_many_actors.py\n2981\t0.42GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3699\t0.35GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n579\t0.19GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3082\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3892\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3894\t0.07GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru\n3944\t0.07GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --",
+    "actors_per_second": 587.9457127979538,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 591.3775923644333
+            "perf_metric_value": 587.9457127979538
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 32.123
+            "perf_metric_value": 69.681
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2575.96
+            "perf_metric_value": 2853.454
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3067.405
+            "perf_metric_value": 4220.801
         }
     ],
     "success": "1",
-    "time": 16.909670114517212
+    "time": 17.008373022079468
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 241.967104,
+    "_dashboard_memory_usage_mb": 227.704832,
     "_dashboard_test_success": true,
-    "_peak_memory": 1.7,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3418\t0.52GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2905\t0.25GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3545\t0.22GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n5388\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1085\t0.12GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3738\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n2801\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n5662\t0.08GiB\tray::StateAPIGeneratorActor.start\n3740\t0.07GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru\n3762\t0.07GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/bin/jupyter-lab --allow-root --ip=127.0.0.1 --",
+    "_peak_memory": 1.67,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3432\t0.51GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2898\t0.26GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3548\t0.2GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n569\t0.19GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n4486\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1113\t0.14GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3751\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n2834\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4785\t0.08GiB\tray::StateAPIGeneratorActor.start\n3753\t0.07GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 201.69050944705367
+            "perf_metric_value": 215.08649039878165
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.567
+            "perf_metric_value": 4.962
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 21.421
+            "perf_metric_value": 17.308
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 78.71
+            "perf_metric_value": 71.325
         }
     ],
     "success": "1",
-    "tasks_per_second": 201.69050944705367,
-    "time": 304.95809149742126,
+    "tasks_per_second": 215.08649039878165,
+    "time": 304.64929246902466,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 195.518464,
+    "_dashboard_memory_usage_mb": 185.561088,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.19,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1107\t6.83GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3448\t0.96GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4572\t0.36GiB\tpython distributed/test_many_pgs.py\n2764\t0.33GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n586\t0.16GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3564\t0.15GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n2519\t0.1GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l\n2997\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3780\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3782\t0.07GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
+    "_peak_memory": 2.21,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1126\t7.49GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3604\t0.97GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4553\t0.36GiB\tpython distributed/test_many_pgs.py\n2520\t0.28GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n580\t0.19GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3720\t0.15GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n2734\t0.1GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l\n3915\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n2832\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3917\t0.07GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13.421786372110379
+            "perf_metric_value": 13.584851090734276
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4.238
+            "perf_metric_value": 3.899
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 16.646
+            "perf_metric_value": 9.284
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 252.85
+            "perf_metric_value": 270.166
         }
     ],
-    "pgs_per_second": 13.421786372110379,
+    "pgs_per_second": 13.584851090734276,
     "success": "1",
-    "time": 74.50573062896729
+    "time": 73.6114068031311
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 716.218368,
+    "_dashboard_memory_usage_mb": 808.189952,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.49,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3576\t1.1GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3692\t0.75GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n4569\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n2796\t0.23GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n585\t0.16GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n1118\t0.13GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3883\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3001\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4744\t0.08GiB\tray::DashboardTester.run\n4808\t0.08GiB\tray::StateAPIGeneratorActor.start",
+    "_peak_memory": 3.7,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3565\t1.21GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3681\t0.88GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n4522\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n2799\t0.26GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n580\t0.19GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n2048\t0.13GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3872\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3161\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4809\t0.08GiB\tray::StateAPIGeneratorActor.start\n4746\t0.08GiB\tray::DashboardTester.run",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 399.43954902981744
+            "perf_metric_value": 367.9840802358416
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 89.962
+            "perf_metric_value": 137.963
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 398.245
+            "perf_metric_value": 627.361
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 589.9
+            "perf_metric_value": 938.359
         }
     ],
     "success": "1",
-    "tasks_per_second": 399.43954902981744,
-    "time": 325.0350773334503,
+    "tasks_per_second": 367.9840802358416,
+    "time": 327.1750886440277,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.43.0"}
+{"release_version": "2.44.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8588.075503140139,
-        214.3386936008847
+        8173.653446206568,
+        30.056715254848964
     ],
     "1_1_actor_calls_concurrent": [
-        5402.532852540871,
-        165.2704589016148
+        5130.570133178275,
+        141.4604558304179
     ],
     "1_1_actor_calls_sync": [
-        2024.9514970549762,
-        39.983445473597456
+        1959.1925407193576,
+        21.592904132679067
     ],
     "1_1_async_actor_calls_async": [
-        4185.269438984466,
-        314.18852893049984
+        4284.370408530537,
+        257.8746291973355
     ],
     "1_1_async_actor_calls_sync": [
-        1434.2085547024217,
-        19.450183004371436
+        1426.2018801386466,
+        30.85915257732358
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2740.2279840306683,
-        84.62716988857152
+        3106.7466600430544,
+        98.06580605137617
     ],
     "1_n_actor_calls_async": [
-        8168.440029557936,
-        267.97497006568267
+        8060.698907411474,
+        159.5027847099027
     ],
     "1_n_async_actor_calls_async": [
-        7589.035727393511,
-        116.23965915521515
+        7741.746631714333,
+        86.62981166379939
     ],
     "client__1_1_actor_calls_async": [
-        1057.2932167754398,
-        9.079193973373348
+        1041.8730021547178,
+        31.906006592386614
     ],
     "client__1_1_actor_calls_concurrent": [
-        1056.4662855748954,
-        16.51803494485674
+        1047.1016344870811,
+        11.862876231087569
     ],
     "client__1_1_actor_calls_sync": [
-        496.227853176116,
-        17.970368774601223
+        527.9555023039422,
+        3.458995118132708
     ],
     "client__get_calls": [
-        1094.7883444776185,
-        66.85851930731262
+        992.4456902391204,
+        8.6332446442905
     ],
     "client__put_calls": [
-        794.8759505022576,
-        35.39399136775509
+        824.1906946636155,
+        31.799894274897753
     ],
     "client__put_gigabytes": [
-        0.14981555197949994,
-        0.0006458480382978393
+        0.1550540296697212,
+        0.0007285894909629222
     ],
     "client__tasks_and_get_batch": [
-        0.9551721070094008,
-        0.029983017294858607
+        0.9197513826205774,
+        0.07766523014806347
     ],
     "client__tasks_and_put_batch": [
-        14341.529664523765,
-        320.24662535145563
+        13601.436104861408,
+        257.8725152130557
     ],
     "multi_client_put_calls_Plasma_Store": [
-        16715.417342144425,
-        255.4664451834791
+        16759.644681044447,
+        258.48189505521646
     ],
     "multi_client_put_gigabytes": [
-        43.246981615749526,
-        4.531224086871732
+        40.39150444280067,
+        2.756325449812855
     ],
     "multi_client_tasks_async": [
-        21682.83981428489,
-        509.23274422335606
+        23258.544455831183,
+        1366.1772490296016
     ],
     "n_n_actor_calls_async": [
-        24718.441650671633,
-        1049.8923008790389
+        27209.70867997587,
+        274.52329453432833
     ],
     "n_n_actor_calls_with_arg_async": [
-        2539.21250893006,
-        11.055019340184344
+        2693.4756033858466,
+        43.64462346586145
     ],
     "n_n_async_actor_calls_async": [
-        22979.306268540124,
-        350.87239640082686
+        23555.066039349047,
+        611.8591542678244
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10975.200393255369
+            "perf_metric_value": 10529.193272608605
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4901.43220832959
+            "perf_metric_value": 4968.781518634253
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 16715.417342144425
+            "perf_metric_value": 16759.644681044447
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 18.30617444315663
+            "perf_metric_value": 17.79739662942353
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 6.116479739439202
+            "perf_metric_value": 5.828378076935622
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 43.246981615749526
+            "perf_metric_value": 40.39150444280067
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 11.752691593157284
+            "perf_metric_value": 12.31636775550824
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4.908150175266516
+            "perf_metric_value": 5.00750150210662
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 981.51641421362
+            "perf_metric_value": 969.8384217890384
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7784.9177487724955
+            "perf_metric_value": 7931.938851598112
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 21682.83981428489
+            "perf_metric_value": 23258.544455831183
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2024.9514970549762
+            "perf_metric_value": 1959.1925407193576
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8588.075503140139
+            "perf_metric_value": 8173.653446206568
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5402.532852540871
+            "perf_metric_value": 5130.570133178275
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8168.440029557936
+            "perf_metric_value": 8060.698907411474
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 24718.441650671633
+            "perf_metric_value": 27209.70867997587
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2539.21250893006
+            "perf_metric_value": 2693.4756033858466
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1434.2085547024217
+            "perf_metric_value": 1426.2018801386466
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4185.269438984466
+            "perf_metric_value": 4284.370408530537
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2740.2279840306683
+            "perf_metric_value": 3106.7466600430544
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7589.035727393511
+            "perf_metric_value": 7741.746631714333
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22979.306268540124
+            "perf_metric_value": 23555.066039349047
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 741.0897046422251
+            "perf_metric_value": 743.5659082964364
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1094.7883444776185
+            "perf_metric_value": 992.4456902391204
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 794.8759505022576
+            "perf_metric_value": 824.1906946636155
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.14981555197949994
+            "perf_metric_value": 0.1550540296697212
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 14341.529664523765
+            "perf_metric_value": 13601.436104861408
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 496.227853176116
+            "perf_metric_value": 527.9555023039422
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1057.2932167754398
+            "perf_metric_value": 1041.8730021547178
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1056.4662855748954
+            "perf_metric_value": 1047.1016344870811
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.9551721070094008
+            "perf_metric_value": 0.9197513826205774
         }
     ],
     "placement_group_create/removal": [
-        741.0897046422251,
-        11.374041408701535
+        743.5659082964364,
+        6.071477547527883
     ],
     "single_client_get_calls_Plasma_Store": [
-        10975.200393255369,
-        270.12299884478415
+        10529.193272608605,
+        143.01908624476275
     ],
     "single_client_get_object_containing_10k_refs": [
-        11.752691593157284,
-        0.2784603975313991
+        12.31636775550824,
+        0.23738920196513993
     ],
     "single_client_put_calls_Plasma_Store": [
-        4901.43220832959,
-        93.36764866781367
+        4968.781518634253,
+        60.43519404123852
     ],
     "single_client_put_gigabytes": [
-        18.30617444315663,
-        9.192049596130419
+        17.79739662942353,
+        7.58063002295452
     ],
     "single_client_tasks_and_get_batch": [
-        6.116479739439202,
-        2.726139136686573
+        5.828378076935622,
+        2.876332516860306
     ],
     "single_client_tasks_async": [
-        7784.9177487724955,
-        305.77224857815514
+        7931.938851598112,
+        360.4555007085703
     ],
     "single_client_tasks_sync": [
-        981.51641421362,
-        4.002662242868348
+        969.8384217890384,
+        18.351730606276284
     ],
     "single_client_wait_1k_refs": [
-        4.908150175266516,
-        0.1479586294007533
+        5.00750150210662,
+        0.0818095088804673
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 17.602684142,
+    "broadcast_time": 17.87641767999999,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.602684142
+            "perf_metric_value": 17.87641767999999
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 18.656692702999997,
-    "get_time": 23.620077062999997,
+    "args_time": 18.865748501,
+    "get_time": 24.215384834000005,
     "large_object_size": 107374182400,
-    "large_object_time": 29.23165342300001,
+    "large_object_time": 29.36276392100001,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 18.656692702999997
+            "perf_metric_value": 18.865748501
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.748432768000001
+            "perf_metric_value": 5.718652900000009
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.620077062999997
+            "perf_metric_value": 24.215384834000005
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 191.976472028
+            "perf_metric_value": 195.30269835
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 29.23165342300001
+            "perf_metric_value": 29.36276392100001
         }
     ],
-    "queued_time": 191.976472028,
-    "returns_time": 5.748432768000001,
+    "queued_time": 195.30269835,
+    "returns_time": 5.718652900000009,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.1939783954620362,
-    "max_iteration_time": 4.9624292850494385,
-    "min_iteration_time": 0.0681600570678711,
+    "avg_iteration_time": 1.220467975139618,
+    "max_iteration_time": 4.791987180709839,
+    "min_iteration_time": 0.06933784484863281,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.1939783954620362
+            "perf_metric_value": 1.220467975139618
         }
     ],
     "success": 1,
-    "total_time": 119.39797282218933
+    "total_time": 122.04691576957703
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 6.343268156051636
+            "perf_metric_value": 7.161974191665649
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.727009963989257
+            "perf_metric_value": 12.67637095451355
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 39.46649179458618
+            "perf_metric_value": 39.70143375396729
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.6967883110046387
+            "perf_metric_value": 1.6947014331817627
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1829.902144908905
+            "perf_metric_value": 1862.925583600998
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.6171852602079066
+            "perf_metric_value": 0.5694189543465601
         }
     ],
-    "stage_0_time": 6.343268156051636,
-    "stage_1_avg_iteration_time": 12.727009963989257,
-    "stage_1_max_iteration_time": 13.265979766845703,
-    "stage_1_min_iteration_time": 11.543980360031128,
-    "stage_1_time": 127.27016830444336,
-    "stage_2_avg_iteration_time": 39.46649179458618,
-    "stage_2_max_iteration_time": 40.12660527229309,
-    "stage_2_min_iteration_time": 38.797585010528564,
-    "stage_2_time": 197.33301377296448,
-    "stage_3_creation_time": 1.6967883110046387,
-    "stage_3_time": 1829.902144908905,
-    "stage_4_spread": 0.6171852602079066,
+    "stage_0_time": 7.161974191665649,
+    "stage_1_avg_iteration_time": 12.67637095451355,
+    "stage_1_max_iteration_time": 13.112669467926025,
+    "stage_1_min_iteration_time": 11.563485145568848,
+    "stage_1_time": 126.76376485824585,
+    "stage_2_avg_iteration_time": 39.70143375396729,
+    "stage_2_max_iteration_time": 40.009204149246216,
+    "stage_2_min_iteration_time": 39.15291666984558,
+    "stage_2_time": 198.50770568847656,
+    "stage_3_creation_time": 1.6947014331817627,
+    "stage_3_time": 1862.925583600998,
+    "stage_4_spread": 0.5694189543465601,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 1.5345107927928425,
-    "avg_pg_remove_time_ms": 1.4037860555554367,
+    "avg_pg_create_time_ms": 1.5311616291286299,
+    "avg_pg_remove_time_ms": 1.2030833633637947,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.5345107927928425
+            "perf_metric_value": 1.5311616291286299
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.4037860555554367
+            "perf_metric_value": 1.2030833633637947
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 9.35%: client__get_calls (THROUGHPUT) regresses from 1094.7883444776185 to 992.4456902391204 in microbenchmark.json
REGRESSION 7.87%: tasks_per_second (THROUGHPUT) regresses from 399.43954902981744 to 367.9840802358416 in benchmarks/many_tasks.json
REGRESSION 6.60%: multi_client_put_gigabytes (THROUGHPUT) regresses from 43.246981615749526 to 40.39150444280067 in microbenchmark.json
REGRESSION 5.16%: client__tasks_and_put_batch (THROUGHPUT) regresses from 14341.529664523765 to 13601.436104861408 in microbenchmark.json
REGRESSION 5.03%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 5402.532852540871 to 5130.570133178275 in microbenchmark.json
REGRESSION 4.83%: 1_1_actor_calls_async (THROUGHPUT) regresses from 8588.075503140139 to 8173.653446206568 in microbenchmark.json
REGRESSION 4.71%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 6.116479739439202 to 5.828378076935622 in microbenchmark.json
REGRESSION 4.06%: single_client_get_calls_Plasma_Store (THROUGHPUT) regresses from 10975.200393255369 to 10529.193272608605 in microbenchmark.json
REGRESSION 3.71%: client__tasks_and_get_batch (THROUGHPUT) regresses from 0.9551721070094008 to 0.9197513826205774 in microbenchmark.json
REGRESSION 3.25%: 1_1_actor_calls_sync (THROUGHPUT) regresses from 2024.9514970549762 to 1959.1925407193576 in microbenchmark.json
REGRESSION 2.78%: single_client_put_gigabytes (THROUGHPUT) regresses from 18.30617444315663 to 17.79739662942353 in microbenchmark.json
REGRESSION 1.46%: client__1_1_actor_calls_async (THROUGHPUT) regresses from 1057.2932167754398 to 1041.8730021547178 in microbenchmark.json
REGRESSION 1.32%: 1_n_actor_calls_async (THROUGHPUT) regresses from 8168.440029557936 to 8060.698907411474 in microbenchmark.json
REGRESSION 1.19%: single_client_tasks_sync (THROUGHPUT) regresses from 981.51641421362 to 969.8384217890384 in microbenchmark.json
REGRESSION 0.89%: client__1_1_actor_calls_concurrent (THROUGHPUT) regresses from 1056.4662855748954 to 1047.1016344870811 in microbenchmark.json
REGRESSION 0.58%: actors_per_second (THROUGHPUT) regresses from 591.3775923644333 to 587.9457127979538 in benchmarks/many_actors.json
REGRESSION 0.56%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1434.2085547024217 to 1426.2018801386466 in microbenchmark.json
REGRESSION 116.92%: dashboard_p50_latency_ms (LATENCY) regresses from 32.123 to 69.681 in benchmarks/many_actors.json
REGRESSION 59.07%: dashboard_p99_latency_ms (LATENCY) regresses from 589.9 to 938.359 in benchmarks/many_tasks.json
REGRESSION 57.53%: dashboard_p95_latency_ms (LATENCY) regresses from 398.245 to 627.361 in benchmarks/many_tasks.json
REGRESSION 53.36%: dashboard_p50_latency_ms (LATENCY) regresses from 89.962 to 137.963 in benchmarks/many_tasks.json
REGRESSION 37.60%: dashboard_p99_latency_ms (LATENCY) regresses from 3067.405 to 4220.801 in benchmarks/many_actors.json
REGRESSION 12.91%: stage_0_time (LATENCY) regresses from 6.343268156051636 to 7.161974191665649 in stress_tests/stress_test_many_tasks.json
REGRESSION 10.77%: dashboard_p95_latency_ms (LATENCY) regresses from 2575.96 to 2853.454 in benchmarks/many_actors.json
REGRESSION 6.85%: dashboard_p99_latency_ms (LATENCY) regresses from 252.85 to 270.166 in benchmarks/many_pgs.json
REGRESSION 2.52%: 10000_get_time (LATENCY) regresses from 23.620077062999997 to 24.215384834000005 in scalability/single_node.json
REGRESSION 2.22%: avg_iteration_time (LATENCY) regresses from 1.1939783954620362 to 1.220467975139618 in stress_tests/stress_test_dead_actors.json
REGRESSION 1.80%: stage_3_time (LATENCY) regresses from 1829.902144908905 to 1862.925583600998 in stress_tests/stress_test_many_tasks.json
REGRESSION 1.73%: 1000000_queued_time (LATENCY) regresses from 191.976472028 to 195.30269835 in scalability/single_node.json
REGRESSION 1.56%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 17.602684142 to 17.87641767999999 in scalability/object_store.json
REGRESSION 1.12%: 10000_args_time (LATENCY) regresses from 18.656692702999997 to 18.865748501 in scalability/single_node.json
REGRESSION 0.60%: stage_2_avg_iteration_time (LATENCY) regresses from 39.46649179458618 to 39.70143375396729 in stress_tests/stress_test_many_tasks.json
REGRESSION 0.45%: 107374182400_large_object_time (LATENCY) regresses from 29.23165342300001 to 29.36276392100001 in scalability/single_node.json
```