### PR TITLE
[data] Skip writing zero sized blocks to bigquery

### DIFF
--- a/python/ray/data/_internal/datasource/bigquery_datasink.py
+++ b/python/ray/data/_internal/datasource/bigquery_datasink.py
@@ -76,6 +76,10 @@ class BigQueryDatasink(Datasink[None]):
             from google.cloud import bigquery
 
             block = BlockAccessor.for_block(block).to_arrow()
+            
+            if block.num_rows == 0:
+                logger.info("Empty block detected. Skipping write to BigQuery.")
+                return
 
             client = bigquery_datasource._create_client(project_id=project_id)
             job_config = bigquery.LoadJobConfig(autodetect=True)


### PR DESCRIPTION
## Why are these changes needed?

Zero-sized blocks writes crashes the bigquery writer as there's no schema for them (see issue).

## Related issue number

Closes #51892

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
