### PR TITLE
[release] Fix perf metrics compare

### DIFF
--- a/release/release_logs/compare_perf_metrics
+++ b/release/release_logs/compare_perf_metrics
@@ -1,4 +1,11 @@
 #!/usr/bin/env python3
+"""
+This script compares benchmark results from two release directories one by one.
+
+Usage:
+python3 release/release_logs/compare_perf_metrics <old-dir> <new-dir>
+"""
+
 import json
 import pathlib
 import argparse
@@ -27,37 +34,43 @@ def parse_args():
 
 
 def main(old_dir_name, new_dir_name):
+    old_files = list(walk(old_dir_name))
+    new_files = list(walk(new_dir_name))
 
-    old_paths = paths_without_root_dir(walk(old_dir_name))
-    new_paths = paths_without_root_dir(walk(new_dir_name))
-    to_compare, missing_in_new, missing_in_old = get_compare_list(old_paths, new_paths)
+    old_by_name = group_by_filename(old_files, old_dir_name)
+    new_by_name = group_by_filename(new_files, new_dir_name)
 
-    for path in missing_in_new:
-        print(new_dir_name, "does not have", path)
-
-    for path in missing_in_old:
-        print(old_dir_name, "does not have", path)
+    all_filenames = set(old_by_name.keys()) | set(new_by_name.keys())
 
     throughput_regressions = []
     latency_regressions = []
     missing_in_new = []
     missing_in_old = []
-    for path in to_compare:
-        old = pathlib.Path(old_dir_name, *path.parts)
-        new = pathlib.Path(new_dir_name, *path.parts)
 
-        throughput, latency, new, old = get_regressions(old, new)
+    for filename in sorted(all_filenames):
+        old_path = old_by_name.get(filename)
+        new_path = new_by_name.get(filename)
+
+        if not old_path:
+            print(f"{old_dir_name} is missing {filename}")
+            continue
+        if not new_path:
+            print(f"{new_dir_name} is missing {filename}")
+            continue
+
+        # Compare the two files
+        throughput, latency, missing_new_metrics, missing_old_metrics = get_regressions(old_path, new_path)
 
         throughput_regressions.extend(throughput)
         latency_regressions.extend(latency)
-        missing_in_new.extend(new)
-        missing_in_old.extend(old)
+        missing_in_new.extend(missing_new_metrics)
+        missing_in_old.extend(missing_old_metrics)
 
-    for perf_metric in missing_in_new:
-        print(f"{new} does not have {perf_metric}")
+    for metric in missing_in_new:
+        print(f"{new_path} does not have {metric}")
 
-    for perf_metric in missing_in_old:
-        print(f"{old} does not have {perf_metric}")
+    for metric in missing_in_old:
+        print(f"{old_path} does not have {metric}")
 
     throughput_regressions.sort()
     for _, regression in throughput_regressions:
@@ -78,9 +91,20 @@ def walk(dir_name):
             stack.extend(root.iterdir())
 
 
-def paths_without_root_dir(paths):
-    for p in paths:
-        yield pathlib.Path(*p.parts[1:])
+def group_by_filename(paths, base_dir):
+    """
+    Return a dict mapping filenames to full paths.
+    If there are duplicates, logging warning and ignore later ones.
+    """
+    file_map = {}
+    for path in paths:
+        name = path.name
+        rel_path = path.relative_to(base_dir)
+        if name not in file_map:
+            file_map[name] = path
+        else:
+            print(f"Warning: duplicate filename {name} found at {rel_path}")
+    return file_map
 
 
 def get_compare_list(old, new):
@@ -92,7 +116,6 @@ def get_compare_list(old, new):
         old_set.difference(new_set),
         new_set.difference(old_set),
     )
-
 
 def get_regressions(old_path, new_path):
 


### PR DESCRIPTION
When doing release benchmark comparison, I found the script is performing comparison on **full filepaths** rather than **release result filenames**.

In details, this is the command I executed
```sh
python3 /home/ubuntu/ray/release/release_logs/compare_perf_metrics /home/ubuntu/ray/release/release_logs/2.22.0 /home/ubuntu/ray/release/release_logs/some_version
```

