### PR TITLE
[Data][minor] fix unclickable file link in ray data error msg

### DIFF
--- a/python/ray/data/exceptions.py
+++ b/python/ray/data/exceptions.py
@@ -64,7 +64,7 @@ def omit_traceback_stdout(fn: Callable) -> Callable:
                         "Exception occurred in user code, with the abbreviated stack "
                         "trace below. By default, the Ray Data internal stack trace "
                         "is omitted from stdout, and only written to the Ray Data log "
-                        f"files at {get_log_directory()}. To "
+                        f"files at `{get_log_directory()}`. To "
                         "output the full stack trace to stdout, set "
                         "`DataContext.log_internal_stack_trace_to_stdout` to True."
                     )


### PR DESCRIPTION
## Why are these changes needed?

When Ray Data raises an error, it links to a logs path:

<img width="1387" alt="image" src="https://github.com/user-attachments/assets/71be6f47-e20d-44fb-bec8-b8dd3cc91214" />

Notice that the trailing period is parsed by the IDE as part of the link, so clicking on it throws an error:

<img width="312" alt="image" src="https://github.com/user-attachments/assets/36d0a402-d1b6-4359-98f2-0b23e117221a" />


## Related issue number

N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
