### PR TITLE
[core][autoscaler] fix Pylance type warning

### DIFF
--- a/python/ray/autoscaler/_private/kuberay/autoscaling_config.py
+++ b/python/ray/autoscaler/_private/kuberay/autoscaling_config.py
@@ -354,14 +354,14 @@ def _get_num_gpus(
 
 
 def _get_num_tpus(
-    custom_resource_dict: Dict[str, str],
+    custom_resource_dict: Dict[str, int],
     k8s_resources: Dict[str, Dict[str, str]],
 ) -> Optional[int]:
     """Get TPU custom resource annotation from custom_resource_dict in ray_start_params,
     or k8s_resources, with priority for custom_resource_dict.
     """
     if "TPU" in custom_resource_dict:
-        return int(custom_resource_dict["TPU"])
+        return custom_resource_dict["TPU"]
     else:
         for typ in ["limits", "requests"]:
             tpu_resource_quantity = k8s_resources.get(typ, {}).get("google.com/tpu")


### PR DESCRIPTION
Pylance complains on line 236 of
`python/ray/autoscaler/_private/kuberay/autoscaling_config.py`

```
Argument of type "Dict[str, int]" cannot be assigned to parameter "custom_resource_dict" of type "Dict[str, str]" in function "_get_num_tpus"
  "Dict[str, int]" is incompatible with "Dict[str, str]"
    Type parameter "_VT@dict" is invariant, but "int" is not the same as "str"
    Consider switching from "dict" to "Mapping" which is covariant in the value typePylancereportArgumentType
```

`_get_custom_resources()` always returns a `Dict[str, int]`. So we update `_get_num_tpus()`'s `custom_resource_dict` to be a `Dict[str int]` instead of `Dict[str, str]`.

The int conversion is also not needed.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
