### PR TITLE
[java] expose ObjectRef from DeploymentResponse

### DIFF
--- a/java/serve/src/main/java/io/ray/serve/handle/DeploymentResponse.java
+++ b/java/serve/src/main/java/io/ray/serve/handle/DeploymentResponse.java
@@ -15,6 +15,10 @@ public class DeploymentResponse {
     this.objectRef = objectRef;
   }
 
+  public ObjectRef<Object> getObjectRef() {
+    return objectRef;
+  }
+
   public Object result() {
     return objectRef.get();
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
As I mentioned in https://github.com/ray-project/ray/issues/51445
in Python, it's possible to convert DeploymentResponse to ObjectRef for compose calls involving DeploymentHandle along with Ray Actors or Tasks. Implementing this in Java is straightforward—we just need to expose ObjectRef. However, this approach might disrupt the encapsulation of DeploymentResponse. 

In my use case, with this feature, Subscriber no need to wait slow processor

## Related issue number
https://github.com/ray-project/ray/issues/51445

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
