### PR TITLE
[FIX] RayJob doc test flaky

### DIFF
--- a/doc/source/cluster/kubernetes/getting-started/rayjob-quick-start.ipynb
+++ b/doc/source/cluster/kubernetes/getting-started/rayjob-quick-start.ipynb
@@ -121,7 +121,7 @@
       "\n",
       "kubectl cluster-info --context kind-kind\n",
       "\n",
-      "Thanks for using kind! 😊\n"
+      "Not sure what to do next? 😅  Check out https://kind.sigs.k8s.io/docs/user/quick-start/\n"
      ]
     }
    ],
@@ -165,7 +165,7 @@
      "output_type": "stream",
      "text": [
       "NAME: kuberay-operator\n",
-      "LAST DEPLOYED: Sun Mar 30 13:44:34 2025\n",
+      "LAST DEPLOYED: Wed Apr  9 18:28:39 2025\n",
       "NAMESPACE: default\n",
       "STATUS: deployed\n",
       "REVISION: 1\n",
@@ -253,7 +253,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "raycluster.ray.io/rayjob-sample-raycluster-ndrdw condition met\n"
+      "raycluster.ray.io/rayjob-sample-raycluster-7965c condition met\n"
      ]
     }
    ],
@@ -280,7 +280,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "pod/rayjob-sample-7ps8z condition met\n"
+      "pod/rayjob-sample-74pmj condition met\n"
      ]
     }
    ],
@@ -305,7 +305,7 @@
      "output_type": "stream",
      "text": [
       "NAME            JOB STATUS   DEPLOYMENT STATUS   RAY CLUSTER NAME                 START TIME             END TIME   AGE\n",
-      "rayjob-sample                Running             rayjob-sample-raycluster-ndrdw   2025-03-30T05:45:15Z              3m1s\n"
+      "rayjob-sample                Running             rayjob-sample-raycluster-7965c   2025-04-09T10:29:17Z              117s\n"
      ]
     }
    ],
@@ -331,7 +331,7 @@
      "output_type": "stream",
      "text": [
       "NAME                             DESIRED WORKERS   AVAILABLE WORKERS   CPUS   MEMORY   GPUS   STATUS   AGE\n",
-      "rayjob-sample-raycluster-ndrdw   1                 1                   400m   0        0      ready    3m2s\n"
+      "rayjob-sample-raycluster-7965c   1                 1                   400m   0        0      ready    117s\n"
      ]
     }
    ],
@@ -357,17 +357,17 @@
      "output_type": "stream",
      "text": [
       "NAME                                                      READY   STATUS    RESTARTS   AGE\n",
-      "kuberay-operator-6bc45dd644-ckxj4                         1/1     Running   0          3m36s\n",
-      "rayjob-sample-7ps8z                                       1/1     Running   0          2s\n",
-      "rayjob-sample-raycluster-ndrdw-head-tfs89                 1/1     Running   0          3m2s\n",
-      "rayjob-sample-raycluster-ndrdw-small-group-worker-9s8hb   1/1     Running   0          3m2s\n"
+      "kuberay-operator-6bc45dd644-tlsfn                         1/1     Running   0          2m26s\n",
+      "rayjob-sample-raycluster-7965c-head-n6nj8                 1/1     Running   0          117s\n",
+      "rayjob-sample-raycluster-7965c-small-group-worker-nlzwx   1/1     Running   0          117s\n",
+      "rayjob-sample-74pmj                                       1/1     Running   0          2s\n"
      ]
     }
    ],
    "source": [
     "# Step 4.3: List all Pods in the `default` namespace.\n",
     "# The Pod created by the Kubernetes Job will be terminated after the Kubernetes Job finishes.\n",
-    "kubectl get pods --sort-by=.metadata.name"
+    "kubectl get pods --sort-by='.metadata.creationTimestamp'"
    ]
   },
   {
@@ -482,16 +482,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2025-03-29 22:48:26,557\tINFO worker.py:1654 -- Connecting to existing Ray cluster at address: 10.244.0.6:6379...\n",
-      "2025-03-29 22:48:26,567\tINFO worker.py:1832 -- Connected to Ray cluster. View the dashboard at \u001b[1m\u001b[32m10.244.0.6:8265 \u001b[39m\u001b[22m\n",
+      "2025-04-09 03:31:23,810\tINFO worker.py:1654 -- Connecting to existing Ray cluster at address: 10.244.0.6:6379...\n",
+      "2025-04-09 03:31:23,818\tINFO worker.py:1832 -- Connected to Ray cluster. View the dashboard at \u001b[1m\u001b[32m10.244.0.6:8265 \u001b[39m\u001b[22m\n",
       "test_counter got 1\n",
       "test_counter got 2\n",
       "test_counter got 3\n",
       "test_counter got 4\n",
       "test_counter got 5\n",
-      "2025-03-29 22:48:30,419\tSUCC cli.py:63 -- \u001b[32m-----------------------------------\u001b[39m\n",
-      "2025-03-29 22:48:30,419\tSUCC cli.py:64 -- \u001b[32mJob 'rayjob-sample-4wbmd' succeeded\u001b[39m\n",
-      "2025-03-29 22:48:30,419\tSUCC cli.py:65 -- \u001b[32m-----------------------------------\u001b[39m\n"
+      "2025-04-09 03:31:32,204\tSUCC cli.py:63 -- \u001b[32m-----------------------------------\u001b[39m\n",
+      "2025-04-09 03:31:32,204\tSUCC cli.py:64 -- \u001b[32mJob 'rayjob-sample-jrrd2' succeeded\u001b[39m\n",
+      "2025-04-09 03:31:32,204\tSUCC cli.py:65 -- \u001b[32m-----------------------------------\u001b[39m\n"
      ]
     }
    ],
@@ -623,7 +623,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "raycluster.ray.io/rayjob-sample-shutdown-raycluster-h8d8t condition met\n"
+      "raycluster.ray.io/rayjob-sample-shutdown-raycluster-pfqsf condition met\n"
      ]
     }
    ],
@@ -738,7 +738,7 @@
      "output_type": "stream",
      "text": [
       "NAME                                      DESIRED WORKERS   AVAILABLE WORKERS   CPUS   MEMORY   GPUS   STATUS   AGE\n",
-      "rayjob-sample-shutdown-raycluster-h8d8t   1                 1                   400m   0        0      ready    52s\n"
+      "rayjob-sample-shutdown-raycluster-pfqsf   1                 1                   400m   0        0      ready    45s\n"
      ]
     }
    ],


### PR DESCRIPTION
## Why are these changes needed?

As mentioned here: https://github.com/ray-project/ray/pull/51756#issuecomment-2787497192, the doc test for rayjob is flaky.

Sort get pods output with create time to prevent flaky. Ensure the doc test passed locally twice.

![image](https://github.com/user-attachments/assets/8f102b28-1e0d-453a-950a-c6ee5d654d0c)

Doc link: https://anyscale-ray--52170.com.readthedocs.build/en/52170/cluster/kubernetes/getting-started/rayjob-quick-start.html

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
