### PR TITLE
[data] Make sql cursor buffered

### DIFF
--- a/python/ray/data/_internal/datasource/sql_datasource.py
+++ b/python/ray/data/_internal/datasource/sql_datasource.py
@@ -53,7 +53,9 @@ def _connect(connection_factory: Callable[[], Connection]) -> Iterator[Cursor]:
     _check_connection_is_dbapi2_compliant(connection)
 
     try:
-        cursor = connection.cursor()
+        # buffered=True because otherwise supports_sharding fails for mysql-connector-python with "Unread result found."
+        # https://stackoverflow.com/questions/29772337/python-mysql-connector-unread-result-found-when-using-fetchone
+        cursor = connection.cursor(buffered=True)
         _check_cursor_is_dbapi2_compliant(cursor)
         yield cursor
         connection.commit()


### PR DESCRIPTION
## Why are these changes needed?

When I use `ray.data.read_sql` it gives me the following error:

```
2025-03-26 16:45:14,498 INFO sql_datasource.py:121 -- Database does not support sharding: Unread result found.
```

After some digging it looks like it's because the cursor isn't buffered: https://stackoverflow.com/questions/29772337/python-mysql-connector-unread-result-found-when-using-fetchone

*NOTE*: I don't know if this will affect other sql connectors negatively; I'm posting the PR to see if there are any unit tests that will run to verify if this works.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
