### PR TITLE
[Serve][LLM] Check GPUType enum value rather than enum itself

### DIFF
--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_models.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_models.py
@@ -162,20 +162,20 @@ class VLLMEngineConfig(BaseModelExtended):
             return True
 
         return self.accelerator_type in (
-            GPUType.NVIDIA_TESLA_V100,
-            GPUType.NVIDIA_TESLA_P100,
-            GPUType.NVIDIA_TESLA_T4,
-            GPUType.NVIDIA_TESLA_P4,
-            GPUType.NVIDIA_TESLA_K80,
-            GPUType.NVIDIA_TESLA_A10G,
-            GPUType.NVIDIA_L4,
-            GPUType.NVIDIA_L40S,
-            GPUType.NVIDIA_A100,
-            GPUType.NVIDIA_H100,
-            GPUType.NVIDIA_H200,
-            GPUType.NVIDIA_H20,
-            GPUType.NVIDIA_A100_40G,
-            GPUType.NVIDIA_A100_80G,
+            GPUType.NVIDIA_TESLA_V100.value,
+            GPUType.NVIDIA_TESLA_P100.value,
+            GPUType.NVIDIA_TESLA_T4.value,
+            GPUType.NVIDIA_TESLA_P4.value,
+            GPUType.NVIDIA_TESLA_K80.value,
+            GPUType.NVIDIA_TESLA_A10G.value,
+            GPUType.NVIDIA_L4.value,
+            GPUType.NVIDIA_L40S.value,
+            GPUType.NVIDIA_A100.value,
+            GPUType.NVIDIA_H100.value,
+            GPUType.NVIDIA_H200.value,
+            GPUType.NVIDIA_H20.value,
+            GPUType.NVIDIA_A100_40G.value,
+            GPUType.NVIDIA_A100_80G.value,
         )
 
     def get_or_create_pg(self) -> PlacementGroup:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Currently `VLLMEngineConfig.accelerator_type` is defined as an enum and used as a string. 

We need to make `accelerator_type` types consistent for the checking to work properly. This PR does so by checking the string value. 

An alternative is to pass in the enum. However, we still need to check string equality because even if we pass in the corresponding enum, pydantic would convert it to a string as `use_enum_values` is set to true.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

This fix is validated by deploying DeepSeek with Ray Serve LLM.

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
