### PR TITLE
[core] thread-safety-reference-return Fixes

### DIFF
--- a/bazel/ray.bzl
+++ b/bazel/ray.bzl
@@ -11,10 +11,6 @@ COPTS_WITHOUT_LOG = select({
         # TODO(mehrdadn): (How to) support dynamic linking?
         "-DRAY_STATIC",
     ],
-    "@platforms//os:osx": [
-        # TODO(dayshah): The fixes required to keep this on break Java tests. Fix ASAP!
-        "-Wno-thread-safety-reference-return",
-    ],
     "//conditions:default": [
         "-Wunused-result",
         "-Wconversion-null",

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -96,7 +96,7 @@ cdef extern from "ray/core_worker/context.h" nogil:
         c_bool GetCurrentActorShouldExit()
         const c_string &GetCurrentSerializedRuntimeEnv()
         int CurrentActorMaxConcurrency()
-        const CActorID &GetRootDetachedActorID()
+        CActorID GetRootDetachedActorID()
 
 cdef extern from "ray/core_worker/generator_waiter.h" nogil:
     cdef cppclass CGeneratorBackpressureWaiter "ray::core::GeneratorBackpressureWaiter": # noqa
@@ -205,10 +205,10 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         CNodeID GetCurrentNodeId()
         int64_t GetTaskDepth()
         c_bool GetCurrentTaskRetryExceptions()
-        CPlacementGroupID GetCurrentPlacementGroupId()
+        CPlacementGroupID GetCurrentPlacementGroupId() const
         CWorkerID GetWorkerID()
         c_bool ShouldCaptureChildTasksInPlacementGroup()
-        const CActorID &GetActorId()
+        CActorID GetActorId() const
         const c_string GetActorName()
         void SetActorTitle(const c_string &title)
         void SetActorReprName(const c_string &repr_name)

--- a/src/ray/core_worker/context.cc
+++ b/src/ray/core_worker/context.cc
@@ -348,10 +348,18 @@ std::shared_ptr<const TaskSpecification> WorkerContext::GetCurrentTask() const {
   return GetThreadContext().GetCurrentTask();
 }
 
+// TODO(dayshah): Fixing thread-safety-reference-return here causes Java test failures.
+// Fix in follow up.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wthread-safety-reference-return"
 const ActorID &WorkerContext::GetCurrentActorID() const {
   absl::ReaderMutexLock lock(&mutex_);
   return current_actor_id_;
 }
+#pragma clang diagnostic pop
+#pragma clang diagnostic pop
 
 ActorID WorkerContext::GetRootDetachedActorID() const {
   absl::ReaderMutexLock lock(&mutex_);

--- a/src/ray/core_worker/context.cc
+++ b/src/ray/core_worker/context.cc
@@ -350,6 +350,7 @@ std::shared_ptr<const TaskSpecification> WorkerContext::GetCurrentTask() const {
 
 // TODO(dayshah): Fixing thread-safety-reference-return here causes Java test failures.
 // Fix in follow up.
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunknown-warning-option"
 #pragma clang diagnostic push
@@ -360,6 +361,7 @@ const ActorID &WorkerContext::GetCurrentActorID() const {
 }
 #pragma clang diagnostic pop
 #pragma clang diagnostic pop
+#endif
 
 ActorID WorkerContext::GetRootDetachedActorID() const {
   absl::ReaderMutexLock lock(&mutex_);

--- a/src/ray/core_worker/context.cc
+++ b/src/ray/core_worker/context.cc
@@ -355,10 +355,12 @@ std::shared_ptr<const TaskSpecification> WorkerContext::GetCurrentTask() const {
 #pragma clang diagnostic ignored "-Wunknown-warning-option"
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wthread-safety-reference-return"
+#endif
 const ActorID &WorkerContext::GetCurrentActorID() const {
   absl::ReaderMutexLock lock(&mutex_);
   return current_actor_id_;
 }
+#ifdef __clang__
 #pragma clang diagnostic pop
 #pragma clang diagnostic pop
 #endif

--- a/src/ray/core_worker/context.cc
+++ b/src/ray/core_worker/context.cc
@@ -227,7 +227,7 @@ const TaskID &WorkerContext::GetCurrentInternalTaskId() const {
   return GetThreadContext().GetCurrentInternalTaskId();
 }
 
-const PlacementGroupID &WorkerContext::GetCurrentPlacementGroupId() const {
+PlacementGroupID WorkerContext::GetCurrentPlacementGroupId() const {
   absl::ReaderMutexLock lock(&mutex_);
   // If the worker is an actor, we should return the actor's placement group id.
   if (current_actor_id_ != ActorID::Nil()) {
@@ -353,7 +353,7 @@ const ActorID &WorkerContext::GetCurrentActorID() const {
   return current_actor_id_;
 }
 
-const ActorID &WorkerContext::GetRootDetachedActorID() const {
+ActorID WorkerContext::GetRootDetachedActorID() const {
   absl::ReaderMutexLock lock(&mutex_);
   return root_detached_actor_id_;
 }

--- a/src/ray/core_worker/context.h
+++ b/src/ray/core_worker/context.h
@@ -63,7 +63,7 @@ class WorkerContext {
 
   TaskID GetMainThreadOrActorCreationTaskID() const;
 
-  const PlacementGroupID &GetCurrentPlacementGroupId() const ABSL_LOCKS_EXCLUDED(mutex_);
+  PlacementGroupID GetCurrentPlacementGroupId() const ABSL_LOCKS_EXCLUDED(mutex_);
 
   bool ShouldCaptureChildTasksInPlacementGroup() const ABSL_LOCKS_EXCLUDED(mutex_);
 
@@ -98,7 +98,7 @@ class WorkerContext {
 
   const ActorID &GetCurrentActorID() const ABSL_LOCKS_EXCLUDED(mutex_);
 
-  const ActorID &GetRootDetachedActorID() const ABSL_LOCKS_EXCLUDED(mutex_);
+  ActorID GetRootDetachedActorID() const ABSL_LOCKS_EXCLUDED(mutex_);
 
   /// Returns whether the current thread is the main worker thread.
   bool CurrentThreadIsMain() const;

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1010,8 +1010,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   ///
 
   ActorID GetActorId() const {
-    // TODO(dayshah): Figure out why Java tests fail if we lock here.
-    // absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(&mutex_);
     return actor_id_;
   }
 
@@ -1832,8 +1831,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   mutable absl::Mutex mutex_;
 
   /// Our actor ID. If this is nil, then we execute only stateless tasks.
-  /// TODO(dayshah): Java tests fail if we access this without a mutex.
-  ActorID actor_id_;
+  ActorID actor_id_ ABSL_GUARDED_BY(mutex_);
 
   /// The currently executing task spec. We have to track this separately since
   /// we cannot access the thread-local worker contexts from GetCoreWorkerStats()

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -305,7 +305,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   // This function is called periodically on the io_service_.
   void TryDelPendingObjectRefStreams();
 
-  const PlacementGroupID &GetCurrentPlacementGroupId() const {
+  PlacementGroupID GetCurrentPlacementGroupId() const {
     return worker_context_.GetCurrentPlacementGroupId();
   }
 
@@ -1009,7 +1009,7 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// Public methods related to task execution. Should not be used by driver processes.
   ///
 
-  const ActorID &GetActorId() const {
+  ActorID GetActorId() const {
     // TODO(dayshah): Figure out why Java tests fail if we lock here.
     // absl::MutexLock lock(&mutex_);
     return actor_id_;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
clang-17 has thread-safety-reference-return, which highlighted some thread safety issues that are fixed here.

There's one spot where we're not fixing because it makes Java tests fail.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
