### PR TITLE
[data.dashboard.x/01] fix operator state

### DIFF
--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -435,8 +435,9 @@ class StreamingExecutor(Executor, threading.Thread):
                     "progress": op_state.num_completed_tasks,
                     "total": op.num_outputs_total(),
                     "total_rows": op.num_output_rows_total(),
-                    "state": 
-                        DatasetState.FINISHED.name if op_state.num_completed_tasks == op.num_outputs_total() and op.num_outputs_total() > 0 else state,
+                    "state": DatasetState.FINISHED.name
+                    if op.execution_finished()
+                    else state,
                 }
                 for i, (op, op_state) in enumerate(self._topology.items())
             },

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -435,7 +435,8 @@ class StreamingExecutor(Executor, threading.Thread):
                     "progress": op_state.num_completed_tasks,
                     "total": op.num_outputs_total(),
                     "total_rows": op.num_output_rows_total(),
-                    "state": state,
+                    "state": 
+                        DatasetState.FINISHED.name if op_state.num_completed_tasks == op.num_outputs_total() and op.num_outputs_total() > 0 else state,
                 }
                 for i, (op, op_state) in enumerate(self._topology.items())
             },


### PR DESCRIPTION
Currently the operator state just mimics the entire dataset state, aka. they show as running even though they already finished. Fix it so that if the number of progress already equals to number of total, move it to FINISHED state.

Test:
- CI

<img width="572" alt="Screenshot 2025-04-09 at 2 33 21 PM" src="https://github.com/user-attachments/assets/236ce1f8-05a8-4ab6-b8bf-2c651375c33e" />
