### PR TITLE
[core][autoscaler] test providers exist with defaults

### DIFF
--- a/python/ray/autoscaler/_private/providers.py
+++ b/python/ray/autoscaler/_private/providers.py
@@ -204,11 +204,11 @@ _PROVIDER_PRETTY_NAMES = {
     "aws": "AWS",
     "gcp": "GCP",
     "azure": "Azure",
-    "kubernetes": "Kubernetes",
     "kuberay": "KubeRay",
     "aliyun": "Aliyun",
     "external": "External",
     "vsphere": "vSphere",
+    "spark": "Spark",
 }
 
 _DEFAULT_CONFIGS = {

--- a/python/ray/tests/autoscaler/providers.py
+++ b/python/ray/tests/autoscaler/providers.py
@@ -1,0 +1,36 @@
+import yaml
+from ray.autoscaler._private.providers import (
+    _DEFAULT_CONFIGS,
+    _NODE_PROVIDERS,
+    _PROVIDER_PRETTY_NAMES,
+)
+import unittest
+
+
+class TestProviders(unittest.TestCase):
+    def test_node_providers(self):
+        for provider_name, provider_cls in _NODE_PROVIDERS.items():
+            config = {"module": "ray.autoscaler._private"}
+
+            try:
+                provider_cls(config)
+            except ImportError as e:
+                if f"ray.autoscaler.{provider_name}" in str(e):
+                    self.fail(
+                        f"Unexpected import error for provider {provider_name}: {e}"
+                    )
+
+    def test_provider_pretty_names(self):
+        self.assertEqual(
+            set(_NODE_PROVIDERS.keys()), set(_PROVIDER_PRETTY_NAMES.keys())
+        )
+
+    def test_default_configs(self):
+        for config_loader in _DEFAULT_CONFIGS.values():
+            config_path = config_loader()
+            with open(config_path) as f:
+                yaml.safe_load(f)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
These tests would've prevented this bug.
https://github.com/ray-project/ray/pull/50650

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
