### PR TITLE
[Feat][Core/Dashboard] Convert JobHead to subprocess module

### DIFF
--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -136,6 +136,7 @@ RAY_JOB_HEADERS = "RAY_JOB_HEADERS"
 DEFAULT_DASHBOARD_IP = "127.0.0.1"
 DEFAULT_DASHBOARD_PORT = 8265
 DASHBOARD_ADDRESS = "dashboard"
+DASHBOARD_CLIENT_MAX_SIZE = 100 * 1024**2
 PROMETHEUS_SERVICE_DISCOVERY_FILE = "prom_metrics_service_discovery.json"
 DEFAULT_DASHBOARD_AGENT_LISTEN_PORT = 52365
 # Default resource requirements for actors when no resource requirements are

--- a/python/ray/dashboard/http_server_head.py
+++ b/python/ray/dashboard/http_server_head.py
@@ -15,6 +15,7 @@ import ray
 import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.timezone_utils as timezone_utils
 import ray.dashboard.utils as dashboard_utils
+from ray import ray_constants
 from ray._common.utils import get_or_create_event_loop
 from ray._private.usage.usage_lib import TagKey, record_extra_usage_tag
 from ray.dashboard.dashboard_metrics import DashboardPrometheusMetrics
@@ -249,7 +250,7 @@ class HttpServerDashboardHead:
         # Http server should be initialized after all modules loaded.
         # working_dir uploads for job submission can be up to 100MiB.
         app = aiohttp.web.Application(
-            client_max_size=100 * 1024**2,
+            client_max_size=ray_constants.DASHBOARD_CLIENT_MAX_SIZE,
             middlewares=[
                 self.metrics_middleware,
                 self.path_clean_middleware,

--- a/python/ray/dashboard/modules/job/job_head.py
+++ b/python/ray/dashboard/modules/job/job_head.py
@@ -8,7 +8,7 @@ from typing import AsyncIterator, Dict, List, Optional, Tuple
 
 import aiohttp.web
 from aiohttp.client import ClientResponse
-from aiohttp.web import Request, Response
+from aiohttp.web import Request, Response, StreamResponse
 
 import ray
 from ray import NodeID
@@ -19,8 +19,6 @@ from ray.dashboard.consts import (
     TRY_TO_GET_AGENT_INFO_INTERVAL_SECONDS,
     WAIT_AVAILABLE_AGENT_TIMEOUT,
 )
-import ray.dashboard.optional_utils as optional_utils
-import ray.dashboard.utils as dashboard_utils
 from ray._common.utils import get_or_create_event_loop
 from ray._private.ray_constants import env_bool, KV_NAMESPACE_DASHBOARD
 from ray._private.runtime_env.packaging import (
@@ -45,11 +43,12 @@ from ray.dashboard.modules.job.utils import (
     parse_and_validate_request,
 )
 from ray.dashboard.modules.version import CURRENT_VERSION, VersionResponse
+from ray.dashboard.subprocesses.routes import SubprocessRouteTable as routes
+from ray.dashboard.subprocesses.module import SubprocessModule
+from ray.dashboard.subprocesses.utils import ResponseType
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-
-routes = optional_utils.DashboardHeadRouteTable
 
 # Feature flag controlling whether critical Ray Job control operations are performed
 # exclusively by the Job Agent running on the Head node (or randomly sampled Worker one)
@@ -146,7 +145,7 @@ class JobAgentSubmissionClient:
                 raise
 
 
-class JobHead(dashboard_utils.DashboardHeadModule):
+class JobHead(SubprocessModule):
     """Runs on the head node of a Ray cluster and handles Ray Jobs APIs.
 
     NOTE(architkulkarni): Please keep this class in sync with the OpenAPI spec at
@@ -164,9 +163,13 @@ class JobHead(dashboard_utils.DashboardHeadModule):
     # to read the logs from until then.
     WAIT_FOR_SUPERVISOR_ACTOR_INTERVAL_S = 1
 
-    def __init__(self, config: dashboard_utils.DashboardHeadModuleConfig):
-        super().__init__(config)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self._job_info_client = None
+
+        # To make sure that the internal KV is initialized by getting the lazy property
+        assert self.gcs_client is not None
+        assert ray.experimental.internal_kv._internal_kv_initialized()
 
         # It contains all `JobAgentSubmissionClient` that
         # `JobHead` has ever used, and will not be deleted
@@ -565,8 +568,10 @@ class JobHead(dashboard_utils.DashboardHeadModule):
                 status=aiohttp.web.HTTPInternalServerError.status_code,
             )
 
-    @routes.get("/api/jobs/{job_or_submission_id}/logs/tail")
-    async def tail_job_logs(self, req: Request) -> Response:
+    @routes.get(
+        "/api/jobs/{job_or_submission_id}/logs/tail", resp_type=ResponseType.WEBSOCKET
+    )
+    async def tail_job_logs(self, req: Request) -> StreamResponse:
         job_or_submission_id = req.match_info["job_or_submission_id"]
         job = await find_job_by_ids(
             self.gcs_aio_client,
@@ -624,10 +629,7 @@ class JobHead(dashboard_utils.DashboardHeadModule):
 
         return self._agents[driver_node_id]
 
-    async def run(self, server):
+    async def run(self):
+        await super().run()
         if not self._job_info_client:
             self._job_info_client = JobInfoStorageClient(self.gcs_aio_client)
-
-    @staticmethod
-    def is_minimal_module():
-        return False

--- a/python/ray/dashboard/modules/job/tests/test_http_job_server.py
+++ b/python/ray/dashboard/modules/job/tests/test_http_job_server.py
@@ -12,10 +12,12 @@ from typing import Optional, List, Union, Dict
 from unittest.mock import patch
 
 import pytest
+import requests
 import yaml
 
 import ray
 from ray import NodeID
+from ray._private.gcs_utils import GcsAioClient
 from ray._private.test_utils import (
     chdir,
     format_web_url,
@@ -23,11 +25,17 @@ from ray._private.test_utils import (
     wait_for_condition,
     wait_until_server_available,
 )
+from ray._private.runtime_env.packaging import (
+    get_uri_for_file,
+    create_package,
+    download_and_unpack_package,
+)
 from ray.dashboard.consts import (
     DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX,
     DASHBOARD_AGENT_ADDR_IP_PREFIX,
 )
 from ray.dashboard.modules.dashboard_sdk import ClusterInfo, parse_cluster_info
+from ray.dashboard.modules.job.common import uri_to_http_components
 from ray.dashboard.modules.job.job_head import JobHead
 from ray.dashboard.modules.job.pydantic_models import JobDetails
 from ray.dashboard.modules.job.tests.test_cli_integration import set_env_var
@@ -422,7 +430,10 @@ def test_http_bad_request(job_sdk_client):
     )
 
     assert r.status_code == 400
-    assert "TypeError: __init__() got an unexpected keyword argument" in r.text
+    assert (
+        "TypeError: JobSubmitRequest.__init__() got an unexpected keyword argument"
+        in r.text
+    )
 
 
 def test_invalid_runtime_env(job_sdk_client):
@@ -928,6 +939,42 @@ async def test_job_head_pick_random_job_agent(monkeypatch):
             job_agent_client = await job_head.get_target_agent()
             assert address is None or address == job_agent_client._agent_address
             address = job_agent_client._agent_address
+
+
+@pytest.mark.asyncio
+async def test_get_upload_package(ray_start_with_dashboard, tmp_path):
+    assert wait_until_server_available(ray_start_with_dashboard["webui_url"])
+    webui_url = format_web_url(ray_start_with_dashboard["webui_url"])
+    gcs_aio_client = GcsAioClient(address=ray_start_with_dashboard["gcs_address"])
+    url = webui_url + "/api/packages/{protocol}/{package_name}"
+
+    pkg_dir = tmp_path / "pkg"
+    pkg_dir.mkdir()
+    filename = "task.py"
+
+    file_content = b"Hello world"
+    with (pkg_dir / filename).open("wb") as f:
+        f.write(file_content)
+
+    package_uri = get_uri_for_file(str(pkg_dir / filename))
+    protocol, package_name = uri_to_http_components(package_uri)
+    package_file = tmp_path / package_name
+    create_package(str(pkg_dir), package_file)
+
+    resp = requests.get(url.format(protocol=protocol, package_name=package_name))
+    assert resp.status_code == 404
+
+    resp = requests.put(
+        url.format(protocol=protocol, package_name=package_name),
+        data=package_file.read_bytes(),
+    )
+    assert resp.status_code == 200
+
+    resp = requests.get(url.format(protocol=protocol, package_name=package_name))
+    assert resp.status_code == 200
+
+    await download_and_unpack_package(package_uri, str(tmp_path), gcs_aio_client)
+    assert (package_file.with_suffix("") / filename).read_bytes() == file_content
 
 
 if __name__ == "__main__":

--- a/python/ray/dashboard/modules/job/tests/test_http_job_server.py
+++ b/python/ray/dashboard/modules/job/tests/test_http_job_server.py
@@ -435,10 +435,7 @@ def test_http_bad_request(job_sdk_client):
     )
 
     assert r.status_code == 400
-    assert (
-        "TypeError: JobSubmitRequest.__init__() got an unexpected keyword argument"
-        in r.text
-    )
+    assert "__init__() got an unexpected keyword argument" in r.text
 
 
 def test_invalid_runtime_env(job_sdk_client):

--- a/python/ray/dashboard/subprocesses/module.py
+++ b/python/ray/dashboard/subprocesses/module.py
@@ -10,6 +10,7 @@ import setproctitle
 import multiprocessing
 
 import ray
+from ray import ray_constants
 from ray._raylet import GcsClient
 from ray._private.gcs_utils import GcsAioClient
 from ray._private.ray_logging import configure_log_file
@@ -100,7 +101,9 @@ class SubprocessModule(abc.ABC):
         Start running the module.
         This method should be called first before the module starts receiving requests.
         """
-        app = aiohttp.web.Application()
+        app = aiohttp.web.Application(
+            client_max_size=ray_constants.DASHBOARD_CLIENT_MAX_SIZE,
+        )
         routes: list[aiohttp.web.RouteDef] = [
             aiohttp.web.get("/api/healthz", self._internal_module_health_check)
         ]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR converts `JobHead` to subprocess module.

- Extracted the `client_max_size` argument for `aiohttp.web.Application` as a constant. This value is needed by both the child process server and the parent process proxy server. Without it, the request body for the `PUT /api/packages/{protocol}/{package_name}` route is too large and the request will fail.

## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
