### PR TITLE
[core] [easy] Mark cgroup tests exclusive

### DIFF
--- a/src/ray/common/cgroup/test/BUILD
+++ b/src/ray/common/cgroup/test/BUILD
@@ -20,7 +20,10 @@ ray_cc_test(
     name = "cgroup_v2_utils_unprivileged_test",
     size = "small",
     srcs = ["cgroup_v2_utils_unprivileged_test.cc"],
-    tags = ["team:core"],
+    tags = [
+        "exclusive",
+        "team:core",
+    ],
     deps = [
         "//src/ray/common/cgroup:cgroup_setup",
         "//src/ray/common/test:testing",
@@ -31,7 +34,10 @@ ray_cc_test(
 ray_cc_test(
     name = "fake_cgroup_setup_test",
     srcs = ["fake_cgroup_setup_test.cc"],
-    tags = ["team:core"],
+    tags = [
+        "exclusive",
+        "team:core",
+    ],
     deps = [
         "//src/ray/common/cgroup:fake_cgroup_setup",
         "@com_google_googletest//:gtest_main",

--- a/src/ray/common/cgroup/test/BUILD
+++ b/src/ray/common/cgroup/test/BUILD
@@ -7,6 +7,7 @@ ray_cc_test(
     tags = [
         # TODO(hjiang, ibrahim, lonnie): Setup CI for cgroup testing environment.
         "manual",
+        "exclusive",
         "team:core",
     ],
     deps = [
@@ -35,7 +36,6 @@ ray_cc_test(
     name = "fake_cgroup_setup_test",
     srcs = ["fake_cgroup_setup_test.cc"],
     tags = [
-        "exclusive",
         "team:core",
     ],
     deps = [


### PR DESCRIPTION
cgroup tests access (read and write) system directory, so they shouldn't be executed in parallel.
For example, `bazel test //src/ray/common/cgroup/tests:all` should run tests one by one.