### PR TITLE
[Feat][Core/Dashboard] Redirect child process stdout and stderr to dashboard_[module_name].err

### DIFF
--- a/python/ray/dashboard/subprocesses/module.py
+++ b/python/ray/dashboard/subprocesses/module.py
@@ -12,6 +12,7 @@ import ray
 from ray._private.gcs_utils import GcsAioClient
 from ray.dashboard.subprocesses.utils import (
     module_logging_filename,
+    setup_err_logging,
     get_socket_path,
     get_named_pipe_path,
 )
@@ -197,8 +198,10 @@ def run_module(
         backup_count=config.logging_rotate_backup_count,
     )
 
+    setup_err_logging(module_name, config.log_dir, config.logging_filename)
+
     loop = asyncio.new_event_loop()
-    loop.create_task(
+    task = loop.create_task(
         run_module_inner(
             cls,
             config,
@@ -217,4 +220,5 @@ def run_module(
 
     ray._private.utils.set_sigterm_handler(sigterm_handler)
 
+    loop.run_until_complete(task)
     loop.run_forever()

--- a/python/ray/dashboard/subprocesses/module.py
+++ b/python/ray/dashboard/subprocesses/module.py
@@ -4,15 +4,17 @@ import aiohttp
 import inspect
 import logging
 import sys
+import os
 from dataclasses import dataclass
 import setproctitle
 import multiprocessing
 
 import ray
 from ray._private.gcs_utils import GcsAioClient
+from ray._private.ray_logging import configure_log_file
+from ray._private.utils import open_log
 from ray.dashboard.subprocesses.utils import (
     module_logging_filename,
-    setup_err_logging,
     get_socket_path,
     get_named_pipe_path,
 )
@@ -198,7 +200,11 @@ def run_module(
         backup_count=config.logging_rotate_backup_count,
     )
 
-    setup_err_logging(module_name, config.log_dir, config.logging_filename)
+    stderr_filename = module_logging_filename(
+        module_name, config.logging_filename, is_stderr=True
+    )
+    err_file = open_log(os.path.join(config.log_dir, stderr_filename), unbuffered=True)
+    configure_log_file(err_file, err_file)
 
     loop = asyncio.new_event_loop()
     task = loop.create_task(

--- a/python/ray/dashboard/subprocesses/tests/test_e2e.py
+++ b/python/ray/dashboard/subprocesses/tests/test_e2e.py
@@ -231,6 +231,17 @@ async def test_logging_in_module(aiohttp_client, default_module_config):
         (file_name, content) in matches for (file_name, content) in expected_logs
     ), f"Expected to contain {expected_logs}, got {matches}"
 
+    # Assert that stdout and stderr are logged to "dashboard.TestModule.err"
+    err_log_file_path = (
+        pathlib.Path(default_module_config.log_dir) / "dashboard_TestModule.err"
+    )
+    with err_log_file_path.open("r") as f:
+        err_log_file_content = f.read()
+    assert (
+        err_log_file_content
+        == "In /logging_in_module, stdout\nIn /logging_in_module, stderr\n"
+    )
+
 
 async def test_logging_in_module_with_multiple_incarnations(
     aiohttp_client, default_module_config

--- a/python/ray/dashboard/subprocesses/tests/utils.py
+++ b/python/ray/dashboard/subprocesses/tests/utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import sys
 import signal
 from typing import AsyncIterator
 
@@ -116,6 +117,8 @@ class TestModule(SubprocessModule):
     async def logging_in_module(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
         request_body_str = await req.text()
         logger.info(f"In /logging_in_module, {request_body_str}.")
+        print("In /logging_in_module, stdout")
+        print("In /logging_in_module, stderr", file=sys.stderr)
         return aiohttp.web.Response(text="done!")
 
     @routes.post("/kill_self")

--- a/python/ray/dashboard/subprocesses/utils.py
+++ b/python/ray/dashboard/subprocesses/utils.py
@@ -1,3 +1,5 @@
+import sys
+import io
 import os
 import enum
 from typing import TypeVar
@@ -13,12 +15,14 @@ class ResponseType(enum.Enum):
     WEBSOCKET = "websocket"
 
 
-def module_logging_filename(module_name: str, logging_filename: str) -> str:
+def module_logging_filename(
+    module_name: str, logging_filename: str, is_stderr=False
+) -> str:
     """
     Parse logging_filename = STEM EXTENSION,
     return STEM _ MODULE_NAME _ EXTENSION
 
-    If logging_filename is empty, return "stderr"
+    If is_stderr is True, EXTENSION is ".err"
 
     Example:
     module_name = "TestModule"
@@ -27,10 +31,27 @@ def module_logging_filename(module_name: str, logging_filename: str) -> str:
     EXTENSION = ".log"
     return "dashboard_TestModule.log"
     """
-    if not logging_filename:
-        return "stderr"
     stem, extension = os.path.splitext(logging_filename)
+    if is_stderr:
+        extension = ".err"
     return f"{stem}_{module_name}{extension}"
+
+
+def setup_err_logging(module_name: str, log_dir: str, logging_filename: str):
+    """
+    Redirect stdout and stderr to a file in log_dir with the name
+    """
+    stderr_filename = module_logging_filename(
+        module_name, logging_filename, is_stderr=True
+    )
+    err_file = open(os.path.join(log_dir, stderr_filename), "wb", buffering=0)
+    err_file_io_wrapper = io.TextIOWrapper(err_file, write_through=True)
+    orig_stdout_fileno = sys.stdout.fileno()
+    orig_stderr_fileno = sys.stderr.fileno()
+    sys.stdout = err_file_io_wrapper
+    os.dup2(err_file.fileno(), orig_stdout_fileno)
+    sys.stderr = err_file_io_wrapper
+    os.dup2(err_file.fileno(), orig_stderr_fileno)
 
 
 def get_socket_path(socket_dir: str, module_name: str) -> str:

--- a/python/ray/dashboard/subprocesses/utils.py
+++ b/python/ray/dashboard/subprocesses/utils.py
@@ -1,5 +1,3 @@
-import sys
-import io
 import os
 import enum
 from typing import TypeVar
@@ -35,23 +33,6 @@ def module_logging_filename(
     if is_stderr:
         extension = ".err"
     return f"{stem}_{module_name}{extension}"
-
-
-def setup_err_logging(module_name: str, log_dir: str, logging_filename: str):
-    """
-    Redirect stdout and stderr to a file in log_dir with the name
-    """
-    stderr_filename = module_logging_filename(
-        module_name, logging_filename, is_stderr=True
-    )
-    err_file = open(os.path.join(log_dir, stderr_filename), "wb", buffering=0)
-    err_file_io_wrapper = io.TextIOWrapper(err_file, write_through=True)
-    orig_stdout_fileno = sys.stdout.fileno()
-    orig_stderr_fileno = sys.stderr.fileno()
-    sys.stdout = err_file_io_wrapper
-    os.dup2(err_file.fileno(), orig_stdout_fileno)
-    sys.stderr = err_file_io_wrapper
-    os.dup2(err_file.fileno(), orig_stderr_fileno)
 
 
 def get_socket_path(socket_dir: str, module_name: str) -> str:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR redirects the unexpected stdout and stderr of the child process in the dashboard subprocess module to `dashboard_[module_name].err`.

stdout is also redirected to match the behavior of the original dashboard.

See https://github.com/ray-project/ray/blob/32cf6328967b662137e18807ec902da14dc37ba9/python/ray/_private/node.py#L1159-L1180 for details (`create_out` is `False`, and `stderr_file` is passed to both `stdout_file` and `stderr_file` arguments for `start_api_server`).
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
