### PR TITLE
[Data] Fix bug where `_resolve_paths_and_filesystem` strips protocol from HTTP paths

### DIFF
--- a/python/ray/data/BUILD
+++ b/python/ray/data/BUILD
@@ -549,6 +549,20 @@ py_test(
 )
 
 py_test(
+    name = "test_path_util",
+    size = "small",
+    srcs = ["tests/test_path_util.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_tensor",
     size = "small",
     srcs = ["tests/test_tensor.py"],

--- a/python/ray/data/datasource/path_util.py
+++ b/python/ray/data/datasource/path_util.py
@@ -3,7 +3,7 @@ import sys
 import urllib
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
-from ray.data._internal.util import _resolve_custom_scheme
+from ray.data._internal.util import RetryingPyFileSystem, _resolve_custom_scheme
 
 if TYPE_CHECKING:
     import pyarrow
@@ -74,7 +74,6 @@ def _resolve_paths_and_filesystem(
     elif len(paths) == 0:
         raise ValueError("Must provide at least one path.")
 
-    need_unwrap_path_protocol = True
     if filesystem and not isinstance(filesystem, FileSystem):
         err_msg = (
             f"The filesystem passed must either conform to "
@@ -92,12 +91,6 @@ def _resolve_paths_and_filesystem(
             raise TypeError(err_msg) from None
         if not isinstance(filesystem, fsspec.spec.AbstractFileSystem):
             raise TypeError(err_msg) from None
-        if isinstance(filesystem, HTTPFileSystem):
-            # If filesystem is fsspec HTTPFileSystem, the protocol/scheme of paths
-            # should not be unwrapped/removed, because HTTPFileSystem expects full file
-            # paths including protocol/scheme. This is different behavior compared to
-            # file systems implementation in pyarrow.fs.FileSystem.
-            need_unwrap_path_protocol = False
 
         filesystem = PyFileSystem(FSSpecHandler(filesystem))
 
@@ -129,19 +122,45 @@ def _resolve_paths_and_filesystem(
 
                     resolved_filesystem = PyFileSystem(FSSpecHandler(HTTPFileSystem()))
                     resolved_path = path
-                    need_unwrap_path_protocol = False
                 else:
                     raise
             else:
                 raise
+
         if filesystem is None:
             filesystem = resolved_filesystem
-        elif need_unwrap_path_protocol:
+
+        # If the PyArrow filesystem is handled by a fsspec HTTPFileSystem, the protocol/
+        # scheme of paths should not be unwrapped/removed, because HTTPFileSystem
+        # expects full file paths including protocol/scheme. This is different behavior
+        # compared to other file system implementation in pyarrow.fs.FileSystem.
+        if not _is_http_filesystem(filesystem):
             resolved_path = _unwrap_protocol(resolved_path)
+
         resolved_path = filesystem.normalize_path(resolved_path)
         resolved_paths.append(resolved_path)
 
     return resolved_paths, filesystem
+
+
+def _is_http_filesystem(fs: "pyarrow.fs.FileSystem") -> bool:
+    """Return whether ``fs`` is a PyFileSystem handled by a fsspec HTTPFileSystem."""
+    from pyarrow.fs import FSSpecHandler, PyFileSystem
+
+    try:
+        from fsspec.implementations.http import HTTPFileSystem
+    except ModuleNotFoundError:
+        return False
+
+    if isinstance(fs, RetryingPyFileSystem):
+        fs = fs.unwrap()
+
+    if not isinstance(fs, PyFileSystem):
+        return False
+
+    return isinstance(fs.handler, FSSpecHandler) and isinstance(
+        fs.handler.fs, HTTPFileSystem
+    )
 
 
 def _unwrap_protocol(path):

--- a/python/ray/data/tests/test_file_based_datasource.py
+++ b/python/ray/data/tests/test_file_based_datasource.py
@@ -1,6 +1,5 @@
 import os
 from typing import Iterator
-from unittest import mock
 
 import pyarrow
 import pytest
@@ -9,22 +8,6 @@ import ray
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data.block import Block
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
-from ray.data.datasource.path_util import _has_file_extension, _is_local_windows_path
-
-
-@pytest.mark.parametrize(
-    "path, extensions, has_extension",
-    [
-        ("foo.csv", ["csv"], True),
-        ("foo.csv", ["json", "csv"], True),
-        ("foo.csv", ["json", "jsonl"], False),
-        ("foo.parquet.crc", ["parquet"], False),
-        ("foo.parquet.crc", ["crc"], True),
-        ("foo.csv", None, True),
-    ],
-)
-def test_has_file_extension(path, extensions, has_extension):
-    assert _has_file_extension(path, extensions) == has_extension
 
 
 class MockFileBasedDatasource(FileBasedDatasource):
@@ -119,13 +102,6 @@ def test_flaky_datasource(ray_start_regular_shared):
     datasource = FlakyCSVDatasource(["example://iris.csv"])
     ds = ray.data.read_datasource(datasource)
     assert len(ds.take()) == 20
-
-
-def test_windows_path():
-    with mock.patch("sys.platform", "win32"):
-        assert _is_local_windows_path("c:/some/where")
-        assert _is_local_windows_path("c:\\some\\where")
-        assert _is_local_windows_path("c:\\some\\where/mixed")
 
 
 @pytest.mark.parametrize("shuffle", [True, False, "file"])

--- a/python/ray/data/tests/test_path_util.py
+++ b/python/ray/data/tests/test_path_util.py
@@ -1,0 +1,61 @@
+from unittest import mock
+
+import pyarrow
+import pytest
+from fsspec.implementations.http import HTTPFileSystem
+from pyarrow.fs import FSSpecHandler, PyFileSystem
+
+from ray.data.datasource.path_util import (
+    _has_file_extension,
+    _is_local_windows_path,
+    _resolve_paths_and_filesystem,
+)
+
+
+@pytest.mark.parametrize(
+    "path, extensions, has_extension",
+    [
+        ("foo.csv", ["csv"], True),
+        ("foo.csv", ["json", "csv"], True),
+        ("foo.csv", ["json", "jsonl"], False),
+        ("foo.parquet.crc", ["parquet"], False),
+        ("foo.parquet.crc", ["crc"], True),
+        ("foo.csv", None, True),
+    ],
+)
+def test_has_file_extension(path, extensions, has_extension):
+    assert _has_file_extension(path, extensions) == has_extension
+
+
+@pytest.mark.parametrize(
+    "filesystem", [None, PyFileSystem(FSSpecHandler(HTTPFileSystem()))]
+)
+def test_resolve_http_paths(filesystem):
+    resolved_paths, resolve_filesystem = _resolve_paths_and_filesystem(
+        "https://google.com", filesystem
+    )
+    # `_resolve_paths_and_filesystem` shouldn't remove the protocol/scheme from the
+    # path for HTTP paths.
+    assert resolved_paths == ["https://google.com"]
+    assert isinstance(resolve_filesystem, pyarrow.fs.PyFileSystem)
+    assert isinstance(resolve_filesystem.handler, pyarrow.fs.FSSpecHandler)
+    assert isinstance(resolve_filesystem.handler.fs, HTTPFileSystem)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "c:/some/where",
+        "c:\\some\\where",
+        "c:\\some\\where/mixed",
+    ],
+)
+def test_windows_path(path):
+    with mock.patch("sys.platform", "win32"):
+        assert _is_local_windows_path(path)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If you want to load data from HTTP paths with a FSSpec HTTPFileSystem, you need to keep the scheme in paths (`http://`). The problem is that `_resolve_paths_and_filesystem` keeps the scheme if `filesystem=None` (expected) but strips the scheme if `filesystem != None` (unexpected).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
