### PR TITLE
[DONOTMERGE] (mostly) Python PoC for GPU objects in Ray

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -440,6 +440,8 @@ class Worker:
         self.node = None
         self.mode = None
         self.actors = {}
+        self.in_actor_object_store : Dict[ObjectRef, List[torch.Tensor]] = {}
+        self.in_actor_object_refs = {}
         # When the worker is constructed. Record the original value of the
         # (CUDA_VISIBLE_DEVICES, ONEAPI_DEVICE_SELECTOR, HIP_VISIBLE_DEVICES,
         # NEURON_RT_VISIBLE_CORES, TPU_VISIBLE_CHIPS, ..) environment variables.

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -4412,7 +4412,7 @@ cdef class CoreWorker:
 
             context = worker.get_serialization_context()
 
-            serialized_object = context.serialize(output)
+            serialized_object = context.serialize(output, return_id.Hex())
             data_size = serialized_object.total_bytes
             metadata_str = serialized_object.metadata
             if ray._private.worker.global_worker.debugger_get_breakpoint:

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -76,6 +76,7 @@ def method(*args, **kwargs):
         "retry_exceptions",
         "_generator_backpressure_num_objects",
         "enable_task_events",
+        "tensor_transport",
     ]
     error_string = (
         "The @ray.method decorator must be applied using at least one of "
@@ -105,6 +106,8 @@ def method(*args, **kwargs):
             ]
         if "enable_task_events" in kwargs and kwargs["enable_task_events"] is not None:
             method.__ray_enable_task_events__ = kwargs["enable_task_events"]
+        if "tensor_transport" in kwargs:
+            method.__ray_tensor_transport__ = kwargs["tensor_transport"]
         return method
 
     return annotate_method
@@ -159,6 +162,7 @@ class ActorMethod:
         decorator=None,
         signature: Optional[List[inspect.Parameter]] = None,
         hardref=False,
+        tensor_transport = None,
     ):
         self._actor_ref = weakref.ref(actor)
         self._method_name = method_name
@@ -190,6 +194,8 @@ class ActorMethod:
             self._actor_hard_ref = actor
         else:
             self._actor_hard_ref = None
+
+        self._tensor_transport = tensor_transport
 
     def __call__(self, *args, **kwargs):
         raise TypeError(
@@ -332,6 +338,7 @@ class ActorMethod:
         concurrency_group=None,
         _generator_backpressure_num_objects=None,
         enable_task_events=None,
+        tensor_transport=None,
     ):
         if num_returns is None:
             num_returns = self._num_returns
@@ -347,12 +354,61 @@ class ActorMethod:
             _generator_backpressure_num_objects = (
                 self._generator_backpressure_num_objects
             )
+        if tensor_transport is None:
+            tensor_transport = self._tensor_transport
 
         def invocation(args, kwargs):
             actor = self._actor_hard_ref or self._actor_ref()
 
             if actor is None:
                 raise RuntimeError("Lost reference to actor")
