### PR TITLE
[core] upgrading macos CI python 3.9 -> 3.9.2 to enable numpy serialization warnings

### DIFF
--- a/ci/build/test-wheels.sh
+++ b/ci/build/test-wheels.sh
@@ -97,7 +97,7 @@ if [[ "$platform" == "macosx" ]]; then
     "$PIP_CMD" install -q "$PYTHON_WHEEL"
 
     # Install the dependencies to run the tests.
-    "$PIP_CMD" install -q aiohttp aiosignal numpy frozenlist 'pytest==7.0.1' requests proxy.py
+    "$PIP_CMD" install -v aiohttp aiosignal numpy frozenlist 'pytest==7.0.1' requests proxy.py
 
     # Run a simple test script to make sure that the wheel works.
     # We set the python path to prefer the directory of the wheel content: https://github.com/ray-project/ray/pull/30090

--- a/ci/build/test-wheels.sh
+++ b/ci/build/test-wheels.sh
@@ -48,8 +48,10 @@ function retry {
 if [[ "$platform" == "macosx" ]]; then
   MACPYTHON_PY_PREFIX=/Library/Frameworks/Python.framework/Versions
 
-  PY_WHEEL_VERSIONS=("39" "310")
-  PY_MMS=("3.9.2" "3.10")
+  # PY_WHEEL_VERSIONS=("39" "310")
+  # PY_MMS=("3.9" "3.10")
+  PY_WHEEL_VERSIONS=("39")
+  PY_MMS=("3.9")
 
   for ((i=0; i<${#PY_MMS[@]}; ++i)); do
     PY_MM="${PY_MMS[i]}"
@@ -70,6 +72,7 @@ if [[ "$platform" == "macosx" ]]; then
       conda create -y -n "$CONDA_ENV_NAME"
       conda activate "$CONDA_ENV_NAME"
       conda remove -y python || true
+      conda config --add channels conda-forge
       conda install -y python="${PY_MM}"
 
       PYTHON_EXE="/opt/homebrew/opt/miniconda/envs/${CONDA_ENV_NAME}/bin/python"

--- a/ci/build/test-wheels.sh
+++ b/ci/build/test-wheels.sh
@@ -49,7 +49,7 @@ if [[ "$platform" == "macosx" ]]; then
   MACPYTHON_PY_PREFIX=/Library/Frameworks/Python.framework/Versions
 
   PY_WHEEL_VERSIONS=("39" "310")
-  PY_MMS=("3.9" "3.10")
+  PY_MMS=("3.9.2" "3.10")
 
   for ((i=0; i<${#PY_MMS[@]}; ++i)); do
     PY_MM="${PY_MMS[i]}"

--- a/python/ray/_private/numpy_serialization.py
+++ b/python/ray/_private/numpy_serialization.py
@@ -1,0 +1,35 @@
+import ray.cloudpickle as cloudpickle
+import warnings
+
+import numpy as np
+
+from ray._private.ray_constants import DEFAULT_MAX_DIRECT_CALL_OBJECT_SIZE
+
+_numpy_serializer_has_warned = False
+
+
+def _register_numpy_ndarray_data_serializer(serialization_context):
+    serialization_context._register_cloudpickle_reducer(
+        np.ndarray, _numpy_ndarray_reduce
+    )
+
+
+def _numpy_ndarray_reduce(obj: np.ndarray):
+    global _numpy_serializer_has_warned
+    if (
+        not _numpy_serializer_has_warned
+        and obj.nbytes >= DEFAULT_MAX_DIRECT_CALL_OBJECT_SIZE
+        and not obj.flags.c_contiguous
+    ):
+
+        warnings.warn(
+            "Non-contiguous numpy arrays cannot be zero-copy "
+            "deserialized which may lead to worse performance. "
+            "To avoid this, use numpy.ascontiguousarray(arr) before "
+            "passing or returning the array."
+            f"\n\tArray shape: {obj.shape}"
+            f"\n\tArray dtype: {obj.dtype}",
+            UserWarning,
+        )
+        _numpy_serializer_has_warned = True
+    return obj.__reduce_ex__(cloudpickle.DEFAULT_PROTOCOL)

--- a/python/ray/tests/test_serialization.py
+++ b/python/ray/tests/test_serialization.py
@@ -5,11 +5,13 @@ import logging
 import re
 import string
 import sys
+
 import weakref
+import warnings
 from dataclasses import make_dataclass
 
-import numpy as np
 import pytest
+import numpy as np
 from numpy import log
 
 import ray
@@ -18,6 +20,19 @@ import ray.exceptions
 from ray import cloudpickle
 
 logger = logging.getLogger(__name__)
+
+
+def test_warn_copying_non_contiguous_numpy_arrays_warns_once(ray_start_regular):
+    warning_regex = re.compile(".*cannot be zero-copy.*")
+    warnings.simplefilter("always")
+    with pytest.warns(UserWarning, match=warning_regex) as record:
+        non_contiguous_arr = np.zeros(1024 * 1204)[::2]
+        ray.put(non_contiguous_arr)
+        ray.put(non_contiguous_arr)
+    numpy_arr_warnings = [
+        warning for warning in record if warning_regex.match(str(warning.message))
+    ]
+    assert len(numpy_arr_warnings) == 1
 
 
 def is_named_tuple(cls):

--- a/python/ray/util/serialization_addons.py
+++ b/python/ray/util/serialization_addons.py
@@ -24,12 +24,25 @@ def register_starlette_serializer(serialization_context):
     )
 
 
+def _register_numpy_serializer(serialization_context):
+
+    try:
+        import numpy  # noqa:F401
+    except ModuleNotFoundError:
+        return
+
+    from ray._private.numpy_serialization import _register_numpy_ndarray_data_serializer
+
+    _register_numpy_ndarray_data_serializer(serialization_context)
+
+
 @DeveloperAPI
 def apply(serialization_context):
     from ray._private.pydantic_compat import register_pydantic_serializers
 
     register_pydantic_serializers(serialization_context)
     register_starlette_serializer(serialization_context)
+    _register_numpy_serializer(serialization_context)
 
     if sys.platform != "win32":
         from ray._private.arrow_serialization import (


### PR DESCRIPTION
See #51287 