### PR TITLE
[core] Add more details about `client_processed_up_to`

### DIFF
--- a/src/ray/core_worker/transport/actor_scheduling_queue.cc
+++ b/src/ray/core_worker/transport/actor_scheduling_queue.cc
@@ -88,7 +88,7 @@ void ActorSchedulingQueue::Add(
 
   RAY_CHECK(std::this_thread::get_id() == main_thread_id_);
   if (client_processed_up_to >= next_seq_no_) {
-    RAY_LOG(ERROR) << "client skipping requests " << next_seq_no_ << " to "
+    RAY_LOG(INFO) << "client skipping requests " << next_seq_no_ << " to "
                    << client_processed_up_to;
     next_seq_no_ = client_processed_up_to + 1;
   }

--- a/src/ray/core_worker/transport/actor_scheduling_queue.cc
+++ b/src/ray/core_worker/transport/actor_scheduling_queue.cc
@@ -89,7 +89,7 @@ void ActorSchedulingQueue::Add(
   RAY_CHECK(std::this_thread::get_id() == main_thread_id_);
   if (client_processed_up_to >= next_seq_no_) {
     RAY_LOG(INFO) << "client skipping requests " << next_seq_no_ << " to "
-                   << client_processed_up_to;
+                  << client_processed_up_to;
     next_seq_no_ = client_processed_up_to + 1;
   }
   RAY_LOG(DEBUG) << "Enqueue " << seq_no << " cur seqno " << next_seq_no_;

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -85,10 +85,26 @@ message PushTaskRequest {
   // out-of-order request messages to arrive as necessary.
   // If set to -1, ordering is disabled and the task executes immediately.
   int64 sequence_number = 3;
-  // The max sequence number the client has processed responses for. This
-  // is a performance optimization that allows the client to tell the server
-  // to cancel any PushTaskRequests with seqno <= this value, rather than
-  // waiting for the server to time out waiting for missing messages.
+  // The maximum sequence number for which the client has processed responses.
+  // This is useful in the following example:
+  //
+  // 1. Client sends a PushTaskRequest with `sequence_number` 0.
+  // 2. The request is lost in the network.
+  // 3. Client resends a PushTaskRequest with `sequence_number` 1.
+  // 4. Server receives the resent request but does not process it immediately
+  //    because it is waiting for the request with `sequence_number` 0 to arrive.
+  // 5. Server times out while waiting for the request with `sequence_number` 0 to arrive.
+  // 6. Server processes the resent request with `sequence_number` 1.
+  //
+  // `client_processed_up_to` is used to tell the server to cancel any PushTaskRequests
+  // with sequence numbers <= this value because the client has already processed
+  // the responses or no longer needs them.
+  //
+  // In the example above, the first request will have `client_processed_up_to` set to -1,
+  // and the second request will have it set to 0. When the server receives the second
+  // request, it will check `client_processed_up_to` and find that it no longer needs to
+  // wait for the request with `sequence_number` 0 to arrive, so it will process the
+  // request immediately.
   int64 client_processed_up_to = 4;
   // Resource mapping ids assigned to the worker executing the task.
   repeated ResourceMapEntry resource_mapping = 5;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds more details about `client_processed_up_to`. The field is useful when requests with smaller seq no are lost.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
