### PR TITLE
[core][dashboard-agent] Fail fast if the dashboard agent fails to launch the HTTP server

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1943,7 +1943,9 @@ def shutdown(_exiting_interpreter: bool = False):
     if _global_node is not None:
         if _global_node.is_head():
             _global_node.destroy_external_storage()
-        _global_node.kill_all_processes(check_alive=False, allow_graceful=True)
+        _global_node.kill_all_processes(
+            check_alive=False, allow_graceful=True, wait=True
+        )
         _global_node = None
     storage._reset()
 

--- a/python/ray/dashboard/agent.py
+++ b/python/ray/dashboard/agent.py
@@ -188,9 +188,7 @@ class DashboardAgent:
                 # TODO(SongGuyang): Catch the exception here because there is
                 # port conflict issue which brought from static port. We should
                 # remove this after we find better port resolution.
-                logger.exception(
-                    "Failed to start HTTP server. Exiting immediately."
-                )
+                logger.exception("Failed to start HTTP server. Exiting immediately.")
                 raise e
 
         # Writes agent address to kv.

--- a/python/ray/dashboard/agent.py
+++ b/python/ray/dashboard/agent.py
@@ -184,14 +184,14 @@ class DashboardAgent:
         if self.http_server:
             try:
                 await self.http_server.start(modules)
-            except Exception:
+            except Exception as e:
                 # TODO(SongGuyang): Catch the exception here because there is
                 # port conflict issue which brought from static port. We should
                 # remove this after we find better port resolution.
                 logger.exception(
-                    "Failed to start http server. Agent will stay alive but "
-                    "disable the http service."
+                    "Failed to start HTTP server. Exiting immediately."
                 )
+                raise e
 
         # Writes agent address to kv.
         # DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX: <node_id> -> (ip, http_port, grpc_port)

--- a/python/ray/dashboard/modules/job/job_head.py
+++ b/python/ray/dashboard/modules/job/job_head.py
@@ -234,7 +234,7 @@ class JobHead(dashboard_utils.DashboardHeadModule):
                 # Fetch agent info from InternalKV, and create a new
                 # JobAgentSubmissionClient. May raise if the node_id is removed in
                 # InternalKV after the _fetch_all_agent_node_ids, though unlikely.
-                ip, http_port, grpc_port = await self._fetch_agent_info(node_id)
+                ip, http_port, _ = await self._fetch_agent_info(node_id)
                 agent_http_address = f"http://{ip}:{http_port}"
                 self._agents[node_id] = JobAgentSubmissionClient(agent_http_address)
 
@@ -249,7 +249,7 @@ class JobHead(dashboard_utils.DashboardHeadModule):
         head_node_id = NodeID.from_hex(head_node_id_hex)
 
         if head_node_id not in self._agents:
-            ip, http_port, grpc_port = await self._fetch_agent_info(head_node_id)
+            ip, http_port, _ = await self._fetch_agent_info(head_node_id)
             agent_http_address = f"http://{ip}:{http_port}"
             self._agents[head_node_id] = JobAgentSubmissionClient(agent_http_address)
 

--- a/python/ray/tests/test_job.py
+++ b/python/ray/tests/test_job.py
@@ -34,7 +34,7 @@ def execute_driver(commands: List[str], input: bytes = None):
         if isinstance(input, str):
             input = input.encode()
 
-        stdout, stderr = p.communicate(input=input)
+        stdout, _ = p.communicate(input=input)
         outs = stdout.decode().split("\n")
         return outs
     finally:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

https://buildkite.com/ray-project/postmerge/builds/9112#0195ceea-bd31-4006-a2c8-6b851955058f

If port 52365 used by the dashboard agent is already in use by another process, the dashboard agent will remain alive, but the HTTP server will not be launched. This hides the real issue (i.e. "port conflict") deeper.

If we submit a Ray job to the cluster using Ray Job Submission, the error is very strange—the HTTP port is "None". The reason is that [await self.http_server.start(modules)](https://github.com/ray-project/ray/blob/5544552b230ce2b821fa28c3f328d308cb410b43/python/ray/dashboard/agent.py#L186) will fail to set `self.http_server.http_port` if the port has already been used. Hence, `self.http_server.http_port` ("None") will be stored into KV store as the HTTP port. It's not easy to debug this issue.

<img width="882" alt="image" src="https://github.com/user-attachments/assets/b6e5a3b2-8c6f-4e33-b76d-6faeeee3c491" />

With this PR, the error becomes:

* The job is submitted to the Raylet before it exits due to fate-sharing with the dashboard agent:
  * It clearly points out the issue of dashboard agent. 
<img width="1728" alt="Screenshot 2025-03-25 at 11 27 02 PM" src="https://github.com/user-attachments/assets/4b41051e-dcae-4915-91d1-cf4885b71bff" />

* The Raylet died before the Ray job was submitted to it:
  * Raylet logs -> Found dashboard agent died 
<img width="1728" alt="Screenshot 2025-03-25 at 11 28 07 PM" src="https://github.com/user-attachments/assets/2b8fc43c-8dba-4343-b8f8-9e1286c8c043" />

It's still not clear for me why the dashboard agent process leaks https://buildkite.com/ray-project/postmerge/builds/9112#0195ceea-bd31-4006-a2c8-6b851955058f.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