+
+            for arg in args:
+                if isinstance(arg, ray.ObjectRef):
+                    worker = ray._private.worker.global_worker
+                    tensor_meta = worker.in_actor_object_refs.get(arg, None)
+                    if tensor_meta is None:
+                        continue
+
+                    src_actor, tensor_meta = tensor_meta
+
+                    def send(self, obj_id, dst_rank):
+                        import torch.distributed as dist
+                        worker = ray._private.worker.global_worker
+                        assert obj_id in worker.in_actor_object_store, worker.in_actor_object_store
+                        tensors = worker.in_actor_object_store[obj_id]
+                        for tensor in tensors:
+                            dist.send(tensor, dst_rank)
+
+                    def recv(self, obj_id, src_rank, tensor_meta):
+                        import torch
+                        import torch.distributed as dist
+                        worker = ray._private.worker.global_worker
+                        tensors = []
+                        for meta in tensor_meta:
+                            shape, dtype = meta
+                            tensor = torch.zeros(shape, dtype=dtype)
+                            dist.recv(tensor, src_rank)
+                            tensors.append(tensor)
+                        worker.in_actor_object_store[obj_id] = tensors
+
+                    from ray.experimental.channel import ChannelContext
+
+                    ctx = ChannelContext.get_current()
+                    for group_id, actors in ctx.communicators.items():
+                        src_rank = None
+                        dst_rank = None
+                        for i, a in enumerate(actors):
+                            if a._ray_actor_id == src_actor._ray_actor_id:
+                                src_rank = i
+                            if a._ray_actor_id == actor._ray_actor_id:
+                                dst_rank = i
+                        assert src_rank is not None
+                        assert dst_rank is not None
+                        assert src_rank != dst_rank
+
+                    src_actor.__ray_call__.remote(send, arg.hex(), dst_rank)
+                    actor.__ray_call__.remote(recv, arg.hex(), src_rank, tensor_meta)
 
             return actor._actor_method_call(
                 self._method_name,
@@ -373,7 +429,24 @@ class ActorMethod:
         if self._decorator is not None:
             invocation = self._decorator(invocation)
 
-        return invocation(args, kwargs)
+        obj_ref = invocation(args, kwargs)
+        if tensor_transport is not None:
+            assert tensor_transport == "nccl"
+            assert num_returns == 1
+
+            def get_tensor_sizes(self, obj_id):
+                worker = ray._private.worker.global_worker
+                return [(t.shape, t.dtype) for t in worker.in_actor_object_store[obj_id]]
+
+            actor = self._actor_hard_ref or self._actor_ref()
+            tensor_meta = actor.__ray_call__.remote(get_tensor_sizes, obj_ref.hex())
+            # Metadata: (actor that hosts the object, tensor shapes)
+            # Driver will provide the NCCL metadata upon submission of a
+            # dependent task.
+            worker = ray._private.worker.global_worker
+            worker.in_actor_object_refs[obj_ref] = (self._actor_ref(), tensor_meta)
+
+        return obj_ref
 
     def __getstate__(self):
         return {
@@ -461,6 +534,7 @@ class _ActorClassMethodMetadata(object):
         self.enable_task_events = {}
         self.generator_backpressure_num_objects = {}
         self.concurrency_group_for_methods = {}
+        self.tensor_transport = {}
 
         for method_name, method in actor_methods:
             # Whether or not this method requires binding of its first
@@ -515,6 +589,9 @@ class _ActorClassMethodMetadata(object):
                 self.generator_backpressure_num_objects[
                     method_name
                 ] = method.__ray_generator_backpressure_num_objects__
+
+            if hasattr(method, "__ray_tensor_transport__"):
+                self.tensor_transport[method_name] = method.__ray_tensor_transport__
 
         # Update cache.
         cls._cache[actor_creation_function_descriptor] = self
@@ -1255,6 +1332,7 @@ class ActorClass:
             meta.method_meta.retry_exceptions,
             meta.method_meta.generator_backpressure_num_objects,
             meta.method_meta.enable_task_events,
+            meta.method_meta.tensor_transport,
             actor_method_cpu,
             meta.actor_creation_function_descriptor,
             worker.current_cluster_and_job,
@@ -1342,6 +1420,7 @@ class ActorHandle:
         method_retry_exceptions: Dict[str, Union[bool, list, tuple]],
         method_generator_backpressure_num_objects: Dict[str, int],
         method_enable_task_events: Dict[str, bool],
+        method_tensor_transport,
         actor_method_cpus: int,
         actor_creation_function_descriptor,
         cluster_and_job,
@@ -1365,6 +1444,7 @@ class ActorHandle:
             method_generator_backpressure_num_objects
         )
         self._ray_method_enable_task_events = method_enable_task_events
+        self._ray_method_tensor_transport = method_tensor_transport
         self._ray_actor_method_cpus = actor_method_cpus
         self._ray_cluster_and_job = cluster_and_job
         self._ray_is_cross_language = language != Language.PYTHON
@@ -1408,6 +1488,7 @@ class ActorHandle:
                     ),
                     decorator=self._ray_method_decorators.get(method_name),
                     signature=self._ray_method_signatures[method_name],
+                    tensor_transport=self._ray_method_tensor_transport.get(method_name),
                 )
                 setattr(self, method_name, method)
 

--- a/python/ray/experimental/channel/serialization_context.py
+++ b/python/ray/experimental/channel/serialization_context.py
@@ -74,6 +74,10 @@ class _SerializationContext:
     def set_use_external_transport(self, use_external_transport: bool) -> None:
         self._use_external_transport = use_external_transport
 
+    @property
+    def use_external_transport(self) -> bool:
+        return self._use_external_transport
+
     def reset_out_of_band_tensors(
         self, tensors: List["torch.Tensor"]
     ) -> Tuple[List["torch.Tensor"], Set[int]]:

--- a/python/ray/includes/object_ref.pxi
+++ b/python/ray/includes/object_ref.pxi
@@ -152,3 +152,6 @@ cdef class ObjectRef(BaseID):
         core_worker = ray._private.worker.global_worker.core_worker
         core_worker.set_get_async_callback(self, py_callback)
         return self
+
+    def set_tensor_meta(self, tensor_meta):
+        self._tensor_meta = tensor_meta

