### PR TITLE
[core] Fix cgroup test on windows

### DIFF
--- a/.buildkite/windows.rayci.yml
+++ b/.buildkite/windows.rayci.yml
@@ -38,7 +38,7 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //:all //src/... core
         --build-name windowsbuild
         --operating-system windows
-        --except-tags no_windows
+        --except-tags no_windows,cgroup
         --test-env=CI="1"
         --test-env=RAY_CI_POST_WHEEL_TESTS="1"
         --test-env=USERPROFILE


### PR DESCRIPTION
Cgroup test is only supposed to run on ubuntu.