### PR TITLE
[release-automation] Add option to add build tag when uploading wheels to pypi

### DIFF
--- a/ci/ray_ci/automation/ray_wheels_lib.py
+++ b/ci/ray_ci/automation/ray_wheels_lib.py
@@ -97,9 +97,7 @@ def add_build_tag_to_wheel(wheel_path: str, build_tag: str) -> None:
     Add build tag to the wheel.
     """
     wheel_name = os.path.basename(wheel_path)
-    print("Wheel name: ", wheel_name)
     directory_path = os.path.dirname(wheel_path)
-    print("Directory path: ", directory_path)
     ray_type, ray_version, python_version, python_version_duplicate, platform = wheel_name.split("-")
     new_wheel_name = f"{ray_type}-{ray_version}-{build_tag}-{python_version}-{python_version_duplicate}-{platform}"
     new_wheel_path = os.path.join(directory_path, new_wheel_name)

--- a/ci/ray_ci/automation/ray_wheels_lib.py
+++ b/ci/ray_ci/automation/ray_wheels_lib.py
@@ -1,5 +1,5 @@
 import boto3
-from typing import List, Optional
+from typing import List
 import os
 
 from ci.ray_ci.utils import logger
@@ -82,7 +82,6 @@ def download_ray_wheels_from_s3(
         commit_hash: The commit hash of the green commit.
         ray_version: The version of Ray.
         directory_path: The directory to download the wheels to.
-        build_tag: The build tag to add to the downloaded wheels.
     """
     full_directory_path = os.path.join(bazel_workspace_dir, directory_path)
     wheels = _get_wheel_names(ray_version=ray_version)
