### PR TITLE
[Data] Refactor `test_ray_remote_args_fn`

### DIFF
--- a/python/ray/data/tests/test_consumption.py
+++ b/python/ray/data/tests/test_consumption.py
@@ -246,54 +246,32 @@ def test_avoid_placement_group_capture(shutdown_only):
     )
 
 
-def test_ray_remote_args_fn(shutdown_only):
+@pytest.fixture
+def remove_named_placement_groups():
+    yield
+    for info in ray.util.placement_group_table().values():
+        if info["name"]:
+            pg = ray.util.get_placement_group(info["name"])
+            ray.util.remove_placement_group(pg)
+
+
+def test_ray_remote_args_fn(shutdown_only, remove_named_placement_groups):
     ray.init()
 
-    global_idx = 1
-    placement_groups = []
+    pg = ray.util.placement_group([{"CPU": 1}], name="test_pg")
 
-    def _generate_ray_remote_args_with_scheduling_strategy():
-        nonlocal placement_groups
-        pg = ray.util.placement_group([{"CPU": global_idx}])
-        placement_groups.append(pg)
-
+    def ray_remote_args_fn():
         scheduling_strategy = PlacementGroupSchedulingStrategy(placement_group=pg)
         return {"scheduling_strategy": scheduling_strategy}
 
     class ActorClass:
-        def __init__(self):
-            # Each time a new actor is created with ActorClass,
-            # global_idx is incremented, and the number of CPUs in its
-            # placement group should match the saved self._idx value.
-            nonlocal global_idx
-            self._idx = global_idx
-            global_idx += 1
-
         def __call__(self, batch):
-            pg = ray.util.get_current_placement_group()
-            if global_idx > 0:
-                assert pg.bundle_specs == [{"CPU": self._idx}]
-            else:
-                assert pg is not None
+            assert ray.util.get_current_placement_group() == pg
             return batch
 
-    ray.data.range(10).map_batches(
-        ActorClass,
-        concurrency=3,
-        ray_remote_args_fn=_generate_ray_remote_args_with_scheduling_strategy,
+    ray.data.range(1).map_batches(
+        ActorClass, concurrency=1, ray_remote_args_fn=ray_remote_args_fn
     ).take_all()
-
-    global_idx = -10
-    with pytest.raises(ValueError):  # cannot use -10 for pg
-        ray.data.range(10).map_batches(
-            ActorClass,
-            concurrency=3,
-            ray_remote_args_fn=_generate_ray_remote_args_with_scheduling_strategy,
-        ).take_all()
-
-    # Be sure to remove placement groups after use.
-    for pg in placement_groups:
-        ray.util.remove_placement_group(pg)
 
 
 def test_dataset_lineage_serialization(shutdown_only):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`test_ray_remote_args_fn` is brittle:
1. The test explicitly cleans up placement groups only if the test succeeds.
2. The test creates a placement group every time the user-provided `ray_remote_args_fn` is called. So, if the function is called before execution starts, there might not be enough resources to execute the pipeline.

It's also incorrect:
* I think it assumes that `global_idx` is shared between actors, but because each actor is run on a separate process, it's not actually global

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
