### PR TITLE
Reapply "[Feat][Core/Dashboard] Add SubprocessModules to the Dashboard routes, and convert HealthzHead (#51282)" (#51512)

### DIFF
--- a/python/ray/_private/usage/usage_lib.py
+++ b/python/ray/_private/usage/usage_lib.py
@@ -548,7 +548,7 @@ def get_total_num_running_jobs_to_report(gcs_client) -> Optional[int]:
                 total_num_running_jobs += 1
         return total_num_running_jobs
     except Exception as e:
-        logger.info(f"Faile to query number of running jobs in the cluster: {e}")
+        logger.info(f"Failed to query number of running jobs in the cluster: {e}")
         return None
 
 
@@ -562,7 +562,7 @@ def get_total_num_nodes_to_report(gcs_client, timeout=None) -> Optional[int]:
                 total_num_nodes += 1
         return total_num_nodes
     except Exception as e:
-        logger.info(f"Faile to query number of nodes in the cluster: {e}")
+        logger.info(f"Failed to query number of nodes in the cluster: {e}")
         return None
 
 
@@ -593,7 +593,7 @@ def get_extra_usage_tags_to_report(gcs_client) -> Dict[str, str]:
                 k, v = kv.split("=")
                 extra_usage_tags[k] = v
         except Exception as e:
-            logger.info(f"Failed to parse extra usage tags env var. Error: {e}")
+            logger.info(f"Failed to parse extra usage tags env var: {e}")
 
     valid_tag_keys = [tag_key.lower() for tag_key in TagKey.keys()]
     try:
@@ -601,16 +601,16 @@ def get_extra_usage_tags_to_report(gcs_client) -> Dict[str, str]:
             usage_constant.EXTRA_USAGE_TAG_PREFIX.encode(),
             namespace=usage_constant.USAGE_STATS_NAMESPACE.encode(),
         )
-        for key in keys:
-            value = gcs_client.internal_kv_get(
-                key, namespace=usage_constant.USAGE_STATS_NAMESPACE.encode()
-            )
+        kv = gcs_client.internal_kv_multi_get(
+            keys, namespace=usage_constant.USAGE_STATS_NAMESPACE.encode()
+        )
+        for key, value in kv.items():
             key = key.decode("utf-8")
             key = key[len(usage_constant.EXTRA_USAGE_TAG_PREFIX) :]
             assert key in valid_tag_keys
             extra_usage_tags[key] = value.decode("utf-8")
     except Exception as e:
-        logger.info(f"Failed to get extra usage tags from kv store {e}")
+        logger.info(f"Failed to get extra usage tags from kv store: {e}")
     return extra_usage_tags
 
 

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1925,3 +1925,18 @@ def get_current_node_cpu_model_name() -> Optional[str]:
     except Exception:
         logger.debug("Failed to get CPU model name", exc_info=True)
         return None
+
+
+def validate_socket_filepath(filepath: str):
+    """
+    Validate the provided filename is a valid Unix socket filename.
+    """
+    # Don't check for Windows as it doesn't support Unix sockets.
+    if sys.platform == "win32":
+        return
+    is_mac = sys.platform.startswith("darwin")
+    maxlen = (104 if is_mac else 108) - 1
+    if len(filepath.encode("utf-8")) > maxlen:
+        raise OSError(
+            f"validate_socket_filename failed: AF_UNIX path length cannot exceed {maxlen} bytes: {filepath}"
+        )

--- a/python/ray/dashboard/dashboard.py
+++ b/python/ray/dashboard/dashboard.py
@@ -44,6 +44,11 @@ class Dashboard:
         serve_frontend: If configured, frontend HTML
             is not served from the dashboard.
         log_dir: Log directory of dashboard.
