### PR TITLE
[ci] add option to disable test db querying for flaky tests

### DIFF
--- a/.buildkite/others.rayci.yml
+++ b/.buildkite/others.rayci.yml
@@ -41,6 +41,18 @@ steps:
         --skip-ray-installation
     depends_on: doctestbuild
 
+  - label: failing doc tests
+    instance_type: large
+    soft_fail: true
+    commands:
+      # doc tests
+      - RAYCI_DISABLE_TEST_DB=1 bazel run //ci/ray_ci:test_in_docker -- //doc:doctest none
+        --build-name doctestbuild
+        --only-tags doctest
+        --except-tags gpu
+        --parallelism-per-worker 3
+    depends_on: doctestbuild
+
   # java
   - label: ":java: java tests"
     tags: java

--- a/ci/ray_ci/test_tester.py
+++ b/ci/ray_ci/test_tester.py
@@ -123,6 +123,7 @@ def test_get_test_targets() -> None:
             "//python/ray/tests:good_test_02",
             "//python/ray/tests:good_test_03",
             "//python/ray/tests:flaky_test_01",
+            "//python/ray/tests:flaky_test_02",
         ]
         test_objects = [
             _stub_test(
@@ -136,6 +137,14 @@ def test_get_test_targets() -> None:
             _stub_test(
                 {
                     "name": "linux://python/ray/tests:flaky_test_01",
+                    "team": "core",
+                    "state": TestState.FLAKY,
+                    Test.KEY_IS_HIGH_IMPACT: "true",
+                }
+            ),
+            _stub_test(
+                {
+                    "name": "linux://python/ray/tests:flaky_test_02",
                     "team": "core",
                     "state": TestState.FLAKY,
                     Test.KEY_IS_HIGH_IMPACT: "true",
@@ -173,6 +182,23 @@ def test_get_test_targets() -> None:
                 "//python/ray/tests:good_test_03",
             }
 
+            assert set(
+                _get_test_targets(
+                    LinuxTesterContainer("core"),
+                    "targets",
+                    "core",
+                    operating_system="linux",
+                    yaml_dir=tmp,
+                    lookup_test_database=False,
+                )
+            ) == {
+                "//python/ray/tests:high_impact_test_01",
+                "//python/ray/tests:good_test_01",
+                "//python/ray/tests:good_test_02",
+                "//python/ray/tests:good_test_03",
+                "//python/ray/tests:flaky_test_02",
+            }
+
             assert _get_test_targets(
                 LinuxTesterContainer("core"),
                 "targets",
@@ -182,6 +208,7 @@ def test_get_test_targets() -> None:
                 get_flaky_tests=True,
             ) == [
                 "//python/ray/tests:flaky_test_01",
+                "//python/ray/tests:flaky_test_02",
             ]
 
             assert _get_test_targets(
@@ -206,6 +233,7 @@ def test_get_test_targets() -> None:
                 get_high_impact_tests=True,
             ) == [
                 "//python/ray/tests:flaky_test_01",
+                "//python/ray/tests:flaky_test_02",
             ]
 
 
@@ -354,7 +382,12 @@ def test_get_flaky_test_targets() -> None:
                 f.write(test["input"]["core_test_yaml"])
             for os_name in ["linux", "windows"]:
                 assert (
-                    _get_flaky_test_targets("core", os_name, yaml_dir=tmp)
+                    _get_flaky_test_targets(
+                        "core",
+                        os_name,
+                        yaml_dir=tmp,
+                        lookup_test_database=True,
+                    )
                     == test["output"][os_name]
                 )
 


### PR DESCRIPTION
so that we have an easy way to remove external, hidden influence on test selection.

this also exposes the failing doc test, which is lost in the limbo because its team tag is "none".
