### PR TITLE
[serve] Remove RAY_SERVE_EAGERLY_START_REPLACEMENT_REPLICAS flag

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -363,12 +363,6 @@ DEFAULT_GRPC_SERVER_OPTIONS = [
     ("grpc.max_receive_message_length", RAY_SERVE_GRPC_MAX_MESSAGE_SIZE),
 ]
 
-# Feature flag to eagerly start replacement replicas. This means new
-# replicas will start before waiting for old replicas to fully stop.
-RAY_SERVE_EAGERLY_START_REPLACEMENT_REPLICAS = (
-    os.environ.get("RAY_SERVE_EAGERLY_START_REPLACEMENT_REPLICAS", "1") == "1"
-)
-
 # Timeout for gracefully shutting down metrics pusher, e.g. in routers or replicas
 METRICS_PUSHER_GRACEFUL_SHUTDOWN_TIMEOUT_S = 10
 

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -37,7 +37,6 @@ from ray.serve._private.config import DeploymentConfig
 from ray.serve._private.constants import (
     MAX_DEPLOYMENT_CONSTRUCTOR_RETRY_COUNT,
     MAX_PER_REPLICA_RETRY_COUNT,
-    RAY_SERVE_EAGERLY_START_REPLACEMENT_REPLICAS,
     RAY_SERVE_ENABLE_TASK_EVENTS,
     RAY_SERVE_FORCE_STOP_UNHEALTHY_REPLICAS,
     RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY,
@@ -1876,11 +1875,6 @@ class DeploymentState:
 
         elif delta_replicas > 0:
             to_add = delta_replicas
-            if not RAY_SERVE_EAGERLY_START_REPLACEMENT_REPLICAS:
-                # Don't ever exceed target_num_replicas.
-                stopping_replicas = self._replicas.count(states=[ReplicaState.STOPPING])
-                to_add = max(delta_replicas - stopping_replicas, 0)
-
             if to_add > 0 and not self._terminally_failed():
                 logger.info(f"Adding {to_add} replica{'s' * (to_add>1)} to {self._id}.")
                 for _ in range(to_add):

--- a/python/ray/serve/tests/BUILD
+++ b/python/ray/serve/tests/BUILD
@@ -301,30 +301,6 @@ py_test(
     ],
 )
 
-# Test old stop-fully-then-start behavior.
-# TODO(zcin): remove this after the old behavior is completely removed
-py_test_module_list(
-    size = "medium",
-    data = glob(["test_config_files/**/*"]),
-    env = {"RAY_SERVE_EAGERLY_START_REPLACEMENT_REPLICAS": "0"},
-    files = [
-        "test_controller_recovery.py",
-        "test_deploy.py",
-        "test_max_replicas_per_node.py",
-    ],
-    name_suffix = "_with_stop_fully_then_start_behavior",
-    tags = [
-        "exclusive",
-        "no_windows",
-        "team:serve",
-    ],
-    deps = [
-        ":common",
-        ":conftest",
-        "//python/ray/serve:serve_lib",
-    ],
-)
-
 # Test feature flag for task events.
 py_test_module_list(
     size = "small",

--- a/python/ray/serve/tests/test_max_replicas_per_node.py
+++ b/python/ray/serve/tests/test_max_replicas_per_node.py
@@ -6,7 +6,6 @@ import pytest
 import ray
 from ray import serve
 from ray._private.test_utils import wait_for_condition
-from ray.serve._private.constants import RAY_SERVE_EAGERLY_START_REPLACEMENT_REPLICAS
 from ray.util.state import list_actors
 
 
@@ -187,8 +186,6 @@ def test_update_max_replicas_per_node(ray_autoscaling_cluster):
         name="app",
     )
 
-    if not RAY_SERVE_EAGERLY_START_REPLACEMENT_REPLICAS:
-        check_alive_nodes(expected=4)
     node_to_deployment_to_num_replicas = get_node_to_deployment_to_num_replicas()
 
     assert len(node_to_deployment_to_num_replicas) == 3
@@ -197,14 +194,13 @@ def test_update_max_replicas_per_node(ray_autoscaling_cluster):
         assert deployment_to_num_replicas["deploy1"] == 1
 
     # Head + 3 worker nodes
-    if RAY_SERVE_EAGERLY_START_REPLACEMENT_REPLICAS:
-        # We wait for this to be satisfied at the end because there may be
-        # more than 3 worker nodes after the deployment finishes deploying,
-        # since replicas are being started and stopped at the same time, and
-        # there is a strict max replicas per node requirement. However nodes
-        # that were hosting the replicas of the old version should eventually
-        # be removed from scale-down.
-        wait_for_condition(check_alive_nodes, expected=4, timeout=60)
+    # We wait for this to be satisfied at the end because there may be
+    # more than 3 worker nodes after the deployment finishes deploying,
+    # since replicas are being started and stopped at the same time, and
+    # there is a strict max replicas per node requirement. However nodes
+    # that were hosting the replicas of the old version should eventually
+    # be removed from scale-down.
+    wait_for_condition(check_alive_nodes, expected=4, timeout=60)
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/BUILD
+++ b/python/ray/serve/tests/unit/BUILD
@@ -21,24 +21,6 @@ py_test_run_all_subdirectory(
 
 py_test_module_list(
     size = "medium",
-    env = {"RAY_SERVE_EAGERLY_START_REPLACEMENT_REPLICAS": "0"},
-    files = [
-        "test_deployment_state.py",
-    ],
-    name_suffix = "_with_stop_fully_then_start_behavior",
-    tags = [
-        "no_windows",
-        "team:serve",
-    ],
-    deps = [
-        ":conftest",
-        "//python/ray/serve:serve_lib",
-        "//python/ray/serve/tests:common",
-    ],
-)
-
-py_test_module_list(
-    size = "medium",
     env = {"RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY": "1"},
     files = [
         "test_deployment_scheduler.py",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR removes a feature flag that controls whether replicas should immediately respawn after stopping. The FF was introduced and enabled by default [over a year ago](https://github.com/ray-project/ray/pull/43187), so let's remove it.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
