### PR TITLE
[core] Fix launch_and_verify_clusters

### DIFF
--- a/python/ray/autoscaler/_private/aws/config.py
+++ b/python/ray/autoscaler/_private/aws/config.py
@@ -40,21 +40,21 @@ DEFAULT_AMI_NAME = "AWS Deep Learning AMI (Ubuntu 18.04) V61.0"
 # TODO(alex) : write a unit test to make sure we update AMI version used in
 # ray/autoscaler/aws/example-full.yaml whenever we update this dict.
 DEFAULT_AMI = {
-    "us-east-1": "ami-068d304eca3399469",  # US East (N. Virginia)
-    "us-east-2": "ami-01d66247b45457f6b",  # US East (Ohio)
-    "us-west-1": "ami-0c1b0805e0f5a63f3",  # US West (N. California)
-    "us-west-2": "ami-0581161e178068142",  # US West (Oregon)
-    "ca-central-1": "ami-002845b64d842a2a1",  # Canada (Central)
-    "eu-central-1": "ami-034aae0781c0f3b1b",  # EU (Frankfurt)
-    "eu-west-1": "ami-08d286977c0d61d60",  # EU (Ireland)
-    "eu-west-2": "ami-06494a8cdbc94835c",  # EU (London)
-    "eu-west-3": "ami-01e329f22a25bcf0b",  # EU (Paris)
-    "sa-east-1": "ami-0b6cebaa28fdd35e7",  # SA (Sao Paulo)
-    "ap-northeast-1": "ami-020f0d5aa9f43db31",  # Asia Pacific (Tokyo)
-    "ap-northeast-2": "ami-0a73968b958434f9f",  # Asia Pacific (Seoul)
-    "ap-northeast-3": "ami-08e961078d46f1616",  # Asia Pacific (Osaka)
-    "ap-southeast-1": "ami-0a22a98eda5bc487e",  # Asia Pacific (Singapore)
-    "ap-southeast-2": "ami-032b58bab6a8ce5da",  # Asia Pacific (Sydney)
+    "us-east-1": "ami-0f2b22c3144288c40",  # US East (N. Virginia)
+    "us-east-2": "ami-05883383eec513504",  # US East (Ohio)
+    "us-west-1": "ami-082e09219e7a6635e",  # US West (N. California)
+    "us-west-2": "ami-0d8b66a93e34cf311",  # US West (Oregon)
+    "ca-central-1": "ami-0cb1b9526f6709463",  # Canada (Central)
+    "eu-central-1": "ami-0fa0f6c1dd324bba6",  # EU (Frankfurt)
+    "eu-west-1": "ami-04b6e086a5e2a5895",  # EU (Ireland)
+    "eu-west-2": "ami-0603aa699f40e9621",  # EU (London)
+    "eu-west-3": "ami-0caac48ecda8a814b",  # EU (Paris)
+    "sa-east-1": "ami-02e0e85cef91948f4",  # SA (Sao Paulo)
+    "ap-northeast-1": "ami-0da90df48e2470563",  # Asia Pacific (Tokyo)
+    "ap-northeast-2": "ami-0ab18f910ebbe39c8",  # Asia Pacific (Seoul)
+    "ap-northeast-3": "ami-0c9d787e70d20bea0",  # Asia Pacific (Osaka)
+    "ap-southeast-1": "ami-0b03415fb4dac6489",  # Asia Pacific (Singapore)
+    "ap-southeast-2": "ami-0ffbfe0c9ef4d62c4",  # Asia Pacific (Sydney)
 }
 
 # todo: cli_logger should handle this assert properly

