### PR TITLE
[core] Enable cgroup unit tests in CI

### DIFF
--- a/.buildkite/cicd.rayci.yml
+++ b/.buildkite/cicd.rayci.yml
@@ -18,7 +18,6 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker --
           //ci/ray_ci:test_privileged ci
-          --only-tags=cgroup
           --cache-test-results
           --build-name oss-ci-base_test
           --build-type cgroup

--- a/.buildkite/cicd.rayci.yml
+++ b/.buildkite/cicd.rayci.yml
@@ -18,6 +18,7 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker --
           //ci/ray_ci:test_privileged ci
+          --only-tags=cgroup
           --cache-test-results
           --build-name oss-ci-base_test
           --build-type cgroup

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -311,16 +311,16 @@ steps:
     tags: core_cpp
     instance_type: large
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --except-tags=cgroup
-        --build-type ubsan --except-tags no_ubsan
+      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core
+        --build-type ubsan --except-tags no_ubsan,cgroup
         --cache-test-results --parallelism-per-worker 2
 
   - label: ":ray: core: cpp tsan tests"
     tags: core_cpp
     instance_type: medium
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --except-tags=cgroup
-        --build-type tsan-clang --except-tags no_tsan
+      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core
+        --build-type tsan-clang --except-tags no_tsan,cgroup
         --cache-test-results --parallelism-per-worker 2
 
   - label: ":ray: core: flaky cpp tests"

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -297,30 +297,30 @@ steps:
     tags: core_cpp
     instance_type: medium
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --build-type clang
+      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --test_tag_filters=-cgroup --build-type clang
         --cache-test-results --parallelism-per-worker 2
 
   - label: ":ray: core: cpp asan tests"
     tags: core_cpp
     instance_type: medium
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --build-type asan-clang
-        --cache-test-results --parallelism-per-worker 2
+      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --test_tag_filters=-cgroup
+        --build-type asan-clang --cache-test-results --parallelism-per-worker 2
 
   - label: ":ray: core: cpp ubsan tests"
     tags: core_cpp
     instance_type: large
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --build-type ubsan
-        --except-tags no_ubsan
+      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --test_tag_filters=-cgroup
+        --build-type ubsan --except-tags no_ubsan
         --cache-test-results --parallelism-per-worker 2
 
   - label: ":ray: core: cpp tsan tests"
     tags: core_cpp
     instance_type: medium
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --build-type tsan-clang
-        --except-tags no_tsan
+      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --test_tag_filters=-cgroup
+        --build-type tsan-clang --except-tags no_tsan
         --cache-test-results --parallelism-per-worker 2
 
   - label: ":ray: core: flaky cpp tests"

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -298,7 +298,7 @@ steps:
     instance_type: medium
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --only-tags=cgroup --build-type cgroup
-        --privileged --cache-test-results --parallelism-per-worker 2
+        --privileged --cache-test-results
 
   - label: ":ray: core: cpp tests"
     tags: core_cpp

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -297,21 +297,21 @@ steps:
     tags: core_cpp
     instance_type: medium
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --test_tag_filters=-cgroup --build-type clang
+      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --except-tags=cgroup --build-type clang
         --cache-test-results --parallelism-per-worker 2
 
   - label: ":ray: core: cpp asan tests"
     tags: core_cpp
     instance_type: medium
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --test_tag_filters=-cgroup
+      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --except-tags=cgroup
         --build-type asan-clang --cache-test-results --parallelism-per-worker 2
 
   - label: ":ray: core: cpp ubsan tests"
     tags: core_cpp
     instance_type: large
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --test_tag_filters=-cgroup
+      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --except-tags=cgroup
         --build-type ubsan --except-tags no_ubsan
         --cache-test-results --parallelism-per-worker 2
 
@@ -319,7 +319,7 @@ steps:
     tags: core_cpp
     instance_type: medium
     commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --test_tag_filters=-cgroup
+      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --except-tags=cgroup
         --build-type tsan-clang --except-tags no_tsan
         --cache-test-results --parallelism-per-worker 2
 

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -293,6 +293,13 @@ steps:
       - "3.13"
 
   # cpp tests
+  - label: ":ray: core: cgroup tests"
+    tags: core_cpp
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core --only-tags=cgroup --build-type cgroup
+        --privileged --cache-test-results --parallelism-per-worker 2
+
   - label: ":ray: core: cpp tests"
     tags: core_cpp
     instance_type: medium

--- a/src/ray/common/cgroup/test/BUILD
+++ b/src/ray/common/cgroup/test/BUILD
@@ -5,8 +5,7 @@ ray_cc_test(
     size = "small",
     srcs = ["cgroup_v2_utils_privileged_test.cc"],
     tags = [
-        # TODO(hjiang, ibrahim, lonnie): Setup CI for cgroup testing environment.
-        "manual",
+        "cgroup",
         "exclusive",
         "team:core",
     ],


### PR DESCRIPTION
This PR is a followup for https://github.com/ray-project/ray/pull/51454, which does:
- Add filter tag to general C++ tests, so they don't execute cgroup related tests
- Add apply tag to cgroup C++ tests, and update test tags accordingly