--- a/test_gpu.py
+++ b/test_gpu.py
@@ -1,0 +1,109 @@
+import ray
+import torch
+import socket
+import os
+import torch.distributed as dist
+import time
+from ray.experimental.channel.torch_tensor_type import TorchTensorType
+from ray.experimental.channel import ChannelContext
+
+
+
+# TODOs:
+# [x] Decorator for GPU tensor returns
+# [x] Custom serializer / deserializer to get value from actor store
+# [ ] Return torch tensor metadata to driver when task finishes
+# [x] register collectives in python
+# [ ] On task submission, driver sends send/recv tasks to actors A and B
+
+
+WORLD_SIZE = 2
+
+@ray.remote
+class Actor:
+
+    def register_custom_serializer(self):
+        TorchTensorType().register_custom_serializer()
+
+    def ping(self):
+        return
+
+    def setup(self, world_size, rank, init_method, group_name="default"):
+        dist.init_process_group(backend="gloo", world_size=world_size, rank=rank, init_method=init_method)
+
+    @ray.method(tensor_transport="nccl")
+    def randn(self, shape):
+        return torch.randn(shape)
+
+    def sum(self, tensor):
+        print("SUM")
+        return tensor.sum().item()
+
+    def send(self, meta, dst_rank):
+        worker = ray._private.worker.global_worker
+        tensor = worker.in_actor_object_store[meta.obj_id]
+        dist.send(tensor, dst_rank)
+
+    def recv(self, meta, src_rank):
+        worker = ray._private.worker.global_worker
+        tensor = torch.zeros(meta.shape, dtype=meta.dtype)
+        dist.recv(tensor, src_rank)
+        worker.in_actor_object_store[meta.obj_id] = tensor
+
+if __name__ == "__main__":
+    actors = [Actor.remote() for _ in range(WORLD_SIZE)]
+    ray.get([a.ping.remote() for a in actors])
+    print("actors started")
+
+    # TODO: Replace with an API call that takes in a list of actors and
+    # returns a handle to the group.
+    init_method = "tcp://localhost:8889"
+    ray.get([actor.setup.remote(WORLD_SIZE, rank, init_method) for rank, actor in enumerate(actors)])
+    actor_ids = [actor._ray_actor_id for actor in actors]
+
+    # TODO(swang): Wrap actors in a Communicator interface.
+    ctx = ChannelContext.get_current()
+    ctx.communicators[0] = actors
+    print("Collective group setup done")
+
+    ray.get([actor.register_custom_serializer.remote() for actor in actors])
+    print("Serialization done")
+
+    shape = (1, )
+
+    ref = actors[0].randn.remote(shape)
+    ref = actors[1].sum.remote(ref)
+    print(ray.get(ref))
+
+    start = time.time()
+    for _ in range(10):
+        ref = actors[0].randn.remote(shape)
+        ref = actors[1].sum.remote(ref)
+        print(ray.get(ref))
+    end = time.time()
+    print((end - start) / 10)
+
+    ## After getting response from actor A, driver will now have in its local
+    ## heap object store:
+    ## ObjRef(xxx) -> OBJECT_IN_ACTOR, A.address
+
+    ## TODO: On task submission to actor B, driver looks up arguments to the task. 
+    ## driver:
+    ## - Driver sees that `ref` argument is on actor A.
+    ## - Driver submits A.send, B.recv tasks. Include ObjRef.
+    ## - Then, driver submits actual B.sum task.
+    ## B:
+    ## - Execute recv. B will have the tensor in its local actor store.
+    ## - Execute sum. When looking up arguments, it sees OBJECT_IN_ACTOR, so it
+    ## gets the actual value from its local actor store (which we know is
+    ## already there).
+    #s = ray.get(actors[1].sum.remote(ref))
+    #t = ray.get(ref)
+    #assert t.sum() == s
+
+    ## Instead of calling send/recv manually, we would like to do it
+    ## automatically, using the above API.
+    #actors[0].send.remote(1, ref)
+    #recved = actors[1].recv.remote(0, shape)
+    #s = ray.get(actors[1].sum.remote(recved))
+    #assert t.sum() == s


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Compared to #51078, same functionality but implemented mainly in Python. For this to work, the user needs to add an annotation to actor methods that return a torch.Tensor, similar to the `with_tensor_transport` hint in compiled graphs. This allows the driver to check when ObjectRefs that contain a torch.Tensor are passed to a downstream task. Before the downstream task is submitted, the driver submits send/recv tasks to the src/dst actors.

In contrast, #51078 works transparently without any user annotations. However, this means that we can't use normal Ray tasks to submit the send/recv tasks, so these have to be implemented as RPCs in C++ instead.
