### PR TITLE
[data] add min_rows_per_file to lance data sink

### DIFF
--- a/python/ray/data/_internal/datasource/lance_datasink.py
+++ b/python/ray/data/_internal/datasource/lance_datasink.py
@@ -28,7 +28,8 @@ def _write_fragment(
     uri: str,
     *,
     schema: Optional["pa.Schema"] = None,
-    max_rows_per_file: int = 1024 * 1024,
+    min_rows_per_file: int = 1024 * 1024,
+    max_rows_per_file: int = 64 * 1024 * 1024,
     max_bytes_per_file: Optional[int] = None,
     max_rows_per_group: int = 1024,  # Only useful for v1 writer.
     data_storage_version: Optional[str] = None,
@@ -63,6 +64,7 @@ def _write_fragment(
         reader,
         uri,
         schema=schema,
+        min_rows_per_file=min_rows_per_file,
         max_rows_per_file=max_rows_per_file,
         max_rows_per_group=max_rows_per_group,
         max_bytes_per_file=max_bytes_per_file,
@@ -169,8 +171,10 @@ class LanceDatasink(_BaseLanceDatasink):
         mode : str, optional
             The write mode. Default is 'append'.
             Choices are 'append', 'create', 'overwrite'.
+        min_rows_per_file : int, optional
+            The minimum number of rows per file. Default is 1024 * 1024.
         max_rows_per_file : int, optional
-            The maximum number of rows per file. Default is 1024 * 1024.
+            The maximum number of rows per file. Default is 64 * 1024 * 1024.
         data_storage_version: optional, str, default None
             The version of the data storage format to use. Newer versions are more
             efficient but require newer versions of lance to read.  The default is
@@ -187,7 +191,8 @@ class LanceDatasink(_BaseLanceDatasink):
         uri: str,
         schema: Optional[pa.Schema] = None,
         mode: Literal["create", "append", "overwrite"] = "create",
-        max_rows_per_file: int = 1024 * 1024,
+        min_rows_per_file: int = 1024 * 1024,
+        max_rows_per_file: int = 64 * 1024 * 1024,
         data_storage_version: Optional[str] = None,
         storage_options: Optional[Dict[str, Any]] = None,
         *args,
@@ -202,14 +207,15 @@ class LanceDatasink(_BaseLanceDatasink):
             **kwargs,
         )
 
+        self.min_rows_per_file = min_rows_per_file
         self.max_rows_per_file = max_rows_per_file
         self.data_storage_version = data_storage_version
         # if mode is append, read_version is read from existing dataset.
         self.read_version: Optional[int] = None
 
     @property
-    def num_rows_per_write(self) -> int:
-        return self.max_rows_per_file
+    def min_rows_per_file(self) -> int:
+        return self.min_rows_per_file
 
     def get_name(self) -> str:
         return self.NAME

--- a/python/ray/data/_internal/datasource/lance_datasink.py
+++ b/python/ray/data/_internal/datasource/lance_datasink.py
@@ -212,7 +212,7 @@ class LanceDatasink(_BaseLanceDatasink):
         self.read_version: Optional[int] = None
 
     @property
-    def min_rows_per_file(self) -> int:
+    def min_rows_per_write(self) -> int:
         return self.min_rows_per_file
 
     def get_name(self) -> str:

--- a/python/ray/data/_internal/datasource/lance_datasink.py
+++ b/python/ray/data/_internal/datasource/lance_datasink.py
@@ -28,7 +28,6 @@ def _write_fragment(
     uri: str,
     *,
     schema: Optional["pa.Schema"] = None,
-    min_rows_per_file: int = 1024 * 1024,
     max_rows_per_file: int = 64 * 1024 * 1024,
     max_bytes_per_file: Optional[int] = None,
     max_rows_per_group: int = 1024,  # Only useful for v1 writer.
@@ -64,7 +63,6 @@ def _write_fragment(
         reader,
         uri,
         schema=schema,
-        min_rows_per_file=min_rows_per_file,
         max_rows_per_file=max_rows_per_file,
         max_rows_per_group=max_rows_per_group,
         max_bytes_per_file=max_bytes_per_file,

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -5151,9 +5151,9 @@ class Dataset:
         import pyarrow as pa
 
         ref_bundles: Iterator[RefBundle] = self.iter_internal_ref_bundles()
-        block_refs: List[ObjectRef["pyarrow.Table"]] = (
-            _ref_bundles_iterator_to_block_refs_list(ref_bundles)
-        )
+        block_refs: List[
+            ObjectRef["pyarrow.Table"]
+        ] = _ref_bundles_iterator_to_block_refs_list(ref_bundles)
         # Schema is safe to call since we have already triggered execution with
         # iter_internal_ref_bundles.
         schema = self.schema(fetch_if_missing=True)

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -4070,7 +4070,8 @@ class Dataset:
         *,
         schema: Optional["pyarrow.Schema"] = None,
         mode: Literal["create", "append", "overwrite"] = "create",
-        max_rows_per_file: int = 1024 * 1024,
+        min_rows_per_file: int = 1024 * 1024,
+        max_rows_per_file: int = 64 * 1024 * 1024,
         data_storage_version: Optional[str] = None,
         storage_options: Optional[Dict[str, Any]] = None,
         ray_remote_args: Dict[str, Any] = None,
@@ -4091,6 +4092,7 @@ class Dataset:
             path: The path to the destination Lance dataset.
             schema: The schema of the dataset. If not provided, it is inferred from the data.
             mode: The write mode. Can be "create", "append", or "overwrite".
+            min_rows_per_file: The minimum number of rows per file.
             max_rows_per_file: The maximum number of rows per file.
             data_storage_version: The version of the data storage format to use. Newer versions are more
                 efficient but require newer versions of lance to read.  The default is
@@ -4102,6 +4104,7 @@ class Dataset:
             path,
             schema=schema,
             mode=mode,
+            min_rows_per_file=min_rows_per_file,
             max_rows_per_file=max_rows_per_file,
             data_storage_version=data_storage_version,
             storage_options=storage_options,
@@ -5148,9 +5151,9 @@ class Dataset:
         import pyarrow as pa
 
         ref_bundles: Iterator[RefBundle] = self.iter_internal_ref_bundles()
-        block_refs: List[
-            ObjectRef["pyarrow.Table"]
-        ] = _ref_bundles_iterator_to_block_refs_list(ref_bundles)
+        block_refs: List[ObjectRef["pyarrow.Table"]] = (
+            _ref_bundles_iterator_to_block_refs_list(ref_bundles)
+        )
         # Schema is safe to call since we have already triggered execution with
         # iter_internal_ref_bundles.
         schema = self.schema(fetch_if_missing=True)


### PR DESCRIPTION
## Why are these changes needed?

When the lance datasink PR was created the property named `num_rows_per_file` controlled the minimum number of rows per file.  Later, that property changed in https://github.com/ray-project/ray/commit/82274f29fb194c255575abc008e30201c3d09314 .  It appears the PR to add `write_lance` was in-flight at the time and so not included in the refactor.  This change fixes that.

## Related issue number

No issue but I can open one if needed.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [X] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
