### PR TITLE
Add new autoscaling parameter `aggregation function`

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1729,11 +1729,6 @@ python/ray/serve/api.py
     DOC103: Function `get_deployment_handle`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_check_exists: bool, _record_telemetry: bool].
     DOC201: Function `get_deployment_handle` does not have a return section in docstring
 --------------------
-python/ray/serve/autoscaling_policy.py
-    DOC101: Function `_calculate_desired_num_replicas`: Docstring contains fewer arguments than in function signature.
-    DOC111: Function `_calculate_desired_num_replicas`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
-    DOC103: Function `_calculate_desired_num_replicas`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [num_running_replicas: int, total_num_requests: int]. Arguments in the docstring but not in the function signature: [current_num_ongoing_requests: List[float]].
---------------------
 python/ray/serve/batching.py
     DOC111: Method `_BatchQueue.__init__`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
     DOC101: Function `batch`: Docstring contains fewer arguments than in function signature.

--- a/doc/source/serve/advanced-guides/advanced-autoscaling.md
+++ b/doc/source/serve/advanced-guides/advanced-autoscaling.md
@@ -154,6 +154,23 @@ or equal to the upscale and downscale delay values. For instance, if you set
 `upscale_delay_s = 3`, but keep `metrics_interval_s = 10`, the autoscaler only
 upscales roughly every 10 seconds.
 
+* **aggregation_function [default_value="mean"]**: One of `"mean","min","max"`.
+This parameter determines how time-series autoscaling metrics (i.e
+ongoing_requests) are aggregated over the `look_back_period_s`. Autoscaling
+decisions are only made when the output of this function is *consistently* above
+or below `target_ongoing_requests` for `upscale_delay_s` or `downscale_delay_s`
+for each replica. The function output is number of requests per single replica.
+* 
+  * `"mean"`: The rounded mean of the windowed timeseries is used.
+  * `"min"`: The minimum value of the windowed timeseries is used.
+  * `"max"`: The maximum value of the windowed timeseries is used.
+
+:::{note}
+This parameter modifies the autoscaling metrics aggregation only. This means it 
+impacts autoscaling decisions, but should not impact node-level prometheus 
+metrics/logs (i.e `running_requests_per_replica`).
+:::
+
 * **look_back_period_s [default_value=30]**: This is the window over which the
 average number of ongoing requests per replica is calculated.
 

--- a/doc/source/serve/api/index.md
+++ b/doc/source/serve/api/index.md
@@ -83,6 +83,7 @@ See the [model composition guide](serve-model-composition) for how to update cod
    serve.config.ProxyLocation
    serve.config.gRPCOptions
    serve.config.HTTPOptions
+   serve.config.AggregationFunction
    serve.config.AutoscalingConfig
    serve.config.AutoscalingPolicy
    serve.config.RequestRouterConfig

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -380,7 +380,7 @@ class AutoscalingState:
         """Get total number of requests aggregated over the past
         `look_back_period_s` number of seconds.
 
-        If there are 0 running replicas, then returns the number
+        If there are 0 running replicas, then returns the aggregated number
         of requests queued at handles.
 
         This code assumes that the metrics are either emmited on handles

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -370,13 +370,11 @@ class AutoscalingState:
         aggregate_function = self._config.aggregation_function
         if aggregate_function == "mean":
             total_requests = merged_metrics.aggregate_avg(self._running_replicas)
-            total_requests += queued_per_replica
         elif aggregate_function == "max":
             total_requests = merged_metrics.aggregate_max(self._running_replicas)
-            total_requests += queued_per_replica
         elif aggregate_function == "min":
             total_requests = merged_metrics.aggregate_min(self._running_replicas)
-            total_requests += queued_per_replica
+        total_requests += queued_per_replica
 
         return total_requests
 

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -351,7 +351,7 @@ class AutoscalingState:
             )
         else:
             logger.debug("No metrics stores detected in autoscaler.")
-            return total_requests, report_count
+            return total_requests, 0
 
         queued_requests = merged_metrics.get_latest(QUEUED_REQUESTS_KEY) or 0.0
         queued_per_replica = (

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -264,13 +264,11 @@ class ServeController:
         self,
         replica_id: str,
         metrics_store: InMemoryMetricsStore,
-        send_timestamp: float
+        send_timestamp: float,
     ):
         """Record metrics for autoscaling directly from replicas. Either this
         method or `record_handle_metrics` should be called, but not both"""
-        logger.debug(
-            f"Received metrics from replica {replica_id} for autoscaling."
-        )
+        logger.debug(f"Received metrics from replica {replica_id} for autoscaling.")
         self.autoscaling_state_manager.record_request_metrics_for_replica(
             replica_id, metrics_store, send_timestamp
         )

--- a/python/ray/serve/_private/metrics_utils.py
+++ b/python/ray/serve/_private/metrics_utils.py
@@ -20,6 +20,7 @@ from ray.serve._private.constants import (
     METRICS_PUSHER_GRACEFUL_SHUTDOWN_TIMEOUT_S,
     SERVE_LOGGER_NAME,
 )
+from ray.serve.config import AggregationFunction
 
 QUEUED_REQUESTS_KEY = "queued"
 
@@ -310,6 +311,26 @@ class InMemoryMetricsStore:
             Returns (None, 0) if no valid keys have data.
         """
         return self._aggregate_reduce(keys, statistics.mean)
