### PR TITLE
[ray.data.llm] Propose log_input_column_names()

### DIFF
--- a/doc/source/data/working-with-llms.rst
+++ b/doc/source/data/working-with-llms.rst
@@ -77,6 +77,19 @@ Upon execution, the Processor object instantiates replicas of the vLLM engine (u
 
     {'answer': 'Snowflakes gently fall\nBlanketing the winter scene\nFrozen peaceful hush'}
 
+If you have no idea about the required input columns for the processor, you can use the following API:
+
+.. testcode::
+
+    processor.log_input_column_names()
+
+.. testoutput::
+    :options: +MOCK
+
+    The first stage of the processor is ChatTemplateStage.
+    Required input columns:
+            messages: A list of messages in OpenAI chat format. See https://platform.openai.com/docs/api-reference/chat/create for details.
+
 Some models may require a Hugging Face token to be specified. You can specify the token in the `runtime_env` argument.
 
 .. testcode::
@@ -84,25 +97,6 @@ Some models may require a Hugging Face token to be specified. You can specify th
     config = vLLMEngineProcessorConfig(
         model_source="unsloth/Llama-3.1-8B-Instruct",
         runtime_env={"env_vars": {"HF_TOKEN": "your_huggingface_token"}},
-        concurrency=1,
-        batch_size=64,
-    )
-
-If your model is hosted on AWS S3, you can specify the S3 path in the `model_source` argument, and specify `load_format="runai_streamer"` in the `engine_kwargs` argument.
-
-.. note::
-    Install vLLM with runai dependencies: `pip install -U "vllm[runai]==0.7.2"`
-
-.. testcode::
-
-    config = vLLMEngineProcessorConfig(
-        model_source="s3://your-bucket/your-model/",  # Make sure adding the trailing slash!
-        engine_kwargs={"load_format": "runai_streamer"},
-        runtime_env={"env_vars": {
-            "AWS_ACCESS_KEY_ID": "your_access_key_id",
-            "AWS_SECRET_ACCESS_KEY": "your_secret_access_key",
-            "AWS_REGION": "your_region",
-        }},
         concurrency=1,
         batch_size=64,
     )
@@ -146,13 +140,32 @@ The underlying `Processor` object instantiates replicas of the vLLM engine and a
 configure parallel workers to handle model parallelism (for tensor parallelism and pipeline parallelism,
 if specified).
 
-To optimize model loading, you can configure the `load_format` to `runai_streamer` or `tensorizer`:
+To optimize model loading, you can configure the `load_format` to `runai_streamer` or `tensorizer`.
+
+.. note::
+    In this case, install vLLM with runai dependencies: `pip install -U "vllm[runai]==0.7.2"`
 
 .. testcode::
 
     config = vLLMEngineProcessorConfig(
         model_source="unsloth/Llama-3.1-8B-Instruct",
         engine_kwargs={"load_format": "runai_streamer"},
+        concurrency=1,
+        batch_size=64,
+    )
+
+If your model is hosted on AWS S3, you can specify the S3 path in the `model_source` argument, and specify `load_format="runai_streamer"` in the `engine_kwargs` argument.
+
+.. testcode::
+
+    config = vLLMEngineProcessorConfig(
+        model_source="s3://your-bucket/your-model/",  # Make sure adding the trailing slash!
+        engine_kwargs={"load_format": "runai_streamer"},
+        runtime_env={"env_vars": {
+            "AWS_ACCESS_KEY_ID": "your_access_key_id",
+            "AWS_SECRET_ACCESS_KEY": "your_secret_access_key",
+            "AWS_REGION": "your_region",
+        }},
         concurrency=1,
         batch_size=64,
     )

--- a/doc/source/data/working-with-llms.rst
+++ b/doc/source/data/working-with-llms.rst
@@ -77,7 +77,7 @@ Upon execution, the Processor object instantiates replicas of the vLLM engine (u
 
     {'answer': 'Snowflakes gently fall\nBlanketing the winter scene\nFrozen peaceful hush'}
 
-If you have no idea about the required input columns for the processor, you can use the following API:
+Each processor requires specific input columns. You can find get more info by using the following API:
 
 .. testcode::
 

--- a/python/ray/data/llm.py
+++ b/python/ray/data/llm.py
@@ -147,6 +147,15 @@ class vLLMEngineProcessorConfig(_vLLMEngineProcessorConfig):
                 ),
             )
 
