### PR TITLE
[core] Revert "[Fix][Core/Dashboard] Log to stderr for subprocess modules wh…

### DIFF
--- a/ci/pipeline/test_conditional_testing.py
+++ b/ci/pipeline/test_conditional_testing.py
@@ -28,7 +28,7 @@ python/ray/train/train.py: lint ml train linux_wheels
 rllib/rllib.py: lint rllib rllib_gpu rllib_directly
 
 python/ray/serve/serve.py: lint serve linux_wheels java
-python/ray/dashboard/dashboard.py: lint dashboard linux_wheels
+python/ray/dashboard/dashboard.py: lint dashboard linux_wheels python
 python/core.py:
     - lint ml tune train data
     - python dashboard linux_wheels macos_wheels java

--- a/ci/pipeline/test_rules.txt
+++ b/ci/pipeline/test_rules.txt
@@ -71,7 +71,7 @@ ci/docker/serve.build.Dockerfile
 ;
 
 python/ray/dashboard/
-@ dashboard linux_wheels
+@ dashboard linux_wheels python
 ;
 
 python/setup.py

--- a/doc/source/ray-observability/user-guides/configure-logging.md
+++ b/doc/source/ray-observability/user-guides/configure-logging.md
@@ -45,9 +45,9 @@ System logs may include information about your applications. For example, ``runt
 - ``worker-[worker_id]-[job_id]-[pid].[out|err]``: Python or Java part of Ray drivers and workers. Ray streams all stdout and stderr from Tasks or Actors to these files. Note that job_id is the ID of the driver.
 
 ### System/component logs
-- ``dashboard.[log|out|err]``: A log file of a Ray Dashboard. ``.log`` files contain logs generated from the dashboard's logger. ``.out`` and ``.err`` files contain stdout and stderr printed from the dashboard respectively. They're usually empty except when the dashboard crashes unexpectedly.
+- ``dashboard.[log|err]``: A log file of a Ray Dashboard. ``.log`` files contain logs generated from the dashboard's logger. ``.err`` files contain stdout and stderr printed from the dashboard. They're usually empty except when the dashboard crashes unexpectedly.
 - ``dashboard_agent.log``: Every Ray node has one dashboard agent. This is a log file of the agent.
-- ``dashboard_[module_name].[log|out|err]``: The log files for the Ray Dashboard child processes, one per each module. ``.log`` files contain logs generated from the module's logger. ``.out`` and ``.err`` files contain stdout and stderr printed from the module respectively. They're usually empty except when the module crashes unexpectedly.
+- ``dashboard_[module_name].[log|err]``: The log files for the Ray Dashboard child processes, one per each module. ``.log`` files contain logs generated from the module's logger. ``.err`` files contain stdout and stderr printed from the module. They're usually empty except when the module crashes unexpectedly.
 - ``gcs_server.[out|err]``: The GCS server is a stateless server that manages Ray cluster metadata. It exists only in the head node.
 - ``io-worker-[worker_id]-[pid].[out|err]``: Ray creates IO workers to spill/restore objects to external storage by default from Ray 1.3+. This is a log file of IO workers.
 - ``log_monitor.[log|err]``: The log monitor is in charge of streaming logs to the driver. ``.log`` files contain logs generated from the log monitor's logger. ``.err`` files contain the stdout and stderr printed from the log monitor. They're usually empty except when the log monitor crashes unexpectedly.

--- a/python/ray/dashboard/subprocesses/module.py
+++ b/python/ray/dashboard/subprocesses/module.py
@@ -13,13 +13,14 @@ import ray
 from ray import ray_constants
 from ray._raylet import GcsClient
 from ray._private.gcs_utils import GcsAioClient, GcsChannel
+from ray._private.ray_logging import configure_log_file
+from ray._private.utils import open_log
 from ray.dashboard.subprocesses.utils import (
     module_logging_filename,
     get_socket_path,
     get_named_pipe_path,
 )
 from ray._private.ray_logging import setup_component_logger
