### PR TITLE
[chore][core] `test_default_sigchld_handler` will always pass

### DIFF
--- a/python/ray/tests/test_kill_subprocesses.py
+++ b/python/ray/tests/test_kill_subprocesses.py
@@ -7,6 +7,7 @@ import psutil
 import logging
 import os
 import sys
+from ray._private.test_utils import wait_for_condition
 
 logger = logging.getLogger(__name__)
 
@@ -137,11 +138,9 @@ def test_default_sigchld_handler(enable_subreaper, shutdown_only):
             """
             process = subprocess.Popen(["true"])
             pid = process.pid
-            time.sleep(1)  # wait for the process to exit.
-
-            # after reaping, it's gone.
-            with pytest.raises(psutil.NoSuchProcess):
-                psutil.Process(pid)
+            wait_for_condition(
+                lambda: not psutil.pid_exists(pid), retry_interval_ms=100
+            )
 
         def manual_reap(self):
             """

--- a/python/ray/tests/test_kill_subprocesses.py
+++ b/python/ray/tests/test_kill_subprocesses.py
@@ -139,7 +139,6 @@ def test_default_sigchld_handler(enable_subreaper, shutdown_only):
             pid = process.pid
             time.sleep(1)  # wait for the process to exit.
 
-            process.wait()
             # after reaping, it's gone.
             with pytest.raises(psutil.NoSuchProcess):
                 psutil.Process(pid)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`test_default_sigchld_handler` is used to test whether the core worker process correctly reaps zombie processes. However, it calls `subprocess.Popen.wait()` before checking whether the PID exists. The `wait()` function always waits for the child process to terminate. Therefore, the test will always pass.

I did a small experiment:

```python
import subprocess
import psutil
import time

process = subprocess.Popen(["true"])
pid = process.pid
process.wait()
print(f"pid: {pid} exists: {psutil.pid_exists(pid)}")
# [Example output]
# pid: 2554148 exists: False
```

```python
import subprocess
import psutil
import time

process = subprocess.Popen(["true"])
pid = process.pid
time.sleep(1)

print(f"pid: {pid} exists: {psutil.pid_exists(pid)}")
# [Example output]
# pid: 2553978 exists: True
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
