### PR TITLE
Add return_future to ActorPool.get_next()

### DIFF
--- a/python/ray/util/actor_pool.py
+++ b/python/ray/util/actor_pool.py
@@ -247,7 +247,7 @@ class ActorPool:
         """
         return bool(self._future_to_actor)
 
-    def get_next(self, timeout=None, ignore_if_timedout=False):
+    def get_next(self, timeout=None, ignore_if_timedout=False, return_future=False):
         """Returns the next pending result in order.
 
         This returns the next result produced by submit(), blocking for up to
@@ -306,9 +306,9 @@ class ActorPool:
             raise TimeoutError(
                 timeout_msg + ". The task {} has been ignored.".format(future)
             )
-        return ray.get(future)
+        return future if return_future else ray.get(future)
 
-    def get_next_unordered(self, timeout=None, ignore_if_timedout=False):
+    def get_next_unordered(self, timeout=None, ignore_if_timedout=False, return_future=False):
         """Returns any of the next pending results.
 
         This returns some result produced by submit(), blocking for up to
@@ -367,7 +367,7 @@ class ActorPool:
             raise TimeoutError(
                 timeout_msg + ". The task {} has been ignored.".format(future)
             )
-        return ray.get(future)
+        return future if return_future else ray.get(future)
 
     def _return_actor(self, actor):
         self._idle_actors.append(actor)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

I want to be able to chain two actor pools like:

```
future = pool1.get_next_unordered()
pool2.submit(lambda a, v: a.foo(v), future)
```

I want the object to be passed between an actor in pool1 and and actor in pool2, without having to be fetched to the driver program.

Open to suggestions for better API names.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
