### PR TITLE
[core][autoscaler][v2] do not removing nodes for upcoming resource requests

### DIFF
--- a/python/ray/autoscaler/v2/scheduler.py
+++ b/python/ray/autoscaler/v2/scheduler.py
@@ -1596,16 +1596,26 @@ class ResourceDemandScheduler(IResourceScheduler):
                 # The node is not idle for too long, skip it.
                 continue
 
+            if node.sched_requests[ResourceRequestSource.PENDING_DEMAND]:
+                # The node is needed by the pending requests.
+                # Skip it.
+                logger.debug(
+                    "Node {} (idle for {} secs) is needed by the pending requests, "
+                    "skip idle termination.".format(
+                        node.ray_node_id, node.idle_duration_ms / s_to_ms
+                    )
+                )
+                continue
+
             if node.sched_requests[ResourceRequestSource.CLUSTER_RESOURCE_CONSTRAINT]:
                 # The node is needed by the resource constraints.
                 # Skip it.
-                if node.idle_duration_ms > ctx.get_idle_timeout_s() * s_to_ms:
-                    logger.debug(
-                        "Node {} (idle for {} secs) is needed by the cluster resource "
-                        "constraints, skip idle termination.".format(
-                            node.ray_node_id, node.idle_duration_ms / s_to_ms
-                        )
+                logger.debug(
+                    "Node {} (idle for {} secs) is needed by the cluster resource "
+                    "constraints, skip idle termination.".format(
+                        node.ray_node_id, node.idle_duration_ms / s_to_ms
                     )
+                )
                 continue
 
             # Honor the min_worker_nodes setting for the node type.

--- a/python/ray/autoscaler/v2/tests/test_scheduler.py
+++ b/python/ray/autoscaler/v2/tests/test_scheduler.py
@@ -1247,7 +1247,14 @@ def test_outdated_nodes(disable_launch_config_check):
 
 @pytest.mark.parametrize("idle_timeout_s", [1, 2, 10])
 @pytest.mark.parametrize("has_resource_constraints", [True, False])
-def test_idle_termination(idle_timeout_s, has_resource_constraints):
+@pytest.mark.parametrize("has_resource_requests", [True, False])
+@pytest.mark.parametrize("has_gang_resource_requests", [True, False])
+def test_idle_termination(
+    idle_timeout_s,
+    has_resource_constraints,
+    has_resource_requests,
+    has_gang_resource_requests,
+):
     """
     Test that idle nodes are terminated.
     """
@@ -1271,11 +1278,23 @@ def test_idle_termination(idle_timeout_s, has_resource_constraints):
     }
 
     idle_time_s = 5
-    constraints = (
-        []
-        if not has_resource_constraints
-        else [ResourceRequestUtil.make({"CPU": 1})] * 2
-    )
+    constraints = []
+    if has_resource_constraints:
+        constraints = [ResourceRequestUtil.make({"CPU": 1})] * 2
+
+    resource_requests = []
+    if has_resource_requests:
+        resource_requests = [ResourceRequestUtil.make({"CPU": 1})] * 2
+
+    ANTI_AFFINITY = ResourceRequestUtil.PlacementConstraintType.ANTI_AFFINITY
+    gang_resource_requests = []
+    if has_gang_resource_requests:
+        gang_resource_requests = [
+            [
+                ResourceRequestUtil.make({"CPU": 1}, [(ANTI_AFFINITY, "pg", "")]),
+                ResourceRequestUtil.make({"CPU": 1}, [(ANTI_AFFINITY, "pg", "")]),
+            ]
+        ]
 
     request = sched_request(
         node_type_configs=node_type_configs,
@@ -1338,11 +1357,18 @@ def test_idle_termination(idle_timeout_s, has_resource_constraints):
         ],
         idle_timeout_s=idle_timeout_s,
         cluster_resource_constraints=constraints,
+        resource_requests=resource_requests,
+        gang_resource_requests=gang_resource_requests,
     )
 
     reply = scheduler.schedule(request)
     _, to_terminate = _launch_and_terminate(reply)
-    if idle_timeout_s <= idle_time_s and not has_resource_constraints:
+    if (
+        idle_timeout_s <= idle_time_s
+        and not has_resource_constraints
+        and not has_resource_requests
+        and not has_gang_resource_requests
+    ):
         assert len(to_terminate) == 1
         assert to_terminate == [("i-2", "r-2", TerminationRequest.Cause.IDLE)]
     else:

--- a/python/ray/autoscaler/v2/tests/test_scheduler.py
+++ b/python/ray/autoscaler/v2/tests/test_scheduler.py
@@ -1290,7 +1290,7 @@ def test_idle_termination(
     gang_resource_requests = []
     if has_gang_resource_requests:
         gang_resource_requests = [
-            [
+            [  # This is a strict spread placement group that requires 2 nodes.
                 ResourceRequestUtil.make({"CPU": 1}, [(ANTI_AFFINITY, "pg", "")]),
                 ResourceRequestUtil.make({"CPU": 1}, [(ANTI_AFFINITY, "pg", "")]),
             ]


### PR DESCRIPTION
## Why are these changes needed?

This PR continues to fix the issue mentioned in https://github.com/ray-project/ray/pull/51122 for the v2 autoscaler: an idle node can still be terminated if upcoming resource requests use it.

This is caused by the fact that the current v2 scheduler doesn't check if a node has `PENDING_DEMAND` requests on it. This PR modifies the v2 scheduler to skip such nodes during `_enforce_idle_termination`.

The current `test_idle_termination` test is also extended to cover `has_resource_requests` and `has_gang_resource_requests` situations, where the idle node in the test should not be terminated if there are upcoming resource requests on it.


## Related issue number

Closes https://github.com/ray-project/ray/issues/51321

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
