### PR TITLE
[Data] Add `Ruleset` abstraction

### DIFF
--- a/python/ray/data/BUILD
+++ b/python/ray/data/BUILD
@@ -888,6 +888,20 @@ py_test(
 )
 
 py_test(
+    name = "test_ruleset",
+    size = "small",
+    srcs = ["tests/test_ruleset.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_size_estimation",
     size = "medium",
     srcs = ["tests/test_size_estimation.py"],

--- a/python/ray/data/_internal/logical/interfaces/optimizer.py
+++ b/python/ray/data/_internal/logical/interfaces/optimizer.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Type
 
 from .plan import Plan
 
@@ -9,6 +9,16 @@ class Rule:
     def apply(self, plan: Plan) -> Plan:
         """Apply the optimization rule to the execution plan."""
         raise NotImplementedError
+
+    @classmethod
+    def dependencies(cls) -> List[Type["Rule"]]:
+        """List of rules that must be applied before this rule."""
+        return []
+
+    @classmethod
+    def dependents(cls) -> List[Type["Rule"]]:
+        """List of rules that must be applied after this rule."""
+        return []
 
 
 class Optimizer:

--- a/python/ray/data/_internal/logical/rules/zero_copy_map_fusion.py
+++ b/python/ray/data/_internal/logical/rules/zero_copy_map_fusion.py
@@ -1,15 +1,16 @@
 from abc import abstractmethod
-from typing import List
+from typing import List, Type
 
 from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.execution.operators.map_transformer import (
     BuildOutputBlocksMapTransformFn,
     MapTransformFn,
-    MapTransformFnDataType,
     MapTransformFnCategory,
+    MapTransformFnDataType,
 )
 from ray.data._internal.logical.interfaces.optimizer import Rule
 from ray.data._internal.logical.interfaces.physical_plan import PhysicalPlan
+from ray.data._internal.logical.rules.operator_fusion import OperatorFusionRule
 
 
 class ZeroCopyMapFusionRule(Rule):
@@ -23,6 +24,10 @@ class ZeroCopyMapFusionRule(Rule):
     should implement the `_optimize` method for the concrete optimization
     strategy.
     """
+
+    @classmethod
+    def dependencies(cls) -> List[Type[Rule]]:
+        return [OperatorFusionRule]
 
     def apply(self, plan: PhysicalPlan) -> PhysicalPlan:
         self._traverse(plan.dag)

--- a/python/ray/data/_internal/logical/ruleset.py
+++ b/python/ray/data/_internal/logical/ruleset.py
@@ -1,0 +1,93 @@
+import collections
+from dataclasses import dataclass, field
+from typing import Dict, Iterator, List, Optional, Type
+
+from ray.data._internal.logical.interfaces import Rule
+from ray.util.annotations import DeveloperAPI
+
+
+@DeveloperAPI
+class Ruleset:
+    """A collection of rules to apply to a plan.
+
+    This is a utility class to ensure that, if rules depend on each other, they're
+    applied in a correct order.
+    """
+
+    @dataclass(frozen=True)
+    class _Node:
+        rule: Type[Rule]
+        dependents: List["Ruleset._Node"] = field(default_factory=list)
+
+    def __init__(self, rules: Optional[List[Type[Rule]]] = None):
+        if rules is None:
+            rules = []
+
+        self._rules = list(rules)
+
+    def add(self, rule: Type[Rule]):
+        if rule in self._rules:
+            raise ValueError(f"Rule {rule} already in ruleset")
+
+        self._rules.append(rule)
+
+        if self._contains_cycle():
+            raise ValueError("Cannot add rule that would create a cycle")
+
+    def remove(self, rule: Type[Rule]):
+        if rule not in self._rules:
+            raise ValueError(f"Rule {rule} not found in ruleset")
+
+        self._rules.remove(rule)
+
+    def __iter__(self) -> Iterator[Type[Rule]]:
+        """Iterate over the rules in this ruleset.
+
+        This method yields rules in dependency order. For example, if B depends on A,
+        then this method yields A before B. The order is otherwise undefined.
+        """
+        roots = self._build_graph()
+        queue = collections.deque(roots)
+        while queue:
+            node = queue.popleft()
+            yield node.rule
+            queue.extend(node.dependents)
+
+    def _build_graph(self) -> List["Ruleset._Node"]:
+        # NOTE: Because the number of rules will always be relatively small, I've opted
+        # for a simpler but inefficient implementation.
+
+        # Step 1: Add edges from dependencies to their dependants.
+        rule_to_node: Dict[Type[Rule], "Ruleset._Node"] = {
+            rule: Ruleset._Node(rule) for rule in self._rules
+        }
+        for rule in self._rules:
+            node = rule_to_node[rule]
+
+            # These are rules that must be applied *before* this rule.
+            for dependency in rule.dependencies():
+                if dependency in rule_to_node:
+                    rule_to_node[dependency].dependents.append(node)
+
+            # These are rules that must be applied *after* this rule.
+            for dependent in rule.dependents():
+                if dependent in rule_to_node:
+                    node.dependents.append(rule_to_node[dependent])
+
+        # Step 2: Determine which nodes are roots.
+        roots = list(rule_to_node.values())
+        for node in rule_to_node.values():
+            for dependent in node.dependents:
+                if dependent in roots:
+                    roots.remove(dependent)
+
+        return roots
+
+    def _contains_cycle(self) -> bool:
+        if not self._rules:
+            return
+
+        # If the graph contains nodes but there aren't any root nodes, it means that
+        # there must be a cycle.
+        roots = self._build_graph()
+        return not roots

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -49,13 +49,7 @@ from ray.data._internal.logical.operators.map_operator import (
 )
 from ray.data._internal.logical.operators.n_ary_operator import Zip
 from ray.data._internal.logical.operators.write_operator import Write
-from ray.data._internal.logical.optimizers import (
-    PhysicalOptimizer,
-    get_logical_rules,
-    get_physical_rules,
-    register_logical_rule,
-    register_physical_rule,
-)
+from ray.data._internal.logical.optimizers import PhysicalOptimizer
 from ray.data._internal.logical.rules.configure_map_task_memory import (
     ConfigureMapTaskMemoryUsingOutputSize,
 )
@@ -1811,46 +1805,6 @@ def test_zero_copy_fusion_eliminate_build_output_blocks(
             BuildOutputBlocksMapTransformFn,
         ],
     )
-
-
-def test_insert_logical_optimization_rules():
-    class FakeRule1:
-        pass
-
-    class FakeRule2:
-        pass
-
-    # By default, add the rule to the end of the list.
-    register_logical_rule(FakeRule1)
-    assert get_logical_rules()[-1] == FakeRule1
-
-    register_logical_rule(FakeRule2, 0)
-    assert get_logical_rules()[0] == FakeRule2
-
-    # 'FakeRule1' is already registered, so it shouldn't be added again.
-    register_logical_rule(FakeRule1, 0)
-    assert get_logical_rules()[-1] == FakeRule1
-    assert get_logical_rules()[0] == FakeRule2
-
-
-def test_insert_physical_optimization_rules():
-    class FakeRule1:
-        pass
-
-    class FakeRule2:
-        pass
-
-    # By default, add the rule to the end of the list.
-    register_physical_rule(FakeRule1)
-    assert get_physical_rules()[-1] == FakeRule1
-
-    register_physical_rule(FakeRule2, 0)
-    assert get_physical_rules()[0] == FakeRule2
-
-    # 'FakeRule1' is already registered, so it shouldn't be added again.
-    register_physical_rule(FakeRule1, 0)
-    assert get_physical_rules()[-1] == FakeRule1
-    assert get_physical_rules()[0] == FakeRule2
 
 
 @pytest.mark.parametrize(

--- a/python/ray/data/tests/test_ruleset.py
+++ b/python/ray/data/tests/test_ruleset.py
@@ -1,0 +1,165 @@
+from typing import List, Type
+
+import pytest
+
+from ray.data._internal.logical.interfaces.optimizer import Rule
+from ray.data._internal.logical.ruleset import Ruleset
+
+
+def test_add_rule():
+    class A(Rule):
+        pass
+
+    ruleset = Ruleset([A])
+    assert list(ruleset) == [A]
+
+
+def test_add_rule_with_dependencies():
+    class A(Rule):
+        pass
+
+    class B(Rule):
+        @classmethod
+        def dependencies(cls) -> List[Type[Rule]]:
+            return [A]
+
+    ruleset = Ruleset([A])
+    ruleset.add(B)
+    assert list(ruleset) == [A, B]
+
+
+def test_add_rule_with_dependents():
+    class A(Rule):
+        pass
+
+    class B(Rule):
+        @classmethod
+        def dependents(cls) -> List[Type[Rule]]:
+            return [A]
+
+    ruleset = Ruleset([A])
+    ruleset.add(B)
+    assert list(ruleset) == [B, A]
+
+
+def test_add_rule_with_multiple_dependencies():
+    class A(Rule):
+        pass
+
+    class B(Rule):
+        pass
+
+    class C(Rule):
+        @classmethod
+        def dependencies(cls) -> List[Type[Rule]]:
+            return [A, B]
+
+    ruleset = Ruleset([A, B])
+    ruleset.add(C)
+
+    rules = list(ruleset)
+    assert set(rules) == {A, B, C}
+    assert rules.index(A) < rules.index(B)
+    assert rules.index(B) < rules.index(C)
+
+
+def test_add_rule_with_multiple_dependents():
+    class A(Rule):
+        pass
+
+    class B(Rule):
+        pass
+
+    class C(Rule):
+        @classmethod
+        def dependents(cls) -> List[Type[Rule]]:
+            return [A, B]
+
+    ruleset = Ruleset([A, B])
+    ruleset.add(C)
+
+    rules = list(ruleset)
+    assert set(rules) == {A, B, C}
+    assert rules[0] == C
+
+
+def test_add_rule_with_missing_dependencies():
+    class A(Rule):
+        pass
+
+    class B(Rule):
+        @classmethod
+        def dependencies(cls) -> List[Type[Rule]]:
+            return [A]
+
+    ruleset = Ruleset()
+    ruleset.add(B)
+    assert list(ruleset) == [B]
+
+
+def test_add_rule_with_missing_dependents():
+    class A(Rule):
+        pass
+
+    class B(Rule):
+        @classmethod
+        def dependents(cls) -> List[Type[Rule]]:
+            return [A]
+
+    ruleset = Ruleset()
+    ruleset.add(B)
+    assert list(ruleset) == [B]
+
+
+def test_add_rule_with_cycle_raises_error():
+    class A(Rule):
+        @classmethod
+        def dependencies(cls) -> List[Type[Rule]]:
+            return [B]
+
+    class B(Rule):
+        @classmethod
+        def dependencies(cls) -> List[Type[Rule]]:
+            return [A]
+
+    ruleset = Ruleset([A])
+    with pytest.raises(ValueError):
+        ruleset.add(B)
+
+
+def test_remove_rule():
+    class A(Rule):
+        pass
+
+    ruleset = Ruleset([A])
+    ruleset.remove(A)
+    assert list(ruleset) == []
+
+
+def test_remove_rule_not_in_ruleset():
+    class A(Rule):
+        pass
+
+    ruleset = Ruleset([])
+    with pytest.raises(ValueError):
+        ruleset.remove(A)
+
+
+def test_remove_rule_with_dependants():
+    class A(Rule):
+        pass
+
+    class B(Rule):
+        @classmethod
+        def dependencies(cls) -> List[Type[Rule]]:
+            return [A]
+
+    ruleset = Ruleset([A, B])
+    ruleset.remove(A)
+    assert list(ruleset) == [B]
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Problems
There are two problems:

1. There's no way to remove a rule
2. We break/mix abstraction barriers in order to enforce rule ordering/dependencies

## Changes
1. Add `Rule.dependencies` to formalize dependencies
2. Introduce a `Ruleset` abstraction to ensure we add, remove, and iterate over rules while respecting dependencies