### PR TITLE
[Data] Configure map task memory based on output size

### DIFF
--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -330,6 +330,11 @@ class MapOperator(OneToOneOperator, ABC):
             # `target_max_block_size` is large (e.g., 1GB), then tasks can OOM even
             # if it just uses enough memory to produce an output block. By setting
             # `memory` to the average output size, we can mitigate this case.
+            #
+            # We set it to 1 target block size out of assumption that *at least* 1 copy of 
+            # data (to process heap) will be made during processing.
+            # Please note that, Ray's "memory" resource is exclusive of the Object Store
+            # memory allocated on the node (ie its total allocatable value is Total memory - Object Store memory)
             ray_remote_args["memory"] = self.metrics.average_bytes_per_output
 
         # For tasks with small args, we will use SPREAD by default to optimize for

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -331,10 +331,12 @@ class MapOperator(OneToOneOperator, ABC):
             # if it just uses enough memory to produce an output block. By setting
             # `memory` to the average output size, we can mitigate this case.
             #
-            # We set it to 1 target block size out of assumption that *at least* 1 copy of 
-            # data (to process heap) will be made during processing.
-            # Please note that, Ray's "memory" resource is exclusive of the Object Store
-            # memory allocated on the node (ie its total allocatable value is Total memory - Object Store memory)
+            # We set it to 1 target block size out of assumption that *at least* 1 copy
+            # of data (to process heap) will be made during processing.
+            #
+            # Note that Ray's "memory" resource is exclusive of the Object Store
+            # memory allocated on the node (ie its total allocatable value is Total
+            # memory - Object Store memory).
             ray_remote_args["memory"] = self.metrics.average_bytes_per_output
 
         # For tasks with small args, we will use SPREAD by default to optimize for

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -322,6 +322,16 @@ class MapOperator(OneToOneOperator, ABC):
             new_remote_args = self._ray_remote_args_fn()
             for k, v in new_remote_args.items():
                 ray_remote_args[k] = v
+
+        if "memory" not in ray_remote_args:
+            # Typically, this configuration won't make a difference because
+            # `average_bytes_per_output` is usually ~128 MiB and each core usually has
+            # 4 GiB of memory. However, if `num_cpus` is small (e.g., 0.01) or
+            # `target_max_block_size` is large (e.g., 1GB), then tasks can OOM even
+            # if it just uses enough memory to produce an output block. By setting
+            # `memory` to the average output size, we can mitigate this case.
+            ray_remote_args["memory"] = self.metrics.average_bytes_per_output
+
         # For tasks with small args, we will use SPREAD by default to optimize for
         # compute load-balancing. For tasks with large args, we will use DEFAULT to
         # allow the Ray locality scheduler a chance to optimize task placement.
@@ -339,10 +349,12 @@ class MapOperator(OneToOneOperator, ABC):
                 # Only save to metrics if we haven't already done so.
                 if "scheduling_strategy" not in self._remote_args_for_metrics:
                     self._remote_args_for_metrics = copy.deepcopy(ray_remote_args)
+
         # This should take precedence over previously set scheduling strategy, as it
         # implements actor-based locality overrides.
         if self._ray_remote_args_factory_actor_locality:
             return self._ray_remote_args_factory_actor_locality(ray_remote_args)
+
         return ray_remote_args
 
     @abstractmethod


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Typically, a map task output is around ~128 MiB and each core has 4 GiB of memory. However, if `num_cpus` is small (e.g., 0.01) or `target_max_block_size` is large (e.g., 1GB), then tasks can OOM even if it just uses enough memory to produce an output block. By setting memory to the average output size, we can mitigate this case.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
