### PR TITLE
[train] mark `RunAttempt` workers as dead after completion

### DIFF
--- a/python/ray/train/v2/tests/test_state.py
+++ b/python/ray/train/v2/tests/test_state.py
@@ -416,8 +416,16 @@ def test_callback_worker_group_lifecycle(
 def test_callback_worker_group_error(
     ray_start_regular, callback, mock_worker_group, mock_worker_group_context
 ):
+    state_actor = get_state_actor()
+
     callback.before_worker_group_start(mock_worker_group_context)
     callback.after_worker_group_start(mock_worker_group)
+
+    attempts = ray.get(state_actor.get_train_run_attempts.remote())
+    attempt = list(attempts.values())[0]["attempt_1"]
+    assert attempt.status == RunAttemptStatus.RUNNING
+    assert len(attempt.workers) == 1
+    assert attempt.workers[0].status == ActorStatus.ALIVE
 
     # Simulate error in worker group
     error_msg = "Test error"
@@ -428,12 +436,13 @@ def test_callback_worker_group_error(
 
     callback.before_worker_group_shutdown(mock_worker_group)
 
-    state_actor = get_state_actor()
     attempts = ray.get(state_actor.get_train_run_attempts.remote())
     attempt = list(attempts.values())[0]["attempt_1"]
     assert attempt.status == RunAttemptStatus.ERRORED
     assert attempt.status_detail == error_msg
     assert attempt.end_time_ns is not None
+    assert len(attempt.workers) == 1
+    assert attempt.workers[0].status == ActorStatus.DEAD
 
 
 def test_callback_log_file_paths(

--- a/python/ray/train/v2/tests/test_state.py
+++ b/python/ray/train/v2/tests/test_state.py
@@ -303,6 +303,8 @@ def test_train_state_manager_run_attempt_lifecycle(ray_start_regular):
     attempt = attempts["test_run"]["attempt_1"]
     assert attempt.status == RunAttemptStatus.FINISHED
     assert attempt.end_time_ns is not None
+    assert len(attempt.workers) == 2
+    assert all(w.status == ActorStatus.DEAD for w in attempt.workers)
 
 
 def test_callback_controller_state_transitions(ray_start_regular, callback):


### PR DESCRIPTION
After a `RunAttempt` reaches a terminal state (`FINISHED`, `ERRORED`, `ABORTED`), mark the `TrainWorker`s as `DEAD`.

Introduces a `_mark_workers_dead` util that modifies the state of the workers in-place.

Note that in the future we may want to query the live state of each actor, but for now there is no scenario where the `RunAttempt` is non-terminal and has partially `DEAD` workers.

## Testing

Ran a script that results in an `ERRORED` attempt and a `FINISHED` attempt. Verified that both mark the workers as `DEAD`.

```bash
RAY_TRAIN_ENABLE_STATE_TRACKING=1 RAY_TRAIN_V2_ENABLED=1 RAY_enable_export_api_write=1 python dead_actors.py
```

```bash
cat /tmp/ray/session_latest/logs/export_events/event_EXPORT_TRAIN_STATE.log | jq -c 'select(.source_type == "EXPORT_TRAIN_RUN_ATTEMPT") | {attempt_id: .event_data.attempt_id, status: .event_data.status, workers: [.event_data.workers[] | {world_rank, status}]}'
{"attempt_id":"01602bc1cffd4419a6f9ac2594f054f6","status":"PENDING","workers":[]}
{"attempt_id":"01602bc1cffd4419a6f9ac2594f054f6","status":"RUNNING","workers":[{"world_rank":0,"status":"ALIVE"},{"world_rank":1,"status":"ALIVE"}]}
{"attempt_id":"01602bc1cffd4419a6f9ac2594f054f6","status":"ERRORED","workers":[{"world_rank":0,"status":"DEAD"},{"world_rank":1,"status":"DEAD"}]}
{"attempt_id":"c9826fe2e0da4b679096bdfa89e49fe2","status":"PENDING","workers":[]}
{"attempt_id":"c9826fe2e0da4b679096bdfa89e49fe2","status":"RUNNING","workers":[{"world_rank":0,"status":"ALIVE"},{"world_rank":1,"status":"ALIVE"}]}
{"attempt_id":"c9826fe2e0da4b679096bdfa89e49fe2","status":"FINISHED","workers":[{"world_rank":0,"status":"DEAD"},{"world_rank":1,"status":"DEAD"}]}
```


## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
