### PR TITLE
[Test][Dashboard] Add API tests for MetricsHead module

### DIFF
--- a/python/ray/dashboard/modules/metrics/tests/test_metrics.py
+++ b/python/ray/dashboard/modules/metrics/tests/test_metrics.py
@@ -16,9 +16,8 @@ def ray_dashboard(ray_start_cluster):
     h = ray_start_cluster.add_node(dashboard_port=dashboard_port)
     uri = f"http://localhost:{dashboard_port}"
 
-    # Ensure the dashboard is accessible
     wait_for_condition(
-        lambda: requests.get(f"{uri}/api/gcs_healthz").status_code == 200
+        lambda: requests.get(f"{uri}/api/grafana_health").status_code == 200
     )
 
     return {"webui_url": uri, "node": h}
@@ -72,12 +71,11 @@ def test_prometheus_health(webui_url):
 
 def test_grafana_health_fail(webui_url, ray_dashboard):
     """
-    Tests /api/grafana_health when Grafana is not running.
+    Tests /api/grafana_health when MetricsHead (Grafana) is not running.
     """
     url = f"{webui_url}/api/grafana_health"
 
-    # Simulate Grafana being down by killing the process
-    ray_dashboard["node"].all_processes[ray_constants.PROCESS_TYPE_GCS_SERVER][
+    ray_dashboard["node"].all_processes[ray_constants.PROCESS_TYPE_METRICS_HEAD][
         0
     ].process.kill()
 
@@ -91,12 +89,11 @@ def test_grafana_health_fail(webui_url, ray_dashboard):
 
 def test_prometheus_health_fail(webui_url, ray_dashboard):
     """
-    Tests /api/prometheus_health when Prometheus is not running.
+    Tests /api/prometheus_health when MetricsHead (Prometheus) is not running.
     """
     url = f"{webui_url}/api/prometheus_health"
 
-    # Simulate Prometheus being down by killing the process
-    ray_dashboard["node"].all_processes[ray_constants.PROCESS_TYPE_GCS_SERVER][
+    ray_dashboard["node"].all_processes[ray_constants.PROCESS_TYPE_METRICS_HEAD][
         0
     ].process.kill()
 

--- a/python/ray/dashboard/modules/metrics/tests/test_metrics.py
+++ b/python/ray/dashboard/modules/metrics/tests/test_metrics.py
@@ -23,8 +23,7 @@ def webui_url(ray_dashboard):
     """
     Returns the formatted Web UI URL after ensuring it is available.
     """
-    url = ray_dashboard["webui_url"]
-    return format_web_url(url)
+    return format_web_url(ray_dashboard["webui_url"])
 
 
 def is_service_ready(url):

--- a/python/ray/dashboard/modules/metrics/tests/test_metrics.py
+++ b/python/ray/dashboard/modules/metrics/tests/test_metrics.py
@@ -1,8 +1,9 @@
 import sys
 import asyncio
-import requests
 import urllib.parse
+import requests
 import pytest
+
 from ray._private.test_utils import wait_for_condition, wait_until_server_available
 from ray.dashboard.tests.conftest import *  # noqa
 
@@ -10,6 +11,7 @@ from ray.dashboard.tests.conftest import *  # noqa
 def test_grafana_health(ray_start_with_dashboard):
     """
     Tests the /api/grafana_health endpoint from MetricsHead module.
+    Prints response body on failure for easier debugging.
     """
     webui_url = ray_start_with_dashboard.address_info["webui_url"]
     if not webui_url.startswith("http"):
@@ -17,23 +19,26 @@ def test_grafana_health(ray_start_with_dashboard):
 
     parsed = urllib.parse.urlparse(webui_url)
     host_port = f"{parsed.hostname}:{parsed.port}"
-    assert wait_until_server_available(host_port)
+    assert wait_until_server_available(
+        host_port
+    ), f"Dashboard not available at {host_port}"
 
     url = f"{webui_url}/api/grafana_health"
-    assert wait_for_condition(
-        lambda: requests.get(url, timeout=3).status_code == 200, timeout=10
-    )
 
-    resp = requests.get(url)
-    assert resp.status_code == 200, resp.text
-    data = resp.json()
-    assert data["result"] is True
-    assert "grafana_host" in data["data"]
+    def condition():
+        resp = requests.get(url, timeout=3)
+        if resp.status_code != 200:
+            print("[test_grafana_health] Status code:", resp.status_code)
+            print("[test_grafana_health] Response body:", resp.text)
+        return resp.status_code == 200
+
+    assert wait_for_condition(condition, timeout=10)
 
 
 def test_prometheus_health(ray_start_with_dashboard):
     """
     Tests the /api/prometheus_health endpoint from MetricsHead module.
+    Prints response body on failure for easier debugging.
     """
     webui_url = ray_start_with_dashboard.address_info["webui_url"]
     if not webui_url.startswith("http"):
@@ -41,23 +46,27 @@ def test_prometheus_health(ray_start_with_dashboard):
 
     parsed = urllib.parse.urlparse(webui_url)
     host_port = f"{parsed.hostname}:{parsed.port}"
-    assert wait_until_server_available(host_port)
+    assert wait_until_server_available(
+        host_port
+    ), f"Dashboard not available at {host_port}"
 
     url = f"{webui_url}/api/prometheus_health"
-    assert wait_for_condition(
-        lambda: requests.get(url, timeout=3).status_code == 200, timeout=10
-    )
 
-    resp = requests.get(url)
-    assert resp.status_code == 200, resp.text
-    data = resp.json()
-    assert data["result"] is True
+    def condition():
+        resp = requests.get(url, timeout=3)
+        if resp.status_code != 200:
+            print("[test_prometheus_health] Status code:", resp.status_code)
+            print("[test_prometheus_health] Response body:", resp.text)
+        return resp.status_code == 200
+
+    assert wait_for_condition(condition, timeout=10)
 
 
 @pytest.mark.asyncio
 async def test_async_health_check(ray_start_with_dashboard):
     """
     Tests asynchronous API health check for robustness.
+    Prints response body on failure for easier debugging.
     """
     webui_url = ray_start_with_dashboard.address_info["webui_url"]
     if not webui_url.startswith("http"):
@@ -65,15 +74,30 @@ async def test_async_health_check(ray_start_with_dashboard):
 
     parsed = urllib.parse.urlparse(webui_url)
     host_port = f"{parsed.hostname}:{parsed.port}"
-    assert wait_until_server_available(host_port)
+    assert wait_until_server_available(
+        host_port
+    ), f"Dashboard not available at {host_port}"
 
     url = f"{webui_url}/api/grafana_health"
-    for _ in range(5):
+
+    resp = None
+    for i in range(5):
         resp = await asyncio.to_thread(requests.get, url)
         if resp.status_code == 200:
             break
+        else:
+            print(
+                f"[test_async_health_check] Attempt {i+1} failed. Status code:",
+                resp.status_code,
+            )
+            print("[test_async_health_check] Response body:", resp.text)
         await asyncio.sleep(1)
-    assert resp.status_code == 200
+
+    assert resp is not None, "No response received at all."
+    assert resp.status_code == 200, (
+        f"Async health check still failed with status {resp.status_code}. "
+        f"Response: {resp.text}"
+    )
 
 
 if __name__ == "__main__":

--- a/python/ray/dashboard/modules/metrics/tests/test_metrics.py
+++ b/python/ray/dashboard/modules/metrics/tests/test_metrics.py
@@ -10,9 +10,11 @@ def test_grafana_health(ray_start_with_dashboard):
     """
     Tests the /api/grafana_health endpoint from MetricsHead module.
     """
-    assert wait_until_server_available(ray_start_with_dashboard["webui_url"])
-    webui_url = ray_start_with_dashboard["webui_url"]
+    webui_url = ray_start_with_dashboard.address_info["webui_url"]
+    if not webui_url.startswith("http"):
+        webui_url = "http://" + webui_url
 
+    assert wait_until_server_available(webui_url)
     url = f"{webui_url}/api/grafana_health"
     assert wait_for_condition(
         lambda: requests.get(url, timeout=3).status_code == 200, timeout=10
@@ -29,9 +31,11 @@ def test_prometheus_health(ray_start_with_dashboard):
     """
     Tests the /api/prometheus_health endpoint from MetricsHead module.
     """
-    assert wait_until_server_available(ray_start_with_dashboard["webui_url"])
-    webui_url = ray_start_with_dashboard["webui_url"]
+    webui_url = ray_start_with_dashboard.address_info["webui_url"]
+    if not webui_url.startswith("http"):
+        webui_url = "http://" + webui_url
 
+    assert wait_until_server_available(webui_url)
     url = f"{webui_url}/api/prometheus_health"
     assert wait_for_condition(
         lambda: requests.get(url, timeout=3).status_code == 200, timeout=10
@@ -48,15 +52,17 @@ async def test_async_health_check(ray_start_with_dashboard):
     """
     Tests asynchronous API health check for robustness.
     """
-    assert wait_until_server_available(ray_start_with_dashboard["webui_url"])
-    webui_url = ray_start_with_dashboard["webui_url"]
+    webui_url = ray_start_with_dashboard.address_info["webui_url"]
+    if not webui_url.startswith("http"):
+        webui_url = "http://" + webui_url
 
+    assert wait_until_server_available(webui_url)
     url = f"{webui_url}/api/grafana_health"
     for _ in range(5):
         resp = await asyncio.to_thread(requests.get, url)
         if resp.status_code == 200:
             break
-        await asyncio.sleep(1)  # Retry every second
+        await asyncio.sleep(1)
     assert resp.status_code == 200
 
 

--- a/python/ray/dashboard/modules/metrics/tests/test_metrics.py
+++ b/python/ray/dashboard/modules/metrics/tests/test_metrics.py
@@ -1,0 +1,38 @@
+import sys
+import requests
+import pytest
+from ray._private.test_utils import format_web_url, wait_until_server_available
+from ray.dashboard.tests.conftest import *  # noqa
+
+
+def test_grafana_health(ray_start_with_dashboard):
+    """
+    Test the /api/grafana_health endpoint from MetricsHead module.
+    """
+    webui_url = ray_start_with_dashboard["webui_url"]
+    assert wait_until_server_available(webui_url)
+    webui_url = format_web_url(webui_url)
+
+    resp = requests.get(f"{webui_url}/api/grafana_health")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["result"] is True
+    assert "grafana_host" in data["data"]
+
+
+def test_prometheus_health(ray_start_with_dashboard):
+    """
+    Test the /api/prometheus_health endpoint from MetricsHead module.
+    """
+    webui_url = ray_start_with_dashboard["webui_url"]
+    assert wait_until_server_available(webui_url)
+    webui_url = format_web_url(webui_url)
+
+    resp = requests.get(f"{webui_url}/api/prometheus_health")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["result"] is True
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/dashboard/modules/metrics/tests/test_metrics.py
+++ b/python/ray/dashboard/modules/metrics/tests/test_metrics.py
@@ -1,38 +1,111 @@
-import sys
+import asyncio
 import requests
 import pytest
-from ray._private.test_utils import format_web_url, wait_until_server_available
+from ray._private.test_utils import (
+    format_web_url,
+    wait_until_server_available,
+    wait_for_condition,
+)
 from ray.dashboard.tests.conftest import *  # noqa
 
 
-def test_grafana_health(ray_start_with_dashboard):
+@pytest.fixture(scope="module")
+def webui_url(ray_start_with_dashboard):
     """
-    Test the /api/grafana_health endpoint from MetricsHead module.
+    Returns the formatted Web UI URL after ensuring it is available.
     """
-    webui_url = ray_start_with_dashboard["webui_url"]
-    assert wait_until_server_available(webui_url)
-    webui_url = format_web_url(webui_url)
+    url = ray_start_with_dashboard["webui_url"]
+    assert wait_until_server_available(url)
+    return format_web_url(url)
 
-    resp = requests.get(f"{webui_url}/api/grafana_health")
+
+def is_service_ready(url):
+    """
+    Checks if the given API endpoint is available.
+    """
+    try:
+        resp = requests.get(url, timeout=5)  # Increased timeout
+        return resp.status_code == 200
+    except requests.exceptions.RequestException:
+        return False
+
+
+def test_grafana_health(webui_url):
+    """
+    Tests the /api/grafana_health endpoint from MetricsHead module.
+    """
+    url = f"{webui_url}/api/grafana_health"
+    wait_for_condition(lambda: is_service_ready(url), timeout=10)
+
+    resp = requests.get(url)
     assert resp.status_code == 200, resp.text
     data = resp.json()
     assert data["result"] is True
     assert "grafana_host" in data["data"]
 
 
-def test_prometheus_health(ray_start_with_dashboard):
+def test_prometheus_health(webui_url):
     """
-    Test the /api/prometheus_health endpoint from MetricsHead module.
+    Tests the /api/prometheus_health endpoint from MetricsHead module.
     """
-    webui_url = ray_start_with_dashboard["webui_url"]
-    assert wait_until_server_available(webui_url)
-    webui_url = format_web_url(webui_url)
+    url = f"{webui_url}/api/prometheus_health"
+    wait_for_condition(lambda: is_service_ready(url), timeout=10)
 
-    resp = requests.get(f"{webui_url}/api/prometheus_health")
+    resp = requests.get(url)
     assert resp.status_code == 200, resp.text
     data = resp.json()
     assert data["result"] is True
 
 
+def test_grafana_health_fail(webui_url):
+    """
+    Tests /api/grafana_health when Grafana is not running.
+    """
+    url = f"{webui_url}/api/grafana_health"
+    resp = requests.get(url)
+
+    if resp.status_code == 200:
+        pytest.skip("Grafana is running, skipping failure test.")
+
+    data = resp.json()
+    assert "exception" in data["data"]
+    assert "Cannot connect" in data["data"]["exception"]
+
+
+def test_prometheus_health_fail(webui_url):
+    """
+    Tests /api/prometheus_health when Prometheus is not running.
+    """
+    url = f"{webui_url}/api/prometheus_health"
+    resp = requests.get(url)
+
+    if resp.status_code == 200:
+        pytest.skip("Prometheus is running, skipping failure test.")
+
+    data = resp.json()
+    assert "reason" in data["data"]
+    assert "Cannot connect" in data["data"]["reason"]
+
+
+@pytest.mark.asyncio
+async def test_async_health_check(webui_url):
+    """
+    Tests asynchronous API health check for robustness.
+    """
+    url = f"{webui_url}/api/grafana_health"
+    for _ in range(5):
+        try:
+            resp = await asyncio.to_thread(requests.get, url)
+            if resp.status_code == 200:
+                assert resp.json()["result"] is True
+                return
+        except requests.exceptions.RequestException:
+            pass
+        await asyncio.sleep(1)
+    pytest.fail("Grafana health check failed after multiple retries")
+
+
 if __name__ == "__main__":
+    import sys
+
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/dashboard/modules/metrics/tests/test_metrics.py
+++ b/python/ray/dashboard/modules/metrics/tests/test_metrics.py
@@ -2,52 +2,21 @@ import sys
 import asyncio
 import requests
 import pytest
-import ray._private.ray_constants as ray_constants
-from ray._private.test_utils import find_free_port, wait_for_condition
+from ray._private.test_utils import wait_for_condition, wait_until_server_available
 from ray.dashboard.tests.conftest import *  # noqa
 
 
-@pytest.fixture(scope="module")
-def ray_dashboard(ray_start_cluster):
-    """
-    Starts Ray cluster with the dashboard and returns the dashboard URL.
-    """
-    dashboard_port = find_free_port()
-    h = ray_start_cluster.add_node(dashboard_port=dashboard_port)
-    uri = f"http://localhost:{dashboard_port}"
-
-    wait_for_condition(
-        lambda: requests.get(f"{uri}/api/grafana_health").status_code == 200
-    )
-
-    return {"webui_url": uri, "node": h}
-
-
-@pytest.fixture(scope="module")
-def webui_url(ray_dashboard):
-    """
-    Extracts the Web UI URL from the Ray dashboard fixture.
-    """
-    return ray_dashboard["webui_url"]
-
-
-def is_service_ready(url):
-    """
-    Checks if the given API endpoint is available.
-    """
-    try:
-        resp = requests.get(url, timeout=3)
-        return resp.status_code == 200
-    except requests.exceptions.RequestException:
-        return False
-
-
-def test_grafana_health(webui_url):
+def test_grafana_health(ray_start_with_dashboard):
     """
     Tests the /api/grafana_health endpoint from MetricsHead module.
     """
+    assert wait_until_server_available(ray_start_with_dashboard["webui_url"])
+    webui_url = ray_start_with_dashboard["webui_url"]
+
     url = f"{webui_url}/api/grafana_health"
-    assert wait_for_condition(lambda: is_service_ready(url), timeout=10)
+    assert wait_for_condition(
+        lambda: requests.get(url, timeout=3).status_code == 200, timeout=10
+    )
 
     resp = requests.get(url)
     assert resp.status_code == 200, resp.text
@@ -56,12 +25,17 @@ def test_grafana_health(webui_url):
     assert "grafana_host" in data["data"]
 
 
-def test_prometheus_health(webui_url):
+def test_prometheus_health(ray_start_with_dashboard):
     """
     Tests the /api/prometheus_health endpoint from MetricsHead module.
     """
+    assert wait_until_server_available(ray_start_with_dashboard["webui_url"])
+    webui_url = ray_start_with_dashboard["webui_url"]
+
     url = f"{webui_url}/api/prometheus_health"
-    assert wait_for_condition(lambda: is_service_ready(url), timeout=10)
+    assert wait_for_condition(
+        lambda: requests.get(url, timeout=3).status_code == 200, timeout=10
+    )
 
     resp = requests.get(url)
     assert resp.status_code == 200, resp.text
@@ -69,47 +43,14 @@ def test_prometheus_health(webui_url):
     assert data["result"] is True
 
 
-def test_grafana_health_fail(webui_url, ray_dashboard):
-    """
-    Tests /api/grafana_health when MetricsHead (Grafana) is not running.
-    """
-    url = f"{webui_url}/api/grafana_health"
-
-    ray_dashboard["node"].all_processes[ray_constants.PROCESS_TYPE_METRICS_HEAD][
-        0
-    ].process.kill()
-
-    try:
-        wait_for_condition(
-            lambda: requests.get(url, timeout=1).status_code != 200, timeout=4
-        )
-    except RuntimeError as e:
-        assert "Read timed out" in str(e)
-
-
-def test_prometheus_health_fail(webui_url, ray_dashboard):
-    """
-    Tests /api/prometheus_health when MetricsHead (Prometheus) is not running.
-    """
-    url = f"{webui_url}/api/prometheus_health"
-
-    ray_dashboard["node"].all_processes[ray_constants.PROCESS_TYPE_METRICS_HEAD][
-        0
-    ].process.kill()
-
-    try:
-        wait_for_condition(
-            lambda: requests.get(url, timeout=1).status_code != 200, timeout=4
-        )
-    except RuntimeError as e:
-        assert "Read timed out" in str(e)
-
-
 @pytest.mark.asyncio
-async def test_async_health_check(webui_url):
+async def test_async_health_check(ray_start_with_dashboard):
     """
     Tests asynchronous API health check for robustness.
     """
+    assert wait_until_server_available(ray_start_with_dashboard["webui_url"])
+    webui_url = ray_start_with_dashboard["webui_url"]
+
     url = f"{webui_url}/api/grafana_health"
     for _ in range(5):
         resp = await asyncio.to_thread(requests.get, url)

--- a/python/ray/dashboard/modules/metrics/tests/test_metrics.py
+++ b/python/ray/dashboard/modules/metrics/tests/test_metrics.py
@@ -1,6 +1,7 @@
 import sys
 import asyncio
 import requests
+import urllib.parse
 import pytest
 from ray._private.test_utils import wait_for_condition, wait_until_server_available
 from ray.dashboard.tests.conftest import *  # noqa
@@ -14,7 +15,10 @@ def test_grafana_health(ray_start_with_dashboard):
     if not webui_url.startswith("http"):
         webui_url = "http://" + webui_url
 
-    assert wait_until_server_available(webui_url)
+    parsed = urllib.parse.urlparse(webui_url)
+    host_port = f"{parsed.hostname}:{parsed.port}"
+    assert wait_until_server_available(host_port)
+
     url = f"{webui_url}/api/grafana_health"
     assert wait_for_condition(
         lambda: requests.get(url, timeout=3).status_code == 200, timeout=10
@@ -35,7 +39,10 @@ def test_prometheus_health(ray_start_with_dashboard):
     if not webui_url.startswith("http"):
         webui_url = "http://" + webui_url
 
-    assert wait_until_server_available(webui_url)
+    parsed = urllib.parse.urlparse(webui_url)
+    host_port = f"{parsed.hostname}:{parsed.port}"
+    assert wait_until_server_available(host_port)
+
     url = f"{webui_url}/api/prometheus_health"
     assert wait_for_condition(
         lambda: requests.get(url, timeout=3).status_code == 200, timeout=10
@@ -56,7 +63,10 @@ async def test_async_health_check(ray_start_with_dashboard):
     if not webui_url.startswith("http"):
         webui_url = "http://" + webui_url
 
-    assert wait_until_server_available(webui_url)
+    parsed = urllib.parse.urlparse(webui_url)
+    host_port = f"{parsed.hostname}:{parsed.port}"
+    assert wait_until_server_available(host_port)
+
     url = f"{webui_url}/api/grafana_health"
     for _ in range(5):
         resp = await asyncio.to_thread(requests.get, url)


### PR DESCRIPTION
## Why are these changes needed?
The `MetricsHead` module currently lacks test coverage. This PR adds API tests to ensure the `/api/grafana_health` and `/api/prometheus_health` endpoints function correctly.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
