### PR TITLE
[data] refine backpressure info on progress bar

### DIFF
--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -250,7 +250,11 @@ class ResourceManager:
                 budget = self._op_resource_allocator._op_budgets[op]
                 usage_str += f", budget=(cpu={budget.cpu:.1f}"
                 usage_str += f",gpu={budget.gpu:.1f}"
-                usage_str += f",object store={budget.object_store_memory_str()})"
+                usage_str += f",object store={budget.object_store_memory_str()}"
+                reserved_for_output = memory_string(
+                    self._op_resource_allocator._reserved_for_op_outputs[op]
+                )
+                usage_str += f", out={reserved_for_output})"
         return usage_str
 
     def op_resource_allocator_enabled(self) -> bool:

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -251,7 +251,7 @@ class ResourceManager:
                 usage_str += f", budget=(cpu={budget.cpu:.1f}"
                 usage_str += f",gpu={budget.gpu:.1f}"
                 usage_str += f",obj_store={budget.object_store_memory_str()}"
-                # Memory budget for reading task outputs.
+                # Remaining memory budget for producing new task outputs.
                 reserved_for_output = memory_string(
                     self._op_resource_allocator._output_budgets.get(op, 0)
                 )
@@ -410,7 +410,7 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
         self._total_shared = ExecutionResources.zero()
         # Resource budgets for each operator, excluding `_reserved_for_op_outputs`.
         self._op_budgets: Dict[PhysicalOperator, ExecutionResources] = {}
-        # Per-op budget allowed for reading task outputs.
+        # Remaining memory budget for generating new task outputs, per operator.
         self._output_budgets: Dict[PhysicalOperator, float] = {}
         # Whether each operator has reserved the minimum resources to run
         # at least one task.

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -250,11 +250,12 @@ class ResourceManager:
                 budget = self._op_resource_allocator._op_budgets[op]
                 usage_str += f", budget=(cpu={budget.cpu:.1f}"
                 usage_str += f",gpu={budget.gpu:.1f}"
-                usage_str += f",object store={budget.object_store_memory_str()}"
+                usage_str += f",obj_store={budget.object_store_memory_str()}"
+                # Memory budget for reading task outputs.
                 reserved_for_output = memory_string(
-                    self._op_resource_allocator._reserved_for_op_outputs[op]
+                    self._op_resource_allocator._output_budgets.get(op, 0)
                 )
-                usage_str += f", out={reserved_for_output})"
+                usage_str += f",out={reserved_for_output})"
         return usage_str
 
     def op_resource_allocator_enabled(self) -> bool:
@@ -409,6 +410,8 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
         self._total_shared = ExecutionResources.zero()
         # Resource budgets for each operator, excluding `_reserved_for_op_outputs`.
         self._op_budgets: Dict[PhysicalOperator, ExecutionResources] = {}
+        # Per-op budget allowed for reading task outputs.
+        self._output_budgets: Dict[PhysicalOperator, float] = {}
         # Whether each operator has reserved the minimum resources to run
         # at least one task.
         # This is used to avoid edge cases where the entire resource limits are not
@@ -557,12 +560,14 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
         op_outputs_usage = self._get_op_outputs_usage_with_downstream(op)
         res += max(self._reserved_for_op_outputs[op] - op_outputs_usage, 0)
         if math.isinf(res):
+            self._output_budgets[op] = res
             return None
 
         res = int(res)
         assert res >= 0
         if res == 0 and self._should_unblock_streaming_output_backpressure(op):
             res = 1
+        self._output_budgets[op] = res
         return res
 
     def _get_downstream_ineligible_ops(

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -273,11 +273,11 @@ class OpState:
             or self.op._in_task_output_backpressure
         ):
             backpressure_types = []
-            if self.op._in_task_output_backpressure:
-                backpressure_types.append("in")
             if self.op._in_task_submission_backpressure:
-                backpressure_types.append("out")
-            desc += f" [backpressured: {','.join(backpressure_types)}]"
+                backpressure_types.append("tasks")
+            if self.op._in_task_output_backpressure:
+                backpressure_types.append("outputs")
+            desc += f" [backpressured:{','.join(backpressure_types)}]"
 
         # Actors info
         desc += self.op.actor_info_progress_str()

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -274,8 +274,10 @@ class OpState:
         ):
             backpressure_types = []
             if self.op._in_task_submission_backpressure:
+                # The op is backpressured from submitting new tasks.
                 backpressure_types.append("tasks")
             if self.op._in_task_output_backpressure:
+                # The op is backpressured from producing new outputs.
                 backpressure_types.append("outputs")
             desc += f" [backpressured:{','.join(backpressure_types)}]"
 

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -272,7 +272,12 @@ class OpState:
             self.op._in_task_submission_backpressure
             or self.op._in_task_output_backpressure
         ):
-            desc += " [backpressured]"
+            backpressure_types = []
+            if self.op._in_task_output_backpressure:
+                backpressure_types.append("in")
+            if self.op._in_task_submission_backpressure:
+                backpressure_types.append("out")
+            desc += f" [backpressured: {','.join(backpressure_types)}]"
 
         # Actors info
         desc += self.op.actor_info_progress_str()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Refine backpressure info on progress bar to avoid confusion
* Add backpresure types
* Add remaining budgets for reading task outputs for the debug message.

Example:
```
Running Dataset. Active & requested resources: 2.1/12 CPU, 800.0MB/1.0GB object store: : 28.0 row [00:20, 1.26s/ row]
- ReadRange->Map(map1): Tasks: 1 [backpressured:tasks,outputs]; Queued blocks: 99; Resources: 1.0 CPU, 640.0MB object store (in=320.0MB,out=320.0MB), budget=(cpu=5.0,gpu=inf,obj_store=0.0B,out=0.0B): : 30.0 row [00:19, 1.44 row/s]
- Map(map2): Tasks: 1 [backpressured:tasks]; Queued blocks: 1; Resources: 1.1 CPU, 160.0MB object store (in=160.0MB,out=0.0B), budget=(cpu=4.9,gpu=inf,obj_store=96.0MB,out=224.0MB): : 26.0 row [00:19, 1.29 row/s]
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
