### PR TITLE
[RLlib] Correct the error message for invalid env registering.

### DIFF
--- a/rllib/utils/error.py
+++ b/rllib/utils/error.py
@@ -49,8 +49,8 @@ Try one of the following:
 a) For Atari support: `pip install gym[atari] autorom[accept-rom-license]`.
    For PyBullet support: `pip install pybullet`.
 b) To register your custom env, do `from ray import tune;
-   tune.register('[name]', lambda cfg: [return env obj from here using cfg])`.
-   Then in your config, do `config['env'] = [name]`.
+   tune.register_env('[name]', lambda cfg: [return env obj from here using cfg])`.
+   Then in your config, do `config.environment(env='[name]').
 c) Make sure you provide a fully qualified classpath, e.g.:
    `ray.rllib.examples.envs.classes.repeat_after_me_env.RepeatAfterMeEnv`
 """


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If a custom env is used and it is not registered properly, the `ERR_MSG_INVALID_ENV_DESCRIPTOR` error message from `rllib.utils.error.py` is raised. The message is incorrect as it tells the user to use tune.register() and use the old `config(env)` to set the env in config.

## Related issue number

Closes #51620 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
