### PR TITLE
[CI] Increase the timeout of `test_basic.py` to avoid flakiness

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -310,9 +310,8 @@ py_test_module_list(
 )
 
 py_test_module_list(
-    size = "large",
+    size = "medium",
     files = [
-        "test_basic.py",
         "test_basic_2.py",
         "test_basic_4.py",
         "test_basic_5.py",
@@ -332,6 +331,7 @@ py_test_module_list(
 py_test_module_list(
     size = "large",
     files = [
+        "test_basic.py",
         "test_basic_3.py",
     ],
     tags = [

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -310,7 +310,7 @@ py_test_module_list(
 )
 
 py_test_module_list(
-    size = "medium",
+    size = "large",
     files = [
         "test_basic.py",
         "test_basic_2.py",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`test_basic.py` is flaky because it can't always finish in 5 mins. This PR increases the timeout from 5 mins to 15 mins to avoid the flakiness ([reference](https://bazel.build/reference/be/common-definitions#test.size)).


Example CI runs:
* https://buildkite.com/ray-project/premerge/builds/37867#01960944-e987-490a-93de-d9a080770f0b
* https://buildkite.com/ray-project/premerge/builds/37867#01960991-b261-4187-9e8a-3408a1aeffba

Example screenshot:
![image](https://github.com/user-attachments/assets/ad34b863-a95c-4dd3-9847-adc430deb005)


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
