### PR TITLE
[Chore][Core/Dashboard] Remove TrainHead's dependency on DataOrganizer

### DIFF
--- a/python/ray/dashboard/modules/actor/actor_head.py
+++ b/python/ray/dashboard/modules/actor/actor_head.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from collections import defaultdict, deque
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Dict
+from typing import Any, Dict, Optional, List
 
 import aiohttp.web
 
@@ -262,7 +262,10 @@ class ActorHead(dashboard_utils.DashboardHeadModule):
     @routes.get("/logical/actors")
     @dashboard_optional_utils.aiohttp_cache
     async def get_all_actors(self, req) -> aiohttp.web.Response:
-        actors = await DataOrganizer.get_actor_infos()
+        actor_ids: Optional[List[str]] = None
+        if "ids" in req.query:
+            actor_ids = req.query["ids"].split(",")
+        actors = await DataOrganizer.get_actor_infos(actor_ids=actor_ids)
         return dashboard_optional_utils.rest_response(
             status_code=dashboard_utils.HTTPStatusCode.OK,
             message="All actors fetched.",

--- a/python/ray/dashboard/modules/actor/tests/test_actor.py
+++ b/python/ray/dashboard/modules/actor/tests/test_actor.py
@@ -23,7 +23,7 @@ def test_actors(disable_aiohttp_cache, ray_start_with_dashboard):
     - alive actors
     - infeasible actors
     - dead actors
-    - pg acrors (with pg_id set and required_resources formatted)
+    - pg actors (with pg_id set and required_resources formatted)
     """
 
     @ray.remote
@@ -144,6 +144,84 @@ def test_actors(disable_aiohttp_cache, ray_start_with_dashboard):
                     pg_actor_response = a
             assert pg_actor_response["placementGroupId"] == placement_group_id
             assert pg_actor_response["requiredResources"] == {"CPU": 1.0}
+
+            break
+        except Exception as ex:
+            last_ex = ex
+        finally:
+            if time.time() > start_time + timeout_seconds:
+                ex_stack = (
+                    traceback.format_exception(
+                        type(last_ex), last_ex, last_ex.__traceback__
+                    )
+                    if last_ex
+                    else []
+                )
+                ex_stack = "".join(ex_stack)
+                raise Exception(f"Timed out while testing, {ex_stack}")
+
+
+def test_actor_with_ids(disable_aiohttp_cache, ray_start_with_dashboard):
+    """
+    Tests the REST API dashboard calls with actor ids in the URL
+    """
+
+    @ray.remote
+    class Actor:
+        def __init__(self, num):
+            self.num = num
+
+        def do_task(self):
+            return self.num
+
+        def get_actor_id(self):
+            return ray.get_runtime_context().get_actor_id()
+
+    webui_url = ray_start_with_dashboard["webui_url"]
+    assert wait_until_server_available(webui_url)
+    webui_url = format_web_url(webui_url)
+    actors = [Actor.options(name=f"Actor{i}").remote(i) for i in range(5)]
+    for actor in actors:
+        actor.do_task.remote()
+
+    actor_ids = [ray.get(actor.get_actor_id.remote()) for actor in actors]
+
+    timeout_seconds = 5
+    start_time = time.time()
+    last_ex = None
+    while True:
+        time.sleep(1)
+        try:
+            actor_idx = 2
+            resp = requests.get(f"{webui_url}/logical/actors/{actor_ids[actor_idx]}")
+            resp_json = resp.json()
+            resp_data = resp_json["data"]
+            actor_detail = resp_data["detail"]
+            assert actor_detail["state"] == "ALIVE"
+            assert actor_detail["name"] == f"Actor{actor_idx}"
+            assert actor_detail["numRestarts"] == "0"
+            assert actor_detail["startTime"] > 0
+            assert actor_detail["requiredResources"] == {}
+            assert actor_detail["endTime"] == 0
+            assert actor_detail["exitDetail"] == "-"
+
+            actor_idxs = [0, 1, 4]
+            actor_idxs_to_id_str = ",".join([str(actor_ids[i]) for i in actor_idxs])
+            resp = requests.get(
+                f"{webui_url}/logical/actors?ids={actor_idxs_to_id_str}"
+            )
+            resp_json = resp.json()
+            resp_actors = resp_json["data"]["actors"]
+            assert len(resp_actors) == len(actor_idxs)
+            for actor_idx in actor_idxs:
+                actor_detail = resp_actors[str(actor_ids[actor_idx])]
+                assert actor_detail["state"] == "ALIVE"
+                assert actor_detail["name"] == f"Actor{actor_idx}"
+                assert actor_detail["numRestarts"] == "0"
+                assert actor_detail["startTime"] > 0
+                assert actor_detail["requiredResources"] == {}
+                assert actor_detail["endTime"] == 0
+                assert actor_detail["exitDetail"] == "-"
 
             break
         except Exception as ex:

--- a/python/ray/dashboard/modules/train/train_head.py
+++ b/python/ray/dashboard/modules/train/train_head.py
@@ -7,7 +7,6 @@ import ray
 import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.utils as dashboard_utils
 from ray.core.generated import gcs_service_pb2_grpc
-from ray.dashboard.datacenter import DataOrganizer
 from ray.dashboard.modules.job.common import JobInfoStorageClient
 from ray.dashboard.modules.job.utils import find_jobs_by_job_ids
 from ray.util.annotations import DeveloperAPI
@@ -184,9 +183,7 @@ class TrainHead(dashboard_utils.DashboardHeadModule):
 
         logger.info(f"Getting all actor info from GCS (actor_ids={actor_ids})")
 
-        train_run_actors = await DataOrganizer.get_actor_infos(
-            actor_ids=actor_ids,
-        )
+        train_run_actors = await self._get_actor_infos(actor_ids)
 
         for train_worker in train_workers:
             actor = train_run_actors.get(train_worker.actor_id, None)
@@ -244,9 +241,7 @@ class TrainHead(dashboard_utils.DashboardHeadModule):
         # train controller.
         # We need to detect this case and mark the train run as ABORTED.
 
-        actor_infos = await DataOrganizer.get_actor_infos(
-            actor_ids=[train_run.controller_actor_id],
-        )
+        actor_infos = await self._get_actor_infos([train_run.controller_actor_id])
         controller_actor_info = actor_infos[train_run.controller_actor_id]
 
         controller_actor_status = (
@@ -332,6 +327,14 @@ class TrainHead(dashboard_utils.DashboardHeadModule):
             content_type="application/json",
         )
 
+    async def _get_actor_infos(self, actor_ids: List[str]):
+        actor_ids_qs_str = ",".join(actor_ids)
+        url = f"http://{self.http_host}:{self.http_port}/logical/actors?ids={actor_ids_qs_str}&nocache=1"
+        async with self._http_session.get(url) as resp:
+            assert resp.status == 200, f"Failed to get actor info: {resp.status}"
+            resp_json = await resp.json()
+        return resp_json["data"]["actors"]
+
     async def _add_actor_status_and_update_run_status(self, train_runs):
         from ray.train._internal.state.schema import (
             ActorStatusEnum,
@@ -349,9 +352,7 @@ class TrainHead(dashboard_utils.DashboardHeadModule):
 
             logger.info(f"Getting all actor info from GCS (actor_ids={actor_ids})")
 
-            train_run_actors = await DataOrganizer.get_actor_infos(
-                actor_ids=actor_ids,
-            )
+            train_run_actors = await self._get_actor_infos(actor_ids)
 
             for worker_info in train_run.workers:
                 actor = train_run_actors.get(worker_info.actor_id, None)

--- a/python/ray/dashboard/modules/train/train_head.py
+++ b/python/ray/dashboard/modules/train/train_head.py
@@ -331,7 +331,7 @@ class TrainHead(dashboard_utils.DashboardHeadModule):
         actor_ids_qs_str = ",".join(actor_ids)
         url = f"http://{self.http_host}:{self.http_port}/logical/actors?ids={actor_ids_qs_str}&nocache=1"
         async with self._http_session.get(url) as resp:
-            assert resp.status == 200, f"Failed to get actor info: {resp.status}"
+            resp.raise_for_status()
             resp_json = await resp.json()
         return resp_json["data"]["actors"]
 

--- a/python/ray/dashboard/optional_utils.py
+++ b/python/ray/dashboard/optional_utils.py
@@ -66,6 +66,10 @@ def aiohttp_cache(
                 #   * (Request, )
                 #   * (self, Request)
                 req = args[-1]
+                # If nocache=1 in query string, bypass cache.
+                if req.query.get("nocache") == "1":
+                    return await handler(*args)
+
                 # Make key.
                 if req.method in _AIOHTTP_CACHE_NOBODY_METHODS:
                     key = req.path_qs

--- a/python/ray/dashboard/tests/test_dashboard.py
+++ b/python/ray/dashboard/tests/test_dashboard.py
@@ -632,41 +632,39 @@ def test_aiohttp_cache(enable_test_module, ray_start_with_dashboard):
     webui_url = ray_start_with_dashboard["webui_url"]
     webui_url = format_web_url(webui_url)
 
-    timeout_seconds = 5
-    start_time = time.time()
-    value1_timestamps = []
-    while True:
-        time.sleep(1)
-        try:
-            for x in range(10):
-                response = requests.get(webui_url + "/test/aiohttp_cache/t1?value=1")
-                response.raise_for_status()
-                timestamp = response.json()["data"]["timestamp"]
-                value1_timestamps.append(timestamp)
-            assert len(collections.Counter(value1_timestamps)) > 1
-            break
-        except (AssertionError, requests.exceptions.ConnectionError) as e:
-            logger.info("Retry because of %s", e)
-        finally:
-            if time.time() > start_time + timeout_seconds:
-                raise Exception("Timed out while testing.")
+    timestamps = set()
+    for _ in range(10):
+        response = requests.get(webui_url + "/test/aiohttp_cache/t1?value=1")
+        response.raise_for_status()
+        timestamp = response.json()["data"]["timestamp"]
+        timestamps.add(timestamp)
+    assert len(timestamps) == 1
 
-    sub_path_timestamps = []
+    timestamps.clear()
+    for x in range(10):
+        response = requests.get(webui_url + "/test/aiohttp_cache/t1?value=1&nocache=1")
+        response.raise_for_status()
+        timestamp = response.json()["data"]["timestamp"]
+        timestamps.add(timestamp)
+    assert len(timestamps) == 10
+
+    timestamps.clear()
     for x in range(10):
         response = requests.get(webui_url + f"/test/aiohttp_cache/tt{x}?value=1")
         response.raise_for_status()
         timestamp = response.json()["data"]["timestamp"]
-        sub_path_timestamps.append(timestamp)
-    assert len(collections.Counter(sub_path_timestamps)) == 10
+        timestamps.add(timestamp)
+    assert len(timestamps) == 10
 
-    volatile_value_timestamps = []
+    timestamps.clear()
     for x in range(10):
         response = requests.get(webui_url + f"/test/aiohttp_cache/tt?value={x}")
         response.raise_for_status()
         timestamp = response.json()["data"]["timestamp"]
-        volatile_value_timestamps.append(timestamp)
-    assert len(collections.Counter(volatile_value_timestamps)) == 10
+        timestamps.add(timestamp)
+    assert len(timestamps) == 10
 
+    timestamps.clear()
     response = requests.get(webui_url + "/test/aiohttp_cache/raise_exception")
     with pytest.raises(Exception):
         response.raise_for_status()
@@ -674,23 +672,23 @@ def test_aiohttp_cache(enable_test_module, ray_start_with_dashboard):
     assert result["result"] is False
     assert "KeyError" in result["msg"]
 
-    volatile_value_timestamps = []
+    timestamps.clear()
     for x in range(10):
         response = requests.get(webui_url + f"/test/aiohttp_cache_lru/tt{x % 4}")
         response.raise_for_status()
         timestamp = response.json()["data"]["timestamp"]
-        volatile_value_timestamps.append(timestamp)
-    assert len(collections.Counter(volatile_value_timestamps)) == 4
+        timestamps.add(timestamp)
+    assert len(timestamps) == 4
 
-    volatile_value_timestamps = []
+    timestamps.clear()
     data = collections.defaultdict(set)
     for x in [0, 1, 2, 3, 4, 5, 2, 1, 0, 3]:
         response = requests.get(webui_url + f"/test/aiohttp_cache_lru/t1?value={x}")
         response.raise_for_status()
         timestamp = response.json()["data"]["timestamp"]
         data[x].add(timestamp)
-        volatile_value_timestamps.append(timestamp)
-    assert len(collections.Counter(volatile_value_timestamps)) == 8
+        timestamps.add(timestamp)
+    assert len(timestamps) == 8
     assert len(data[3]) == 2
     assert len(data[0]) == 2
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR removes `TrainHead`'s dependency on `DataOrganizer`.
- Added `nocache` query string support to the `aiohttp_cache` decorator. If it's set to `"1"`, the cache will be bypassed.  
- Fixed the `test_aiohttp_cache` test:  
  - Replaced the use of `Counter` with `set`, which makes more sense here.  
  - Removed the `while` loop in the test since we don't need to retry for this. 
  - Added a test case for the `nocache` query string.
- Added `ids` query string support to `ActorHead`. We can now use `GET /logical/actors?ids=id1,id2,id3` to fetch info for multiple actors. Also added a test for this.  
- Updated `TrainHead` to stop calling `DataOrganizer.get_actor_infos` directly. It now makes an HTTP request to `ActorHead`, which will call `DataOrganizer.get_actor_infos` on its behalf.
## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
