### PR TITLE
[serve] don't stop retrying replicas when a deployment is scaling back up from zero

### DIFF
--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -2057,20 +2057,20 @@ class DeploymentState:
         # Update the deployment message only if replicas are failing during
         # the very first time the controller is trying to start replicas of
         # this version.
+        retrying_msg = ""
         if not self._replica_has_started:
-            retrying_msg = "Retrying"
             remaining_retries = max(
                 self._failed_to_start_threshold
                 - self._replica_constructor_retry_counter,
                 0,
             )
-            retrying_msg += f" {remaining_retries} more time(s)"
+            retrying_msg = f" {remaining_retries} more time(s)"
 
-            message = (
-                f"A replica failed to start with exception. {retrying_msg}. Error:\n"
-                f"{error_msg}"
-            )
-            self._curr_status_info = self._curr_status_info.update_message(message)
+        message = (
+            f"A replica failed to start with exception. Retrying{retrying_msg}. "
+            f"Error:\n{error_msg}"
+        )
+        self._curr_status_info = self._curr_status_info.update_message(message)
 
     def stop_replicas(self, replicas_to_stop) -> None:
         for replica in self._replicas.pop():

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -1270,8 +1270,14 @@ class DeploymentState:
         self._target_state: DeploymentTargetState = DeploymentTargetState.default()
 
         self._prev_startup_warning: float = time.time()
-        self._replica_constructor_retry_counter: int = 0
         self._replica_constructor_error_msg: Optional[str] = None
+        # Counter for how many times replicas failed to start. This is reset to 0 when:
+        # (1) The deployment is deployed / re-deployed.
+        # (2) The deployment reaches the HEALTHY state.
+        self._replica_constructor_retry_counter: int = 0
+        # Flag for whether any replicas of the target version has successfully started.
+        # This is reset to False when the deployment is re-deployed.
+        self._replica_has_started: bool = False
 
         self._replicas: ReplicaStateContainer = ReplicaStateContainer()
         self._curr_status_info: DeploymentStatusInfo = DeploymentStatusInfo(
@@ -1393,10 +1399,27 @@ class DeploymentState:
             self._target_state.target_num_replicas * MAX_PER_REPLICA_RETRY_COUNT,
         )
 
-    @property
-    def is_failed(self) -> bool:
-        """Whether the deployment failed to deploy."""
-        return self._curr_status_info.status == DeploymentStatus.DEPLOY_FAILED
+    def _replica_startup_failing(self) -> bool:
+        """Check whether replicas are currently failing and the number of
+        failures has exceeded a threshold.
+        """
+        if (
+            self._target_state.target_num_replicas > 0
+            and self._replica_constructor_retry_counter
+            >= self._failed_to_start_threshold
+        ):
+            return True
+
+        return False
+
+    def _version_terminally_failed(self) -> bool:
+        """Check whether the deployment is terminally errored.
+
+        The deployment is considered terminally errored if the number of
+        replica failures has exceeded a threshold, and there hasn't been
+        any replicas of the target version that has successfully started.
+        """
+        return not self._replica_has_started and self._replica_startup_failing()
 
     def get_alive_replica_actor_ids(self) -> Set[str]:
         return {replica.actor_id for replica in self._replicas.get()}
