### PR TITLE
[Data] (De)serialization of PyArrow Extension Arrays

### DIFF
--- a/python/ray/_private/arrow_serialization.py
+++ b/python/ray/_private/arrow_serialization.py
@@ -13,8 +13,6 @@ from ray._private.utils import is_in_test
 if TYPE_CHECKING:
     import pyarrow
 
-    from ray.data.extensions import ArrowTensorArray
-
 RAY_DISABLE_CUSTOM_ARROW_JSON_OPTIONS_SERIALIZATION = (
     "RAY_DISABLE_CUSTOM_ARROW_JSON_OPTIONS_SERIALIZATION"
 )
@@ -611,22 +609,6 @@ def _map_array_to_array_payload(a: "pyarrow.MapArray") -> "PicklableArrayPayload
         null_count=a.null_count,
         offset=0,
         children=children,
-    )
-
-
-def _tensor_array_to_array_payload(a: "ArrowTensorArray") -> "PicklableArrayPayload":
-    """Serialize tensor arrays to PicklableArrayPayload."""
-    # Offset is propagated to storage array, and the storage array items align with the
-    # tensor elements, so we only need to do the straightforward creation of the storage
-    # array payload.
-    storage_payload = _array_to_array_payload(a.storage)
-    return PicklableArrayPayload(
-        type=a.type,
-        length=len(a),
-        buffers=[],
-        null_count=a.null_count,
-        offset=0,
-        children=[storage_payload],
     )
 
 

--- a/python/ray/_private/arrow_serialization.py
+++ b/python/ray/_private/arrow_serialization.py
@@ -254,7 +254,7 @@ def _array_payload_to_array(payload: "PicklableArrayPayload") -> "pyarrow.Array"
         assert len(children) == 3, len(children)
         offsets, keys, items = children
         return pa.MapArray.from_arrays(offsets, keys, items)
-    elif isinstance(payload.type, (pa.ExtensionType, pa.BaseExtensionType)):
+    elif isinstance(payload.type, pa.BaseExtensionType):
         assert len(children) == 1, len(children)
         storage = children[0]
         return payload.type.wrap_array(storage)
@@ -305,7 +305,7 @@ def _array_to_array_payload(a: "pyarrow.Array") -> "PicklableArrayPayload":
         return _dictionary_array_to_array_payload(a)
     elif pa.types.is_map(a.type):
         return _map_array_to_array_payload(a)
-    elif isinstance(a.type, (pa.ExtensionType, pa.BaseExtensionType)):
+    elif isinstance(a.type, pa.BaseExtensionType):
         return _extension_array_to_array_payload(a)
     else:
         raise ValueError("Unhandled Arrow array type:", a.type)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This feature adds the ability to (de)serialize arbitrary PyArrow extension arrays. This is needed to use Ray in code bases that use extension arrays.

~The serialization already seemed sufficiently general, but as far as I can tell, the deserialization can not be done in generality. Hence, this setup allows registration of custom deserializers for extension types.~

~For serialization, the selector has been changed from `ExtensionType` to `BaseExtensionType` to accommodate for non-Python ExtensionArrays, like `pyarrow.FixedShapeTensorArray`.~

~This is at the moment a proof-of-concept. If you like the idea, I suppose the registration function may need to move to a better place, and docs need adding.~

The implementation now works without registration on any extension type.

## Related issue number

Closes #51959

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [X] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Generalizes Arrow array (de)serialization to any `pyarrow.BaseExtensionType`, removing tensor-specific handling and adding tests for fixed/variable-shape tensors.
> 
> - **Arrow (De)serialization**:
>   - Switch from tensor-specific checks to generic `pyarrow.BaseExtensionType` handling.
>   - Reconstruct extension arrays via `type.wrap_array(storage)`; serialize via storage payload wrapped with extension metadata.
>   - Remove `ray.air.util.tensor_extensions.arrow` dependencies and special-casing.
> - **Tests**:
>   - Add roundtrip tests for `pa.FixedShapeTensorArray` and a custom variable-shape `ExtensionType`.
>   - Import `PicklableArrayPayload` in tests for constructing payloads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bbcdbea7515b39513a41231b6f36ff551833e83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->