### PR TITLE
[Data] Fix bug where pandas blocks don't use tensor extension

### DIFF
--- a/python/ray/air/util/data_batch_conversion.py
+++ b/python/ray/air/util/data_batch_conversion.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.air.data_batch_type import DataBatchType
+from ray.air.util.tensor_extensions.utils import _should_convert_to_tensor
 from ray.util.annotations import Deprecated, DeveloperAPI
 
 if TYPE_CHECKING:
@@ -292,10 +293,7 @@ def _cast_ndarray_columns_to_tensor_extension(df: "pd.DataFrame") -> "pd.DataFra
         # SettingWithCopyWarning was moved to pd.errors in Pandas 1.5.0.
         SettingWithCopyWarning = pd.errors.SettingWithCopyWarning
 
-    from ray.air.util.tensor_extensions.pandas import (
-        TensorArray,
-        column_needs_tensor_extension,
-    )
+    from ray.air.util.tensor_extensions.pandas import TensorArray
 
     # Try to convert any ndarray columns to TensorArray columns.
     # TODO(Clark): Once Pandas supports registering extension types for type
@@ -305,7 +303,7 @@ def _cast_ndarray_columns_to_tensor_extension(df: "pd.DataFrame") -> "pd.DataFra
     # column names containing tensor columns, to make this an O(# of tensor columns)
     # check rather than the current O(# of columns) check.
     for col_name, col in df.items():
-        if column_needs_tensor_extension(col):
+        if _should_convert_to_tensor(col, col_name):
             try:
                 # Suppress Pandas warnings:
                 # https://github.com/ray-project/ray/issues/29270

--- a/python/ray/data/_internal/numpy_support.py
+++ b/python/ray/data/_internal/numpy_support.py
@@ -130,12 +130,13 @@ def convert_to_numpy(column_values: Any) -> np.ndarray:
     Raises:
         ValueError if an input was array-like but we failed to convert it to an array.
     """
+    import pandas as pd
 
     if isinstance(column_values, np.ndarray):
         # No copy/conversion needed, just keep it verbatim.
         return column_values
 
-    elif isinstance(column_values, list):
+    elif isinstance(column_values, (list, pd.Series)):
         if len(column_values) == 1 and isinstance(column_values[0], np.ndarray):
             # Optimization to avoid conversion overhead from list to np.array.
             return np.expand_dims(column_values[0], axis=0)

--- a/python/ray/data/extensions/__init__.py
+++ b/python/ray/data/extensions/__init__.py
@@ -19,7 +19,6 @@ from ray.data.extensions.tensor_extension import (
     TensorArray,
     TensorArrayElement,
     TensorDtype,
-    column_needs_tensor_extension,
 )
 
 __all__ = [
@@ -32,7 +31,6 @@ __all__ = [
     "ArrowTensorArray",
     "ArrowVariableShapedTensorType",
     "ArrowVariableShapedTensorArray",
-    "column_needs_tensor_extension",
     "ArrowConversionError",
     # Object array extension
     "ArrowPythonObjectArray",

--- a/python/ray/data/extensions/tensor_extension.py
+++ b/python/ray/data/extensions/tensor_extension.py
@@ -10,6 +10,5 @@ from ray.air.util.tensor_extensions.pandas import (  # noqa: F401
     TensorArray,
     TensorArrayElement,
     TensorDtype,
-    column_needs_tensor_extension,
 )
 from ray.air.util.tensor_extensions.utils import create_ragged_ndarray  # noqa: F401


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If you return a pandas DataFrame containing Torch tensors from your `map_batches` function, Ray Data won't use the tensor extension type, and this can cause Ray Data to incorrectly estimate the size of resulting blocks.

This PR fixes that bug by making `PandasBlockBuilder` use the same code path used to construct blocks from NumPy batches.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
