### PR TITLE
Upgrading Arrow dependency to latest stable version

### DIFF
--- a/.buildkite/others.rayci.yml
+++ b/.buildkite/others.rayci.yml
@@ -10,7 +10,7 @@ steps:
       # uncomment the following line to update the pinned versions of pip dependencies
       # to the latest versions; otherwise, the pinned versions will be re-used as much
       # as possible
-      # - rm ./python/requirements_compiled.txt
+      - rm ./python/requirements_compiled.txt
       - cp ./python/requirements_compiled.txt requirements_compiled_backup.txt
       - ./ci/ci.sh compile_pip_dependencies
       - cp -f ./python/requirements_compiled.txt /artifact-mount/

--- a/.buildkite/others.rayci.yml
+++ b/.buildkite/others.rayci.yml
@@ -11,7 +11,8 @@ steps:
       # to the latest versions; otherwise, the pinned versions will be re-used as much
       # as possible
       - rm ./python/requirements_compiled.txt
-      - cp ./python/requirements_compiled.txt requirements_compiled_backup.txt
+      - touch requirements_compiled_backup.txt
+      # - cp ./python/requirements_compiled.txt requirements_compiled_backup.txt
       - ./ci/ci.sh compile_pip_dependencies
       - cp -f ./python/requirements_compiled.txt /artifact-mount/
       - diff ./python/requirements_compiled.txt requirements_compiled_backup.txt || (echo "requirements_compiled.txt is not up to date. Please download it from Artifacts tab and git push the changes." && exit 1)

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -26,7 +26,8 @@ grpcio == 1.54.2; sys_platform == "darwin"
 grpcio >= 1.54.2; sys_platform != "darwin"
 numpy>=1.20
 
-pyarrow >= 9.0.0
+# TODO revert
+pyarrow >= 19.0.0
 
 # ray[all]
 smart_open

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -14,7 +14,8 @@ jsonschema
 msgpack<2.0.0,>=1.0.0
 packaging
 protobuf!=3.19.5,>=3.15.3
-pyyaml
+# Following Pyyaml versions are incompatible with Cython 3.0.0
+pyyaml!=6.0.0,!=5.4.0,!=5.4.1
 aiosignal
 frozenlist
 requests

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -25,10 +25,7 @@ grpcio == 1.54.2; sys_platform == "darwin"
 grpcio >= 1.54.2; sys_platform != "darwin"
 numpy>=1.20
 
-# pyarrow 18 causes macos build failures.
-# See https://github.com/ray-project/ray/pull/48300
 pyarrow >= 9.0.0
-pyarrow <18; sys_platform == "darwin" and platform_machine == "x86_64"
 
 # ray[all]
 smart_open

--- a/python/requirements/ml/core-requirements.txt
+++ b/python/requirements/ml/core-requirements.txt
@@ -1,6 +1,6 @@
 # ML tracking integrations
 comet-ml==3.44.1
-mlflow==2.9.2
+mlflow==2.21.0
 wandb==0.17.0
 
 # ML training frameworks

--- a/python/requirements/test-requirements.txt
+++ b/python/requirements/test-requirements.txt
@@ -34,10 +34,10 @@ moto[s3,server]==4.2.12
 mypy==1.7.0
 numba==0.59.1
 openpyxl==3.0.10
-opentelemetry-api==1.9.0
-opentelemetry-sdk==1.9.0
-opentelemetry-exporter-otlp==1.1.0
-opentelemetry-exporter-opencensus==0.20b0
+opentelemetry-api==1.31.0
+opentelemetry-sdk==1.31.0
+opentelemetry-exporter-otlp==1.31.0
+opentelemetry-exporter-opencensus==0.52b0
 pexpect==4.8.0
 Pillow==10.3.0; platform_system != "Windows"
 proxy.py==2.4.3

--- a/python/requirements/test-requirements.txt
+++ b/python/requirements/test-requirements.txt
@@ -34,8 +34,8 @@ moto[s3,server]==4.2.12
 mypy==1.7.0
 numba==0.59.1
 openpyxl==3.0.10
-opentelemetry-api==1.1.0
-opentelemetry-sdk==1.1.0
+opentelemetry-api==1.9.0
+opentelemetry-sdk==1.9.0
 opentelemetry-exporter-otlp==1.1.0
 opentelemetry-exporter-opencensus==0.20b0
 pexpect==4.8.0

--- a/python/setup.py
+++ b/python/setup.py
@@ -230,7 +230,6 @@ if setup_spec.type == SetupType.RAY:
     numpy_dep = "numpy >= 1.20"
     pyarrow_deps = [
         "pyarrow >= 9.0.0",
-        "pyarrow <18; sys_platform == 'darwin' and platform_machine == 'x86_64'",
     ]
     pydantic_dep = "pydantic!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,<3"
     setup_spec.extras = {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

 - To remove constraint `pyarrow < 18.0`
 - Bumping up pinned version in compiled requirements

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
