### PR TITLE
[data] correct name of map operator submit task

### DIFF
--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -227,7 +227,7 @@ class ActorPoolMapOperator(MapOperator):
             )
             gen = actor.submit.options(
                 num_returns="streaming",
-                name=self.name,
+                name=f"{self.name}.submit",
                 **self._ray_actor_task_remote_args,
             ).remote(
                 self.data_context,

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -169,11 +169,13 @@ def test_dataset(
         identity_func = identity_fn
         empty_func = empty_fn
         func_name = "identity_fn"
+        task_name = f"ReadRandomBytes->MapBatches({func_name})"
     else:
         compute = ray.data.ActorPoolStrategy()
         identity_func = IdentityClass
         empty_func = EmptyClass
         func_name = "IdentityClass"
+        task_name = f"ReadRandomBytes->MapBatches({func_name}).submit"
 
     ray.shutdown()
     # We need at least 2 CPUs to run a actorpool streaming
@@ -225,7 +227,7 @@ def test_dataset(
                 f"({func_name})).get_location": lambda count: True,
                 "_MapWorker.__init__": lambda count: True,
                 "_MapWorker.get_location": lambda count: True,
-                f"ReadRandomBytes->MapBatches({func_name})": num_tasks,
+                task_name: num_tasks,
             },
         ),
         last_snapshot,


### PR DESCRIPTION
Following up from https://github.com/ray-project/ray/pull/51962, correct the name of the `submit` task.

Test:
- CI