### PR TITLE
[Serve] Fix multiplex fallback logic during burst requests (#51389)

### DIFF
--- a/python/ray/serve/tests/unit/test_pow_2_replica_scheduler.py
+++ b/python/ray/serve/tests/unit/test_pow_2_replica_scheduler.py
@@ -1361,6 +1361,41 @@ class TestModelMultiplexing:
             assert done.pop() == m2_tasks[0]
             m2_tasks = m2_tasks[1:]
 
+    async def test_replicas_with_model_id_not_chosen_when_busy(self, pow_2_scheduler):
+        """
+        Setup 3 replicas, one of which has the model ID, the other two do not. Verifies
+        that when the replica with the model ID is busy, the other replicas are chosen.
+        """
+        s = pow_2_scheduler
+        loop = get_or_create_event_loop()
+
+        r1 = FakeRunningReplica("r1", model_ids={"m1"})
+        r1.set_queue_len_response(DEFAULT_MAX_ONGOING_REQUESTS)
+        r2 = FakeRunningReplica("r2", model_ids={})
+        r2.set_queue_len_response(0)
+        r3 = FakeRunningReplica("r3", model_ids={})
+        r3.set_queue_len_response(0)
+        s.update_replicas([r1, r2, r3])
+
+        # Sending burst of requests with model_id=m1.
+        tasks = [
+            loop.create_task(
+                s.choose_replica_for_request(fake_pending_request(model_id="m1"))
+            )
+            for _ in range(100)
+        ]
+
+        # Ensure that all tasks are scheduled to r2 and r3 right away, since r1 is busy.
+        #
+        # The timeout is important in this test, else the request can still wait for the
+        # multiplexed_matching_timeout to expire then to go to other replicas. This
+        # timeout ensures that the request is scheduled to other replicas right away
+        # after first try.
+        done, _ = await asyncio.wait(tasks, timeout=0.1)
+        assert len(done) == 100
+        for task in done:
+            assert task.result() in {r2, r3}
+
 
 @pytest.mark.asyncio
 async def test_get_queue_len_cancelled_on_timeout(pow_2_scheduler):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Cherry-pick of https://github.com/ray-project/ray/pull/51389

When there are burst of requests, our existing implementation will send all of them to the replica that has the loaded model in every scheduling loop until the multiplex timeout expired. This is undesirable when there are other replicas that can handle the request immediately. This PR addressed the case by keeping a flag to check whether it's the first time checking multiplex replicas. Then it goes into the multiplex fallback logic since the second loop. Did this in TDD way to write a test that fails then add the logics to fix it.

## Related issue number

Closes
https://anyscaleteam.slack.com/archives/C011RJWAV08/p1741987056393629

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've added any new APIs to the API Reference. For example, if I added a
method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

---------

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