+        logging_level: The logging level (e.g. logging.INFO, logging.DEBUG)
+        logging_format: The format string for log messages
+        logging_filename: The name of the log file
+        logging_rotate_bytes: Max size in bytes before rotating log file
+        logging_rotate_backup_count: Number of backup files to keep when rotating
     """
 
     def __init__(
@@ -55,7 +60,12 @@ class Dashboard:
         cluster_id_hex: str,
         grpc_port: int,
         node_ip_address: str,
-        log_dir: str = None,
+        log_dir: str,
+        logging_level: int,
+        logging_format: str,
+        logging_filename: str,
+        logging_rotate_bytes: int,
+        logging_rotate_backup_count: int,
         temp_dir: str = None,
         session_dir: str = None,
         minimal: bool = False,
@@ -71,6 +81,11 @@ class Dashboard:
             node_ip_address=node_ip_address,
             grpc_port=grpc_port,
             log_dir=log_dir,
+            logging_level=logging_level,
+            logging_format=logging_format,
+            logging_filename=logging_filename,
+            logging_rotate_bytes=logging_rotate_bytes,
+            logging_rotate_backup_count=logging_rotate_backup_count,
             temp_dir=temp_dir,
             session_dir=session_dir,
             minimal=minimal,
@@ -236,6 +251,11 @@ if __name__ == "__main__":
             grpc_port=args.grpc_port,
             node_ip_address=args.node_ip_address,
             log_dir=args.log_dir,
+            logging_level=args.logging_level,
+            logging_format=args.logging_format,
+            logging_filename=args.logging_filename,
+            logging_rotate_bytes=args.logging_rotate_bytes,
+            logging_rotate_backup_count=args.logging_rotate_backup_count,
             temp_dir=args.temp_dir,
             session_dir=args.session_dir,
             minimal=args.minimal,

--- a/python/ray/dashboard/head.py
+++ b/python/ray/dashboard/head.py
@@ -2,8 +2,9 @@ import asyncio
 import logging
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Optional, Set
+from typing import Optional, Set, List, Tuple, TYPE_CHECKING
 
+import ray
 import ray.dashboard.consts as dashboard_consts
 import ray.dashboard.utils as dashboard_utils
 import ray.experimental.internal_kv as internal_kv
@@ -26,6 +27,8 @@ try:
 except ImportError:
     prometheus_client = None
 
+if TYPE_CHECKING:
+    from ray.dashboard.subprocesses.handle import SubprocessModuleHandle
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +73,11 @@ class DashboardHead:
         node_ip_address: str,
         grpc_port: int,
         log_dir: str,
+        logging_level: int,
+        logging_format: str,
+        logging_filename: str,
+        logging_rotate_bytes: int,
+        logging_rotate_backup_count: int,
         temp_dir: str,
         session_dir: str,
         minimal: bool,
@@ -83,6 +91,11 @@ class DashboardHead:
             http_port_retries: The maximum retry to bind ports for the Http server.
             gcs_address: The GCS address in the {address}:{port} format.
             log_dir: The log directory. E.g., /tmp/session_latest/logs.
+            logging_level: The logging level (e.g. logging.INFO, logging.DEBUG)
+            logging_format: The format string for log messages
+            logging_filename: The name of the log file
+            logging_rotate_bytes: Max size in bytes before rotating log file
+            logging_rotate_backup_count: Number of backup files to keep when rotating
             temp_dir: The temp directory. E.g., /tmp.
             session_dir: The session directory. E.g., tmp/session_latest.
             minimal: Whether or not it will load the minimal modules.
@@ -117,6 +130,11 @@ class DashboardHead:
         self.gcs_address = gcs_address
         self.cluster_id_hex = cluster_id_hex
         self.log_dir = log_dir
+        self.logging_level = logging_level
+        self.logging_format = logging_format
+        self.logging_filename = logging_filename
+        self.logging_rotate_bytes = logging_rotate_bytes
+        self.logging_rotate_backup_count = logging_rotate_backup_count
         self.temp_dir = temp_dir
         self.session_dir = session_dir
         self.session_name = Path(session_dir).name
@@ -137,7 +155,11 @@ class DashboardHead:
         # be configured to expose APIs.
         self.http_server = None
 
-    async def _configure_http_server(self, modules):
+    async def _configure_http_server(
+        self,
+        dashboard_head_modules: List[DashboardHeadModule],
+        subprocess_module_handles: List["SubprocessModuleHandle"],
+    ):
         from ray.dashboard.http_server_head import HttpServerDashboardHead
 
         self.http_server = HttpServerDashboardHead(
@@ -149,7 +171,7 @@ class DashboardHead:
             self.session_name,
             self.metrics,
         )
-        await self.http_server.run(modules)
+        await self.http_server.run(dashboard_head_modules, subprocess_module_handles)
 
     @property
     def http_session(self):
@@ -173,8 +195,41 @@ class DashboardHead:
         except Exception:
             logger.warning("Failed to check gcs aliveness, will retry", exc_info=True)
 
-    def _load_modules(self, modules_to_load: Optional[Set[str]] = None):
-        """Load dashboard head modules.
+    def _load_modules(
+        self, modules_to_load: Optional[Set[str]] = None
+    ) -> Tuple[List[DashboardHeadModule], List["SubprocessModuleHandle"]]:
+        """
+        If minimal, only load DashboardHeadModule.
+        If non-minimal, load both kinds of modules: DashboardHeadModule, SubprocessModule.
+
+        If modules_to_load is not None, only load the modules in the set.
+        """
+        dashboard_head_modules = self._load_dashboard_head_modules(modules_to_load)
+        subprocess_module_handles = self._load_subprocess_module_handles(
+            modules_to_load
+        )
+
+        all_names = {type(m).__name__ for m in dashboard_head_modules} | {
+            h.module_cls.__name__ for h in subprocess_module_handles
+        }
+        assert len(all_names) == len(dashboard_head_modules) + len(
+            subprocess_module_handles
+        ), "Duplicate module names. A module name can't be a DashboardHeadModule and a SubprocessModule at the same time."
+
+        # Verify modules are loaded as expected.
+        if modules_to_load is not None and all_names != modules_to_load:
+            assert False, (
+                f"Actual loaded modules {all_names}, doesn't match the requested modules "
+                f"to load, {modules_to_load}."
+            )
+
+        self._modules_loaded = True
+        return dashboard_head_modules, subprocess_module_handles
+
+    def _load_dashboard_head_modules(
+        self, modules_to_load: Optional[Set[str]] = None
+    ) -> List[DashboardHeadModule]:
+        """Load `DashboardHeadModule`s.
 
         Args:
             modules: A list of module names to load. By default (None),
@@ -198,26 +253,71 @@ class DashboardHead:
         )
 
         # Select modules to load.
-        modules_to_load = modules_to_load or {m.__name__ for m in head_cls_list}
-        logger.info("Modules to load: %s", modules_to_load)
+        if modules_to_load is not None:
+            head_cls_list = [
+                cls for cls in head_cls_list if cls.__name__ in modules_to_load
+            ]
+
+        logger.info(f"DashboardHeadModules to load: {modules_to_load}.")
 
         for cls in head_cls_list:
-            logger.info("Loading %s: %s", DashboardHeadModule.__name__, cls)
-            if cls.__name__ in modules_to_load:
-                c = cls(config)
-                modules.append(c)
+            logger.info(f"Loading {DashboardHeadModule.__name__}: {cls}.")
+            c = cls(config)
+            modules.append(c)
 
-        # Verify modules are loaded as expected.
-        loaded_modules = {type(m).__name__ for m in modules}
-        if loaded_modules != modules_to_load:
-            assert False, (
-                "Actual loaded modules, {}, doesn't match the requested modules "
-                "to load, {}".format(loaded_modules, modules_to_load)
-            )
-
-        self._modules_loaded = True
-        logger.info("Loaded %d modules. %s", len(modules), modules)
+        logger.info(f"Loaded {len(modules)} dashboard head modules: {modules}.")
         return modules
+
+    def _load_subprocess_module_handles(
+        self, modules_to_load: Optional[Set[str]] = None
+    ) -> List["SubprocessModuleHandle"]:
+        """
+        If minimal, return an empty list.
+        If non-minimal, load `SubprocessModule`s by creating Handles to them.
+
+        Args:
+            modules: A list of module names to load. By default (None),
+                it loads all modules.
+        """
+        if self.minimal:
+            logger.info("Subprocess modules not loaded in minimal mode.")
+            return []
+
+        from ray.dashboard.subprocesses.module import (
+            SubprocessModule,
+            SubprocessModuleConfig,
+        )
+        from ray.dashboard.subprocesses.handle import SubprocessModuleHandle
+
+        handles = []
+        subprocess_cls_list = dashboard_utils.get_all_modules(SubprocessModule)
+
+        loop = ray._common.utils.get_or_create_event_loop()
+        config = SubprocessModuleConfig(
+            cluster_id_hex=self.cluster_id_hex,
+            gcs_address=self.gcs_address,
+            logging_level=self.logging_level,
+            logging_format=self.logging_format,
+            log_dir=self.log_dir,
+            logging_filename=self.logging_filename,
+            logging_rotate_bytes=self.logging_rotate_bytes,
+            logging_rotate_backup_count=self.logging_rotate_backup_count,
+            socket_dir=str(Path(self.session_dir) / "sockets"),
+        )
+
+        # Select modules to load.
+        if modules_to_load is not None:
+            subprocess_cls_list = [
+                cls for cls in subprocess_cls_list if cls.__name__ in modules_to_load
+            ]
+
+        for cls in subprocess_cls_list:
+            logger.info(f"Loading {SubprocessModule.__name__}: {cls}.")
+            handle = SubprocessModuleHandle(loop, cls, config)
+            handles.append(handle)
+
+        logger.info(f"Loaded {len(handles)} subprocess modules: {handles}.")
+        return handles
 
     async def _setup_metrics(self, gcs_aio_client):
         metrics = DashboardPrometheusMetrics()
@@ -291,12 +391,22 @@ class DashboardHead:
                 except Exception:
                     logger.exception(f"Error notifying coroutine {co}")
 
-        modules = self._load_modules(self._modules_to_load)
+        dashboard_head_modules, subprocess_module_handles = self._load_modules(
+            self._modules_to_load
+        )
+        # Parallel start all subprocess modules.
+        for handle in subprocess_module_handles:
+            handle.start_module()
+        # Wait for all subprocess modules to be ready.
+        for handle in subprocess_module_handles:
+            handle.wait_for_module_ready()
 
         http_host, http_port = self.http_host, self.http_port
         if self.serve_frontend:
             logger.info("Initialize the http server.")
-            await self._configure_http_server(modules)
+            await self._configure_http_server(
+                dashboard_head_modules, subprocess_module_handles
+            )
             http_host, http_port = self.http_server.get_address()
             logger.info(f"http server initialized at {http_host}:{http_port}")
         else:
@@ -336,7 +446,7 @@ class DashboardHead:
             DataOrganizer.purge(),
             DataOrganizer.organize(self._executor),
         ]
-        for m in modules:
+        for m in dashboard_head_modules:
             concurrent_tasks.append(m.run(self.server))
         if self.server:
             concurrent_tasks.append(self.server.wait_for_termination())

--- a/python/ray/dashboard/http_server_head.py
+++ b/python/ray/dashboard/http_server_head.py
@@ -7,6 +7,7 @@ import pathlib
 import sys
 import time
 from math import floor
+from typing import List
 
 from packaging.version import Version
 
@@ -17,6 +18,10 @@ import ray.dashboard.utils as dashboard_utils
 from ray._common.utils import get_or_create_event_loop
 from ray._private.usage.usage_lib import TagKey, record_extra_usage_tag
 from ray.dashboard.dashboard_metrics import DashboardPrometheusMetrics
+from ray.dashboard.head import DashboardHeadModule
+
+from ray.dashboard.subprocesses.handle import SubprocessModuleHandle
+from ray.dashboard.subprocesses.routes import SubprocessRouteTable
 
 # All third-party dependencies that are not included in the minimal Ray
 # installation must be included in this file. This allows us to determine if
@@ -229,10 +234,17 @@ class HttpServerDashboardHead:
             return response
         return await handler(request)
 
-    async def run(self, modules):
+    async def run(
+        self,
+        dashboard_head_modules: List[DashboardHeadModule],
+        subprocess_module_handles: List[SubprocessModuleHandle],
+    ):
         # Bind http routes of each module.
-        for c in modules:
-            dashboard_optional_utils.DashboardHeadRouteTable.bind(c)
+        for m in dashboard_head_modules:
+            dashboard_optional_utils.DashboardHeadRouteTable.bind(m)
+
+        for h in subprocess_module_handles:
+            SubprocessRouteTable.bind(h)
 
         # Http server should be initialized after all modules loaded.
         # working_dir uploads for job submission can be up to 100MiB.
@@ -246,6 +258,7 @@ class HttpServerDashboardHead:
             ],
         )
         app.add_routes(routes=routes.bound_routes())
+        app.add_routes(routes=SubprocessRouteTable.bound_routes())
 
         self.runner = aiohttp.web.AppRunner(
             app,

--- a/python/ray/dashboard/modules/healthz/healthz_head.py
+++ b/python/ray/dashboard/modules/healthz/healthz_head.py
@@ -1,21 +1,23 @@
 from aiohttp.web import HTTPServiceUnavailable, Request, Response
 
-import ray.dashboard.optional_utils as optional_utils
-import ray.dashboard.utils as dashboard_utils
 from ray.dashboard.modules.healthz.utils import HealthChecker
+from ray.dashboard.subprocesses.routes import SubprocessRouteTable as routes
+from ray.dashboard.subprocesses.module import SubprocessModule
 
-routes = optional_utils.DashboardHeadRouteTable
+import logging
+
+logger = logging.getLogger(__name__)
 
 
-class HealthzHead(dashboard_utils.DashboardHeadModule):
+class HealthzHead(SubprocessModule):
     """Health check in the head.
 
     This module adds health check related endpoint to the head to check
