### PR TITLE
[train] fix print redirection new line

### DIFF
--- a/python/ray/train/v2/_internal/logging/patch_print.py
+++ b/python/ray/train/v2/_internal/logging/patch_print.py
@@ -41,7 +41,7 @@ def redirected_print(*objects, sep=" ", end="\n", file=None, flush=False):
         return _original_print(objects, sep=sep, end=end, file=file, flush=flush)
 
     root_logger = logging.getLogger()
-    message = sep.join(map(str, objects)) + end
+    message = sep.join(map(str, objects))
     # Use the original `print` method for the scope of the logger call, in order to
     # avoid infinite recursion errors if any exceptions get raised (since exception
     # handling involves another `print(..., file=sys.stderr)`.

--- a/python/ray/train/v2/tests/test_logging.py
+++ b/python/ray/train/v2/tests/test_logging.py
@@ -147,7 +147,8 @@ def test_worker_app_print_redirect(worker_logging, context):
     print("ham")
 
     log_contents = get_file_contents(f"ray-train-app-worker-{worker_id}.log")
-    assert "ham" in log_contents
+    assert "ham" in log_contents, log_contents
+    assert "ham\\n" not in log_contents, log_contents
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes an issue where print patching logic adds a newline `\n` suffix, which is not needed when redirecting to logging.

## Test

```python
from ray.train.v2.api.data_parallel_trainer import DataParallelTrainer

def train_func():
    print("Hello, world!")

trainer = DataParallelTrainer(train_func)
trainer.fit()
```

### Before
```bash
(TrainController pid=50261) Attempting to start training worker group of size 1 with the following resources: [{'CPU': 1}] * 1
(RayTrainWorker pid=50264) Hello, world!
(RayTrainWorker pid=50264) 
```

```bash
cat /tmp/ray/session_latest/logs/train/ray-train-app-worker-9b30c2310bbf600bdca06e4522c2588fad68e5c647778354ca450c46.log | jq .message
"Hello, world!\n"
```

### After
```bash
(TrainController pid=50818) Attempting to start training worker group of size 1 with the following resources: [{'CPU': 1}] * 1
(RayTrainWorker pid=50821) Hello, world!
```

```bash
cat /tmp/ray/session_latest/logs/train/ray-train-app-worker-a9cc301f5f7211c6336ccd30db1681515520d712b7ea4329ecef4970.log | jq .message
"Hello, world!"
```
