### PR TITLE
[core] [easy] [noop] Add comments on client call

### DIFF
--- a/src/ray/rpc/client_call.h
+++ b/src/ray/rpc/client_call.h
@@ -190,7 +190,7 @@ using PrepareAsyncFunction = std::unique_ptr<grpc::ClientAsyncResponseReader<Rep
 /// `CompletionQueue`, and post the callback function to the main event loop when a reply
 /// is received.
 ///
-/// Multiple clients can share one `ClientCallManager`, with responses deleted to a
+/// Multiple clients can share one `ClientCallManager`, with responses delegated to one
 /// completion queue in the round-robin style.
 class ClientCallManager {
  public:
@@ -224,7 +224,7 @@ class ClientCallManager {
       cq->Shutdown();
     }
     for (auto &polling_thread : polling_threads_) {
-      RAY_DCHECK(polling_thread.joinable());
+      RAY_CHECK(polling_thread.joinable());
       polling_thread.join();
     }
   }

--- a/src/ray/rpc/client_call.h
+++ b/src/ray/rpc/client_call.h
@@ -186,10 +186,12 @@ using PrepareAsyncFunction = std::unique_ptr<grpc::ClientAsyncResponseReader<Rep
 /// `ClientCallManager` is used to manage outgoing gRPC requests and the lifecycles of
 /// `ClientCall` objects.
 ///
-/// It maintains a thread that keeps polling events from `CompletionQueue`, and post
-/// the callback function to the main event loop when a reply is received.
+/// It maintains multiple threads that keep polling events from its corresponding
+/// `CompletionQueue`, and post the callback function to the main event loop when a reply
+/// is received.
 ///
-/// Multiple clients can share one `ClientCallManager`.
+/// Multiple clients can share one `ClientCallManager`, with responses deleted to a
+/// completion queue in the round-robin style.
 class ClientCallManager {
  public:
   /// Constructor.
@@ -210,7 +212,7 @@ class ClientCallManager {
     // Start the polling threads.
     cqs_.reserve(num_threads_);
     for (int i = 0; i < num_threads_; i++) {
-      cqs_.push_back(std::make_unique<grpc::CompletionQueue>());
+      cqs_.emplace_back(std::make_unique<grpc::CompletionQueue>());
       polling_threads_.emplace_back(
           &ClientCallManager::PollEventsFromCompletionQueue, this, i);
     }
@@ -222,6 +224,7 @@ class ClientCallManager {
       cq->Shutdown();
     }
     for (auto &polling_thread : polling_threads_) {
+      RAY_DCHECK(polling_thread.joinable());
       polling_thread.join();
     }
   }

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -188,12 +188,12 @@ class GrpcClient {
   ClientCallManager &client_call_manager_;
   /// The gRPC-generated stub.
   std::unique_ptr<typename GrpcService::Stub> stub_;
-  /// Whether to use TLS.
-  bool use_tls_;
   /// The channel of the stub.
   std::shared_ptr<grpc::Channel> channel_;
   /// Whether CallMethod is invoked.
   std::atomic<bool> call_method_invoked_ = false;
+  /// Whether to use TLS.
+  bool use_tls_;
 };
 
 }  // namespace rpc


### PR DESCRIPTION
Add some comments on completion queue / thread usage for client call manager, didn't figure it out at first place.

Meanwhile, I'm really surprised multiple threads/completion queues could improve performance.
Paste the original PR here: https://github.com/ray-project/ray/pull/6067