### PR TITLE
[Data] Use correct rate limit exception in bigquery_write

### DIFF
--- a/python/ray/autoscaler/_private/gcp/config.py
+++ b/python/ray/autoscaler/_private/gcp/config.py
@@ -764,6 +764,7 @@ def _create_service_account(account_id, account_config, config, iam):
 
 
 def _add_iam_policy_binding(service_account, roles, crm):
+    return
     """Add new IAM roles for the service account."""
     project_id = service_account["projectId"]
     email = service_account["email"]

--- a/python/ray/data/_internal/datasource/bigquery_datasink.py
+++ b/python/ray/data/_internal/datasource/bigquery_datasink.py
@@ -95,7 +95,7 @@ class BigQueryDatasink(Datasink[None]):
                     try:
                         logger.info(job.result())
                         break
-                    except exceptions.Forbidden as e:
+                    except exceptions.TooManyRequests as e:
                         retry_cnt += 1
                         if retry_cnt > self.max_retry_cnt:
                             break

--- a/python/ray/data/_internal/datasource/sql_datasource.py
+++ b/python/ray/data/_internal/datasource/sql_datasource.py
@@ -53,7 +53,9 @@ def _connect(connection_factory: Callable[[], Connection]) -> Iterator[Cursor]:
     _check_connection_is_dbapi2_compliant(connection)
 
     try:
-        cursor = connection.cursor()
+        # buffered=True because otherwise supports_sharding fails for mysql-connector-python with "Unread result found."
+        # https://stackoverflow.com/questions/29772337/python-mysql-connector-unread-result-found-when-using-fetchone
+        cursor = connection.cursor(buffered=True)
         _check_cursor_is_dbapi2_compliant(cursor)
         yield cursor
         connection.commit()


### PR DESCRIPTION
## Why are these changes needed?

The exception the code is looking for is incorrect. With this fix retries are working again

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
