### PR TITLE
Solved  warning system

### DIFF
--- a/python/ray/test.py
+++ b/python/ray/test.py
@@ -1,0 +1,25 @@
+import ray
+import warnings
+
+ray.init()
+
+# Test case that should trigger warning
+@ray.remote(num_returns=0)
+def returns_value():
+    print("Function executing")
+    return 123  # This should trigger warning
+
+# Test case that shouldn't trigger warning
+@ray.remote(num_returns=0)
+def returns_none():
+    print("Function executing")
+    return None  # This is fine
+
+# Capture warnings to verify
+with warnings.catch_warnings(record=True) as w:
+    returns_value.remote()
+    returns_none.remote()
+    
+    # Verify warning was raised for returns_value
+    assert len(w) == 1
+    assert "num_returns=0" in str(w[0].message)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## These changes are needed to warn users when they accidentally return values from functions marked with num_returns=0, preventing silent bugs and confusion.

<!-- Please give a short summary of the change and the problem this solves. -->

## #51827


<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
