### PR TITLE
[core] Fix test_threaded_actor flaky on mac

### DIFF
--- a/python/ray/tests/test_threaded_actor.py
+++ b/python/ray/tests/test_threaded_actor.py
@@ -16,7 +16,7 @@ def ensure_cpu_returned(expected_cpus):
     )
 
 
-def test_threaded_actor_basic(shutdown_only):
+def test_threaded_actor_basic(ray_start_cluster):
     """Test the basic threaded actor."""
     ray.init(num_cpus=1)
 
@@ -45,7 +45,7 @@ def test_threaded_actor_basic(shutdown_only):
     ensure_cpu_returned(1)
 
 
-def test_threaded_actor_api_thread_safe(shutdown_only):
+def test_threaded_actor_api_thread_safe(ray_start_cluster):
     """Test if Ray APIs are thread safe
     when they are used within threaded actor.
     """


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
It would fail on 
```
FAILED python/ray/tests/test_threaded_actor.py::test_threaded_actor_basic - ValueError: When connecting to an existing cluster, num_cpus and num_gpus must not be provided.
```
so instead just creating the cluster directly.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Closes https://github.com/ray-project/ray/issues/44663
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
