### PR TITLE
[ray.data.llm] Add retries and exponential backoff to `HTTPRequestStage`

### DIFF
--- a/python/ray/llm/_internal/batch/processor/http_request_proc.py
+++ b/python/ray/llm/_internal/batch/processor/http_request_proc.py
@@ -80,6 +80,7 @@ def build_http_request_processor(
                 qps=config.qps,
                 max_retries=config.max_retries,
                 base_retry_wait_time_in_s=config.base_retry_wait_time_in_s,
+                session_factory=config.session_factory,
             ),
             map_batches_kwargs=dict(
                 concurrency=config.concurrency,

--- a/python/ray/llm/_internal/batch/processor/http_request_proc.py
+++ b/python/ray/llm/_internal/batch/processor/http_request_proc.py
@@ -51,6 +51,8 @@ class HttpRequestProcessorConfig(ProcessorConfig):
     session_factory: Optional[Callable[[], ClientSession]] = Field(
         default=None,
         description="Optional session factory to be used for initializing a client session. ",
+        # exclude from JSON serialization since `session_factory` is a callable
+        exclude=True,
     )
 
 

--- a/python/ray/llm/_internal/batch/processor/http_request_proc.py
+++ b/python/ray/llm/_internal/batch/processor/http_request_proc.py
@@ -1,9 +1,8 @@
 """The HTTP request processor."""
 
-from typing import Any, Dict, Optional, Callable
+from typing import Any, Dict, Optional
 
 from pydantic import Field
-from aiohttp import ClientSession
 
 from ray.data.block import UserDefinedFunction
 
@@ -48,9 +47,10 @@ class HttpRequestProcessorConfig(ProcessorConfig):
         default=1,
         description="The base wait time for a retry during exponential backoff.",
     )
