### PR TITLE
[core] Disable invoke once for test

### DIFF
--- a/src/ray/util/BUILD
+++ b/src/ray/util/BUILD
@@ -370,8 +370,10 @@ ray_cc_library(
 
 ray_cc_library(
     name = "invoke_once_token",
+    srcs = ["invoke_once_token.cc"],
     hdrs = ["invoke_once_token.h"],
     deps = [
         ":logging",
+        "//src/ray/util:env",
     ],
 )

--- a/src/ray/util/tests/BUILD
+++ b/src/ray/util/tests/BUILD
@@ -364,6 +364,7 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/util:invoke_once_token",
+        "//src/ray/util:scoped_env_setter",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/src/ray/util/tests/invoke_once_token_test.cc
+++ b/src/ray/util/tests/invoke_once_token_test.cc
@@ -16,6 +16,8 @@
 
 #include <gtest/gtest.h>
 
+#include "ray/util/scoped_env_setter.h"
+
 namespace ray {
 
 TEST(InvokeOnceToken, InvokeOnce) {
@@ -29,5 +31,13 @@ TEST(InvokeOnceToken, InvokeTwice) {
   // Second invocation fails.
   EXPECT_DEATH(token.CheckInvokeOnce(), "Invoke once token has been visited before.");
 };
+
+TEST(InvokeOnceToken, DisableInvokeOnce) {
+  ScopedEnvSetter scoped_env_setter{/*env_name=*/"RAY_DISABLE_INVOKE_ONCE_FOR_TEST",
+                                    /*value=*/"true"};
+  InvokeOnceToken token;
+  token.CheckInvokeOnce();  // First invocation.
+  token.CheckInvokeOnce();  // Second invocation.
+}
 
 }  // namespace ray


### PR DESCRIPTION
`InvokeOnceToken` is useful in production code, to make sure certain piece of code is only invoke once per-process;
but when I am doing the cgroup related unit test (the initialization for cgroup definitely happens only once), it's causing me some headache.
So I made this PR to add a env to pass around only in unit test.