### PR TITLE
[core] Actor reconstruction when a creation arg is in plasma

### DIFF
--- a/src/mock/ray/rpc/worker/core_worker_client.h
+++ b/src/mock/ray/rpc/worker/core_worker_client.h
@@ -129,6 +129,11 @@ class MockCoreWorkerClientInterface : public ray::pubsub::MockSubscriberClientIn
               (const AssignObjectOwnerRequest &request,
                const ClientCallback<AssignObjectOwnerReply> &callback),
               (override));
+  MOCK_METHOD(void,
+              OwnedActorDead,
+              (const OwnedActorDeadRequest &request,
+               const ClientCallback<OwnedActorDeadReply> &callback),
+              (override));
 };
 
 class MockCoreWorkerClientConfigurableRunningTasks

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1268,6 +1268,11 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   void HandleNumPendingTasks(rpc::NumPendingTasksRequest request,
                              rpc::NumPendingTasksReply *reply,
                              rpc::SendReplyCallback send_reply_callback) override;
+
+  void HandleOwnedActorDead(rpc::OwnedActorDeadRequest request,
+                            rpc::OwnedActorDeadReply *reply,
+                            rpc::SendReplyCallback send_reply_callback) override;
+
   ///
   /// Public methods related to async actor call. This should only be used when
   /// the actor is (1) direct actor and (2) using async mode.
@@ -1955,6 +1960,9 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// Maps serialized runtime env info to **immutable** deserialized protobuf.
   mutable utils::container::ThreadSafeSharedLruCache<std::string, rpc::RuntimeEnvInfo>
       runtime_env_json_serialization_cache_;
+
+  // Reconstructable actors owned by this worker.
+  absl::flat_hash_set<ActorID> owned_actor_ids_;
 };
 
 // Lease request rate-limiter based on cluster node size.

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -166,6 +166,12 @@ class ReferenceCounter : public ReferenceCounterInterface,
                                     std::vector<ObjectID> *deleted)
       ABSL_LOCKS_EXCLUDED(mutex_);
 
+  /// Decrements the lineage ref count for the object ID's and deletes the reference if
+  /// they can be deleted.
+  /// \param[in] object_ids The object IDs to decrement the lineage ref count for.
+  /// \returns: The object ID's that can be deleted.
+  std::vector<ObjectID> DecrementLineageRefCount(const std::vector<ObjectID> &object_ids);
+
   /// Add an object that we own. The object may depend on other objects.
   /// Dependencies for each ObjectID must be set at most once. The local
   /// reference count for the ObjectID is set to zero, which assumes that an

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -454,6 +454,15 @@ message RegisterMutableObjectReaderReply {
   // Empty for now.
 }
 
+message OwnedActorDeadRequest {
+  bytes actor_id = 1;
+  repeated bytes plasma_dependency_ids = 2;
+}
+
+message OwnedActorDeadReply {
+  // Empty
+}
+
 service CoreWorkerService {
   // Raylet notifies its workers that the GCS has restarted.
   // Failure: Always from local raylet, should not fail.
@@ -576,4 +585,8 @@ service CoreWorkerService {
   // Failure: TODO: Needs failure behavior.
   rpc RegisterMutableObjectReader(RegisterMutableObjectReaderRequest)
       returns (RegisterMutableObjectReaderReply);
+
+  // Reports that an actor is dead.
+  // Failure: Retries and is idempotent.
+  rpc OwnedActorDead(OwnedActorDeadRequest) returns (OwnedActorDeadReply);
 }

--- a/src/ray/rpc/worker/core_worker_client.h
+++ b/src/ray/rpc/worker/core_worker_client.h
@@ -189,6 +189,9 @@ class CoreWorkerClientInterface : public pubsub::SubscriberClientInterface {
       const RayletNotifyGCSRestartRequest &request,
       const ClientCallback<RayletNotifyGCSRestartReply> &callback) {}
 
+  virtual void OwnedActorDead(const OwnedActorDeadRequest &request,
+                              const ClientCallback<OwnedActorDeadReply> &callback) {}
+
   virtual ~CoreWorkerClientInterface() = default;
 };
 
@@ -341,6 +344,13 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
                          grpc_client_,
                          /*method_timeout_ms*/ -1,
                          override)
+
+  VOID_RETRYABLE_RPC_CLIENT_METHOD(retryable_grpc_client_,
+                                   CoreWorkerService,
+                                   OwnedActorDead,
+                                   grpc_client_,
+                                   /*method_timeout_ms*/ -1,
+                                   override)
 
   void PushActorTask(std::unique_ptr<PushTaskRequest> request,
                      bool skip_queue,

--- a/src/ray/rpc/worker/core_worker_server.h
+++ b/src/ray/rpc/worker/core_worker_server.h
@@ -59,7 +59,8 @@ namespace rpc {
   RAY_CORE_WORKER_RPC_SERVICE_HANDLER(PlasmaObjectReady)           \
   RAY_CORE_WORKER_RPC_SERVICE_HANDLER(Exit)                        \
   RAY_CORE_WORKER_RPC_SERVICE_HANDLER(AssignObjectOwner)           \
-  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(NumPendingTasks)
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(NumPendingTasks)             \
+  RAY_CORE_WORKER_RPC_SERVICE_HANDLER(OwnedActorDead)
 
 #define RAY_CORE_WORKER_DECLARE_RPC_HANDLERS                           \
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(PushTask)                    \
@@ -85,7 +86,8 @@ namespace rpc {
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(PlasmaObjectReady)           \
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(Exit)                        \
   DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(AssignObjectOwner)           \
-  DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(NumPendingTasks)
+  DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(NumPendingTasks)             \
+  DECLARE_VOID_RPC_SERVICE_HANDLER_METHOD(OwnedActorDead)
 
 /// Interface of the `CoreWorkerServiceHandler`, see `src/ray/protobuf/core_worker.proto`.
 class CoreWorkerServiceHandler : public DelayedServiceHandler {


### PR DESCRIPTION
## Problem
The current issue is that on success of initial actor creation `lineage_ref_count` for args in plasma is decremented, even if the actor could restart later. Therefore the objects won't stick around and could get deleted by the time the actor needs to restart.

For context, the actor creation task is initially submitted by the owner. But all the actor restart, restart scheduling, and actor death logic happens in the gcs actor manager. This necessitates a more complicated solution. An ideal solution would be to use the gcs actor manager only for detached actors and have normal actors managed by an actor manager on the owner worker.

## Solution:
1. Incrementing `lineage_ref_count`
    - Tell the task manager that the actor creation task has retries if `task_spec.MaxActorRestarts() != 0 && !task_spec.IsDetachedActor()`. Because of this, the task manager will not decrement the `lineage_ref_count` when the actor creation task finishes for the first time.
2. Decrementing `lineage_ref_count`
    - Send a gcs → owner `OwnedActorDead` rpc on actor death (no restarts left + not detached) to decrement the `lineage_ref_count` for all the objects that it was incremented for in step 1.

Idempotency of `HandleOwnedActorDead`: Keeping a new set of owned actor id's in the core worker. Adding to it when an actor creation task is first submitted. Removing on the first execution of `HandleOwnedActorDead` and never executing it if the actor id is not in the set.

Note: This feature will still not work for detached actors because there is inherently no owner.
