### PR TITLE
[train] include scheduling status detail

### DIFF
--- a/python/ray/train/v2/_internal/callbacks/state_manager.py
+++ b/python/ray/train/v2/_internal/callbacks/state_manager.py
@@ -16,6 +16,9 @@ from ray.train.v2._internal.execution.controller.state import (
     SchedulingState,
     TrainControllerState,
 )
+from ray.train.v2._internal.execution.scaling_policy.scaling_policy import (
+    ResizeDecision,
+)
 from ray.train.v2._internal.execution.worker_group import (
     WorkerGroup,
     WorkerGroupContext,
@@ -68,8 +71,21 @@ class StateManagerCallback(ControllerCallback, WorkerGroupCallback):
             return
 
         if isinstance(current_state, SchedulingState):
+            # TODO: This should probably always be set.
+            num_workers_and_resources_per_worker = None
+
+            scaling_decision = current_state.scaling_decision
+            if isinstance(scaling_decision, ResizeDecision):
+                num_workers = scaling_decision.num_workers
+                resources_per_worker = scaling_decision.resources_per_worker
+                num_workers_and_resources_per_worker = (
+                    num_workers,
+                    resources_per_worker,
+                )
+
             self._state_manager.update_train_run_scheduling(
                 run_id=self._run_id,
+                num_workers_and_resources_per_worker=num_workers_and_resources_per_worker,
             )
 
         elif isinstance(current_state, RunningState):

--- a/python/ray/train/v2/_internal/callbacks/state_manager.py
+++ b/python/ray/train/v2/_internal/callbacks/state_manager.py
@@ -71,21 +71,15 @@ class StateManagerCallback(ControllerCallback, WorkerGroupCallback):
             return
 
         if isinstance(current_state, SchedulingState):
-            # TODO: This should probably always be set.
-            num_workers_and_resources_per_worker = None
-
-            scaling_decision = current_state.scaling_decision
-            if isinstance(scaling_decision, ResizeDecision):
-                num_workers = scaling_decision.num_workers
-                resources_per_worker = scaling_decision.resources_per_worker
-                num_workers_and_resources_per_worker = (
-                    num_workers,
-                    resources_per_worker,
-                )
+            # TODO: This should probably always be ResizeDecision.
+            if isinstance(current_state.scaling_decision, ResizeDecision):
+                resize_decision = current_state.scaling_decision
+            else:
+                resize_decision = None
 
             self._state_manager.update_train_run_scheduling(
                 run_id=self._run_id,
-                num_workers_and_resources_per_worker=num_workers_and_resources_per_worker,
+                resize_decision=resize_decision,
             )
 
         elif isinstance(current_state, RunningState):

--- a/python/ray/train/v2/_internal/state/state_manager.py
+++ b/python/ray/train/v2/_internal/state/state_manager.py
@@ -3,9 +3,11 @@ import time
 from collections import defaultdict
 from typing import Dict, List, Optional
 
-from click import Tuple
 from ray.actor import ActorHandle
 from ray.train.v2._internal.execution.context import DistributedContext
+from ray.train.v2._internal.execution.scaling_policy.scaling_policy import (
+    ResizeDecision,
+)
 from ray.train.v2._internal.execution.worker_group import ActorMetadata, Worker
 from ray.train.v2._internal.state.schema import (
     ActorStatus,
@@ -60,14 +62,11 @@ class TrainStateManager:
     def update_train_run_scheduling(
         self,
         run_id: str,
-        num_workers_and_resources_per_worker: Optional[
-            Tuple[int, Dict[str, float]]
-        ] = None,
+        resize_decision: Optional[ResizeDecision] = None,
     ) -> None:
-        if num_workers_and_resources_per_worker is not None:
-            num_workers, resources_per_worker = num_workers_and_resources_per_worker
+        if resize_decision is not None:
             status_detail = _get_scheduling_status_detail(
-                num_workers, resources_per_worker
+                resize_decision.num_workers, resize_decision.resources_per_worker
             )
         else:
             status_detail = None


### PR DESCRIPTION
This PR adds `status_detail` information for `TrainRun.SCHEDULING` and `TrainRunAttempt.PENDING`. The status detail will contain brief scheduling information (`num_workers`, `resources_per_worker`).

## Changes

1. Create a simple `_get_scheduling_status_detail` utility method to construct the status detail when the run/attempt is getting scheduled.
    - This can be updated if we want to change the copy.
3. Propagate `ResizeDecision` to the `StateManager` to pass `num_workers` and `resources_per_worker`.
    - Note that there is some branching logic to check if the `ScalingDecision` is a `ResizeDecision` or not. It may make sense for `SCHEDULING` state to always correspond to a `ResizeDecision`, but this is left as a future TODO in this PR.

## Related issue number

<!-- For example: "Closes #1234" -->

## Testing

Ran a simple repro and verified the following information was emitted
```bash
RAY_TRAIN_ENABLE_STATE_TRACKING=1 RAY_TRAIN_V2_ENABLED=1 RAY_enable_export_api_write=1 python repro.py
```

```bash
cat /tmp/ray/session_latest/logs/export_events/event_EXPORT_TRAIN_STATE.log | jq '{source_type, status: .event_data.status, status_detail: .event_data.status_detail}'
{
  "source_type": "EXPORT_TRAIN_RUN",
  "status": "INITIALIZING",
  "status_detail": null
}
{
  "source_type": "EXPORT_TRAIN_RUN",
  "status": "SCHEDULING",
  "status_detail": "Scheduling 2 workers, each requiring: {'GPU': 1}."
}
{
  "source_type": "EXPORT_TRAIN_RUN_ATTEMPT",
  "status": "PENDING",
  "status_detail": "Scheduling 2 workers, each requiring: {'GPU': 1}."
}
```

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