@@ -92,16 +91,24 @@ def download_ray_wheels_from_s3(
 
     _check_downloaded_wheels(full_directory_path, wheels)
 
+
 def add_build_tag_to_wheel(wheel_path: str, build_tag: str) -> None:
     """
     Add build tag to the wheel.
     """
     wheel_name = os.path.basename(wheel_path)
     directory_path = os.path.dirname(wheel_path)
-    ray_type, ray_version, python_version, python_version_duplicate, platform = wheel_name.split("-")
+    (
+        ray_type,
+        ray_version,
+        python_version,
+        python_version_duplicate,
+        platform,
+    ) = wheel_name.split("-")
     new_wheel_name = f"{ray_type}-{ray_version}-{build_tag}-{python_version}-{python_version_duplicate}-{platform}"
     new_wheel_path = os.path.join(directory_path, new_wheel_name)
     os.rename(wheel_path, new_wheel_path)
+
 
 def add_build_tag_to_wheels(directory_path: str, build_tag: str) -> None:
     """

--- a/ci/ray_ci/automation/test_ray_wheels_lib.py
+++ b/ci/ray_ci/automation/test_ray_wheels_lib.py
@@ -13,6 +13,8 @@ from ci.ray_ci.automation.ray_wheels_lib import (
     PYTHON_VERSIONS,
     ALL_PLATFORMS,
     RAY_TYPES,
+    add_build_tag_to_wheels,
+    add_build_tag_to_wheel,
 )
 
 SAMPLE_WHEELS = [
@@ -231,5 +233,30 @@ def test_download_ray_wheels_from_s3_fail_download(
     assert mock_check_wheels.call_count == 0
 
 
+def test_add_build_tag_to_wheel():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        wheel_name = "ray-1.0.0-cp39-cp39-manylinux2014_x86_64.whl"
+        wheel_path = os.path.join(tmp_dir, wheel_name)
+        with open(wheel_path, "w") as f:
+            f.write("")
+        add_build_tag_to_wheel(wheel_path=wheel_path, build_tag="123")
+        expected_wheel_name = "ray-1.0.0-123-cp39-cp39-manylinux2014_x86_64.whl"
+        expected_wheel_path = os.path.join(tmp_dir, expected_wheel_name)
+        assert os.path.exists(expected_wheel_path)
+
+def test_add_build_tag_to_wheels():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        wheels = [
+            "ray-1.0.0-cp39-cp39-manylinux2014_x86_64.whl",
+            "ray-1.0.0-cp39-cp39-manylinux2014_aarch64.whl",
+        ]
+        for wheel in wheels:
+            with open(os.path.join(tmp_dir, wheel), "w") as f:
+                f.write("")
+        add_build_tag_to_wheels(directory_path=tmp_dir, build_tag="123")
+        assert os.path.exists(os.path.join(tmp_dir, "ray-1.0.0-123-cp39-cp39-manylinux2014_x86_64.whl"))
+        assert os.path.exists(os.path.join(tmp_dir, "ray-1.0.0-123-cp39-cp39-manylinux2014_aarch64.whl"))
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))
+

--- a/ci/ray_ci/automation/test_ray_wheels_lib.py
+++ b/ci/ray_ci/automation/test_ray_wheels_lib.py
@@ -244,6 +244,7 @@ def test_add_build_tag_to_wheel():
         expected_wheel_path = os.path.join(tmp_dir, expected_wheel_name)
         assert os.path.exists(expected_wheel_path)
 
+
 def test_add_build_tag_to_wheels():
     with tempfile.TemporaryDirectory() as tmp_dir:
         wheels = [
@@ -254,8 +255,13 @@ def test_add_build_tag_to_wheels():
             with open(os.path.join(tmp_dir, wheel), "w") as f:
                 f.write("")
         add_build_tag_to_wheels(directory_path=tmp_dir, build_tag="123")
-        assert os.path.exists(os.path.join(tmp_dir, "ray-1.0.0-123-cp39-cp39-manylinux2014_x86_64.whl"))
-        assert os.path.exists(os.path.join(tmp_dir, "ray-1.0.0-123-cp39-cp39-manylinux2014_aarch64.whl"))
+        assert os.path.exists(
+            os.path.join(tmp_dir, "ray-1.0.0-123-cp39-cp39-manylinux2014_x86_64.whl")
+        )
+        assert os.path.exists(
+            os.path.join(tmp_dir, "ray-1.0.0-123-cp39-cp39-manylinux2014_aarch64.whl")
+        )
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/ci/ray_ci/automation/test_ray_wheels_lib.py
+++ b/ci/ray_ci/automation/test_ray_wheels_lib.py
@@ -259,4 +259,3 @@ def test_add_build_tag_to_wheels():
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))
-

--- a/ci/ray_ci/automation/upload_wheels_pypi.py
+++ b/ci/ray_ci/automation/upload_wheels_pypi.py
@@ -1,15 +1,21 @@
 import click
 import tempfile
 from typing import Optional
-from ci.ray_ci.automation.ray_wheels_lib import download_ray_wheels_from_s3, add_build_tag_to_wheels
+from ci.ray_ci.automation.ray_wheels_lib import (
+    download_ray_wheels_from_s3,
+    add_build_tag_to_wheels,
+)
 from ci.ray_ci.automation.pypi_lib import upload_wheels_to_pypi
+
 
 @click.command()
 @click.option("--ray_version", required=True, type=str)
 @click.option("--commit_hash", required=True, type=str)
 @click.option("--pypi_env", required=True, type=click.Choice(["test", "prod"]))
 @click.option("--build_tag", required=False, type=str)
-def main(ray_version: str, commit_hash: str, pypi_env: str, build_tag: Optional[str] = None):
+def main(
+    ray_version: str, commit_hash: str, pypi_env: str, build_tag: Optional[str] = None
+):
     with tempfile.TemporaryDirectory() as temp_dir:
         download_ray_wheels_from_s3(
             commit_hash=commit_hash,
@@ -19,6 +25,7 @@ def main(ray_version: str, commit_hash: str, pypi_env: str, build_tag: Optional[
         if build_tag:
             add_build_tag_to_wheels(directory_path=temp_dir, build_tag=build_tag)
         upload_wheels_to_pypi(pypi_env=pypi_env, directory_path=temp_dir)
+
 
 if __name__ == "__main__":
     main()

--- a/ci/ray_ci/automation/upload_wheels_pypi.py
+++ b/ci/ray_ci/automation/upload_wheels_pypi.py
@@ -1,21 +1,24 @@
 import click
 import tempfile
-
-from ci.ray_ci.automation.ray_wheels_lib import download_ray_wheels_from_s3
+from typing import Optional
+from ci.ray_ci.automation.ray_wheels_lib import download_ray_wheels_from_s3, add_build_tag_to_wheels
 from ci.ray_ci.automation.pypi_lib import upload_wheels_to_pypi
-
 
 @click.command()
 @click.option("--ray_version", required=True, type=str)
 @click.option("--commit_hash", required=True, type=str)
 @click.option("--pypi_env", required=True, type=click.Choice(["test", "prod"]))
-def main(ray_version, commit_hash, pypi_env):
+@click.option("--build_tag", required=False, type=str)
+def main(ray_version: str, commit_hash: str, pypi_env: str, build_tag: Optional[str] = None):
     with tempfile.TemporaryDirectory() as temp_dir:
         download_ray_wheels_from_s3(
-            commit_hash=commit_hash, ray_version=ray_version, directory_path=temp_dir
+            commit_hash=commit_hash,
+            ray_version=ray_version,
+            directory_path=temp_dir,
         )
+        if build_tag:
+            add_build_tag_to_wheels(directory_path=temp_dir, build_tag=build_tag)
         upload_wheels_to_pypi(pypi_env=pypi_env, directory_path=temp_dir)
-
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
- Add helper function to add build tag (e.g. `-1`) right after Ray version in the wheel name, in cases where original wheels uploaded to pypi/test pypi are corrupted.