+
+    def aggregate(self, keys: Iterable[Hashable], method: AggregationFunction):
+        """Aggregate the entire set of timeseries values across the specified keys.
+
+        Args:
+            keys: Iterable of keys to aggregate across.
+            method: Aggregation method to use.
+        Returns:
+            A tuple of (float, int) where the first element is the aggregated value
+            and the second element is the number of valid keys used.
+            Returns (None, 0) if no valid keys have data.
+        """
+        if method == AggregationFunction.MAX:
+            return self.aggregate_max(keys)
+        elif method == AggregationFunction.MIN:
+            return self.aggregate_min(keys)
+        elif method == AggregationFunction.MEAN:
+            return self.aggregate_avg(keys)
+        else:
+            raise ValueError(f"Unknown aggregation method: {method}")
 
 
 def _bucket_latest_by_window(

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -331,7 +331,7 @@ class ReplicaMetricsManager:
         self._metrics_store.prune_keys_and_compact_data(time.time() - look_back_period)
         self._controller_handle.record_autoscaling_metrics.remote(
             replica_id=self._replica_id,
-            metrics_store=self._metrics_store,
+            metrics_dict=self._metrics_store.data,
             send_timestamp=time.time(),
         )
 

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -326,12 +326,12 @@ class ReplicaMetricsManager:
             else:
                 self._request_counter.inc(tags={"route": route})
 
-    def _push_autoscaling_metrics(self) -> Dict[str, Any]:
+    def _push_autoscaling_metrics(self) -> None:
         look_back_period = self._autoscaling_config.look_back_period_s
         self._metrics_store.prune_keys_and_compact_data(time.time() - look_back_period)
         self._controller_handle.record_autoscaling_metrics.remote(
             replica_id=self._replica_id,
-            window_avg=self._metrics_store.aggregate_avg([self._replica_id])[0],
+            metrics_store=self._metrics_store,
             send_timestamp=time.time(),
         )
 

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -367,7 +367,7 @@ class RouterMetricsManager:
             handle_id=self._handle_id,
             actor_id=self._self_actor_id,
             handle_source=self._handle_source,
-            metrics_store=self._get_metrics_store(),
+            metrics_dict=self._get_metrics_store().data,
         )
 
     def _add_autoscaling_metrics_point(self):

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -367,7 +367,7 @@ class RouterMetricsManager:
             handle_id=self._handle_id,
             actor_id=self._self_actor_id,
             handle_source=self._handle_source,
-            metrics_store=self._get_metrics_store()
+            metrics_store=self._get_metrics_store(),
         )
 
     def _add_autoscaling_metrics_point(self):

