### PR TITLE
[core] Separate thread_pool into a new bazel target

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1137,7 +1137,6 @@ ray_cc_library(
         "src/ray/core_worker/transport/scheduling_util.cc",
         "src/ray/core_worker/transport/sequential_actor_submit_queue.cc",
         "src/ray/core_worker/transport/task_receiver.cc",
-        "src/ray/core_worker/transport/thread_pool.cc",
     ],
     hdrs = [
         "src/ray/core_worker/actor_creator.h",
@@ -1174,7 +1173,6 @@ ray_cc_library(
         "src/ray/core_worker/transport/scheduling_util.h",
         "src/ray/core_worker/transport/sequential_actor_submit_queue.h",
         "src/ray/core_worker/transport/task_receiver.h",
-        "src/ray/core_worker/transport/thread_pool.h",
     ],
     deps = [
         ":gcs",
@@ -1183,6 +1181,7 @@ ray_cc_library(
         ":ray_common",
         ":raylet_client_lib",
         ":stats_lib",
+        ":thread_pool",
         ":worker_rpc",
         "//src/ray/protobuf:worker_cc_proto",
         "//src/ray/util",
@@ -1201,6 +1200,18 @@ ray_cc_library(
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/container:node_hash_map",
         "@nlohmann_json",
+    ],
+)
+
+ray_cc_library(
+    name = "thread_pool",
+    srcs = [
+        "src/ray/core_worker/transport/thread_pool.cc",
+    ],
+    hdrs = ["src/ray/core_worker/transport/thread_pool.h"],
+    deps = [
+        "//src/ray/util:logging",
+        "@boost//:asio",
     ],
 )
 

--- a/src/ray/core_worker/transport/actor_scheduling_queue.cc
+++ b/src/ray/core_worker/transport/actor_scheduling_queue.cc
@@ -34,7 +34,7 @@ ActorSchedulingQueue::ActorSchedulingQueue(
     int64_t reorder_wait_seconds)
     : reorder_wait_seconds_(reorder_wait_seconds),
       wait_timer_(main_io_service),
-      main_thread_id_(boost::this_thread::get_id()),
+      main_thread_id_(std::this_thread::get_id()),
       waiter_(waiter),
       task_event_buffer_(task_event_buffer),
       pool_manager_(pool_manager),
@@ -86,7 +86,7 @@ void ActorSchedulingQueue::Add(
   // A seq_no of -1 means no ordering constraint. Actor tasks must be executed in order.
   RAY_CHECK(seq_no != -1);
 
-  RAY_CHECK(boost::this_thread::get_id() == main_thread_id_);
+  RAY_CHECK(std::this_thread::get_id() == main_thread_id_);
   if (client_processed_up_to >= next_seq_no_) {
     RAY_LOG(ERROR) << "client skipping requests " << next_seq_no_ << " to "
                    << client_processed_up_to;
@@ -113,7 +113,7 @@ void ActorSchedulingQueue::Add(
         rpc::TaskStatus::PENDING_ACTOR_TASK_ARGS_FETCH,
         /* include_task_info */ false));
     waiter_.Wait(dependencies, [seq_no, this]() {
-      RAY_CHECK(boost::this_thread::get_id() == main_thread_id_);
+      RAY_CHECK(std::this_thread::get_id() == main_thread_id_);
       auto it = pending_actor_tasks_.find(seq_no);
       if (it != pending_actor_tasks_.end()) {
         const TaskSpecification &task_spec = it->second.TaskSpec();
@@ -221,7 +221,7 @@ void ActorSchedulingQueue::ScheduleRequests() {
 
 /// Called when we time out waiting for an earlier task to show up.
 void ActorSchedulingQueue::OnSequencingWaitTimeout() {
-  RAY_CHECK(boost::this_thread::get_id() == main_thread_id_);
+  RAY_CHECK(std::this_thread::get_id() == main_thread_id_);
   RAY_LOG(ERROR) << "timed out waiting for " << next_seq_no_
                  << ", cancelling all queued tasks";
   while (!pending_actor_tasks_.empty()) {

--- a/src/ray/core_worker/transport/actor_scheduling_queue.h
+++ b/src/ray/core_worker/transport/actor_scheduling_queue.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <boost/thread.hpp>
 #include <map>
 #include <memory>
 #include <vector>

--- a/src/ray/core_worker/transport/actor_scheduling_queue.h
+++ b/src/ray/core_worker/transport/actor_scheduling_queue.h
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <boost/thread.hpp>
 #include <map>
 #include <memory>
+#include <thread>
 #include <vector>
 
 #include "absl/base/thread_annotations.h"
@@ -99,7 +99,7 @@ class ActorSchedulingQueue : public SchedulingQueue {
   /// io service, which is fine since it only ever fires if no tasks are running.
   boost::asio::deadline_timer wait_timer_;
   /// The id of the thread that constructed this scheduling queue.
-  boost::thread::id main_thread_id_;
+  std::thread::id main_thread_id_;
   /// Reference to the waiter owned by the task receiver.
   DependencyWaiter &waiter_;
   worker::TaskEventBuffer &task_event_buffer_;

--- a/src/ray/core_worker/transport/out_of_order_actor_scheduling_queue.cc
+++ b/src/ray/core_worker/transport/out_of_order_actor_scheduling_queue.cc
@@ -14,6 +14,7 @@
 
 #include "ray/core_worker/transport/out_of_order_actor_scheduling_queue.h"
 
+#include <boost/thread.hpp>
 #include <memory>
 #include <utility>
 #include <vector>

--- a/src/ray/core_worker/transport/out_of_order_actor_scheduling_queue.cc
+++ b/src/ray/core_worker/transport/out_of_order_actor_scheduling_queue.cc
@@ -14,8 +14,8 @@
 
 #include "ray/core_worker/transport/out_of_order_actor_scheduling_queue.h"
 
-#include <boost/thread.hpp>
 #include <memory>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -32,7 +32,7 @@ OutOfOrderActorSchedulingQueue::OutOfOrderActorSchedulingQueue(
     int fiber_max_concurrency,
     const std::vector<ConcurrencyGroup> &concurrency_groups)
     : io_service_(main_io_service),
-      main_thread_id_(boost::this_thread::get_id()),
+      main_thread_id_(std::this_thread::get_id()),
       waiter_(waiter),
       task_event_buffer_(task_event_buffer),
       pool_manager_(pool_manager),
@@ -87,7 +87,7 @@ void OutOfOrderActorSchedulingQueue::Add(
   // The reason why we don't run multiple attempts of the same
   // task concurrently is that it's not safe to assume user's
   // code can handle concurrent execution of the same actor method.
-  RAY_CHECK(boost::this_thread::get_id() == main_thread_id_);
+  RAY_CHECK(std::this_thread::get_id() == main_thread_id_);
   auto task_id = task_spec.TaskId();
   auto request = InboundRequest(std::move(accept_request),
                                 std::move(reject_request),
@@ -184,7 +184,7 @@ void OutOfOrderActorSchedulingQueue::RunRequest(InboundRequest request) {
     // Make a copy since request is going to be moved.
     auto dependencies = request.PendingDependencies();
     waiter_.Wait(dependencies, [this, request = std::move(request)]() mutable {
-      RAY_CHECK_EQ(boost::this_thread::get_id(), main_thread_id_);
+      RAY_CHECK_EQ(std::this_thread::get_id(), main_thread_id_);
 
       const TaskSpecification &task_spec = request.TaskSpec();
       RAY_UNUSED(task_event_buffer_.RecordTaskStatusEventIfNeeded(

--- a/src/ray/core_worker/transport/out_of_order_actor_scheduling_queue.h
+++ b/src/ray/core_worker/transport/out_of_order_actor_scheduling_queue.h
@@ -14,8 +14,8 @@
 
 #pragma once
 
-#include <boost/thread.hpp>
 #include <memory>
+#include <thread>
 #include <vector>
 
 #include "absl/base/thread_annotations.h"
@@ -88,7 +88,7 @@ class OutOfOrderActorSchedulingQueue : public SchedulingQueue {
 
   instrumented_io_context &io_service_;
   /// The id of the thread that constructed this scheduling queue.
-  boost::thread::id main_thread_id_;
+  std::thread::id main_thread_id_;
   /// Reference to the waiter owned by the task receiver.
   DependencyWaiter &waiter_;
   worker::TaskEventBuffer &task_event_buffer_;

--- a/src/ray/core_worker/transport/out_of_order_actor_scheduling_queue.h
+++ b/src/ray/core_worker/transport/out_of_order_actor_scheduling_queue.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <boost/thread.hpp>
 #include <memory>
 #include <vector>
 

--- a/src/ray/core_worker/transport/thread_pool.cc
+++ b/src/ray/core_worker/transport/thread_pool.cc
@@ -14,7 +14,6 @@
 
 #include "ray/core_worker/transport/thread_pool.h"
 
-#include <boost/asio/post.hpp>
 #include <memory>
 
 namespace ray {

--- a/src/ray/core_worker/transport/thread_pool.h
+++ b/src/ray/core_worker/transport/thread_pool.h
@@ -16,18 +16,11 @@
 
 #include <boost/asio/post.hpp>
 #include <boost/asio/thread_pool.hpp>
-#include <boost/thread.hpp>
-#include <list>
+#include <functional>
 #include <memory>
-#include <queue>
-#include <set>
 #include <utility>
 
-#include "absl/base/thread_annotations.h"
-#include "absl/container/flat_hash_map.h"
-#include "absl/container/flat_hash_set.h"
-#include "absl/synchronization/mutex.h"
-#include "ray/common/task/task_spec.h"
+#include "ray/util/logging.h"
 
 namespace ray {
 namespace core {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I tried to reproduce the ASAN errors in `scheduling_queue_test.cc` for #51516 by running:

```
bazel test --features=asan -c dbg //:scheduling_queue_test  --test_output=all
```

However, I got the following ODR error instead of the actual data racing error.

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/0d495f26-efaa-4586-a6ec-be1729b185da" />

It looks like we have two packages `@com_github_madler_zlib//:zlib` and `@net_zlib_zlib//:zlib` in our C++ codebase. 

```sh
bazel query --noimplicit_deps \
    'allpaths(//:scheduling_queue_test, @net_zlib_zlib//:zlib)'

# Output
//:core_worker_lib
//:scheduling_queue_test
//src/ray/util:pipe_logger
//src/ray/util:stream_redirection_utils
@boost//:iostreams
@net_zlib_zlib//:zlib
Loading: 7 packages loaded
```

My initial thought was to avoid having `scheduling_queue_test` use `@net_zlib_zlib//:zlib`, so I tried separating CoreWorker into smaller BAZEL targets. However, I found it non-trivial and eventually gave up, using the following command as a workaround.

```sh
bazel test --features=asan -c dbg //:scheduling_queue_test  --test_output=all --test_env=ASAN_OPTIONS="detect_odr_violation=0"
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
