### PR TITLE
[Data] Add environment variable support for Ray Data execution callbacks.

### DIFF
--- a/python/ray/data/_internal/execution/execution_callback.py
+++ b/python/ray/data/_internal/execution/execution_callback.py
@@ -1,4 +1,6 @@
 from typing import List, TYPE_CHECKING
+import importlib
+import os
 
 from ray.data.context import DataContext
 
@@ -6,6 +8,8 @@ if TYPE_CHECKING:
     from ray.data._internal.execution.streaming_executor import StreamingExecutor
 
 EXECUTION_CALLBACKS_CONFIG_KEY = "execution_callbacks"
+EXECUTION_CALLBACKS_ENV_VAR = "RAY_DATA_EXECUTION_CALLBACKS"
+ENV_CALLBACKS_INITIALIZED_KEY = "_env_callbacks_initialized"
 
 
 class ExecutionCallback:
@@ -28,8 +32,34 @@ class ExecutionCallback:
         ...
 
 
+def _initialize_env_callbacks(context: DataContext) -> None:
+    """Initialize callbacks from environment variable and add them to the context."""
+    callbacks_str = os.environ.get(EXECUTION_CALLBACKS_ENV_VAR, "")
+    if not callbacks_str:
+        return
+
+    for callback_path in callbacks_str.split(","):
+        callback_path = callback_path.strip()
+        if not callback_path:
+            continue
+
+        try:
+            module_path, class_name = callback_path.rsplit(".", 1)
+            module = importlib.import_module(module_path)
+            callback_cls = getattr(module, class_name)
+            callback = callback_cls()
+            add_execution_callback(callback, context)
+        except (ImportError, AttributeError, ValueError) as e:
+            raise ValueError(f"Failed to import callback from '{callback_path}': {e}")
+
+
 def get_execution_callbacks(context: DataContext) -> List[ExecutionCallback]:
     """Get all ExecutionCallbacks from the DataContext."""
+    # Initialize environment callbacks if not already done for this context
+    if not context.get_config(ENV_CALLBACKS_INITIALIZED_KEY, False):
+        _initialize_env_callbacks(context)
+        context.set_config(ENV_CALLBACKS_INITIALIZED_KEY, True)
+
     return context.get_config(EXECUTION_CALLBACKS_CONFIG_KEY, [])
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This change adds support for loading Ray Data execution callbacks from an environment variable (`RAY_DATA_EXECUTION_CALLBACKS`). Users can now specify a comma-separated list of callback class paths, which will be dynamically imported and added to the DataContext.
This allows for easy instrumentation and monitoring of Ray Data executions without modifying application code, which is useful for deb ugging and observability in production environments.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
