### PR TITLE
Revert "[serve] Log rejected requests at router side (#51346)"

### DIFF
--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -637,7 +637,7 @@ class ReplicaBase(ABC):
         limit = self._deployment_config.max_ongoing_requests
         num_ongoing_requests = self.get_num_ongoing_requests()
         if num_ongoing_requests >= limit:
-            logger.debug(
+            logger.warning(
                 f"Replica at capacity of max_ongoing_requests={limit}, "
                 f"rejecting request {request_metadata.request_id}.",
                 extra={"log_to_stderr": False},

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -541,14 +541,6 @@ class AsyncioRouter:
                 self._replica_scheduler.on_new_queue_len_info(r.replica_id, queue_info)
                 if queue_info.accepted:
                     return result, r.replica_id
-                else:
-                    logger.info(
-                        f"{r.replica_id} rejected request because it is at max "
-                        f"capacity of {r.max_ongoing_requests} ongoing request"
-                        f"{'s' if r.max_ongoing_requests > 1 else ''}. "
-                        f"Retrying request {pr.metadata.request_id}.",
-                        extra={"log_to_stderr": False},
-                    )
             except asyncio.CancelledError:
                 # NOTE(edoakes): this is not strictly necessary because there are
                 # currently no `await` statements between getting the ref and returning,

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -91,10 +91,6 @@ class FakeReplica(RunningReplica):
         return self._replica_id
 
     @property
-    def max_ongoing_requests(self) -> int:
-        return 5
-
-    @property
     def is_cross_language(self) -> bool:
         return self._is_cross_language
 


### PR DESCRIPTION
This reverts commit 65514ea90ac668fd3db5100352b2446f087f1062.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Logging the rejected requests is causing lower serve throughput. The regression was originally flagged from the microbenchmark test that runs in the nightly release tests.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
