### PR TITLE
[Fix][Core/Dashboard] Remove `format=leading_1` query string from `get_logs` in StateHead

### DIFF
--- a/python/ray/dashboard/client/src/pages/job/JobDriverLogs.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/job/JobDriverLogs.component.test.tsx
@@ -47,7 +47,7 @@ describe("JobDriverLogs", () => {
     expect(screen.getByText(/foo/)).toBeVisible();
 
     expect(mockedGet).toBeCalledWith(
-      `api/v0/logs/file?node_id=node-id-0&filename=job-driver-raysubmit_12345.log&lines=${MAX_LINES_FOR_LOGS}&format=leading_1`,
+      `api/v0/logs/file?node_id=node-id-0&filename=job-driver-raysubmit_12345.log&lines=${MAX_LINES_FOR_LOGS}`,
     );
   });
 });

--- a/python/ray/dashboard/client/src/service/log.ts
+++ b/python/ray/dashboard/client/src/service/log.ts
@@ -21,10 +21,6 @@ export type StateApiLogInput = {
    * -1 for all lines.
    */
   maxLines?: number;
-  /**
-   * Use "text" for orignal log, "leading_1" for an error bit for each chunk.
-   */
-  format?: "text" | "leading_1";
 };
 
 export const getStateApiDownloadLogUrl = ({
@@ -33,7 +29,6 @@ export const getStateApiDownloadLogUrl = ({
   taskId,
   actorId,
   suffix,
-  format = "text",
   maxLines = MAX_LINES_FOR_LOGS,
 }: StateApiLogInput) => {
   if (
@@ -56,14 +51,13 @@ export const getStateApiDownloadLogUrl = ({
       : []),
     ...(suffix !== undefined ? [`suffix=${encodeURIComponent(suffix)}`] : []),
     `lines=${maxLines}`,
-    `format=${format}`,
   ];
 
   return `api/v0/logs/file?${variables.join("&")}`;
 };
 
 export const getStateApiLog = async (props: StateApiLogInput) => {
-  const url = getStateApiDownloadLogUrl({ ...props, format: "leading_1" });
+  const url = getStateApiDownloadLogUrl({ ...props });
   if (url === null) {
     return undefined;
   }
@@ -72,11 +66,7 @@ export const getStateApiLog = async (props: StateApiLogInput) => {
   if (resp.status === 200 && resp.data.length === 0) {
     return "";
   }
-  // TODO(aguo): get rid of this first byte check once we support state-api logs without this streaming byte.
-  if (resp.data[0] !== "1") {
-    throw new Error(resp.data.substring(1));
-  }
-  return resp.data.substring(1);
+  return resp.data;
 };
 
 type ListStateApiLogsResponse = {

--- a/python/ray/dashboard/client/src/service/log.unit.test.ts
+++ b/python/ray/dashboard/client/src/service/log.unit.test.ts
@@ -10,17 +10,16 @@ describe("getStateApiDownloadLogUrl", () => {
         filename: "file.log",
       }),
     ).toStrictEqual(
-      `api/v0/logs/file?node_id=node-id&filename=file.log&lines=${MAX_LINES_FOR_LOGS}&format=text`,
+      `api/v0/logs/file?node_id=node-id&filename=file.log&lines=${MAX_LINES_FOR_LOGS}`,
     );
 
     expect(
       getStateApiDownloadLogUrl({
         nodeId: "node-id",
         filename: "file.log",
-        format: "leading_1",
       }),
     ).toStrictEqual(
-      `api/v0/logs/file?node_id=node-id&filename=file.log&lines=${MAX_LINES_FOR_LOGS}&format=leading_1`,
+      `api/v0/logs/file?node_id=node-id&filename=file.log&lines=${MAX_LINES_FOR_LOGS}`,
     );
 
     expect(
@@ -29,7 +28,7 @@ describe("getStateApiDownloadLogUrl", () => {
         suffix: "err",
       }),
     ).toStrictEqual(
-      `api/v0/logs/file?task_id=task-id&suffix=err&lines=${MAX_LINES_FOR_LOGS}&format=text`,
+      `api/v0/logs/file?task_id=task-id&suffix=err&lines=${MAX_LINES_FOR_LOGS}`,
     );
 
     expect(
@@ -38,7 +37,7 @@ describe("getStateApiDownloadLogUrl", () => {
         suffix: "out",
       }),
     ).toStrictEqual(
-      `api/v0/logs/file?task_id=task-id&suffix=out&lines=${MAX_LINES_FOR_LOGS}&format=text`,
+      `api/v0/logs/file?task_id=task-id&suffix=out&lines=${MAX_LINES_FOR_LOGS}`,
     );
 
     expect(
@@ -47,7 +46,7 @@ describe("getStateApiDownloadLogUrl", () => {
         suffix: "err",
       }),
     ).toStrictEqual(
-      `api/v0/logs/file?actor_id=actor-id&suffix=err&lines=${MAX_LINES_FOR_LOGS}&format=text`,
+      `api/v0/logs/file?actor_id=actor-id&suffix=err&lines=${MAX_LINES_FOR_LOGS}`,
     );
 
     expect(

--- a/python/ray/dashboard/modules/state/state_head.py
+++ b/python/ray/dashboard/modules/state/state_head.py
@@ -250,6 +250,7 @@ class StateHead(SubprocessModule, RateLimitedModule):
             async for logs in logs_gen:
                 await response.write(logs)
         except Exception:
+            logger.exception("Error while streaming logs")
             response.force_close()
             raise
 

--- a/python/ray/dashboard/modules/state/state_head.py
+++ b/python/ray/dashboard/modules/state/state_head.py
@@ -3,7 +3,7 @@ import logging
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict
 from datetime import datetime
-from typing import AsyncIterable, Optional
+from typing import Optional
 
 import aiohttp.web
 from aiohttp.web import Response
@@ -198,16 +198,8 @@ class StateHead(SubprocessModule, RateLimitedModule):
     async def get_logs(self, req: aiohttp.web.Request):
         """
         Fetches logs from the given criteria.
-
-        Output format is from the query parameter `format`.
-        - `leading_1` (default): Each chunk of data is prepended with a char `1` if the
-            chunk is successful, or `0` if the chunk is failed. After a `0` and its
-            error message, the stream is closed.
-        - `text`: Plain text format. Returns the original log data as-is. If an
-            exception occurs, yields `[get_logs] Fetch log error` with error message and
-            closes the stream.
-
-        Note: all formats always return 200 even if the log fetching fails.
+        If an exception occurs, yields `[get_logs] Fetch log error`
+        with error message and closes the stream.
         """
         record_extra_usage_tag(TagKey.CORE_STATE_API_GET_LOG, "1")
         options = GetLogOptions(
@@ -226,8 +218,7 @@ class StateHead(SubprocessModule, RateLimitedModule):
             attempt_number=req.query.get("attempt_number", 0),
         )
 
-        output_format = req.query.get("format", "leading_1")
-        logger.info(f"Streaming logs with format {output_format} options: {options}")
+        logger.info(f"Streaming logs with options: {options}")
 
         async def get_actor_fn(actor_id: ActorID) -> Optional[ActorTableData]:
             actor_info_dict = await self.gcs_aio_client.get_all_actor_info(
@@ -237,54 +228,33 @@ class StateHead(SubprocessModule, RateLimitedModule):
                 return None
             return actor_info_dict[actor_id]
 
-        async def formatter_text(response, async_gen: AsyncIterable[bytes]):
-            try:
-                async for logs in async_gen:
-                    await response.write(logs)
-            except asyncio.CancelledError:
-                # This happens when the client side closes the connection.
-                # Force close the connection and do no-op.
-                response.force_close()
-                raise
-            except Exception as e:
-                logger.exception("Error while streaming logs")
-                await response.write(f"[get_logs] Fetch log error: {e}".encode())
-
-        async def formatter_leading_1(response, async_gen: AsyncIterable[bytes]):
-            # NOTE: The first byte indicates the success / failure of individual
-            # stream. If the first byte is b"1", it means the stream was successful.
-            # If it is b"0", it means it is failed.
-            try:
-                async for logs in async_gen:
-                    logs_to_stream = bytearray(b"1")
-                    logs_to_stream.extend(logs)
-                    await response.write(bytes(logs_to_stream))
-            except asyncio.CancelledError:
-                # This happens when the client side closes the connection.
-                # Fofce close the connection and do no-op.
-                response.force_close()
-                raise
-            except Exception as e:
-                logger.exception("Error while streaming logs")
-                error_msg = bytearray(b"0")
-                error_msg.extend(
-                    f"Closing HTTP stream due to internal server error.\n{e}".encode()
-                )
-                await response.write(bytes(error_msg))
-
         response = aiohttp.web.StreamResponse()
         response.content_type = "text/plain"
-        await response.prepare(req)
 
         logs_gen = self._log_api.stream_logs(options, get_actor_fn)
-        if output_format == "text":
-            await formatter_text(response, logs_gen)
-        elif output_format == "leading_1":
-            await formatter_leading_1(response, logs_gen)
-        else:
-            raise ValueError(
-                f"Unsupported format: {output_format}, use 'text' or " "'leading_1'"
-            )
+        # Handle the first chunk separately and returns 500 if an error occurs.
+        try:
+            first_chunk = await logs_gen.__anext__()
+            await response.prepare(req)
+            await response.write(first_chunk)
+        except StopAsyncIteration:
+            pass
+        except asyncio.CancelledError:
+            # This happens when the client side closes the connection.
+            # Force close the connection and do no-op.
+            response.force_close()
+            raise
+        except Exception as e:
+            logger.exception("Error while streaming logs")
+            raise aiohttp.web.HTTPInternalServerError(text=str(e))
+
+        try:
+            async for logs in logs_gen:
+                await response.write(logs)
+        except Exception:
+            response.force_close()
+            raise
+
         await response.write_eof()
         return response
 

--- a/python/ray/dashboard/modules/state/state_head.py
+++ b/python/ray/dashboard/modules/state/state_head.py
@@ -198,8 +198,6 @@ class StateHead(SubprocessModule, RateLimitedModule):
     async def get_logs(self, req: aiohttp.web.Request):
         """
         Fetches logs from the given criteria.
-        If an exception occurs, yields `[get_logs] Fetch log error`
-        with error message and closes the stream.
         """
         record_extra_usage_tag(TagKey.CORE_STATE_API_GET_LOG, "1")
         options = GetLogOptions(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Because the chunks may be split, it's unreliable to use the prepended "0" or "1" bytes as an indicator of success or error. After inspecting the code, most errors are raised during the setup of the async generator to generate the async stream. So this PR removes the `format` query string in the `get_logs` function entirely and handles the first chunk separately. If an error is raised while processing the first chunk, a normal HTTP response with a 500 status code is returned. After the first chunk, we return a stream response with a 200 status code and handle it as the "text" formatter did before.

![image](https://github.com/user-attachments/assets/1711c5be-1091-4aa4-9341-647cfb7d342a)


## Related issue number

<!-- For example: "Closes #1234" -->
Closes #51762

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
