### PR TITLE
[core] [easy] [no-op] Fix rotation comment

### DIFF
--- a/python/ray/_private/log_monitor.py
+++ b/python/ray/_private/log_monitor.py
@@ -516,7 +516,7 @@ if __name__ == "__main__":
         type=str,
         default=ray_constants.LOG_MONITOR_LOG_FILE_NAME,
         help="Specify the name of log file, "
-        "log to stdout if set empty, default is "
+        "log to stderr if set empty, default is "
         f'"{ray_constants.LOG_MONITOR_LOG_FILE_NAME}"',
     )
     parser.add_argument(


### PR DESCRIPTION
The correct destination is stderr but not stdout.

- We've mentioned effect to stream to stderr here: https://github.com/ray-project/ray/blob/a42e6580a59dff3291a56595a74ff27c04d9e29d/python/ray/_private/services.py#L1142-L1144
- Stream handler is used when logging filename not specified, which streams to stderr: https://docs.python.org/3/library/logging.handlers.html#logging.StreamHandler