### PR TITLE
[llm][test] Use smolVLM in unit tests

### DIFF
--- a/python/ray/llm/tests/batch/gpu/processor/test_vllm_engine_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_vllm_engine_proc.py
@@ -176,20 +176,22 @@ def test_embedding_model(gpu_type, model_opt_125m):
     assert all("prompt" in out for out in outs)
 
 
-def test_vision_model(gpu_type, model_llava_354m):
+def test_vision_model(gpu_type, model_smolvlm_256m):
     processor_config = vLLMEngineProcessorConfig(
-        model_source=model_llava_354m,
+        model_source=model_smolvlm_256m,
         task_type="generate",
         engine_kwargs=dict(
             # Skip CUDA graph capturing to reduce startup time.
             enforce_eager=True,
+            # # CI uses T4 GPU which does not support bfloat16.
+            dtype="half",
         ),
         # CI uses T4 GPU which is not supported by vLLM v1 FlashAttn.
-        # runtime_env=dict(
-        #     env_vars=dict(
-        #         VLLM_USE_V1="1",
-        #     ),
-        # ),
+        runtime_env=dict(
+            env_vars=dict(
+                VLLM_USE_V1="0",
+            ),
+        ),
         apply_chat_template=True,
         has_image=True,
         tokenize=False,

--- a/python/ray/llm/tests/batch/gpu/processor/test_vllm_engine_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_vllm_engine_proc.py
@@ -183,7 +183,7 @@ def test_vision_model(gpu_type, model_smolvlm_256m):
         engine_kwargs=dict(
             # Skip CUDA graph capturing to reduce startup time.
             enforce_eager=True,
-            # # CI uses T4 GPU which does not support bfloat16.
+            # CI uses T4 GPU which does not support bfloat16.
             dtype="half",
         ),
         # CI uses T4 GPU which is not supported by vLLM v1 FlashAttn.

--- a/python/ray/llm/tests/conftest.py
+++ b/python/ray/llm/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 from typing import Generator, List
 
 S3_ARTIFACT_URL = "https://air-example-data.s3.amazonaws.com/"
+S3_ARTIFACT_LLM_OSSCI_URL = S3_ARTIFACT_URL + "rayllm-ossci/"
 
 
 def download_model_from_s3(
@@ -65,6 +66,27 @@ def model_llava_354m():
         "tokenizer.json",
         "tokenizer.model",
         "tokenizer_config.json",
+    ]
+    yield from download_model_from_s3(REMOTE_URL, FILE_LIST)
+
+
+@pytest.fixture(scope="session")
+def model_smolvlm_256m():
+    """The vision language model for testing."""
+    REMOTE_URL = f"{S3_ARTIFACT_LLM_OSSCI_URL}smolvlm-256m-instruct/"
+    FILE_LIST = [
+        "added_tokens.json",
+        "chat_template.json",
+        "config.json",
+        "generation_config.json",
+        "merges.txt",
+        "model.safetensors",
+        "preprocessor_config.json",
+        "processor_config.json",
+        "special_tokens_map.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "vocab.json",
     ]
     yield from download_model_from_s3(REMOTE_URL, FILE_LIST)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

While [bumping vLLM to 0.8.2](https://github.com/ray-project/ray/pull/51726), `test_vision_model` is failing because:
* the previously used `llava-354m` model was random generated
* during test, `multi_modal_projector(..)` returns `[[nan, nan, ...]...]`
* [this line](https://github.com/vllm-project/vllm/blame/f98a4920f968b1514c185bcdb881125903059c70/vllm/model_executor/models/vision.py#L222) introduced in vLLM 0.8.* does not like `nan`, resulting an empty mm_embedding, and further failures
* so instead of using fake model (llava-354m), let's start using a real yet small vision model (smolVLM)

The model is copied from `HuggingFaceTB/SmolVLM-256M-Instruct ` following [this instruction](https://www.notion.so/anyscale-hq/Upload-Huggingface-Model-to-S3-1c7027c809cb80c98c8ac325867645e5?pvs=4)

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
   - [x] Manually tested: install vllm0.8.2 locally, unit tests pass