-    GCS's heath.
+    GCS's health.
     """
 
-    def __init__(self, config: dashboard_utils.DashboardHeadModuleConfig):
-        super().__init__(config)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self._health_checker = HealthChecker(self.gcs_aio_client)
 
     @routes.get("/api/gcs_healthz")
@@ -32,10 +34,3 @@ class HealthzHead(dashboard_utils.DashboardHeadModule):
             return HTTPServiceUnavailable(reason=f"Health check failed: {e}")
 
         return HTTPServiceUnavailable(reason="Health check failed")
-
-    async def run(self, server):
-        pass
-
-    @staticmethod
-    def is_minimal_module():
-        return True

--- a/python/ray/dashboard/subprocesses/handle.py
+++ b/python/ray/dashboard/subprocesses/handle.py
@@ -16,6 +16,7 @@ from ray.dashboard.subprocesses.module import (
 from ray.dashboard.subprocesses.utils import (
     module_logging_filename,
     ResponseType,
+    get_socket_path,
 )
 
 """
@@ -116,14 +117,18 @@ class SubprocessModuleHandle:
         """
         Start the module. Should be non-blocking.
         """
+        if not os.path.exists(self.config.socket_dir):
+            os.makedirs(self.config.socket_dir)
         self.process = self.mp_context.Process(
             target=run_module,
             args=(
                 self.module_cls,
                 self.config,
+                self.incarnation,
                 self.process_ready_event,
             ),
             daemon=True,
+            name=f"{self.module_cls.__name__}-{self.incarnation}",
         )
         self.process.start()
 
