### PR TITLE
[Fix][Core] Fail fast if the dashboard agent fails to launch the HTTP server

### DIFF
--- a/python/ray/dashboard/agent.py
+++ b/python/ray/dashboard/agent.py
@@ -180,43 +180,36 @@ class DashboardAgent:
 
         modules = self._load_modules()
 
-        launch_http_server = True
         if self.http_server:
             try:
                 await self.http_server.start(modules)
             except Exception as e:
-                # TODO(kevin85421): We should fail the agent if the HTTP server
-                # fails to start to avoid hiding the root cause. However,
-                # agent processes are not cleaned up correctly after some tests
-                # finish. If we fail the agent, the CI will always fail until
-                # we fix the leak.
                 logger.exception(
                     f"Failed to start HTTP server with exception: {e}. "
                     "The agent will stay alive but the HTTP service will be disabled.",
                 )
-                launch_http_server = False
+                raise e
 
-        if launch_http_server:
-            # Writes agent address to kv.
-            # DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX: <node_id> -> (ip, http_port, grpc_port)
-            # DASHBOARD_AGENT_ADDR_IP_PREFIX: <ip> -> (node_id, http_port, grpc_port)
-            # -1 should indicate that http server is not started.
-            http_port = -1 if not self.http_server else self.http_server.http_port
-            grpc_port = -1 if not self.server else self.grpc_port
-            put_by_node_id = self.gcs_aio_client.internal_kv_put(
-                f"{dashboard_consts.DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX}{self.node_id}".encode(),
-                json.dumps([self.ip, http_port, grpc_port]).encode(),
-                True,
-                namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
-            )
-            put_by_ip = self.gcs_aio_client.internal_kv_put(
-                f"{dashboard_consts.DASHBOARD_AGENT_ADDR_IP_PREFIX}{self.ip}".encode(),
-                json.dumps([self.node_id, http_port, grpc_port]).encode(),
-                True,
-                namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
-            )
+        # Writes agent address to kv.
+        # DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX: <node_id> -> (ip, http_port, grpc_port)
+        # DASHBOARD_AGENT_ADDR_IP_PREFIX: <ip> -> (node_id, http_port, grpc_port)
+        # -1 should indicate that http server is not started.
+        http_port = -1 if not self.http_server else self.http_server.http_port
+        grpc_port = -1 if not self.server else self.grpc_port
+        put_by_node_id = self.gcs_aio_client.internal_kv_put(
+            f"{dashboard_consts.DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX}{self.node_id}".encode(),
+            json.dumps([self.ip, http_port, grpc_port]).encode(),
+            True,
+            namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
+        )
+        put_by_ip = self.gcs_aio_client.internal_kv_put(
+            f"{dashboard_consts.DASHBOARD_AGENT_ADDR_IP_PREFIX}{self.ip}".encode(),
+            json.dumps([self.node_id, http_port, grpc_port]).encode(),
+            True,
+            namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
+        )
 
-            await asyncio.gather(put_by_node_id, put_by_ip)
+        await asyncio.gather(put_by_node_id, put_by_ip)
 
         tasks = [m.run(self.server) for m in modules]
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
See the description in the corresponding issue for details.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes: ray-project/ray#51925

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