And here's the benchmark files within
```sh
[~/ray] (master) [gke_hjiang-proj-cgroup-experiment_us-west1_hjiang-cgroup-test]
ubuntu@hjiang-devbox-pg$ ls -lR /home/ubuntu/ray/release/release_logs/2.22.0
/home/ubuntu/ray/release/release_logs/2.22.0:
total 24
drwxrwxr-x 2 ubuntu ubuntu 4096 Dec 10 03:34 benchmarks
-rw-rw-r-- 1 ubuntu ubuntu 8704 Dec 10 03:34 microbenchmark.json
drwxrwxr-x 2 ubuntu ubuntu 4096 Dec 10 03:34 scalability
drwxrwxr-x 2 ubuntu ubuntu 4096 Dec 10 03:34 stress_tests

/home/ubuntu/ray/release/release_logs/2.22.0/benchmarks:
total 16
-rw-rw-r-- 1 ubuntu ubuntu 1845 Dec 10 03:34 many_actors.json
-rw-rw-r-- 1 ubuntu ubuntu 1976 Dec 10 03:34 many_nodes.json
-rw-rw-r-- 1 ubuntu ubuntu 1828 Dec 10 03:34 many_pgs.json
-rw-rw-r-- 1 ubuntu ubuntu 1983 Dec 10 03:34 many_tasks.json

/home/ubuntu/ray/release/release_logs/2.22.0/scalability:
total 8
-rw-rw-r-- 1 ubuntu ubuntu  341 Dec 10 03:34 object_store.json
-rw-rw-r-- 1 ubuntu ubuntu 1222 Dec 10 03:34 single_node.json

/home/ubuntu/ray/release/release_logs/2.22.0/stress_tests:
total 12
-rw-rw-r-- 1 ubuntu ubuntu  394 Dec 10 03:34 stress_test_dead_actors.json
-rw-rw-r-- 1 ubuntu ubuntu 1642 Dec 10 03:34 stress_test_many_tasks.json
-rw-rw-r-- 1 ubuntu ubuntu  493 Dec 10 03:34 stress_test_placement_group.json
(myenv) (myenv) 



[~/ray] (master) [gke_hjiang-proj-cgroup-experiment_us-west1_hjiang-cgroup-test]
ubuntu@hjiang-devbox-pg$ ls -lR /home/ubuntu/ray/release/release_logs/some_version
/home/ubuntu/ray/release/release_logs/some_version:
total 24
drwxrwxr-x 2 ubuntu ubuntu 4096 Mar 24 22:17 benchmarks
-rw-rw-r-- 1 ubuntu ubuntu 8711 Mar 24 22:17 microbenchmark.json
drwxrwxr-x 2 ubuntu ubuntu 4096 Mar 24 22:17 scalability
drwxrwxr-x 2 ubuntu ubuntu 4096 Mar 24 22:17 stress_tests

/home/ubuntu/ray/release/release_logs/some_version/benchmarks:
total 16
-rw-rw-r-- 1 ubuntu ubuntu 2029 Mar 24 22:17 many_actors.json
-rw-rw-r-- 1 ubuntu ubuntu 2112 Mar 24 22:17 many_nodes.json
-rw-rw-r-- 1 ubuntu ubuntu 2015 Mar 24 22:17 many_pgs.json
-rw-rw-r-- 1 ubuntu ubuntu 2123 Mar 24 22:17 many_tasks.json

/home/ubuntu/ray/release/release_logs/some_version/scalability:
total 8
-rw-rw-r-- 1 ubuntu ubuntu  343 Mar 24 22:17 object_store.json
-rw-rw-r-- 1 ubuntu ubuntu 1230 Mar 24 22:17 single_node.json

/home/ubuntu/ray/release/release_logs/some_version/stress_tests:
total 12
-rw-rw-r-- 1 ubuntu ubuntu  393 Mar 24 22:17 stress_test_dead_actors.json
-rw-rw-r-- 1 ubuntu ubuntu 1638 Mar 24 22:17 stress_test_many_tasks.json
-rw-rw-r-- 1 ubuntu ubuntu  493 Mar 24 22:17 stress_test_placement_group.json
```
As you could tell, the result filenames (items) are exactly the same, but the script fails to recognize it.
```sh
ubuntu@hjiang-devbox-pg$ python3 /home/ubuntu/ray/release/release_logs/compare_perf_metrics 
old paths = [PosixPath('home/ubuntu/ray/release/release_logs/2.22.0/scalability/single_node.json'), PosixPath('home/ubuntu/ray/release/release_logs/2.22.0/scalability/object_store.json'), PosixPath('home/ubuntu/ray/release/release_logs/2.22.0/stress_tests/stress_test_many_tasks.json'), PosixPath('home/ubuntu/ray/release/release_logs/2.22.0/stress_tests/stress_test_placement_group.json'), PosixPath('home/ubuntu/ray/release/release_logs/2.22.0/stress_tests/stress_test_dead_actors.json'), PosixPath('home/ubuntu/ray/release/release_logs/2.22.0/benchmarks/many_actors.json'), PosixPath('home/ubuntu/ray/release/release_logs/2.22.0/benchmarks/many_nodes.json'), PosixPath('home/ubuntu/ray/release/release_logs/2.22.0/benchmarks/many_pgs.json'), PosixPath('home/ubuntu/ray/release/release_logs/2.22.0/benchmarks/many_tasks.json'), PosixPath('home/ubuntu/ray/release/release_logs/2.22.0/microbenchmark.json')]
new paths = [PosixPath('home/ubuntu/ray/release/release_logs/some_version/scalability/single_node.json'), PosixPath('home/ubuntu/ray/release/release_logs/some_version/scalability/object_store.json'), PosixPath('home/ubuntu/ray/release/release_logs/some_version/stress_tests/stress_test_many_tasks.json'), PosixPath('home/ubuntu/ray/release/release_logs/some_version/stress_tests/stress_test_placement_group.json'), PosixPath('home/ubuntu/ray/release/release_logs/some_version/stress_tests/stress_test_dead_actors.json'), PosixPath('home/ubuntu/ray/release/release_logs/some_version/benchmarks/many_actors.json'), PosixPath('home/ubuntu/ray/release/release_logs/some_version/benchmarks/many_nodes.json'), PosixPath('home/ubuntu/ray/release/release_logs/some_version/benchmarks/many_pgs.json'), PosixPath('home/ubuntu/ray/release/release_logs/some_version/benchmarks/many_tasks.json'), PosixPath('home/ubuntu/ray/release/release_logs/some_version/microbenchmark.json')]
/home/ubuntu/ray/release/release_logs/2.22.0 /home/ubuntu/ray/release/release_logs/some_version 
/home/ubuntu/ray/release/release_logs/some_version does not have home/ubuntu/ray/release/release_logs/2.22.0/benchmarks/many_actors.json
/home/ubuntu/ray/release/release_logs/some_version does not have home/ubuntu/ray/release/release_logs/2.22.0/scalability/single_node.json
/home/ubuntu/ray/release/release_logs/some_version does not have home/ubuntu/ray/release/release_logs/2.22.0/benchmarks/many_pgs.json
/home/ubuntu/ray/release/release_logs/some_version does not have home/ubuntu/ray/release/release_logs/2.22.0/microbenchmark.json
/home/ubuntu/ray/release/release_logs/some_version does not have home/ubuntu/ray/release/release_logs/2.22.0/stress_tests/stress_test_placement_group.json
/home/ubuntu/ray/release/release_logs/some_version does not have home/ubuntu/ray/release/release_logs/2.22.0/stress_tests/stress_test_many_tasks.json
/home/ubuntu/ray/release/release_logs/some_version does not have home/ubuntu/ray/release/release_logs/2.22.0/benchmarks/many_tasks.json
/home/ubuntu/ray/release/release_logs/some_version does not have home/ubuntu/ray/release/release_logs/2.22.0/scalability/object_store.json
/home/ubuntu/ray/release/release_logs/some_version does not have home/ubuntu/ray/release/release_logs/2.22.0/benchmarks/many_nodes.json
/home/ubuntu/ray/release/release_logs/some_version does not have home/ubuntu/ray/release/release_logs/2.22.0/stress_tests/stress_test_dead_actors.json
/home/ubuntu/ray/release/release_logs/2.22.0 does not have home/ubuntu/ray/release/release_logs/some_version/stress_tests/stress_test_dead_actors.json
/home/ubuntu/ray/release/release_logs/2.22.0 does not have home/ubuntu/ray/release/release_logs/some_version/stress_tests/stress_test_many_tasks.json
/home/ubuntu/ray/release/release_logs/2.22.0 does not have home/ubuntu/ray/release/release_logs/some_version/benchmarks/many_tasks.json
/home/ubuntu/ray/release/release_logs/2.22.0 does not have home/ubuntu/ray/release/release_logs/some_version/stress_tests/stress_test_placement_group.json
/home/ubuntu/ray/release/release_logs/2.22.0 does not have home/ubuntu/ray/release/release_logs/some_version/microbenchmark.json
/home/ubuntu/ray/release/release_logs/2.22.0 does not have home/ubuntu/ray/release/release_logs/some_version/scalability/single_node.json
/home/ubuntu/ray/release/release_logs/2.22.0 does not have home/ubuntu/ray/release/release_logs/some_version/scalability/object_store.json
/home/ubuntu/ray/release/release_logs/2.22.0 does not have home/ubuntu/ray/release/release_logs/some_version/benchmarks/many_nodes.json
/home/ubuntu/ray/release/release_logs/2.22.0 does not have home/ubuntu/ray/release/release_logs/some_version/benchmarks/many_actors.json
/home/ubuntu/ray/release/release_logs/2.22.0 does not have home/ubuntu/ray/release/release_logs/some_version/benchmarks/many_pgs.json
to compare = set()
```

In this PR, I tried to map from filenames / item names to its full filepaths.