### PR TITLE
[Feat][Core/Dashboard] Remove ReportEventService and replace with HTTP API

### DIFF
--- a/python/ray/dashboard/modules/event/event_agent.py
+++ b/python/ray/dashboard/modules/event/event_agent.py
@@ -6,10 +6,8 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Union
 
 import ray._private.ray_constants as ray_constants
-import ray._private.utils as utils
 import ray.dashboard.consts as dashboard_consts
 import ray.dashboard.utils as dashboard_utils
-from ray.core.generated import event_pb2, event_pb2_grpc
 from ray.dashboard.modules.event import event_consts
 from ray.dashboard.modules.event.event_utils import monitor_events
 from ray.dashboard.utils import async_loop_forever, create_task
@@ -31,7 +29,9 @@ class EventAgent(dashboard_utils.DashboardAgentModule):
         self._event_dir = os.path.join(self._dashboard_agent.log_dir, "events")
         os.makedirs(self._event_dir, exist_ok=True)
         self._monitor: Union[asyncio.Task, None] = None
-        self._stub: Union[event_pb2_grpc.ReportEventServiceStub, None] = None
+        # Lazy initialized on first use. Once initialized, it will not be
+        # changed.
+        self._dashboard_http_address = None
         self._cached_events = asyncio.Queue(event_consts.EVENT_AGENT_CACHE_SIZE)
         self._gcs_aio_client = dashboard_agent.gcs_aio_client
         # Total number of event created from this agent.
@@ -47,33 +47,27 @@ class EventAgent(dashboard_utils.DashboardAgentModule):
 
         logger.info("Event agent cache buffer size: %s", self._cached_events.maxsize)
 
-    async def _connect_to_dashboard(self):
-        """Connect to the dashboard. If the dashboard is not started, then
-        this method will never returns.
-
-        Returns:
-            The ReportEventServiceStub object.
+    async def _get_dashboard_http_address(self):
+        """
+        Lazily get the dashboard http address from InternalKV. If it's not set, sleep
+        and retry forever.
         """
         while True:
+            if self._dashboard_http_address:
+                return self._dashboard_http_address
             try:
-                dashboard_rpc_address = await self._gcs_aio_client.internal_kv_get(
-                    dashboard_consts.DASHBOARD_RPC_ADDRESS.encode(),
+                dashboard_http_address = await self._gcs_aio_client.internal_kv_get(
+                    ray_constants.DASHBOARD_ADDRESS.encode(),
                     namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
-                    timeout=1,
+                    timeout=dashboard_consts.GCS_RPC_TIMEOUT_SECONDS,
                 )
-                dashboard_rpc_address = dashboard_rpc_address.decode()
-                if dashboard_rpc_address:
-                    logger.info("Report events to %s", dashboard_rpc_address)
-                    options = ray_constants.GLOBAL_GRPC_OPTIONS
-                    channel = utils.init_grpc_channel(
-                        dashboard_rpc_address, options=options, asynchronous=True
-                    )
-                    return event_pb2_grpc.ReportEventServiceStub(channel)
+                if not dashboard_http_address:
+                    raise ValueError("Dashboard http address not found in InternalKV.")
+                self._dashboard_http_address = dashboard_http_address.decode()
+                return self._dashboard_http_address
             except Exception:
-                logger.exception("Connect to dashboard failed.")
-            await asyncio.sleep(
-                event_consts.RETRY_CONNECT_TO_DASHBOARD_INTERVAL_SECONDS
-            )
+                logger.exception("Get dashboard http address failed.")
+            await asyncio.sleep(1)
 
     @async_loop_forever(event_consts.EVENT_AGENT_REPORT_INTERVAL_SECONDS)
     async def report_events(self):
@@ -82,18 +76,22 @@ class EventAgent(dashboard_utils.DashboardAgentModule):
 
         This method will never returns.
         """
+        dashboard_http_address = await self._get_dashboard_http_address()
         data = await self._cached_events.get()
         self.total_event_reported += len(data)
         for _ in range(event_consts.EVENT_AGENT_RETRY_TIMES):
             try:
                 logger.debug("Report %s events.", len(data))
-                request = event_pb2.ReportEventsRequest(event_strings=data)
-                await self._stub.ReportEvents(request)
+                async with self._dashboard_agent.http_session.post(
+                    f"{dashboard_http_address}/report_events",
+                    json=data,
+                ) as response:
+                    response.raise_for_status()
+                    assert response.json()["success"]
                 self.total_request_sent += 1
                 break
             except Exception:
-                logger.exception("Report event failed, reconnect to the " "dashboard.")
-                self._stub = await self._connect_to_dashboard()
+                logger.exception("Report event failed, reconnect to the dashboard.")
         else:
             data_str = str(data)
             limit = event_consts.LOG_ERROR_EVENT_STRING_LENGTH_LIMIT
@@ -115,8 +113,6 @@ class EventAgent(dashboard_utils.DashboardAgentModule):
         }
 
     async def run(self, server):
-        # Connect to dashboard.
-        self._stub = await self._connect_to_dashboard()
         # Start monitor task.
         self._monitor = monitor_events(
             self._event_dir,

--- a/python/ray/dashboard/modules/event/event_agent.py
+++ b/python/ray/dashboard/modules/event/event_agent.py
@@ -87,11 +87,10 @@ class EventAgent(dashboard_utils.DashboardAgentModule):
                     json=data,
                 ) as response:
                     response.raise_for_status()
