### PR TITLE
[core] Adapt redirect_stdout_stderr_if_needed to dashboard agent

### DIFF
--- a/python/ray/dashboard/agent.py
+++ b/python/ray/dashboard/agent.py
@@ -18,8 +18,7 @@ from ray._private.gcs_utils import GcsAioClient
 from ray._private.process_watcher import create_check_raylet_task
 from ray._private.ray_constants import AGENT_GRPC_MAX_MESSAGE_LENGTH
 from ray._private.ray_logging import setup_component_logger
-from ray._raylet import StreamRedirector
-from ray._private.utils import open_log
+from ray._private import logging_utils
 
 logger = logging.getLogger(__name__)
 
@@ -427,31 +426,12 @@ if __name__ == "__main__":
 
         # Setup stdout/stderr redirect files
         out_filepath, err_filepath = get_capture_filepaths(args.log_dir)
-        StreamRedirector.redirect_stdout(
+        logging_utils.redirect_stdout_stderr_if_needed(
             out_filepath,
-            logging_rotation_bytes,
-            logging_rotation_backup_count,
-            False,
-            False,
-        )
-        StreamRedirector.redirect_stderr(
             err_filepath,
             logging_rotation_bytes,
             logging_rotation_backup_count,
-            False,
-            False,
         )
-
-        # Setup stdout/stderr redirect files
-        stdout_fileno = sys.stdout.fileno()
-        stderr_fileno = sys.stderr.fileno()
-        # We also manually set sys.stdout and sys.stderr because that seems to
-        # have an effect on the output buffering. Without doing this, stdout
-        # and stderr are heavily buffered resulting in seemingly lost logging
-        # statements. We never want to close the stdout file descriptor, dup2 will
-        # close it when necessary and we don't want python's GC to close it.
-        sys.stdout = open_log(stdout_fileno, unbuffered=True, closefd=False)
-        sys.stderr = open_log(stderr_fileno, unbuffered=True, closefd=False)
 
         agent = DashboardAgent(
             args.node_ip_address,


### PR DESCRIPTION
Just code cleanup, adapt all existing stdout/stderr redirection callsites to leverage logging utils.