### PR TITLE
[Data] Cleaning up `find_partitions` method

### DIFF
--- a/python/ray/data/BUILD
+++ b/python/ray/data/BUILD
@@ -213,6 +213,20 @@ py_test(
 )
 
 py_test(
+    name = "test_block",
+    size = "small",
+    srcs = ["tests/test_block.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_block_batching",
     size = "medium",
     srcs = ["tests/block_batching/test_block_batching.py"],

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -20,7 +20,7 @@ from ray.air.util.tensor_extensions.utils import _should_convert_to_tensor
 from ray.data._internal.numpy_support import convert_to_numpy
 from ray.data._internal.row import TableRow
 from ray.data._internal.table_block import TableBlockAccessor, TableBlockBuilder
-from ray.data._internal.util import find_partitions, is_null
+from ray.data._internal.util import is_null
 from ray.data.block import (
     Block,
     BlockAccessor,
@@ -179,6 +179,13 @@ class PandasBlockColumnAccessor(BlockColumnAccessor):
 
     def to_pylist(self) -> List[Any]:
         return self._column.to_list()
+
+    def to_numpy(self, zero_copy_only: bool = False) -> np.ndarray:
+        """NOTE: Unlike Arrow, specifying `zero_copy_only=True` isn't a guarantee
+        that no copy will be made
+        """
+
+        return self._column.to_numpy(copy=not zero_copy_only)
 
     def _as_arrow_compatible(self) -> Union[List[Any], "pyarrow.Array"]:
         return self.to_pylist()
@@ -541,7 +548,9 @@ class PandasBlockAccessor(TableBlockAccessor):
         elif len(boundaries) == 0:
             return [table]
 
-        return find_partitions(table, boundaries, sort_key)
+        return BlockAccessor.for_block(table)._find_partitions_sorted(
+            boundaries, sort_key
+        )
 
     @staticmethod
     def merge_sorted_blocks(

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -507,6 +507,21 @@ class BlockAccessor:
         """Aggregate partially combined and sorted blocks."""
         raise NotImplementedError
 
+    def _find_partitions_sorted(
+        self,
+        boundaries: List[Tuple[Any]],
+        sort_key: "SortKey",
+    ) -> List[Block]:
+        """NOTE: PLEASE READ CAREFULLY
+
+        Returns dataset partitioned using list of boundaries
+
+        This method requires that
+            - Block being sorted (according to `sort_key`)
+            - Boundaries is a sorted list of tuples
+        """
+        raise NotImplementedError
+
     def block_type(self) -> BlockType:
         """Return the block type of this block."""
         raise NotImplementedError
@@ -600,6 +615,10 @@ class BlockColumnAccessor:
 
     def to_pylist(self) -> List[Any]:
         """Converts block column to a list of Python native objects"""
+        raise NotImplementedError()
+
+    def to_numpy(self, zero_copy_only: bool = False) -> np.ndarray:
+        """Converts underlying column to Numpy"""
         raise NotImplementedError()
 
     def _as_arrow_compatible(self) -> Union[List[Any], "pyarrow.Array"]:

--- a/python/ray/data/tests/test_block.py
+++ b/python/ray/data/tests/test_block.py
@@ -1,0 +1,158 @@
+from datetime import datetime
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from ray.data._internal.planner.exchange.sort_task_spec import SortKey
+from ray.data.block import BlockAccessor, BlockColumnAccessor
+
+
+def test_find_partitions_single_column_ascending():
+    table = pa.table({"value": [1, 2, 2, 3, 5]})
+    sort_key = SortKey(key=["value"], descending=[False])
+    boundaries = [(0,), (2,), (4,), (6,)]
+    partitions = BlockAccessor.for_block(table)._find_partitions_sorted(
+        boundaries, sort_key
+    )
+    assert len(partitions) == 5
+    assert partitions[0].to_pydict() == {"value": []}  # <0
+    assert partitions[1].to_pydict() == {"value": [1]}  # [0,2)
+    assert partitions[2].to_pydict() == {"value": [2, 2, 3]}  # [2,4)
+    assert partitions[3].to_pydict() == {"value": [5]}  # [4,6)
+    assert partitions[4].to_pydict() == {"value": []}  # >=6
+
+
+def test_find_partitions_single_column_descending():
+    table = pa.table({"value": [5, 3, 2, 2, 1]})
+    sort_key = SortKey(key=["value"], descending=[True])
+    boundaries = [(6,), (3,), (2,), (0,)]
+    partitions = BlockAccessor.for_block(table)._find_partitions_sorted(
+        boundaries, sort_key
+    )
+    assert len(partitions) == 5
+    assert partitions[0].to_pydict() == {"value": []}  # >=6
+    assert partitions[1].to_pydict() == {"value": [5, 3]}  # [3, 6)
+    assert partitions[2].to_pydict() == {"value": [2, 2]}  # [2, 3)
+    assert partitions[3].to_pydict() == {"value": [1]}  # [0, 2)
+    assert partitions[4].to_pydict() == {"value": []}  # <0
+
+
+def test_find_partitions_multi_column_ascending_first():
+    table = pa.table({"col1": [1, 1, 1, 1, 1, 2, 2], "col2": [4, 3, 2.5, 2, 1, 2, 1]})
+    sort_key = SortKey(key=["col1", "col2"], descending=[False, True])
+    boundaries = [(1, 3), (1, 2), (2, 2), (2, 0)]
+    partitions = BlockAccessor.for_block(table)._find_partitions_sorted(
+        boundaries, sort_key
+    )
+    assert len(partitions) == 5
+    assert partitions[0].to_pydict() == {"col1": [1], "col2": [4]}
+    assert partitions[1].to_pydict() == {"col1": [1, 1], "col2": [3, 2.5]}
+    assert partitions[2].to_pydict() == {"col1": [1, 1], "col2": [2, 1]}
+    assert partitions[3].to_pydict() == {"col1": [2, 2], "col2": [2, 1]}
+    assert partitions[4].to_pydict() == {"col1": [], "col2": []}
+
+
+def test_find_partitions_multi_column_descending_first():
+    table = pa.table({"col1": [2, 2, 1, 1, 1, 1, 1], "col2": [1, 2, 1, 2, 3, 4, 5]})
+    sort_key = SortKey(key=["col1", "col2"], descending=[True, False])
+    boundaries = [(2, 0), (2, 2), (1, 2), (1, 6)]
+    partitions = BlockAccessor.for_block(table)._find_partitions_sorted(
+        boundaries, sort_key
+    )
+    assert len(partitions) == 5
+    assert partitions[0].to_pydict() == {"col1": [], "col2": []}
+    assert partitions[1].to_pydict() == {"col1": [2, 2], "col2": [1, 2]}
+    assert partitions[2].to_pydict() == {"col1": [1, 1], "col2": [1, 2]}
+    assert partitions[3].to_pydict() == {"col1": [1, 1, 1], "col2": [3, 4, 5]}
+    assert partitions[4].to_pydict() == {"col1": [], "col2": []}
+
+
+@pytest.mark.parametrize("null", [None, np.nan])
+def test_find_partitions_table_with_nulls(null):
+    table = pa.table({"value": [1, 2, 3, null, null]})
+    sort_key = SortKey(key=["value"], descending=[False])
+    boundaries = [(2,), (4,)]
+
+    partitions = BlockAccessor.for_block(table)._find_partitions_sorted(
+        boundaries, sort_key
+    )
+
+    assert len(partitions) == 3
+    assert partitions[0].to_pydict() == {"value": [1]}  # <2
+    assert partitions[1].to_pydict() == {"value": [2, 3]}  # [2, 4)
+
+    if null is None:
+        assert partitions[2].to_pydict() == {"value": [null, null]}  # >=4
+    else:
+        # NOTE: NaNs couldn't be compared directly
+        result = partitions[2].to_pydict()
+        assert len(result["value"]) == 2 and all([np.isnan(v) for v in result["value"]])
+
+
+@pytest.mark.parametrize("dtype", ["str", "datetime"])
+def test_find_partitions_object_table_with_nulls(dtype):
+    if dtype == "str":
+        col = pa.array(["a", "b", "c", None, None])
+    elif dtype == "datetime":
+        col = pa.array(
+            [
+                datetime.fromordinal(1),
+                datetime.fromordinal(2),
+                datetime.fromordinal(3),
+                None,
+                None,
+            ]
+        )
+    else:
+        raise ValueError(f"Unexpected dtype={dtype}")
+
+    table = pa.table({"value": col})
+
+    sort_key = SortKey(key=["value"], descending=[False])
+
+    ndarray = BlockColumnAccessor.for_column(col).to_numpy(zero_copy_only=False)
+
+    # Compose boundaries
+    boundaries = [(ndarray[1],), (None,)]
+
+    partitions = BlockAccessor.for_block(table)._find_partitions_sorted(
+        boundaries, sort_key
+    )
+
+    assert len(partitions) == 3
+    assert (
+        partitions[0]["value"].to_pylist() == col[0:1].to_pylist()
+    )  # < second element
+    assert partitions[1]["value"].to_pylist() == col[1:3].to_pylist()  # < None
+    assert partitions[2]["value"].to_pylist() == col[3:].to_pylist()  # remaining
+
+
+@pytest.mark.parametrize("null", [None, np.nan])
+def test_find_partitions_null_boundary(null):
+    table = pa.table({"value": [1, 2, 3]})
+    sort_key = SortKey(key=["value"], descending=[False])
+    boundaries = [(2,), (null,)]
+
+    partitions = BlockAccessor.for_block(table)._find_partitions_sorted(
+        boundaries, sort_key
+    )
+
+    assert len(partitions) == 3
+    assert partitions[0].to_pydict() == {"value": [1]}  # <2
+    assert partitions[1].to_pydict() == {"value": [2, 3]}  # < null (nulls go last)
+    assert partitions[2].to_pydict() == {"value": []}
+
+
+def test_find_partitions_duplicates():
+    table = pa.table({"value": [2, 2, 2, 2, 2]})
+    sort_key = SortKey(key=["value"], descending=[False])
+    boundaries = [(1,), (2,), (3,)]
+    partitions = BlockAccessor.for_block(table)._find_partitions_sorted(
+        boundaries, sort_key
+    )
+    assert len(partitions) == 4
+    assert partitions[0].to_pydict() == {"value": []}  # <1
+    assert partitions[1].to_pydict() == {"value": []}  # [1,2)
+    assert partitions[2].to_pydict() == {"value": [2, 2, 2, 2, 2]}  # [2,3)
+    assert partitions[3].to_pydict() == {"value": []}  # >=3

--- a/python/ray/data/tests/test_util.py
+++ b/python/ray/data/tests/test_util.py
@@ -41,9 +41,30 @@ def test_cached_remote_fn():
 
 def test_null_sentinel():
     """Check that NULL_SENTINEL sorts greater than any other value."""
+
+    assert NULL_SENTINEL != NULL_SENTINEL
+    assert NULL_SENTINEL < NULL_SENTINEL
+    assert NULL_SENTINEL <= NULL_SENTINEL
+    assert not NULL_SENTINEL > NULL_SENTINEL
+    assert not NULL_SENTINEL >= NULL_SENTINEL
+
+    # With NoneType
+    assert None > NULL_SENTINEL
+    assert None >= NULL_SENTINEL
+    assert NULL_SENTINEL < None
+    assert NULL_SENTINEL <= None
+    assert NULL_SENTINEL != None  # noqa: E711
+
+    # With np.nan
+    assert np.nan > NULL_SENTINEL
+    assert np.nan >= NULL_SENTINEL
+    assert NULL_SENTINEL < np.nan
+    assert NULL_SENTINEL <= np.nan
+    assert NULL_SENTINEL != np.nan
+
+    # Rest
     assert NULL_SENTINEL > 1000
     assert NULL_SENTINEL > "abc"
-    assert NULL_SENTINEL == NULL_SENTINEL
     assert NULL_SENTINEL != 1000
     assert NULL_SENTINEL != "abc"
     assert not NULL_SENTINEL < 1000

--- a/python/ray/data/tests/test_util.py
+++ b/python/ray/data/tests/test_util.py
@@ -19,7 +19,6 @@ from ray.data._internal.util import (
     NULL_SENTINEL,
     _check_pyarrow_version,
     find_partition_index,
-    find_partitions,
     iterate_with_retry,
 )
 from ray.data.tests.conftest import *  # noqa: F401, F403
@@ -298,7 +297,7 @@ def test_find_partition_index_with_nulls():
     # Insert (4,) -> belongs before any null => index 3
     assert find_partition_index(table, (4,), sort_key) == 3
     # Insert (None,) -> always belongs at the end
-    assert find_partition_index(table, (None,), sort_key) == 5
+    assert find_partition_index(table, (None,), sort_key) == 3
 
 
 def test_find_partition_index_duplicates():
@@ -321,81 +320,6 @@ def test_find_partition_index_duplicates_descending():
     assert find_partition_index(table, (1,), sort_key) == 5
     # Insert (3,) -> belongs at index 0
     assert find_partition_index(table, (3,), sort_key) == 0
-
-
-def test_find_partitions_single_column_ascending():
-    table = pa.table({"value": [1, 2, 2, 3, 5]})
-    sort_key = SortKey(key=["value"], descending=[False])
-    boundaries = [(0,), (2,), (4,), (6,)]
-    partitions = find_partitions(table, boundaries, sort_key)
-    assert len(partitions) == 5
-    assert partitions[0].to_pydict() == {"value": []}  # <0
-    assert partitions[1].to_pydict() == {"value": [1]}  # [0,2)
-    assert partitions[2].to_pydict() == {"value": [2, 2, 3]}  # [2,4)
-    assert partitions[3].to_pydict() == {"value": [5]}  # [4,6)
-    assert partitions[4].to_pydict() == {"value": []}  # >=6
-
-
-def test_find_partitions_single_column_descending():
-    table = pa.table({"value": [5, 3, 2, 2, 1]})
-    sort_key = SortKey(key=["value"], descending=[True])
-    boundaries = [(6,), (3,), (2,), (0,)]
-    partitions = find_partitions(table, boundaries, sort_key)
-    assert len(partitions) == 5
-    assert partitions[0].to_pydict() == {"value": []}  # >=6
-    assert partitions[1].to_pydict() == {"value": [5, 3]}  # [3, 6)
-    assert partitions[2].to_pydict() == {"value": [2, 2]}  # [2, 3)
-    assert partitions[3].to_pydict() == {"value": [1]}  # [0, 2)
-    assert partitions[4].to_pydict() == {"value": []}  # <0
-
-
-def test_find_partitions_multi_column_ascending_first():
-    table = pa.table({"col1": [1, 1, 1, 1, 1, 2, 2], "col2": [4, 3, 2.5, 2, 1, 2, 1]})
-    sort_key = SortKey(key=["col1", "col2"], descending=[False, True])
-    boundaries = [(1, 3), (1, 2), (2, 2), (2, 0)]
-    partitions = find_partitions(table, boundaries, sort_key)
-    assert len(partitions) == 5
-    assert partitions[0].to_pydict() == {"col1": [1], "col2": [4]}
-    assert partitions[1].to_pydict() == {"col1": [1, 1], "col2": [3, 2.5]}
-    assert partitions[2].to_pydict() == {"col1": [1, 1], "col2": [2, 1]}
-    assert partitions[3].to_pydict() == {"col1": [2, 2], "col2": [2, 1]}
-    assert partitions[4].to_pydict() == {"col1": [], "col2": []}
-
-
-def test_find_partitions_multi_column_descending_first():
-    table = pa.table({"col1": [2, 2, 1, 1, 1, 1, 1], "col2": [1, 2, 1, 2, 3, 4, 5]})
-    sort_key = SortKey(key=["col1", "col2"], descending=[True, False])
-    boundaries = [(2, 0), (2, 2), (1, 2), (1, 6)]
-    partitions = find_partitions(table, boundaries, sort_key)
-    assert len(partitions) == 5
-    assert partitions[0].to_pydict() == {"col1": [], "col2": []}
-    assert partitions[1].to_pydict() == {"col1": [2, 2], "col2": [1, 2]}
-    assert partitions[2].to_pydict() == {"col1": [1, 1], "col2": [1, 2]}
-    assert partitions[3].to_pydict() == {"col1": [1, 1, 1], "col2": [3, 4, 5]}
-    assert partitions[4].to_pydict() == {"col1": [], "col2": []}
-
-
-def test_find_partitions_with_nulls():
-    table = pa.table({"value": [1, 2, 3, None, None]})
-    sort_key = SortKey(key=["value"], descending=[False])
-    boundaries = [(2,), (4,)]
-    partitions = find_partitions(table, boundaries, sort_key)
-    assert len(partitions) == 3
-    assert partitions[0].to_pydict() == {"value": [1]}  # <2
-    assert partitions[1].to_pydict() == {"value": [2, 3]}  # [2, 4)
-    assert partitions[2].to_pydict() == {"value": [None, None]}  # >=4
-
-
-def test_find_partitions_duplicates():
-    table = pa.table({"value": [2, 2, 2, 2, 2]})
-    sort_key = SortKey(key=["value"], descending=[False])
-    boundaries = [(1,), (2,), (3,)]
-    partitions = find_partitions(table, boundaries, sort_key)
-    assert len(partitions) == 4
-    assert partitions[0].to_pydict() == {"value": []}  # <1
-    assert partitions[1].to_pydict() == {"value": []}  # [1,2)
-    assert partitions[2].to_pydict() == {"value": [2, 2, 2, 2, 2]}  # [2,3)
-    assert partitions[3].to_pydict() == {"value": []}  # >=3
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

1. Relocating `find_partitions` into `BlockAccessor) (as `_find_partitions_sorted`)
2. Avoid unnecessary patching ndarrays with null-sentinels
3. Fixing `_OrderedNullSentinel` semantic to follow that one of `np.nan` 
4. Added more tests

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
