### PR TITLE
[Refactor][Core/Dashboard] Make `datacenter.py` a private implementation for NodeHead

### DIFF
--- a/python/ray/dashboard/head.py
+++ b/python/ray/dashboard/head.py
@@ -15,7 +15,6 @@ from ray._private.usage.usage_lib import TagKey, record_extra_usage_tag
 from ray._raylet import GcsClient
 from ray.dashboard.consts import DASHBOARD_METRIC_PORT
 from ray.dashboard.dashboard_metrics import DashboardPrometheusMetrics
-from ray.dashboard.datacenter import DataOrganizer
 from ray.dashboard.utils import (
     DashboardHeadModule,
     DashboardHeadModuleConfig,
@@ -141,7 +140,6 @@ class DashboardHead:
         self.gcs_error_subscriber = None
         self.gcs_log_subscriber = None
         self.ip = node_ip_address
-        DataOrganizer.head_node_ip = self.ip
 
         if self.minimal:
             self.server, self.grpc_port = None, None
@@ -445,8 +443,6 @@ class DashboardHead:
         concurrent_tasks = [
             self._gcs_check_alive(),
             _async_notify(),
-            DataOrganizer.purge(),
-            DataOrganizer.organize(self._executor),
         ]
         for m in dashboard_head_modules:
             concurrent_tasks.append(m.run(self.server))

--- a/python/ray/dashboard/modules/node/datacenter.py
+++ b/python/ray/dashboard/modules/node/datacenter.py
@@ -39,8 +39,6 @@ class DataSource:
 
 
 class DataOrganizer:
-    head_node_ip = None
-
     @staticmethod
     @async_loop_forever(dashboard_consts.RAY_DASHBOARD_STATS_PURGING_INTERVAL)
     async def purge():

--- a/python/ray/dashboard/modules/tests/test_head.py
+++ b/python/ray/dashboard/modules/tests/test_head.py
@@ -8,7 +8,6 @@ import ray.dashboard.modules.tests.test_utils as test_utils
 import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.utils as dashboard_utils
 from ray._private.ray_constants import env_bool
-from ray.dashboard.datacenter import DataSource
 
 logger = logging.getLogger(__name__)
 routes = dashboard_optional_utils.DashboardHeadRouteTable
@@ -40,28 +39,6 @@ class TestHead(dashboard_utils.DashboardHeadModule):
     @routes.view("/test/route_view")
     async def route_view(self, req) -> aiohttp.web.Response:
         pass
-
-    @routes.get("/test/dump")
-    async def dump(self, req) -> aiohttp.web.Response:
-        key = req.query.get("key")
-        if key is None:
-            all_data = {
-                k: dict(v)
-                for k, v in DataSource.__dict__.items()
-                if not k.startswith("_")
-            }
-            return dashboard_optional_utils.rest_response(
-                status_code=dashboard_utils.HTTPStatusCode.OK,
-                message="Fetch all data from datacenter success.",
-                **all_data,
-            )
-        else:
-            data = dict(DataSource.__dict__.get(key))
-            return dashboard_optional_utils.rest_response(
-                status_code=dashboard_utils.HTTPStatusCode.OK,
-                message=f"Fetch {key} from datacenter success.",
-                **{key: data},
-            )
 
     @routes.get("/test/http_get")
     async def get_url(self, req) -> aiohttp.web.Response:


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR makes `DataSource` and `DataOrganizer` in `datacenter.py` private implementations for `NodeHead` to remove inter-dependencies between dashboard modules. The `datacenter.py` file is moved to the `python/ray/dashboard/modules/node/` folder. After this PR, only `node_head.py` uses `datacenter.py`.

## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
