### PR TITLE
[core][autoscaler] Don't error if rayStartParams absent

### DIFF
--- a/python/ray/autoscaler/_private/kuberay/autoscaling_config.py
+++ b/python/ray/autoscaler/_private/kuberay/autoscaling_config.py
@@ -225,7 +225,7 @@ def _get_ray_resources_from_group_spec(
     TODO: Expose a better interface in the RayCluster CRD for Ray resource annotations.
     For now, we take the rayStartParams as the primary source of truth.
     """
-    ray_start_params = group_spec["rayStartParams"]
+    ray_start_params = group_spec.get("rayStartParams", {})
     # In KubeRay, Ray container is always the first application container of a Ray Pod.
     k8s_resources = group_spec["template"]["spec"]["containers"][0].get("resources", {})
     group_name = _HEAD_GROUP_NAME if is_head else group_spec["groupName"]

--- a/python/ray/tests/kuberay/test_autoscaling_e2e.py
+++ b/python/ray/tests/kuberay/test_autoscaling_e2e.py
@@ -88,6 +88,8 @@ class KubeRayAutoscalingTest(unittest.TestCase):
                 config = k8s_object
                 break
         head_group = config["spec"]["headGroupSpec"]
+        if "rayStartParams" not in head_group:
+            head_group["rayStartParams"] = {}
         head_group["rayStartParams"][
             "resources"
         ] = '"{\\"Custom1\\": 1, \\"Custom2\\": 5}"'
@@ -97,6 +99,8 @@ class KubeRayAutoscalingTest(unittest.TestCase):
         cpu_group["minReplicas"] = min_replicas
         # Keep maxReplicas big throughout the test.
         cpu_group["maxReplicas"] = 300
+        if "rayStartParams" not in cpu_group:
+            cpu_group["rayStartParams"] = {}
         cpu_group["rayStartParams"][
             "resources"
         ] = '"{\\"Custom1\\": 1, \\"Custom2\\": 5}"'
@@ -105,6 +109,8 @@ class KubeRayAutoscalingTest(unittest.TestCase):
         # (We're not using real GPUs, just adding a GPU annotation for the autoscaler
         # and Ray scheduler.)
         gpu_group = copy.deepcopy(cpu_group)
+        if "rayStartParams" not in gpu_group:
+            gpu_group["rayStartParams"] = {}
         gpu_group["rayStartParams"]["num-gpus"] = "1"
         gpu_group["replicas"] = gpu_replicas
         gpu_group["minReplicas"] = 0


### PR DESCRIPTION
We are planning on making `rayStartParams` optional
and not present in the RayCluster K8s custom resource output
if it's empty. https://github.com/ray-project/kuberay/pull/3202

We need to make its autoscaler code not error when it's absent.
This change is also needed for the integration tests in that PR to pass.

Signed-off-by: David Xia <david@davidxia.com>


## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