-from ray._private import logging_utils
 
 logger = logging.getLogger(__name__)
 
@@ -258,19 +259,11 @@ def run_module(
         backup_count=config.logging_rotate_backup_count,
     )
 
-    if config.logging_filename:
-        stdout_filename = module_logging_filename(
-            module_name, config.logging_filename, extension=".out"
-        )
-        stderr_filename = module_logging_filename(
-            module_name, config.logging_filename, extension=".err"
-        )
-        logging_utils.redirect_stdout_stderr_if_needed(
-            os.path.join(config.log_dir, stdout_filename),
-            os.path.join(config.log_dir, stderr_filename),
-            config.logging_rotate_bytes,
-            config.logging_rotate_backup_count,
-        )
+    stderr_filename = module_logging_filename(
+        module_name, config.logging_filename, is_stderr=True
+    )
+    err_file = open_log(os.path.join(config.log_dir, stderr_filename), unbuffered=True)
+    configure_log_file(err_file, err_file)
 
     loop = asyncio.new_event_loop()
     task = loop.create_task(

--- a/python/ray/dashboard/subprocesses/tests/test_e2e.py
+++ b/python/ray/dashboard/subprocesses/tests/test_e2e.py
@@ -277,21 +277,16 @@ async def test_logging_in_module(aiohttp_client, default_module_config):
         (file_name, content) in matches for (file_name, content) in expected_logs
     ), f"Expected to contain {expected_logs}, got {matches}"
 
-    # Assert that stdout is logged to "dashboard_TestModule.out"
-    out_log_file_path = (
-        pathlib.Path(default_module_config.log_dir) / "dashboard_TestModule.out"
-    )
-    with out_log_file_path.open("r") as f:
-        out_log_file_content = f.read()
-    assert out_log_file_content == "In /logging_in_module, stdout\n"
-
-    # Assert that stderr is logged to "dashboard_TestModule.err"
+    # Assert that stdout and stderr are logged to "dashboard.TestModule.err"
     err_log_file_path = (
         pathlib.Path(default_module_config.log_dir) / "dashboard_TestModule.err"
     )
     with err_log_file_path.open("r") as f:
         err_log_file_content = f.read()
-    assert err_log_file_content == "In /logging_in_module, stderr\n"
+    assert (
+        err_log_file_content
+        == "In /logging_in_module, stdout\nIn /logging_in_module, stderr\n"
+    )
 
 
 async def test_logging_in_module_with_multiple_incarnations(

--- a/python/ray/dashboard/subprocesses/utils.py
+++ b/python/ray/dashboard/subprocesses/utils.py
@@ -17,14 +17,13 @@ class ResponseType(enum.Enum):
 
 
 def module_logging_filename(
-    module_name: str, logging_filename: str, extension: str = ""
+    module_name: str, logging_filename: str, is_stderr=False
 ) -> str:
     """
     Parse logging_filename = STEM EXTENSION,
     return STEM _ MODULE_NAME _ EXTENSION
 
-    If logging_filename is empty, return empty string.
-    If extension is empty, use the extension from logging_filename.
+    If is_stderr is True, EXTENSION is ".err"
 
     Example:
     module_name = "TestModule"
@@ -33,11 +32,9 @@ def module_logging_filename(
     EXTENSION = ".log"
     return "dashboard_TestModule.log"
     """
-    if not logging_filename:
-        return ""
-    stem, ext = os.path.splitext(logging_filename)
-    if not extension:
-        extension = ext
+    stem, extension = os.path.splitext(logging_filename)
+    if is_stderr:
+        extension = ".err"
     return f"{stem}_{module_name}{extension}"
 
 


### PR DESCRIPTION
…en `RAY_LOG_TO_STDERR` is set (#52047)"

This reverts commit 2f7f03a895a6055a7956d1f282e6e9a6cc6410de.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This causes Windows tests to fail so reverting here.

Also merged the windows test for dashboard tagging to test.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
