### PR TITLE
[Serve.llm][docs] Remove accelerator_type from quick start

### DIFF
--- a/doc/source/serve/llm/serving-llms.rst
+++ b/doc/source/serve/llm/serving-llms.rst
@@ -551,7 +551,8 @@ For multimodal models that can process both text and images:
         :sync: server
 
         .. code-block:: python
-
+            
+            # This example needs >= 40GB of GRAM per GPU to work (e.g. L40S, A100, etc.)
             from ray import serve
             from ray.serve.llm import LLMConfig, build_openai_app
 

--- a/doc/source/serve/llm/serving-llms.rst
+++ b/doc/source/serve/llm/serving-llms.rst
@@ -84,8 +84,6 @@ Deployment through ``LLMRouter``
                         min_replicas=1, max_replicas=2,
                     )
                 ),
-                # Pass the desired accelerator type (e.g. A10G, L4, etc.)
-                accelerator_type="A10G",
                 # You can customize the engine arguments (e.g. vLLM engine kwargs)
                 engine_kwargs=dict(
                     tensor_parallel_size=2,
@@ -113,8 +111,6 @@ Deployment through ``LLMRouter``
                         min_replicas=1, max_replicas=2,
                     )
                 ),
-                # Pass the desired accelerator type (e.g. A10G, L4, etc.)
-                accelerator_type="A10G",
                 # You can customize the engine arguments (e.g. vLLM engine kwargs)
                 engine_kwargs=dict(
                     tensor_parallel_size=2,
@@ -188,7 +184,6 @@ For deploying multiple models, you can pass a list of ``LLMConfig`` objects to t
                         min_replicas=1, max_replicas=2,
                     )
                 ),
-                accelerator_type="A10G",
             )
 
             llm_config2 = LLMConfig(
@@ -201,7 +196,6 @@ For deploying multiple models, you can pass a list of ``LLMConfig`` objects to t
                         min_replicas=1, max_replicas=2,
                     )
                 ),
-                accelerator_type="A10G",
             )
 
             app = build_openai_app({"llm_configs": [llm_config1, llm_config2]})
@@ -226,7 +220,6 @@ For deploying multiple models, you can pass a list of ``LLMConfig`` objects to t
                         min_replicas=1, max_replicas=2,
                     )
                 ),
-                accelerator_type="A10G",
             )
 
             llm_config2 = LLMConfig(
@@ -239,7 +232,6 @@ For deploying multiple models, you can pass a list of ``LLMConfig`` objects to t
                         min_replicas=1, max_replicas=2,
                     )
                 ),
-                accelerator_type="A10G",
             )
 
             # Deploy the application
@@ -268,7 +260,6 @@ For production deployments, Ray Serve LLM provides utilities for config-driven d
                     - model_loading_config:
                         model_id: qwen-0.5b
                         model_source: Qwen/Qwen2.5-0.5B-Instruct
-                      accelerator_type: A10G
                       deployment_config:
                         autoscaling_config:
                             min_replicas: 1
@@ -276,7 +267,6 @@ For production deployments, Ray Serve LLM provides utilities for config-driven d
                     - model_loading_config:
                         model_id: qwen-1.5b
                         model_source: Qwen/Qwen2.5-1.5B-Instruct
-                      accelerator_type: A10G
                       deployment_config:
                         autoscaling_config:
                             min_replicas: 1
@@ -308,7 +298,6 @@ For production deployments, Ray Serve LLM provides utilities for config-driven d
             model_loading_config:
               model_id: qwen-0.5b
               model_source: Qwen/Qwen2.5-0.5B-Instruct
-            accelerator_type: A10G
             deployment_config:
               autoscaling_config:
                 min_replicas: 1
@@ -320,7 +309,6 @@ For production deployments, Ray Serve LLM provides utilities for config-driven d
             model_loading_config:
               model_id: qwen-1.5b
               model_source: Qwen/Qwen2.5-1.5B-Instruct
-            accelerator_type: A10G
             deployment_config:
               autoscaling_config:
                 min_replicas: 1
@@ -402,7 +390,6 @@ This allows the weights to be loaded on each replica on-the-fly and be cached vi
                         max_replicas=2,
                     )
                 ),
-                accelerator_type="A10G",
             )
 
             # Build and deploy the model
@@ -458,7 +445,6 @@ For structured output, you can use JSON mode similar to OpenAI's API:
                         max_replicas=2,
                     )
                 ),
-                accelerator_type="A10G",
             )
 
             # Build and deploy the model
@@ -582,7 +568,6 @@ For multimodal models that can process both text and images:
                         max_replicas=2,
                     )
                 ),
-                accelerator_type="L40S",
                 engine_kwargs=dict(
                     tensor_parallel_size=1,
                     max_model_len=8192,
@@ -660,8 +645,7 @@ You can then specify the `bucket_uri` in the `model_loading_config` to point to 
     applications:
     - args:
         llm_configs:
-            - accelerator_type: A10G
-              engine_kwargs:
+            - engine_kwargs:
                 max_model_len: 8192
               model_loading_config:
                 model_id: my_llama
@@ -697,8 +681,6 @@ To set the deployment options, you can use the ``get_serve_options`` method on t
                 min_replicas=1, max_replicas=2,
             )
         ),
-        # Pass the desired accelerator type (e.g. A10G, L4, etc.)
-        accelerator_type="A10G",
         runtime_env=dict(
             env_vars=dict(
                 HF_TOKEN=os.environ["HF_TOKEN"]
@@ -734,8 +716,6 @@ If you are using huggingface models, you can enable fast download by setting `HF
                 min_replicas=1, max_replicas=2,
             )
         ),
-        # Pass the desired accelerator type (e.g. A10G, L4, etc.)
-        accelerator_type="A10G",
         runtime_env=dict(
             env_vars=dict(
                 HF_TOKEN=os.environ["HF_TOKEN"],

--- a/python/ray/llm/_internal/serve/configs/server_models.py
+++ b/python/ray/llm/_internal/serve/configs/server_models.py
@@ -202,7 +202,10 @@ class LLMConfig(BaseModelExtended):
 
     accelerator_type: Optional[str] = Field(
         default=None,
-        description=f"The type of accelerator runs the model on. Only the following values are supported: {str([t.value for t in GPUType])}",
+        description=f"The type of accelerator runs the model on. Only the following values are supported: {str([t.value for t in GPUType])}. "
+        "To specifiy the exact accelerator_type your cluster should show the `accelerator_type:xxx` when you run `ray status`. "
+        "If that is not the case, you need to define it as a custom resource when initializing the ray cluster. "
+        "See https://docs.ray.io/en/latest/ray-core/scheduling/resources.html#custom-resources for more details.",
     )
 
     lora_config: Optional[LoraConfig] = Field(


### PR DESCRIPTION
This [thread](https://discuss.ray.io/t/ray-serve-llm-example-in-document-cannot-work/22199) suggests that leaving accelerator_type as part of the quick start might not be a good idea. If the cluster is not setup properly this path will fail and user may be simply on a head node with GPU not knowing anything about ray's cluster setup. In this case, a simple LLMConfig() should be sufficient to get started. 