### PR TITLE
[core] Correctly spill up to max_fused_object_count

### DIFF
--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -188,9 +188,9 @@ bool LocalObjectManager::SpillObjectsOfSize(int64_t num_bytes_to_spill) {
       bytes_to_spill += ray_object->GetSize();
       objects_to_spill.push_back(object_id);
       ++num_to_spill;
-    }
-    if (num_to_spill == max_fused_object_count_) {
-      break;
+      if (num_to_spill == max_fused_object_count_) {
+        break;
+      }
     }
     ++idx;
   }

--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -264,9 +264,10 @@ void LocalObjectManager::SpillObjectsInternal(
     std::function<void(const ray::Status &)> callback) {
   std::vector<ObjectID> objects_to_spill;
   // Filter for the objects that can be spilled.
-  // TODO(dayshah): The logic here should be moved to SpillObjectsOfSize. We can do all of
-  // this logic while creating what we pass into object_ids here and don't need to
-  // recreate objects_to_spill.
+  // TODO(dayshah): The logic in this loop should be moved to SpillObjectsOfSize. We can
+  // do this logic while creating what we pass into object_ids here and don't need
+  // to recreate objects_to_spill. The error status is also thrown away in the callback
+  // here as a debug log, so we wouldn't know if we failed to spill because of the check.
   for (const auto &id : object_ids) {
     // We should not spill an object that we are not the primary copy for, or
     // objects that are already being spilled.

--- a/src/ray/raylet/local_object_manager.cc
+++ b/src/ray/raylet/local_object_manager.cc
@@ -81,7 +81,7 @@ void LocalObjectManager::PinObjectsAndWaitForFree(
     // Callback is invoked when the owner publishes the object to evict.
     auto subscription_callback = [this, owner_address](const rpc::PubMessage &msg) {
       RAY_CHECK(msg.has_worker_object_eviction_message());
-      const auto object_eviction_msg = msg.worker_object_eviction_message();
+      const auto &object_eviction_msg = msg.worker_object_eviction_message();
       const auto object_id = ObjectID::FromBinary(object_eviction_msg.object_id());
       ReleaseFreedObject(object_id);
       core_worker_subscriber_->Unsubscribe(
@@ -122,10 +122,10 @@ void LocalObjectManager::ReleaseFreedObject(const ObjectID &object_id) {
 
   RAY_LOG(DEBUG) << "Unpinning object " << object_id;
   // The object should be in one of these states: pinned, spilling, or spilled.
-  RAY_CHECK((pinned_objects_.count(object_id) > 0) ||
-            (spilled_objects_url_.count(object_id) > 0) ||
-            (objects_pending_spill_.count(object_id) > 0));
-  if (pinned_objects_.count(object_id)) {
+  RAY_CHECK(pinned_objects_.contains(object_id) ||
+            spilled_objects_url_.contains(object_id) ||
+            objects_pending_spill_.contains(object_id));
+  if (pinned_objects_.contains(object_id)) {
     pinned_objects_size_ -= pinned_objects_[object_id]->GetSize();
     pinned_objects_.erase(object_id);
     local_objects_.erase(it);
@@ -167,17 +167,11 @@ void LocalObjectManager::SpillObjectUptoMaxThroughput() {
     if (!SpillObjectsOfSize(min_spilling_size_)) {
       break;
     }
-    {
-      absl::MutexLock lock(&mutex_);
-      can_spill_more = num_active_workers_ < max_active_workers_;
-    }
+    can_spill_more = num_active_workers_ < max_active_workers_;
   }
 }
 
-bool LocalObjectManager::IsSpillingInProgress() {
-  absl::MutexLock lock(&mutex_);
-  return num_active_workers_ > 0;
-}
+bool LocalObjectManager::IsSpillingInProgress() { return num_active_workers_ > 0; }
 
 bool LocalObjectManager::SpillObjectsOfSize(int64_t num_bytes_to_spill) {
   if (RayConfig::instance().object_spilling_config().empty()) {
@@ -186,22 +180,25 @@ bool LocalObjectManager::SpillObjectsOfSize(int64_t num_bytes_to_spill) {
 
   RAY_LOG(DEBUG) << "Choosing objects to spill of total size " << num_bytes_to_spill;
   int64_t bytes_to_spill = 0;
-  auto it = pinned_objects_.begin();
   std::vector<ObjectID> objects_to_spill;
-  int64_t counts = 0;
-  while (it != pinned_objects_.end() && counts < max_fused_object_count_) {
-    if (is_plasma_object_spillable_(it->first)) {
-      bytes_to_spill += it->second->GetSize();
-      objects_to_spill.push_back(it->first);
+  int64_t num_to_spill = 0;
+  size_t idx = 0;
+  for (const auto &[object_id, ray_object] : pinned_objects_) {
+    if (is_plasma_object_spillable_(object_id)) {
+      bytes_to_spill += ray_object->GetSize();
+      objects_to_spill.push_back(object_id);
+      ++num_to_spill;
     }
-    it++;
-    counts += 1;
+    if (num_to_spill == max_fused_object_count_) {
+      break;
+    }
+    ++idx;
   }
   if (objects_to_spill.empty()) {
     return false;
   }
 
-  if (it == pinned_objects_.end() && bytes_to_spill < num_bytes_to_spill &&
+  if (idx == objects_pending_spill_.size() && bytes_to_spill < num_bytes_to_spill &&
       !objects_pending_spill_.empty()) {
     // We have gone through all spillable objects but we have not yet reached
     // the minimum bytes to spill and we are already spilling other objects.
@@ -259,7 +256,7 @@ bool LocalObjectManager::SpillObjectsOfSize(int64_t num_bytes_to_spill) {
 
 void LocalObjectManager::SpillObjects(const std::vector<ObjectID> &object_ids,
                                       std::function<void(const ray::Status &)> callback) {
-  SpillObjectsInternal(object_ids, callback);
+  SpillObjectsInternal(object_ids, std::move(callback));
 }
 
 void LocalObjectManager::SpillObjectsInternal(
@@ -267,6 +264,9 @@ void LocalObjectManager::SpillObjectsInternal(
     std::function<void(const ray::Status &)> callback) {
   std::vector<ObjectID> objects_to_spill;
   // Filter for the objects that can be spilled.
+  // TODO(dayshah): The logic here should be moved to SpillObjectsOfSize. We can do all of
+  // this logic while creating what we pass into object_ids here and don't need to
+  // recreate objects_to_spill.
   for (const auto &id : object_ids) {
     // We should not spill an object that we are not the primary copy for, or
     // objects that are already being spilled.
@@ -302,77 +302,70 @@ void LocalObjectManager::SpillObjectsInternal(
     }
     return;
   }
-  {
-    absl::MutexLock lock(&mutex_);
-    num_active_workers_ += 1;
-  }
-  io_worker_pool_.PopSpillWorker(
-      [this, objects_to_spill, callback](std::shared_ptr<WorkerInterface> io_worker) {
-        rpc::SpillObjectsRequest request;
-        std::vector<ObjectID> requested_objects_to_spill;
-        for (const auto &object_id : objects_to_spill) {
-          auto it = objects_pending_spill_.find(object_id);
-          RAY_CHECK(it != objects_pending_spill_.end());
-          auto freed_it = local_objects_.find(object_id);
-          // If the object hasn't already been freed, spill it.
-          if (freed_it == local_objects_.end() || freed_it->second.is_freed) {
-            num_bytes_pending_spill_ -= it->second->GetSize();
-            objects_pending_spill_.erase(it);
-          } else {
-            auto ref = request.add_object_refs_to_spill();
-            ref->set_object_id(object_id.Binary());
-            ref->mutable_owner_address()->CopyFrom(freed_it->second.owner_address);
-            RAY_LOG(DEBUG) << "Sending spill request for object " << object_id;
-            requested_objects_to_spill.push_back(object_id);
-          }
-        }
+  num_active_workers_ += 1;
+  io_worker_pool_.PopSpillWorker([this, objects_to_spill, callback = std::move(callback)](
+                                     std::shared_ptr<WorkerInterface> io_worker) mutable {
+    rpc::SpillObjectsRequest request;
+    std::vector<ObjectID> requested_objects_to_spill;
+    for (const auto &object_id : objects_to_spill) {
+      auto it = objects_pending_spill_.find(object_id);
+      RAY_CHECK(it != objects_pending_spill_.end());
+      auto freed_it = local_objects_.find(object_id);
+      // If the object hasn't already been freed, spill it.
+      if (freed_it == local_objects_.end() || freed_it->second.is_freed) {
+        num_bytes_pending_spill_ -= it->second->GetSize();
+        objects_pending_spill_.erase(it);
+      } else {
+        auto ref = request.add_object_refs_to_spill();
+        ref->set_object_id(object_id.Binary());
+        ref->mutable_owner_address()->CopyFrom(freed_it->second.owner_address);
+        RAY_LOG(DEBUG) << "Sending spill request for object " << object_id;
+        requested_objects_to_spill.push_back(object_id);
+      }
+    }
 
-        if (request.object_refs_to_spill_size() == 0) {
-          {
-            absl::MutexLock lock(&mutex_);
-            num_active_workers_ -= 1;
-          }
+    if (request.object_refs_to_spill_size() == 0) {
+      { num_active_workers_ -= 1; }
+      io_worker_pool_.PushSpillWorker(io_worker);
+      callback(Status::OK());
+      return;
+    }
+
+    io_worker->rpc_client()->SpillObjects(
+        request,
+        [this,
+         requested_objects_to_spill = std::move(requested_objects_to_spill),
+         callback = std::move(callback),
+         io_worker](const ray::Status &status, const rpc::SpillObjectsReply &r) {
+          num_active_workers_ -= 1;
           io_worker_pool_.PushSpillWorker(io_worker);
-          callback(Status::OK());
-          return;
-        }
+          size_t num_objects_spilled = status.ok() ? r.spilled_objects_url_size() : 0;
+          // Object spilling is always done in the order of the request.
+          // For example, if an object succeeded, it'll guarentee that all objects
+          // before this will succeed.
+          RAY_CHECK(num_objects_spilled <= requested_objects_to_spill.size());
+          for (size_t i = num_objects_spilled; i != requested_objects_to_spill.size();
+               ++i) {
+            const auto &object_id = requested_objects_to_spill[i];
+            auto it = objects_pending_spill_.find(object_id);
+            RAY_CHECK(it != objects_pending_spill_.end());
+            pinned_objects_size_ += it->second->GetSize();
+            num_bytes_pending_spill_ -= it->second->GetSize();
+            pinned_objects_.emplace(object_id, std::move(it->second));
+            objects_pending_spill_.erase(it);
+          }
 
-        io_worker->rpc_client()->SpillObjects(
-            request,
-            [this, requested_objects_to_spill, callback, io_worker](
-                const ray::Status &status, const rpc::SpillObjectsReply &r) {
-              {
-                absl::MutexLock lock(&mutex_);
-                num_active_workers_ -= 1;
-              }
-              io_worker_pool_.PushSpillWorker(io_worker);
-              size_t num_objects_spilled = status.ok() ? r.spilled_objects_url_size() : 0;
-              // Object spilling is always done in the order of the request.
-              // For example, if an object succeeded, it'll guarentee that all objects
-              // before this will succeed.
-              RAY_CHECK(num_objects_spilled <= requested_objects_to_spill.size());
-              for (size_t i = num_objects_spilled; i != requested_objects_to_spill.size();
-                   ++i) {
-                const auto &object_id = requested_objects_to_spill[i];
-                auto it = objects_pending_spill_.find(object_id);
-                RAY_CHECK(it != objects_pending_spill_.end());
-                pinned_objects_size_ += it->second->GetSize();
-                num_bytes_pending_spill_ -= it->second->GetSize();
-                pinned_objects_.emplace(object_id, std::move(it->second));
-                objects_pending_spill_.erase(it);
-              }
-
-              if (!status.ok()) {
-                RAY_LOG(ERROR) << "Failed to send object spilling request: "
-                               << status.ToString();
-              } else {
-                OnObjectSpilled(requested_objects_to_spill, r);
-              }
-              if (callback) {
-                callback(status);
-              }
-            });
-      });
+          if (!status.ok()) {
+            RAY_LOG(ERROR) << "Failed to send object spilling request: "
+                           << status.ToString();
+          } else {
+            OnObjectSpilled(requested_objects_to_spill, r);
+          }
+          if (callback) {
+            callback(status);
+          }
+        });
+  });
 
   // Deleting spilled objects can fall behind when there is a lot
   // of concurrent spilling and object frees. Clear the queue here
@@ -469,7 +462,7 @@ void LocalObjectManager::AsyncRestoreSpilledObject(
     auto start_time = absl::GetCurrentTimeNanos();
     RAY_LOG(DEBUG) << "Sending restore spilled object request";
     rpc::RestoreSpilledObjectsRequest request;
-    request.add_spilled_objects_url(std::move(object_url));
+    request.add_spilled_objects_url(object_url);
     request.add_object_ids_to_restore(object_id.Binary());
     io_worker->rpc_client()->RestoreSpilledObjects(
         request,
@@ -561,7 +554,7 @@ void LocalObjectManager::ProcessSpilledObjectsDeleteQueue(uint32_t max_batch_siz
     local_objects_.erase(object_id);
     spilled_object_pending_delete_.pop();
   }
-  if (object_urls_to_delete.size() > 0) {
+  if (!object_urls_to_delete.empty()) {
     DeleteSpilledObjects(std::move(object_urls_to_delete));
   }
 }
@@ -569,17 +562,19 @@ void LocalObjectManager::ProcessSpilledObjectsDeleteQueue(uint32_t max_batch_siz
 void LocalObjectManager::DeleteSpilledObjects(std::vector<std::string> urls_to_delete,
                                               int64_t num_retries) {
   io_worker_pool_.PopDeleteWorker(
-      [this, urls_to_delete, num_retries](std::shared_ptr<WorkerInterface> io_worker) {
+      [this, urls_to_delete, num_retries](
+          std::shared_ptr<WorkerInterface> io_worker) mutable {
         RAY_LOG(DEBUG) << "Sending delete spilled object request. Length: "
                        << urls_to_delete.size();
         rpc::DeleteSpilledObjectsRequest request;
         for (const auto &url : urls_to_delete) {
-          request.add_spilled_objects_url(std::move(url));
+          request.add_spilled_objects_url(url);
         }
         io_worker->rpc_client()->DeleteSpilledObjects(
             request,
             [this, urls_to_delete = std::move(urls_to_delete), num_retries, io_worker](
-                const ray::Status &status, const rpc::DeleteSpilledObjectsReply &reply) {
+                const ray::Status &status,
+                const rpc::DeleteSpilledObjectsReply &reply) mutable {
               io_worker_pool_.PushDeleteWorker(io_worker);
               if (!status.ok()) {
                 num_failed_deletion_requests_ += 1;
@@ -589,10 +584,12 @@ void LocalObjectManager::DeleteSpilledObjects(std::vector<std::string> urls_to_d
                 if (num_retries > 0) {
                   // retry failed requests.
                   io_service_.post(
-                      [this, urls_to_delete = std::move(urls_to_delete), num_retries]() {
-                        DeleteSpilledObjects(urls_to_delete, num_retries - 1);
+                      [this,
+                       urls_to_delete = std::move(urls_to_delete),
+                       num_retries]() mutable {
+                        DeleteSpilledObjects(std::move(urls_to_delete), num_retries - 1);
                       },
-                      "LocaObjectManager.RetryDeleteSpilledObjects");
+                      "LocalObjectManager.RetryDeleteSpilledObjects");
                 }
               }
             });

--- a/src/ray/raylet/local_object_manager.h
+++ b/src/ray/raylet/local_object_manager.h
@@ -103,6 +103,8 @@ class LocalObjectManager {
   /// \return True if spilling is in progress.
   void SpillObjectUptoMaxThroughput();
 
+  /// TODO(dayshah): This function is only used for testing, we should remove and just
+  /// keep SpillObjectsInternal.
   /// Spill objects to external storage.
   ///
   /// \param objects_ids_to_spill The objects to be spilled.

--- a/src/ray/raylet/local_object_manager.h
+++ b/src/ray/raylet/local_object_manager.h
@@ -183,7 +183,7 @@ class LocalObjectManager {
           object_size(object_size) {}
     rpc::Address owner_address;
     bool is_freed = false;
-    const std::optional<ObjectID> generator_id;
+    std::optional<ObjectID> generator_id;
     size_t object_size;
   };
 
@@ -314,12 +314,8 @@ class LocalObjectManager {
   /// Minimum bytes to spill to a single IO spill worker.
   int64_t min_spilling_size_;
 
-  /// This class is accessed by both the raylet and plasma store threads. The
-  /// mutex protects private members that relate to object spilling.
-  mutable absl::Mutex mutex_;
-
   /// The current number of active spill workers.
-  int64_t num_active_workers_ ABSL_GUARDED_BY(mutex_);
+  std::atomic<int64_t> num_active_workers_;
 
   /// The max number of active spill workers.
   const int64_t max_active_workers_;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This PR contains a fix to correctly spill up to `max_fused_object_count`. Before we would still count objects we decide not to spill if https://github.com/ray-project/ray/blob/2fab5eb87c87d7ab8dbeb5c5f74bc0a60ff66e1b/src/ray/object_manager/plasma/store.cc#L571-L579 returned false. 

This PR also removes the mutex in local_object_manager since it did nothing but protect an int that can just be an atomic. 

Also some of the moves here were moves from function captures which are effectively const if the lambda isn't mutable, so fixed that and added some extra moves to avoid more copies.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
