### PR TITLE
add web serve port to replica details

### DIFF
--- a/python/ray/dashboard/modules/serve/tests/test_serve_dashboard.py
+++ b/python/ray/dashboard/modules/serve/tests/test_serve_dashboard.py
@@ -463,6 +463,8 @@ def test_get_serve_instance_details(ray_start_stop, f_deployment_options, url):
                 assert deployment.name in replica.actor_name
                 assert replica.actor_id and replica.node_id and replica.node_ip
                 assert replica.start_time_s > app_details[app].last_deployed_time_s
+                assert replica.http_port == 8000
+                assert replica.grpc_port == 9000
                 file_path = "/tmp/ray/session_latest/logs" + replica.log_file_path
                 assert os.path.exists(file_path)
 
@@ -560,6 +562,8 @@ def test_get_serve_instance_details_for_imperative_apps(ray_start_stop, url):
                 assert deployment.name in replica.actor_name
                 assert replica.actor_id and replica.node_id and replica.node_ip
                 assert replica.start_time_s > app_details[app].last_deployed_time_s
+                assert replica.http_port == 8000
+                assert replica.grpc_port == 9000
                 file_path = "/tmp/ray/session_latest/logs" + replica.log_file_path
                 assert os.path.exists(file_path)
 

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -911,6 +911,9 @@ class DeploymentReplica:
             replica_id=self._replica_id.unique_id,
             state=ReplicaState.STARTING,
             start_time_s=0,
+            # TODO(abrar): ports will be populated by the controller the server.
+            http_port=8000,
+            grpc_port=9000,
         )
         self._multiplexed_model_ids: List = []
 

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -937,6 +937,8 @@ class ReplicaDetails(ServeActorDetails, frozen=True):
             "state from the running replica actor."
         )
     )
+    http_port: Optional[int] = Field(description="Port for the HTTP server.")
+    grpc_port: Optional[int] = Field(description="Port for the gRPC server.")
 
 
 @PublicAPI(stability="stable")

--- a/python/ray/serve/tests/test_controller.py
+++ b/python/ray/serve/tests/test_controller.py
@@ -196,6 +196,8 @@ def test_get_serve_instance_details_json_serializable(serve_instance, policy):
                                     "state": "RUNNING",
                                     "pid": replica.pid,
                                     "start_time_s": replica.start_time_s,
+                                    "http_port": 8000,
+                                    "grpc_port": 9000,
                                 }
                             ],
                         }


### PR DESCRIPTION
This change adds the server port to the replica details. This information will be used by the Admin Zone to set up an ALB  to route traffic directly to replicas.

Currently, the ports are hardcoded, meaning all replicas on a node share the same port for HTTPS and gRPC. This change unblocks a subsequent update in the Admin Zone. In the future, ports will be dynamically assigned when the web server starts on the replica. However, at present, no web server is running on the replica.


`curl --location '127.0.0.1:8265/api/serve/applications/'`

returns
```
{
    "controller_info": {
        "node_id": "64652faeeb04e098ea72da643bb1bded3736063b3b3e9c22b67ac56b",
        "node_ip": "127.0.0.1",
        "actor_id": "9070107b8a775068f12d355f01000000",
        "actor_name": "SERVE_CONTROLLER_ACTOR",
        "worker_id": "12601bf985162bd42f78b40bf2dbf8e892dac82dc9c36ea009cb85b9",
        "log_file_path": "/serve/controller_7280.log"
    },
    "proxy_location": "EveryNode",
    "http_options": {
        "host": "0.0.0.0",
        "port": 8000,
        "root_path": "",
        "request_timeout_s": null,
        "keep_alive_timeout_s": 5
    },
    "grpc_options": {
        "port": 9000,
        "grpc_servicer_functions": []
    },
    "proxies": {
        "64652faeeb04e098ea72da643bb1bded3736063b3b3e9c22b67ac56b": {
            "node_id": "64652faeeb04e098ea72da643bb1bded3736063b3b3e9c22b67ac56b",
            "node_ip": "127.0.0.1",
            "actor_id": "e587c08a0f15161b8d514c7601000000",
            "actor_name": "SERVE_PROXY_ACTOR-64652faeeb04e098ea72da643bb1bded3736063b3b3e9c22b67ac56b",
            "worker_id": "14104fb007a8c9744c8839f076f0b426862d5d37133fd94b8b07b5e2",
            "log_file_path": "/serve/proxy_127.0.0.1.log",
            "status": "HEALTHY"
        }
    },
    "applications": {
        "default": {
            "name": "default",
            "route_prefix": "/",
            "docs_path": null,
            "status": "RUNNING",
            "message": "",
            "last_deployed_time_s": 1742874408.004471,
            "deployed_app_config": {
                "import_path": "app2:app",
                "runtime_env": {},
                "args": {}
            },
            "source": "declarative",
            "deployments": {
                "App2": {
                    "name": "App2",
                    "status": "HEALTHY",
                    "status_trigger": "CONFIG_UPDATE_COMPLETED",
                    "message": "",
                    "deployment_config": {
                        "name": "App2",
                        "num_replicas": 1,
                        "max_ongoing_requests": 5,
                        "max_queued_requests": -1,
                        "user_config": null,
                        "graceful_shutdown_wait_loop_s": 2.0,
                        "graceful_shutdown_timeout_s": 20.0,
                        "health_check_period_s": 10.0,
                        "health_check_timeout_s": 30.0,
                        "ray_actor_options": {
                            "num_cpus": 1.0
                        }
                    },
                    "target_num_replicas": 1,
                    "required_resources": {
                        "CPU": 1
                    },
                    "replicas": [
                        {
                            "node_id": "64652faeeb04e098ea72da643bb1bded3736063b3b3e9c22b67ac56b",
                            "node_ip": "127.0.0.1",
                            "actor_id": "ab8ae8b8f0c04264aeaa73d301000000",
                            "actor_name": "SERVE_REPLICA::default#App2#viibq0aq",
                            "worker_id": "a4eb2581aee1c204baafe37c7953f6b9f9558118cbec4f06d132d839",
                            "log_file_path": "/serve/replica_default_App2_viibq0aq.log",
                            "replica_id": "viibq0aq",
                            "state": "RUNNING",
                            "pid": 7274,
                            "start_time_s": 1742874408.128712,
                            "http_port": 8000,
                            "grpc_port": 9000
                        }
                    ]
                }
            }
        }
    },
    "target_capacity": null
}
```