-    session_factory: Optional[Callable[[], ClientSession]] = Field(
+    # Since `session_factory` is a callable, we use type Any to avoid pydantic serialization issues
+    session_factory: Optional[Any] = Field(
         default=None,
-        description="Optional session factory to be used for initializing a client session. ",
+        description="Optional session factory to be used for initializing a client session. Type: Callable[[], ClientSession]",
         # exclude from JSON serialization since `session_factory` is a callable
         exclude=True,
     )

--- a/python/ray/llm/_internal/batch/stages/http_request_stage.py
+++ b/python/ray/llm/_internal/batch/stages/http_request_stage.py
@@ -12,7 +12,6 @@ from ray.llm._internal.batch.stages.base import StatefulStage, StatefulStageUDF
 
 
 class HttpRequestUDF(StatefulStageUDF):
-
     RETRYABLE_STATUS_CODES = [429, 408, 504, 502, 503]
 
     def __init__(
@@ -58,7 +57,7 @@ class HttpRequestUDF(StatefulStageUDF):
             A generator of rows of the response of the HTTP request.
         """
         # preprocess to get request body for the given batch
-        request_bodies = []
+        request_bodies = [None] * len(batch)
         for row in batch:
             # Normalize the row to a JSON body.
             json_body = {}
@@ -67,7 +66,8 @@ class HttpRequestUDF(StatefulStageUDF):
                     json_body[key] = value.tolist()
                 else:
                     json_body[key] = value
-            request_bodies.append(json_body)
+            request_bodies[row[self.IDX_IN_BATCH_COLUMN]] = json_body
+
         async with self.session_factory() as session:
             start_time = time.time()
             request_count = 0

--- a/python/ray/llm/_internal/batch/stages/http_request_stage.py
+++ b/python/ray/llm/_internal/batch/stages/http_request_stage.py
@@ -78,10 +78,8 @@ class HttpRequestUDF(StatefulStageUDF):
 
             # First send all requests based on QPS
             for row_idx_in_list, row in enumerate(batch):
-                print(f"HEREERERE: {self.qps}")
                 # Rate limit based on qps if specified
                 if self.qps is not None:
-                    print("INSIDE")
                     request_count += 1
                     expected_time = request_count / self.qps
                     elapsed = time.time() - start_time
@@ -125,7 +123,6 @@ class HttpRequestUDF(StatefulStageUDF):
                                 await asyncio.sleep(wait_time)
                                 continue
                             resp_json = await response.json()
-                            print(f"json : {resp_json}")
                             if self.IDX_IN_BATCH_COLUMN in resp_json:
                                 raise ValueError(
                                     "The response of the HTTP request must not contain "

--- a/python/ray/llm/tests/batch/cpu/stages/test_http_request_stage.py
+++ b/python/ray/llm/tests/batch/cpu/stages/test_http_request_stage.py
@@ -1,84 +1,70 @@
 import sys
 
+import aiohttp.web_exceptions
 import pytest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, patch, call
 from ray.llm._internal.batch.stages.http_request_stage import HttpRequestUDF
+import asyncio
+import aiohttp
 
 
 @pytest.fixture
 def mock_response():
-    async def mock_json():
-        return {"response": "test"}
-
     mock = AsyncMock()
-    mock.json = mock_json
+    mock.json = AsyncMock(return_value={"response": "test"})
     return mock
 
 
 @pytest.fixture
-def mock_session():
-    async def mock_post(*args, **kwargs):
-        return mock_response()
-
-    mock = AsyncMock()
-    mock.post = AsyncMock(side_effect=mock_post)
-    return mock
+def mock_session(mock_response):
+    session = AsyncMock()
+    session.post.return_value.__aenter__.return_value = mock_response
+    session_cm = AsyncMock()
+    session_cm.__aenter__.return_value = session
+    return session_cm
 
 
 @pytest.mark.asyncio
-async def test_http_request_udf_basic():
+async def test_http_request_udf_basic(mock_session):
     udf = HttpRequestUDF(
         data_column="__data",
         expected_input_keys=["payload"],
         url="http://test.com/api",
         additional_header={"Authorization": "Bearer 1234567890"},
         qps=None,
+        session_factory=lambda: mock_session,  # noqa: E731
     )
 
     batch = {"__data": [{"payload": {"text": "hello", "metadata": "test"}}]}
 
-    with patch("aiohttp.ClientSession") as mock_session_cls:
-        session = AsyncMock()
-        session.post.return_value.__aenter__.return_value.json = AsyncMock(
-            return_value={"response": "test"}
-        )
-        mock_session_cls.return_value.__aenter__.return_value = session
+    async for result in udf(batch):
+        assert result["__data"][0]["http_response"]["response"] == "test"
 
-        async for result in udf(batch):
-            assert result["__data"][0]["http_response"]["response"] == "test"
-
-        session.post.assert_called_once_with(
-            "http://test.com/api",
-            headers={
-                "Content-Type": "application/json",
-                "Authorization": "Bearer 1234567890",
-            },
-            json={"text": "hello", "metadata": "test"},
-        )
+    mock_session.__aenter__.return_value.post.assert_called_once_with(
+        "http://test.com/api",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": "Bearer 1234567890",
+        },
+        json={"text": "hello", "metadata": "test"},
+    )
 
 
 @pytest.mark.asyncio
-async def test_http_request_udf_with_qps():
+async def test_http_request_udf_with_qps(mock_session):
     udf = HttpRequestUDF(
         data_column="__data",
         expected_input_keys=["payload"],
         url="http://test.com/api",
         qps=2,
+        session_factory=lambda: mock_session,  # noqa: E731
     )
 
     batch = {
         "__data": [{"payload": {"text": "hello1"}}, {"payload": {"text": "hello2"}}]
     }
 
-    with patch("aiohttp.ClientSession") as mock_session_cls, patch(
-        "time.time"
-    ) as mock_time, patch("asyncio.sleep") as mock_sleep:
-
-        session = AsyncMock()
-        session.post.return_value.__aenter__.return_value.json = AsyncMock(
-            return_value={"response": "test"}
-        )
-        mock_session_cls.return_value.__aenter__.return_value = session
+    with patch("time.time") as mock_time, patch("asyncio.sleep") as mock_sleep:
 
         # Mock time to test QPS limiting. Req2 cannot be sent until 0.5s,
         # so the asyncio.sleep should be called once.
@@ -91,6 +77,54 @@ async def test_http_request_udf_with_qps():
 
         assert len(results) == 2
         assert mock_sleep.called  # Should have called sleep for QPS limiting
+
+
+@pytest.mark.asyncio
+async def test_http_request_udf_with_retry(mock_response):
+
+    batch = {
+        "__data": [{"payload": {"text": "hello1"}}, {"payload": {"text": "hello2"}}]
+    }
+    # Create a fake session
+    # create another response
+    retry_resp = AsyncMock(status=429)
+    retry_resp.json = AsyncMock(return_value={"detail": "Too Many Requests"})
+
+    session = AsyncMock()
+    session.post.return_value.__aenter__.side_effect = [
+        mock_response,  # First request: success
+        asyncio.TimeoutError(),  # Second request, initial attempt: timeout
+        aiohttp.ClientConnectionError(),  # Second request, first retry: connection error
+        retry_resp,  # Second request, second retry: HTTP 429 error
+        mock_response,  # Final retry: success
+    ]
+    session_cm = AsyncMock()
+    session_cm.__aenter__.return_value = session
+    fake_session_factory = lambda: session_cm  # noqa: E731
+
+    udf = HttpRequestUDF(
+        data_column="__data",
+        expected_input_keys=["payload"],
+        url="http://test.com/api",
+        max_retries=3,
+        base_retry_wait_time_in_s=1,
+        session_factory=fake_session_factory,
+    )
+
+    with patch("asyncio.sleep") as mock_sleep:
+        results = []
+        async for result in udf(batch):
+            results.append(result)
+
+        assert len(results) == 2
+        mock_sleep.assert_called()
+        mock_sleep.assert_has_calls(
+            [
+                call(udf.base_retry_wait_time_in_s),
+                call(udf.base_retry_wait_time_in_s * 2),
+                call(udf.base_retry_wait_time_in_s * 2 * 2),
+            ]
+        )
 
 
 if __name__ == "__main__":

--- a/python/ray/llm/tests/batch/cpu/stages/test_http_request_stage.py
+++ b/python/ray/llm/tests/batch/cpu/stages/test_http_request_stage.py
@@ -65,7 +65,6 @@ async def test_http_request_udf_with_qps(mock_session):
     }
 
     with patch("time.time") as mock_time, patch("asyncio.sleep") as mock_sleep:
-
         # Mock time to test QPS limiting. Req2 cannot be sent until 0.5s,
         # so the asyncio.sleep should be called once.
         # [start_time, req1_time, req2_time]
@@ -81,7 +80,6 @@ async def test_http_request_udf_with_qps(mock_session):
 
 @pytest.mark.asyncio
 async def test_http_request_udf_with_retry(mock_response):
-
     batch = {
         "__data": [{"payload": {"text": "hello1"}}, {"payload": {"text": "hello2"}}]
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, `HTTPRequestStage` provides a very basic implementation of sending a batch of requests and yielding responses one by one. However, this can fail if the server is overwhelmed or for time out with very long running requests.  

This PR adds support for exponential backoff and configurable session timeouts. 

Currently, if we realize that a request fails, I retry them individually. A potential improvement is to somehow batch failed requests together and retry. However, that is non-trivial and I'm not sure how beneficial that is. I'm leaving that as a future optimization. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
