### PR TITLE
[Fix][Core/Dashboard] Don't create `__init__.py` dynamically in tests

### DIFF
--- a/python/ray/dashboard/tests/conftest.py
+++ b/python/ray/dashboard/tests/conftest.py
@@ -1,5 +1,4 @@
 import os
-import pathlib
 
 import pytest
 
@@ -10,13 +9,8 @@ from ray.tests.conftest import *  # noqa
 @pytest.fixture
 def enable_test_module():
     os.environ["RAY_DASHBOARD_MODULE_TEST"] = "true"
-    import ray.dashboard.tests
-
-    p = pathlib.Path(ray.dashboard.modules.__path__[0]) / "tests" / "__init__.py"
-    p.touch(exist_ok=False)
     yield
     os.environ.pop("RAY_DASHBOARD_MODULE_TEST", None)
-    p.unlink(missing_ok=False)
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR fixes dashboard flaky tests by avoiding the dynamic creation of `__init__.py` in tests.

https://buildkite.com/ray-project/postmerge/builds/9359#01960486-c194-4be9-b979-77ce5aa456bc
https://buildkite.com/ray-project/postmerge/builds/9359#01960459-3106-4ce3-9843-9a642b90ba28

## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
