### PR TITLE
[core] Remove deprecated boost asio io_service and work usage

### DIFF
--- a/src/ray/common/asio/asio_util.h
+++ b/src/ray/common/asio/asio_util.h
@@ -60,7 +60,9 @@ class InstrumentedIOContextWithThread {
    */
   explicit InstrumentedIOContextWithThread(const std::string &thread_name,
                                            bool enable_lag_probe = false)
-      : io_service_(enable_lag_probe), work_(io_service_), thread_name_(thread_name) {
+      : io_service_(enable_lag_probe),
+        work_(io_service_.get_executor()),
+        thread_name_(thread_name) {
     io_thread_ = std::thread([this] {
       SetThreadName(this->thread_name_);
       io_service_.run();
@@ -89,7 +91,8 @@ class InstrumentedIOContextWithThread {
 
  private:
   instrumented_io_context io_service_;
-  boost::asio::io_service::work work_;  // to keep io_service_ running
+  boost::asio::executor_work_guard<boost::asio::io_context::executor_type>
+      work_;  // to keep io_service_ running
   std::thread io_thread_;
   std::string thread_name_;
 };

--- a/src/ray/common/asio/io_service_pool.cc
+++ b/src/ray/common/asio/io_service_pool.cc
@@ -27,7 +27,8 @@ void IOServicePool::Run() {
     io_services_.emplace_back(std::make_unique<instrumented_io_context>());
     instrumented_io_context &io_service = *io_services_[i];
     threads_.emplace_back([&io_service] {
-      boost::asio::io_service::work work(io_service);
+      boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work(
+          io_service.get_executor());
       io_service.run();
     });
   }

--- a/src/ray/common/file_system_monitor.cc
+++ b/src/ray/common/file_system_monitor.cc
@@ -27,10 +27,10 @@ FileSystemMonitor::FileSystemMonitor(std::vector<std::string> paths,
     : paths_(std::move(paths)),
       capacity_threshold_(capacity_threshold),
       over_capacity_(CheckIfAnyPathOverCapacity()),
-      io_context_(),
       monitor_thread_([this] {
         /// The asio work to keep io_contex_ alive.
-        boost::asio::io_service::work io_service_work_(io_context_);
+        boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work(
+            io_context_.get_executor());
         io_context_.run();
       }),
       runner_(PeriodicalRunner::Create(io_context_)) {

--- a/src/ray/common/test/memory_monitor_test.cc
+++ b/src/ray/common/test/memory_monitor_test.cc
@@ -32,7 +32,8 @@ class MemoryMonitorTest : public ::testing::Test {
  protected:
   void SetUp() override {
     thread_ = std::make_unique<std::thread>([this]() {
-      boost::asio::io_context::work work(io_context_);
+      boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work(
+          io_context_.get_executor());
       io_context_.run();
     });
   }

--- a/src/ray/common/test/syncer_service_e2e_test.cc
+++ b/src/ray/common/test/syncer_service_e2e_test.cc
@@ -128,7 +128,8 @@ int main(int argc, char *argv[]) {
     syncer.Connect(ray::NodeID::FromRandom().Binary(), channel);
   }
 
-  boost::asio::io_context::work work(io_context);
+  boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work(
+      io_context.get_executor());
   io_context.run();
 
   return 0;

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -368,14 +368,14 @@ CoreWorker::CoreWorker(CoreWorkerOptions options, const WorkerID &worker_id)
                          ? options_.get_lang_stack
                          : nullptr),
       worker_context_(options_.worker_type, worker_id, GetProcessJobID(options_)),
-      io_work_(io_service_),
+      io_work_(io_service_.get_executor()),
       client_call_manager_(new rpc::ClientCallManager(io_service_)),
       periodical_runner_(PeriodicalRunner::Create(io_service_)),
       task_queue_length_(0),
       num_executed_tasks_(0),
       resource_ids_(),
       grpc_service_(io_service_, *this),
-      task_execution_service_work_(task_execution_service_),
+      task_execution_service_work_(task_execution_service_.get_executor()),
       exiting_detail_(std::nullopt),
       pid_(getpid()),
       runtime_env_json_serialization_cache_(kDefaultSerializationCacheCap) {

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1732,7 +1732,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   instrumented_io_context io_service_;
 
   /// Keeps the io_service_ alive.
-  boost::asio::io_service::work io_work_;
+  boost::asio::executor_work_guard<boost::asio::io_context::executor_type> io_work_;
 
   /// Shared client call manager.
   std::unique_ptr<rpc::ClientCallManager> client_call_manager_;
@@ -1870,7 +1870,8 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   instrumented_io_context task_execution_service_;
 
   /// The asio work to keep task_execution_service_ alive.
-  boost::asio::io_service::work task_execution_service_work_;
+  boost::asio::executor_work_guard<boost::asio::io_context::executor_type>
+      task_execution_service_work_;
 
   // Queue of tasks to resubmit when the specified time passes.
   std::priority_queue<TaskToRetry, std::deque<TaskToRetry>, TaskToRetryDescComparator>

--- a/src/ray/core_worker/core_worker_process.cc
+++ b/src/ray/core_worker/core_worker_process.cc
@@ -266,7 +266,8 @@ void CoreWorkerProcessImpl::InitializeSystemConfig() {
   std::promise<std::string> promise;
   std::thread thread([&] {
     instrumented_io_context io_service;
-    boost::asio::io_service::work work(io_service);
+    boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work(
+        io_service.get_executor());
     rpc::ClientCallManager client_call_manager(io_service);
     auto grpc_client = rpc::NodeManagerWorkerClient::make(
         options_.raylet_ip_address, options_.node_manager_port, client_call_manager);

--- a/src/ray/core_worker/test/direct_actor_transport_mock_test.cc
+++ b/src/ray/core_worker/test/direct_actor_transport_mock_test.cc
@@ -33,7 +33,7 @@ using ::testing::_;
 
 class DirectTaskTransportTest : public ::testing::Test {
  public:
-  DirectTaskTransportTest() : io_work(io_context) {}
+  DirectTaskTransportTest() : io_work(io_context.get_executor()) {}
 
   void SetUp() override {
     gcs_client = std::make_shared<ray::gcs::MockGcsClient>();
@@ -80,7 +80,7 @@ class DirectTaskTransportTest : public ::testing::Test {
 
  protected:
   instrumented_io_context io_context;
-  boost::asio::io_service::work io_work;
+  boost::asio::executor_work_guard<boost::asio::io_context::executor_type> io_work;
   std::unique_ptr<ActorTaskSubmitter> actor_task_submitter;
   std::shared_ptr<rpc::CoreWorkerClientPool> client_pool;
   std::unique_ptr<CoreWorkerMemoryStore> memory_store;

--- a/src/ray/core_worker/test/direct_actor_transport_test.cc
+++ b/src/ray/core_worker/test/direct_actor_transport_test.cc
@@ -114,7 +114,7 @@ class ActorTaskSubmitterTest : public ::testing::TestWithParam<bool> {
         worker_client_(std::make_shared<MockWorkerClient>()),
         store_(std::make_shared<CoreWorkerMemoryStore>(io_context)),
         task_finisher_(std::make_shared<MockTaskFinisherInterface>()),
-        io_work(io_context),
+        io_work(io_context.get_executor()),
         reference_counter_(std::make_shared<MockReferenceCounter>()),
         submitter_(
             *client_pool_,
@@ -137,7 +137,7 @@ class ActorTaskSubmitterTest : public ::testing::TestWithParam<bool> {
   std::shared_ptr<CoreWorkerMemoryStore> store_;
   std::shared_ptr<MockTaskFinisherInterface> task_finisher_;
   instrumented_io_context io_context;
-  boost::asio::io_service::work io_work;
+  boost::asio::executor_work_guard<boost::asio::io_context::executor_type> io_work;
   std::shared_ptr<MockReferenceCounter> reference_counter_;
   ActorTaskSubmitter submitter_;
 

--- a/src/ray/gcs/gcs_client/global_state_accessor.cc
+++ b/src/ray/gcs/gcs_client/global_state_accessor.cc
@@ -34,8 +34,8 @@ GlobalStateAccessor::GlobalStateAccessor(const GcsClientOptions &gcs_client_opti
   std::promise<bool> promise;
   thread_io_service_ = std::make_unique<std::thread>([this, &promise] {
     SetThreadName("global.accessor");
-    std::unique_ptr<boost::asio::io_service::work> work(
-        new boost::asio::io_service::work(*io_service_));
+    boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work(
+        io_service_->get_executor());
     promise.set_value(true);
     io_service_->run();
   });

--- a/src/ray/gcs/gcs_client/test/gcs_client_reconnection_test.cc
+++ b/src/ray/gcs/gcs_client/test/gcs_client_reconnection_test.cc
@@ -46,8 +46,8 @@ class GcsClientReconnectionTest : public ::testing::Test {
     gcs_server_ = std::make_unique<gcs::GcsServer>(config_, *server_io_service_);
     gcs_server_->Start();
     server_io_service_thread_ = std::make_unique<std::thread>([this] {
-      std::unique_ptr<boost::asio::io_service::work> work(
-          new boost::asio::io_service::work(*server_io_service_));
+      boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work(
+          server_io_service_->get_executor());
       server_io_service_->run();
     });
 
@@ -91,8 +91,8 @@ class GcsClientReconnectionTest : public ::testing::Test {
     RAY_CHECK(gcs_client_ == nullptr);
     client_io_service_ = std::make_unique<instrumented_io_context>();
     client_io_service_thread_ = std::make_unique<std::thread>([this] {
-      std::unique_ptr<boost::asio::io_service::work> work(
-          new boost::asio::io_service::work(*client_io_service_));
+      boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work(
+          client_io_service_->get_executor());
       client_io_service_->run();
     });
     gcs::GcsClientOptions options("127.0.0.1",

--- a/src/ray/gcs/gcs_client/test/gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/gcs_client_test.cc
@@ -76,8 +76,8 @@ class GcsClientTest : public ::testing::TestWithParam<bool> {
     // test targets.
     client_io_service_ = std::make_unique<instrumented_io_context>();
     client_io_service_thread_ = std::make_unique<std::thread>([this] {
-      std::unique_ptr<boost::asio::io_service::work> work(
-          new boost::asio::io_service::work(*client_io_service_));
+      boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work(
+          client_io_service_->get_executor());
       client_io_service_->run();
     });
 
@@ -85,8 +85,8 @@ class GcsClientTest : public ::testing::TestWithParam<bool> {
     gcs_server_ = std::make_unique<gcs::GcsServer>(config_, *server_io_service_);
     gcs_server_->Start();
     server_io_service_thread_ = std::make_unique<std::thread>([this] {
-      std::unique_ptr<boost::asio::io_service::work> work(
-          new boost::asio::io_service::work(*server_io_service_));
+      boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work(
+          server_io_service_->get_executor());
       server_io_service_->run();
     });
 
@@ -148,8 +148,8 @@ class GcsClientTest : public ::testing::TestWithParam<bool> {
     gcs_server_.reset(new gcs::GcsServer(config_, *server_io_service_));
     gcs_server_->Start();
     server_io_service_thread_.reset(new std::thread([this] {
-      std::unique_ptr<boost::asio::io_service::work> work(
-          new boost::asio::io_service::work(*server_io_service_));
+      boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work(
+          server_io_service_->get_executor());
       server_io_service_->run();
     }));
 

--- a/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
+++ b/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
@@ -65,7 +65,9 @@ class GlobalStateAccessorTest : public ::testing::TestWithParam<bool> {
     io_service_.reset(new instrumented_io_context());
     gcs_server_.reset(new gcs::GcsServer(config, *io_service_));
     gcs_server_->Start();
-    work_ = boost::asio::executor_work_guard(io_service_->get_executor());
+    work_ = std::make_unique<
+        boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>(
+        io_service_->get_executor());
     thread_io_service_.reset(new std::thread([this] { io_service_->run(); }));
 
     // Wait until server starts listening.

--- a/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
+++ b/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
@@ -121,7 +121,9 @@ class GlobalStateAccessorTest : public ::testing::TestWithParam<bool> {
 
   // Timeout waiting for GCS server reply, default is 2s.
   const std::chrono::milliseconds timeout_ms_{2000};
-  boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work_;
+  std::unique_ptr<
+      boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>
+      work_;
 };
 
 TEST_P(GlobalStateAccessorTest, TestJobTable) {

--- a/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
+++ b/src/ray/gcs/gcs_client/test/global_state_accessor_test.cc
@@ -65,7 +65,7 @@ class GlobalStateAccessorTest : public ::testing::TestWithParam<bool> {
     io_service_.reset(new instrumented_io_context());
     gcs_server_.reset(new gcs::GcsServer(config, *io_service_));
     gcs_server_->Start();
-    work_ = std::make_unique<boost::asio::io_service::work>(*io_service_);
+    work_ = boost::asio::executor_work_guard(io_service_->get_executor());
     thread_io_service_.reset(new std::thread([this] { io_service_->run(); }));
 
     // Wait until server starts listening.
@@ -119,7 +119,7 @@ class GlobalStateAccessorTest : public ::testing::TestWithParam<bool> {
 
   // Timeout waiting for GCS server reply, default is 2s.
   const std::chrono::milliseconds timeout_ms_{2000};
-  std::unique_ptr<boost::asio::io_service::work> work_;
+  boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work_;
 };
 
 TEST_P(GlobalStateAccessorTest, TestJobTable) {

--- a/src/ray/gcs/gcs_server/gcs_server_main.cc
+++ b/src/ray/gcs/gcs_server/gcs_server_main.cc
@@ -117,7 +117,8 @@ int main(int argc, char *argv[]) {
   instrumented_io_context main_service(/*enable_lag_probe=*/true);
   // Ensure that the IO service keeps running. Without this, the main_service will exit
   // as soon as there is no more work to be processed.
-  boost::asio::io_service::work work(main_service);
+  boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work(
+      main_service.get_executor());
 
   ray::stats::enable_grpc_metrics_collection_if_needed("gcs");
 

--- a/src/ray/gcs/gcs_server/test/export_api/gcs_actor_manager_export_event_test.cc
+++ b/src/ray/gcs/gcs_server/test/export_api/gcs_actor_manager_export_event_test.cc
@@ -132,8 +132,8 @@ class GcsActorManagerTest : public ::testing::Test {
   )");
     std::promise<bool> promise;
     thread_io_service_.reset(new std::thread([this, &promise] {
-      std::unique_ptr<boost::asio::io_service::work> work(
-          new boost::asio::io_service::work(io_service_));
+      boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work(
+          io_service_.get_executor());
       promise.set_value(true);
       io_service_.run();
     }));

--- a/src/ray/gcs/gcs_server/test/export_api/gcs_job_manager_export_event_test.cc
+++ b/src/ray/gcs/gcs_server/test/export_api/gcs_job_manager_export_event_test.cc
@@ -41,8 +41,8 @@ class GcsJobManagerTest : public ::testing::Test {
   GcsJobManagerTest() : runtime_env_manager_(nullptr) {
     std::promise<bool> promise;
     thread_io_service_ = std::make_unique<std::thread>([this, &promise] {
-      std::unique_ptr<boost::asio::io_service::work> work(
-          new boost::asio::io_service::work(io_service_));
+      boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work(
+          io_service_.get_executor());
       promise.set_value(true);
       io_service_.run();
     });

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -131,8 +131,8 @@ class GcsActorManagerTest : public ::testing::Test {
   )");
     std::promise<bool> promise;
     thread_io_service_.reset(new std::thread([this, &promise] {
-      std::unique_ptr<boost::asio::io_service::work> work(
-          new boost::asio::io_service::work(io_service_));
+      boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work(
+          io_service_.get_executor());
       promise.set_value(true);
       io_service_.run();
     }));

--- a/src/ray/gcs/gcs_server/test/gcs_health_check_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_health_check_manager_test.cc
@@ -37,7 +37,7 @@ using namespace boost::asio::ip;  // NOLINT
 #include "ray/gcs/gcs_server/gcs_health_check_manager.h"
 
 int GetFreePort() {
-  io_service io_service;
+  io_context io_service;
   tcp::acceptor acceptor(io_service);
   tcp::endpoint endpoint;
 
@@ -265,7 +265,8 @@ TEST_F(GcsHealthCheckManagerTest, StressTest) {
 #ifdef _RAY_TSAN_BUILD
   GTEST_SKIP() << "Disabled in tsan because of performance";
 #endif
-  boost::asio::io_service::work work(io_service);
+  boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work(
+      io_service.get_executor());
   std::srand(std::time(nullptr));
   auto t = std::make_unique<std::thread>([this]() { this->io_service.run(); });
 

--- a/src/ray/gcs/gcs_server/test/gcs_job_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_job_manager_test.cc
@@ -38,8 +38,8 @@ class GcsJobManagerTest : public ::testing::Test {
   GcsJobManagerTest() : runtime_env_manager_(nullptr) {
     std::promise<bool> promise;
     thread_io_service_ = std::make_unique<std::thread>([this, &promise] {
-      std::unique_ptr<boost::asio::io_service::work> work(
-          new boost::asio::io_service::work(io_service_));
+      boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work(
+          io_service_.get_executor());
       promise.set_value(true);
       io_service_.run();
     });

--- a/src/ray/gcs/gcs_server/test/gcs_kv_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_kv_manager_test.cc
@@ -32,7 +32,8 @@ class GcsKVManagerTest : public ::testing::TestWithParam<std::string> {
 
   void SetUp() override {
     thread_io_service = std::make_unique<std::thread>([this] {
-      boost::asio::io_service::work work(io_service);
+      boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work(
+          io_service.get_executor());
       io_service.run();
     });
     ray::gcs::RedisClientOptions redis_client_options(

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_scheduler_test.cc
@@ -39,8 +39,8 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
  public:
   void SetUp() override {
     thread_io_service_.reset(new std::thread([this] {
-      std::unique_ptr<boost::asio::io_service::work> work(
-          new boost::asio::io_service::work(io_service_));
+      boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work(
+          io_service_.get_executor());
       io_service_.run();
     }));
     for (int index = 0; index < 3; ++index) {

--- a/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_server_rpc_test.cc
@@ -45,8 +45,8 @@ class GcsServerTest : public ::testing::Test {
     gcs_server_->Start();
 
     thread_io_service_ = std::make_unique<std::thread>([this] {
-      std::unique_ptr<boost::asio::io_service::work> work(
-          new boost::asio::io_service::work(io_service_));
+      boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work(
+          io_service_.get_executor());
       io_service_.run();
     });
 

--- a/src/ray/gcs/gcs_server/test/gcs_task_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_task_manager_test.cc
@@ -1222,7 +1222,7 @@ TEST_F(GcsTaskManagerTest, TestJobFinishesWithoutTaskEvents) {
 
   task_manager->OnJobFinished(JobID::FromInt(1), 5);  // in ms
 
-  boost::asio::io_service io;
+  boost::asio::io_context io;
   boost::asio::deadline_timer timer(
       io,
       boost::posix_time::milliseconds(
@@ -1250,7 +1250,7 @@ TEST_F(GcsTaskManagerTest, TestJobFinishesFailAllRunningTasks) {
   task_manager->OnJobFinished(JobID::FromInt(1), 5);  // in ms
 
   // Wait for longer than the default timer
-  boost::asio::io_service io;
+  boost::asio::io_context io;
   boost::asio::deadline_timer timer(
       io,
       boost::posix_time::milliseconds(
@@ -1583,7 +1583,7 @@ TEST_F(GcsTaskManagerTest, TestMultipleJobsDataLoss) {
     task_manager->OnJobFinished(JobID::FromInt(0), 3);
 
     // Wait for longer than the default timer
-    boost::asio::io_service io;
+    boost::asio::io_context io;
     boost::asio::deadline_timer timer(
         io,
         boost::posix_time::milliseconds(

--- a/src/ray/gcs/gcs_server/test/gcs_worker_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_worker_manager_test.cc
@@ -47,8 +47,8 @@ class GcsWorkerManagerTest : public Test {
     // Alternatively, we can manually run io service. In this test, we chose to
     // start a new thread as other GCS tests do.
     thread_io_service_ = std::make_unique<std::thread>([this] {
-      std::unique_ptr<boost::asio::io_service::work> work(
-          new boost::asio::io_service::work(io_service_));
+      boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work(
+          io_service_.get_executor());
       io_service_.run();
     });
     worker_manager_ = std::make_shared<gcs::GcsWorkerManager>(

--- a/src/ray/gcs/store_client/redis_store_client.cc
+++ b/src/ray/gcs/store_client/redis_store_client.cc
@@ -510,7 +510,8 @@ bool RedisDelKeyPrefixSync(const std::string &host,
   instrumented_io_context io_service;
 
   auto thread = std::make_unique<std::thread>([&]() {
-    boost::asio::io_service::work work(io_service);
+    boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work(
+        io_service.get_executor());
     io_service.run();
   });
 

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -103,7 +103,7 @@ ObjectManager::ObjectManager(
           })),
       buffer_pool_store_client_(std::make_shared<plasma::PlasmaClient>()),
       buffer_pool_(buffer_pool_store_client_, config_.object_chunk_size),
-      rpc_work_(rpc_service_),
+      rpc_work_(rpc_service_.get_executor()),
       object_manager_server_("ObjectManager",
                              config_.object_manager_port,
                              config_.object_manager_address == "127.0.0.1",

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -417,7 +417,7 @@ class ObjectManager : public ObjectManagerInterface,
   instrumented_io_context rpc_service_;
 
   /// Keep rpc service running when no task in rpc service.
-  boost::asio::io_service::work rpc_work_;
+  boost::asio::executor_work_guard<boost::asio::io_context::executor_type> rpc_work_;
 
   /// The thread pool used for running `rpc_service`.
   /// Data copy operations during request are done in this thread pool.

--- a/src/ray/object_manager/test/get_request_queue_test.cc
+++ b/src/ray/object_manager/test/get_request_queue_test.cc
@@ -59,7 +59,7 @@ class MockObjectLifecycleManager : public IObjectLifecycleManager {
 
 struct GetRequestQueueTest : public Test {
  public:
-  GetRequestQueueTest() : io_work_(io_context_) {}
+  GetRequestQueueTest() : io_work_(io_context_.get_executor()) {}
   void SetUp() override {
     Test::SetUp();
     object_id1 = ObjectID::FromRandom();
@@ -111,7 +111,7 @@ struct GetRequestQueueTest : public Test {
 
  protected:
   instrumented_io_context io_context_;
-  boost::asio::io_service::work io_work_;
+  boost::asio::executor_work_guard<boost::asio::io_context::executor_type> io_work_;
   std::thread thread_;
   LocalObject object1{Allocation()};
   LocalObject object2{Allocation()};

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -242,7 +242,8 @@ int main(int argc, char *argv[]) {
 
   // Ensure that the IO service keeps running. Without this, the service will exit as soon
   // as there is no more work to be processed.
-  boost::asio::io_service::work main_work(main_service);
+  boost::asio::executor_work_guard<boost::asio::io_context::executor_type>
+      main_service_work(main_service.get_executor());
 
   // Initialize gcs client
   std::shared_ptr<ray::gcs::GcsClient> gcs_client;

--- a/src/ray/raylet/runtime_env_agent_client_test.cc
+++ b/src/ray/raylet/runtime_env_agent_client_test.cc
@@ -41,7 +41,7 @@ using tcp = boost::asio::ip::tcp;
 using boost::asio::ip::port_type;
 
 port_type GetFreePort() {
-  boost::asio::io_service io_service;
+  boost::asio::io_context io_service;
   boost::asio::ip::tcp::acceptor acceptor(io_service);
   boost::asio::ip::tcp::endpoint endpoint;
 

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -418,8 +418,8 @@ class WorkerPoolTest : public ::testing::Test {
                         {"java", "RAY_WORKER_DYNAMIC_OPTION_PLACEHOLDER", "MainClass"}}});
     std::promise<bool> promise;
     thread_io_service_.reset(new std::thread([this, &promise] {
-      std::unique_ptr<boost::asio::io_service::work> work(
-          new boost::asio::io_service::work(io_service_));
+      boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work(
+          io_service_.get_executor());
       promise.set_value(true);
       io_service_.run();
     }));

--- a/src/ray/rpc/test/grpc_bench/grpc_bench.cc
+++ b/src/ray/rpc/test/grpc_bench/grpc_bench.cc
@@ -74,7 +74,8 @@ int main() {
   GrpcServer server("grpc_bench", 50051, false, parallelism);
   instrumented_io_context main_service;
   std::thread t([&main_service] {
-    boost::asio::io_service::work work(main_service);
+    boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work(
+        main_service.get_executor());
     main_service.run();
   });
   GreeterServiceHandler handler;

--- a/src/ray/rpc/test/grpc_server_client_test.cc
+++ b/src/ray/rpc/test/grpc_server_client_test.cc
@@ -107,7 +107,8 @@ class TestGrpcServerClientFixture : public ::testing::Test {
     // Prepare and start test server.
     handler_thread_ = std::make_unique<std::thread>([this]() {
       /// The asio work to keep handler_io_service_ alive.
-      boost::asio::io_service::work handler_io_service_work_(handler_io_service_);
+      boost::asio::executor_work_guard<boost::asio::io_context::executor_type>
+          handler_io_service_work_(handler_io_service_.get_executor());
       handler_io_service_.run();
     });
     test_service_.reset(new TestGrpcService(handler_io_service_, test_service_handler_));
@@ -123,7 +124,8 @@ class TestGrpcServerClientFixture : public ::testing::Test {
     // Prepare a client
     client_thread_ = std::make_unique<std::thread>([this]() {
       /// The asio work to keep client_io_service_ alive.
-      boost::asio::io_service::work client_io_service_work_(client_io_service_);
+      boost::asio::executor_work_guard<boost::asio::io_context::executor_type>
+          client_io_service_work_(client_io_service_.get_executor());
       client_io_service_.run();
     });
     client_call_manager_.reset(new ClientCallManager(client_io_service_));


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
As part of the work to move to bzlmod, I'm upgrading libraries. #51834

io_service and work is deprecated in the version of boost asio we currently have, and it no longer exists in the current version of boost so we can't upgrade unless we move away from all the deprecated usage.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
