### PR TITLE
[Chore][Autoscaler] Clarify disable_launch_config_check comment in StandardAutoscaler

### DIFF
--- a/python/ray/autoscaler/_private/autoscaler.py
+++ b/python/ray/autoscaler/_private/autoscaler.py
@@ -279,9 +279,10 @@ class StandardAutoscaler:
         )
         logger.info(f"{DISABLE_NODE_UPDATERS_KEY}:{self.disable_node_updaters}")
 
-        # Disable launch config checking if true.
-        # This is set in the fake_multinode situations where there isn't any
-        # meaningful node "type" to enforce.
+        # Disable launch configuration checking if set to true.
+        # This setting is used in scenarios where there is no meaningful node type
+        # to enforce, such as in fake multinode situations. When this option is enabled,
+        # outdated nodes will not be terminated.
         self.disable_launch_config_check = self.config["provider"].get(
             DISABLE_LAUNCH_CONFIG_CHECK_KEY, False
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

- This pull request updates the comment for the disable_launch_config_check setting in autoscaler.py to provide a clearer explanation, aligning it with the description found in [scheduler.py](https://github.com/ray-project/ray/blob/master/python/ray/autoscaler/v2/scheduler.py).
- The goal is to clarify the purpose of the disable_launch_config_check setting specifically in the context of StandardAutoscaler. This change enhances the understanding of its purpose and usage scenarios.
- Additionally, if logs are required when disable_launch_config_check is enabled, similar to the behavior in scheduler.py, they will be added to functions in autoscaler.py. This change improves clarity regarding its purpose and usage scenarios.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
