### PR TITLE
[core][autoscaler] test providers exist with defaults

### DIFF
--- a/python/ray/autoscaler/_private/providers.py
+++ b/python/ray/autoscaler/_private/providers.py
@@ -204,11 +204,11 @@ _PROVIDER_PRETTY_NAMES = {
     "aws": "AWS",
     "gcp": "GCP",
     "azure": "Azure",
-    "kubernetes": "Kubernetes",
     "kuberay": "KubeRay",
     "aliyun": "Aliyun",
     "external": "External",
     "vsphere": "vSphere",
+    "spark": "Spark",
 }
 
 _DEFAULT_CONFIGS = {

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -564,6 +564,22 @@ py_test_module_list(
 py_test_module_list(
     size = "small",
     files = [
+        "autoscaler/test_providers.py",
+    ],
+    tags = [
+        "exclusive",
+        "small_size_python_tests",
+        "team:core",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test_module_list(
+    size = "small",
+    files = [
         "kuberay/test_autoscaling_config.py",
         "kuberay/test_kuberay_node_provider.py",
         "test_cli_logger.py",

--- a/python/ray/tests/autoscaler/test_providers.py
+++ b/python/ray/tests/autoscaler/test_providers.py
@@ -1,0 +1,36 @@
+from ray.autoscaler._private.providers import (
+    _NODE_PROVIDERS,
+    _PROVIDER_PRETTY_NAMES,
+    _DEFAULT_CONFIGS,
+)
+import unittest
+import yaml
+
+
+class TestProviders(unittest.TestCase):
+    def test_node_providers(self):
+        for provider_name, provider_cls in _NODE_PROVIDERS.items():
+            config = {"module": "ray.autoscaler._private"}
+
+            try:
+                provider_cls(config)
+            except ImportError as e:
+                if f"ray.autoscaler.{provider_name}" in str(e):
+                    self.fail(
+                        f"Unexpected import error for provider {provider_name}: {e}"
+                    )
+
+    def test_provider_pretty_names(self):
+        self.assertEqual(
+            set(_NODE_PROVIDERS.keys()), set(_PROVIDER_PRETTY_NAMES.keys())
+        )
+
+    def test_default_configs(self):
+        for config_loader in _DEFAULT_CONFIGS.values():
+            config_path = config_loader()
+            with open(config_path) as f:
+                yaml.safe_load(f)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
[core][autoscaler] test providers exist with defaults

These tests would've prevented this bug. #50650

Also test providers pretty names match 1-to-1 with the node providers.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
