### PR TITLE
[core] Suppress C++ warning

### DIFF
--- a/bazel/ray.bzl
+++ b/bazel/ray.bzl
@@ -15,8 +15,6 @@ COPTS_WITHOUT_LOG = select({
         "-Wunused-result",
         "-Wconversion-null",
         "-Wno-misleading-indentation",
-        # [[deprecated]] shouldn't be treated as compilation error.
-        "-Wno-error=deprecated-declarations",
         # [[maybe_unused]] shouldn't be treated as compilation error.
         "-Wno-error=attributes",
     ],

--- a/bazel/ray.bzl
+++ b/bazel/ray.bzl
@@ -15,6 +15,10 @@ COPTS_WITHOUT_LOG = select({
         "-Wunused-result",
         "-Wconversion-null",
         "-Wno-misleading-indentation",
+        # [[deprecated]] shouldn't be treated as compilation error.
+        "-Wno-error=deprecated-declarations",
+        # [[maybe_unused]] shouldn't be treated as compilation error.
+        "-Wno-error=attributes",
     ],
 }) + select({
     "//:clang-cl": [


### PR DESCRIPTION
See my inline comments, certain C++ attributes shouldn't be treated as compilation errors (which loss the purpose of attributes).