### PR TITLE
[core] Avoid test logic that relies on actor tasks executing on the main thread

### DIFF
--- a/src/ray/core_worker/test/scheduling_queue_test.cc
+++ b/src/ray/core_worker/test/scheduling_queue_test.cc
@@ -139,6 +139,8 @@ TEST(SchedulingQueueTest, TestTaskEvents) {
 
   ASSERT_EQ(n_ok, 2);
   ASSERT_EQ(n_rej, 0);
+
+  queue.Stop();
 }
 
 TEST(SchedulingQueueTest, TestInOrder) {
@@ -179,6 +181,8 @@ TEST(SchedulingQueueTest, TestInOrder) {
 
   ASSERT_EQ(n_ok, 4);
   ASSERT_EQ(n_rej, 0);
+
+  queue.Stop();
 }
 
 TEST(SchedulingQueueTest, TestWaitForObjects) {
@@ -235,6 +239,8 @@ TEST(SchedulingQueueTest, TestWaitForObjects) {
   default_executor->Join();
 
   ASSERT_EQ(n_ok, 4);
+
+  queue.Stop();
 }
 
 TEST(SchedulingQueueTest, TestWaitForObjectsNotSubjectToSeqTimeout) {
@@ -284,6 +290,8 @@ TEST(SchedulingQueueTest, TestWaitForObjectsNotSubjectToSeqTimeout) {
   default_executor->Join();
 
   ASSERT_EQ(n_ok, 2);
+
+  queue.Stop();
 }
 
 TEST(SchedulingQueueTest, TestOutOfOrder) {
@@ -324,6 +332,8 @@ TEST(SchedulingQueueTest, TestOutOfOrder) {
 
   ASSERT_EQ(n_ok, 4);
   ASSERT_EQ(n_rej, 0);
+
+  queue.Stop();
 }
 
 TEST(SchedulingQueueTest, TestSeqWaitTimeout) {
@@ -369,6 +379,8 @@ TEST(SchedulingQueueTest, TestSeqWaitTimeout) {
 
   ASSERT_EQ(n_ok, 3);
   ASSERT_EQ(n_rej, 2);
+
+  queue.Stop();
 }
 
 TEST(SchedulingQueueTest, TestSkipAlreadyProcessedByClient) {
@@ -408,6 +420,8 @@ TEST(SchedulingQueueTest, TestSkipAlreadyProcessedByClient) {
 
   ASSERT_EQ(n_ok, 1);
   ASSERT_EQ(n_rej, 2);
+
+  queue.Stop();
 }
 
 TEST(SchedulingQueueTest, TestCancelQueuedTask) {
@@ -512,6 +526,8 @@ TEST(OutOfOrderActorSchedulingQueueTest, TestTaskEvents) {
 
   ASSERT_EQ(n_ok, 2);
   ASSERT_EQ(n_rej, 0);
+
+  queue.Stop();
 }
 
 TEST(OutOfOrderActorSchedulingQueueTest, TestSameTaskMultipleAttempts) {

--- a/src/ray/core_worker/test/scheduling_queue_test.cc
+++ b/src/ray/core_worker/test/scheduling_queue_test.cc
@@ -25,8 +25,9 @@ namespace ray {
 namespace core {
 
 // Helper function that returns a condition checker to verify if a variable equals a
-// target value. It uses an atomic variable to avoid race conditions between the main thread
-// and the underlying executor (i.e., thread), which may result in errors from ASAN.
+// target value. It uses an atomic variable to avoid race conditions between the main
+// thread and the underlying executor (i.e., thread), which may result in errors from
+// ASAN.
 std::function<bool()> CreateEqualsConditionChecker(const std::atomic<int> *var,
                                                    int target) {
   return [var, target]() { return var->load() == target; };


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, some tests in `scheduling_queue_test.cc` rely on the behavior that both actor tasks and control plane logic execute on the same thread. This causes #51058 CI failures.

This PR causes these tests to always run Ray actor tasks on the default executor instead of on the main thread.

1. If a test wants to check the status after all submitted tasks have finished, we call `default_executor->Join();` to wait for them to complete.
2. If the test wants to check the status after a part of submitted tasks have finished, we use `WaitForCondition` instead.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
