### PR TITLE
[core] Disable windows test for cgroup test

### DIFF
--- a/src/ray/common/cgroup/test/BUILD
+++ b/src/ray/common/cgroup/test/BUILD
@@ -7,6 +7,7 @@ ray_cc_test(
     tags = [
         "cgroup",
         "exclusive",
+        "no_windows",  # Only works on linux.
         "team:core",
     ],
     deps = [


### PR DESCRIPTION
Fix https://github.com/ray-project/ray/issues/51900
The issue is, privileged test requires platform to be linux.