### PR TITLE
[serve][test] Change the response_time_s to response_time_ms

### DIFF
--- a/release/serve_tests/workloads/locust_utils.py
+++ b/release/serve_tests/workloads/locust_utils.py
@@ -57,7 +57,7 @@ class FailedRequest:
     request_id: str
     status_code: int
     exception: str
-    response_time_s: float
+    response_time_ms: float
     start_time_s: float
 
 
@@ -107,7 +107,7 @@ class LocustClient:
                         request_id=request_id,
                         status_code=response.status_code,
                         exception=response.text,
-                        response_time_s=response_time,
+                        response_time_ms=response_time,
                         start_time_s=start_time,
                     )
                     self.errors.append(err)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The locust request duration is milliseconds.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
