### PR TITLE
[Serve][LLM] Fix inconsistent v0/v1 config passed to vLLM

### DIFF
--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
@@ -327,9 +327,12 @@ class VLLMEngine:
             return await self._start_engine_v0()
         return await self._start_engine_v1()
 
-    async def _prepare_engine_config(self):
+    async def _prepare_engine_config(self, use_v1: bool):
         """
         Prepare the engine config to start the engine.
+
+        Args:
+            use_v1: Whether to use v1 engine.
 
         Returns:
             engine_args: The engine arguments.
@@ -349,9 +352,14 @@ class VLLMEngine:
                         accelerator_type=self.llm_config.accelerator_type,
                     )(_get_vllm_engine_config)
                     .options(
+                        runtime_env=dict(
+                            env_vars=dict(
+                                VLLM_USE_V1=str(int(use_v1)),
+                            ),
+                        ),
                         scheduling_strategy=PlacementGroupSchedulingStrategy(
                             placement_group=node_initialization.placement_group,
-                        )
+                        ),
                     )
                     .remote(self.llm_config)
                 )
@@ -381,7 +389,7 @@ class VLLMEngine:
             engine_args,
             engine_config,
             node_initialization,
-        ) = await self._prepare_engine_config()
+        ) = await self._prepare_engine_config(use_v1=True)
 
         return self._start_async_llm_engine(
             engine_args,
@@ -397,7 +405,7 @@ class VLLMEngine:
             engine_args,
             engine_config,
             node_initialization,
-        ) = await self._prepare_engine_config()
+        ) = await self._prepare_engine_config(use_v1=False)
 
         if MQLLMEngineClient.is_unsupported_config(engine_config):
             # If the engine is not supported, we fall back to the legacy async engine.

--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
@@ -332,7 +332,7 @@ class VLLMEngine:
         Prepare the engine config to start the engine.
 
         Args:
-            use_v1: Whether to use v1 engine.
+            use_v1: Whether to use vLLM V1 engine.
 
         Returns:
             engine_args: The engine arguments.
@@ -352,6 +352,10 @@ class VLLMEngine:
                         accelerator_type=self.llm_config.accelerator_type,
                     )(_get_vllm_engine_config)
                     .options(
+                        # If VLLM_USE_V1 is not set explicitly, vLLM may automatically
+                        # decide which engine to use based on the passed configs.
+                        # Here we set it explicitly to make sure Ray LLM and vLLM
+                        # configs are consistent.
                         runtime_env=dict(
                             env_vars=dict(
                                 VLLM_USE_V1=str(int(use_v1)),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

We observed the following error in deploying Ray LLM V0:

```

2025-04-09, 10:50:12.511 | worker |   | ip-10-0-97-109 | return run_method(self, method, args, kwargs)
-- | -- | -- | -- | --
U | 2025-04-09, 10:50:12.511 | worker |   | ip-10-0-97-109 | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
U | 2025-04-09, 10:50:12.511 | worker |   | ip-10-0-97-109 | File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/utils.py", line 2255, in run_method
U | 2025-04-09, 10:50:12.511 | worker |   | ip-10-0-97-109 | return func(*args, **kwargs)
U | 2025-04-09, 10:50:12.511 | worker |   | ip-10-0-97-109 | ^^^^^^^^^^^^^^^^^^^^^
U | 2025-04-09, 10:50:12.511 | worker |   | ip-10-0-97-109 | File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/worker/worker_base.py", line 604, in init_device
U | 2025-04-09, 10:50:12.511 | worker |   | ip-10-0-97-109 | self.worker.init_device()  # type: ignore
U | 2025-04-09, 10:50:12.511 | worker |   | ip-10-0-97-109 | ^^^^^^^^^^^^^^^^^^^^^^^^^
U | 2025-04-09, 10:50:12.511 | worker |   | ip-10-0-97-109 | File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/worker/gpu_worker.py", line 120, in init_device
U | 2025-04-09, 10:50:12.511 | worker |   | ip-10-0-97-109 | self.model_runner: GPUModelRunner = GPUModelRunner(
U | 2025-04-09, 10:50:12.511 | worker |   | ip-10-0-97-109 | ^^^^^^^^^^^^^^^
U | 2025-04-09, 10:50:12.511 | worker |   | ip-10-0-97-109 | File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/worker/gpu_model_runner.py", line 110, in __init__
U | 2025-04-09, 10:50:12.511 | worker |   | ip-10-0-97-109 | self.attn_backend = get_attn_backend(
U | 2025-04-09, 10:50:12.511 | worker |   | ip-10-0-97-109 | ^^^^^^^^^^^^^^^^^
U | 2025-04-09, 10:50:12.511 | worker |   | ip-10-0-97-109 | File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/attention/selector.py", line 95, in get_attn_backend
U | 2025-04-09, 10:50:12.511 | worker |   | ip-10-0-97-109 | return _cached_get_attn_backend(Show Details
U | 2025-04-09, 10:50:12.511 | worker |   | ip-10-0-97-109 | ^^^^^^^^^^^^^^^^^^^^^^^^^
U | 2025-04-09, 10:50:12.511 | worker |   | ip-10-0-97-109 | File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/attention/selector.py", line 148, in _cached_get_attn_backend
U | 2025-04-09, 10:50:12.511 | worker |   | ip-10-0-97-109 | attention_cls = current_platform.get_attn_backend_cls(
U | 2025-04-09, 10:50:12.511 | worker |   | ip-10-0-97-109 | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
U | 2025-04-09, 10:50:12.511 | worker |   | ip-10-0-97-109 | File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/platforms/cuda.py", line 270, in get_attn_backend_cls
U | 2025-04-09, 10:50:12.511 | worker |   | ip-10-0-97-109 | and kv_cache_dtype.startswith("fp8"))
U | 2025-04-09, 10:50:12.511 | worker |   | ip-10-0-97-109 | ^^^^^^^^^^^^^^^^^^^^^^^^^
U | 2025-04-09, 10:50:12.511 | worker |   | ip-10-0-97-109 | AttributeError: 'torch.dtype' object has no attribute 'startswith'

```

This is because vLLM has inconsistent logic when handling `kv_cache_dtype`. For V0, it is a string and for V1, it is a torch.dtype. And when the V0 and V1 configs are messed up, this issue manifests.

Another recent change in vLLM is that it auto tries V1 and use V1 configs if possible. Therefore, when we are not using an environment VLLM_USE_V1, Ray LLM defaults to V0 and vLLM may use V1. This PR fixes the inconsistency by always explicitly passing the environment variable.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