--- a/python/ray/serve/autoscaling_policy.py
+++ b/python/ray/serve/autoscaling_policy.py
@@ -22,9 +22,10 @@ def _calculate_desired_num_replicas(
     Args:
         autoscaling_config: The autoscaling parameters to use for this
             calculation.
-        total_num_requests (float): A list of the number of
-            ongoing requests for each replica.  Assumes each entry has already
-            been time-averaged over the desired lookback window.
+        total_num_requests: The total aggregate number of requests running
+            across all replicas of a deployment.
+        num_running_replicas: The current count of running replicas for this
+            a deployment.
         override_min_replicas: Overrides min_replicas from the config
             when calculating the final number of replicas.
         override_max_replicas: Overrides max_replicas from the config
@@ -97,7 +98,7 @@ def replica_queue_length_autoscaling_policy(
     """
 
     curr_target_num_replicas: int = ctx.target_num_replicas
-    total_num_requests: int = ctx.total_num_requests
+    total_num_requests: float = ctx.total_num_requests
     num_running_replicas: int = ctx.current_num_replicas
     config: Optional[AutoscalingConfig] = ctx.config
     capacity_adjusted_min_replicas: int = ctx.capacity_adjusted_min_replicas

--- a/python/ray/serve/autoscaling_policy.py
+++ b/python/ray/serve/autoscaling_policy.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(SERVE_LOGGER_NAME)
 
 def _calculate_desired_num_replicas(
     autoscaling_config: AutoscalingConfig,
-    total_num_requests: int,
+    current_requests_per_replica: int,
     num_running_replicas: int,
     override_min_replicas: Optional[float] = None,
     override_max_replicas: Optional[float] = None,
@@ -22,9 +22,9 @@ def _calculate_desired_num_replicas(
     Args:
         autoscaling_config: The autoscaling parameters to use for this
             calculation.
-        current_num_ongoing_requests (List[float]): A list of the number of
-            ongoing requests for each replica.  Assumes each entry has already
-            been time-averaged over the desired lookback window.
+        current_requests_per_replica: Aggregated request count per replica
+            across all currently running replicas. The aggregation method
+             (e.g., average, max, min) is configurable.
         override_min_replicas: Overrides min_replicas from the config
             when calculating the final number of replicas.
         override_max_replicas: Overrides max_replicas from the config
@@ -41,9 +41,9 @@ def _calculate_desired_num_replicas(
     # Example: if error_ratio == 2.0, we have two times too many ongoing
     # requests per replica, so we desire twice as many replicas.
     target_num_requests = (
-        autoscaling_config.get_target_ongoing_requests() * num_running_replicas
+        autoscaling_config.get_target_ongoing_requests()
     )
-    error_ratio: float = total_num_requests / target_num_requests
+    error_ratio: float = current_requests_per_replica / target_num_requests
 
     # If error ratio >= 1, then the number of ongoing requests per
     # replica exceeds the target and we will make an upscale decision,
@@ -120,7 +120,7 @@ def replica_queue_length_autoscaling_policy(
 
     desired_num_replicas = _calculate_desired_num_replicas(
         config,
-        total_num_requests,
+        current_requests_per_replica,
         num_running_replicas=num_running_replicas,
         override_min_replicas=capacity_adjusted_min_replicas,
         override_max_replicas=capacity_adjusted_max_replicas,

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -229,6 +229,10 @@ class AutoscalingConfig(BaseModel):
         default=30.0, description="How long to wait before scaling up replicas."
     )
 
+    # Determines how handle metrics are aggregated to make scaling decisions.
+    aggregation_function: str = "mean"
+    _aggregation_functions = {"mean", "max", "min"}
+
     # Cloudpickled policy definition.
     _serialized_policy_def: bytes = PrivateAttr(default=b"")
 
@@ -274,6 +278,14 @@ class AutoscalingConfig(BaseModel):
                 DeprecationWarning,
             )
         return v
+
+    @validator("aggregation_function", always=True)
+    def aggregation_function_valid(cls, aggregation_function: str):
+        if aggregation_function not in cls._aggregation_functions:
+            raise ValueError(
+                f"scaling_function must be one of {list(cls._aggregation_functions)}"
+            )
+        return aggregation_function
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -236,7 +236,10 @@ class AutoscalingConfig(BaseModel):
         default=30.0, description="How long to wait before scaling up replicas."
     )
 
-    aggregation_function: Union[str, AggregationFunction] = AggregationFunction.MEAN
+    aggregation_function: Union[str, AggregationFunction] = Field(
+        default=AggregationFunction.MEAN,
+        description="Function used to aggregate metrics across replicas.",
+    )
 
     # Cloudpickled policy definition.
     _serialized_policy_def: bytes = PrivateAttr(default=b"")

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -163,6 +163,7 @@ class RequestRouterConfig(BaseModel):
 DEFAULT_METRICS_INTERVAL_S = 10.0
 
 
+@PublicAPI(stability="alpha")
 class AggregationFunction(str, Enum):
     MEAN = "mean"
     MAX = "max"

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -325,11 +325,13 @@ def get_metrics_store(replicas, request_count, queued=0) -> InMemoryMetricsStore
     metrics_store = InMemoryMetricsStore()
     for replica in replicas:
         metrics_store.add_metrics_point(
-            {replica._actor.replica_id: request_count}, 0,
+            {replica._actor.replica_id: request_count},
+            0,
         )
     if queued:
         metrics_store.add_metrics_point(
-            {"queued": queued}, 0,
+            {"queued": queued},
+            0,
         )
     return metrics_store
 
@@ -2996,7 +2998,9 @@ class TestAutoscaling:
         else:
             for replica in replicas:
                 asm.record_request_metrics_for_replica(
-                    replica._actor.replica_id, get_metrics_store(replicas, 2), timer.time()
+                    replica._actor.replica_id,
+                    get_metrics_store(replicas, 2),
+                    timer.time(),
                 )
 
         # status=UPSCALING, status_trigger=AUTOSCALE
@@ -3072,7 +3076,9 @@ class TestAutoscaling:
         else:
             for replica in replicas:
                 asm.record_request_metrics_for_replica(
-                    replica._actor.replica_id, get_metrics_store(replicas, 1), timer.time()
+                    replica._actor.replica_id,
+                    get_metrics_store(replicas, 1),
+                    timer.time(),
                 )
 
         # status=DOWNSCALING, status_trigger=AUTOSCALE
@@ -3161,7 +3167,9 @@ class TestAutoscaling:
         else:
             for replica in replicas:
                 asm.record_request_metrics_for_replica(
-                    replica._actor.replica_id, get_metrics_store(replicas, 1), timer.time()
+                    replica._actor.replica_id,
+                    get_metrics_store(replicas, 1),
+                    timer.time(),
                 )
 
         check_counts(ds, total=3, by_state=[(ReplicaState.RUNNING, 3, None)])
@@ -3438,7 +3446,7 @@ class TestAutoscaling:
             handle_id="random",
             actor_id=None,
             handle_source=DeploymentHandleSource.UNKNOWN,
-            metrics_store= get_metrics_store([ds._replicas.get()[0]], 2),
+            metrics_store=get_metrics_store([ds._replicas.get()[0]], 2),
             send_timestamp=timer.time(),
         )
         asm.drop_stale_handle_metrics(dsm.get_alive_replica_actor_ids())
@@ -3463,7 +3471,7 @@ class TestAutoscaling:
         timer.advance(10)
         asm.drop_stale_handle_metrics(dsm.get_alive_replica_actor_ids())
         dsm.update()
-        #check_counts(ds, total=2, by_state=[(ReplicaState.RUNNING, 2, None)])
+        check_counts(ds, total=2, by_state=[(ReplicaState.RUNNING, 2, None)])
         assert asm.get_total_num_requests(TEST_DEPLOYMENT_ID) == 2
 
         # Another 10 seconds later handle still fails to push metrics. At

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -626,8 +626,6 @@ def check_counts(
         state: deployment_state._replicas.count(states=[state])
         for state in ALL_REPLICA_STATES
     }
-    print("TOTAL: ", deployment_state._replicas.count())
-    print("STATES", replicas)
     if total is not None:
         assert deployment_state._replicas.count() == total, f"Replicas: {replicas}"
 
@@ -2837,14 +2835,14 @@ class TestAutoscaling:
                 handle_id="random",
                 actor_id=None,
                 handle_source=DeploymentHandleSource.UNKNOWN,
-                metrics_store=get_metrics_store(replicas, req_per_replica),
+                metrics_dict=get_metrics_store(replicas, req_per_replica).data,
                 send_timestamp=timer.time(),
             )
         else:
             for replica in replicas:
                 asm.record_request_metrics_for_replica(
                     replica_id=replica._actor.replica_id,
-                    metrics_store=get_metrics_store(replicas, req_per_replica),
+                    metrics_dict=get_metrics_store(replicas, req_per_replica).data,
                     send_timestamp=timer.time(),
                 )
 
@@ -2992,14 +2990,14 @@ class TestAutoscaling:
                 handle_id="random",
                 actor_id=None,
                 handle_source=DeploymentHandleSource.UNKNOWN,
-                metrics_store=get_metrics_store(replicas, 2),
+                metrics_dict=get_metrics_store(replicas, 2).data,
                 send_timestamp=timer.time(),
             )
         else:
             for replica in replicas:
                 asm.record_request_metrics_for_replica(
                     replica._actor.replica_id,
-                    get_metrics_store(replicas, 2),
+                    get_metrics_store(replicas, 2).data,
                     timer.time(),
                 )
 
@@ -3070,14 +3068,14 @@ class TestAutoscaling:
                 handle_id="random",
                 actor_id=None,
                 handle_source=DeploymentHandleSource.UNKNOWN,
-                metrics_store=get_metrics_store(replicas, 1),
+                metrics_dict=get_metrics_store(replicas, 1).data,
                 send_timestamp=timer.time(),
             )
         else:
             for replica in replicas:
                 asm.record_request_metrics_for_replica(
                     replica._actor.replica_id,
-                    get_metrics_store(replicas, 1),
+                    get_metrics_store(replicas, 1).data,
                     timer.time(),
                 )
 
@@ -3161,14 +3159,14 @@ class TestAutoscaling:
                 handle_id="random",
                 actor_id=None,
                 handle_source=DeploymentHandleSource.UNKNOWN,
-                metrics_store=get_metrics_store(replicas, 1),
+                metrics_dict=get_metrics_store(replicas, 1).data,
                 send_timestamp=timer.time(),
             )
         else:
             for replica in replicas:
                 asm.record_request_metrics_for_replica(
                     replica._actor.replica_id,
-                    get_metrics_store(replicas, 1),
+                    get_metrics_store(replicas, 1).data,
                     timer.time(),
                 )
 
@@ -3260,7 +3258,7 @@ class TestAutoscaling:
             handle_id="random",
             actor_id=None,
             handle_source=DeploymentHandleSource.UNKNOWN,
-            metrics_store=get_metrics_store([], 0, queued=1),
+            metrics_dict=get_metrics_store([], 0, queued=1).data,
             send_timestamp=timer.time(),
         )
 
@@ -3373,7 +3371,7 @@ class TestAutoscaling:
             handle_id="random",
             actor_id=None,
             handle_source=DeploymentHandleSource.UNKNOWN,
-            metrics_store=get_metrics_store([], 0, queued=1),
+            metrics_dict=get_metrics_store([], 0, queued=1).data,
             send_timestamp=timer.time(),
         )
 
@@ -3446,7 +3444,7 @@ class TestAutoscaling:
             handle_id="random",
             actor_id=None,
             handle_source=DeploymentHandleSource.UNKNOWN,
-            metrics_store=get_metrics_store([ds._replicas.get()[0]], 2),
+            metrics_dict=get_metrics_store([ds._replicas.get()[0]], 2).data,
             send_timestamp=timer.time(),
         )
         asm.drop_stale_handle_metrics(dsm.get_alive_replica_actor_ids())
@@ -3531,7 +3529,7 @@ class TestAutoscaling:
             handle_id="random",
             actor_id="d2_replica_actor_id",
             handle_source=DeploymentHandleSource.REPLICA,
-            metrics_store=get_metrics_store([ds1._replicas.get()[0]], 2),
+            metrics_dict=get_metrics_store([ds1._replicas.get()[0]], 2).data,
             send_timestamp=timer.time(),
         )
         asm.drop_stale_handle_metrics(dsm.get_alive_replica_actor_ids())

--- a/src/ray/protobuf/serve.proto
+++ b/src/ray/protobuf/serve.proto
@@ -82,6 +82,9 @@ message AutoscalingConfig {
 
   // The multiplicative "gain" factor to limit downscale.
   optional double downscaling_factor = 15;
+
+  // How handle metrics are aggregated for autoscaling. One of "mean", "max", "min", "sum".
+  string aggregation_function = 16;
 }
 
 //[Begin] LOGGING CONFIG

--- a/src/ray/protobuf/serve.proto
+++ b/src/ray/protobuf/serve.proto
@@ -83,7 +83,7 @@ message AutoscalingConfig {
   // The multiplicative "gain" factor to limit downscale.
   optional double downscaling_factor = 15;
 
-  // How handle metrics are aggregated for autoscaling. One of "mean", "max", "min", "sum".
+  // How handle metrics are aggregated for autoscaling. One of "mean", "max", "min".
   string aggregation_function = 16;
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, the serve autoscaler makes scaling decisions only based on the most recent Serve Controller computation, even if the serve controller has made many scaling calculations over the scaling delay period. This results in poor autoscaling when clusters utilize long upscale/downscale delays. This PR allows more sensitive scaling by implementing min and max aggregate functions to handle metric collection in addition to the current average.

An alternate fix to this issue was proposed [here.](https://github.com/ray-project/ray/pull/47837). 

## Related issue number

https://github.com/ray-project/ray/issues/46497

## Checks

- [ ✓] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ✓] I've run `scripts/format.sh` to lint the changes in this PR.
- [✓ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ✓ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ✓] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [✓ ] Unit tests
   - [✓ ] Release tests
   - [] This PR is not tested :(