-                    assert response.json()["success"]
                 self.total_request_sent += 1
                 break
-            except Exception:
-                logger.exception("Report event failed, reconnect to the dashboard.")
+            except Exception as e:
+                logger.warning(f"Report event failed, retrying... {e}")
         else:
             data_str = str(data)
             limit = event_consts.LOG_ERROR_EVENT_STRING_LENGTH_LIMIT

--- a/python/ray/dashboard/modules/event/event_consts.py
+++ b/python/ray/dashboard/modules/event/event_consts.py
@@ -2,7 +2,6 @@ from ray._private.ray_constants import env_float, env_integer
 from ray.core.generated import event_pb2
 
 LOG_ERROR_EVENT_STRING_LENGTH_LIMIT = 1000
-RETRY_CONNECT_TO_DASHBOARD_INTERVAL_SECONDS = 2
 # Monitor events
 SCAN_EVENT_DIR_INTERVAL_SECONDS = env_integer("SCAN_EVENT_DIR_INTERVAL_SECONDS", 2)
 SCAN_EVENT_START_OFFSET_SECONDS = -30 * 60

--- a/python/ray/dashboard/modules/event/event_head.py
+++ b/python/ray/dashboard/modules/event/event_head.py
@@ -6,7 +6,7 @@ from collections import OrderedDict, defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from itertools import islice
-from typing import Dict, Union
+from typing import Dict, Union, List
 
 import aiohttp.web
 
@@ -15,7 +15,6 @@ import ray.dashboard.utils as dashboard_utils
 from ray._common.utils import get_or_create_event_loop
 from ray._private.ray_constants import env_integer
 from ray._private.usage.usage_lib import TagKey, record_extra_usage_tag
-from ray.core.generated import event_pb2, event_pb2_grpc
 from ray.dashboard.consts import (
     RAY_STATE_SERVER_MAX_HTTP_REQUEST,
     RAY_STATE_SERVER_MAX_HTTP_REQUEST_ALLOWED,
@@ -82,7 +81,6 @@ async def _list_cluster_events_impl(
 class EventHead(
     dashboard_utils.DashboardHeadModule,
     dashboard_utils.RateLimitedModule,
-    event_pb2_grpc.ReportEventServiceServicer,
 ):
     def __init__(self, config: dashboard_utils.DashboardHeadModuleConfig):
         dashboard_utils.DashboardHeadModule.__init__(self, config)
@@ -143,15 +141,24 @@ class EventHead(
                 while len(job_events) > MAX_EVENTS_TO_CACHE:
                     job_events.popitem(last=False)
 
-    async def ReportEvents(self, request, context):
-        received_events = []
-        if request.event_strings:
-            received_events.extend(parse_event_strings(request.event_strings))
-        logger.debug("Received %d events", len(received_events))
-        self._update_events(received_events)
+    @routes.post("/report_events")
+    async def report_events(self, request):
+        """
+        Report events to the dashboard.
+        The request body is a JSON array of event strings in type string.
+        Response should contain {"success": true}.
+        """
+        request_body: List[str] = await request.json()
+        events = [parse_event_strings(event_str) for event_str in request_body]
+        logger.debug("Received %d events", len(events))
+        self._update_events(events)
         self.total_report_events_count += 1
-        self.total_events_received += len(received_events)
-        return event_pb2.ReportEventsReply(send_success=True)
+        self.total_events_received += len(events)
+        return dashboard_optional_utils.rest_response(
+            success=True,
+            message="",
+            status_code=dashboard_utils.HTTPStatusCode.OK,
+        )
 
     async def _periodic_state_print(self):
         if self.total_events_received <= 0 or self.total_report_events_count <= 0:
@@ -202,7 +209,6 @@ class EventHead(
         return await handle_list_api(list_api_fn, req)
 
     async def run(self, server):
-        event_pb2_grpc.add_ReportEventServiceServicer_to_server(self, server)
         self._monitor = monitor_events(
             self._event_dir,
             lambda data: self._update_events(parse_event_strings(data)),

--- a/src/ray/protobuf/event.proto
+++ b/src/ray/protobuf/event.proto
@@ -66,15 +66,3 @@ message Event {
   // store custom key such as node_id, job_id, task_id
   map<string, string> custom_fields = 9;
 }
-
-message ReportEventsReply {
-  bool send_success = 1;
-}
-
-message ReportEventsRequest {
-  repeated string event_strings = 1;
-}
-
-service ReportEventService {
-  rpc ReportEvents(ReportEventsRequest) returns (ReportEventsReply);
-}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Use https://github.com/ray-project/ray/pull/50020 as a reference and resolves conflicts.

EventHead exposes a gRPC server that we don't have a good support in subprocessification. We can do that by defining a whole new set of messages and proxies to do it but it's not needed - the only Head that uses it is EventHead, and called by EventAgent: it's purely internal and does not require any fancy features from gRPC.

Change it to a HTTP-based API. Delete ReportEventService definition.

After this is merged we can convert EventHead into a subprocess module.

It's worth noting that after this PR, there's nobody uses "dashboard grpc server" so we can remove it all for good. But that will be a larger PR than this.

## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
