### PR TITLE
[data] Allow specifying a job_config for bigquery writes

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -4038,7 +4038,7 @@ class Dataset:
                 to control number of tasks to run concurrently. This doesn't change the
                 total number of tasks run. By default, concurrency is dynamically
                 decided based on the available resources.
-            job_config: A bigquery load job configuration object. See 
+            job_config: A bigquery load job configuration object. See
                 https://cloud.google.com/python/docs/reference/bigquery/latest/google.cloud.bigquery.job.LoadJobConfig
                 for valid values.
         """  # noqa: E501

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3998,6 +3998,7 @@ class Dataset:
         overwrite_table: Optional[bool] = True,
         ray_remote_args: Dict[str, Any] = None,
         concurrency: Optional[int] = None,
+        job_config: Optional[Any] = None,
     ) -> None:
         """Write the dataset to a BigQuery dataset table.
 
@@ -4037,6 +4038,9 @@ class Dataset:
                 to control number of tasks to run concurrently. This doesn't change the
                 total number of tasks run. By default, concurrency is dynamically
                 decided based on the available resources.
+            job_config: A bigquery load job configuration object. See 
+                https://cloud.google.com/python/docs/reference/bigquery/latest/google.cloud.bigquery.job.LoadJobConfig
+                for valid values.
         """  # noqa: E501
         if ray_remote_args is None:
             ray_remote_args = {}
@@ -4056,6 +4060,7 @@ class Dataset:
             dataset=dataset,
             max_retry_cnt=max_retry_cnt,
             overwrite_table=overwrite_table,
+            job_config=job_config,
         )
         self.write_datasink(
             datasink,


### PR DESCRIPTION
## Why are these changes needed?

Right now it's not possible to specify a schema for the bigquery table when using `write_bigquery` (it will just guess based on the pyarrow table). This patch makes it possible to do things like:

```
job_config = bigquery.LoadJobConfig(schema=[
    bigquery.SchemaField("content_id", "INTEGER"),
    bigquery.SchemaField("description_embedding", "FLOAT64", mode="REPEATED"),
])
ds.write_bigquery(GOOGLE_PROJECT_ID, f"medal_ml.{self.name}_embeddings", job_config=job_config)
```

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
