### PR TITLE
[core][autoscaler] let AWS node provider retry instance retrieval to handle eventual consistency

### DIFF
--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -604,9 +604,10 @@ class AWSNodeProvider(NodeProvider):
             if len(matches) == 1:
                 return matches[0]
             cli_logger.warning(
-                "get_node({}): Attempt failed with len(matches) == {}, retrying ({}/{}).",
+                "Unable to find {} from {} EC2 instances. Will retry after {} seconds ({}/{}).",
                 node_id,
                 len(matches),
+                LIST_RETRY_DELAY_SEC,
                 attempts + 1,
                 BOTO_MAX_RETRIES,
             )

--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -604,7 +604,7 @@ class AWSNodeProvider(NodeProvider):
             if len(matches) == 1:
                 return matches[0]
             cli_logger.warning(
-                "Unable to find the id {} from {} EC2 instances. Will retry after {} seconds ({}/{}).",
+                "Attempt to fetch EC2 instances that have instance ID {}. Got {} matching EC2 instances. Will retry after {} second. This is retry number {}, and the maximum number of retries is {}.",
                 node_id,
                 len(matches),
                 LIST_RETRY_DELAY_SEC,

--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -38,7 +38,7 @@ from ray.autoscaler.tags import (
 logger = logging.getLogger(__name__)
 
 TAG_BATCH_DELAY = 1
-LIST_RETRY_DELAY = 1
+LIST_RETRY_DELAY_SEC = 1
 
 
 def to_aws_format(tags):
@@ -610,7 +610,7 @@ class AWSNodeProvider(NodeProvider):
                 attempts + 1,
                 BOTO_MAX_RETRIES,
             )
-            time.sleep(LIST_RETRY_DELAY)
+            time.sleep(LIST_RETRY_DELAY_SEC)
         raise AssertionError("Invalid instance id {}".format(node_id))
 
     def _get_cached_node(self, node_id):

--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -604,7 +604,7 @@ class AWSNodeProvider(NodeProvider):
             if len(matches) == 1:
                 return matches[0]
             cli_logger.warning(
-                "Unable to find {} from {} EC2 instances. Will retry after {} seconds ({}/{}).",
+                "Unable to find id = {} from {} EC2 instances. Will retry after {} seconds ({}/{}).",
                 node_id,
                 len(matches),
                 LIST_RETRY_DELAY_SEC,

--- a/python/ray/autoscaler/_private/aws/node_provider.py
+++ b/python/ray/autoscaler/_private/aws/node_provider.py
@@ -604,7 +604,7 @@ class AWSNodeProvider(NodeProvider):
             if len(matches) == 1:
                 return matches[0]
             cli_logger.warning(
-                "Unable to find id = {} from {} EC2 instances. Will retry after {} seconds ({}/{}).",
+                "Unable to find the id {} from {} EC2 instances. Will retry after {} seconds ({}/{}).",
                 node_id,
                 len(matches),
                 LIST_RETRY_DELAY_SEC,

--- a/python/ray/tests/aws/test_autoscaler_aws.py
+++ b/python/ray/tests/aws/test_autoscaler_aws.py
@@ -769,6 +769,36 @@ def test_terminate_nodes(num_on_demand_nodes, num_spot_nodes, stop):
         assert nodes_to_include_in_call == nodes_included_in_call
 
 
+def test_retry_get_node():
+    """
+    This tests _get_node() retries `ec2.instances.filter` if the first call returns an empty list.
+    This is important because the EC2 API is eventually consistent, and it may take some time for the
+    instance to be available after it has been launched.
+    """
+
+    with patch("ray.autoscaler._private.aws.node_provider.make_ec2_resource"):
+        provider = AWSNodeProvider(
+            provider_config={"region": "nowhere"},
+            cluster_name="default",
+        )
+
+    attempts = 0
+    fake_instance = {"id": "i-1234567890abcdef0"}
+
+    def mock_filter(*args, **kwargs):
+        nonlocal attempts
+        if kwargs.get("InstanceIds") == [fake_instance["id"]]:
+            attempts += 1
+            if attempts > 1:
+                return [fake_instance]
+        return []
+
+    provider.ec2.instances.filter.side_effect = mock_filter
+
+    assert provider._get_node(fake_instance["id"]) == fake_instance
+    assert attempts == 2
+
+
 def test_use_subnets_ordered_by_az(ec2_client_stub):
     """
     This test validates that when bootstrap_aws populates the SubnetIds field,


### PR DESCRIPTION
## Why are these changes needed?

Fixes https://github.com/ray-project/ray/issues/51861. The issue fails on the assertion:
https://github.com/ray-project/ray/blob/574cf65b3996513d476ba40c48b899d8de0a27a0/python/ray/autoscaler/_private/aws/node_provider.py#L597-L598

The assertion can only fail on `len(matches) == 0` because AWS will never return duplicate instances in the API.

As documented [here](https://docs.aws.amazon.com/ec2/latest/devguide/eventual-consistency.html), the AWS EC2 API follows an eventual consistency model. It is possible that we can't query an instance by using `ec2.instances.filter(InstanceIds=[node_id])` immediately after the instance is created. We need to retry for a few seconds. This PR reuses the `BOTO_MAX_RETRIES` environment variable, which is 12 by default, to retry the operation. That's up to 12 seconds.


## Related issue number

Closes https://github.com/ray-project/ray/issues/51861

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
