### PR TITLE
[RLlib] Avoid `len()`, which causes static batch sizes on export (old API stack torch models).

### DIFF
--- a/rllib/models/torch/misc.py
+++ b/rllib/models/torch/misc.py
@@ -307,7 +307,7 @@ class AppendBiasLayer(nn.Module):
         self.register_parameter("log_std", self.log_std)
 
     def forward(self, x: TensorType) -> TensorType:
-        out = torch.cat([x, self.log_std.unsqueeze(0).repeat([len(x), 1])], axis=1)
+        out = torch.cat([x, self.log_std.expand(x.shape)], axis=1)
         return out
 
 


### PR DESCRIPTION
To solve the issue #51518, I have modified a torch layer to avoid the use of `len` in favour of torch primitives.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

See #51519 

## Related issue number

Closes #51519 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   - [x] Ad hoc inference test in custom environment and in Pendulum-v1. 
