### PR TITLE
[CI] Upgrade pytest-aiohttp to 1.1.0

### DIFF
--- a/python/requirements/test-requirements.txt
+++ b/python/requirements/test-requirements.txt
@@ -49,8 +49,8 @@ Pygments==2.18.0
 pymongo==4.3.2
 pyspark==3.4.1
 pytest==7.4.4
-pytest-asyncio==0.17.0
-pytest-aiohttp==0.3.0
+pytest-asyncio==0.17.2
+pytest-aiohttp==1.1.0
 pytest-httpserver==1.0.6
 pytest-rerunfailures==11.1.2
 pytest-sugar==0.9.5

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -43,7 +43,9 @@ aiofiles==22.1.0
     #   aim
     #   gradio
     #   ypy-websocket
-aiohttp==3.9.5
+aiohappyeyeballs==2.6.1
+    # via aiohttp
+aiohttp==3.11.14
     # via
     #   -r python/requirements.txt
     #   -r python/requirements/cloud-requirements.txt
@@ -1486,6 +1488,10 @@ promise==2.3
     # via tensorflow-datasets
 prompt-toolkit==3.0.41
     # via ipython
+propcache==0.3.0
+    # via
+    #   aiohttp
+    #   yarl
 prophet==1.1.5
     # via -r python/requirements/ml/tune-test-requirements.txt
 proto-plus==1.22.3
@@ -1686,10 +1692,12 @@ pytest==7.4.4
     #   pytest-sugar
     #   pytest-timeout
     #   pytest-virtualenv
-pytest-aiohttp==0.3.0
+pytest-aiohttp==1.1.0
     # via -r python/requirements/test-requirements.txt
-pytest-asyncio==0.17.0
-    # via -r python/requirements/test-requirements.txt
+pytest-asyncio==0.17.2
+    # via
+    #   -r python/requirements/test-requirements.txt
+    #   pytest-aiohttp
 pytest-docker-tools==3.1.3
     # via -r python/requirements/test-requirements.txt
 pytest-fixture-config==1.7.0
@@ -2506,7 +2514,7 @@ y-py==0.6.2
     #   ypy-websocket
 yahp==0.1.1
     # via mosaicml
-yarl==1.9.4
+yarl==1.18.3
     # via
     #   aiohttp
     #   delta-sharing


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR upgrades `pytest-aiohttp` to 1.1.0 to fix some weird test errors while converting dashboard modules to subprocess modules.

## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
