### PR TITLE
[train] differentiate between train v1 and v2 export data

### DIFF
--- a/python/ray/train/_internal/backend_executor.py
+++ b/python/ray/train/_internal/backend_executor.py
@@ -565,9 +565,6 @@ class BackendExecutor:
             from ray.train._internal.state.schema import RunStatusEnum
 
             core_context = ray.runtime_context.get_runtime_context()
-            controller_log_file_path = (
-                ray._private.worker.global_worker.get_err_file_path()
-            )
 
             self.state_manager.register_train_run(
                 run_id=self._trial_info.run_id,
@@ -578,7 +575,6 @@ class BackendExecutor:
                 worker_group=self.worker_group,
                 start_time_ms=self._start_time_ms,
                 run_status=RunStatusEnum.RUNNING,
-                controller_log_file_path=controller_log_file_path,
                 resources=[self._resources_per_worker] * self._num_workers,
             )
 

--- a/python/ray/train/_internal/state/export.py
+++ b/python/ray/train/_internal/state/export.py
@@ -12,6 +12,7 @@ from ray.train._internal.state.schema import (
 
 
 TRAIN_SCHEMA_VERSION = 1
+RAY_TRAIN_VERSION = 1
 
 # Status mapping dictionaries
 _ACTOR_STATUS_MAP = {
@@ -61,7 +62,6 @@ def _to_proto_worker(worker: TrainWorkerInfo) -> ProtoTrainRunAttempt.TrainWorke
         gpu_ids=worker.gpu_ids,
         status=_ACTOR_STATUS_MAP[worker.status],
         resources=_to_proto_resources(worker.resources),
-        log_file_path=worker.worker_log_file_path,
     )
 
     return proto_worker
@@ -72,6 +72,7 @@ def train_run_info_to_proto_run(run_info: TrainRunInfo) -> ProtoTrainRun:
     """Convert TrainRunInfo to TrainRun protobuf format."""
     proto_run = ProtoTrainRun(
         schema_version=TRAIN_SCHEMA_VERSION,
+        ray_train_version=RAY_TRAIN_VERSION,
         id=run_info.id,
         name=run_info.name,
         job_id=bytes.fromhex(run_info.job_id),
@@ -80,7 +81,6 @@ def train_run_info_to_proto_run(run_info: TrainRunInfo) -> ProtoTrainRun:
         status_detail=run_info.status_detail,
         start_time_ns=_ms_to_ns(run_info.start_time_ms),
         end_time_ns=_ms_to_ns(run_info.end_time_ms),
-        controller_log_file_path=run_info.controller_log_file_path,
     )
 
     return proto_run
@@ -91,6 +91,7 @@ def train_run_info_to_proto_attempt(run_info: TrainRunInfo) -> ProtoTrainRunAtte
 
     proto_attempt = ProtoTrainRunAttempt(
         schema_version=TRAIN_SCHEMA_VERSION,
+        ray_train_version=RAY_TRAIN_VERSION,
         run_id=run_info.id,
         attempt_id=run_info.id,  # Same as run_id
         status=_RUN_ATTEMPT_STATUS_MAP[run_info.run_status],

--- a/python/ray/train/_internal/state/schema.py
+++ b/python/ray/train/_internal/state/schema.py
@@ -53,7 +53,6 @@ class TrainWorkerInfo(BaseModel):
     resources: Dict[str, float] = Field(
         description="The resources allocated to the worker."
     )
-    worker_log_file_path: str = Field(description="The path to the worker log file.")
 
 
 @DeveloperAPI
@@ -142,9 +141,6 @@ class TrainRunInfo(BaseModel):
     end_time_ms: Optional[int] = Field(
         description="The UNIX timestamp of the end time of this Train run. "
         "If null, the Train run has not ended yet."
-    )
-    controller_log_file_path: str = Field(
-        description="The path to the controller log file."
     )
     resources: List[Dict[str, float]] = Field(
         description="The resources allocated to the worker."

--- a/python/ray/train/_internal/state/state_manager.py
+++ b/python/ray/train/_internal/state/state_manager.py
@@ -38,7 +38,6 @@ class TrainRunStateManager:
         datasets: Dict[str, Dataset],
         worker_group: WorkerGroup,
         start_time_ms: float,
-        controller_log_file_path: str,
         resources: List[Dict[str, float]],
         status_detail: str = "",
     ) -> None:
@@ -53,7 +52,6 @@ class TrainRunStateManager:
         def collect_train_worker_info():
             train_context = ray.train.get_context()
             core_context = ray.runtime_context.get_runtime_context()
-            worker_log_file_path = ray._private.worker.global_worker.get_err_file_path()
             return TrainWorkerInfo(
                 world_rank=train_context.get_world_rank(),
                 local_rank=train_context.get_local_rank(),
@@ -64,7 +62,6 @@ class TrainRunStateManager:
                 gpu_ids=ray.get_gpu_ids(),
                 pid=os.getpid(),
                 resources=resources[0],
-                worker_log_file_path=worker_log_file_path,
                 status=ActorStatusEnum.ALIVE,
             )
 
@@ -103,7 +100,6 @@ class TrainRunStateManager:
             start_time_ms=start_time_ms,
             run_status=run_status,
             status_detail=status_detail,
-            controller_log_file_path=controller_log_file_path,
             resources=resources,
         )
 

--- a/python/ray/train/tests/test_state.py
+++ b/python/ray/train/tests/test_state.py
@@ -51,7 +51,6 @@ RUN_INFO_JSON_SAMPLE = """{
     "run_status": "RUNNING",
     "status_detail": "",
     "end_time_ms": null,
-    "controller_log_file_path": "/tmp/ray/session_xxx/logs/worker-controller.err",
     "resources": [{"CPU": 1}, {"CPU": 1}],
     "workers": [
         {
@@ -65,7 +64,6 @@ RUN_INFO_JSON_SAMPLE = """{
         "gpu_ids": [0],
         "status": "ALIVE",
         "resources": {"CPU": 1},
-        "worker_log_file_path": "/tmp/ray/session_xxx/logs/worker-0.err"
         },
         {
         "actor_id": "8f162dd8365346d1b5c98ebd7338c4f9",
@@ -78,7 +76,6 @@ RUN_INFO_JSON_SAMPLE = """{
         "gpu_ids": [1],
         "status": "ALIVE",
         "resources": {"CPU": 1},
-        "worker_log_file_path": "/tmp/ray/session_xxx/logs/worker-1.err"
         }
     ],
     "datasets": [
@@ -107,7 +104,6 @@ def _get_run_info_sample(run_id=None, run_name=None) -> TrainRunInfo:
         gpu_ids=[0],
         status=ActorStatusEnum.ALIVE,
         resources={"CPU": 1},
-        worker_log_file_path="/tmp/ray/session_xxx/logs/worker-0.err",
     )
 
     worker_info_1 = TrainWorkerInfo(
@@ -121,7 +117,6 @@ def _get_run_info_sample(run_id=None, run_name=None) -> TrainRunInfo:
         gpu_ids=[1],
         status=ActorStatusEnum.ALIVE,
         resources={"CPU": 1},
-        worker_log_file_path="/tmp/ray/session_xxx/logs/worker-1.err",
     )
 
     run_info = TrainRunInfo(
@@ -134,7 +129,6 @@ def _get_run_info_sample(run_id=None, run_name=None) -> TrainRunInfo:
         start_time_ms=1717448423000,
         run_status=RunStatusEnum.RUNNING,
         status_detail="",
-        controller_log_file_path="/tmp/ray/session_xxx/logs/worker-controller.err",
         resources=[{"CPU": 1}, {"CPU": 1}],
     )
     return run_info
@@ -197,7 +191,6 @@ def test_state_manager(ray_start_gpu_cluster):
         worker_group=worker_group,
         start_time_ms=int(time.time() * 1000),
         run_status=RunStatusEnum.RUNNING,
-        controller_log_file_path="/tmp/ray/session_xxx/logs/worker-controller.err",
         resources=[{"CPU": 1}, {"CPU": 1}],
     )
 
@@ -219,7 +212,6 @@ def test_state_manager(ray_start_gpu_cluster):
                 worker_group=worker_group,
                 start_time_ms=int(time.time() * 1000),
                 run_status=RunStatusEnum.RUNNING,
-                controller_log_file_path="/tmp/ray/session_xxx/logs/worker-controller.err",
                 resources=[{"CPU": 1}, {"CPU": 1}],
             )
 

--- a/python/ray/train/tests/test_state.py
+++ b/python/ray/train/tests/test_state.py
@@ -63,7 +63,7 @@ RUN_INFO_JSON_SAMPLE = """{
         "pid": 76071,
         "gpu_ids": [0],
         "status": "ALIVE",
-        "resources": {"CPU": 1},
+        "resources": {"CPU": 1}
         },
         {
         "actor_id": "8f162dd8365346d1b5c98ebd7338c4f9",
@@ -75,7 +75,7 @@ RUN_INFO_JSON_SAMPLE = """{
         "pid": 76072,
         "gpu_ids": [1],
         "status": "ALIVE",
-        "resources": {"CPU": 1},
+        "resources": {"CPU": 1}
         }
     ],
     "datasets": [

--- a/python/ray/train/tests/test_state_export.py
+++ b/python/ray/train/tests/test_state_export.py
@@ -30,7 +30,6 @@ def create_mock_train_run_info(run_status=RunStatusEnum.RUNNING):
         gpu_ids=[0],
         status=ActorStatusEnum.ALIVE,
         resources={"CPU": 1},
-        worker_log_file_path="/tmp/ray/session_xxx/logs/train/worker-0.err",
     )
 
     return TrainRunInfo(
@@ -46,7 +45,6 @@ def create_mock_train_run_info(run_status=RunStatusEnum.RUNNING):
         end_time_ms=2000
         if run_status in [RunStatusEnum.FINISHED, RunStatusEnum.ERRORED]
         else None,
-        controller_log_file_path="/tmp/ray/session_xxx/logs/train/worker-controller.err",
         resources=[{"CPU": 1}],
     )
 
@@ -56,11 +54,11 @@ def test_train_run_info_to_proto_run():
     run_info = create_mock_train_run_info()
     proto_run = train_run_info_to_proto_run(run_info)
 
+    assert proto_run.ray_train_version == 1
     assert proto_run.id == run_info.id
     assert proto_run.name == run_info.name
     assert proto_run.job_id == bytes.fromhex(run_info.job_id)
     assert proto_run.status == ProtoTrainRun.RunStatus.RUNNING
-    assert proto_run.controller_log_file_path == run_info.controller_log_file_path
 
 
 def test_train_run_info_to_proto_attempt():
@@ -68,6 +66,7 @@ def test_train_run_info_to_proto_attempt():
     run_info = create_mock_train_run_info()
     proto_attempt = train_run_info_to_proto_attempt(run_info)
 
+    assert proto_attempt.ray_train_version == 1
     assert proto_attempt.run_id == run_info.id
     assert proto_attempt.status == ProtoTrainRunAttempt.RunAttemptStatus.RUNNING
 
@@ -78,7 +77,6 @@ def test_train_run_info_to_proto_attempt():
 
     assert proto_worker.world_rank == worker_info.world_rank
     assert proto_worker.actor_id == bytes.fromhex(worker_info.actor_id)
-    assert proto_worker.log_file_path == worker_info.worker_log_file_path
 
 
 def test_status_mapping():

--- a/python/ray/train/v2/_internal/state/export.py
+++ b/python/ray/train/v2/_internal/state/export.py
@@ -12,6 +12,7 @@ from ray.train.v2._internal.state.schema import (
 )
 
 TRAIN_SCHEMA_VERSION = 1
+RAY_TRAIN_VERSION = 2
 
 # Status mapping dictionaries
 _ACTOR_STATUS_MAP = {
@@ -71,6 +72,7 @@ def train_run_attempt_to_proto(attempt: TrainRunAttempt) -> ProtoTrainRunAttempt
     """Convert TrainRunAttempt to protobuf format."""
     proto_attempt = ProtoTrainRunAttempt(
         schema_version=TRAIN_SCHEMA_VERSION,
+        ray_train_version=RAY_TRAIN_VERSION,
         run_id=attempt.run_id,
         attempt_id=attempt.attempt_id,
         status=_RUN_ATTEMPT_STATUS_MAP[attempt.status],
@@ -88,6 +90,7 @@ def train_run_to_proto(run: TrainRun) -> ProtoTrainRun:
     """Convert TrainRun to protobuf format."""
     proto_run = ProtoTrainRun(
         schema_version=TRAIN_SCHEMA_VERSION,
+        ray_train_version=RAY_TRAIN_VERSION,
         id=run.id,
         name=run.name,
         job_id=bytes.fromhex(run.job_id),

--- a/src/ray/protobuf/export_api/export_train_state.proto
+++ b/src/ray/protobuf/export_api/export_train_state.proto
@@ -23,6 +23,9 @@ message ExportTrainRunEventData {
   // Version of the message schema
   uint32 schema_version = 1;
 
+  // Version of Ray Train
+  uint32 ray_train_version = 11;
+
   // Enumeration of the possible statuses for a Train run
   enum RunStatus {
     // Default value required by proto3
@@ -60,12 +63,16 @@ message ExportTrainRunEventData {
   optional uint64 end_time_ns = 9;
   // The path to the log file for the Train run controller.
   string controller_log_file_path = 10;
+  // WARNING: 11 is reserved for ray_train_version
 }
 
 // Metadata for an individual attempt to execute a Train run
 message ExportTrainRunAttemptEventData {
   // Version of the message schema
   uint32 schema_version = 1;
+
+  // Version of Ray Train
+  uint32 ray_train_version = 10;
 
   // Enumeration of the possible statuses for a Train run attempt
   enum RunAttemptStatus {
@@ -143,4 +150,5 @@ message ExportTrainRunAttemptEventData {
   repeated TrainResources resources = 8;
   // List of Train workers participating in this attempt, sorted by global ranks
   repeated TrainWorker workers = 9;
+  // WARNING: 10 is reserved for ray_train_version
 }

--- a/src/ray/protobuf/export_api/export_train_state.proto
+++ b/src/ray/protobuf/export_api/export_train_state.proto
@@ -23,9 +23,6 @@ message ExportTrainRunEventData {
   // Version of the message schema
   uint32 schema_version = 1;
 
-  // Version of Ray Train
-  uint32 ray_train_version = 11;
-
   // Enumeration of the possible statuses for a Train run
   enum RunStatus {
     // Default value required by proto3
@@ -63,16 +60,14 @@ message ExportTrainRunEventData {
   optional uint64 end_time_ns = 9;
   // The path to the log file for the Train run controller.
   optional string controller_log_file_path = 10;
-  // WARNING: 11 is reserved for ray_train_version
+  // Version of Ray Train
+  uint32 ray_train_version = 11;
 }
 
 // Metadata for an individual attempt to execute a Train run
 message ExportTrainRunAttemptEventData {
   // Version of the message schema
   uint32 schema_version = 1;
-
-  // Version of Ray Train
-  uint32 ray_train_version = 10;
 
   // Enumeration of the possible statuses for a Train run attempt
   enum RunAttemptStatus {
@@ -150,5 +145,6 @@ message ExportTrainRunAttemptEventData {
   repeated TrainResources resources = 8;
   // List of Train workers participating in this attempt, sorted by global ranks
   repeated TrainWorker workers = 9;
-  // WARNING: 10 is reserved for ray_train_version
+  // Version of Ray Train
+  uint32 ray_train_version = 10;
 }

--- a/src/ray/protobuf/export_api/export_train_state.proto
+++ b/src/ray/protobuf/export_api/export_train_state.proto
@@ -62,7 +62,7 @@ message ExportTrainRunEventData {
   // in progress
   optional uint64 end_time_ns = 9;
   // The path to the log file for the Train run controller.
-  string controller_log_file_path = 10;
+  optional string controller_log_file_path = 10;
   // WARNING: 11 is reserved for ray_train_version
 }
 
@@ -130,7 +130,7 @@ message ExportTrainRunAttemptEventData {
     // The resources allocated to this Train worker
     TrainResources resources = 10;
     // The path to the log file for the Train worker
-    string log_file_path = 11;
+    optional string log_file_path = 11;
   }
 
   // Unique identifier for the parent Train run


### PR DESCRIPTION
1. Add `ray_train_version` to differentiate between Train V1 and V2 records.
2. Remove `controller_log_file_path` and worker `log_file_path` for V1.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
