### PR TITLE
[llm] trigger llm tests on llm doc changes

### DIFF
--- a/ci/pipeline/test_rules.txt
+++ b/ci/pipeline/test_rules.txt
@@ -16,6 +16,7 @@ python/ray/air/
 ;
 
 python/ray/llm/
+doc/source/llm/
 .buildkite/llm.rayci.yml
 ci/docker/llm.build.Dockerfile
 python/requirements_compiled_*.txt


### PR DESCRIPTION
as llm doc example tests are running inside llm special test jobs
