### PR TITLE
[core] split bazel target stats into another folder

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -155,7 +155,7 @@ ray_cc_library(
     srcs = ["src/ray/rpc/server_call.cc"],
     hdrs = ["src/ray/rpc/server_call.h"],
     deps = [
-        ":stats_metric",
+        "//src/ray/stats:stats_metric",
         "//src/ray/common:asio",
         "//src/ray/common:grpc_util",
         "//src/ray/common:id",
@@ -508,7 +508,7 @@ ray_cc_library(
         ":plasma_eviction_policy",
         ":plasma_get_request_queue",
         ":plasma_malloc",
-        ":stats_metric",
+        "//src/ray/stats:stats_metric",
         "//src/ray/common:asio",
         "//src/ray/common:file_system_monitor",
         "//src/ray/common:id",
@@ -561,7 +561,7 @@ ray_cc_library(
     hdrs = ["src/ray/object_manager/plasma/stats_collector.h"],
     deps = [
         ":object_manager_plasma_common",
-        ":stats_metric",
+        "//src/ray/stats:stats_metric",
         "//src/ray/util:counter_map",
     ],
 )
@@ -762,7 +762,7 @@ cc_grpc_library(
 ray_cc_library(
     name = "ray_common",
     deps = [
-        ":stats_metric",
+        "//src/ray/stats:stats_metric",
         "//src/ray/common:asio",
         "//src/ray/common:constants",
         "//src/ray/common:event_stats",
@@ -940,7 +940,7 @@ ray_cc_library(
         ":gcs_service_rpc",
         ":gcs_table_storage",
         ":gcs_usage_stats_client",
-        ":stats_metric",
+        "//src/ray/stats:stats_metric",
     ],
 )
 
@@ -949,7 +949,7 @@ ray_cc_library(
     srcs = ["src/ray/gcs/gcs_server/gcs_health_check_manager.cc"],
     hdrs = ["src/ray/gcs/gcs_server/gcs_health_check_manager.h"],
     deps = [
-        ":stats_metric",
+        "//src/ray/stats:stats_metric",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_github_grpc_grpc//:grpc++",
         "//src/ray/common:id",
@@ -998,7 +998,7 @@ ray_cc_library(
     srcs = ["src/ray/gcs/gcs_server/gcs_job_manager.cc"],
     deps = [
         ":gcs_pb_util",
-        ":stats_metric",
+        "//src/ray/stats:stats_metric",
         "//src/ray/util:event",
         "//src/ray/util:thread_checker",
         ":worker_rpc",
@@ -1081,7 +1081,7 @@ ray_cc_binary(
     visibility = ["//java:__subpackages__"],
     deps = [
         ":gcs_server_lib",
-        ":stats_lib",
+        "//src/ray/stats:stats_lib",
         "//src/ray/util:stream_redirection",
         "//src/ray/util:stream_redirection_options",
         "@com_github_gflags_gflags//:gflags",
@@ -1129,68 +1129,6 @@ ray_cc_library(
     deps = [
         ":publisher_lib",
         ":subscriber_lib",
-    ],
-)
-
-ray_cc_library(
-    name = "stats_opentelemetry",
-    srcs = ["src/ray/stats/opentelemetry_metrics.cc"],
-    deps = [
-        "@io_opentelemetry_cpp//sdk/src/logs",
-        "@io_opentelemetry_cpp//sdk/src/trace",
-    ],
-)
-
-ray_cc_library(
-    name = "stats_metric",
-    srcs = [
-        "src/ray/stats/metric.cc",
-        "src/ray/stats/metric_defs.cc",
-        "src/ray/stats/tag_defs.cc",
-    ],
-    hdrs = [
-        "src/ray/stats/metric.h",
-        "src/ray/stats/metric_defs.h",
-        "src/ray/stats/tag_defs.h",
-    ],
-    deps = [
-        "//src/ray/util",
-        "//src/ray/util:logging",
-        "//src/ray/util:size_literals",
-        "@com_github_jupp0r_prometheus_cpp//pull",
-        "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_absl//absl/memory",
-        "@com_google_absl//absl/strings",
-        "@com_google_googletest//:gtest_prod",
-        "@io_opencensus_cpp//opencensus/stats",
-        "@io_opencensus_cpp//opencensus/tags",
-    ],
-)
-
-ray_cc_library(
-    name = "stats_lib",
-    srcs = [
-        "src/ray/stats/metric_exporter.cc",
-    ],
-    hdrs = [
-        "src/ray/stats/metric.h",
-        "src/ray/stats/metric_exporter.h",
-        "src/ray/stats/stats.h",
-        "src/ray/stats/tag_defs.h",
-    ],
-    linkopts = select({
-        "@platforms//os:windows": [
-        ],
-        "//conditions:default": [
-            "-lpthread",
-        ],
-    }),
-    deps = [
-        ":reporter_rpc",
-        ":stats_metric",
-        "//src/ray/util:size_literals",
-        "@com_github_grpc_grpc//:grpc_opencensus_plugin",
     ],
 )
 
@@ -1336,7 +1274,7 @@ ray_cc_library(
         ":pubsub_lib",
         ":raylet_agent_manager",
         ":runtime_env_agent_client",
-        ":stats_lib",
+        "//src/ray/stats:stats_lib",
         ":wait_manager",
         ":worker",
         ":worker_pool",
@@ -2420,37 +2358,6 @@ ray_cc_test(
     ],
 )
 
-ray_cc_test(
-    name = "stats_test",
-    size = "small",
-    srcs = ["src/ray/stats/stats_test.cc"],
-    tags = [
-        "no_tsan",
-        "stats",
-        "team:core",
-    ],
-    deps = [
-        ":stats_lib",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
-
-ray_cc_test(
-    name = "metric_exporter_grpc_test",
-    size = "small",
-    srcs = [
-        "src/ray/stats/metric_exporter_grpc_test.cc",
-    ],
-    tags = [
-        "stats",
-        "team:core",
-    ],
-    deps = [
-        ":stats_lib",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
-
 ray_cc_library(
     name = "gcs_test_util_lib",
     hdrs = [
@@ -2999,7 +2906,7 @@ ray_cc_library(
     srcs = ["src/ray/object_manager/push_manager.cc"],
     hdrs = ["src/ray/object_manager/push_manager.h"],
     deps = [
-        ":stats_metric",
+        "//src/ray/stats:stats_metric",
         "//src/ray/common:id",
         "//src/ray/common:ray_config",
         "//src/ray/common:status",
@@ -3016,7 +2923,7 @@ ray_cc_library(
     deps = [
         ":object_manager_rpc",
         ":ownership_based_object_directory",
-        ":stats_metric",
+        "//src/ray/stats:stats_metric",
         "//src/ray/common:id",
         "//src/ray/common:ray_config",
         "//src/ray/common:ray_object",
@@ -3243,7 +3150,7 @@ ray_cc_library(
         "//src/ray/common:asio",
         "//src/ray/common:status",
         "//src/ray/common:ray_config",
-        ":stats_lib",
+        "//src/ray/stats:stats_lib",
         "//src/ray/util",
         "//src/ray/util:exponential_backoff",
         "@boost//:asio",
@@ -3550,7 +3457,7 @@ pyx_library(
         "//:redis_client",
         "//:src/ray/ray_exported_symbols.lds",
         "//:src/ray/ray_version_script.lds",
-        "//:stats_lib",
+        "//src/ray/stats:stats_lib",
         "//src/ray/protobuf:serialization_cc_proto",
         "//src/ray/util",
         "//src/ray/util:memory",
@@ -3584,7 +3491,7 @@ ray_cc_binary(
         "//:global_state_accessor_lib",
         "//:src/ray/ray_exported_symbols.lds",
         "//:src/ray/ray_version_script.lds",
-        "//:stats_lib",
+        "//src/ray/stats:stats_lib",
         "@bazel_tools//tools/jdk:jni",
     ],
 )

--- a/src/ray/common/BUILD
+++ b/src/ray/common/BUILD
@@ -233,7 +233,7 @@ ray_cc_library(
     ],
     deps = [
         ":ray_config",
-        "//:stats_metric",
+        "//src/ray/stats:stats_metric",
         "//src/ray/util",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/synchronization",

--- a/src/ray/raylet/scheduling/BUILD.bazel
+++ b/src/ray/raylet/scheduling/BUILD.bazel
@@ -87,7 +87,7 @@ ray_cc_library(
         ":local_task_manager_interface",
         ":scheduler_internal",
         ":scheduler_resource_reporter",
-        "//:stats_lib",
+        "//src/ray/stats:stats_lib",
         "//src/ray/common:ray_config",
         "//src/ray/common:ray_object",
         "//src/ray/common:task_common",

--- a/src/ray/stats/BUILD.bazel
+++ b/src/ray/stats/BUILD.bazel
@@ -1,0 +1,94 @@
+load("//bazel:ray.bzl", "ray_cc_library", "ray_cc_test")
+
+ray_cc_library(
+    name = "stats_opentelemetry",
+    srcs = ["opentelemetry_metrics.cc"],
+    deps = [
+        "@io_opentelemetry_cpp//sdk/src/logs",
+        "@io_opentelemetry_cpp//sdk/src/trace",
+    ],
+)
+
+ray_cc_library(
+    name = "stats_metric",
+    srcs = [
+        "metric.cc",
+        "metric_defs.cc",
+        "tag_defs.cc",
+    ],
+    hdrs = [
+        "metric.h",
+        "metric_defs.h",
+        "tag_defs.h",
+    ],
+    deps = [
+        "//src/ray/util",
+        "//src/ray/util:logging",
+        "//src/ray/util:size_literals",
+        "@com_github_jupp0r_prometheus_cpp//pull",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_prod",
+        "@io_opencensus_cpp//opencensus/stats",
+        "@io_opencensus_cpp//opencensus/tags",
+    ],
+)
+
+ray_cc_library(
+    name = "stats_lib",
+    srcs = [
+        "metric_exporter.cc",
+    ],
+    hdrs = [
+        "metric.h",
+        "metric_exporter.h",
+        "stats.h",
+        "tag_defs.h",
+    ],
+    linkopts = select({
+        "@platforms//os:windows": [
+        ],
+        "//conditions:default": [
+            "-lpthread",
+        ],
+    }),
+    deps = [
+        ":stats_metric",
+        "//:reporter_rpc",
+        "//src/ray/util:size_literals",
+        "@com_github_grpc_grpc//:grpc_opencensus_plugin",
+    ],
+)
+
+ray_cc_test(
+    name = "stats_test",
+    size = "small",
+    srcs = ["stats_test.cc"],
+    tags = [
+        "no_tsan",
+        "stats",
+        "team:core",
+    ],
+    deps = [
+        ":stats_lib",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+ray_cc_test(
+    name = "metric_exporter_grpc_test",
+    size = "small",
+    srcs = [
+        "metric_exporter_grpc_test.cc",
+    ],
+    tags = [
+        "stats",
+        "team:core",
+    ],
+    deps = [
+        ":stats_lib",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/src/ray/stats/tests/BUILD
+++ b/src/ray/stats/tests/BUILD
@@ -6,7 +6,7 @@ ray_cc_test(
     srcs = ["opentelemetry_metrics_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//:stats_opentelemetry",
+        "//src/ray/stats:stats_opentelemetry",
         "@com_google_googletest//:gtest_main",
     ],
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
This PR address the stats part in https://github.com/ray-project/ray/issues/51969. 

Which puts the stats related target into `src/ray/stats`.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/ray-project/ray/issues/52022

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