+            # The processor requires specific input columns, which depend on
+            # your processor config. You can use the following API to check
+            # the required input columns:
+            processor.log_input_column_names()
+            # Example log:
+            # The first stage of the processor is ChatTemplateStage.
+            # Required input columns:
+            #     messages: A list of messages in OpenAI chat format.
+
             ds = ray.data.range(300)
             ds = processor(ds)
             for row in ds.take_all():

--- a/python/ray/llm/_internal/batch/stages/base.py
+++ b/python/ray/llm/_internal/batch/stages/base.py
@@ -218,6 +218,9 @@ class StatefulStageUDF:
                     f"{self.__class__.__name__}. Input keys: {input_keys}"
                 )
 
+    async def udf(self, rows: List[Dict[str, Any]]) -> AsyncIterator[Dict[str, Any]]:
+        raise NotImplementedError("StageUDF must implement the udf method")
+
 
 class StatefulStage(BaseModel):
     """

--- a/python/ray/llm/_internal/batch/stages/base.py
+++ b/python/ray/llm/_internal/batch/stages/base.py
@@ -1,6 +1,6 @@
 """The base class for all stages."""
 import logging
-from typing import Any, Dict, AsyncIterator, List, Callable, Type
+from typing import Any, Dict, AsyncIterator, List, Callable, Type, Optional
 
 import pyarrow
 from pydantic import BaseModel, Field
@@ -71,14 +71,18 @@ class StatefulStageUDF:
         __call__ method will take the data column as the input of the udf
         method, and encapsulate the output of the udf method into the data
         column for the next stage.
+        expected_input_keys: The expected input keys of the stage.
     """
 
     # The internal column name for the index of the row in the batch.
     # This is used to align the output of the UDF with the input batch.
     IDX_IN_BATCH_COLUMN: str = "__idx_in_batch"
 
-    def __init__(self, data_column: str):
+    def __init__(
+        self, data_column: str, expected_input_keys: Optional[List[str]] = None
+    ):
         self.data_column = data_column
+        self.expected_input_keys = set(expected_input_keys or [])
 
     async def __call__(self, batch: Dict[str, Any]) -> AsyncIterator[Dict[str, Any]]:
         """A stage UDF wrapper that processes the input and output columns
@@ -195,8 +199,6 @@ class StatefulStageUDF:
         Raises:
             ValueError: If the required keys are not found.
         """
-        expected_input_keys = set(self.expected_input_keys)
-
         for inp in inputs:
             input_keys = set(inp.keys())
 
@@ -206,28 +208,15 @@ class StatefulStageUDF:
                     "for internal use."
                 )
 
-            if not expected_input_keys:
+            if not self.expected_input_keys:
                 continue
 
-            missing_required = expected_input_keys - input_keys
+            missing_required = self.expected_input_keys - input_keys
             if missing_required:
                 raise ValueError(
                     f"Required input keys {missing_required} not found at the input of "
                     f"{self.__class__.__name__}. Input keys: {input_keys}"
                 )
-
-    @property
-    def expected_input_keys(self) -> List[str]:
-        """A list of required input keys. Missing required keys will raise
-        an exception.
-
-        Returns:
-            A list of required input keys.
-        """
-        return []
-
-    async def udf(self, rows: List[Dict[str, Any]]) -> AsyncIterator[Dict[str, Any]]:
-        raise NotImplementedError("StageUDF must implement the udf method")
 
 
 class StatefulStage(BaseModel):
@@ -246,6 +235,14 @@ class StatefulStage(BaseModel):
         default_factory=lambda: {"concurrency": 1},
         description="The arguments of .map_batches(). Default {'concurrency': 1}.",
     )
+
+    def get_required_input_keys(self) -> Dict[str, str]:
+        """The required input keys of the stage and their descriptions."""
+        return {}
+
+    def get_optional_input_keys(self) -> Dict[str, str]:
+        """The optional input keys of the stage and their descriptions."""
+        return {}
 
     def get_dataset_map_batches_kwargs(
         self,
@@ -280,6 +277,9 @@ class StatefulStage(BaseModel):
             )
 
         kwargs["fn_constructor_kwargs"]["data_column"] = data_column
+        kwargs["fn_constructor_kwargs"]["expected_input_keys"] = list(
+            self.get_required_input_keys().keys()
+        )
         return kwargs
 
     class Config:

