### PR TITLE
[Core] Split `core_worker` into smaller targets to improve build performance

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1670,105 +1670,362 @@ ray_cc_library(
 ray_cc_library(
     name = "core_worker_lib",
     srcs = [
-        "src/ray/core_worker/actor_handle.cc",
-        "src/ray/core_worker/actor_manager.cc",
-        "src/ray/core_worker/common.cc",
-        "src/ray/core_worker/context.cc",
         "src/ray/core_worker/core_worker.cc",
         "src/ray/core_worker/core_worker_process.cc",
-        "src/ray/core_worker/experimental_mutable_object_manager.cc",
-        "src/ray/core_worker/experimental_mutable_object_provider.cc",
-        "src/ray/core_worker/future_resolver.cc",
-        "src/ray/core_worker/generator_waiter.cc",
-        "src/ray/core_worker/lease_policy.cc",
-        "src/ray/core_worker/object_recovery_manager.cc",
-        "src/ray/core_worker/profile_event.cc",
-        "src/ray/core_worker/reference_count.cc",
-        "src/ray/core_worker/store_provider/memory_store/memory_store.cc",
-        "src/ray/core_worker/store_provider/plasma_store_provider.cc",
-        "src/ray/core_worker/task_event_buffer.cc",
-        "src/ray/core_worker/task_manager.cc",
-        "src/ray/core_worker/transport/actor_scheduling_queue.cc",
-        "src/ray/core_worker/transport/actor_task_submitter.cc",
-        "src/ray/core_worker/transport/concurrency_group_manager.cc",
-        "src/ray/core_worker/transport/dependency_resolver.cc",
-        "src/ray/core_worker/transport/normal_scheduling_queue.cc",
-        "src/ray/core_worker/transport/normal_task_submitter.cc",
-        "src/ray/core_worker/transport/out_of_order_actor_scheduling_queue.cc",
-        "src/ray/core_worker/transport/out_of_order_actor_submit_queue.cc",
-        "src/ray/core_worker/transport/scheduling_util.cc",
-        "src/ray/core_worker/transport/sequential_actor_submit_queue.cc",
-        "src/ray/core_worker/transport/task_receiver.cc",
     ],
     hdrs = [
-        "src/ray/core_worker/actor_creator.h",
-        "src/ray/core_worker/actor_handle.h",
-        "src/ray/core_worker/actor_manager.h",
-        "src/ray/core_worker/common.h",
-        "src/ray/core_worker/context.h",
         "src/ray/core_worker/core_worker.h",
         "src/ray/core_worker/core_worker_options.h",
         "src/ray/core_worker/core_worker_process.h",
-        "src/ray/core_worker/experimental_mutable_object_manager.h",
-        "src/ray/core_worker/experimental_mutable_object_provider.h",
         "src/ray/core_worker/fiber.h",
-        "src/ray/core_worker/future_resolver.h",
-        "src/ray/core_worker/generator_waiter.h",
-        "src/ray/core_worker/lease_policy.h",
-        "src/ray/core_worker/object_recovery_manager.h",
-        "src/ray/core_worker/profile_event.h",
-        "src/ray/core_worker/reference_count.h",
+        "src/ray/core_worker/transport/actor_submit_queue.h",
+        "src/ray/core_worker/transport/scheduling_queue.h",
+    ],
+    deps = [
+        ":actor_handle",
+        ":experimental_mutable_object_provider",
+        ":future_resolver",
+        ":generator_waiter",
+        ":normal_task_submitter",
+        ":object_recovery_manager",
+        ":plasma_store_provider",
+        ":profile_event",
+        "//src/ray/util:env",
+        "//src/ray/util:shared_lru",
+        "//src/ray/util:stream_redirection",
+    ],
+)
+
+ray_cc_library(
+    name = "core_worker_common",
+    srcs = ["src/ray/core_worker/common.cc"],
+    hdrs = ["src/ray/core_worker/common.h"],
+    deps = [
+        ":raylet_client_lib",
+        ":ray_common",
+    ],
+)
+
+ray_cc_library(
+    name = "core_worker_context",
+    srcs = ["src/ray/core_worker/context.cc"],
+    hdrs = ["src/ray/core_worker/context.h"],
+    deps = [
+        ":core_worker_common",
+        ":ray_common",
+        "@boost//:thread",
+    ]
+)
+
+ray_cc_library(
+    name = "actor_handle",
+    srcs = ["src/ray/core_worker/actor_handle.cc"],
+    hdrs = ["src/ray/core_worker/actor_handle.h"],
+    deps = [
+        ":core_worker_context",
+         "//src/ray/protobuf:worker_cc_proto",
+    ]
+)
+
+ray_cc_library(
+    name = "actor_manager",
+    srcs = [
+        "src/ray/core_worker/actor_manager.cc",
+    ],
+    hdrs = [
+        "src/ray/core_worker/actor_creator.h",
+        "src/ray/core_worker/actor_manager.h",
+    ],
+    deps = [
+        ":actor_handle",
+        ":gcs_client_lib",
+        ":reference_count",
+        ":task_receiver",
+    ]
+)
+
+ray_cc_library(
+    name = "reference_count",
+    srcs = ["src/ray/core_worker/reference_count.cc"],
+    hdrs = ["src/ray/core_worker/reference_count.h"],
+    deps = [
+        ":lease_policy",
+        ":pubsub_lib",
+        ":worker_rpc"
+    ]
+)
+
+ray_cc_library(
+    name = "lease_policy",
+    srcs = ["src/ray/core_worker/lease_policy.cc"],
+    hdrs = ["src/ray/core_worker/lease_policy.h"],
+    deps = [
+        ":ray_common",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
+    ]
+)
+
+ray_cc_library(
+    name = "task_event_buffer",
+    srcs = ["src/ray/core_worker/task_event_buffer.cc"],
+    hdrs = ["src/ray/core_worker/task_event_buffer.h"],
+    deps = [
+        ":ray_common",
+        ":gcs_client_lib",
+        "//src/ray/util:counter_map",
+        "@boost//:circular_buffer",
+    ]
+)
+
+ray_cc_library(
+    name = "out_of_order_actor_submit_queue",
+    srcs = ["src/ray/core_worker/transport/out_of_order_actor_submit_queue.cc"],
+    hdrs = [
+        "src/ray/core_worker/transport/out_of_order_actor_submit_queue.h",
+        "src/ray/core_worker/transport/actor_submit_queue.h",
+    ],
+    deps = [
+        ":ray_common"
+    ]
+)
+
+ray_cc_library(
+    name = "sequential_actor_submit_queue",
+    srcs = ["src/ray/core_worker/transport/sequential_actor_submit_queue.cc"],
+    hdrs = [
+        "src/ray/core_worker/transport/sequential_actor_submit_queue.h",
+        "src/ray/core_worker/transport/actor_submit_queue.h",
+    ],
+    deps = [
+        ":ray_common"
+    ]
+)
+
+ray_cc_library(
+    name = "memory_store",
+    srcs = ["src/ray/core_worker/store_provider/memory_store/memory_store.cc"],
+    hdrs = [
         "src/ray/core_worker/store_provider/memory_store/memory_store.h",
-        "src/ray/core_worker/store_provider/plasma_store_provider.h",
-        "src/ray/core_worker/task_event_buffer.h",
+    ],
+    deps = [
+        ":core_worker_context",
+        ":ray_common",
+        ":reference_count",
+    ]
+)
+
+ray_cc_library(
+    name = "task_manager",
+    srcs = ["src/ray/core_worker/task_manager.cc"],
+    hdrs = [
+        "src/ray/core_worker/task_finisher.h",
         "src/ray/core_worker/task_manager.h",
-        "src/ray/core_worker/transport/actor_scheduling_queue.h",
+    ],
+    deps = [
+        ":actor_manager",
+        ":ray_common",
+        ":memory_store",
+        ":task_event_buffer",
+    ]
+)
+
+ray_cc_library(
+    name = "dependency_resolver",
+    srcs = ["src/ray/core_worker/transport/dependency_resolver.cc"],
+    hdrs = [
+        "src/ray/core_worker/actor_creator.h",
+        "src/ray/core_worker/task_finisher.h",
+        "src/ray/core_worker/transport/dependency_resolver.h",
+    ],
+    deps = [
+        ":gcs_client_lib",
+        ":memory_store",
+        ":ray_common",
+    ]
+)
+
+ray_cc_library(
+    name = "actor_task_submitter",
+    srcs = ["src/ray/core_worker/transport/actor_task_submitter.cc"],
+    hdrs = [
+        "src/ray/core_worker/actor_creator.h",
         "src/ray/core_worker/transport/actor_submit_queue.h",
         "src/ray/core_worker/transport/actor_task_submitter.h",
-        "src/ray/core_worker/transport/concurrency_group_manager.h",
-        "src/ray/core_worker/transport/dependency_resolver.h",
+    ],
+    deps = [
+        ":dependency_resolver",
+        ":out_of_order_actor_submit_queue",
+        ":sequential_actor_submit_queue",
+    ]
+)
+
+ray_cc_library(
+    name = "scheduling_util",
+    srcs = ["src/ray/core_worker/transport/scheduling_util.cc"],
+    hdrs = ["src/ray/core_worker/transport/scheduling_util.h"],
+    deps = [
+        ":raylet_client_lib",
+        ":ray_common",
+        "//src/ray/protobuf:worker_cc_proto",
+    ]
+)
+
+ray_cc_library(
+    name = "normal_scheduling_queue",
+    srcs = ["src/ray/core_worker/transport/normal_scheduling_queue.cc"],
+    hdrs = [
         "src/ray/core_worker/transport/normal_scheduling_queue.h",
-        "src/ray/core_worker/transport/normal_task_submitter.h",
-        "src/ray/core_worker/transport/out_of_order_actor_scheduling_queue.h",
-        "src/ray/core_worker/transport/out_of_order_actor_submit_queue.h",
         "src/ray/core_worker/transport/scheduling_queue.h",
-        "src/ray/core_worker/transport/scheduling_util.h",
-        "src/ray/core_worker/transport/sequential_actor_submit_queue.h",
+    ],
+    deps = [
+        ":scheduling_util"
+    ]
+)
+
+ray_cc_library(
+    name = "actor_scheduling_queue",
+    srcs = ["src/ray/core_worker/transport/actor_scheduling_queue.cc"],
+    hdrs = [
+        "src/ray/core_worker/fiber.h",
+        "src/ray/core_worker/transport/actor_scheduling_queue.h",
+        "src/ray/core_worker/transport/scheduling_queue.h",
+    ],
+    deps = [
+        ":concurrency_group_manager",
+        ":scheduling_util",
+        ":task_event_buffer",
+        "@boost//:fiber",
+    ]
+)
+
+ray_cc_library(
+    name = "concurrency_group_manager",
+    srcs = ["src/ray/core_worker/transport/concurrency_group_manager.cc"],
+    hdrs = [
+        "src/ray/core_worker/fiber.h",
+        "src/ray/core_worker/transport/concurrency_group_manager.h",
+    ],
+    deps = [
+        ":ray_common",
+        ":thread_pool",
+        "@boost//:fiber",
+    ]
+)
+
+ray_cc_library(
+    name = "out_of_order_actor_scheduling_queue",
+    srcs = ["src/ray/core_worker/transport/out_of_order_actor_scheduling_queue.cc"],
+    hdrs = [
+        "src/ray/core_worker/fiber.h",
+        "src/ray/core_worker/transport/out_of_order_actor_scheduling_queue.h",
+        "src/ray/core_worker/transport/scheduling_queue.h",
+    ],
+    deps = [
+        ":concurrency_group_manager",
+        ":scheduling_util",
+        ":task_event_buffer",
+    ]
+)
+
+ray_cc_library(
+    name = "task_receiver",
+    srcs = ["src/ray/core_worker/transport/task_receiver.cc"],
+    hdrs = [
+        "src/ray/core_worker/fiber.h",
+        "src/ray/core_worker/transport/scheduling_queue.h",
         "src/ray/core_worker/transport/task_receiver.h",
     ],
     deps = [
-        ":gcs",
-        ":gcs_client_lib",
+        ":actor_handle",
+        ":actor_scheduling_queue",
+        ":actor_task_submitter",
+        ":concurrency_group_manager",
+        ":normal_scheduling_queue",
+        ":out_of_order_actor_scheduling_queue",
+    ]
+)
+
+ray_cc_library(
+    name = "experimental_mutable_object_manager",
+    srcs = ["src/ray/core_worker/experimental_mutable_object_manager.cc"],
+    hdrs = ["src/ray/core_worker/experimental_mutable_object_manager.h"],
+    deps = [
         ":plasma_client",
         ":ray_common",
-        ":raylet_client_lib",
-        ":stats_lib",
-        ":thread_pool",
-        ":worker_rpc",
-        "//src/ray/common/cgroup:base_cgroup_setup",
-        "//src/ray/common/cgroup:cgroup_context",
-        "//src/ray/common/cgroup:cgroup_manager",
-        "//src/ray/common/cgroup:constants",
-        "//src/ray/common/cgroup:scoped_cgroup_handle",
-        "//src/ray/protobuf:worker_cc_proto",
-        "//src/ray/util",
-        "//src/ray/util:container_util",
-        "//src/ray/util:counter_map",
-        "//src/ray/util:env",
-        "//src/ray/util:mutex_protected",
-        "//src/ray/util:process",
-        "//src/ray/util:shared_lru",
-        "//src/ray/util:stream_redirection",
-        "//src/ray/util:stream_redirection_options",
-        "@boost//:circular_buffer",
-        "@boost//:fiber",
-        "@com_google_absl//absl/cleanup",
-        "@com_google_absl//absl/container:btree",
-        "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/container:node_hash_map",
-        "@nlohmann_json",
-    ],
+    ]
+)
+
+ray_cc_library(
+    name = "future_resolver",
+    srcs = ["src/ray/core_worker/future_resolver.cc"],
+    hdrs = ["src/ray/core_worker/future_resolver.h"],
+    deps = [
+        ":memory_store",
+        ":ray_common",
+    ]
+)
+
+ray_cc_library(
+    name = "experimental_mutable_object_provider",
+    srcs = ["src/ray/core_worker/experimental_mutable_object_provider.cc"],
+    hdrs = ["src/ray/core_worker/experimental_mutable_object_provider.h"],
+    deps = [
+        ":experimental_mutable_object_manager",
+        ":raylet_client_lib",
+    ]
+)
+
+ray_cc_library(
+    name = "generator_waiter",
+    srcs = ["src/ray/core_worker/generator_waiter.cc"],
+    hdrs = ["src/ray/core_worker/generator_waiter.h"],
+    deps = [
+        ":core_worker_common",
+    ]
+)
+
+ray_cc_library(
+    name = "object_recovery_manager",
+    srcs = ["src/ray/core_worker/object_recovery_manager.cc"],
+    hdrs = ["src/ray/core_worker/object_recovery_manager.h"],
+    deps = [
+        ":reference_count",
+        ":task_manager",
+    ]
+)
+
+ray_cc_library(
+    name = "profile_event",
+    srcs = ["src/ray/core_worker/profile_event.cc"],
+    hdrs = ["src/ray/core_worker/profile_event.h"],
+    deps = [
+        ":core_worker_context",
+        ":task_event_buffer",
+    ]
+)
+
+ray_cc_library(
+    name = "plasma_store_provider",
+    srcs = ["src/ray/core_worker/store_provider/plasma_store_provider.cc"],
+    hdrs = ["src/ray/core_worker/store_provider/plasma_store_provider.h"],
+    deps = [
+        ":core_worker_context",
+        ":plasma_client",
+        ":reference_count",
+        ":ray_common",
+    ]
+)
+
+ray_cc_library(
+    name = "normal_task_submitter",
+    srcs = ["src/ray/core_worker/transport/normal_task_submitter.cc"],
+    hdrs = ["src/ray/core_worker/transport/normal_task_submitter.h"],
+    deps = [
+        ":task_manager",
+        ":task_receiver",
+    ]
 )
 
 ray_cc_library(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1675,25 +1675,47 @@ ray_cc_library(
     ],
     hdrs = [
         "src/ray/core_worker/core_worker.h",
-        "src/ray/core_worker/core_worker_options.h",
         "src/ray/core_worker/core_worker_process.h",
-        "src/ray/core_worker/fiber.h",
-        "src/ray/core_worker/transport/actor_submit_queue.h",
-        "src/ray/core_worker/transport/scheduling_queue.h",
     ],
     deps = [
         ":actor_handle",
+        ":actor_submit_queue",
+        ":core_worker_options",
         ":experimental_mutable_object_provider",
+        ":fiber",
         ":future_resolver",
         ":generator_waiter",
         ":normal_task_submitter",
         ":object_recovery_manager",
         ":plasma_store_provider",
         ":profile_event",
+        ":scheduling_queue",
+        "//src/ray/common/cgroup:cgroup_context",
+        "//src/ray/common/cgroup:cgroup_manager",
         "//src/ray/util:env",
         "//src/ray/util:shared_lru",
         "//src/ray/util:stream_redirection",
     ],
+)
+
+ray_cc_library(
+    name = "core_worker_options",
+    hdrs = ["src/ray/core_worker/core_worker_options.h"]
+)
+
+ray_cc_library(
+    name = "fiber",
+    hdrs = ["src/ray/core_worker/fiber.h"]
+)
+
+ray_cc_library(
+    name = "actor_submit_queue",
+    hdrs = ["src/ray/core_worker/transport/actor_submit_queue.h"]
+)
+
+ray_cc_library(
+    name = "scheduling_queue",
+    hdrs = ["src/ray/core_worker/transport/scheduling_queue.h"]
 )
 
 ray_cc_library(
@@ -1728,15 +1750,18 @@ ray_cc_library(
 )
 
 ray_cc_library(
-    name = "actor_manager",
-    srcs = [
-        "src/ray/core_worker/actor_manager.cc",
-    ],
+    name = "actor_creator",
     hdrs = [
         "src/ray/core_worker/actor_creator.h",
-        "src/ray/core_worker/actor_manager.h",
     ],
+)
+
+ray_cc_library(
+    name = "actor_manager",
+    srcs = ["src/ray/core_worker/actor_manager.cc"],
+    hdrs = ["src/ray/core_worker/actor_manager.h"],
     deps = [
+        ":actor_creator",
         ":actor_handle",
         ":gcs_client_lib",
         ":reference_count",
@@ -1781,11 +1806,9 @@ ray_cc_library(
 ray_cc_library(
     name = "out_of_order_actor_submit_queue",
     srcs = ["src/ray/core_worker/transport/out_of_order_actor_submit_queue.cc"],
-    hdrs = [
-        "src/ray/core_worker/transport/out_of_order_actor_submit_queue.h",
-        "src/ray/core_worker/transport/actor_submit_queue.h",
-    ],
+    hdrs = ["src/ray/core_worker/transport/out_of_order_actor_submit_queue.h"],
     deps = [
+        "actor_submit_queue",
         ":ray_common"
     ]
 )
@@ -1793,11 +1816,9 @@ ray_cc_library(
 ray_cc_library(
     name = "sequential_actor_submit_queue",
     srcs = ["src/ray/core_worker/transport/sequential_actor_submit_queue.cc"],
-    hdrs = [
-        "src/ray/core_worker/transport/sequential_actor_submit_queue.h",
-        "src/ray/core_worker/transport/actor_submit_queue.h",
-    ],
+    hdrs = ["src/ray/core_worker/transport/sequential_actor_submit_queue.h"],
     deps = [
+        "actor_submit_queue",
         ":ray_common"
     ]
 )
@@ -1805,9 +1826,7 @@ ray_cc_library(
 ray_cc_library(
     name = "memory_store",
     srcs = ["src/ray/core_worker/store_provider/memory_store/memory_store.cc"],
-    hdrs = [
-        "src/ray/core_worker/store_provider/memory_store/memory_store.h",
-    ],
+    hdrs = ["src/ray/core_worker/store_provider/memory_store/memory_store.h"],
     deps = [
         ":core_worker_context",
         ":ray_common",
@@ -1816,44 +1835,43 @@ ray_cc_library(
 )
 
 ray_cc_library(
+    name = "task_finisher",
+    hdrs = ["src/ray/core_worker/task_finisher.h"],
+)
+
+ray_cc_library(
     name = "task_manager",
     srcs = ["src/ray/core_worker/task_manager.cc"],
-    hdrs = [
-        "src/ray/core_worker/task_finisher.h",
-        "src/ray/core_worker/task_manager.h",
-    ],
+    hdrs = ["src/ray/core_worker/task_manager.h"],
     deps = [
         ":actor_manager",
         ":ray_common",
         ":memory_store",
         ":task_event_buffer",
+        ":task_finisher",
     ]
 )
 
 ray_cc_library(
     name = "dependency_resolver",
     srcs = ["src/ray/core_worker/transport/dependency_resolver.cc"],
-    hdrs = [
-        "src/ray/core_worker/actor_creator.h",
-        "src/ray/core_worker/task_finisher.h",
-        "src/ray/core_worker/transport/dependency_resolver.h",
-    ],
+    hdrs = ["src/ray/core_worker/transport/dependency_resolver.h"],
     deps = [
+        "actor_creator",
         ":gcs_client_lib",
         ":memory_store",
         ":ray_common",
+        ":task_finisher",
     ]
 )
 
 ray_cc_library(
     name = "actor_task_submitter",
     srcs = ["src/ray/core_worker/transport/actor_task_submitter.cc"],
-    hdrs = [
-        "src/ray/core_worker/actor_creator.h",
-        "src/ray/core_worker/transport/actor_submit_queue.h",
-        "src/ray/core_worker/transport/actor_task_submitter.h",
-    ],
+    hdrs = ["src/ray/core_worker/transport/actor_task_submitter.h"],
     deps = [
+        ":actor_creator",
+        ":actor_submit_queue",
         ":dependency_resolver",
         ":out_of_order_actor_submit_queue",
         ":sequential_actor_submit_queue",
@@ -1874,25 +1892,21 @@ ray_cc_library(
 ray_cc_library(
     name = "normal_scheduling_queue",
     srcs = ["src/ray/core_worker/transport/normal_scheduling_queue.cc"],
-    hdrs = [
-        "src/ray/core_worker/transport/normal_scheduling_queue.h",
-        "src/ray/core_worker/transport/scheduling_queue.h",
-    ],
+    hdrs = ["src/ray/core_worker/transport/normal_scheduling_queue.h"],
     deps = [
-        ":scheduling_util"
+        "scheduling_queue",
+        ":scheduling_util",
     ]
 )
 
 ray_cc_library(
     name = "actor_scheduling_queue",
     srcs = ["src/ray/core_worker/transport/actor_scheduling_queue.cc"],
-    hdrs = [
-        "src/ray/core_worker/fiber.h",
-        "src/ray/core_worker/transport/actor_scheduling_queue.h",
-        "src/ray/core_worker/transport/scheduling_queue.h",
-    ],
+    hdrs = ["src/ray/core_worker/transport/actor_scheduling_queue.h"],
     deps = [
         ":concurrency_group_manager",
+        ":fiber",
+        ":scheduling_queue",
         ":scheduling_util",
         ":task_event_buffer",
         "@boost//:fiber",
@@ -1902,11 +1916,9 @@ ray_cc_library(
 ray_cc_library(
     name = "concurrency_group_manager",
     srcs = ["src/ray/core_worker/transport/concurrency_group_manager.cc"],
-    hdrs = [
-        "src/ray/core_worker/fiber.h",
-        "src/ray/core_worker/transport/concurrency_group_manager.h",
-    ],
+    hdrs = ["src/ray/core_worker/transport/concurrency_group_manager.h"],
     deps = [
+        ":fiber",
         ":ray_common",
         ":thread_pool",
         "@boost//:fiber",
@@ -1916,13 +1928,11 @@ ray_cc_library(
 ray_cc_library(
     name = "out_of_order_actor_scheduling_queue",
     srcs = ["src/ray/core_worker/transport/out_of_order_actor_scheduling_queue.cc"],
-    hdrs = [
-        "src/ray/core_worker/fiber.h",
-        "src/ray/core_worker/transport/out_of_order_actor_scheduling_queue.h",
-        "src/ray/core_worker/transport/scheduling_queue.h",
-    ],
+    hdrs = ["src/ray/core_worker/transport/out_of_order_actor_scheduling_queue.h"],
     deps = [
         ":concurrency_group_manager",
+        ":fiber",
+        ":scheduling_queue",
         ":scheduling_util",
         ":task_event_buffer",
     ]
@@ -1931,18 +1941,16 @@ ray_cc_library(
 ray_cc_library(
     name = "task_receiver",
     srcs = ["src/ray/core_worker/transport/task_receiver.cc"],
-    hdrs = [
-        "src/ray/core_worker/fiber.h",
-        "src/ray/core_worker/transport/scheduling_queue.h",
-        "src/ray/core_worker/transport/task_receiver.h",
-    ],
+    hdrs = ["src/ray/core_worker/transport/task_receiver.h"],
     deps = [
         ":actor_handle",
         ":actor_scheduling_queue",
         ":actor_task_submitter",
         ":concurrency_group_manager",
+        ":fiber",
         ":normal_scheduling_queue",
         ":out_of_order_actor_scheduling_queue",
+        "scheduling_queue",
     ]
 )
 

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.cc
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.cc
@@ -22,7 +22,6 @@
 
 #include "ray/common/ray_config.h"
 #include "ray/core_worker/context.h"
-#include "ray/core_worker/core_worker.h"
 
 namespace ray {
 namespace core {

--- a/src/ray/core_worker/store_provider/plasma_store_provider.cc
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.cc
@@ -22,7 +22,6 @@
 
 #include "ray/common/ray_config.h"
 #include "ray/core_worker/context.h"
-#include "ray/core_worker/core_worker.h"
 #include "src/ray/protobuf/gcs.pb.h"
 
 namespace ray {

--- a/src/ray/core_worker/task_finisher.h
+++ b/src/ray/core_worker/task_finisher.h
@@ -16,13 +16,22 @@
 
 #include <vector>
 
+#include "absl/types/optional.h"
+#include "ray/common/id.h"
+#include "ray/common/scheduling/scheduling_ids.h"
+#include "ray/common/status.h"
 #include "ray/common/task/task.h"
+#include "ray/common/task/task_spec.h"
+#include "src/ray/protobuf/common.pb.h"
+#include "src/ray/protobuf/core_worker.pb.h"
 
 namespace ray {
 namespace core {
 
 class TaskFinisherInterface {
  public:
+  virtual ~TaskFinisherInterface() = default;
+
   virtual void CompletePendingTask(const TaskID &task_id,
                                    const rpc::PushTaskReply &reply,
                                    const rpc::Address &actor_addr,
@@ -58,8 +67,6 @@ class TaskFinisherInterface {
   virtual absl::optional<TaskSpecification> GetTaskSpec(const TaskID &task_id) const = 0;
 
   virtual bool IsTaskPending(const TaskID &task_id) const = 0;
-
-  virtual ~TaskFinisherInterface() = default;
 };
 
 }  // namespace core

--- a/src/ray/core_worker/task_finisher.h
+++ b/src/ray/core_worker/task_finisher.h
@@ -1,0 +1,66 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <vector>
+
+#include "ray/common/task/task.h"
+
+namespace ray {
+namespace core {
+
+class TaskFinisherInterface {
+ public:
+  virtual void CompletePendingTask(const TaskID &task_id,
+                                   const rpc::PushTaskReply &reply,
+                                   const rpc::Address &actor_addr,
+                                   bool is_application_error) = 0;
+
+  virtual bool RetryTaskIfPossible(const TaskID &task_id,
+                                   const rpc::RayErrorInfo &error_info) = 0;
+
+  virtual void FailPendingTask(const TaskID &task_id,
+                               rpc::ErrorType error_type,
+                               const Status *status = nullptr,
+                               const rpc::RayErrorInfo *ray_error_info = nullptr) = 0;
+
+  virtual bool FailOrRetryPendingTask(const TaskID &task_id,
+                                      rpc::ErrorType error_type,
+                                      const Status *status,
+                                      const rpc::RayErrorInfo *ray_error_info = nullptr,
+                                      bool mark_task_object_failed = true,
+                                      bool fail_immediately = false) = 0;
+
+  virtual void MarkTaskWaitingForExecution(const TaskID &task_id,
+                                           const NodeID &node_id,
+                                           const WorkerID &worker_id) = 0;
+
+  virtual void OnTaskDependenciesInlined(
+      const std::vector<ObjectID> &inlined_dependency_ids,
+      const std::vector<ObjectID> &contained_ids) = 0;
+
+  virtual void MarkDependenciesResolved(const TaskID &task_id) = 0;
+
+  virtual bool MarkTaskCanceled(const TaskID &task_id) = 0;
+
+  virtual absl::optional<TaskSpecification> GetTaskSpec(const TaskID &task_id) const = 0;
+
+  virtual bool IsTaskPending(const TaskID &task_id) const = 0;
+
+  virtual ~TaskFinisherInterface() = default;
+};
+
+}  // namespace core
+}  // namespace ray

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -27,6 +27,7 @@
 #include "ray/common/task/task.h"
 #include "ray/core_worker/store_provider/memory_store/memory_store.h"
 #include "ray/core_worker/task_event_buffer.h"
+#include "ray/core_worker/task_finisher.h"
 #include "ray/stats/metric_defs.h"
 #include "ray/util/counter_map.h"
 #include "src/ray/protobuf/common.pb.h"
@@ -37,47 +38,6 @@ namespace ray {
 namespace core {
 
 class ActorManager;
-
-class TaskFinisherInterface {
- public:
-  virtual void CompletePendingTask(const TaskID &task_id,
-                                   const rpc::PushTaskReply &reply,
-                                   const rpc::Address &actor_addr,
-                                   bool is_application_error) = 0;
-
-  virtual bool RetryTaskIfPossible(const TaskID &task_id,
-                                   const rpc::RayErrorInfo &error_info) = 0;
-
-  virtual void FailPendingTask(const TaskID &task_id,
-                               rpc::ErrorType error_type,
-                               const Status *status = nullptr,
-                               const rpc::RayErrorInfo *ray_error_info = nullptr) = 0;
-
-  virtual bool FailOrRetryPendingTask(const TaskID &task_id,
-                                      rpc::ErrorType error_type,
-                                      const Status *status,
-                                      const rpc::RayErrorInfo *ray_error_info = nullptr,
-                                      bool mark_task_object_failed = true,
-                                      bool fail_immediately = false) = 0;
-
-  virtual void MarkTaskWaitingForExecution(const TaskID &task_id,
-                                           const NodeID &node_id,
-                                           const WorkerID &worker_id) = 0;
-
-  virtual void OnTaskDependenciesInlined(
-      const std::vector<ObjectID> &inlined_dependency_ids,
-      const std::vector<ObjectID> &contained_ids) = 0;
-
-  virtual void MarkDependenciesResolved(const TaskID &task_id) = 0;
-
-  virtual bool MarkTaskCanceled(const TaskID &task_id) = 0;
-
-  virtual absl::optional<TaskSpecification> GetTaskSpec(const TaskID &task_id) const = 0;
-
-  virtual bool IsTaskPending(const TaskID &task_id) const = 0;
-
-  virtual ~TaskFinisherInterface() = default;
-};
 
 class TaskResubmissionInterface {
  public:

--- a/src/ray/core_worker/transport/dependency_resolver.h
+++ b/src/ray/core_worker/transport/dependency_resolver.h
@@ -23,7 +23,7 @@
 #include "ray/common/task/task_spec.h"
 #include "ray/core_worker/actor_creator.h"
 #include "ray/core_worker/store_provider/memory_store/memory_store.h"
-#include "ray/core_worker/task_manager.h"
+#include "ray/core_worker/task_finisher.h"
 
 namespace ray {
 namespace core {

--- a/src/ray/core_worker/transport/scheduling_util.cc
+++ b/src/ray/core_worker/transport/scheduling_util.cc
@@ -18,8 +18,6 @@
 #include <utility>
 #include <vector>
 
-#include "ray/core_worker/transport/actor_scheduling_queue.h"
-
 namespace ray {
 namespace core {
 

--- a/src/ray/core_worker/transport/task_receiver.h
+++ b/src/ray/core_worker/transport/task_receiver.h
@@ -37,7 +37,6 @@
 #include "ray/core_worker/context.h"
 #include "ray/core_worker/fiber.h"
 #include "ray/core_worker/store_provider/memory_store/memory_store.h"
-#include "ray/core_worker/task_manager.h"
 #include "ray/core_worker/transport/actor_scheduling_queue.h"
 #include "ray/core_worker/transport/actor_task_submitter.h"
 #include "ray/core_worker/transport/concurrency_group_manager.h"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

As of now, ray core uses [bazel](https://bazel.build/) as build system, which encourages small targets.
Ray core is not following the best practice, which bundles all related files into several giant targets.

## Related issue number

Closes: #51815

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