--- a/python/ray/autoscaler/_private/aws/config.py
+++ b/python/ray/autoscaler/_private/aws/config.py
@@ -43,7 +43,7 @@ DEFAULT_AMI = {
     "us-east-1": "ami-052c6353a5e5bc8a0",  # US East (N. Virginia)
     "us-east-2": "ami-06a6e5ba35fb10195",  # US East (Ohio)
     "us-west-1": "ami-01f4231bddbd3f02d",  # US West (N. California)
-    "us-west-2": "ami-0122024eb82690a10",  # US West (Oregon)
+    "us-west-2": "ami-01444f6591a50534f",  # US West (Oregon)
     "ca-central-1": "ami-04b133dbe6b6dd5fa",  # Canada (Central)
     "eu-central-1": "ami-07bb55c8e51ca0e1a",  # EU (Frankfurt)
     "eu-west-1": "ami-0ba30a95934d2d24b",  # EU (Ireland)

--- a/python/ray/autoscaler/_private/aws/config.py
+++ b/python/ray/autoscaler/_private/aws/config.py
@@ -40,21 +40,21 @@ DEFAULT_AMI_NAME = "AWS Deep Learning AMI (Ubuntu 18.04) V61.0"
 # TODO(alex) : write a unit test to make sure we update AMI version used in
 # ray/autoscaler/aws/example-full.yaml whenever we update this dict.
 DEFAULT_AMI = {
-    "us-east-1": "ami-0f2b22c3144288c40",  # US East (N. Virginia)
-    "us-east-2": "ami-05883383eec513504",  # US East (Ohio)
-    "us-west-1": "ami-082e09219e7a6635e",  # US West (N. California)
-    "us-west-2": "ami-0d8b66a93e34cf311",  # US West (Oregon)
-    "ca-central-1": "ami-0cb1b9526f6709463",  # Canada (Central)
-    "eu-central-1": "ami-0fa0f6c1dd324bba6",  # EU (Frankfurt)
-    "eu-west-1": "ami-04b6e086a5e2a5895",  # EU (Ireland)
-    "eu-west-2": "ami-0603aa699f40e9621",  # EU (London)
-    "eu-west-3": "ami-0caac48ecda8a814b",  # EU (Paris)
-    "sa-east-1": "ami-02e0e85cef91948f4",  # SA (Sao Paulo)
-    "ap-northeast-1": "ami-0da90df48e2470563",  # Asia Pacific (Tokyo)
-    "ap-northeast-2": "ami-0ab18f910ebbe39c8",  # Asia Pacific (Seoul)
-    "ap-northeast-3": "ami-0c9d787e70d20bea0",  # Asia Pacific (Osaka)
-    "ap-southeast-1": "ami-0b03415fb4dac6489",  # Asia Pacific (Singapore)
-    "ap-southeast-2": "ami-0ffbfe0c9ef4d62c4",  # Asia Pacific (Sydney)
+    "us-east-1": "ami-052c6353a5e5bc8a0",  # US East (N. Virginia)
+    "us-east-2": "ami-06a6e5ba35fb10195",  # US East (Ohio)
+    "us-west-1": "ami-01f4231bddbd3f02d",  # US West (N. California)
+    "us-west-2": "ami-0122024eb82690a10",  # US West (Oregon)
+    "ca-central-1": "ami-04b133dbe6b6dd5fa",  # Canada (Central)
+    "eu-central-1": "ami-07bb55c8e51ca0e1a",  # EU (Frankfurt)
+    "eu-west-1": "ami-0ba30a95934d2d24b",  # EU (Ireland)
+    "eu-west-2": "ami-02671d135b94c3eae",  # EU (London)
+    "eu-west-3": "ami-0d243952631656f48",  # EU (Paris)
+    "sa-east-1": "ami-0fb25d839afe30ff1",  # SA (Sao Paulo)
+    "ap-northeast-1": "ami-06693a5177a8e855a",  # Asia Pacific (Tokyo)
+    "ap-northeast-2": "ami-02ffe31674b40c5f4",  # Asia Pacific (Seoul)
+    "ap-northeast-3": "ami-0f59668cb966b7ebb",  # Asia Pacific (Osaka)
+    "ap-southeast-1": "ami-0c69822a62365df57",  # Asia Pacific (Singapore)
+    "ap-southeast-2": "ami-09a3801dc7a8acd57",  # Asia Pacific (Sydney)
 }
 
 # todo: cli_logger should handle this assert properly

--- a/python/ray/autoscaler/_private/aws/config.py
+++ b/python/ray/autoscaler/_private/aws/config.py
@@ -33,10 +33,18 @@ DEFAULT_RAY_INSTANCE_PROFILE = RAY + "-v1"
 DEFAULT_RAY_IAM_ROLE = RAY + "-v1"
 SECURITY_GROUP_TEMPLATE = RAY + "-{}"
 
-# V61.0 has CUDA 11.2
-DEFAULT_AMI_NAME = "AWS Deep Learning AMI (Ubuntu 18.04) V61.0"
+DEFAULT_AMI_NAME = "Deep Learning AMI GPU TensorFlow 2.13 (Ubuntu 20.04) 20230821"
 
-# Obtained from https://aws.amazon.com/marketplace/pp/B07Y43P7X5 on 6/10/2022.
+# Obtained with:
+# for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do
+#   echo "Region: $region";
+#   aws ec2 describe-images \
+#     --region $region \
+#     --filters "Name=name,Values=Deep Learning AMI GPU TensorFlow 2.13 (Ubuntu 20.04) 20230821*" \
+#     --query "Images[].[ImageId, Name]" \
+#     --output text;
+#   echo "--------------------------";
+# done
 # TODO(alex) : write a unit test to make sure we update AMI version used in
 # ray/autoscaler/aws/example-full.yaml whenever we update this dict.
 DEFAULT_AMI = {

--- a/python/ray/autoscaler/_private/aws/config.py
+++ b/python/ray/autoscaler/_private/aws/config.py
@@ -40,21 +40,21 @@ DEFAULT_AMI_NAME = "AWS Deep Learning AMI (Ubuntu 18.04) V61.0"
 # TODO(alex) : write a unit test to make sure we update AMI version used in
 # ray/autoscaler/aws/example-full.yaml whenever we update this dict.
 DEFAULT_AMI = {
-    "us-east-1": "ami-0dd6adfad4ad37eec",  # US East (N. Virginia)
-    "us-east-2": "ami-0c77cd5ca05bf1281",  # US East (Ohio)
-    "us-west-1": "ami-020ab1b368a5ed1db",  # US West (N. California)
-    "us-west-2": "ami-0387d929287ab193e",  # US West (Oregon)
-    "ca-central-1": "ami-07dbafdbd38f18d98",  # Canada (Central)
-    "eu-central-1": "ami-0383bd0c1fc4c63ec",  # EU (Frankfurt)
-    "eu-west-1": "ami-0a074b0a311a837ac",  # EU (Ireland)
-    "eu-west-2": "ami-094ba2b4651f761ca",  # EU (London)
-    "eu-west-3": "ami-031da10fbf225bf5f",  # EU (Paris)
-    "sa-east-1": "ami-0be7c1f1dd96d7337",  # SA (Sao Paulo)
-    "ap-northeast-1": "ami-0d69b2fd9641af433",  # Asia Pacific (Tokyo)
-    "ap-northeast-2": "ami-0d6d00bd58046ff91",  # Asia Pacific (Seoul)
-    "ap-northeast-3": "ami-068feab7122f7558d",  # Asia Pacific (Osaka)
-    "ap-southeast-1": "ami-05006b266c1be4e8f",  # Asia Pacific (Singapore)
-    "ap-southeast-2": "ami-066aa744514f9f95c",  # Asia Pacific (Sydney)
+    "us-east-1": "ami-068d304eca3399469",  # US East (N. Virginia)
+    "us-east-2": "ami-01d66247b45457f6b",  # US East (Ohio)
+    "us-west-1": "ami-0c1b0805e0f5a63f3",  # US West (N. California)
+    "us-west-2": "ami-0581161e178068142",  # US West (Oregon)
+    "ca-central-1": "ami-002845b64d842a2a1",  # Canada (Central)
+    "eu-central-1": "ami-034aae0781c0f3b1b",  # EU (Frankfurt)
+    "eu-west-1": "ami-08d286977c0d61d60",  # EU (Ireland)
+    "eu-west-2": "ami-06494a8cdbc94835c",  # EU (London)
+    "eu-west-3": "ami-01e329f22a25bcf0b",  # EU (Paris)
+    "sa-east-1": "ami-0b6cebaa28fdd35e7",  # SA (Sao Paulo)
+    "ap-northeast-1": "ami-020f0d5aa9f43db31",  # Asia Pacific (Tokyo)
+    "ap-northeast-2": "ami-0a73968b958434f9f",  # Asia Pacific (Seoul)
+    "ap-northeast-3": "ami-08e961078d46f1616",  # Asia Pacific (Osaka)
+    "ap-southeast-1": "ami-0a22a98eda5bc487e",  # Asia Pacific (Singapore)
+    "ap-southeast-2": "ami-032b58bab6a8ce5da",  # Asia Pacific (Sydney)
 }
 
 # todo: cli_logger should handle this assert properly

--- a/python/ray/autoscaler/_private/aws/config.py
+++ b/python/ray/autoscaler/_private/aws/config.py
@@ -40,21 +40,21 @@ DEFAULT_AMI_NAME = "AWS Deep Learning AMI (Ubuntu 18.04) V61.0"
 # TODO(alex) : write a unit test to make sure we update AMI version used in
 # ray/autoscaler/aws/example-full.yaml whenever we update this dict.
 DEFAULT_AMI = {
-    "us-east-1": "ami-052c6353a5e5bc8a0",  # US East (N. Virginia)
-    "us-east-2": "ami-06a6e5ba35fb10195",  # US East (Ohio)
-    "us-west-1": "ami-01f4231bddbd3f02d",  # US West (N. California)
+    "us-east-1": "ami-018f96b40b9cca2dd",  # US East (N. Virginia)
+    "us-east-2": "ami-0800985e773ff0a63",  # US East (Ohio)
+    "us-west-1": "ami-0c21382e5b6e96373",  # US West (N. California)
     "us-west-2": "ami-01444f6591a50534f",  # US West (Oregon)
-    "ca-central-1": "ami-04b133dbe6b6dd5fa",  # Canada (Central)
-    "eu-central-1": "ami-07bb55c8e51ca0e1a",  # EU (Frankfurt)
-    "eu-west-1": "ami-0ba30a95934d2d24b",  # EU (Ireland)
-    "eu-west-2": "ami-02671d135b94c3eae",  # EU (London)
-    "eu-west-3": "ami-0d243952631656f48",  # EU (Paris)
-    "sa-east-1": "ami-0fb25d839afe30ff1",  # SA (Sao Paulo)
-    "ap-northeast-1": "ami-06693a5177a8e855a",  # Asia Pacific (Tokyo)
-    "ap-northeast-2": "ami-02ffe31674b40c5f4",  # Asia Pacific (Seoul)
-    "ap-northeast-3": "ami-0f59668cb966b7ebb",  # Asia Pacific (Osaka)
-    "ap-southeast-1": "ami-0c69822a62365df57",  # Asia Pacific (Singapore)
-    "ap-southeast-2": "ami-09a3801dc7a8acd57",  # Asia Pacific (Sydney)
+    "ca-central-1": "ami-073e125962d3c0a46",  # Canada (Central)
+    "eu-central-1": "ami-0a74622af8e2032bf",  # EU (Frankfurt)
+    "eu-west-1": "ami-00ea3df103dca3785",  # EU (Ireland)
+    "eu-west-2": "ami-0c4821ed9efff6332",  # EU (London)
+    "eu-west-3": "ami-06334b72f7cd4538e",  # EU (Paris)
+    "sa-east-1": "ami-077c4439200485dcc",  # SA (Sao Paulo)
+    "ap-northeast-1": "ami-0786cb4215415e974",  # Asia Pacific (Tokyo)
+    "ap-northeast-2": "ami-033219a7382f6c8e3",  # Asia Pacific (Seoul)
+    "ap-northeast-3": "ami-0723ec3a13b9e5de0",  # Asia Pacific (Osaka)
+    "ap-southeast-1": "ami-03c83d8b58683f512",  # Asia Pacific (Singapore)
+    "ap-southeast-2": "ami-0445957826dad2c4e",  # Asia Pacific (Sydney)
 }
 
 # todo: cli_logger should handle this assert properly

--- a/python/ray/autoscaler/_private/aws/config.py
+++ b/python/ray/autoscaler/_private/aws/config.py
@@ -33,14 +33,15 @@ DEFAULT_RAY_INSTANCE_PROFILE = RAY + "-v1"
 DEFAULT_RAY_IAM_ROLE = RAY + "-v1"
 SECURITY_GROUP_TEMPLATE = RAY + "-{}"
 
-DEFAULT_AMI_NAME = "Deep Learning AMI GPU TensorFlow 2.13 (Ubuntu 20.04) 20230821"
+# V71.0 has CUDA 11.2
+DEFAULT_AMI_NAME = "AWS Deep Learning AMI (Ubuntu 18.04) V71.0"
 
 # Obtained with:
 # for region in $(aws ec2 describe-regions --query "Regions[].RegionName" --output text); do
 #   echo "Region: $region";
 #   aws ec2 describe-images \
 #     --region $region \
-#     --filters "Name=name,Values=Deep Learning AMI GPU TensorFlow 2.13 (Ubuntu 20.04) 20230821*" \
+#     --filters "Name=name,Values=Deep Learning AMI (Ubuntu 18.04) Version 71.0*" \
 #     --query "Images[].[ImageId, Name]" \
 #     --output text;
 #   echo "--------------------------";
@@ -48,21 +49,21 @@ DEFAULT_AMI_NAME = "Deep Learning AMI GPU TensorFlow 2.13 (Ubuntu 20.04) 2023082
 # TODO(alex) : write a unit test to make sure we update AMI version used in
 # ray/autoscaler/aws/example-full.yaml whenever we update this dict.
 DEFAULT_AMI = {
-    "us-east-1": "ami-018f96b40b9cca2dd",  # US East (N. Virginia)
-    "us-east-2": "ami-0800985e773ff0a63",  # US East (Ohio)
-    "us-west-1": "ami-0c21382e5b6e96373",  # US West (N. California)
-    "us-west-2": "ami-01444f6591a50534f",  # US West (Oregon)
-    "ca-central-1": "ami-073e125962d3c0a46",  # Canada (Central)
-    "eu-central-1": "ami-0a74622af8e2032bf",  # EU (Frankfurt)
-    "eu-west-1": "ami-00ea3df103dca3785",  # EU (Ireland)
-    "eu-west-2": "ami-0c4821ed9efff6332",  # EU (London)
-    "eu-west-3": "ami-06334b72f7cd4538e",  # EU (Paris)
-    "sa-east-1": "ami-077c4439200485dcc",  # SA (Sao Paulo)
-    "ap-northeast-1": "ami-0786cb4215415e974",  # Asia Pacific (Tokyo)
-    "ap-northeast-2": "ami-033219a7382f6c8e3",  # Asia Pacific (Seoul)
-    "ap-northeast-3": "ami-0723ec3a13b9e5de0",  # Asia Pacific (Osaka)
-    "ap-southeast-1": "ami-03c83d8b58683f512",  # Asia Pacific (Singapore)
-    "ap-southeast-2": "ami-0445957826dad2c4e",  # Asia Pacific (Sydney)
+    "us-east-1": "ami-0271ce88f6c03e149",  # US East (N. Virginia)
+    "us-east-2": "ami-0ce21b0ce8e0f5a37",  # US East (Ohio)
+    "us-west-1": "ami-030896954b2b72361",  # US West (N. California)
+    "us-west-2": "ami-0a2b85e15b7c0ac34",  # US West (Oregon)
+    "ca-central-1": "ami-044b98bea12677052",  # Canada (Central)
+    "eu-central-1": "ami-004d285ecf53fb335",  # EU (Frankfurt)
+    "eu-west-1": "ami-0e17ed40febe794a6",  # EU (Ireland)
+    "eu-west-2": "ami-0ad9e6b9d4e22df1a",  # EU (London)
+    "eu-west-3": "ami-05698775025146698",  # EU (Paris)
+    "sa-east-1": "ami-004b19c7ed8d790bc",  # SA (Sao Paulo)
+    "ap-northeast-1": "ami-03e45b1f18378ea97",  # Asia Pacific (Tokyo)
+    "ap-northeast-2": "ami-095bae3e623e2ff99",  # Asia Pacific (Seoul)
+    "ap-northeast-3": "ami-02fd0ba69c1ef37ad",  # Asia Pacific (Osaka)
+    "ap-southeast-1": "ami-03ef1223872072e95",  # Asia Pacific (Singapore)
+    "ap-southeast-2": "ami-0bcf4f75e44e0a866",  # Asia Pacific (Sydney)
 }
 
 # todo: cli_logger should handle this assert properly

--- a/python/ray/autoscaler/aws/defaults.yaml
+++ b/python/ray/autoscaler/aws/defaults.yaml
@@ -124,9 +124,6 @@ setup_commands:
     - >-
         (stat $HOME/anaconda3/envs/tensorflow2_p310/ &> /dev/null &&
         echo 'export PATH="$HOME/anaconda3/envs/tensorflow2_p310/bin:$PATH"' >> ~/.bashrc) || true
-    - ls -la $HOME/anaconda3/envs/ || true
-    - python3 --version || true
-    - which python3 || true
     - which ray || pip install -U "ray[default] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp310-cp310-manylinux2014_x86_64.whl"
 
 # Custom commands that will be run on the head node after common setup.

--- a/python/ray/autoscaler/aws/defaults.yaml
+++ b/python/ray/autoscaler/aws/defaults.yaml
@@ -125,9 +125,9 @@ setup_commands:
         (stat $HOME/anaconda3/envs/tensorflow2_p39/ &> /dev/null &&
         echo 'export PATH="$HOME/anaconda3/envs/tensorflow2_p39/bin:$PATH"' >> ~/.bashrc) || true
     - ls -la $HOME/anaconda3/envs/ || true
-    - python --version || true
-    - which python || true
-    - which ray || pip install -U "ray[default] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl"
+    - python3 --version || true
+    - which python3 || true
+    - which ray || pip install -U "ray[default] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp310-cp310-manylinux2014_x86_64.whl"
 
 # Custom commands that will be run on the head node after common setup.
 head_setup_commands:

--- a/python/ray/autoscaler/aws/defaults.yaml
+++ b/python/ray/autoscaler/aws/defaults.yaml
@@ -122,8 +122,8 @@ initialization_commands: []
 # List of shell commands to run to set up nodes.
 setup_commands:
     - >-
-        (stat $HOME/anaconda3/envs/tensorflow2_p39/ &> /dev/null &&
-        echo 'export PATH="$HOME/anaconda3/envs/tensorflow2_p39/bin:$PATH"' >> ~/.bashrc) || true
+        (stat $HOME/anaconda3/envs/tensorflow2_p310/ &> /dev/null &&
+        echo 'export PATH="$HOME/anaconda3/envs/tensorflow2_p310/bin:$PATH"' >> ~/.bashrc) || true
     - ls -la $HOME/anaconda3/envs/ || true
     - python3 --version || true
     - which python3 || true

--- a/python/ray/autoscaler/aws/defaults.yaml
+++ b/python/ray/autoscaler/aws/defaults.yaml
@@ -122,9 +122,9 @@ initialization_commands: []
 # List of shell commands to run to set up nodes.
 setup_commands:
     - >-
-        (stat $HOME/anaconda3/envs/tensorflow2_p38/ &> /dev/null &&
-        echo 'export PATH="$HOME/anaconda3/envs/tensorflow2_p38/bin:$PATH"' >> ~/.bashrc) || true
-    - which ray || pip install -U "ray[default] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl"
+        (stat $HOME/anaconda3/envs/tensorflow2_p39/ &> /dev/null &&
+        echo 'export PATH="$HOME/anaconda3/envs/tensorflow2_p39/bin:$PATH"' >> ~/.bashrc) || true
+    - which ray || pip install -U "ray[default] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl"
 
 # Custom commands that will be run on the head node after common setup.
 head_setup_commands:

--- a/python/ray/autoscaler/aws/defaults.yaml
+++ b/python/ray/autoscaler/aws/defaults.yaml
@@ -124,6 +124,9 @@ setup_commands:
     - >-
         (stat $HOME/anaconda3/envs/tensorflow2_p39/ &> /dev/null &&
         echo 'export PATH="$HOME/anaconda3/envs/tensorflow2_p39/bin:$PATH"' >> ~/.bashrc) || true
+    - ls -la $HOME/anaconda3/envs/ || true
+    - python --version || true
+    - which python || true
     - which ray || pip install -U "ray[default] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl"
 
 # Custom commands that will be run on the head node after common setup.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Release test `aws_cluster_launcher` ran into a failure:
```

2025-03-17 06:11:03 UTC | 2025-03-17 06:09:46,628	ERROR services.py:1398 -- 'ABCMeta' object is not subscriptable
-- | --
  | 2025-03-17 06:11:03 UTC | Traceback (most recent call last):
  | 2025-03-17 06:11:03 UTC | File "/home/ubuntu/anaconda3/envs/tensorflow2_p38/bin/ray", line 8, in <module>
  | 2025-03-17 06:11:03 UTC | sys.exit(main())
  | 2025-03-17 06:11:03 UTC | File "/home/ubuntu/anaconda3/envs/tensorflow2_p38/lib/python3.8/site-packages/ray/scripts/scripts.py", line 2498, in main
  | 2025-03-17 06:11:03 UTC | return cli()
  | 2025-03-17 06:11:03 UTC | File "/home/ubuntu/anaconda3/envs/tensorflow2_p38/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
  | 2025-03-17 06:11:03 UTC | return self.main(*args, **kwargs)
  | 2025-03-17 06:11:03 UTC | File "/home/ubuntu/anaconda3/envs/tensorflow2_p38/lib/python3.8/site-packages/click/core.py", line 1053, in main
  | 2025-03-17 06:11:03 UTC | rv = self.invoke(ctx)
  | 2025-03-17 06:11:03 UTC | File "/home/ubuntu/anaconda3/envs/tensorflow2_p38/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
  | 2025-03-17 06:11:03 UTC | return _process_result(sub_ctx.command.invoke(sub_ctx))
  | 2025-03-17 06:11:03 UTC | File "/home/ubuntu/anaconda3/envs/tensorflow2_p38/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
  | 2025-03-17 06:11:03 UTC | return ctx.invoke(self.callback, **ctx.params)
  | 2025-03-17 06:11:03 UTC | File "/home/ubuntu/anaconda3/envs/tensorflow2_p38/lib/python3.8/site-packages/click/core.py", line 754, in invoke
  | 2025-03-17 06:11:03 UTC | return __callback(*args, **kwargs)
  | 2025-03-17 06:11:03 UTC | File "/home/ubuntu/anaconda3/envs/tensorflow2_p38/lib/python3.8/site-packages/ray/autoscaler/_private/cli_logger.py", line 856, in wrapper
  | 2025-03-17 06:11:03 UTC | return f(*args, **kwargs)
  | 2025-03-17 06:11:03 UTC | File "/home/ubuntu/anaconda3/envs/tensorflow2_p38/lib/python3.8/site-packages/ray/scripts/scripts.py", line 771, in start
  | 2025-03-17 06:11:03 UTC | node = ray._private.node.Node(
  | 2025-03-17 06:11:03 UTC | File "/home/ubuntu/anaconda3/envs/tensorflow2_p38/lib/python3.8/site-packages/ray/_private/node.py", line 309, in __init__
  | 2025-03-17 06:11:03 UTC | self.start_ray_processes()
  | 2025-03-17 06:11:03 UTC | File "/home/ubuntu/anaconda3/envs/tensorflow2_p38/lib/python3.8/site-packages/ray/_private/node.py", line 1367, in start_ray_processes
  | 2025-03-17 06:11:03 UTC | self.start_raylet(plasma_directory, object_store_memory)
  | 2025-03-17 06:11:03 UTC | File "/home/ubuntu/anaconda3/envs/tensorflow2_p38/lib/python3.8/site-packages/ray/_private/node.py", line 1151, in start_raylet
  | 2025-03-17 06:11:03 UTC | process_info = ray._private.services.start_raylet(
  | 2025-03-17 06:11:03 UTC | File "/home/ubuntu/anaconda3/envs/tensorflow2_p38/lib/python3.8/site-packages/ray/_private/services.py", line 1731, in start_raylet
  | 2025-03-17 06:11:03 UTC | if not ray._private.utils.check_dashboard_dependencies_installed():
  | 2025-03-17 06:11:03 UTC | File "/home/ubuntu/anaconda3/envs/tensorflow2_p38/lib/python3.8/site-packages/ray/_private/utils.py", line 1337, in check_dashboard_dependencies_installed
  | 2025-03-17 06:11:03 UTC | import ray.dashboard.optional_deps  # noqa: F401
  | 2025-03-17 06:11:03 UTC | File "/home/ubuntu/anaconda3/envs/tensorflow2_p38/lib/python3.8/site-packages/ray/dashboard/optional_deps.py", line 14, in <module>
  | 2025-03-17 06:11:03 UTC | import aiohttp_cors  # noqa: F401
  | 2025-03-17 06:11:03 UTC | File "/home/ubuntu/anaconda3/envs/tensorflow2_p38/lib/python3.8/site-packages/aiohttp_cors/__init__.py", line 32, in <module>
  | 2025-03-17 06:11:03 UTC | from .cors_config import CorsConfig
  | 2025-03-17 06:11:03 UTC | File "/home/ubuntu/anaconda3/envs/tensorflow2_p38/lib/python3.8/site-packages/aiohttp_cors/cors_config.py", line 48, in <module>
  | 2025-03-17 06:11:03 UTC | config: Mapping[str, Union[ResourceOptions, Mapping[str, Any]]] = None,
  | 2025-03-17 06:11:03 UTC | TypeError: 'ABCMeta' object is not subscriptable

```

This is because Python 3.8 was used, which is not compatible with newer aiohttp code.

We needed to change to later version of the AMI which has later Python versions.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
