### PR TITLE
[core][state] Fix false alarm in `get_logs` when a server chunk splits into multiple client chunks

### DIFF
--- a/python/ray/util/state/api.py
+++ b/python/ray/util/state/api.py
@@ -1297,7 +1297,6 @@ def get_log(
             # indicator of success or failure. This seems to be an uncommon pattern,
             # and it doesn't seem important for the client side.
             if bytes.startswith(b"0"):
-                assert bytes.startswith(b"0")
                 error_msg = bytes.decode("utf-8")
                 raise RayStateApiException(error_msg)
             else:

--- a/python/ray/util/state/api.py
+++ b/python/ray/util/state/api.py
@@ -1284,16 +1284,28 @@ def get_log(
             raise RayStateApiException(r.text)
         for bytes in r.iter_content(chunk_size=None):
             bytes = bytearray(bytes)
-            # First byte 1 means success.
-            if bytes.startswith(b"1"):
-                bytes.pop(0)
-                logs = bytes
-                if encoding is not None:
-                    logs = bytes.decode(encoding=encoding, errors=errors)
-            else:
+            # Note that each iteration of the loop doesn't always get
+            # the entire chunk yielded from the server side.
+            # That is, the first byte isn't always 0 or 1.
+            #
+            # 1. If a server chunk starting with b"0" is split into two client chunks,
+            # an error will be raised during iteration of the first client chunk.
+            #
+            # 2. If a client chunk starts with b"1" or any other bytes, it succeeds.
+            #
+            # TODO (kevin85421): We should consider not using the first byte as an
+            # indicator of success or failure. This seems to be an uncommon pattern,
+            # and it doesn't seem important for the client side.
+            if bytes.startswith(b"0"):
                 assert bytes.startswith(b"0")
                 error_msg = bytes.decode("utf-8")
                 raise RayStateApiException(error_msg)
+            else:
+                if bytes.startswith(b"1"):
+                    bytes.pop(0)
+                logs = bytes
+                if encoding is not None:
+                    logs = bytes.decode(encoding=encoding, errors=errors)
             yield logs
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In `go/flaky`, the test [test_large_log_file](https://github.com/ray-project/ray/blob/5195be51f484900f1ab385906a8592369032dbe2/release/nightly_tests/stress_tests/test_state_api_scale.py#L240) is flaky, and the error message is shown in the screenshot below ([example run](https://buildkite.com/ray-project/postmerge/builds/9160#0195d5fe-6e7e-489f-ad71-2f784bb576fb)).

![image](https://github.com/user-attachments/assets/716741a3-5211-45d4-b7c9-87815d13ff2b)

The issue is that when using `with requests.get(..., stream=True)`, the exact chunk produced by the server is not always returned during each iteration of `for bytes in r.iter_content(chunk_size=None)`. It seems to depend on the underlying TCP.

The producer of the chunks (i.e., the server) is [state_head](https://github.com/ray-project/ray/blob/5195be51f484900f1ab385906a8592369032dbe2/python/ray/dashboard/modules/state/state_head.py#L253). It adds `b"1"` as the first byte of a chunk to indicate success, and `b"0"` to indicate failure.

However, in the original logic, an exception is thrown if the client receives a chunk that doesn't start with `b"1"`. This will cause false alarms when a chunk starts with `b"1"` from server got splitting into two chunks in the client side. For example,

```
server: 1 chunk
[b"1" part 1 + part 2]

client: 2 chunks
* 1st chunk: [b"1" part 1]
* 2nd chunk: [part 2] <----- an exception will be thrown from the client side
```

False alarms can still occur if part 2 starts with `b"0"`, because it depends on the user's program output. Since we cannot control that, we should consider eliminating the use of the first byte to determine whether the result is a success or a failure.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

[outdated] Normally, it's not easy to reproduce locally. Luckily, I have a WIP PR (#51735) that makes this occur more frequently. I don't know whether the new commits in the PR are causing this or if the different base commit between the two PRs is responsible.

The blame commit which makes it happen more frequently seems to be https://github.com/ray-project/ray/pull/51749.

[Gist](https://gist.github.com/kevin85421/94e73ac6b3ca9b0fa7135712ec5c5c06)

* #51735 only: It fails 6 out of 20 times.
* #51735 + this PR: Passes 20 out of 20 times.



- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
