### PR TITLE
[core] add actor labels to export events

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -272,6 +272,7 @@ void GcsActor::WriteActorExportEvent() const {
   export_actor_data_ptr->set_node_id(actor_table_data_.node_id());
   export_actor_data_ptr->set_placement_group_id(actor_table_data_.placement_group_id());
   export_actor_data_ptr->set_repr_name(actor_table_data_.repr_name());
+  export_actor_data_ptr->set_labels(*task_spec_.labels())
 
   RayExportEvent(export_actor_data_ptr).SendEvent();
 }

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -272,8 +272,13 @@ void GcsActor::WriteActorExportEvent() const {
   export_actor_data_ptr->set_node_id(actor_table_data_.node_id());
   export_actor_data_ptr->set_placement_group_id(actor_table_data_.placement_group_id());
   export_actor_data_ptr->set_repr_name(actor_table_data_.repr_name());
-  export_actor_data_ptr->mutable_labels()->insert(task_spec_.get()->labels().begin(),
-                                                  task_spec_.get()->labels().end());
+
+  // Add data operator id if it exists.
+  auto task_spec_labels = task_spec_.get()->labels();
+  auto data_operator_label = task_spec_labels.find("__data_operator_id");
+  if (data_operator_label != task_spec_labels.end()) {
+    export_actor_data_ptr->set_ray_data_operator_id(data_operator_label->second);
+  }
 
   RayExportEvent(export_actor_data_ptr).SendEvent();
 }

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -272,7 +272,8 @@ void GcsActor::WriteActorExportEvent() const {
   export_actor_data_ptr->set_node_id(actor_table_data_.node_id());
   export_actor_data_ptr->set_placement_group_id(actor_table_data_.placement_group_id());
   export_actor_data_ptr->set_repr_name(actor_table_data_.repr_name());
-  export_actor_data_ptr->set_labels(*task_spec_.labels())
+  export_actor_data_ptr->mutable_labels()->insert(task_spec_.get()->labels().begin(),
+                                                  task_spec_.get()->labels().end());
 
   RayExportEvent(export_actor_data_ptr).SendEvent();
 }

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -272,13 +272,8 @@ void GcsActor::WriteActorExportEvent() const {
   export_actor_data_ptr->set_node_id(actor_table_data_.node_id());
   export_actor_data_ptr->set_placement_group_id(actor_table_data_.placement_group_id());
   export_actor_data_ptr->set_repr_name(actor_table_data_.repr_name());
-
-  // Add data operator id if it exists.
-  auto task_spec_labels = task_spec_.get()->labels();
-  auto data_operator_label = task_spec_labels.find("__data_operator_id");
-  if (data_operator_label != task_spec_labels.end()) {
-    export_actor_data_ptr->set_ray_data_operator_id(data_operator_label->second);
-  }
+  export_actor_data_ptr->mutable_labels()->insert(task_spec_.get()->labels().begin(),
+                                                  task_spec_.get()->labels().end());
 
   RayExportEvent(export_actor_data_ptr).SendEvent();
 }

--- a/src/ray/gcs/gcs_server/test/export_api/gcs_actor_manager_export_event_test.cc
+++ b/src/ray/gcs/gcs_server/test/export_api/gcs_actor_manager_export_event_test.cc
@@ -269,6 +269,8 @@ TEST_F(GcsActorManagerTest, TestBasic) {
   rpc::CreateActorRequest create_actor_request;
   create_actor_request.mutable_task_spec()->CopyFrom(
       registered_actor->GetCreationTaskSpecification().GetMessage());
+  create_actor_request.mutable_task_spec()->mutable_labels()->insert(
+      {"__data_operator_id", "hi"});
   RAY_CHECK_EQ(
       gcs_actor_manager_->CountFor(rpc::ActorTableData::DEPENDENCIES_UNREADY, ""), 1);
 
@@ -318,6 +320,9 @@ TEST_F(GcsActorManagerTest, TestBasic) {
               event_data["death_cause"]["actor_died_error_context"]["error_message"],
               "The actor is dead because all references to the actor were removed "
               "including lineage ref count.");
+        }
+        if (expected_states[event_idx] == "ALIVE") {
+          ASSERT_EQ(event_data["ray_data_operator_id"], "hi");
         }
       }
       return;

--- a/src/ray/gcs/gcs_server/test/export_api/gcs_actor_manager_export_event_test.cc
+++ b/src/ray/gcs/gcs_server/test/export_api/gcs_actor_manager_export_event_test.cc
@@ -269,8 +269,7 @@ TEST_F(GcsActorManagerTest, TestBasic) {
   rpc::CreateActorRequest create_actor_request;
   create_actor_request.mutable_task_spec()->CopyFrom(
       registered_actor->GetCreationTaskSpecification().GetMessage());
-  create_actor_request.mutable_task_spec()->mutable_labels()->insert(
-      {"__data_operator_id", "hi"});
+  create_actor_request.mutable_task_spec()->mutable_labels()->insert({"w00t", "hi"});
   RAY_CHECK_EQ(
       gcs_actor_manager_->CountFor(rpc::ActorTableData::DEPENDENCIES_UNREADY, ""), 1);
 
@@ -322,7 +321,7 @@ TEST_F(GcsActorManagerTest, TestBasic) {
               "including lineage ref count.");
         }
         if (expected_states[event_idx] == "ALIVE") {
-          ASSERT_EQ(event_data["ray_data_operator_id"], "hi");
+          ASSERT_EQ(event_data["labels"]["w00t"], "hi");
         }
       }
       return;

--- a/src/ray/protobuf/export_api/export_actor_data.proto
+++ b/src/ray/protobuf/export_api/export_actor_data.proto
@@ -73,4 +73,6 @@ message ExportActorData {
   // might depend on actor fields to be initialized in __init__.
   // Default to empty string if no customized repr is defined.
   string repr_name = 14;
+  // The key-value labels for task and actor.
+  map<string, string> labels = 15;
 }

--- a/src/ray/protobuf/export_api/export_actor_data.proto
+++ b/src/ray/protobuf/export_api/export_actor_data.proto
@@ -73,6 +73,6 @@ message ExportActorData {
   // might depend on actor fields to be initialized in __init__.
   // Default to empty string if no customized repr is defined.
   string repr_name = 14;
-  // The key-value labels for task and actor.
-  map<string, string> labels = 15;
+  // The data operator id if this actor is created from a ray data pipeline execution
+  optional string ray_data_operator_id = 15;
 }

--- a/src/ray/protobuf/export_api/export_actor_data.proto
+++ b/src/ray/protobuf/export_api/export_actor_data.proto
@@ -73,6 +73,6 @@ message ExportActorData {
   // might depend on actor fields to be initialized in __init__.
   // Default to empty string if no customized repr is defined.
   string repr_name = 14;
-  // The data operator id if this actor is created from a ray data pipeline execution
-  optional string ray_data_operator_id = 15;
+  // The key-value labels for task and actor.
+  map<string, string> labels = 15;
 }


### PR DESCRIPTION
We added the `labels` field to actor in https://github.com/ray-project/ray/pull/48715/files. This PR populates this field to the export events.

Test:
- CI
- Check that `labels` field are exported successfully

<img width="676" alt="Screenshot 2025-03-25 at 2 37 37 PM" src="https://github.com/user-attachments/assets/5879229d-2d06-4a76-8a25-3afcdd0d63a0" />
