### PR TITLE
Add uv to Docker image

### DIFF
--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -78,7 +78,7 @@ wget --quiet \
 /bin/bash /tmp/miniforge.sh -b -u -p $HOME/anaconda3
 
 $HOME/anaconda3/bin/conda init
-echo 'export PATH=$HOME/anaconda3/bin:$PATH' >> /home/ray/.bashrc
+echo 'export PATH=$HOME/anaconda3/bin:$PATH' >> $HOME/.bashrc
 rm /tmp/miniforge.sh
 $HOME/anaconda3/bin/conda install -y libgcc-ng python=$PYTHON_VERSION
 $HOME/anaconda3/bin/conda install -y -c conda-forge libffi=3.4.2
@@ -105,13 +105,22 @@ if [[ "$AUTOSCALER" == "autoscaler" ]]; then
     )
 fi
 
-$HOME/anaconda3/bin/pip install --no-cache-dir \
+# Install uv
+wget -qO- https://astral.sh/uv/install.sh | sh
+echo 'export PATH=$HOME/.local/bin:$PATH' >> $HOME/.bashrc
+
+# Some packages are on PyPI as well as other indices, but the latter
+# (unhelpfully) take precedence. We use `--index-strategy unsafe-best-match`
+# to ensure that the best match is chosen from the available indices.
+$HOME/.local/bin/uv pip install \
+    --system --no-cache-dir \
+    --index-strategy unsafe-best-match \
     -c $HOME/requirements_compiled.txt \
     "${PIP_PKGS[@]}"
 
 # To avoid the following error on Jenkins:
 # AttributeError: 'numpy.ufunc' object has no attribute '__module__'
-$HOME/anaconda3/bin/pip uninstall -y dask
+$HOME/.local/bin/uv pip uninstall --system dask
 
 # We install cmake temporarily to get psutil
 sudo apt-get autoremove -y cmake zlib1g-dev

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -106,21 +106,21 @@ if [[ "$AUTOSCALER" == "autoscaler" ]]; then
 fi
 
 # Install uv
-wget -qO- https://astral.sh/uv/install.sh | sh
-echo 'export PATH=$HOME/.local/bin:$PATH' >> $HOME/.bashrc
+wget -qO- https://astral.sh/uv/install.sh | sudo env UV_UNMANAGED_INSTALL="/usr/local/bin" sh
+
+# Set up Conda as system Python
+export PATH=$HOME/anaconda3/bin:$PATH
 
 # Some packages are on PyPI as well as other indices, but the latter
 # (unhelpfully) take precedence. We use `--index-strategy unsafe-best-match`
 # to ensure that the best match is chosen from the available indices.
-$HOME/.local/bin/uv pip install \
-    --system --no-cache-dir \
-    --index-strategy unsafe-best-match \
+uv pip install --system --no-cache-dir --index-strategy unsafe-best-match \
     -c $HOME/requirements_compiled.txt \
     "${PIP_PKGS[@]}"
 
 # To avoid the following error on Jenkins:
 # AttributeError: 'numpy.ufunc' object has no attribute '__module__'
-$HOME/.local/bin/uv pip uninstall --system dask
+uv pip uninstall --system dask
 
 # We install cmake temporarily to get psutil
 sudo apt-get autoremove -y cmake zlib1g-dev


### PR DESCRIPTION
## Why are these changes needed?

Ray has recently added uv support but it's not shipped with base images. This PR addresses that.

## Related issue number

Closes https://github.com/ray-project/ray/issues/51592

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