@@ -134,9 +139,7 @@ class SubprocessModuleHandle:
         """
         self.process_ready_event.wait()
 
-        socket_path = os.path.join(
-            self.config.socket_dir, "dashboard_" + self.module_cls.__name__
-        )
+        socket_path = get_socket_path(self.config.socket_dir, self.module_cls.__name__)
         if sys.platform == "win32":
             connector = aiohttp.NamedPipeConnector(socket_path)
         else:

--- a/python/ray/dashboard/subprocesses/handle.py
+++ b/python/ray/dashboard/subprocesses/handle.py
@@ -17,6 +17,7 @@ from ray.dashboard.subprocesses.utils import (
     module_logging_filename,
     ResponseType,
     get_socket_path,
+    get_named_pipe_path,
 )
 
 """
@@ -139,10 +140,12 @@ class SubprocessModuleHandle:
         """
         self.process_ready_event.wait()
 
-        socket_path = get_socket_path(self.config.socket_dir, self.module_cls.__name__)
+        module_name = self.module_cls.__name__
         if sys.platform == "win32":
-            connector = aiohttp.NamedPipeConnector(socket_path)
+            named_pipe_path = get_named_pipe_path(module_name)
+            connector = aiohttp.NamedPipeConnector(named_pipe_path)
         else:
+            socket_path = get_socket_path(self.config.socket_dir, module_name)
             connector = aiohttp.UnixConnector(socket_path)
         self.http_client_session = aiohttp.ClientSession(connector=connector)
 

--- a/python/ray/dashboard/subprocesses/module.py
+++ b/python/ray/dashboard/subprocesses/module.py
@@ -113,7 +113,7 @@ class SubprocessModule(abc.ABC):
                 )
             )
         app.add_routes(routes)
-        runner = aiohttp.web.AppRunner(app)
+        runner = aiohttp.web.AppRunner(app, access_log=None)
         await runner.setup()
 
         socket_path = get_socket_path(self._config.socket_dir, self.__class__.__name__)

--- a/python/ray/dashboard/subprocesses/tests/test_e2e.py
+++ b/python/ray/dashboard/subprocesses/tests/test_e2e.py
@@ -24,6 +24,8 @@ def default_module_config(tmp_path) -> SubprocessModuleConfig:
     Creates a tmpdir to hold the logs.
     """
     yield SubprocessModuleConfig(
+        cluster_id_hex="test_cluster_id",
+        gcs_address="",
         logging_level=ray_constants.LOGGER_LEVEL,
         logging_format=ray_constants.LOGGER_FORMAT,
         log_dir=str(tmp_path),
@@ -228,6 +230,44 @@ async def test_logging_in_module(aiohttp_client, default_module_config):
     assert all(
         (file_name, content) in matches for (file_name, content) in expected_logs
     ), f"Expected to contain {expected_logs}, got {matches}"
+
+
+async def test_logging_in_module_with_multiple_incarnations(
+    aiohttp_client, default_module_config
+):
+    app = await start_http_server_app(default_module_config, [TestModule])
+    client = await aiohttp_client(app)
+
+    response = await client.post(
+        "/logging_in_module", data=b"this is from incarnation 0"
+    )
+    assert response.status == 200
+    assert await response.text() == "done!"
+
+    response = await client.post("/kill_self", data=b"")
+    assert response.status == 500
+    assert (
+        await response.text()
+        == "500 Internal Server Error\n\nServer got itself in trouble"
+    )
+
+    async def verify():
+        response = await client.post(
+            "/logging_in_module", data=b"and this is from incarnation 1"
+        )
+        assert response.status == 200
+        assert await response.text() == "done!"
+        return True
+
+    await async_wait_for_condition(verify)
+
+    log_file_path = (
+        pathlib.Path(default_module_config.log_dir) / "dashboard_TestModule.log"
+    )
+    with log_file_path.open("r") as f:
+        log_file_content = f.read()
+    assert "In /logging_in_module, this is from incarnation 0." in log_file_content
+    assert "In /logging_in_module, and this is from incarnation 1." in log_file_content
 
 
 if __name__ == "__main__":

--- a/python/ray/dashboard/subprocesses/tests/utils.py
+++ b/python/ray/dashboard/subprocesses/tests/utils.py
@@ -22,7 +22,8 @@ class TestModule(SubprocessModule):
         super().__init__(*args, **kwargs)
         self.run_finished = False
 
-    async def init(self):
+    async def run(self):
+        await super().run()
         logger.info("TestModule is initing")
         self.run_finished = True
         await asyncio.sleep(0.1)
@@ -129,9 +130,6 @@ class TestModule1(SubprocessModule):
     """
     For some reason you can't put this inline with the pytest that calls pytest.main.
     """
-
-    async def init(self):
-        pass
 
     @property
     def gcs_aio_client(self):

--- a/python/ray/dashboard/subprocesses/utils.py
+++ b/python/ray/dashboard/subprocesses/utils.py
@@ -1,6 +1,7 @@
 import os
 import enum
 from typing import TypeVar
+from ray._private.utils import validate_socket_filepath
 
 K = TypeVar("K")
 V = TypeVar("V")
@@ -15,14 +16,24 @@ class ResponseType(enum.Enum):
 def module_logging_filename(module_name: str, logging_filename: str) -> str:
     """
     Parse logging_filename = STEM EXTENSION,
-    return STEM _ MODULE_NAME EXTENSION
+    return STEM _ MODULE_NAME _ EXTENSION
+
+    If logging_filename is empty, return "stderr"
 
     Example:
     module_name = "TestModule"
     logging_filename = "dashboard.log"
     STEM = "dashboard"
     EXTENSION = ".log"
-    return "dashboard-TestModule.log"
+    return "dashboard_TestModule.log"
     """
+    if not logging_filename:
+        return "stderr"
     stem, extension = os.path.splitext(logging_filename)
     return f"{stem}_{module_name}{extension}"
+
+
+def get_socket_path(socket_dir: str, module_name: str) -> str:
+    socket_path = os.path.join(socket_dir, "dash_" + module_name)
+    validate_socket_filepath(socket_path)
+    return socket_path

--- a/python/ray/dashboard/subprocesses/utils.py
+++ b/python/ray/dashboard/subprocesses/utils.py
@@ -37,3 +37,7 @@ def get_socket_path(socket_dir: str, module_name: str) -> str:
     socket_path = os.path.join(socket_dir, "dash_" + module_name)
     validate_socket_filepath(socket_path)
     return socket_path
+
+
+def get_named_pipe_path(module_name: str) -> str:
+    return r"\\.\pipe\dash_" + module_name

--- a/python/ray/dashboard/tests/test_dashboard.py
+++ b/python/ray/dashboard/tests/test_dashboard.py
@@ -56,6 +56,7 @@ try:
     import ray.dashboard.optional_utils as dashboard_optional_utils
 
     head_routes = dashboard_optional_utils.DashboardHeadRouteTable
+    from ray.dashboard.subprocesses.module import SubprocessModule
 except Exception:
     pass
 
@@ -1155,7 +1156,8 @@ def test_dashboard_requests_fail_on_missing_deps(ray_start_regular):
     os.environ.get("RAY_DEFAULT") != "1",
     reason="This test only works for default installation.",
 )
