### PR TITLE
[core] Fix ray id implicit fall through

### DIFF
--- a/src/ray/common/id.cc
+++ b/src/ray/common/id.cc
@@ -104,16 +104,22 @@ __suppress_ubsan__("undefined") uint64_t
   switch (len & 7) {
   case 7:
     h ^= uint64_t(data2[6]) << 48;
+    [[fallthrough]];
   case 6:
     h ^= uint64_t(data2[5]) << 40;
+    [[fallthrough]];
   case 5:
     h ^= uint64_t(data2[4]) << 32;
+    [[fallthrough]];
   case 4:
     h ^= uint64_t(data2[3]) << 24;
+    [[fallthrough]];
   case 3:
     h ^= uint64_t(data2[2]) << 16;
+    [[fallthrough]];
   case 2:
     h ^= uint64_t(data2[1]) << 8;
+    [[fallthrough]];
   case 1:
     h ^= uint64_t(data2[0]);
     h *= m;


### PR DESCRIPTION
It fails with `-Wimplicit-fallthrough` flag, which is suggested by https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++
I'm trying to enable the compilation option at https://github.com/ray-project/ray/pull/51857