### PR TITLE
[Core] Native CPU affinity support for accelerators

### DIFF
--- a/cpp/src/ray/config_internal.cc
+++ b/cpp/src/ray/config_internal.cc
@@ -98,6 +98,16 @@ ABSL_FLAG(std::string,
           "The namespace of job. If not set,"
           " a unique value will be randomly generated.");
 
+ABSL_FLAG(std::string,
+          ray_accelerator_cpu_mask,
+          "",
+          "The CPU mask for the affinity of accelerator, "
+          "it is a string of digits separated by commas. The mapping "
+          "is specified to be node specific and identical mapping is "
+          "applied to the tasks on each node with same accelerator id. "
+          "If the number of accelerators exceeds the number of elements "
+          "in this list, elements in the list will be reused as needed "
+          "starting from the beginning of the list.");
 using json = nlohmann::json;
 
 namespace ray {
@@ -195,6 +205,9 @@ void ConfigInternal::Init(RayConfig &config, int argc, char **argv) {
     if (!FLAGS_ray_default_actor_lifetime.CurrentValue().empty()) {
       default_actor_lifetime =
           ParseDefaultActorLifetimeType(FLAGS_ray_default_actor_lifetime.CurrentValue());
+    }
+    if (!FLAGS_ray_accelerator_cpu_mask.CurrentValue().empty()) {
+      accelerator_cpu_mask = FLAGS_ray_accelerator_cpu_mask.CurrentValue();
     }
     if (!FLAGS_ray_runtime_env.CurrentValue().empty()) {
       runtime_env = RuntimeEnv::Deserialize(FLAGS_ray_runtime_env.CurrentValue());

--- a/cpp/src/ray/config_internal.h
+++ b/cpp/src/ray/config_internal.h
@@ -76,6 +76,8 @@ class ConfigInternal {
 
   std::string ray_namespace = "";
 
+  std::string accelerator_cpu_mask = "";
+
   static ConfigInternal &Instance() {
     static ConfigInternal config;
     return config;

--- a/cpp/src/ray/runtime/task/task_executor.cc
+++ b/cpp/src/ray/runtime/task/task_executor.cc
@@ -139,7 +139,8 @@ Status TaskExecutor::ExecuteTask(
     bool is_streaming_generator,
     bool retry_exception,
     int64_t generator_backpressure_num_objects,
-    const rpc::TensorTransport &tensor_transport) {
+    const rpc::TensorTransport &tensor_transport,
+    const std::string &accelerator_cpu_mask) {
   RAY_LOG(DEBUG) << "Execute task type: " << TaskType_Name(task_type)
                  << " name:" << task_name;
   RAY_CHECK(ray_function.GetLanguage() == ray::Language::CPP);

--- a/cpp/src/ray/runtime/task/task_executor.h
+++ b/cpp/src/ray/runtime/task/task_executor.h
@@ -98,7 +98,8 @@ class TaskExecutor {
       int64_t generator_backpressure_num_objects,
       /* This is used by the in-actor GPU object store. However, it is only supported in
        * the Python frontend. */
-      const rpc::TensorTransport &tensor_transport);
+      const rpc::TensorTransport &tensor_transport,
+      const std::string &accelerator_cpu_mask);
 
   virtual ~TaskExecutor(){};
 

--- a/cpp/src/ray/util/process_helper.cc
+++ b/cpp/src/ray/util/process_helper.cc
@@ -155,6 +155,7 @@ void ProcessHelper::RayStart(CoreWorkerOptions::TaskExecutionCallback callback) 
   options.task_execution_callback = callback;
   options.startup_token = ConfigInternal::Instance().startup_token;
   options.runtime_env_hash = ConfigInternal::Instance().runtime_env_hash;
+  options.accelerator_cpu_mask = ConfigInternal::Instance().accelerator_cpu_mask;
   rpc::JobConfig job_config;
   job_config.set_default_actor_lifetime(
       ConfigInternal::Instance().default_actor_lifetime);

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -587,6 +587,12 @@ class Node:
         return self._plasma_store_socket_name
 
     @property
+    def accelerator_cpu_mask(self):
+        """Get the node's CPU affinity mask for accelerators."""
+        mask = self._ray_params.accelerator_cpu_mask
+        return mask if mask is not None else ""
+
+    @property
     def unique_id(self):
         """Get a unique identifier for this node."""
         return f"{self.node_ip_address}:{self._plasma_store_socket_name}"
@@ -1239,6 +1245,7 @@ class Node:
             node_name=self._ray_params.node_name,
             webui=self._webui_url,
             resource_isolation_config=self.resource_isolation_config,
+            accelerator_cpu_mask=self.accelerator_cpu_mask,
         )
         assert ray_constants.PROCESS_TYPE_RAYLET not in self.all_processes
         self.all_processes[ray_constants.PROCESS_TYPE_RAYLET] = [process_info]

--- a/python/ray/_private/parameter.py
+++ b/python/ray/_private/parameter.py
@@ -99,6 +99,14 @@ class RayParams:
         include_log_monitor: If True, then start a log monitor to
             monitor the log files for all processes on this node and push their
             contents to Redis.
+        accelerator_cpu_mask: The CPU mask for the affinity of accelerator, it
+            is a string of digits separated by commas. The mapping
+            is specified to be node specific and identical mapping is
+            applied to the tasks on each node with same accelerator id.
+            If provided, the CPU affinity of the accelerator will
+            be set when the task first starts. If the number of accelerators
+            exceeds the number of elements in this list, elements in the list
+            will be reused as needed starting from the beginning of the list.
         autoscaling_config: path to autoscaling config file.
         metrics_agent_port: The port to bind metrics agent.
         metrics_export_port: The port at which metrics are exposed
@@ -167,6 +175,7 @@ class RayParams:
         temp_dir: Optional[str] = None,
         runtime_env_dir_name: Optional[str] = None,
         include_log_monitor: Optional[str] = None,
+        accelerator_cpu_mask: Optional[str] = None,
         autoscaling_config: Optional[str] = None,
         ray_debugger_external: bool = False,
         _system_config: Optional[Dict[str, str]] = None,
@@ -225,6 +234,7 @@ class RayParams:
             runtime_env_dir_name or ray_constants.DEFAULT_RUNTIME_ENV_DIR_NAME
         )
         self.include_log_monitor = include_log_monitor
+        self.accelerator_cpu_mask = accelerator_cpu_mask
         self.autoscaling_config = autoscaling_config
         self.metrics_agent_port = metrics_agent_port
         self.metrics_export_port = metrics_export_port

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1572,6 +1572,7 @@ def start_raylet(
     env_updates: Optional[dict] = None,
     node_name: Optional[str] = None,
     webui: Optional[str] = None,
+    accelerator_cpu_mask: Optional[str] = None,
 ):
     """Start a raylet, which is a combined local scheduler and object manager.
 
@@ -1648,6 +1649,13 @@ def start_raylet(
         env_updates: Environment variable overrides.
         node_name: The name of the node.
         webui: The url of the UI.
+        accelerator_cpu_mask: The CPU mask for the affinity of accelerator,
+            it is a string of digits separated by commas. The mapping
+            is specified to be node specific and identical mapping is
+            applied to the tasks on each node with same accelerator id.
+            If the number of accelerators exceeds the number of elements
+            in this list, elements in the list will be reused as needed
+            starting from the beginning of the list.
     Returns:
         ProcessInfo for the process that was started.
     """
@@ -1710,6 +1718,7 @@ def start_raylet(
             log_dir,
             node_ip_address,
             setup_worker_path,
+            accelerator_cpu_mask,
         )
     else:
         cpp_worker_command = []
@@ -1740,6 +1749,7 @@ def start_raylet(
             f"--temp-dir={temp_dir}",
             f"--webui={webui}",
             f"--cluster-id={cluster_id}",
+            f"--accelerator-cpu-mask={accelerator_cpu_mask}",
         ]
     )
 
@@ -2035,6 +2045,7 @@ def build_cpp_worker_command(
     log_dir: str,
     node_ip_address: str,
     setup_worker_path: str,
+    accelerator_cpu_mask: str,
 ):
     """This method assembles the command used to start a CPP worker.
 
@@ -2050,6 +2061,13 @@ def build_cpp_worker_command(
         node_ip_address: The ip address for this node.
         setup_worker_path: The path of the Python file that will set up
             the environment for the worker process.
+        accelerator_cpu_mask: The CPU mask for the affinity of accelerator,
+            it is a string of digits separated by commas. The mapping
+            is specified to be node specific and identical mapping is
+            applied to the tasks on each node with same accelerator id.
+            If the number of accelerators exceeds the number of elements
+            in this list, elements in the list will be reused as needed
+            starting from the beginning of the list.
     Returns:
         The command string for starting CPP worker.
     """
@@ -2067,6 +2085,7 @@ def build_cpp_worker_command(
         f"--ray_session_dir={session_dir}",
         f"--ray_logs_dir={log_dir}",
         f"--ray_node_ip_address={node_ip_address}",
+        f"--ray_accelerator_cpu_mask={accelerator_cpu_mask}",
         "RAY_WORKER_DYNAMIC_OPTION_PLACEHOLDER",
     ]
 

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1372,6 +1372,7 @@ def init(
     enable_resource_isolation: bool = False,
     system_reserved_cpu: Optional[float] = None,
     system_reserved_memory: Optional[int] = None,
+    accelerator_cpu_mask: Optional[str] = None,
     **kwargs,
 ) -> BaseContext:
     """
@@ -1498,6 +1499,14 @@ def init(
             The raylet must have read/write permissions to this path.
             Cgroup memory and cpu controllers be enabled for this cgroup.
             This option only works if enable_resource_isolation is True.
+        accelerator_cpu_mask: The CPU mask for the affinity of accelerator, it
+            is a string of digits separated by commas. The mapping
+            is specified to be node specific and identical mapping is
+            applied to the tasks on each node with same accelerator id.
+            If provided, the CPU affinity of the accelerator will
+            be set when the task first starts. If the number of accelerators
+            exceeds the number of elements in this list, elements in the list
+            will be reused as needed starting from the beginning of the list.
         _enable_object_reconstruction: If True, when an object stored in
             the distributed plasma store is lost due to node failure, Ray will
             attempt to reconstruct the object by re-executing the task that
@@ -1827,6 +1836,7 @@ def init(
             tracing_startup_hook=_tracing_startup_hook,
             node_name=_node_name,
             resource_isolation_config=resource_isolation_config,
+            accelerator_cpu_mask=accelerator_cpu_mask,
         )
         # Start the Ray processes. We set shutdown_at_exit=False because we
         # shutdown the node in the ray.shutdown call that happens in the atexit
@@ -1850,6 +1860,11 @@ def init(
             raise ValueError(
                 "When connecting to an existing cluster, "
                 "resources must not be provided."
+            )
+        if accelerator_cpu_mask is not None:
+            raise ValueError(
+                "When connecting to an existing cluster, "
+                "accelerator_cpu_mask must not be provided."
             )
         if labels is not None:
             raise ValueError(
@@ -2581,6 +2596,7 @@ def connect(
         worker_launched_time_ms,
         debug_source,
         enable_resource_isolation,
+        node.accelerator_cpu_mask,
     )
 
     if mode == SCRIPT_MODE:

--- a/python/ray/_private/workers/default_worker.py
+++ b/python/ray/_private/workers/default_worker.py
@@ -197,6 +197,17 @@ parser.add_argument(
     ),
 )
 
+parser.add_argument(
+    "--accelerator-cpu-mask",
+    required=False,
+    type=str,
+    default="",
+    help=(
+        "A comma-separated list of CPU cores to use for accelerators. "
+        "This is used to set the CPU affinity of the accelerator. "
+    ),
+)
+
 if __name__ == "__main__":
     # NOTE(sang): For some reason, if we move the code below
     # to a separate function, tensorflow will capture that method
@@ -238,6 +249,7 @@ if __name__ == "__main__":
         webui=args.webui,
         cluster_id=args.cluster_id,
         node_id=args.node_id,
+        accelerator_cpu_mask=args.accelerator_cpu_mask,
     )
     node = ray._private.node.Node(
         ray_params,

--- a/python/ray/cluster_utils.py
+++ b/python/ray/cluster_utils.py
@@ -224,6 +224,7 @@ class Cluster:
         }
         ray_params = ray._private.parameter.RayParams(**node_args)
         ray_params.update_if_absent(**default_kwargs)
+        ray_params.update_if_absent(accelerator_cpu_mask="")
         with disable_client_hook():
             if self.head_node is None:
                 node = ray._private.node.Node(

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -407,7 +407,8 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
             c_bool is_streaming_generator,
             c_bool should_retry_exceptions,
             int64_t generator_backpressure_num_objects,
-            CTensorTransport tensor_transport
+            CTensorTransport tensor_transport,
+            const c_string accelerator_cpu_mask
         ) nogil) task_execution_callback
         (void(const CObjectID &) nogil) free_actor_object_callback
         (function[void()]() nogil) initialize_thread_callback
@@ -443,6 +444,7 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         int64_t worker_launched_time_ms
         c_string debug_source
         c_bool enable_resource_isolation
+        c_string accelerator_cpu_mask
 
     cdef cppclass CCoreWorkerProcess "ray::core::CoreWorkerProcess":
         @staticmethod

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -672,6 +672,13 @@ Windows powershell users need additional escaping:
     "Cgroup memory and cpu controllers be enabled for this cgroup. "
     "This option only works if --enable-resource-isolation is set.",
 )
+@click.option(
+    "--accelerator-cpu-mask",
+    required=False,
+    default="",
+    type=str,
+    help="CPU masks for the affinity of accelerator devices.",
+)
 @add_click_logging_options
 @PublicAPI
 def start(
@@ -720,6 +727,7 @@ def start(
     system_reserved_cpu,
     system_reserved_memory,
     cgroup_path,
+    accelerator_cpu_mask,
 ):
     """Start Ray processes manually on the local machine."""
 
@@ -829,6 +837,7 @@ def start(
         ray_debugger_external=ray_debugger_external,
         include_log_monitor=include_log_monitor,
         resource_isolation_config=resource_isolation_config,
+        accelerator_cpu_mask=accelerator_cpu_mask,
     )
 
     if ray_constants.RAY_START_HOOK in os.environ:

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2892,7 +2892,8 @@ Status CoreWorker::ExecuteTask(
       /*retry_exception=*/task_spec.ShouldRetryExceptions(),
       /*generator_backpressure_num_objects=*/
       task_spec.GeneratorBackpressureNumObjects(),
-      /*tensor_transport=*/task_spec.TensorTransport());
+      /*tensor_transport=*/task_spec.TensorTransport(),
+      /*accelerator_cpu_mask=*/options_.accelerator_cpu_mask);
 
   // Get the reference counts for any IDs that we borrowed during this task,
   // remove the local reference for these IDs, and return the ref count info to

--- a/src/ray/core_worker/core_worker_options.h
+++ b/src/ray/core_worker/core_worker_options.h
@@ -72,7 +72,9 @@ struct CoreWorkerOptions {
       // The max number of unconsumed objects where a generator
       // can run without a pause.
       int64_t generator_backpressure_num_objects,
-      const rpc::TensorTransport &tensor_transport)>;
+      const rpc::TensorTransport &tensor_transport,
+      // The CPU affinity mask for the accelerator devices.
+      const std::string &accelerator_cpu_mask)>;
 
   CoreWorkerOptions()
       : store_socket(""),
@@ -108,7 +110,8 @@ struct CoreWorkerOptions {
         worker_launch_time_ms(-1),
         worker_launched_time_ms(-1),
         debug_source(""),
-        enable_resource_isolation(false) {}
+        enable_resource_isolation(false),
+        accelerator_cpu_mask("") {}
 
   /// Type of this worker (i.e., DRIVER or WORKER).
   WorkerType worker_type;
@@ -216,6 +219,8 @@ struct CoreWorkerOptions {
   // If true, core worker enables resource isolation through cgroupv2 by reserving
   // resources for ray system processes.
   bool enable_resource_isolation = false;
+  // CPU affinity mask for the accelerator devices.
+  std::string accelerator_cpu_mask;
 };
 }  // namespace core
 }  // namespace ray

--- a/src/ray/core_worker/lib/java/io_ray_runtime_RayNativeRuntime.cc
+++ b/src/ray/core_worker/lib/java/io_ray_runtime_RayNativeRuntime.cc
@@ -141,7 +141,8 @@ Java_io_ray_runtime_RayNativeRuntime_nativeInitialize(JNIEnv *env,
          bool is_streaming_generator,
          bool should_retry_exceptions,
          int64_t generator_backpressure_num_objects,
-         const rpc::TensorTransport &tensor_transport) {
+         const rpc::TensorTransport &tensor_transport,
+         const std::string &accelerator_cpu_mask) {
         // These 3 parameters are used for Python only, and Java worker
         // will not use them.
         RAY_UNUSED(defined_concurrency_groups);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds native CPU affinity support for accelerators, users can now specify the CPU affinity masks with `accelerator_cpu_mask`, in a string of digits separated by commas. The mapping is specified to be node specific and identical mapping is applied to the tasks on each node with same accelerator id (even for different accelerator kind). If the number of accelerators exceeds the number of elements in this list, elements in the list will be reused as needed starting from the beginning of the list.

The affinity is set via `psutil.Process().cpu_affinity` before an actor task starts.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Resolves #55097
<!-- For example: "Closes #1234" -->

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [X] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [X] Release tests
   - [ ] This PR is not tested :(