--- a/python/ray/llm/_internal/batch/stages/chat_template_stage.py
+++ b/python/ray/llm/_internal/batch/stages/chat_template_stage.py
@@ -13,6 +13,7 @@ class ChatTemplateUDF(StatefulStageUDF):
     def __init__(
         self,
         data_column: str,
+        expected_input_keys: List[str],
         model: str,
         chat_template: Optional[str] = None,
     ):
@@ -21,6 +22,7 @@ class ChatTemplateUDF(StatefulStageUDF):
 
         Args:
             data_column: The data column name.
+            expected_input_keys: The expected input keys of the stage.
             model: The model to use for the chat template.
             chat_template: The chat template in Jinja template format. This is
             usually not needed if the model checkpoint already contains the
@@ -28,7 +30,7 @@ class ChatTemplateUDF(StatefulStageUDF):
         """
         from transformers import AutoProcessor
 
-        super().__init__(data_column)
+        super().__init__(data_column, expected_input_keys)
 
         # NOTE: We always use processor instead of tokenizer in this stage,
         # because tokenizers of VLM models may not have chat template attribute.
@@ -95,11 +97,6 @@ class ChatTemplateUDF(StatefulStageUDF):
         """
         return conversation[-1]["role"] == "user"
 
-    @property
-    def expected_input_keys(self) -> List[str]:
-        """The expected input keys."""
-        return ["messages"]
-
 
 class ChatTemplateStage(StatefulStage):
     """
@@ -107,3 +104,11 @@ class ChatTemplateStage(StatefulStage):
     """
 
     fn: Type[StatefulStageUDF] = ChatTemplateUDF
+
+    def get_required_input_keys(self) -> Dict[str, str]:
+        """The required input keys of the stage and their descriptions."""
+        return {
+            "messages": "A list of messages in OpenAI chat format. "
+            "See https://platform.openai.com/docs/api-reference/chat/create "
+            "for details."
+        }

