### PR TITLE
Revert "[cg] Move default device logic into channel utils (#51305)"

### DIFF
--- a/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
@@ -11,6 +11,7 @@ import ray.cluster_utils
 import ray.experimental.collective as collective
 import torch
 import time
+from ray.air._internal import torch_utils
 from ray.dag import InputNode
 from ray.exceptions import RayChannelError, RayTaskError
 from ray.dag.output_node import MultiOutputNode
@@ -18,7 +19,6 @@ from ray.experimental.channel.communicator import (
     Communicator,
     TorchTensorAllocator,
 )
-from ray.experimental.channel.utils import get_default_torch_device
 from ray.experimental.channel.torch_tensor_type import TorchTensorType
 from ray.experimental.channel.nccl_group import _NcclGroup
 from ray._private.test_utils import (
@@ -40,7 +40,7 @@ USE_GPU = bool(os.environ.get("RAY_PYTEST_USE_GPU", 0))
 @ray.remote
 class TorchTensorWorker:
     def __init__(self):
-        self.device = get_default_torch_device(allow_cpu=True)
+        self.device = torch_utils.get_devices()[0]
 
     def init_distributed(self, world_size, rank):
         torch.distributed.init_process_group(
@@ -569,7 +569,7 @@ def test_torch_tensor_custom_comm_inited(ray_start_regular):
                 rank == expected_rank
             ), f"NCCL actor's rank {rank} does not match expected rank {expected_rank}"
             self._rank = rank
-            self._device = get_default_torch_device(allow_cpu=True)
+            self._device = torch_utils.get_devices()[0]
 
         def get_rank(self, actor: ray.actor.ActorHandle) -> int:
             actor_ids = [a._ray_actor_id for a in self._actor_handles]
@@ -703,7 +703,7 @@ def test_torch_tensor_default_comm(ray_start_regular, transports):
                 rank == expected_rank
             ), f"NCCL actor's rank {rank} does not match expected rank {expected_rank}"
             self._rank = rank
-            self._device = get_default_torch_device(allow_cpu=True)
+            self._device = torch_utils.get_devices()[0]
 
         def get_rank(self, actor: ray.actor.ActorHandle) -> int:
             actor_ids = [a._ray_actor_id for a in self._actor_handles]
@@ -850,7 +850,7 @@ def test_torch_tensor_invalid_custom_comm(ray_start_regular):
                 rank == expected_rank
             ), f"NCCL actor's rank {rank} does not match expected rank {expected_rank}"
             self._rank = rank
-            self._device = get_default_torch_device(allow_cpu=True)
+            self._device = torch_utils.get_devices()[0]
 
         def get_rank(self, actor: ray.actor.ActorHandle) -> int:
             actor_ids = [a._ray_actor_id for a in self._actor_handles]

--- a/python/ray/experimental/channel/common.py
+++ b/python/ray/experimental/channel/common.py
@@ -19,7 +19,6 @@ from typing import (
 import ray
 import ray.exceptions
 from ray.experimental.channel.communicator import Communicator
-from ray.experimental.channel.utils import get_default_torch_device
 from ray.experimental.channel.serialization_context import _SerializationContext
 from ray.util.annotations import DeveloperAPI, PublicAPI
 
@@ -163,7 +162,17 @@ class ChannelContext:
     @property
     def torch_device(self) -> "torch.device":
         if self._torch_device is None:
-            self._torch_device = get_default_torch_device(allow_cpu=True)
+
+            if not ray.get_gpu_ids():
+                import torch
+
+                # torch_utils defaults to returning GPU 0 if no GPU IDs were assigned
+                # by Ray. We instead want the default to be CPU.
+                self._torch_device = torch.device("cpu")
+
+            from ray.air._internal import torch_utils
+
+            self._torch_device = torch_utils.get_devices()[0]
 
         return self._torch_device
 

--- a/python/ray/experimental/channel/nccl_group.py
+++ b/python/ray/experimental/channel/nccl_group.py
@@ -6,7 +6,6 @@ import ray
 from ray.exceptions import RayChannelError
 from ray.experimental.channel.communicator import Communicator, TorchTensorAllocator
 from ray.experimental.util.types import ReduceOp
-from ray.experimental.channel.utils import get_default_torch_device
 
 if TYPE_CHECKING:
     import cupy as cp
@@ -101,8 +100,10 @@ class _NcclGroup(Communicator):
 
             import cupy as cp
 
+            from ray.air._internal import torch_utils
+
             # TODO(swang): Allow default device to be overridden.
-            device = get_default_torch_device(allow_cpu=False)
+            device = torch_utils.get_devices()[0]
             self._cuda_stream = cp.cuda.ExternalStream(
                 cuda_stream, device_id=device.index
             )

--- a/python/ray/experimental/channel/utils.py
+++ b/python/ray/experimental/channel/utils.py
@@ -1,9 +1,6 @@
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 import ray
-
-if TYPE_CHECKING:
-    import torch
 
 
 def get_self_actor() -> Optional["ray.actor.ActorHandle"]:
@@ -93,24 +90,3 @@ def get_actor_node(actor: Optional["ray.actor.ActorHandle"]) -> str:
                 lambda self: ray.get_runtime_context().get_node_id()
             )
         )
-
-
-def get_default_torch_device(*, allow_cpu: bool) -> "torch.device":
-    """Get the default torch device inside this actor or driver.
-
-    If any GPUs are available, the default device will be cuda:0 and we will rely on
-    torch to handle mapping CUDA_VISIBLE_DEVICES to a physical device.
-
-    If no GPUs are available, a CPU device will be returned if allow_cpu is true, else
-    the function will raise a RuntimeError.
-    """
-    import torch
-
-    accelerator_ids = ray.get_runtime_context().get_accelerator_ids()
-    if not accelerator_ids.get("GPU", []):
-        if allow_cpu:
-            return torch.device("cpu")
-        else:
-            raise RuntimeError("No CUDA device available.")
-
-    return torch.device("cuda:0")


### PR DESCRIPTION
This reverts commit 8707d584809319e2a42dbf8bb2b2196585e976c0.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This fixes the illegal memory access in https://github.com/ray-project/ray/issues/51596

I will follow up and investigate the exact reason that caused the failure.

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #51596

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
