### PR TITLE
[ci] Allow dependency failure for kuberay ci kickoff

### DIFF
--- a/.buildkite/release-automation/pre_release.rayci.yml
+++ b/.buildkite/release-automation/pre_release.rayci.yml
@@ -56,6 +56,7 @@ steps:
     trigger: "ray-ecosystem-ci-kuberay-ci"
     key: trigger-kuberay
     depends_on: trigger-postmerge-nightly
+    allow_dependency_failure: true
     build:
       branch: "release-1.3"
       message: "Triggered by release-automation build #${BUILDKITE_BUILD_NUMBER}"

--- a/.buildkite/release-automation/pre_release.rayci.yml
+++ b/.buildkite/release-automation/pre_release.rayci.yml
@@ -55,8 +55,7 @@ steps:
     if: build.env("RAYCI_WEEKLY_RELEASE_NIGHTLY") == "1"
     trigger: "ray-ecosystem-ci-kuberay-ci"
     key: trigger-kuberay
-    depends_on: trigger-postmerge-nightly
-    allow_dependency_failure: true
+    depends_on: check-ray-commit
     build:
       branch: "release-1.3"
       message: "Triggered by release-automation build #${BUILDKITE_BUILD_NUMBER}"

--- a/.buildkite/release-automation/pre_release.rayci.yml
+++ b/.buildkite/release-automation/pre_release.rayci.yml
@@ -51,6 +51,17 @@ steps:
         RAYCI_RELEASE: 1
         RAYCI_SCHEDULE: "nightly"
 
+- label: "Check Ray commit in {{matrix}} nightly images"
+  key: check-ray-commit
+  if: build.branch !~ /^releases\// && build.env("RAYCI_WEEKLY_RELEASE_NIGHTLY") == "1"
+  depends_on: trigger-postmerge-nightly
+  allow_dependency_failure: true
+  commands:
+    - bazel run //ci/ray_ci/automation:check_nightly_ray_commit -- --ray_type={{matrix}} --expected_commit="${BUILDKITE_COMMIT}"
+  matrix:
+    - ray
+    - ray-ml
+
   - label: "Trigger :kubernetes: Kuberay CI Tests"
     if: build.env("RAYCI_WEEKLY_RELEASE_NIGHTLY") == "1"
     trigger: "ray-ecosystem-ci-kuberay-ci"
@@ -125,14 +136,3 @@ steps:
       env:
         AUTOMATIC: 1
         RELEASE_FREQUENCY: "weekly"
-
-  - label: "Check Ray commit in {{matrix}} nightly images"
-    key: check-ray-commit
-    if: build.branch !~ /^releases\// && build.env("RAYCI_WEEKLY_RELEASE_NIGHTLY") == "1"
-    depends_on: trigger-postmerge-nightly
-    allow_dependency_failure: true
-    commands:
-      - bazel run //ci/ray_ci/automation:check_nightly_ray_commit -- --ray_type={{matrix}} --expected_commit="${BUILDKITE_COMMIT}"
-    matrix:
-      - ray
-      - ray-ml


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Kuberay ci kickoff won't happen if the postmerge nightly build and test step fails. The postmerge nightly tests will fail almost all the time, we should still kick off kuberay tests.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
