### PR TITLE
[core] Skip sigkill actor failure tests on windows

### DIFF
--- a/python/ray/tests/test_actor_failures.py
+++ b/python/ray/tests/test_actor_failures.py
@@ -1162,6 +1162,7 @@ def test_exit_actor_queued(shutdown_only):
     assert " Worker unexpectedly exits" not in str(exc_info.value)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="SIGKILL not supported on windows")
 def test_actor_restart_and_actor_received_task(shutdown_only):
     # Create an actor with max_restarts=1 and max_task_retries=1.
     # Submit a task to the actor and kill the actor after it receives
@@ -1197,6 +1198,7 @@ def test_actor_restart_and_actor_received_task(shutdown_only):
     assert ray.get(ref) == 1
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="SIGKILL not supported on windows")
 def test_actor_restart_and_partial_task_not_completed(shutdown_only):
     # Create an actor with max_restarts=1 and max_task_retries=1.
     # Submit 3 tasks to the actor and wait for them to complete.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
These tests fail on windows because sigkill doesn't exist on windows.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
