### PR TITLE
[serve] catch timeout error when checking if proxy is dead

### DIFF
--- a/python/ray/serve/_private/proxy_state.py
+++ b/python/ray/serve/_private/proxy_state.py
@@ -9,7 +9,7 @@ from typing import Dict, List, Optional, Set, Tuple, Type
 import ray
 from ray import ObjectRef
 from ray.actor import ActorHandle
-from ray.exceptions import RayActorError
+from ray.exceptions import GetTimeoutError, RayActorError
 from ray.serve._private.cluster_node_info_cache import ClusterNodeInfoCache
 from ray.serve._private.common import NodeId
 from ray.serve._private.constants import (
@@ -283,6 +283,8 @@ class ActorProxyWrapper(ProxyWrapper):
         except RayActorError:
             # The actor is dead, so it's ready for shutdown.
             return True
+        except GetTimeoutError:
+            pass
 
         # The actor is still alive, so it's not ready for shutdown.
         return False


### PR DESCRIPTION
## Why are these changes needed?

If the controller checks whether the proxy is dead, and it isn't, then a `GetTimeoutError` will be thrown which pollutes the controller logs with:
```
(ServeController pid=2194548) Traceback (most recent call last):
(ServeController pid=2194548)   File "/home/ubuntu/ray/python/ray/serve/_private/controller.py", line 386, in run_control_loop
(ServeController pid=2194548)     self.shutdown()
(ServeController pid=2194548)   File "/home/ubuntu/ray/python/ray/util/tracing/tracing_helper.py", line 463, in _resume_span
(ServeController pid=2194548)     return method(self, *_args, **_kwargs)
(ServeController pid=2194548)   File "/home/ubuntu/ray/python/ray/serve/_private/controller.py", line 686, in shutdown
(ServeController pid=2194548)     or self.proxy_state_manager.is_ready_for_shutdown()
(ServeController pid=2194548)   File "/home/ubuntu/ray/python/ray/serve/_private/proxy_state.py", line 585, in is_ready_for_shutdown
(ServeController pid=2194548)     return all(
(ServeController pid=2194548)   File "/home/ubuntu/ray/python/ray/serve/_private/proxy_state.py", line 586, in <genexpr>
(ServeController pid=2194548)     proxy_state.is_ready_for_shutdown()
(ServeController pid=2194548)   File "/home/ubuntu/ray/python/ray/serve/_private/proxy_state.py", line 529, in is_ready_for_shutdown
(ServeController pid=2194548)     return self._actor_proxy_wrapper.is_shutdown()
(ServeController pid=2194548)   File "/home/ubuntu/ray/python/ray/serve/_private/proxy_state.py", line 282, in is_shutdown
(ServeController pid=2194548)     ray.get(self._actor_handle.check_health.remote(), timeout=0)
(ServeController pid=2194548)   File "/home/ubuntu/ray/python/ray/_private/auto_init_hook.py", line 21, in auto_init_wrapper
(ServeController pid=2194548)     return fn(*args, **kwargs)
(ServeController pid=2194548)   File "/home/ubuntu/ray/python/ray/_private/client_mode_hook.py", line 103, in wrapper
(ServeController pid=2194548)     return func(*args, **kwargs)
(ServeController pid=2194548)   File "/home/ubuntu/ray/python/ray/_private/worker.py", line 2792, in get
(ServeController pid=2194548)     values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
(ServeController pid=2194548)   File "/home/ubuntu/ray/python/ray/_private/worker.py", line 903, in get_objects
(ServeController pid=2194548)     ] = self.core_worker.get_objects(
(ServeController pid=2194548)   File "python/ray/_raylet.pyx", line 3212, in ray._raylet.CoreWorker.get_objects
(ServeController pid=2194548)     check_status(op_status)
(ServeController pid=2194548)   File "python/ray/includes/common.pxi", line 85, in ray._raylet.check_status
(ServeController pid=2194548)     raise GetTimeoutError(message)
(ServeController pid=2194548) ray.exceptions.GetTimeoutError: Get timed out: some object(s) not ready.
```

Catch `GetTimeoutError` since it means the actor is not yet dead.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
