### PR TITLE
[core] Pass filename instead of filepath for python logging

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1135,7 +1135,6 @@ def start_log_monitor(
         f"--gcs-address={gcs_address}",
         f"--logging-rotate-bytes={max_bytes}",
         f"--logging-rotate-backup-count={backup_count}",
-        f"--logging-filename={logs_dir}/log_monitor.log",
     ]
 
     if stdout_filepath:


### PR DESCRIPTION
Filename is joined with logging directory.
```py
os.path.join(log_dir, filename)
```
If we pass in logging directory, directory will appear twice in the final path.

Example
```py
>>> import os
>>> os.path.join("/tmp/logs", "/tmp/log/log.txt")
'/tmp/log/log.txt'
```