### PR TITLE
[Serve][LLM] Fix ServeReplica deployment failure for DeepSeek

### DIFF
--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
@@ -93,7 +93,7 @@ def _get_async_engine_args(llm_config: LLMConfig) -> "AsyncEngineArgs":
     )
 
 
-@ray.remote()
+@ray.remote
 def _get_vllm_engine_config(
     llm_config: LLMConfig,
 ) -> Tuple["AsyncEngineArgs", "VllmConfig"]:

--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
@@ -343,6 +343,7 @@ class VLLMEngine:
             engine_args,
             engine_config,
             args.placement_group,
+            use_v1=True,
         )
 
     async def _start_engine_v0(self) -> "EngineClient":
@@ -361,6 +362,7 @@ class VLLMEngine:
                 engine_args,
                 engine_config,
                 args.placement_group,
+                use_v1=False,
             )
 
         return await self._start_mq_engine(
@@ -436,9 +438,13 @@ class VLLMEngine:
         engine_args: "AsyncEngineArgs",
         vllm_config: "VllmConfig",
         placement_group: PlacementGroup,
+        use_v1: bool = False,
     ) -> "EngineClient":
         """Creates an async LLM engine from the engine arguments."""
-        from vllm.executor.ray_distributed_executor import RayDistributedExecutor
+        if use_v1:
+            from vllm.v1.executor.ray_distributed_executor import RayDistributedExecutor
+        else:
+            from vllm.executor.ray_distributed_executor import RayDistributedExecutor
 
         vllm_config.parallel_config.placement_group = placement_group
 

--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_models.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_models.py
@@ -150,6 +150,36 @@ class VLLMEngineConfig(BaseModelExtended):
 
         return bundles
 
+    @property
+    def use_gpu(self) -> bool:
+        """
+        Returns True if vLLM is configured to use GPU resources.
+        """
+        if self.resources_per_bundle and self.resources_per_bundle.get("GPU", 0) > 0:
+            return True
+        if not self.accelerator_type:
+            # By default, GPU resources are used
+            return True
+
+        import ray.util.accelerators.accelerators as accelerators
+
+        return self.accelerator_type in (
+            accelerators.NVIDIA_TESLA_V100,
+            accelerators.NVIDIA_TESLA_P100,
+            accelerators.NVIDIA_TESLA_T4,
+            accelerators.NVIDIA_TESLA_P4,
+            accelerators.NVIDIA_TESLA_K80,
+            accelerators.NVIDIA_TESLA_A10G,
+            accelerators.NVIDIA_L4,
+            accelerators.NVIDIA_L40S,
+            accelerators.NVIDIA_A100,
+            accelerators.NVIDIA_H100,
+            accelerators.NVIDIA_H200,
+            accelerators.NVIDIA_H20,
+            accelerators.NVIDIA_A100_40G,
+            accelerators.NVIDIA_A100_80G,
+        )
+
     def get_or_create_pg(self) -> PlacementGroup:
         """Gets or a creates a placement group.
 

--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_models.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_models.py
@@ -161,23 +161,21 @@ class VLLMEngineConfig(BaseModelExtended):
             # By default, GPU resources are used
             return True
 
-        import ray.util.accelerators.accelerators as accelerators
-
         return self.accelerator_type in (
-            accelerators.NVIDIA_TESLA_V100,
-            accelerators.NVIDIA_TESLA_P100,
-            accelerators.NVIDIA_TESLA_T4,
-            accelerators.NVIDIA_TESLA_P4,
-            accelerators.NVIDIA_TESLA_K80,
-            accelerators.NVIDIA_TESLA_A10G,
-            accelerators.NVIDIA_L4,
-            accelerators.NVIDIA_L40S,
-            accelerators.NVIDIA_A100,
-            accelerators.NVIDIA_H100,
-            accelerators.NVIDIA_H200,
-            accelerators.NVIDIA_H20,
-            accelerators.NVIDIA_A100_40G,
-            accelerators.NVIDIA_A100_80G,
+            GPUType.NVIDIA_TESLA_V100,
+            GPUType.NVIDIA_TESLA_P100,
+            GPUType.NVIDIA_TESLA_T4,
+            GPUType.NVIDIA_TESLA_P4,
+            GPUType.NVIDIA_TESLA_K80,
+            GPUType.NVIDIA_TESLA_A10G,
+            GPUType.NVIDIA_L4,
+            GPUType.NVIDIA_L40S,
+            GPUType.NVIDIA_A100,
+            GPUType.NVIDIA_H100,
+            GPUType.NVIDIA_H200,
+            GPUType.NVIDIA_H20,
+            GPUType.NVIDIA_A100_40G,
+            GPUType.NVIDIA_A100_80G,
         )
 
     def get_or_create_pg(self) -> PlacementGroup:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

When testing DeepSeek TP=8, PP=2 with Ray Serve LLM, got the following error:

```
(ServeController pid=1381) ray.exceptions.RayTaskError(RuntimeError): ray::ServeReplica:default:vLLM:deepseek.initialize_and_get_metadata() (pid=750, ip=10.99.48.141, actor_id=db60bea1a2a045da9011b7be01000000, repr=<ray.serve._private.replica.ServeReplica:default:vLLM:deepseek object at 0x7fc8f61e4710>)
...
(ServeController pid=1381)   File "/usr/local/lib/python3.12/dist-packages/vllm/engine/arg_utils.py", line 1313, in create_engine_config
(ServeController pid=1381)     config = VllmConfig(
(ServeController pid=1381)              ^^^^^^^^^^^
(ServeController pid=1381)   File "<string>", line 19, in __init__
(ServeController pid=1381)   File "/usr/local/lib/python3.12/dist-packages/vllm/config.py", line 3625, in __post_init__
(ServeController pid=1381)     current_platform.check_and_update_config(self)
(ServeController pid=1381)   File "/usr/local/lib/python3.12/dist-packages/vllm/platforms/cuda.py", line 157, in check_and_update_config
(ServeController pid=1381)     if use_flashmla and is_flashmla_supported()[0] \
(ServeController pid=1381)                         ^^^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=1381)   File "/usr/local/lib/python3.12/dist-packages/vllm/attention/ops/flashmla.py", line 28, in is_flashmla_supported
(ServeController pid=1381)     if current_platform.get_device_capability()[0] != 9:
(ServeController pid=1381)        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
(ServeController pid=1381) TypeError: 'NoneType' object is not subscriptable
```

This is because `ServeReplica` has no access to GPU.

This PR addresses this issue by running `create_engine_config` on a task with access to GPU.

This PR also fixes V1 distributed ray executor import issue.

With this change, we were able to unblock and run DeepSeek on Ray Serve LLM.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
