### PR TITLE
[tests] Reassign dashboard tests to core team

### DIFF
--- a/python/ray/dashboard/BUILD
+++ b/python/ray/dashboard/BUILD
@@ -38,12 +38,14 @@ py_test_run_all_subdirectory(
         "modules/node/tests/test_node.py",
         "tests/test_dashboard.py",
         "tests/test_state_head.py",
+        "modules/serve/tests/deploy_imperative_serve_apps.py",
         "modules/serve/tests/test_serve_dashboard.py",
+        "modules/serve/tests/test_serve_dashboard_2.py",
     ],
     extra_srcs = [],
     tags = [
         "exclusive",
-        "team:serve",
+        "team:core",
     ],
     deps = [":conftest"],
 )
@@ -54,7 +56,7 @@ py_test(
     srcs = ["modules/job/tests/test_cli_integration.py"],
     tags = [
         "exclusive",
-        "team:serve",
+        "team:core",
     ],
     deps = [":conftest"],
 )
@@ -73,7 +75,7 @@ py_test(
     ]),
     tags = [
         "exclusive",
-        "team:serve",
+        "team:core",
     ],
     deps = [":conftest"],
 )
@@ -84,7 +86,7 @@ py_test(
     srcs = ["modules/node/tests/test_node.py"],
     tags = [
         "exclusive",
-        "team:serve",
+        "team:core",
     ],
     deps = [":conftest"],
 )
@@ -96,7 +98,7 @@ py_test(
     tags = [
         "exclusive",
         "minimal",
-        "team:serve",
+        "team:core",
     ],
     deps = [":conftest"],
 )

--- a/python/ray/dashboard/BUILD
+++ b/python/ray/dashboard/BUILD
@@ -38,9 +38,7 @@ py_test_run_all_subdirectory(
         "modules/node/tests/test_node.py",
         "tests/test_dashboard.py",
         "tests/test_state_head.py",
-        "modules/serve/tests/deploy_imperative_serve_apps.py",
-        "modules/serve/tests/test_serve_dashboard.py",
-        "modules/serve/tests/test_serve_dashboard_2.py",
+        "modules/serve/tests/**/*.py",
     ],
     extra_srcs = [],
     tags = [


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
These tests should be owned by core.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
