### PR TITLE
[chore][core] Make the error message more actionable when Protobuf-generated code and `custom_types.py` are inconsistent

### DIFF
--- a/python/ray/_private/custom_types.py
+++ b/python/ray/_private/custom_types.py
@@ -127,8 +127,8 @@ def validate_protobuf_enum(grpc_enum, custom_enum):
     if len(enum_vals) > 0:
         assert enum_vals == set(
             custom_enum
-        ), """Literals and protos out of sync,\
-consider building //:install_py_proto with bazel?"""
+        ), """Literals in `custom_types.py` and `.proto` files are out of sync. \
+Consider building //:install_py_proto with Bazel or updating `custom_types.py`."""
 
 
 # Do the enum validation here.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The validation fails when I update a `.proto` file, compile the Ray codebase, and run a Ray program. However, the original error message instructs me to generate the Protobuf code again, which I have already done. Instead, I need to update `custom_types.py` to fix the issue.

The error message with this PR:

<img width="1132" alt="Screenshot 2025-03-20 at 2 49 18 PM" src="https://github.com/user-attachments/assets/96ca439d-6e35-49c0-aabf-759ed618cd91" />


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
