### PR TITLE
Fix multi_node_train_benchmark train step

### DIFF
--- a/release/nightly_tests/dataset/multi_node_train_benchmark.py
+++ b/release/nightly_tests/dataset/multi_node_train_benchmark.py
@@ -360,10 +360,10 @@ def train_loop_per_worker():
                 outputs = model(inputs)
                 loss = criterion(outputs, labels)
 
-                # zero the parameter gradients
-                optimizer.zero_grad()
                 loss.backward()
                 optimizer.step()
+                # zero the parameter gradients
+                optimizer.zero_grad()
 
                 num_batches += 1
                 total_loss += loss.item()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Fix issue in the Train Step. Need to zero out the gradients only after optimizer step or before forward pass.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
