### PR TITLE
[core][cgraph] Refactor get_devices() for compiled graph

### DIFF
--- a/python/ray/experimental/channel/utils.py
+++ b/python/ray/experimental/channel/utils.py
@@ -101,11 +101,12 @@ def get_devices() -> List["torch.device"]:
     Gets the torch devices configured for this process.
 
     This method assumes that `CUDA_VISIBLE_DEVICES` is set and is a
-    superset of the `ray.get_gpu_ids()`.
+    superset of the `ray.get_gpu_ids()`. It does NOT assume
+    `CUDA_VISIBLE_DEVICES` is set to a single GPU ID.
 
     Returns:
         A list of torch devices allocated for the current worker.
-        If no devices are assigned, then it returns a list with
+        If no CUDA devices are assigned, then it returns a list with
         a single CPU device.
     """
 
@@ -117,7 +118,6 @@ def get_devices() -> List["torch.device"]:
 
     device_ids = []
 
-    assert len(gpu_ids) > 0, "No GPUs found"
     cuda_visible_str = os.environ.get("CUDA_VISIBLE_DEVICES", "")
     if cuda_visible_str and cuda_visible_str != "NoDevFiles":
         cuda_visible_list = cuda_visible_str.split(",")

--- a/python/ray/experimental/channel/utils.py
+++ b/python/ray/experimental/channel/utils.py
@@ -96,66 +96,47 @@ def get_actor_node(actor: Optional["ray.actor.ActorHandle"]) -> str:
         )
 
 
-def get_cuda_devices() -> List["torch.device"]:
-    """Gets the correct torch cuda device list configured for this process.
-
-    Assumes that `CUDA_VISIBLE_DEVICES` is set and is a
-    superset of the `ray.get_gpu_ids()`.
+def get_devices() -> List["torch.device"]:
     """
-    # Note: currently this method replicates the logic from
-    # `CUDATorchDeviceManager.get_devices()`.
-    # TODO(rui): tailor and clean up the logic for proper use in
-    # Compiled Graphs.
+    Gets the torch devices configured for this process.
+
+    This method assumes that `CUDA_VISIBLE_DEVICES` is set and is a
+    superset of the `ray.get_gpu_ids()`.
+
+    Returns:
+        A list of torch devices allocated for the current worker.
+        If no devices are assigned, then it returns a list with
+        a single CPU device.
+    """
+
     import torch
 
-    # GPU IDs are assigned by Ray after you specify "use_gpu"
-    # GPU `ray.get_gpu_ids()` may return ints or may return strings.
-    # We should always convert to strings.
     gpu_ids = [str(id) for id in ray.get_gpu_ids()]
+    if len(gpu_ids) == 0:
+        return [torch.device("cpu")]
 
     device_ids = []
 
-    if len(gpu_ids) > 0:
-        cuda_visible_str = os.environ.get("CUDA_VISIBLE_DEVICES", "")
-        if cuda_visible_str and cuda_visible_str != "NoDevFiles":
-            cuda_visible_list = cuda_visible_str.split(",")
-        else:
-            cuda_visible_list = []
-
-        # By default, there should only be one GPU ID if `use_gpu=True`.
-        # If there are multiple GPUs, return a list of devices.
-        # If using fractional GPUs, these IDs are not guaranteed
-        # to be unique across different processes.
-        for gpu_id in gpu_ids:
-            try:
-                device_ids.append(cuda_visible_list.index(gpu_id))
-            except IndexError:
-                raise RuntimeError(
-                    "CUDA_VISIBLE_DEVICES set incorrectly. "
-                    f"Got {cuda_visible_str}, expected to include {gpu_id}. "
-                    "Did you override the `CUDA_VISIBLE_DEVICES` environment"
-                    " variable? If not, please help file an issue on Github."
-                )
-
+    assert len(gpu_ids) > 0, "No GPUs found"
+    cuda_visible_str = os.environ.get("CUDA_VISIBLE_DEVICES", "")
+    if cuda_visible_str and cuda_visible_str != "NoDevFiles":
+        cuda_visible_list = cuda_visible_str.split(",")
     else:
-        # If called on the driver or outside of Ray Train, return the
-        # 0th device.
-        device_ids.append(0)
+        cuda_visible_list = []
+
+    # By default, there should only be one GPU ID if `use_gpu=True`.
+    # If there are multiple GPUs, return a list of devices.
+    # If using fractional GPUs, these IDs are not guaranteed
+    # to be unique across different processes.
+    for gpu_id in gpu_ids:
+        try:
+            device_ids.append(cuda_visible_list.index(gpu_id))
+        except IndexError:
+            raise RuntimeError(
+                "CUDA_VISIBLE_DEVICES set incorrectly. "
+                f"Got {cuda_visible_str}, expected to include {gpu_id}. "
+                "Did you override the `CUDA_VISIBLE_DEVICES` environment"
+                " variable? If not, please help file an issue on Github."
+            )
 
     return [torch.device(f"cuda:{device_id}") for device_id in device_ids]
-
-
-def get_devices() -> List["torch.device"]:
-    """Gets the correct torch device list configured for this process.
-
-    Returns a list of torch devices allocated for the current worker.
-    If no devices are assigned, then it returns a list with a single CPU device.
-    """
-
-    import torch
-
-    gpu_ids = [str(id) for id in ray.get_gpu_ids()]
-    if len(gpu_ids) > 0:
-        return get_cuda_devices()
-    else:
-        return [torch.device("cpu")]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This is a follow up for https://github.com/ray-project/ray/pull/51734

The reason https://github.com/ray-project/ray/pull/51305 caused illegal GPU memory access in vLLM is that it assumes `CUDA_VISIBLE_DEVICES` for an actor is limited to a single GPU ID, and the worker can always accesses the GPU with `cuda:0`. While this is a reasonable assumption for Ray backed applications in general, it is not the case for vLLM. Historically vLLM alters `CUDA_VISIBLE_DEVICES` and sets it to the list of local GPUs (on the same node) for maintaining distributed groups for both the Ray and MP backends. While this could be cleaned up, it will be a longer-term process.

This PR refactors and cleans up the utils.get_devices() API.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