--- a/python/ray/llm/_internal/batch/stages/http_request_stage.py
+++ b/python/ray/llm/_internal/batch/stages/http_request_stage.py
@@ -13,6 +13,7 @@ class HttpRequestUDF(StatefulStageUDF):
     def __init__(
         self,
         data_column: str,
+        expected_input_keys: List[str],
         url: str,
         additional_header: Optional[Dict[str, Any]] = None,
         qps: Optional[int] = None,
@@ -22,11 +23,12 @@ class HttpRequestUDF(StatefulStageUDF):
 
         Args:
             data_column: The data column name.
+            expected_input_keys: The expected input keys of the stage.
             url: The URL to send the HTTP request to.
             additional_header: The additional headers to send with the HTTP request.
             qps: The maximum number of requests per second.
         """
-        super().__init__(data_column)
+        super().__init__(data_column, expected_input_keys)
         self.url = url
         self.additional_header = additional_header or {}
         self.qps = qps
@@ -90,10 +92,6 @@ class HttpRequestUDF(StatefulStageUDF):
                         "http_response": resp_json,
                     }
 
-    @property
-    def expected_input_keys(self) -> List[str]:
-        return ["payload"]
-
 
 class HttpRequestStage(StatefulStage):
     """
@@ -101,3 +99,10 @@ class HttpRequestStage(StatefulStage):
     """
 
     fn: Type[StatefulStageUDF] = HttpRequestUDF
+
+    def get_required_input_keys(self) -> Dict[str, str]:
+        """The required input keys of the stage and their descriptions."""
+        return {
+            "payload": "The payload to send to the HTTP request. "
+            "It should be in JSON format."
+        }

--- a/python/ray/llm/_internal/batch/stages/prepare_image_stage.py
+++ b/python/ray/llm/_internal/batch/stages/prepare_image_stage.py
@@ -304,8 +304,8 @@ class ImageProcessor:
 
 
 class PrepareImageUDF(StatefulStageUDF):
-    def __init__(self, data_column: str):
-        super().__init__(data_column)
+    def __init__(self, data_column: str, expected_input_keys: List[str]):
+        super().__init__(data_column, expected_input_keys)
         self.Image = importlib.import_module("PIL.Image")
         self.image_processor = ImageProcessor()
 
@@ -365,13 +365,16 @@ class PrepareImageUDF(StatefulStageUDF):
                 img_start_idx += num_images_in_req
             yield ret
 
-    @property
-    def expected_input_keys(self) -> List[str]:
-        """The expected input keys."""
-        return ["messages"]
-
 
 class PrepareImageStage(StatefulStage):
     """A stage to prepare images from OpenAI chat template messages."""
 
     fn: StatefulStageUDF = PrepareImageUDF
+
+    def get_required_input_keys(self) -> Dict[str, str]:
+        """The required input keys of the stage and their descriptions."""
+        return {
+            "messages": "A list of messages in OpenAI chat format. "
+            "See https://platform.openai.com/docs/api-reference/chat/create "
+            "for details."
+        }

--- a/python/ray/llm/_internal/batch/stages/tokenize_stage.py
+++ b/python/ray/llm/_internal/batch/stages/tokenize_stage.py
@@ -16,6 +16,7 @@ class TokenizeUDF(StatefulStageUDF):
     def __init__(
         self,
         data_column: str,
+        expected_input_keys: List[str],
         model: str,
     ):
         """
@@ -23,11 +24,12 @@ class TokenizeUDF(StatefulStageUDF):
 
         Args:
             data_column: The data column name.
+            expected_input_keys: The expected input keys of the stage.
             model: The model to use for the chat template.
         """
         from transformers import AutoTokenizer
 
-        super().__init__(data_column)
+        super().__init__(data_column, expected_input_keys)
         model_path = download_hf_model(model, tokenizer_only=True)
         self.tokenizer = get_cached_tokenizer(
             AutoTokenizer.from_pretrained(
@@ -55,11 +57,6 @@ class TokenizeUDF(StatefulStageUDF):
                 "tokenized_prompt": prompt_token_ids,
             }
 
-    @property
-    def expected_input_keys(self) -> List[str]:
-        """The expected input keys."""
-        return ["prompt"]
-
 
 class TokenizeStage(StatefulStage):
     """
@@ -68,11 +65,16 @@ class TokenizeStage(StatefulStage):
 
     fn: Type[StatefulStageUDF] = TokenizeUDF
 
+    def get_required_input_keys(self) -> Dict[str, str]:
+        """The required input keys of the stage and their descriptions."""
+        return {"prompt": "The text prompt (str) to tokenize."}
+
 
 class DetokenizeUDF(StatefulStageUDF):
     def __init__(
         self,
         data_column: str,
+        expected_input_keys: List[str],
         model: str,
     ):
         """
@@ -80,11 +82,12 @@ class DetokenizeUDF(StatefulStageUDF):
 
         Args:
             data_column: The data column name.
+            expected_input_keys: The expected input keys of the stage.
             model: The model to use for the chat template.
         """
         from transformers import AutoTokenizer
 
-        super().__init__(data_column)
+        super().__init__(data_column, expected_input_keys)
         model_path = download_hf_model(model, tokenizer_only=True)
         self.tokenizer = get_cached_tokenizer(
             AutoTokenizer.from_pretrained(
@@ -115,11 +118,6 @@ class DetokenizeUDF(StatefulStageUDF):
                 "generated_text": generated_text,
             }
 
-    @property
-    def expected_input_keys(self) -> List[str]:
-        """The expected input keys."""
-        return ["generated_tokens"]
-
 
 class DetokenizeStage(StatefulStage):
     """
@@ -127,3 +125,7 @@ class DetokenizeStage(StatefulStage):
     """
 
     fn: Type[StatefulStageUDF] = DetokenizeUDF
+
+    def get_required_input_keys(self) -> Dict[str, str]:
+        """The required input keys of the stage and their descriptions."""
+        return {"generated_tokens": "A list of generated tokens (int) to detokenize."}

--- a/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
+++ b/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
@@ -62,9 +62,10 @@ def test_processor_with_stages(has_extra: bool):
         def __init__(
             self,
             data_column: str,
+            expected_input_keys: List[str],
             factor: int,
         ):
-            super().__init__(data_column)
+            super().__init__(data_column, expected_input_keys)
             self.factor = factor
 
         async def udf(
@@ -80,14 +81,13 @@ def test_processor_with_stages(has_extra: bool):
                     self.IDX_IN_BATCH_COLUMN: row[self.IDX_IN_BATCH_COLUMN],
                 }
 
-        @property
-        def expected_input_keys(self) -> List[str]:
-            return ["val"]
-
     class DummyStage(StatefulStage):
         fn: Type[StatefulStageUDF] = DummyStatefulStageUDF
         fn_constructor_kwargs: Dict[str, Any] = {}
         map_batches_kwargs: Dict[str, Any] = dict(concurrency=1)
+
+        def get_required_input_keys(self) -> Dict[str, str]:
+            return {"val": "The value to multiply."}
 
     stages = [
         DummyStage(fn_constructor_kwargs=dict(factor=2)),

--- a/python/ray/llm/tests/batch/cpu/stages/test_chat_template_stage.py
+++ b/python/ray/llm/tests/batch/cpu/stages/test_chat_template_stage.py
@@ -20,6 +20,7 @@ async def test_chat_template_udf_basic(mock_tokenizer_setup):
 
     udf = ChatTemplateUDF(
         data_column="__data",
+        expected_input_keys=["messages"],
         model="test-model",
     )
 
@@ -52,6 +53,7 @@ async def test_chat_template_udf_multiple_messages(mock_tokenizer_setup):
 
     udf = ChatTemplateUDF(
         data_column="__data",
+        expected_input_keys=["messages"],
         model="test-model",
     )
 
@@ -80,20 +82,6 @@ async def test_chat_template_udf_multiple_messages(mock_tokenizer_setup):
     assert mock_tokenizer.apply_chat_template.call_count == 2
 
 
-def test_chat_template_udf_expected_input_keys(mock_tokenizer_setup):
-    mock_tokenizer = mock_tokenizer_setup
-    mock_tokenizer.apply_chat_template.side_effect = [
-        "<chat>Hello AI</chat>",
-        "<chat>How are you?</chat>",
-    ]
-
-    udf = ChatTemplateUDF(
-        data_column="__data",
-        model="test-model",
-    )
-    assert udf.expected_input_keys == ["messages"]
-
-
 @pytest.mark.asyncio
 async def test_chat_template_udf_assistant_prefill(mock_tokenizer_setup):
     mock_tokenizer = mock_tokenizer_setup
@@ -104,6 +92,7 @@ async def test_chat_template_udf_assistant_prefill(mock_tokenizer_setup):
 
     udf = ChatTemplateUDF(
         data_column="__data",
+        expected_input_keys=["messages"],
         model="test-model",
     )
 

--- a/python/ray/llm/tests/batch/cpu/stages/test_http_request_stage.py
+++ b/python/ray/llm/tests/batch/cpu/stages/test_http_request_stage.py
@@ -29,6 +29,7 @@ def mock_session():
 async def test_http_request_udf_basic():
     udf = HttpRequestUDF(
         data_column="__data",
+        expected_input_keys=["payload"],
         url="http://test.com/api",
         additional_header={"Authorization": "Bearer 1234567890"},
         qps=None,
@@ -60,6 +61,7 @@ async def test_http_request_udf_basic():
 async def test_http_request_udf_with_qps():
     udf = HttpRequestUDF(
         data_column="__data",
+        expected_input_keys=["payload"],
         url="http://test.com/api",
         qps=2,
     )

--- a/python/ray/llm/tests/batch/cpu/stages/test_prepare_image_stage.py
+++ b/python/ray/llm/tests/batch/cpu/stages/test_prepare_image_stage.py
@@ -45,7 +45,7 @@ def mock_image_processor(mock_http_connection, mock_image):
 
 @pytest.mark.asyncio
 async def test_prepare_image_udf_basic(mock_image_processor, mock_image):
-    udf = PrepareImageUDF(data_column="__data")
+    udf = PrepareImageUDF(data_column="__data", expected_input_keys=["messages"])
 
     # Test batch with one message containing an image URL
     batch = {
@@ -75,7 +75,7 @@ async def test_prepare_image_udf_basic(mock_image_processor, mock_image):
 
 @pytest.mark.asyncio
 async def test_prepare_image_udf_multiple_images(mock_image_processor, mock_image):
-    udf = PrepareImageUDF(data_column="__data")
+    udf = PrepareImageUDF(data_column="__data", expected_input_keys=["messages"])
 
     # Test batch with multiple images in one message
     batch = {
@@ -104,7 +104,7 @@ async def test_prepare_image_udf_multiple_images(mock_image_processor, mock_imag
 
 @pytest.mark.asyncio
 async def test_prepare_image_udf_no_images(mock_image_processor):
-    udf = PrepareImageUDF(data_column="__data")
+    udf = PrepareImageUDF(data_column="__data", expected_input_keys=["messages"])
 
     # Test batch with no images
     batch = {"__data": [{"messages": [{"content": "Hello, world!"}]}]}
@@ -140,13 +140,13 @@ async def test_image_processor_fetch_images(mock_http_connection, mock_image):
 
 
 def test_prepare_image_udf_expected_keys():
-    udf = PrepareImageUDF(data_column="__data")
-    assert udf.expected_input_keys == ["messages"]
+    udf = PrepareImageUDF(data_column="__data", expected_input_keys=["messages"])
+    assert udf.expected_input_keys == {"messages"}
 
 
 @pytest.mark.asyncio
 async def test_prepare_image_udf_invalid_image_type(mock_image_processor):
-    udf = PrepareImageUDF(data_column="__data")
+    udf = PrepareImageUDF(data_column="__data", expected_input_keys=["messages"])
 
     # Test batch with invalid image type
     batch = {

--- a/python/ray/llm/tests/batch/cpu/stages/test_tokenize_stage.py
+++ b/python/ray/llm/tests/batch/cpu/stages/test_tokenize_stage.py
@@ -27,7 +27,9 @@ async def test_tokenize_udf_basic(mock_tokenizer_setup):
         {"input_ids": [4, 5, 6]},
     ]
 
-    udf = TokenizeUDF(data_column="__data", model="test-model")
+    udf = TokenizeUDF(
+        data_column="__data", model="test-model", expected_input_keys=["prompt"]
+    )
     batch = {"__data": [{"prompt": "Hello"}, {"prompt": "World"}]}
 
     results = []
@@ -47,7 +49,11 @@ async def test_detokenize_udf_basic(mock_tokenizer_setup):
     mock_tokenizer = mock_tokenizer_setup
     mock_tokenizer.batch_decode.return_value = ["Hello", "World"]
 
-    udf = DetokenizeUDF(data_column="__data", model="test-model")
+    udf = DetokenizeUDF(
+        data_column="__data",
+        model="test-model",
+        expected_input_keys=["generated_tokens"],
+    )
     batch = {
         "__data": [
             {"generated_tokens": [1, 2, 3]},
@@ -65,16 +71,6 @@ async def test_detokenize_udf_basic(mock_tokenizer_setup):
     mock_tokenizer.batch_decode.assert_called_once_with(
         [[1, 2, 3], [4, 5, 6]], skip_special_tokens=True
     )
-
-
-def test_tokenize_udf_expected_keys(mock_tokenizer_setup):
-    udf = TokenizeUDF(data_column="__data", model="test-model")
-    assert udf.expected_input_keys == ["prompt"]
-
-
-def test_detokenize_udf_expected_keys(mock_tokenizer_setup):
-    udf = DetokenizeUDF(data_column="__data", model="test-model")
-    assert udf.expected_input_keys == ["generated_tokens"]
 
 
 if __name__ == "__main__":

--- a/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
+++ b/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
@@ -109,6 +109,7 @@ async def test_vllm_engine_udf_basic(mock_vllm_wrapper, model_llama_3_2_216M):
     # Create UDF instance - it will use the mocked wrapper
     udf = vLLMEngineStageUDF(
         data_column="__data",
+        expected_input_keys=["prompt", "sampling_params"],
         model=model_llama_3_2_216M,
         task_type=vLLMTaskType.GENERATE,
         engine_kwargs={


### PR DESCRIPTION
## Why are these changes needed?

It's tricky for users to implement `preprocess` function when constructing a Processor, because users may not have an idea about what's the input dataset should look like (i.e. what's the expected schema). This PR proposes a new API `log_input_column_names()` that logs the expected schema. Example:

```python
import ray
from ray.data.llm import build_llm_processor, vLLMEngineProcessorConfig

processor_config = vLLMEngineProcessorConfig(...)
processor = build_llm_processor(...)
processor.log_input_column_names()
# The first stage of the processor is ChatTemplateStage.
# Required input columns:
#     messages: A list of messages in OpenAI chat format. See https://platform.openai.com/docs/api-reference/chat/create for details.

processor_config = vLLMEngineProcessorConfig(
    apply_chat_template=False,
    tokenize=False,
)
processor = build_llm_processor(...)
processor.log_input_column_names()
# The first stage of the processor is vLLMEngineStage.
# Required input columns:
#    prompt: The text prompt (str).
#    sampling_params: The sampling parameters. See https://docs.vllm.ai/en/latest/api/inference_params.html#sampling-parameters for details.
# Optional input columns:
#    tokenized_prompt: The tokenized prompt. If provided, the prompt will not be tokenized by the vLLM engine.
#    images: The images to generate text from. If provided, the prompt will be a multimodal prompt.
#    model: The model to use for this request. If the model is different from the model set in the stage, then this is a LoRA request.
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