@@ -1454,7 +1477,7 @@ class DeploymentState:
         multiplexed model IDs.
         """
         running_replica_infos = self.get_running_replica_infos()
-        is_available = not self.is_failed
+        is_available = not self._version_terminally_failed()
 
         running_replicas_changed = (
             set(self._last_broadcasted_running_replica_infos)
@@ -1637,6 +1660,7 @@ class DeploymentState:
             f"(initial target replicas: {target_num_replicas})."
         )
         self._replica_constructor_retry_counter = 0
+        self._replica_has_started = False
         return True
 
     def autoscale(self) -> int:
@@ -1860,7 +1884,7 @@ class DeploymentState:
                 stopping_replicas = self._replicas.count(states=[ReplicaState.STOPPING])
                 to_add = max(delta_replicas - stopping_replicas, 0)
 
-            if to_add > 0 and not self.is_failed:
+            if to_add > 0 and not self._version_terminally_failed():
                 logger.info(f"Adding {to_add} replica{'s' * (to_add>1)} to {self._id}.")
                 for _ in range(to_add):
                     replica_id = ReplicaID(get_random_string(), deployment_id=self._id)
@@ -1909,34 +1933,30 @@ class DeploymentState:
             states=[ReplicaState.RUNNING], version=target_version
         )
 
-        failed_to_start_count = self._replica_constructor_retry_counter
-
         # Got to make a call to complete current deploy() goal after
         # start failure threshold reached, while we might still have
         # pending replicas in current goal.
-        if (
-            failed_to_start_count >= self._failed_to_start_threshold
-            and self._failed_to_start_threshold != 0
-        ):
-            if running_at_target_version_replica_cnt > 0:
-                # At least one RUNNING replica at target state, partial
-                # success; We can stop tracking constructor failures and
-                # leave it to the controller to fully scale to target
-                # number of replicas and only return as completed once
-                # reached target replica count
-                self._replica_constructor_retry_counter = -1
-            else:
-                self._curr_status_info = self._curr_status_info.handle_transition(
-                    trigger=DeploymentStatusInternalTrigger.REPLICA_STARTUP_FAILED,
-                    message=(
-                        f"The deployment failed to start {failed_to_start_count} times "
-                        "in a row. This may be due to a problem with its "
-                        "constructor or initial health check failing. See "
-                        "controller logs for details. Error:\n"
-                        f"{self._replica_constructor_error_msg}"
-                    ),
-                )
-                return False, any_replicas_recovering
+        if running_at_target_version_replica_cnt > 0:
+            # At least one RUNNING replica at target state, partial
+            # success; We can stop tracking constructor failures and
+            # leave it to the controller to fully scale to target
+            # number of replicas and only return as completed once
+            # reached target replica count
+            # self._replica_constructor_retry_counter = -1
+            self._replica_has_started = True
+        elif self._replica_startup_failing():
+            self._curr_status_info = self._curr_status_info.handle_transition(
+                trigger=DeploymentStatusInternalTrigger.REPLICA_STARTUP_FAILED,
+                message=(
+                    "The deployment failed to start "
+                    f"{self._replica_constructor_retry_counter} times "
+                    "in a row. This may be due to a problem with its "
+                    "constructor or initial health check failing. See "
+                    "controller logs for details. Error:\n"
+                    f"{self._replica_constructor_error_msg}"
+                ),
+            )
+            return False, any_replicas_recovering
 
         # If we have pending ops, the current goal is *not* ready.
         if (
@@ -1962,6 +1982,7 @@ class DeploymentState:
                 self._curr_status_info = self._curr_status_info.handle_transition(
                     trigger=DeploymentStatusInternalTrigger.HEALTHY
                 )
+                self._replica_constructor_retry_counter = 0
                 return False, any_replicas_recovering
 
         return False, any_replicas_recovering
@@ -2029,19 +2050,25 @@ class DeploymentState:
     def record_replica_startup_failure(self, error_msg: str):
         """Record that a replica failed to start."""
 
-        if self._replica_constructor_retry_counter >= 0:
-            # Increase startup failure counter if we're tracking it
-            self._replica_constructor_retry_counter += 1
-            self._replica_constructor_error_msg = error_msg
+        # There is no need to record replica failures if the target is 0.
+        if self._target_state.target_num_replicas == 0:
+            return
 
+        # Increase startup failure counter
+        self._replica_constructor_retry_counter += 1
+        self._replica_constructor_error_msg = error_msg
+
+        # Update the deployment message only if replicas are failing during
+        # the very first time the controller is trying to start replicas of
+        # this version.
+        if not self._replica_has_started:
             retrying_msg = "Retrying"
-            if self._failed_to_start_threshold != 0:
-                remaining_retries = max(
-                    self._failed_to_start_threshold
-                    - self._replica_constructor_retry_counter,
-                    0,
-                )
-                retrying_msg += f" {remaining_retries} more time(s)"
+            remaining_retries = max(
+                self._failed_to_start_threshold
+                - self._replica_constructor_retry_counter,
+                0,
+            )
+            retrying_msg += f" {remaining_retries} more time(s)"
 
             message = (
                 f"A replica failed to start with exception. {retrying_msg}. Error:\n"

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -1403,14 +1403,11 @@ class DeploymentState:
         """Check whether replicas are currently failing and the number of
         failures has exceeded a threshold.
         """
-        if (
+        return (
             self._target_state.target_num_replicas > 0
             and self._replica_constructor_retry_counter
             >= self._failed_to_start_threshold
-        ):
-            return True
-
-        return False
+        )
 
     def _terminally_failed(self) -> bool:
         """Check whether the current version is terminally errored.

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -1860,11 +1860,7 @@ class DeploymentState:
                 stopping_replicas = self._replicas.count(states=[ReplicaState.STOPPING])
                 to_add = max(delta_replicas - stopping_replicas, 0)
 