-def test_dashboard_module_load(tmpdir):
+@pytest.mark.asyncio
+async def test_dashboard_module_load(tmpdir):
     """Verify if the head module can load only selected modules."""
     head = DashboardHead(
         http_host="127.0.0.1",
@@ -1166,6 +1168,11 @@ def test_dashboard_module_load(tmpdir):
         cluster_id_hex=ray.ClusterID.from_random().hex(),
         grpc_port=0,
         log_dir=str(tmpdir),
+        logging_level=ray_constants.LOGGER_LEVEL,
+        logging_format=ray_constants.LOGGER_FORMAT,
+        logging_filename=dashboard_consts.DASHBOARD_LOG_FILENAME,
+        logging_rotate_bytes=ray_constants.LOGGING_ROTATE_BYTES,
+        logging_rotate_backup_count=ray_constants.LOGGING_ROTATE_BACKUP_COUNT,
         temp_dir=str(tmpdir),
         session_dir=str(tmpdir),
         minimal=False,
@@ -1174,25 +1181,34 @@ def test_dashboard_module_load(tmpdir):
 
     # Test basic.
     loaded_modules_expected = {"UsageStatsHead", "JobHead"}
-    loaded_modules = head._load_modules(modules_to_load=loaded_modules_expected)
-    loaded_modules_actual = {type(m).__name__ for m in loaded_modules}
-    assert loaded_modules_actual == loaded_modules_expected
+    dashboard_head_modules, subprocess_module_handles = head._load_modules(
+        modules_to_load=loaded_modules_expected
+    )
+    assert {type(m).__name__ for m in dashboard_head_modules} == loaded_modules_expected
+    assert len(subprocess_module_handles) == 0
 
     # Test modules that don't exist.
     loaded_modules_expected = {"StateHea"}
     with pytest.raises(AssertionError):
-        loaded_modules = head._load_modules(modules_to_load=loaded_modules_expected)
+        head._load_modules(modules_to_load=loaded_modules_expected)
 
     # Test the base case.
     # It is needed to pass assertion check from one of modules.
     gcs_client = MagicMock()
     _initialize_internal_kv(gcs_client)
-    loaded_modules_expected = {
+    loaded_dashboard_head_modules_expected = {
         m.__name__ for m in dashboard_utils.get_all_modules(DashboardHeadModule)
     }
-    loaded_modules = head._load_modules()
-    loaded_modules_actual = {type(m).__name__ for m in loaded_modules}
-    assert loaded_modules_actual == loaded_modules_expected
+    loaded_subprocess_module_handles_expected = {
+        m.__name__ for m in dashboard_utils.get_all_modules(SubprocessModule)
+    }
+    dashboard_head_modules, subprocess_module_handles = head._load_modules()
+    assert {
+        type(m).__name__ for m in dashboard_head_modules
+    } == loaded_dashboard_head_modules_expected
+    assert {
+        m.module_cls.__name__ for m in subprocess_module_handles
+    } == loaded_subprocess_module_handles_expected
 
 
 @pytest.mark.skipif(
@@ -1212,6 +1228,11 @@ def test_extra_prom_headers_validation(tmpdir, monkeypatch):
         cluster_id_hex=ray.ClusterID.from_random().hex(),
         grpc_port=0,
         log_dir=str(tmpdir),
+        logging_level=ray_constants.LOGGER_LEVEL,
+        logging_format=ray_constants.LOGGER_FORMAT,
+        logging_filename=dashboard_consts.DASHBOARD_LOG_FILENAME,
+        logging_rotate_bytes=ray_constants.LOGGING_ROTATE_BYTES,
+        logging_rotate_backup_count=ray_constants.LOGGING_ROTATE_BACKUP_COUNT,
         temp_dir=str(tmpdir),
         session_dir=str(tmpdir),
         minimal=False,

--- a/python/ray/tests/test_tempfile.py
+++ b/python/ray/tests/test_tempfile.py
@@ -118,7 +118,7 @@ def test_raylet_tempfiles(shutdown_only):
     assert log_files.issuperset(log_files_expected)
 
     socket_files = set(os.listdir(node.get_sockets_dir_path()))
-    assert socket_files == expected_socket_files
+    assert socket_files.issuperset(expected_socket_files)
     ray.shutdown()
 
     ray.init(num_cpus=2)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR reapplies https://github.com/ray-project/ray/pull/51282. (Commit https://github.com/ray-project/ray/pull/51523/commits/b82ae16aaef5a4d4bf9559f1cd9ffea0d914c044)

https://github.com/ray-project/ray/pull/51282 was reverted by https://github.com/ray-project/ray/pull/51512 because postmerge CI failed for all Windows tests.

This PR fixes this issue by constructing the correct named pipe path using the `get_named_pipe_path` function. (Commit https://github.com/ray-project/ray/pull/51523/commits/6269b42314c3b32b59fa8877c16fda6475363f33)

This PR also improves some of the log messages for subprocess modules:

1. Currently we send the healthz requests from parent to each child periodically and the child logs is full of
```
025-03-18 07:52:07,721 INFO web_log.py:206 --  [18/Mar/2025:14:52:07 +0000] "GET /api/healthz HTTP/1.1" 200 163 "-" "Python/3.9 aiohttp/3.8.6"
2025-03-18 07:52:08,725 INFO web_log.py:206 --  [18/Mar/2025:14:52:08 +0000] "GET /api/healthz HTTP/1.1" 200 163 "-" "Python/3.9 aiohttp/3.8.6"
2025-03-18 07:52:09,729 INFO web_log.py:206 --  [18/Mar/2025:14:52:09 +0000] "GET /api/healthz HTTP/1.1" 200 163 "-" "Python/3.9 aiohttp/3.8.6"
```
This PR disables them because they are too spammy. It is disabled by passing `access_log=None` to `AppRunner`. (Commit https://github.com/ray-project/ray/pull/51523/commits/980e698feecdda441bd702d4729552e63eaa0ad3)

2. In the log file, if the parent process died and the child process detected it, it'll print the following log.

```
2025-03-18 07:52:42,606 WARNING module.py:71 -- Parent process 64325 died. Exiting...
2025-03-18 07:52:42,631 ERROR base_events.py:1753 -- Task exception was never retrieved
future: <Task finished name='Task-2' coro=<SubprocessModule._detect_parent_process_death() done, defined at /Users/jjyao/Workspace/ray1/python/ray/dashboard/subprocesses/module.py:65> exception=SystemExit()>
Traceback (most recent call last):
  File "/Users/jjyao/anaconda3/envs/ray/lib/python3.9/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/Users/jjyao/anaconda3/envs/ray/lib/python3.9/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/jjyao/Workspace/ray1/python/ray/dashboard/subprocesses/module.py", line 213, in run_module
    loop.run_forever()
  File "/Users/jjyao/anaconda3/envs/ray/lib/python3.9/asyncio/base_events.py", line 601, in run_forever
    self._run_once()
  File "/Users/jjyao/anaconda3/envs/ray/lib/python3.9/asyncio/base_events.py", line 1905, in _run_once
    handle._run()
  File "/Users/jjyao/anaconda3/envs/ray/lib/python3.9/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "/Users/jjyao/Workspace/ray1/python/ray/dashboard/subprocesses/module.py", line 74, in _detect_parent_process_death
    sys.exit()
SystemExit
```
This PR removes the traceback for `SystemExit`. It is removed by moving `sys.exit` to the done callback for the asyncio task. (Commit https://github.com/ray-project/ray/pull/51523/commits/aed94b08528f335d3e7813350c0b08bd492b803a)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
