### PR TITLE
[Fix][Core/Dashboard] Log to stderr for subprocess modules when `RAY_LOG_TO_STDERR` is set

### DIFF
--- a/doc/source/ray-observability/user-guides/configure-logging.md
+++ b/doc/source/ray-observability/user-guides/configure-logging.md
@@ -45,9 +45,9 @@ System logs may include information about your applications. For example, ``runt
 - ``worker-[worker_id]-[job_id]-[pid].[out|err]``: Python or Java part of Ray drivers and workers. Ray streams all stdout and stderr from Tasks or Actors to these files. Note that job_id is the ID of the driver.
 
 ### System/component logs
-- ``dashboard.[log|err]``: A log file of a Ray Dashboard. ``.log`` files contain logs generated from the dashboard's logger. ``.err`` files contain stdout and stderr printed from the dashboard. They're usually empty except when the dashboard crashes unexpectedly.
+- ``dashboard.[log|out|err]``: A log file of a Ray Dashboard. ``.log`` files contain logs generated from the dashboard's logger. ``.out`` and ``.err`` files contain stdout and stderr printed from the dashboard respectively. They're usually empty except when the dashboard crashes unexpectedly.
 - ``dashboard_agent.log``: Every Ray node has one dashboard agent. This is a log file of the agent.
-- ``dashboard_[module_name].[log|err]``: The log files for the Ray Dashboard child processes, one per each module. ``.log`` files contain logs generated from the module's logger. ``.err`` files contain stdout and stderr printed from the module. They're usually empty except when the module crashes unexpectedly.
+- ``dashboard_[module_name].[log|out|err]``: The log files for the Ray Dashboard child processes, one per each module. ``.log`` files contain logs generated from the module's logger. ``.out`` and ``.err`` files contain stdout and stderr printed from the module respectively. They're usually empty except when the module crashes unexpectedly.
 - ``gcs_server.[out|err]``: The GCS server is a stateless server that manages Ray cluster metadata. It exists only in the head node.
 - ``io-worker-[worker_id]-[pid].[out|err]``: Ray creates IO workers to spill/restore objects to external storage by default from Ray 1.3+. This is a log file of IO workers.
 - ``log_monitor.[log|err]``: The log monitor is in charge of streaming logs to the driver. ``.log`` files contain logs generated from the log monitor's logger. ``.err`` files contain the stdout and stderr printed from the log monitor. They're usually empty except when the log monitor crashes unexpectedly.

--- a/python/ray/dashboard/subprocesses/tests/test_e2e.py
+++ b/python/ray/dashboard/subprocesses/tests/test_e2e.py
@@ -277,16 +277,21 @@ async def test_logging_in_module(aiohttp_client, default_module_config):
         (file_name, content) in matches for (file_name, content) in expected_logs
     ), f"Expected to contain {expected_logs}, got {matches}"
 
-    # Assert that stdout and stderr are logged to "dashboard.TestModule.err"
+    # Assert that stdout is logged to "dashboard.TestModule.out"
+    out_log_file_path = (
+        pathlib.Path(default_module_config.log_dir) / "dashboard_TestModule.out"
+    )
+    with out_log_file_path.open("r") as f:
+        out_log_file_content = f.read()
+    assert out_log_file_content == "In /logging_in_module, stdout\n"
+
+    # Assert that stderr is logged to "dashboard.TestModule.err"
     err_log_file_path = (
         pathlib.Path(default_module_config.log_dir) / "dashboard_TestModule.err"
     )
     with err_log_file_path.open("r") as f:
         err_log_file_content = f.read()
-    assert (
-        err_log_file_content
-        == "In /logging_in_module, stdout\nIn /logging_in_module, stderr\n"
-    )
+    assert err_log_file_content == "In /logging_in_module, stderr\n"
 
 
 async def test_logging_in_module_with_multiple_incarnations(

--- a/python/ray/dashboard/subprocesses/tests/test_e2e.py
+++ b/python/ray/dashboard/subprocesses/tests/test_e2e.py
@@ -277,7 +277,7 @@ async def test_logging_in_module(aiohttp_client, default_module_config):
         (file_name, content) in matches for (file_name, content) in expected_logs
     ), f"Expected to contain {expected_logs}, got {matches}"
 
-    # Assert that stdout is logged to "dashboard.TestModule.out"
+    # Assert that stdout is logged to "dashboard_TestModule.out"
     out_log_file_path = (
         pathlib.Path(default_module_config.log_dir) / "dashboard_TestModule.out"
     )
@@ -285,7 +285,7 @@ async def test_logging_in_module(aiohttp_client, default_module_config):
         out_log_file_content = f.read()
     assert out_log_file_content == "In /logging_in_module, stdout\n"
 
-    # Assert that stderr is logged to "dashboard.TestModule.err"
+    # Assert that stderr is logged to "dashboard_TestModule.err"
     err_log_file_path = (
         pathlib.Path(default_module_config.log_dir) / "dashboard_TestModule.err"
     )

--- a/python/ray/dashboard/subprocesses/utils.py
+++ b/python/ray/dashboard/subprocesses/utils.py
@@ -17,13 +17,14 @@ class ResponseType(enum.Enum):
 
 
 def module_logging_filename(
-    module_name: str, logging_filename: str, is_stderr=False
+    module_name: str, logging_filename: str, extension: str = ""
 ) -> str:
     """
     Parse logging_filename = STEM EXTENSION,
     return STEM _ MODULE_NAME _ EXTENSION
 
-    If is_stderr is True, EXTENSION is ".err"
+    If logging_filename is empty, return empty string.
+    If extension is empty, use the extension from logging_filename.
 
     Example:
     module_name = "TestModule"
@@ -32,9 +33,11 @@ def module_logging_filename(
     EXTENSION = ".log"
     return "dashboard_TestModule.log"
     """
-    stem, extension = os.path.splitext(logging_filename)
-    if is_stderr:
-        extension = ".err"
+    if not logging_filename:
+        return ""
+    stem, ext = os.path.splitext(logging_filename)
+    if not extension:
+        extension = ext
     return f"{stem}_{module_name}{extension}"
 
 


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR:

- Fixes the bug where `RAY_LOG_TO_STDERR` is set but dashboard subprocess modules still log to files.  
- Enables log rotation for dashboard subprocess modules.  
- Updates the extension for stdout of dashboard subprocess modules to `.out` to match the dashboard parent process.  
- Updates the corresponding documentation for dashboard log file names.

## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
