### PR TITLE
[core] Remove unused macro

### DIFF
--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -528,4 +528,3 @@ int main(int argc, char *argv[]) {
 
   main_service.run();
 }
-#endif

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -111,8 +111,6 @@ DEFINE_string(labels,
               "",
               "Define the key-value format of node labels, which is a serialized JSON.");
 
-#ifndef RAYLET_TEST
-
 absl::flat_hash_map<std::string, std::string> parse_node_labels(
     const std::string &labels_json_str) {
   absl::flat_hash_map<std::string, std::string> labels;


### PR DESCRIPTION
It's not used anywhere.
```sh
[~/ray] (master) [gke_hjiang-proj-cgroup-experiment_us-west1_hjiang-cgroup-test]
ubuntu@hjiang-devbox-pg$ git grep "RAYLET_TEST"
src/ray/raylet/main.cc:#ifndef RAYLET_TEST
```