-            if (
-                to_add > 0
-                and self._replica_constructor_retry_counter
-                < self._failed_to_start_threshold
-            ):
+            if to_add > 0 and not self.is_failed:
                 logger.info(f"Adding {to_add} replica{'s' * (to_add>1)} to {self._id}.")
                 for _ in range(to_add):
                     replica_id = ReplicaID(get_random_string(), deployment_id=self._id)

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -2416,7 +2416,7 @@ def test_deploy_with_partial_constructor_failure(
 
     dsm.update()
     # Ensure our goal returned with replica_has_started flag set
-    assert ds._replica_has_started == True
+    assert ds._replica_has_started
     # Deployment should NOT be considered complete yet
     assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
@@ -2614,7 +2614,7 @@ def test_deploy_with_transient_constructor_failure(mock_deployment_state_manager
     check_counts(ds, total=2, by_state=[(ReplicaState.RUNNING, 2, None)])
 
     assert ds._replica_constructor_retry_counter == 0
-    assert ds._replica_has_started == True
+    assert ds._replica_has_started
     assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
         ds.curr_status_info.status_trigger

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -3447,7 +3447,9 @@ class TestAutoscaling:
             == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
         )
 
-    def test_replicas_fail_during_initial_scale_from_zero(self, mock_deployment_state_manager):
+    def test_replicas_fail_during_initial_scale_from_zero(
+        self, mock_deployment_state_manager
+    ):
         """Test the following case:
 
         - An "erroneous" deployment (w/ autoscaling enabled) is deployed
@@ -3480,18 +3482,15 @@ class TestAutoscaling:
         ds: DeploymentState = dsm._deployment_states[TEST_DEPLOYMENT_ID]
 
         # Send request metrics to controller to make the deployment upscale
-        if RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE:
-            asm.record_request_metrics_for_handle(
-                deployment_id=TEST_DEPLOYMENT_ID,
-                handle_id="random",
-                actor_id=None,
-                handle_source=DeploymentHandleSource.UNKNOWN,
-                queued_requests=1,
-                running_requests={},
-                send_timestamp=timer.time(),
-            )
-        else:
-            1 / 0
+        asm.record_request_metrics_for_handle(
+            deployment_id=TEST_DEPLOYMENT_ID,
+            handle_id="random",
+            actor_id=None,
+            handle_source=DeploymentHandleSource.UNKNOWN,
+            queued_requests=1,
+            running_requests={},
+            send_timestamp=timer.time(),
+        )
 
         # The controller should try to start a new replica. If that replica repeatedly
         # fails to start, the deployment should transition to UNHEALTHY and NOT retry
@@ -3519,7 +3518,9 @@ class TestAutoscaling:
                         ],
                     )
                 else:
-                    check_counts(ds, total=1, by_state=[(ReplicaState.STOPPING, 1, None)])
+                    check_counts(
+                        ds, total=1, by_state=[(ReplicaState.STOPPING, 1, None)]
+                    )
 
                 # Set replica finished stopping
                 replica._actor.set_done_stopping()
@@ -3531,8 +3532,9 @@ class TestAutoscaling:
                     == DeploymentStatusTrigger.REPLICA_STARTUP_FAILED
                 )
 
-
-    def test_replicas_fail_during_subsequent_scale_from_zero(self, mock_deployment_state_manager):
+    def test_replicas_fail_during_subsequent_scale_from_zero(
+        self, mock_deployment_state_manager
+    ):
         """Test the following case:
 
         - An autoscaling deployment is deployed and it reaches HEALTHY
@@ -3594,18 +3596,15 @@ class TestAutoscaling:
         check_counts(ds, total=0)
 
         # Send request metrics to controller to make the deployment upscale
-        if RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE:
-            asm.record_request_metrics_for_handle(
-                deployment_id=TEST_DEPLOYMENT_ID,
-                handle_id="random",
-                actor_id=None,
-                handle_source=DeploymentHandleSource.UNKNOWN,
-                queued_requests=1,
-                running_requests={},
-                send_timestamp=timer.time(),
-            )
-        else:
-            1 / 0
+        asm.record_request_metrics_for_handle(
+            deployment_id=TEST_DEPLOYMENT_ID,
+            handle_id="random",
+            actor_id=None,
+            handle_source=DeploymentHandleSource.UNKNOWN,
+            queued_requests=1,
+            running_requests={},
+            send_timestamp=timer.time(),
+        )
 
         # The controller should try to start a new replica. If that replica repeatedly
         # fails to start, the deployment should transition to UNHEALTHY. Meanwhile

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -2292,7 +2292,7 @@ def test_deploy_with_consistent_constructor_failure(
 
     The deployment should get marked FAILED.
     """
-    create_dsm, _, _, _ = mock_deployment_state_manager
+    create_dsm, timer, _, _ = mock_deployment_state_manager
     dsm: DeploymentStateManager = create_dsm()
 
     b_info_1, _ = deployment_info(num_replicas=2)
@@ -2317,6 +2317,13 @@ def test_deploy_with_consistent_constructor_failure(
     )
     check_counts(ds, total=2)
     assert ds.curr_status_info.message != ""
+
+    # No more replicas should be retried.
+    for _ in range(20):
+        dsm.update()
+        assert ds._replica_constructor_retry_counter == 4
+        check_counts(ds, total=0)
+        timer.advance(10)  # simulate time passing between each call to update
 
 
 def test_deploy_with_partial_constructor_failure(
@@ -2408,8 +2415,8 @@ def test_deploy_with_partial_constructor_failure(
     starting_replica._actor.set_failed_to_start()
 
     dsm.update()
-    # Ensure our goal returned with construtor start counter reset
-    assert ds._replica_constructor_retry_counter == -1
+    # Ensure our goal returned with replica_has_started flag set
+    assert ds._replica_has_started == True
     # Deployment should NOT be considered complete yet
     assert ds.curr_status_info.status == DeploymentStatus.UPDATING
     assert (
@@ -2589,6 +2596,7 @@ def test_deploy_with_transient_constructor_failure(mock_deployment_state_manager
         ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
+    assert ds._replica_constructor_retry_counter == 4
 
     # Let both replicas succeed in last try.
     dsm.update()
@@ -2598,50 +2606,20 @@ def test_deploy_with_transient_constructor_failure(mock_deployment_state_manager
         ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
     )
+    ds._replicas.get()[0]._actor.set_ready()
+    ds._replicas.get()[1]._actor.set_ready()
 
-    assert ds._replica_constructor_retry_counter == 4
-    replica_1 = ds._replicas.get()[0]
-    replica_2 = ds._replicas.get()[1]
-
-    replica_1._actor.set_ready()
-    replica_2._actor.set_ready()
+    # Everything should be running and healthy now
     dsm.update()
     check_counts(ds, total=2, by_state=[(ReplicaState.RUNNING, 2, None)])
 
-    assert ds._replica_constructor_retry_counter == 4
+    assert ds._replica_constructor_retry_counter == 0
+    assert ds._replica_has_started == True
     assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
     assert (
         ds.curr_status_info.status_trigger
         == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
     )
-
-
-def test_deploy_failed(mock_deployment_state_manager):
-    """Once deployment failed to deploy, should not retry replicas."""
-
-    create_dsm, timer, _, _ = mock_deployment_state_manager
-    dsm: DeploymentStateManager = create_dsm()
-
-    b_info_1, _ = deployment_info(num_replicas=2)
-    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_1)
-    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
-
-    assert ds.curr_status_info.status == DeploymentStatus.UPDATING
-    assert (
-        ds.curr_status_info.status_trigger
-        == DeploymentStatusTrigger.CONFIG_UPDATE_STARTED
-    )
-
-    _constructor_failure_loop_two_replica(dsm, ds, 3)
-    assert ds._replica_constructor_retry_counter == 6
-    assert ds.curr_status_info.status == DeploymentStatus.DEPLOY_FAILED
-
-    # No more replicas should be retried.
-    for _ in range(20):
-        dsm.update()
-        assert ds._replica_constructor_retry_counter == 6
-        check_counts(ds, total=0)
-        timer.advance(10)  # simulate time passing between each call to update
 
 
 def test_recover_state_from_replica_names(mock_deployment_state_manager):
@@ -3469,7 +3447,106 @@ class TestAutoscaling:
             == DeploymentStatusTrigger.CONFIG_UPDATE_COMPLETED
         )
 
-    def test_replicas_fail_during_scale_from_zero(self, mock_deployment_state_manager):
+    def test_replicas_fail_during_initial_scale_from_zero(self, mock_deployment_state_manager):
+        """Test the following case:
+
+        - An "erroneous" deployment (w/ autoscaling enabled) is deployed
+          with initial replicas set to 0. Since no replicas are started,
+          no errors have occurred from trying to start the replicas yet.
+        - A request is sent, triggering an upscale.
+        - The controller tries to start new replicas, but fails because
+          of a constructor error.
+
+        In this case, the deployment should transition to UNHEALTHY and
+        stop retrying after a threshold.
+        """
+        create_dsm, timer, _, asm = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm()
+        asm: AutoscalingStateManager = asm
+
+        # Deploy deployment with 1 initial replica
+        info, _ = deployment_info(
+            autoscaling_config={
+                "target_ongoing_requests": 1,
+                "min_replicas": 0,
+                "max_replicas": 2,
+                "initial_replicas": 0,
+                "upscale_delay_s": 0,
+                "downscale_delay_s": 0,
+                "metrics_interval_s": 100,
+            }
+        )
+        dsm.deploy(TEST_DEPLOYMENT_ID, info)
+        ds: DeploymentState = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+
+        # Send request metrics to controller to make the deployment upscale
+        if RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE:
+            asm.record_request_metrics_for_handle(
+                deployment_id=TEST_DEPLOYMENT_ID,
+                handle_id="random",
+                actor_id=None,
+                handle_source=DeploymentHandleSource.UNKNOWN,
+                queued_requests=1,
+                running_requests={},
+                send_timestamp=timer.time(),
+            )
+        else:
+            1 / 0
+
+        # The controller should try to start a new replica. If that replica repeatedly
+        # fails to start, the deployment should transition to UNHEALTHY and NOT retry
+        # replicas anymore
+        for i in range(10):
+            dsm.update()
+            if i < 3:
+                check_counts(ds, total=1, by_state=[(ReplicaState.STARTING, 1, None)])
+                assert ds.curr_status_info.status == DeploymentStatus.UPSCALING
+                assert (
+                    ds.curr_status_info.status_trigger
+                    == DeploymentStatusTrigger.AUTOSCALING
+                )
+                # Set replica failed to start
+                replica = ds._replicas.get()[0]
+                replica._actor.set_failed_to_start()
+                dsm.update()
+                if i < 2 and RAY_SERVE_EAGERLY_START_REPLACEMENT_REPLICAS:
+                    check_counts(
+                        ds,
+                        total=2,
+                        by_state=[
+                            (ReplicaState.STOPPING, 1, None),
+                            (ReplicaState.STARTING, 1, None),
+                        ],
+                    )
+                else:
+                    check_counts(ds, total=1, by_state=[(ReplicaState.STOPPING, 1, None)])
+
+                # Set replica finished stopping
+                replica._actor.set_done_stopping()
+            else:
+                check_counts(ds, total=0)
+                assert ds.curr_status_info.status == DeploymentStatus.UNHEALTHY
+                assert (
+                    ds.curr_status_info.status_trigger
+                    == DeploymentStatusTrigger.REPLICA_STARTUP_FAILED
+                )
+
+
+    def test_replicas_fail_during_subsequent_scale_from_zero(self, mock_deployment_state_manager):
+        """Test the following case:
+
+        - An autoscaling deployment is deployed and it reaches HEALTHY
+          with a non-zero number of replicas.
+        - After a period of no traffic, the deployment scales down to 0.
+        - New traffic is sent, triggering an upscale.
+        - The controller tries to start new replicas, but for some
+          reason some replicas fail to start because of transient errors
+
+        In this case, the deployment should transition to UNHEALTHY and
+        keep retrying, since at least one replica of this version has
+        successfully started in the past, meaning we don't know if it is
+        an unrecoverable user code error.
+        """
         create_dsm, timer, _, asm = mock_deployment_state_manager
         dsm: DeploymentStateManager = create_dsm()
         asm: AutoscalingStateManager = asm
@@ -3516,7 +3593,7 @@ class TestAutoscaling:
         dsm.update()
         check_counts(ds, total=0)
 
-        # Send request metrics to controller to make the deployment upscale x2
+        # Send request metrics to controller to make the deployment upscale
         if RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE:
             asm.record_request_metrics_for_handle(
                 deployment_id=TEST_DEPLOYMENT_ID,
@@ -3532,7 +3609,7 @@ class TestAutoscaling:
 
         # The controller should try to start a new replica. If that replica repeatedly
         # fails to start, the deployment should transition to UNHEALTHY. Meanwhile
-        # the controller should continue retrying.
+        # the controller should continue retrying after 3 times.
         for i in range(10):
             dsm.update()
             check_counts(ds, total=1, by_state=[(ReplicaState.STARTING, 1, None)])


### PR DESCRIPTION
## Why are these changes needed?

Previously we added a new deployment status `DEPLOY_FAILED`, which a deployment transitions into if the replicas repeatedly fail to start after a new config update / new deployment. After a certain number of retries, the controller will stop retrying replicas for that deployment and it enters a terminal state. However that causes deployments whose replicas fail during autoscaling (from zero) to also stop retrying after the threshold. This PR fixes that.

Summary of failure scenarios and how we now handle them:
1. A deployment is first deployed / re-deployed. If the number of replica failures exceed a threshold (`3 * target`), and not a single replica was able to start successfully, the deployment transitions to `DEPLOY_FAILED` and no more replicas are retried. This state is terminal, and user must redeploy.
2. An autoscaling deployment is deployed with `initial_replicas = 0`. A request is sent and replicas fail to start. Similarly if the number of replica failures exceed a threshold (`3 * target`), and not a single replica was able to start successfully, no more replicas are retried. The deployment transitions to `UNHEALTHY`.
3. An autoscaling deployment is deployed and replicas start successfully. It later scales down and tries to scale back up again, but there are a lot of replica failures. Here the deployment could transition to `UNHEALTHY` if there are enough replica failures, but replicas will _continue_ to retry.

## Related issue number

closes #50710
