### PR TITLE
[Data] Adding in missing emitting of metrics to prometheus

### DIFF
--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -248,6 +248,14 @@ class _StatsActor:
             )
         )
 
+        # Actor related metrics
+        self.execution_metrics_actors = (
+            self._create_prometheus_metrics_for_execution_metrics(
+                metrics_group=MetricsGroup.ACTORS,
+                tag_keys=op_tags_keys,
+            )
+        )
+
         # Miscellaneous metrics
         self.execution_metrics_misc = (
             self._create_prometheus_metrics_for_execution_metrics(
@@ -416,6 +424,9 @@ class _StatsActor:
                 field_name,
                 prom_metric,
             ) in self.execution_metrics_obj_store_memory.items():
+                prom_metric.set(stats.get(field_name, 0), tags)
+
+            for field_name, prom_metric in self.execution_metrics_actors.items():
                 prom_metric.set(stats.get(field_name, 0), tags)
 
             for field_name, prom_metric in self.execution_metrics_misc.items():


### PR DESCRIPTION
## Why are these changes needed?
The previous PR to add these actor metrics ([here](https://github.com/ray-project/ray/pull/51082)) was missing the last piece that actually allows the metrics to be emitted to prometheus, this simply adds them in.
<img width="1642" alt="image" src="https://github.com/user-attachments/assets/3b156520-92d9-44c6-afcb-b8235138503f" />


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
