### PR TITLE
[core] Rename plasma targets

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -478,9 +478,9 @@ ray_cc_library(
     linkopts = PLASMA_LINKOPTS,
     deps = [
         ":object_lifecycle_manager",
-        ":object_store",
+        ":plasma_object_store",
         ":plasma_allocator",
-        ":store",
+        ":plasma_store",
         "//src/ray/common:asio",
         "//src/ray/common:file_system_monitor",
         "//src/ray/common:ray_config",
@@ -490,19 +490,19 @@ ray_cc_library(
 )
 
 ray_cc_library(
-    name = "store",
+    name = "plasma_store",
     srcs = ["src/ray/object_manager/plasma/store.cc"],
     hdrs = ["src/ray/object_manager/plasma/store.h"],
     deps = [
-        ":connection_protocol",
-        ":create_request_queue",
-        ":get_request_queue",
         ":object_lifecycle_manager",
         ":object_manager_common",
         ":object_manager_plasma_common",
-        ":object_store",
+        ":plasma_object_store",
         ":plasma_allocator",
+        ":plasma_create_request_queue",
+        ":plasma_connection_protocol",
         ":plasma_eviction_policy",
+        ":plasma_get_request_queue",
         ":plasma_malloc",
         ":stats_metric",
         "//src/ray/common:asio",
@@ -520,11 +520,11 @@ ray_cc_library(
 )
 
 ray_cc_library(
-    name = "get_request_queue",
+    name = "plasma_get_request_queue",
     srcs = ["src/ray/object_manager/plasma/get_request_queue.cc"],
     hdrs = ["src/ray/object_manager/plasma/get_request_queue.h"],
     deps = [
-        ":connection_protocol",
+        ":plasma_connection_protocol",
         ":object_lifecycle_manager",
         "//src/ray/common:asio",
         "//src/ray/common:id",
@@ -536,9 +536,9 @@ ray_cc_library(
     srcs = ["src/ray/object_manager/plasma/object_lifecycle_manager.cc"],
     hdrs = ["src/ray/object_manager/plasma/object_lifecycle_manager.h"],
     deps = [
-        ":connection_protocol",
+        ":plasma_connection_protocol",
         ":object_manager_common",
-        ":object_store",
+        ":plasma_object_store",
         ":plasma_allocator",
         ":plasma_eviction_policy",
         ":stats_collector",
@@ -587,24 +587,24 @@ ray_cc_library(
     deps = [
         ":object_manager_common",
         ":object_manager_plasma_common",
-        ":object_store",
+        ":plasma_object_store",
         ":plasma_allocator",
     ],
 )
 
 ray_cc_library(
-    name = "object_store",
+    name = "plasma_object_store",
     srcs = ["src/ray/object_manager/plasma/object_store.cc"],
     hdrs = ["src/ray/object_manager/plasma/object_store.h"],
     deps = [
-        ":allocator",
+        ":plasma_allocator_interface",
         ":object_manager_plasma_common",
         "@com_google_absl//absl/container:flat_hash_map",
     ],
 )
 
 ray_cc_library(
-    name = "allocator",
+    name = "plasma_allocator_interface",
     hdrs = ["src/ray/object_manager/plasma/allocator.h"],
     deps = [
         ":object_manager_common",
@@ -621,8 +621,8 @@ ray_cc_library(
     srcs = ["src/ray/object_manager/plasma/plasma_allocator.cc"],
     hdrs = ["src/ray/object_manager/plasma/plasma_allocator.h"],
     deps = [
-        ":allocator",
         ":object_manager_common",
+        ":plasma_allocator_interface",
         ":plasma_malloc",
         "//src/ray/common:ray_config",
         "//src/ray/util:logging",
@@ -631,13 +631,13 @@ ray_cc_library(
 )
 
 ray_cc_library(
-    name = "create_request_queue",
+    name = "plasma_create_request_queue",
     srcs = ["src/ray/object_manager/plasma/create_request_queue.cc"],
     hdrs = ["src/ray/object_manager/plasma/create_request_queue.h"],
     deps = [
-        ":connection_protocol",
         ":object_manager_common",
         ":object_manager_plasma_common",
+        ":plasma_connection_protocol",
         "//src/ray/common:file_system_monitor",
         "//src/ray/common:status",
         "@com_google_absl//absl/container:flat_hash_map",
@@ -669,7 +669,7 @@ ray_cc_library(
 )
 
 ray_cc_library(
-    name = "connection_protocol",
+    name = "plasma_connection_protocol",
     srcs = [
         "src/ray/object_manager/plasma/connection.cc",
         "src/ray/object_manager/plasma/protocol.cc",


### PR DESCRIPTION
Followup on https://github.com/ray-project/ray/pull/51825
I found quite a few targets are not named properly;
for example, `allocator` and `store` are pretty general naming and easy to get conflict.

The general practice for bazel is to place bazel targets (aka, BUILD file) into separate folders so they're naturally namespace-d, but somehow we're putting everything under root and we just tolerate it.. at least we manually prefix component name to make it a little clearer.