### PR TITLE
[core] `test_job_isolation` passes even when exceptions are thrown

### DIFF
--- a/python/ray/tests/test_job.py
+++ b/python/ray/tests/test_job.py
@@ -59,11 +59,12 @@ def test_invalid_gcs_address():
 @pytest.mark.skipif(
     sys.version_info >= (3, 12), reason="lib is not supported on Python 3.12"
 )
-def test_job_isolation(call_ray_start):
+def test_job_isolation(ray_start_regular):
     # Make sure two jobs with same module name
     # don't interfere with each other
     # (https://github.com/ray-project/ray/issues/19358).
-    address = call_ray_start
+    gcs_address = ray_start_regular.address_info["gcs_address"]
+
     lib_template = """
 import ray
 
@@ -88,7 +89,7 @@ assert ray.get(lib.task.remote()) == {}
         with open(v1_lib, "w") as f:
             f.write(lib_template.format(1))
         with open(v1_driver, "w") as f:
-            f.write(driver_template.format(address, 1))
+            f.write(driver_template.format(gcs_address, 1))
 
         os.makedirs(os.path.join(tmpdir, "v2"))
         v2_lib = os.path.join(tmpdir, "v2", "lib.py")
@@ -96,10 +97,25 @@ assert ray.get(lib.task.remote()) == {}
         with open(v2_lib, "w") as f:
             f.write(lib_template.format(2))
         with open(v2_driver, "w") as f:
-            f.write(driver_template.format(address, 2))
+            f.write(driver_template.format(gcs_address, 2))
 
         subprocess.check_call([sys.executable, v1_driver])
         subprocess.check_call([sys.executable, v2_driver])
+
+    dashboard_url = ray_start_regular.dashboard_url
+    client = JobSubmissionClient(f"http://{dashboard_url}")
+    jobs = client.list_jobs()
+    assert len(jobs) == 3  # ray_start_regular, v1, v2
+
+    num_succeeded = 0
+    num_running = 0
+    for job in jobs:
+        if job.status == "SUCCEEDED":
+            num_succeeded += 1
+        elif job.status == "RUNNING":
+            num_running += 1
+    assert num_succeeded == 2
+    assert num_running == 1
 
 
 def test_job_observability(ray_start_regular):

--- a/python/ray/tests/test_job.py
+++ b/python/ray/tests/test_job.py
@@ -56,9 +56,6 @@ def test_invalid_gcs_address():
         JobSubmissionClient("abc:abc")
 
 
-@pytest.mark.skipif(
-    sys.version_info >= (3, 12), reason="lib is not supported on Python 3.12"
-)
 def test_job_isolation(ray_start_regular):
     # Make sure two jobs with same module name
     # don't interfere with each other


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`call_ray_start` uses an unusual method to obtain the GCS address. It executes a `ray start` command and then parses the command's STDOUT. However, this method will return "None" as address. See the following screenshot for more details.

https://github.com/ray-project/ray/blob/a5bab234e651d19b91d5860be0606d4c6c01d118/python/ray/tests/conftest.py#L771-L789

<img width="880" alt="image" src="https://github.com/user-attachments/assets/7547592c-e6c3-41fb-b0fe-47783775f0e5" />



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
