### PR TITLE
[Chore][Core/Dashboard] Improve log message for subprocess modules

### DIFF
--- a/python/ray/dashboard/subprocesses/module.py
+++ b/python/ray/dashboard/subprocesses/module.py
@@ -113,7 +113,7 @@ class SubprocessModule(abc.ABC):
                 )
             )
         app.add_routes(routes)
-        runner = aiohttp.web.AppRunner(app)
+        runner = aiohttp.web.AppRunner(app, access_log=None)
         await runner.setup()
 
         socket_path = get_socket_path(self._config.socket_dir, self.__class__.__name__)


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

1. Currently we send the healthz requests from parent to each child periodically and the child logs is full of
```
025-03-18 07:52:07,721 INFO web_log.py:206 --  [18/Mar/2025:14:52:07 +0000] "GET /api/healthz HTTP/1.1" 200 163 "-" "Python/3.9 aiohttp/3.8.6"
2025-03-18 07:52:08,725 INFO web_log.py:206 --  [18/Mar/2025:14:52:08 +0000] "GET /api/healthz HTTP/1.1" 200 163 "-" "Python/3.9 aiohttp/3.8.6"
2025-03-18 07:52:09,729 INFO web_log.py:206 --  [18/Mar/2025:14:52:09 +0000] "GET /api/healthz HTTP/1.1" 200 163 "-" "Python/3.9 aiohttp/3.8.6"
```
This PR disables them because they are too spammy. It is disabled by passing `access_log=None` to `AppRunner`.

2. In the log file, if the parent process died and the child process detected it, it'll print the following log.

```
2025-03-18 07:52:42,606 WARNING module.py:71 -- Parent process 64325 died. Exiting...
2025-03-18 07:52:42,631 ERROR base_events.py:1753 -- Task exception was never retrieved
future: <Task finished name='Task-2' coro=<SubprocessModule._detect_parent_process_death() done, defined at /Users/jjyao/Workspace/ray1/python/ray/dashboard/subprocesses/module.py:65> exception=SystemExit()>
Traceback (most recent call last):
  File "/Users/jjyao/anaconda3/envs/ray/lib/python3.9/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/Users/jjyao/anaconda3/envs/ray/lib/python3.9/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/jjyao/Workspace/ray1/python/ray/dashboard/subprocesses/module.py", line 213, in run_module
    loop.run_forever()
  File "/Users/jjyao/anaconda3/envs/ray/lib/python3.9/asyncio/base_events.py", line 601, in run_forever
    self._run_once()
  File "/Users/jjyao/anaconda3/envs/ray/lib/python3.9/asyncio/base_events.py", line 1905, in _run_once
    handle._run()
  File "/Users/jjyao/anaconda3/envs/ray/lib/python3.9/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "/Users/jjyao/Workspace/ray1/python/ray/dashboard/subprocesses/module.py", line 74, in _detect_parent_process_death
    sys.exit()
SystemExit
```
This PR removes the traceback for `SystemExit`. It is removed by moving `sys.exit` to the done callback for the asyncio task.

## Related issue number

<!-- For example: "Closes #1234" -->
Follow-up for https://github.com/ray-project/ray/pull/51282

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
