### PR TITLE
[core] Replace `absl::optional` with `std::optional`

### DIFF
--- a/src/mock/ray/core_worker/reference_count.h
+++ b/src/mock/ray/core_worker/reference_count.h
@@ -39,7 +39,7 @@ class MockReferenceCounter : public ReferenceCounterInterface {
                     const int64_t object_size,
                     bool is_reconstructable,
                     bool add_local_ref,
-                    const absl::optional<NodeID> &pinned_at_raylet_id));
+                    const std::optional<NodeID> &pinned_at_raylet_id));
 
   MOCK_METHOD2(AddObjectOutOfScopeOrFreedCallback,
                bool(const ObjectID &object_id,

--- a/src/mock/ray/core_worker/task_manager.h
+++ b/src/mock/ray/core_worker/task_manager.h
@@ -48,7 +48,7 @@ class MockTaskFinisherInterface : public TaskFinisherInterface {
                const std::vector<ObjectID> &contained_ids),
               (override));
   MOCK_METHOD(bool, MarkTaskCanceled, (const TaskID &task_id), (override));
-  MOCK_METHOD(absl::optional<TaskSpecification>,
+  MOCK_METHOD(std::optional<TaskSpecification>,
               GetTaskSpec,
               (const TaskID &task_id),
               (const, override));

--- a/src/ray/common/bundle_location_index.cc
+++ b/src/ray/common/bundle_location_index.cc
@@ -115,7 +115,7 @@ bool BundleLocationIndex::Erase(const PlacementGroupID &placement_group_id) {
   return true;
 }
 
-const absl::optional<std::shared_ptr<BundleLocations> const>
+const std::optional<std::shared_ptr<BundleLocations> const>
 BundleLocationIndex::GetBundleLocations(
     const PlacementGroupID &placement_group_id) const {
   auto it = placement_group_to_bundle_locations_.find(placement_group_id);
@@ -125,7 +125,7 @@ BundleLocationIndex::GetBundleLocations(
   return it->second;
 }
 
-const absl::optional<std::shared_ptr<BundleLocations> const>
+const std::optional<std::shared_ptr<BundleLocations> const>
 BundleLocationIndex::GetBundleLocationsOnNode(const NodeID &node_id) const {
   auto it = node_to_leased_bundles_.find(node_id);
   if (it == node_to_leased_bundles_.end()) {

--- a/src/ray/common/bundle_location_index.h
+++ b/src/ray/common/bundle_location_index.h
@@ -66,14 +66,14 @@ class BundleLocationIndex {
   ///
   /// \param placement_group_id Placement group id of this bundle locations.
   /// \return Bundle locations that are associated with a given placement group id.
-  const absl::optional<std::shared_ptr<BundleLocations> const> GetBundleLocations(
+  const std::optional<std::shared_ptr<BundleLocations> const> GetBundleLocations(
       const PlacementGroupID &placement_group_id) const;
 
   /// Get BundleLocation of node id.
   ///
   /// \param node_id Node id of this bundle locations.
   /// \return Bundle locations that are associated with a given node id.
-  const absl::optional<std::shared_ptr<BundleLocations> const> GetBundleLocationsOnNode(
+  const std::optional<std::shared_ptr<BundleLocations> const> GetBundleLocationsOnNode(
       const NodeID &node_id) const;
 
   std::optional<NodeID> GetBundleLocation(const BundleID &bundle_id) const;

--- a/src/ray/common/event_stats.cc
+++ b/src/ray/common/event_stats.cc
@@ -186,7 +186,7 @@ GlobalStats EventTracker::get_global_stats() const {
   return to_global_stats_view(global_stats_);
 }
 
-absl::optional<EventStats> EventTracker::get_event_stats(
+std::optional<EventStats> EventTracker::get_event_stats(
     const std::string &event_name) const {
   absl::ReaderMutexLock lock(&mutex_);
   auto it = post_handler_stats_.find(event_name);

--- a/src/ray/common/event_stats.h
+++ b/src/ray/common/event_stats.h
@@ -138,7 +138,7 @@ class EventTracker {
   ///
   /// \param event_name The name of the event whose stats should be returned.
   /// \return A snapshot view of the event's stats.
-  absl::optional<EventStats> get_event_stats(const std::string &event_name) const
+  std::optional<EventStats> get_event_stats(const std::string &event_name) const
       ABSL_LOCKS_EXCLUDED(mutex_);
 
   /// Returns snapshot views of the count, queueing, and execution statistics for all

--- a/src/ray/common/scheduling/cluster_resource_data.h
+++ b/src/ray/common/scheduling/cluster_resource_data.h
@@ -315,7 +315,7 @@ class NodeResources {
   int64_t draining_deadline_timestamp_ms = -1;
 
   // The timestamp of the last resource update if there was a resource report.
-  absl::optional<absl::Time> last_resource_update_time = absl::nullopt;
+  std::optional<absl::Time> last_resource_update_time = absl::nullopt;
 
   /// Normal task resources could be uploaded by 1) Raylets' periodical reporters; 2)
   /// Rejected RequestWorkerLeaseReply. So we need the timestamps to decide whether an

--- a/src/ray/core_worker/actor_handle.cc
+++ b/src/ray/core_worker/actor_handle.cc
@@ -35,7 +35,7 @@ rpc::ActorHandle CreateInnerActorHandle(
     const std::string &ray_namespace,
     int32_t max_pending_calls,
     bool execute_out_of_order,
-    absl::optional<bool> enable_task_events,
+    std::optional<bool> enable_task_events,
     const std::unordered_map<std::string, std::string> &labels) {
   rpc::ActorHandle inner;
   inner.set_actor_id(actor_id.Data(), actor_id.Size());
@@ -105,7 +105,7 @@ ActorHandle::ActorHandle(
     const std::string &ray_namespace,
     int32_t max_pending_calls,
     bool execute_out_of_order,
-    absl::optional<bool> enable_task_events,
+    std::optional<bool> enable_task_events,
     const std::unordered_map<std::string, std::string> &labels)
     : ActorHandle(CreateInnerActorHandle(actor_id,
                                          owner_id,

--- a/src/ray/core_worker/actor_handle.h
+++ b/src/ray/core_worker/actor_handle.h
@@ -49,7 +49,7 @@ class ActorHandle {
               const std::string &ray_namespace,
               int32_t max_pending_calls,
               bool execute_out_of_order = false,
-              absl::optional<bool> enable_task_events = absl::nullopt,
+              std::optional<bool> enable_task_events = absl::nullopt,
               const std::unordered_map<std::string, std::string> &labels = {});
 
   /// Constructs an ActorHandle from a serialized string.

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -819,7 +819,7 @@ CoreWorker::CoreWorker(CoreWorkerOptions options, const WorkerID &worker_id)
                                                                reference_counter_);
 
   auto node_addr_factory = [this](const NodeID &node_id) {
-    absl::optional<rpc::Address> addr;
+    std::optional<rpc::Address> addr;
     if (auto node_info = gcs_client_->Nodes().Get(node_id)) {
       rpc::Address address;
       address.set_raylet_id(node_info->node_id());
@@ -880,12 +880,12 @@ CoreWorker::CoreWorker(CoreWorkerOptions options, const WorkerID &worker_id)
   object_lookup_fn = [this, node_addr_factory](const ObjectID &object_id,
                                                const ObjectLookupCallback &callback) {
     std::vector<rpc::Address> locations;
-    const absl::optional<absl::flat_hash_set<NodeID>> object_locations =
+    const std::optional<absl::flat_hash_set<NodeID>> object_locations =
         reference_counter_->GetObjectLocations(object_id);
     if (object_locations.has_value()) {
       locations.reserve(object_locations.value().size());
       for (const auto &node_id : object_locations.value()) {
-        absl::optional<rpc::Address> addr = node_addr_factory(node_id);
+        std::optional<rpc::Address> addr = node_addr_factory(node_id);
         if (addr.has_value()) {
           locations.emplace_back(std::move(addr.value()));
           continue;

--- a/src/ray/core_worker/lease_policy.cc
+++ b/src/ray/core_worker/lease_policy.cc
@@ -47,13 +47,13 @@ std::pair<rpc::Address, bool> LocalityAwareLeasePolicy::GetBestNodeForTask(
 }
 
 /// Criteria for "best" node: The node with the most object bytes (from object_ids) local.
-absl::optional<NodeID> LocalityAwareLeasePolicy::GetBestNodeIdForTask(
+std::optional<NodeID> LocalityAwareLeasePolicy::GetBestNodeIdForTask(
     const TaskSpecification &spec) {
   const auto object_ids = spec.GetDependencyIds();
   // Number of object bytes (from object_ids) that a given node has local.
   absl::flat_hash_map<NodeID, uint64_t> bytes_local_table;
   uint64_t max_bytes = 0;
-  absl::optional<NodeID> max_bytes_node;
+  std::optional<NodeID> max_bytes_node;
   // Finds the node with the maximum number of object bytes local.
   for (const ObjectID &object_id : object_ids) {
     if (auto locality_data = locality_data_provider_.GetLocalityData(object_id)) {

--- a/src/ray/core_worker/lease_policy.h
+++ b/src/ray/core_worker/lease_policy.h
@@ -34,7 +34,7 @@ struct LocalityData {
 /// Interface for providers of locality data to the lease policy.
 class LocalityDataProviderInterface {
  public:
-  virtual absl::optional<LocalityData> GetLocalityData(
+  virtual std::optional<LocalityData> GetLocalityData(
       const ObjectID &object_id) const = 0;
 
   virtual ~LocalityDataProviderInterface() = default;
@@ -50,8 +50,7 @@ class LeasePolicyInterface {
   virtual ~LeasePolicyInterface() = default;
 };
 
-using NodeAddrFactory =
-    std::function<absl::optional<rpc::Address>(const NodeID &node_id)>;
+using NodeAddrFactory = std::function<std::optional<rpc::Address>(const NodeID &node_id)>;
 
 /// Class used by the core worker to implement a locality-aware lease policy for
 /// picking a worker node for a lease request. This class is not thread-safe.
@@ -72,7 +71,7 @@ class LocalityAwareLeasePolicy : public LeasePolicyInterface {
 
  private:
   /// Get the best worker node for a lease request for the provided task.
-  absl::optional<NodeID> GetBestNodeIdForTask(const TaskSpecification &spec);
+  std::optional<NodeID> GetBestNodeIdForTask(const TaskSpecification &spec);
 
   /// Provider of locality data that will be used in choosing the best lessor.
   LocalityDataProviderInterface &locality_data_provider_;

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -195,7 +195,7 @@ void ReferenceCounter::AddOwnedObject(const ObjectID &object_id,
                                       const int64_t object_size,
                                       bool is_reconstructable,
                                       bool add_local_ref,
-                                      const absl::optional<NodeID> &pinned_at_raylet_id) {
+                                      const std::optional<NodeID> &pinned_at_raylet_id) {
   absl::MutexLock lock(&mutex_);
   RAY_CHECK(AddOwnedObjectInternal(object_id,
                                    inner_ids,
@@ -233,7 +233,7 @@ void ReferenceCounter::AddDynamicReturn(const ObjectID &object_id,
                                     /*object_size=*/-1,
                                     outer_it->second.is_reconstructable,
                                     /*add_local_ref=*/false,
-                                    absl::optional<NodeID>()));
+                                    std::optional<NodeID>()));
   AddNestedObjectIdsInternal(generator_id, {object_id}, owner_address);
 }
 
@@ -268,7 +268,7 @@ void ReferenceCounter::OwnDynamicStreamingTaskReturnRef(const ObjectID &object_i
                                     /*object_size=*/-1,
                                     outer_it->second.is_reconstructable,
                                     /*add_local_ref=*/true,
-                                    absl::optional<NodeID>()));
+                                    std::optional<NodeID>()));
 }
 
 void ReferenceCounter::TryReleaseLocalRefs(const std::vector<ObjectID> &object_ids,
@@ -317,7 +317,7 @@ bool ReferenceCounter::AddOwnedObjectInternal(
     const int64_t object_size,
     bool is_reconstructable,
     bool add_local_ref,
-    const absl::optional<NodeID> &pinned_at_raylet_id) {
+    const std::optional<NodeID> &pinned_at_raylet_id) {
   if (object_id_refs_.count(object_id) != 0) {
     return false;
   }
@@ -1391,7 +1391,7 @@ void ReferenceCounter::UpdateObjectPendingCreationInternal(const ObjectID &objec
   }
 }
 
-absl::optional<absl::flat_hash_set<NodeID>> ReferenceCounter::GetObjectLocations(
+std::optional<absl::flat_hash_set<NodeID>> ReferenceCounter::GetObjectLocations(
     const ObjectID &object_id) {
   absl::MutexLock lock(&mutex_);
   auto it = object_id_refs_.find(object_id);
@@ -1442,7 +1442,7 @@ bool ReferenceCounter::HandleObjectSpilled(const ObjectID &object_id,
   return true;
 }
 
-absl::optional<LocalityData> ReferenceCounter::GetLocalityData(
+std::optional<LocalityData> ReferenceCounter::GetLocalityData(
     const ObjectID &object_id) const {
   absl::MutexLock lock(&mutex_);
   // Uses the reference table to return locality data for an object.
@@ -1478,7 +1478,7 @@ absl::optional<LocalityData> ReferenceCounter::GetLocalityData(
   }
 
   // We should only reach here if we have valid locality data to return.
-  absl::optional<LocalityData> locality_data(
+  std::optional<LocalityData> locality_data(
       {static_cast<uint64_t>(object_size), std::move(node_ids)});
   return locality_data;
 }

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -56,7 +56,7 @@ class ReferenceCounterInterface {
       const int64_t object_size,
       bool is_reconstructable,
       bool add_local_ref,
-      const absl::optional<NodeID> &pinned_at_raylet_id = absl::optional<NodeID>()) = 0;
+      const std::optional<NodeID> &pinned_at_raylet_id = std::optional<NodeID>()) = 0;
   virtual bool AddObjectOutOfScopeOrFreedCallback(
       const ObjectID &object_id,
       const std::function<void(const ObjectID &)> callback) = 0;
@@ -196,8 +196,8 @@ class ReferenceCounter : public ReferenceCounterInterface,
                       const int64_t object_size,
                       bool is_reconstructable,
                       bool add_local_ref,
-                      const absl::optional<NodeID> &pinned_at_raylet_id =
-                          absl::optional<NodeID>()) override ABSL_LOCKS_EXCLUDED(mutex_);
+                      const std::optional<NodeID> &pinned_at_raylet_id =
+                          std::optional<NodeID>()) override ABSL_LOCKS_EXCLUDED(mutex_);
 
   /// Add an owned object that was dynamically created. These are objects that
   /// were created by a task that we called, but that we own.
@@ -512,8 +512,8 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// \param[in] object_id The object to get locations for.
   /// \return The nodes that have the object if the reference exists, empty optional
   ///         otherwise.
-  absl::optional<absl::flat_hash_set<NodeID>> GetObjectLocations(
-      const ObjectID &object_id) ABSL_LOCKS_EXCLUDED(mutex_);
+  std::optional<absl::flat_hash_set<NodeID>> GetObjectLocations(const ObjectID &object_id)
+      ABSL_LOCKS_EXCLUDED(mutex_);
 
   /// Publish the snapshot of the object location for the given object id.
   /// Publish the empty locations if object is already evicted or not owned by this
@@ -548,7 +548,7 @@ class ReferenceCounter : public ReferenceCounterInterface,
   ///
   /// \param[in] object_id Object whose locality data we want.
   /// \return Locality data.
-  absl::optional<LocalityData> GetLocalityData(const ObjectID &object_id) const override;
+  std::optional<LocalityData> GetLocalityData(const ObjectID &object_id) const override;
 
   /// Report locality data for object. This is used by the FutureResolver to report
   /// locality data for borrowed refs.
@@ -645,7 +645,7 @@ class ReferenceCounter : public ReferenceCounterInterface,
               std::string call_site,
               int64_t object_size,
               bool is_reconstructable,
-              absl::optional<NodeID> pinned_at_raylet_id)
+              std::optional<NodeID> pinned_at_raylet_id)
         : call_site(std::move(call_site)),
           object_size(object_size),
           owner_address(std::move(owner_address)),
@@ -757,11 +757,11 @@ class ReferenceCounter : public ReferenceCounterInterface,
     /// owner, then this is added during creation of the Reference. If this is
     /// process is a borrower, the borrower must add the owner's address before
     /// using the ObjectID.
-    absl::optional<rpc::Address> owner_address;
+    std::optional<rpc::Address> owner_address;
     /// If this object is owned by us and stored in plasma, and reference
     /// counting is enabled, then some raylet must be pinning the object value.
     /// This is the address of that raylet.
-    absl::optional<NodeID> pinned_at_raylet_id;
+    std::optional<NodeID> pinned_at_raylet_id;
     /// Whether we own the object. If we own the object, then we are
     /// responsible for tracking the state of the task that creates the object
     /// (see task_manager.h).
@@ -846,7 +846,7 @@ class ReferenceCounter : public ReferenceCounterInterface,
                               const int64_t object_size,
                               bool is_reconstructable,
                               bool add_local_ref,
-                              const absl::optional<NodeID> &pinned_at_raylet_id)
+                              const std::optional<NodeID> &pinned_at_raylet_id)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   void SetNestedRefInUseRecursive(ReferenceTable::iterator inner_ref_it)

--- a/src/ray/core_worker/task_event_buffer.cc
+++ b/src/ray/core_worker/task_event_buffer.cc
@@ -35,7 +35,7 @@ TaskStatusEvent::TaskStatusEvent(
     const rpc::TaskStatus &task_status,
     int64_t timestamp,
     const std::shared_ptr<const TaskSpecification> &task_spec,
-    absl::optional<const TaskStatusEvent::TaskStateUpdate> state_update)
+    std::optional<const TaskStatusEvent::TaskStateUpdate> state_update)
     : TaskEvent(task_id, job_id, attempt_number),
       task_status_(task_status),
       timestamp_(timestamp),
@@ -212,7 +212,7 @@ bool TaskEventBuffer::RecordTaskStatusEventIfNeeded(
     const TaskSpecification &spec,
     rpc::TaskStatus status,
     bool include_task_info,
-    absl::optional<const TaskStatusEvent::TaskStateUpdate> state_update) {
+    std::optional<const TaskStatusEvent::TaskStateUpdate> state_update) {
   if (!Enabled()) {
     return false;
   }

--- a/src/ray/core_worker/task_event_buffer.h
+++ b/src/ray/core_worker/task_event_buffer.h
@@ -245,8 +245,7 @@ class TaskEventBuffer {
       const TaskSpecification &spec,
       rpc::TaskStatus status,
       bool include_task_info = false,
-      absl::optional<const TaskStatusEvent::TaskStateUpdate> state_update =
-          absl::nullopt);
+      std::optional<const TaskStatusEvent::TaskStateUpdate> state_update = absl::nullopt);
 
   /// Add a task event to be reported.
   ///

--- a/src/ray/core_worker/task_finisher.h
+++ b/src/ray/core_worker/task_finisher.h
@@ -64,7 +64,7 @@ class TaskFinisherInterface {
 
   virtual bool MarkTaskCanceled(const TaskID &task_id) = 0;
 
-  virtual absl::optional<TaskSpecification> GetTaskSpec(const TaskID &task_id) const = 0;
+  virtual std::optional<TaskSpecification> GetTaskSpec(const TaskID &task_id) const = 0;
 
   virtual bool IsTaskPending(const TaskID &task_id) const = 0;
 };

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -1364,11 +1364,11 @@ void TaskManager::MarkTaskReturnObjectsFailed(
   }
 }
 
-absl::optional<TaskSpecification> TaskManager::GetTaskSpec(const TaskID &task_id) const {
+std::optional<TaskSpecification> TaskManager::GetTaskSpec(const TaskID &task_id) const {
   absl::MutexLock lock(&mu_);
   auto it = submissible_tasks_.find(task_id);
   if (it == submissible_tasks_.end()) {
-    return absl::optional<TaskSpecification>();
+    return std::optional<TaskSpecification>();
   }
   return it->second.spec;
 }
@@ -1476,7 +1476,7 @@ void TaskManager::MarkTaskRetryOnFailed(TaskEntry &task_entry,
 void TaskManager::SetTaskStatus(
     TaskEntry &task_entry,
     rpc::TaskStatus status,
-    const absl::optional<const rpc::RayErrorInfo> &error_info) {
+    const std::optional<const rpc::RayErrorInfo> &error_info) {
   task_entry.SetStatus(status);
   RAY_UNUSED(task_event_buffer_.RecordTaskStatusEventIfNeeded(
       task_entry.spec.TaskId(),

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -505,7 +505,7 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
   bool MarkTaskCanceled(const TaskID &task_id) override;
 
   /// Return the spec for a pending task.
-  absl::optional<TaskSpecification> GetTaskSpec(const TaskID &task_id) const override;
+  std::optional<TaskSpecification> GetTaskSpec(const TaskID &task_id) const override;
 
   /// Return specs for pending children tasks of the given parent task.
   std::vector<TaskID> GetPendingChildrenTasks(const TaskID &parent_task_id) const;
@@ -739,7 +739,7 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
   void SetTaskStatus(
       TaskEntry &task_entry,
       rpc::TaskStatus status,
-      const absl::optional<const rpc::RayErrorInfo> &error_info = absl::nullopt);
+      const std::optional<const rpc::RayErrorInfo> &error_info = absl::nullopt);
 
   /// Update the task entry for the task attempt to reflect retry on resubmit.
   ///

--- a/src/ray/core_worker/test/dependency_resolver_test.cc
+++ b/src/ray/core_worker/test/dependency_resolver_test.cc
@@ -111,7 +111,7 @@ class MockTaskFinisher : public TaskFinisherInterface {
 
   bool MarkTaskCanceled(const TaskID &task_id) override { return true; }
 
-  absl::optional<TaskSpecification> GetTaskSpec(const TaskID &task_id) const override {
+  std::optional<TaskSpecification> GetTaskSpec(const TaskID &task_id) const override {
     TaskSpecification task = BuildEmptyTaskSpec();
     return task;
   }

--- a/src/ray/core_worker/test/lease_policy_test.cc
+++ b/src/ray/core_worker/test/lease_policy_test.cc
@@ -44,7 +44,7 @@ class MockLocalityDataProvider : public LocalityDataProviderInterface {
       absl::flat_hash_map<ObjectID, LocalityData> locality_data)
       : locality_data_(locality_data) {}
 
-  absl::optional<LocalityData> GetLocalityData(const ObjectID &object_id) const {
+  std::optional<LocalityData> GetLocalityData(const ObjectID &object_id) const {
     num_locality_data_fetches++;
     return locality_data_[object_id];
   };
@@ -55,14 +55,14 @@ class MockLocalityDataProvider : public LocalityDataProviderInterface {
   mutable absl::flat_hash_map<ObjectID, LocalityData> locality_data_;
 };
 
-absl::optional<rpc::Address> MockNodeAddrFactory(const NodeID &node_id) {
+std::optional<rpc::Address> MockNodeAddrFactory(const NodeID &node_id) {
   rpc::Address mock_rpc_address;
   mock_rpc_address.set_raylet_id(node_id.Binary());
-  absl::optional<rpc::Address> opt_mock_rpc_address = mock_rpc_address;
+  std::optional<rpc::Address> opt_mock_rpc_address = mock_rpc_address;
   return opt_mock_rpc_address;
 }
 
-absl::optional<rpc::Address> MockNodeAddrFactoryAlwaysNull(const NodeID &node_id) {
+std::optional<rpc::Address> MockNodeAddrFactoryAlwaysNull(const NodeID &node_id) {
   return absl::nullopt;
 }
 

--- a/src/ray/core_worker/test/normal_task_submitter_test.cc
+++ b/src/ray/core_worker/test/normal_task_submitter_test.cc
@@ -177,7 +177,7 @@ class MockTaskFinisher : public TaskFinisherInterface {
 
   bool MarkTaskCanceled(const TaskID &task_id) override { return true; }
 
-  absl::optional<TaskSpecification> GetTaskSpec(const TaskID &task_id) const override {
+  std::optional<TaskSpecification> GetTaskSpec(const TaskID &task_id) const override {
     TaskSpecification task = BuildEmptyTaskSpec();
     return task;
   }

--- a/src/ray/core_worker/test/reference_count_test.cc
+++ b/src/ray/core_worker/test/reference_count_test.cc
@@ -655,7 +655,7 @@ TEST_F(ReferenceCountTest, TestHandleObjectSpilled) {
                      object_size,
                      false,
                      /*add_local_ref=*/true,
-                     absl::optional<NodeID>(node1));
+                     std::optional<NodeID>(node1));
   rc->HandleObjectSpilled(obj1, "url1", node1);
   rpc::WorkerObjectLocationsPubMessage object_info;
   rc->FillObjectInformation(obj1, &object_info);
@@ -685,7 +685,7 @@ TEST_F(ReferenceCountTest, TestGetLocalityData) {
                      object_size,
                      false,
                      /*add_local_ref=*/true,
-                     absl::optional<NodeID>(node1));
+                     std::optional<NodeID>(node1));
   auto locality_data_obj1 = rc->GetLocalityData(obj1);
   ASSERT_TRUE(locality_data_obj1.has_value());
   ASSERT_EQ(locality_data_obj1->object_size, object_size);
@@ -760,7 +760,7 @@ TEST_F(ReferenceCountTest, TestGetLocalityData) {
                      -1,
                      false,
                      /*add_local_ref=*/true,
-                     absl::optional<NodeID>(node2));
+                     std::optional<NodeID>(node2));
   auto locality_data_obj2_no_object_size = rc->GetLocalityData(obj2);
   ASSERT_FALSE(locality_data_obj2_no_object_size.has_value());
 

--- a/src/ray/core_worker/test/task_event_buffer_export_event_test.cc
+++ b/src/ray/core_worker/test/task_event_buffer_export_event_test.cc
@@ -81,7 +81,7 @@ class TaskEventTestWriteExport : public ::testing::Test {
       TaskID task_id,
       int32_t attempt_num,
       int64_t running_ts = 1,
-      absl::optional<const TaskStatusEvent::TaskStateUpdate> state_update =
+      std::optional<const TaskStatusEvent::TaskStateUpdate> state_update =
           absl::nullopt) {
     return std::make_unique<TaskStatusEvent>(task_id,
                                              JobID::FromInt(0),

--- a/src/ray/core_worker/test/task_event_buffer_test.cc
+++ b/src/ray/core_worker/test/task_event_buffer_test.cc
@@ -77,7 +77,7 @@ class TaskEventBufferTest : public ::testing::Test {
       TaskID task_id,
       int32_t attempt_num,
       int64_t running_ts = 1,
-      absl::optional<const TaskStatusEvent::TaskStateUpdate> state_update =
+      std::optional<const TaskStatusEvent::TaskStateUpdate> state_update =
           absl::nullopt) {
     return std::make_unique<TaskStatusEvent>(task_id,
                                              JobID::FromInt(0),

--- a/src/ray/core_worker/transport/actor_submit_queue.h
+++ b/src/ray/core_worker/transport/actor_submit_queue.h
@@ -70,7 +70,7 @@ class IActorSubmitQueue {
   ///   - nullopt if no task ready to send
   ///   - a pair of task and bool represents the task to be send and if the receiver
   ///     should SKIP THE SCHEDULING QUEUE while executing it.
-  virtual absl::optional<std::pair<TaskSpecification, bool>> PopNextTaskToSend() = 0;
+  virtual std::optional<std::pair<TaskSpecification, bool>> PopNextTaskToSend() = 0;
   /// On client connect/reconnect, find all the tasks that's known to be
   /// executed out of order. This is specific to SequentialActorSubmitQueue.
   virtual std::map<uint64_t, TaskSpecification> PopAllOutOfOrderCompletedTasks() = 0;

--- a/src/ray/core_worker/transport/normal_task_submitter.h
+++ b/src/ray/core_worker/transport/normal_task_submitter.h
@@ -94,7 +94,7 @@ class NormalTaskSubmitter {
       std::shared_ptr<ActorCreatorInterface> actor_creator,
       const JobID &job_id,
       std::shared_ptr<LeaseRequestRateLimiter> lease_request_rate_limiter,
-      absl::optional<boost::asio::steady_timer> cancel_timer = absl::nullopt)
+      std::optional<boost::asio::steady_timer> cancel_timer = absl::nullopt)
       : rpc_address_(std::move(rpc_address)),
         local_lease_client_(lease_client),
         lease_client_factory_(lease_client_factory),
@@ -377,7 +377,7 @@ class NormalTaskSubmitter {
   std::shared_ptr<LeaseRequestRateLimiter> lease_request_rate_limiter_;
 
   // Retries cancelation requests if they were not successful.
-  absl::optional<boost::asio::steady_timer> cancel_retry_timer_;
+  std::optional<boost::asio::steady_timer> cancel_retry_timer_;
 
   int64_t num_tasks_submitted_ = 0;
   int64_t num_leases_requested_ ABSL_GUARDED_BY(mu_) = 0;

--- a/src/ray/core_worker/transport/out_of_order_actor_submit_queue.cc
+++ b/src/ray/core_worker/transport/out_of_order_actor_submit_queue.cc
@@ -86,7 +86,7 @@ std::vector<TaskID> OutofOrderActorSubmitQueue::ClearAllTasks() {
   return task_ids;
 }
 
-absl::optional<std::pair<TaskSpecification, bool>>
+std::optional<std::pair<TaskSpecification, bool>>
 OutofOrderActorSubmitQueue::PopNextTaskToSend() {
   auto it = sending_queue_.begin();
   if (it == sending_queue_.end()) {

--- a/src/ray/core_worker/transport/out_of_order_actor_submit_queue.h
+++ b/src/ray/core_worker/transport/out_of_order_actor_submit_queue.h
@@ -58,7 +58,7 @@ class OutofOrderActorSubmitQueue : public IActorSubmitQueue {
   ///   - nullopt if no task ready to send
   ///   - a pair of task and bool represents the task to be send and if the receiver
   ///     should SKIP THE SCHEDULING QUEUE while executing it.
-  absl::optional<std::pair<TaskSpecification, bool>> PopNextTaskToSend() override;
+  std::optional<std::pair<TaskSpecification, bool>> PopNextTaskToSend() override;
   /// On client connect/reconnect, find all the TASK that's known to be
   /// executed out of order. This ALWAYS RETURNS empty.
   std::map<uint64_t, TaskSpecification> PopAllOutOfOrderCompletedTasks() override;

--- a/src/ray/core_worker/transport/sequential_actor_submit_queue.cc
+++ b/src/ray/core_worker/transport/sequential_actor_submit_queue.cc
@@ -68,7 +68,7 @@ std::vector<TaskID> SequentialActorSubmitQueue::ClearAllTasks() {
   return task_ids;
 }
 
-absl::optional<std::pair<TaskSpecification, bool>>
+std::optional<std::pair<TaskSpecification, bool>>
 SequentialActorSubmitQueue::PopNextTaskToSend() {
   auto head = requests.begin();
   if (head != requests.end() && (/*seqno*/ head->first <= next_send_position) &&

--- a/src/ray/core_worker/transport/sequential_actor_submit_queue.h
+++ b/src/ray/core_worker/transport/sequential_actor_submit_queue.h
@@ -54,7 +54,7 @@ class SequentialActorSubmitQueue : public IActorSubmitQueue {
   ///   - nullopt if no task ready to send
   ///   - a pair of task and bool represents the task to be send and if the receiver
   ///     should SKIP THE SCHEDULING QUEUE while executing it.
-  absl::optional<std::pair<TaskSpecification, bool>> PopNextTaskToSend() override;
+  std::optional<std::pair<TaskSpecification, bool>> PopNextTaskToSend() override;
   /// On client connect/reconnect, find all the tasks which are known to be
   /// executed out of order.
   std::map<uint64_t, TaskSpecification> PopAllOutOfOrderCompletedTasks() override;

--- a/src/ray/gcs/gcs_server/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.cc
@@ -296,7 +296,7 @@ void GcsNodeManager::HandleGetAllNodeInfo(rpc::GetAllNodeInfoRequest request,
   ++counts_[CountType::GET_ALL_NODE_INFO_REQUEST];
 }
 
-absl::optional<std::shared_ptr<rpc::GcsNodeInfo>> GcsNodeManager::GetAliveNode(
+std::optional<std::shared_ptr<rpc::GcsNodeInfo>> GcsNodeManager::GetAliveNode(
     const ray::NodeID &node_id) const {
   auto iter = alive_nodes_.find(node_id);
   if (iter == alive_nodes_.end()) {

--- a/src/ray/gcs/gcs_server/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_node_manager.h
@@ -123,7 +123,7 @@ class GcsNodeManager : public rpc::NodeInfoHandler {
   ///
   /// \param node_id The id of the node.
   /// \return the node if it is alive. Optional empty value if it is not alive.
-  absl::optional<std::shared_ptr<rpc::GcsNodeInfo>> GetAliveNode(
+  std::optional<std::shared_ptr<rpc::GcsNodeInfo>> GetAliveNode(
       const NodeID &node_id) const;
 
   /// Get all alive nodes.

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.cc
@@ -180,7 +180,7 @@ void GcsPlacementGroupScheduler::MarkScheduleCancelled(
 
 void GcsPlacementGroupScheduler::PrepareResources(
     const std::vector<std::shared_ptr<const BundleSpecification>> &bundles,
-    const absl::optional<std::shared_ptr<ray::rpc::GcsNodeInfo>> &node,
+    const std::optional<std::shared_ptr<ray::rpc::GcsNodeInfo>> &node,
     const StatusCallback &callback) {
   if (!node.has_value()) {
     callback(Status::NotFound("Node is already dead."));
@@ -211,7 +211,7 @@ void GcsPlacementGroupScheduler::PrepareResources(
 
 void GcsPlacementGroupScheduler::CommitResources(
     const std::vector<std::shared_ptr<const BundleSpecification>> &bundles,
-    const absl::optional<std::shared_ptr<ray::rpc::GcsNodeInfo>> &node,
+    const std::optional<std::shared_ptr<ray::rpc::GcsNodeInfo>> &node,
     const StatusCallback callback) {
   RAY_CHECK(node.has_value());
   const auto lease_client = GetLeaseClientFromNode(node.value());
@@ -237,7 +237,7 @@ void GcsPlacementGroupScheduler::CommitResources(
 
 void GcsPlacementGroupScheduler::CancelResourceReserve(
     const std::shared_ptr<const BundleSpecification> &bundle_spec,
-    const absl::optional<std::shared_ptr<ray::rpc::GcsNodeInfo>> &node,
+    const std::optional<std::shared_ptr<ray::rpc::GcsNodeInfo>> &node,
     int max_retry,
     int current_retry_cnt) {
   if (!node.has_value()) {

--- a/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_scheduler.h
@@ -380,7 +380,7 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   /// \param callback
   void PrepareResources(
       const std::vector<std::shared_ptr<const BundleSpecification>> &bundles,
-      const absl::optional<std::shared_ptr<ray::rpc::GcsNodeInfo>> &node,
+      const std::optional<std::shared_ptr<ray::rpc::GcsNodeInfo>> &node,
       const StatusCallback &callback);
 
   /// Send bundles COMMIT request to a node. This means the placement group creation
@@ -391,7 +391,7 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   /// \param callback
   void CommitResources(
       const std::vector<std::shared_ptr<const BundleSpecification>> &bundles,
-      const absl::optional<std::shared_ptr<ray::rpc::GcsNodeInfo>> &node,
+      const std::optional<std::shared_ptr<ray::rpc::GcsNodeInfo>> &node,
       const StatusCallback callback);
 
   /// Cacnel prepared or committed resources from a node.
@@ -404,7 +404,7 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   /// \param retry_cnt The number of times the cancel request is retried.
   void CancelResourceReserve(
       const std::shared_ptr<const BundleSpecification> &bundle_spec,
-      const absl::optional<std::shared_ptr<ray::rpc::GcsNodeInfo>> &node,
+      const std::optional<std::shared_ptr<ray::rpc::GcsNodeInfo>> &node,
       int max_retry,
       int current_retry_cnt);
 

--- a/src/ray/gcs/gcs_server/gcs_resource_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_resource_manager.h
@@ -185,7 +185,7 @@ class GcsResourceManager : public rpc::NodeResourceInfoHandler,
   absl::flat_hash_map<NodeID, rpc::ResourcesData> node_resource_usages_;
 
   /// Placement group load information that is used for autoscaler.
-  absl::optional<std::shared_ptr<rpc::PlacementGroupLoad>> placement_group_load_;
+  std::optional<std::shared_ptr<rpc::PlacementGroupLoad>> placement_group_load_;
   /// The resources changed listeners.
   std::vector<std::function<void()>> resources_changed_listeners_;
 

--- a/src/ray/gcs/gcs_server/test/gcs_task_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_task_manager_test.cc
@@ -104,7 +104,7 @@ class GcsTaskManagerTest : public ::testing::Test {
       const std::vector<std::pair<rpc::TaskStatus, int64_t>> &status_timestamps,
       const TaskID &parent_task_id = TaskID::Nil(),
       int job_id = 0,
-      absl::optional<rpc::RayErrorInfo> error_info = absl::nullopt,
+      std::optional<rpc::RayErrorInfo> error_info = absl::nullopt,
       ActorID actor_id = ActorID::Nil()) {
     auto events = GenTaskEvents(
         tasks,
@@ -228,7 +228,7 @@ class GcsTaskManagerTest : public ::testing::Test {
   }
 
   rpc::GetTaskEventsReply SyncGetTaskEvents(absl::flat_hash_set<TaskID> task_ids,
-                                            absl::optional<JobID> job_id = absl::nullopt,
+                                            std::optional<JobID> job_id = absl::nullopt,
                                             int64_t limit = -1,
                                             bool exclude_driver = true,
                                             const std::string &task_name = "",
@@ -307,10 +307,10 @@ class GcsTaskManagerTest : public ::testing::Test {
       const std::vector<TaskID> &task_ids,
       int32_t attempt_number = 0,
       int32_t job_id = 0,
-      absl::optional<rpc::ProfileEvents> profile_events = absl::nullopt,
-      absl::optional<rpc::TaskStateUpdate> state_update = absl::nullopt,
-      absl::optional<rpc::TaskInfoEntry> task_info = absl::nullopt,
-      absl::optional<rpc::RayErrorInfo> error_info = absl::nullopt) {
+      std::optional<rpc::ProfileEvents> profile_events = absl::nullopt,
+      std::optional<rpc::TaskStateUpdate> state_update = absl::nullopt,
+      std::optional<rpc::TaskInfoEntry> task_info = absl::nullopt,
+      std::optional<rpc::RayErrorInfo> error_info = absl::nullopt) {
     std::vector<rpc::TaskEvents> result;
     for (auto const &task_id : task_ids) {
       rpc::TaskEvents events;

--- a/src/ray/gcs/pb_util.h
+++ b/src/ray/gcs/pb_util.h
@@ -431,7 +431,7 @@ inline std::string FormatPlacementGroupDetails(
 /// \param strategy The placement strategy of placement group.
 /// \return The placement constraint for placement group if it's not a strict
 ///   strategy, else absl::nullopt.
-inline absl::optional<rpc::autoscaler::PlacementConstraint>
+inline std::optional<rpc::autoscaler::PlacementConstraint>
 GenPlacementConstraintForPlacementGroup(const std::string &pg_id,
                                         rpc::PlacementStrategy strategy) {
   rpc::autoscaler::PlacementConstraint pg_constraint;

--- a/src/ray/object_manager/chunk_object_reader.cc
+++ b/src/ray/object_manager/chunk_object_reader.cc
@@ -33,7 +33,7 @@ uint64_t ChunkObjectReader::GetNumChunks() const {
          chunk_size_;
 }
 
-absl::optional<std::string> ChunkObjectReader::GetChunk(uint64_t chunk_index) const {
+std::optional<std::string> ChunkObjectReader::GetChunk(uint64_t chunk_index) const {
   // The spilled file stores metadata before data. But the GetChunk needs to
   // return data before metadata. We achieve by first read from data section,
   // then read from metadata section.
@@ -50,7 +50,7 @@ absl::optional<std::string> ChunkObjectReader::GetChunk(uint64_t chunk_index) co
     auto offset = cur_chunk_offset;
     auto data_size = std::min(object_->GetDataSize() - cur_chunk_offset, cur_chunk_size);
     if (!object_->ReadFromDataSection(offset, data_size, result)) {
-      return absl::optional<std::string>();
+      return std::optional<std::string>();
     }
   }
 
@@ -61,9 +61,9 @@ absl::optional<std::string> ChunkObjectReader::GetChunk(uint64_t chunk_index) co
     auto size = std::min(cur_chunk_offset + cur_chunk_size - object_->GetDataSize(),
                          cur_chunk_size);
     if (!object_->ReadFromMetadataSection(offset, size, result)) {
-      return absl::optional<std::string>();
+      return std::optional<std::string>();
     }
   }
-  return absl::optional<std::string>(std::move(result));
+  return std::optional<std::string>(std::move(result));
 }
 };  // namespace ray

--- a/src/ray/object_manager/chunk_object_reader.h
+++ b/src/ray/object_manager/chunk_object_reader.h
@@ -37,7 +37,7 @@ class ChunkObjectReader {
   ///
   /// \param chunk_index the index of chunk to return. index greater or
   ///                    equal to GetNumChunks() yields undefined behavior.
-  absl::optional<std::string> GetChunk(uint64_t chunk_index) const;
+  std::optional<std::string> GetChunk(uint64_t chunk_index) const;
 
   const IObjectReader &GetObject() const { return *object_; }
 

--- a/src/ray/object_manager/plasma/allocator.h
+++ b/src/ray/object_manager/plasma/allocator.h
@@ -32,7 +32,7 @@ class IAllocator {
   ///
   /// \param bytes Number of bytes.
   /// \return allocated memory. returns empty if not enough space.
-  virtual absl::optional<Allocation> Allocate(size_t bytes) = 0;
+  virtual std::optional<Allocation> Allocate(size_t bytes) = 0;
 
   // Same as Allocate, but allocates pages from the filesystem. The footprint limit
   // is not enforced for these allocations, but allocations here are still tracked
@@ -41,7 +41,7 @@ class IAllocator {
   // TODO(scv119) ideally we should have mem/disk allocator implementations
   // so we don't need FallbackAllocate. However the dlmalloc has some limitation
   // prevents us from doing so.
-  virtual absl::optional<Allocation> FallbackAllocate(size_t bytes) = 0;
+  virtual std::optional<Allocation> FallbackAllocate(size_t bytes) = 0;
 
   /// Frees the memory space pointed to by mem, which must have been returned by
   /// a previous call to Allocate/FallbackAllocate or it yield undefined behavior.

--- a/src/ray/object_manager/plasma/plasma_allocator.cc
+++ b/src/ray/object_manager/plasma/plasma_allocator.cc
@@ -84,7 +84,7 @@ PlasmaAllocator::PlasmaAllocator(const std::string &plasma_directory,
   Free(std::move(allocation.value()));
 }
 
-absl::optional<Allocation> PlasmaAllocator::Allocate(size_t bytes) {
+std::optional<Allocation> PlasmaAllocator::Allocate(size_t bytes) {
   RAY_LOG(DEBUG) << "allocating " << bytes;
   void *mem = dlmemalign(kAlignment, bytes);
   RAY_LOG(DEBUG) << "allocated " << bytes << " at " << mem;
@@ -95,7 +95,7 @@ absl::optional<Allocation> PlasmaAllocator::Allocate(size_t bytes) {
   return BuildAllocation(mem, bytes, /* is_fallback_allocated */ false);
 }
 
-absl::optional<Allocation> PlasmaAllocator::FallbackAllocate(size_t bytes) {
+std::optional<Allocation> PlasmaAllocator::FallbackAllocate(size_t bytes) {
   bool is_fallback_allocated = false;
 
   // Forces allocation as a separate file.
@@ -135,9 +135,9 @@ int64_t PlasmaAllocator::Allocated() const { return allocated_; }
 
 int64_t PlasmaAllocator::FallbackAllocated() const { return fallback_allocated_; }
 
-absl::optional<Allocation> PlasmaAllocator::BuildAllocation(void *addr,
-                                                            size_t size,
-                                                            bool is_fallback_allocated) {
+std::optional<Allocation> PlasmaAllocator::BuildAllocation(void *addr,
+                                                           size_t size,
+                                                           bool is_fallback_allocated) {
   if (addr == nullptr) {
     return absl::nullopt;
   }

--- a/src/ray/object_manager/plasma/plasma_allocator.h
+++ b/src/ray/object_manager/plasma/plasma_allocator.h
@@ -54,7 +54,7 @@ class PlasmaAllocator : public IAllocator {
   ///
   /// \param bytes Number of bytes.
   /// \return allocated memory. returns empty if not enough space.
-  absl::optional<Allocation> Allocate(size_t bytes) override;
+  std::optional<Allocation> Allocate(size_t bytes) override;
 
   /// Fallback allocate memory from disk mmaped file. This is useful
   /// when we running out of memory but still want to allocate memory
@@ -67,7 +67,7 @@ class PlasmaAllocator : public IAllocator {
   ///
   /// \param bytes Number of bytes.
   /// \return allocated memory. returns empty if not enough space.
-  absl::optional<Allocation> FallbackAllocate(size_t bytes) override;
+  std::optional<Allocation> FallbackAllocate(size_t bytes) override;
 
   /// Frees the memory space pointed to by mem, which must have been returned by
   /// a previous call to Allocate/FallbackAllocate or it yields undefined behavior.
@@ -85,9 +85,9 @@ class PlasmaAllocator : public IAllocator {
   int64_t FallbackAllocated() const override;
 
  private:
-  absl::optional<Allocation> BuildAllocation(void *addr,
-                                             size_t size,
-                                             bool is_fallback_allocated);
+  std::optional<Allocation> BuildAllocation(void *addr,
+                                            size_t size,
+                                            bool is_fallback_allocated);
 
  private:
   const int64_t kFootprintLimit;

--- a/src/ray/object_manager/plasma/test/eviction_policy_test.cc
+++ b/src/ray/object_manager/plasma/test/eviction_policy_test.cc
@@ -82,8 +82,8 @@ TEST(LRUCacheTest, Test) {
 
 class MockAllocator : public IAllocator {
  public:
-  MOCK_METHOD1(Allocate, absl::optional<Allocation>(size_t bytes));
-  MOCK_METHOD1(FallbackAllocate, absl::optional<Allocation>(size_t bytes));
+  MOCK_METHOD1(Allocate, std::optional<Allocation>(size_t bytes));
+  MOCK_METHOD1(FallbackAllocate, std::optional<Allocation>(size_t bytes));
   MOCK_METHOD1(Free, void(Allocation));
   MOCK_CONST_METHOD0(GetFootprintLimit, int64_t());
   MOCK_CONST_METHOD0(Allocated, int64_t());

--- a/src/ray/object_manager/plasma/test/object_store_test.cc
+++ b/src/ray/object_manager/plasma/test/object_store_test.cc
@@ -84,8 +84,8 @@ const ObjectID kId2 = []() {
 
 class MockAllocator : public IAllocator {
  public:
-  MOCK_METHOD1(Allocate, absl::optional<Allocation>(size_t bytes));
-  MOCK_METHOD1(FallbackAllocate, absl::optional<Allocation>(size_t bytes));
+  MOCK_METHOD1(Allocate, std::optional<Allocation>(size_t bytes));
+  MOCK_METHOD1(FallbackAllocate, std::optional<Allocation>(size_t bytes));
   MOCK_METHOD1(Free, void(Allocation));
   MOCK_CONST_METHOD0(GetFootprintLimit, int64_t());
   MOCK_CONST_METHOD0(Allocated, int64_t());
@@ -102,7 +102,7 @@ TEST(ObjectStoreTest, PassThroughTest) {
 
     EXPECT_CALL(allocator, Allocate(10)).Times(1).WillOnce(Invoke([&](size_t bytes) {
       EXPECT_EQ(bytes, 10);
-      return absl::optional<Allocation>(std::move(allocation));
+      return std::optional<Allocation>(std::move(allocation));
     }));
     auto entry = store.CreateObject(info, {}, /*fallback_allocate*/ false);
     EXPECT_NE(entry, nullptr);
@@ -150,7 +150,7 @@ TEST(ObjectStoreTest, PassThroughTest) {
     // allocation failure
     EXPECT_CALL(allocator, Allocate(12)).Times(1).WillOnce(Invoke([&](size_t bytes) {
       EXPECT_EQ(bytes, 12);
-      return absl::optional<Allocation>();
+      return std::optional<Allocation>();
     }));
 
     EXPECT_EQ(nullptr, store.CreateObject(info, {}, /*fallback_allocate*/ false));
@@ -163,7 +163,7 @@ TEST(ObjectStoreTest, PassThroughTest) {
         .Times(1)
         .WillOnce(Invoke([&](size_t bytes) {
           EXPECT_EQ(bytes, 12);
-          return absl::optional<Allocation>(std::move(allocation));
+          return std::optional<Allocation>(std::move(allocation));
         }));
 
     auto entry = store.CreateObject(info, {}, /*fallback_allocate*/ true);

--- a/src/ray/object_manager/plasma/test/stats_collector_test.cc
+++ b/src/ray/object_manager/plasma/test/stats_collector_test.cc
@@ -36,14 +36,14 @@ int64_t Random(int64_t max) {
 
 class DummyAllocator : public IAllocator {
  public:
-  absl::optional<Allocation> Allocate(size_t bytes) override {
+  std::optional<Allocation> Allocate(size_t bytes) override {
     allocated_ += bytes;
     auto allocation = Allocation();
     allocation.size = bytes;
     return std::move(allocation);
   }
 
-  absl::optional<Allocation> FallbackAllocate(size_t bytes) override {
+  std::optional<Allocation> FallbackAllocate(size_t bytes) override {
     return absl::nullopt;
   }
 

--- a/src/ray/object_manager/spilled_object_reader.cc
+++ b/src/ray/object_manager/spilled_object_reader.cc
@@ -26,7 +26,7 @@ namespace {
 const size_t UINT64_size = sizeof(uint64_t);
 }
 
-/* static */ absl::optional<SpilledObjectReader>
+/* static */ std::optional<SpilledObjectReader>
 SpilledObjectReader::CreateSpilledObjectReader(const std::string &object_url) {
   std::string file_path;
   uint64_t object_offset = 0;
@@ -35,7 +35,7 @@ SpilledObjectReader::CreateSpilledObjectReader(const std::string &object_url) {
   if (!SpilledObjectReader::ParseObjectURL(
           object_url, file_path, object_offset, object_size)) {
     RAY_LOG(WARNING) << "Failed to parse spilled object url: " << object_url;
-    return absl::optional<SpilledObjectReader>();
+    return std::optional<SpilledObjectReader>();
   }
 
   uint64_t data_offset = 0;
@@ -53,10 +53,10 @@ SpilledObjectReader::CreateSpilledObjectReader(const std::string &object_url) {
                                                      metadata_size,
                                                      owner_address)) {
     RAY_LOG(WARNING) << "Failed to parse object header for spilled object " << object_url;
-    return absl::optional<SpilledObjectReader>();
+    return std::optional<SpilledObjectReader>();
   }
 
-  return absl::optional<SpilledObjectReader>(
+  return std::optional<SpilledObjectReader>(
       SpilledObjectReader(std::move(file_path),
                           object_size,
                           data_offset,

--- a/src/ray/object_manager/spilled_object_reader.h
+++ b/src/ray/object_manager/spilled_object_reader.h
@@ -30,7 +30,7 @@ class SpilledObjectReader : public IObjectReader {
   /// malformed url; corrupted/deleted file.
   ///
   /// \param object_url the object url in the form of {path}?offset={offset}&size={size}
-  static absl::optional<SpilledObjectReader> CreateSpilledObjectReader(
+  static std::optional<SpilledObjectReader> CreateSpilledObjectReader(
       const std::string &object_url);
 
   uint64_t GetDataSize() const override;

--- a/src/ray/pubsub/subscriber.h
+++ b/src/ray/pubsub/subscriber.h
@@ -154,7 +154,7 @@ class SubscriberChannel {
 
   /// Returns a subscription callback; Returns a nullopt if the object id is not
   /// subscribed.
-  absl::optional<SubscriptionItemCallback> GetSubscriptionItemCallback(
+  std::optional<SubscriptionItemCallback> GetSubscriptionItemCallback(
       const rpc::Address &publisher_address, const std::string &key_id) const {
     const auto publisher_id = PublisherID::FromBinary(publisher_address.worker_id());
     auto subscription_it = subscription_map_.find(publisher_id);
@@ -173,7 +173,7 @@ class SubscriberChannel {
 
   /// Returns a publisher failure callback; Returns a nullopt if the object id is not
   /// subscribed.
-  absl::optional<SubscriptionFailureCallback> GetFailureCallback(
+  std::optional<SubscriptionFailureCallback> GetFailureCallback(
       const rpc::Address &publisher_address, const std::string &key_id) const {
     const auto publisher_id = PublisherID::FromBinary(publisher_address.worker_id());
     auto subscription_it = subscription_map_.find(publisher_id);

--- a/src/ray/raylet/scheduling/local_resource_manager.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager.cc
@@ -207,7 +207,7 @@ void LocalResourceManager::SetResourceIdle(const scheduling::ResourceID &resourc
   last_idle_times_[resource_id] = absl::Now();
 }
 
-absl::optional<absl::Time> LocalResourceManager::GetResourceIdleTime() const {
+std::optional<absl::Time> LocalResourceManager::GetResourceIdleTime() const {
   // If all the resources are idle.
   absl::Time all_idle_time = absl::InfinitePast();
 

--- a/src/ray/raylet/scheduling/local_resource_manager.h
+++ b/src/ray/raylet/scheduling/local_resource_manager.h
@@ -211,7 +211,7 @@ class LocalResourceManager : public syncer::ReporterInterface {
 
   void SetResourceNonIdle(const scheduling::ResourceID &resource_id);
 
-  absl::optional<absl::Time> GetResourceIdleTime() const;
+  std::optional<absl::Time> GetResourceIdleTime() const;
 
   /// Get the draining deadline if node is in draining state.
   ///
@@ -225,7 +225,7 @@ class LocalResourceManager : public syncer::ReporterInterface {
   NodeResourceInstances local_resources_;
 
   /// A map storing when the resource was last idle.
-  absl::flat_hash_map<WorkArtifact, absl::optional<absl::Time>> last_idle_times_;
+  absl::flat_hash_map<WorkArtifact, std::optional<absl::Time>> last_idle_times_;
   /// Function to get used object store memory.
   std::function<int64_t(void)> get_used_object_store_memory_;
   /// Function to get whether the pull manager is at capacity.

--- a/src/ray/raylet/scheduling/policy/scheduling_context.h
+++ b/src/ray/raylet/scheduling/policy/scheduling_context.h
@@ -31,11 +31,11 @@ struct SchedulingContext {
 struct BundleSchedulingContext : public SchedulingContext {
  public:
   explicit BundleSchedulingContext(
-      absl::optional<std::shared_ptr<BundleLocations>> bundle_locations)
+      std::optional<std::shared_ptr<BundleLocations>> bundle_locations)
       : bundle_locations_(std::move(bundle_locations)) {}
 
   /// The locations of existing bundles for this placement group.
-  absl::optional<std::shared_ptr<BundleLocations>> bundle_locations_;
+  std::optional<std::shared_ptr<BundleLocations>> bundle_locations_;
 };
 
 struct AffinityWithBundleSchedulingContext : public SchedulingContext {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

1. Make coding style consistent.
2. There is no reason to use `absl::optional` in case we use C++ 17.

* https://github.com/abseil/abseil-cpp/blob/fddfe7b356fdc407a76d5788b7de265e6e729217/absl/types/optional.h#L19-L21

![image](https://github.com/user-attachments/assets/0e260ca3-7e9a-4988-b5e1-08c6c880283e)


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
