### PR TITLE
[data] deanonymize map operator actors

### DIFF
--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
@@ -170,7 +171,8 @@ class ActorPoolMapOperator(MapOperator):
         if self._ray_remote_args_fn:
             self._refresh_actor_cls()
         actor = self._cls.options(
-            _labels={self._OPERATOR_ID_LABEL_KEY: self.id}
+            name=f"{self.name}.{uuid.uuid4()}",
+            _labels={self._OPERATOR_ID_LABEL_KEY: self.id},
         ).remote(
             ctx,
             src_fn_name=self.name,

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -415,6 +415,11 @@ std::vector<std::string> TaskSpecification::DynamicWorkerOptions() const {
       message_->actor_creation_task_spec().dynamic_worker_options());
 }
 
+const std::string TaskSpecification::ActorName() const {
+  RAY_CHECK(IsActorCreationTask());
+  return message_->actor_creation_task_spec().name();
+}
+
 TaskID TaskSpecification::CallerId() const {
   return TaskID::FromBinary(message_->caller_id());
 }

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -440,6 +440,8 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
 
   int64_t MaxActorRestarts() const;
 
+  const std::string ActorName() const;
+
   std::vector<std::string> DynamicWorkerOptions() const;
 
   std::vector<std::string> DynamicWorkerOptionsOrEmpty() const;

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -3354,7 +3354,11 @@ Status CoreWorker::ExecuteTask(
     return_objects->pop_back();
     task_type = TaskType::ACTOR_CREATION_TASK;
     SetActorId(task_spec.ActorCreationId());
-    task_counter_.BecomeActor(task_spec.FunctionDescriptor()->ClassName());
+    auto actor_name = task_spec.ActorName();
+    if (actor_name.empty()) {
+      actor_name = task_spec.FunctionDescriptor()->ClassName();
+    }
+    task_counter_.BecomeActor(actor_name);
     {
       auto self_actor_handle =
           std::make_unique<ActorHandle>(task_spec.GetSerializedActorHandle());


### PR DESCRIPTION
Currently when the _MapWorker actors are logged into promethetus, they all look the same as _MapWorker. This PR deanonymize these names, by attaching the map function name to these actors.

Test:
- CI

<img width="1858" alt="Screenshot 2025-04-04 at 12 21 44 PM" src="https://github.com/user-attachments/assets/6484eeca-c9f8-4bf5-8c11-77c2794bd0c4" />
