### PR TITLE
[Test][KubeRay] Add a deliberate failure test to ensure doctests fail on error

### DIFF
--- a/ci/k8s/run-kuberay-doc-tests.sh
+++ b/ci/k8s/run-kuberay-doc-tests.sh
@@ -10,6 +10,61 @@ pip install -c python/requirements_compiled.txt pytest nbval bash_kernel
 python -m bash_kernel.install
 pip install "ray[default]==2.41.0"
 
+echo "--- Run a deliberate failure test to ensure the test script fails on error"
+# The following Jupyter notebook only contains a single cell that runs the `date` command.
+# The test script should fail because the output of the `date` command is different everytime.
+cat <<EOF > test.ipynb
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "43a8bb95-f6f2-45a8-ba48-b16856b2106d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wed Mar 26 06:28:51 PM CST 2025\n"
+     ]
+    }
+   ],
+   "source": [
+    "date"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Bash",
+   "language": "bash",
+   "name": "bash"
+  },
+  "language_info": {
+   "codemirror_mode": "shell",
+   "file_extension": ".sh",
+   "mimetype": "text/x-sh",
+   "name": "bash"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}
+EOF
+set +e
+if pytest --nbval test.ipynb --nbval-kernel-name bash; then
+  echo "The test script should have failed but it didn't."
+  exit 1
+fi
+set -e
+
 echo "--- Run doc tests"
 cd doc/source/cluster/kubernetes
-py.test --nbval getting-started/raycluster-quick-start.ipynb --nbval-kernel-name bash --sanitize-with doc_sanitize.cfg
+TESTS=(
+  "getting-started/raycluster-quick-start.ipynb"
+)
+for test in "${TESTS[@]}"; do
+  echo "Running test: ${test}"
+  pytest --nbval "${test}" --nbval-kernel-name bash --sanitize-with doc_sanitize.cfg
+done


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
As title.

![image](https://github.com/user-attachments/assets/38d94195-08c2-4b2f-96e7-802b1fd11159)


## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
