### PR TITLE
[Core] Fix Interleaved Placement Group Creation Process due to Node Failure

### DIFF
--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -832,7 +832,7 @@ void GcsPlacementGroupManager::OnNodeDead(const NodeID &node_id) {
         // pending queue for other states (RESCHEDULING, PREPARED). This is because
         // RESCHEDULING and PREPARED state indicate that the placement group is in
         // scheduling process and when completing the scheduling, we will check
-        // whether all bundles in the palcement group has been successfully scheduled.
+        // whether all bundles in the placement group has been successfully scheduled.
         // If not, the unplaced bundles will be rescheduled and thus the unplaced
         // bundles due to the node death will be handled there.
         iter->second->UpdateState(rpc::PlacementGroupTableData::RESCHEDULING);

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -815,7 +815,26 @@ void GcsPlacementGroupManager::OnNodeDead(const NodeID &node_id) {
       // TODO(ffbin): If we have a placement group bundle that requires a unique resource
       // (for example gpu resource when there's only one gpu node), this can postpone
       // creating until a node with the resources is added. we will solve it in next pr.
-      if (iter->second->GetState() != rpc::PlacementGroupTableData::RESCHEDULING) {
+
+      // check to make sure the placement group shouldn't be in PENDING or REMOVED state
+      RAY_CHECK_NE(iter->second->GetState(), rpc::PlacementGroupTableData::PENDING)
+          << "Placement group that is pending rescheduling shouldn't be in PENDING "
+             "state. placement_group_id="
+          << iter->second->GetPlacementGroupID();
+      RAY_CHECK_NE(iter->second->GetState(), rpc::PlacementGroupTableData::REMOVED)
+          << "Placement group that is pending rescheduling shouldn't be in REMOVED "
+             "state. placement_group_id="
+          << iter->second->GetPlacementGroupID();
+
+      if (iter->second->GetState() == rpc::PlacementGroupTableData::CREATED) {
+        // Only update the placement group state to RESCHEDULING if it is in CREATED
+        // state. We don't need to update the placement group state or add to the
+        // pending queue for other states (RESCHEDULING, PREPARED). This is because
+        // RESCHEDULING and PREPARED state indicate that the placement group is in
+        // scheduling process and when completing the scheduling, we will check
+        // whether all bundles in the palcement group has been successfully scheduled.
+        // If not, the unplaced bundles will be rescheduled and thus the unplaced
+        // bundles due to the node death will be handled there.
         iter->second->UpdateState(rpc::PlacementGroupTableData::RESCHEDULING);
         iter->second->GetMutableStats()->set_scheduling_state(
             rpc::PlacementGroupStats::QUEUED);

--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
@@ -817,14 +817,14 @@ void GcsPlacementGroupManager::OnNodeDead(const NodeID &node_id) {
       // creating until a node with the resources is added. we will solve it in next pr.
 
       // check to make sure the placement group shouldn't be in PENDING or REMOVED state
-      RAY_CHECK_NE(iter->second->GetState(), rpc::PlacementGroupTableData::PENDING)
-          << "Placement group that is pending rescheduling shouldn't be in PENDING "
-             "state. placement_group_id="
-          << iter->second->GetPlacementGroupID();
-      RAY_CHECK_NE(iter->second->GetState(), rpc::PlacementGroupTableData::REMOVED)
-          << "Placement group that is pending rescheduling shouldn't be in REMOVED "
-             "state. placement_group_id="
-          << iter->second->GetPlacementGroupID();
+      RAY_CHECK(iter->second->GetState() != rpc::PlacementGroupTableData::PENDING)
+              .WithField(iter->second->GetPlacementGroupID())
+              .WithField(node_id)
+          << "PENDING placement group should have no scheduled bundles on the dead node.";
+      RAY_CHECK(iter->second->GetState() != rpc::PlacementGroupTableData::REMOVED)
+              .WithField(iter->second->GetPlacementGroupID())
+              .WithField(node_id)
+          << "REMOVED placement group should have no scheduled bundles on the dead node.";
 
       if (iter->second->GetState() == rpc::PlacementGroupTableData::CREATED) {
         // Only update the placement group state to RESCHEDULING if it is in CREATED

--- a/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_placement_group_manager_test.cc
@@ -123,8 +123,63 @@ class GcsPlacementGroupManagerTest : public ::testing::Test {
     promise.get_future().get();
   }
 
+  // Mock receiving prepare request for a placement group and update the committed
+  // resources for each bundle
+  void MockReceivePrepareRequest(
+      const std::shared_ptr<gcs::GcsPlacementGroup> &placement_group) {
+    int bundles_size = placement_group->GetPlacementGroupTableData().bundles_size();
+    for (int bundle_index = 0; bundle_index < bundles_size; bundle_index++) {
+      placement_group->GetMutableBundle(bundle_index)
+          ->set_node_id(NodeID::FromRandom().Binary());
+    }
+  }
+
+  // Mock receiving prepare request for specific bundle in a placement group
+  // and update the committed resources for the specific bundles
+  void MockReceivePrepareRequestWithBundleIndexes(
+      const std::shared_ptr<gcs::GcsPlacementGroup> &placement_group,
+      const std::vector<int> &bundle_indices) {
+    for (const auto &bundle_index : bundle_indices) {
+      placement_group->GetMutableBundle(bundle_index)
+          ->set_node_id(NodeID::FromRandom().Binary());
+    }
+  }
+
+  // Mock prepare resource bundles for a placement group
+  void PrepareBundleResources(
+      const std::shared_ptr<gcs::GcsPlacementGroup> &placement_group) {
+    // mock all bundles of pg have prepared and committed resource.
+    MockReceivePrepareRequest(placement_group);
+
+    // A placement group must first become PREPARED then it can become CREATED.
+    // Normally transition to PREPARED is performed by
+    // GcsPlacementGroupScheduler::OnAllBundlePrepareRequestReturned.
+    placement_group->UpdateState(rpc::PlacementGroupTableData::PREPARED);
+  }
+
+  // Mock prepare resource bundles for a placement group with specific bundle indexes
+  void PrepareBundleResourcesWithIndex(
+      const std::shared_ptr<gcs::GcsPlacementGroup> &placement_group,
+      const std::vector<int> &bundle_indices) {
+    // mock prepare resource bundles with committed resource for specific bundle indexes
+    MockReceivePrepareRequestWithBundleIndexes(placement_group, bundle_indices);
+
+    // A placement group must first become PREPARED then it can become CREATED.
+    // Normally transition to PREPARED is performed by
+    // GcsPlacementGroupScheduler::OnAllBundlePrepareRequestReturned.
+    placement_group->UpdateState(rpc::PlacementGroupTableData::PREPARED);
+  }
+
+  // Mock committing resource bundles for a placement group
+  void CommitBundleResources(
+      const std::shared_ptr<gcs::GcsPlacementGroup> &placement_group) {
+    gcs_placement_group_manager_->OnPlacementGroupCreationSuccess(placement_group);
+    RunIOService();
+  }
+
   // We need this to ensure that `MarkSchedulingDone` and `SchedulePendingPlacementGroups`
   // was already invoked when we have invoked `OnPlacementGroupCreationSuccess`.
+  // Mock creating a placement group
   void OnPlacementGroupCreationSuccess(
       const std::shared_ptr<gcs::GcsPlacementGroup> &placement_group) {
     std::promise<void> promise;
@@ -134,18 +189,8 @@ class GcsPlacementGroupManagerTest : public ::testing::Test {
           promise.set_value();
         });
 
-    // mock all bundles of pg have prepared and committed resource.
-    int bundles_size = placement_group->GetPlacementGroupTableData().bundles_size();
-    for (int bundle_index = 0; bundle_index < bundles_size; bundle_index++) {
-      placement_group->GetMutableBundle(bundle_index)
-          ->set_node_id(NodeID::FromRandom().Binary());
-    }
-    // A placement group must first become PREPARED then it can become CREATED.
-    // Normally transition to PREPARED is performed by
-    // GcsPlacementGroupScheduler::OnAllBundlePrepareRequestReturned.
-    placement_group->UpdateState(rpc::PlacementGroupTableData::PREPARED);
-    gcs_placement_group_manager_->OnPlacementGroupCreationSuccess(placement_group);
-    RunIOService();
+    PrepareBundleResources(placement_group);
+    CommitBundleResources(placement_group);
     promise.get_future().get();
   }
 
@@ -526,14 +571,229 @@ TEST_F(GcsPlacementGroupManagerTest, TestRescheduleWhenNodeDead) {
   RunIOService();
   ASSERT_EQ(mock_placement_group_scheduler_->placement_groups_[0]->GetPlacementGroupID(),
             placement_group->GetPlacementGroupID());
-  const auto &bundles =
-      mock_placement_group_scheduler_->placement_groups_[0]->GetBundles();
+  const auto &bundles = placement_group->GetBundles();
+  mock_placement_group_scheduler_->placement_groups_.pop_back();
   EXPECT_TRUE(NodeID::FromBinary(bundles[0]->GetMessage().node_id()).IsNil());
   EXPECT_FALSE(NodeID::FromBinary(bundles[1]->GetMessage().node_id()).IsNil());
   ASSERT_EQ(placement_group->GetState(), rpc::PlacementGroupTableData::RESCHEDULING);
 
   // Test placement group rescheduling success.
+  OnPlacementGroupCreationSuccess(placement_group);
+  ASSERT_EQ(placement_group->GetState(), rpc::PlacementGroupTableData::CREATED);
+}
+
+TEST_F(GcsPlacementGroupManagerTest, TestNodeDeadBeforePlacementGroupCreated) {
+  ///
+  /// Test the case where a node dies before the placement group is created.
+  /// pg scheduled -> node dead -> pg created -> pg rescheduled.
+  ///
+  auto request1 = Mocker::GenCreatePlacementGroupRequest();
+  std::atomic<int> registered_placement_group_count(0);
+  RegisterPlacementGroup(request1, [&registered_placement_group_count](Status status) {
+    ++registered_placement_group_count;
+  });
+  ASSERT_EQ(registered_placement_group_count, 1);
+  ASSERT_EQ(mock_placement_group_scheduler_->GetPlacementGroupCount(), 1);
+  auto placement_group = mock_placement_group_scheduler_->placement_groups_.back();
   mock_placement_group_scheduler_->placement_groups_.pop_back();
+  PrepareBundleResources(placement_group);
+
+  // Node dies before the placement group is created.
+  // Expect the placement group state continues to be PREPARED.
+  mock_placement_group_scheduler_->group_on_dead_node_ =
+      placement_group->GetPlacementGroupID();
+  mock_placement_group_scheduler_->bundles_on_dead_node_.push_back(0);
+  gcs_placement_group_manager_->OnNodeDead(NodeID::FromRandom());
+  RunIOService();
+  const auto &bundles = placement_group->GetBundles();
+  EXPECT_TRUE(NodeID::FromBinary(bundles[0]->GetMessage().node_id()).IsNil());
+  EXPECT_FALSE(NodeID::FromBinary(bundles[1]->GetMessage().node_id()).IsNil());
+  ASSERT_EQ(placement_group->GetState(), rpc::PlacementGroupTableData::PREPARED);
+
+  // Test placement group rescheduling success.
+  CommitBundleResources(placement_group);
+  ASSERT_EQ(mock_placement_group_scheduler_->placement_groups_[0]->GetPlacementGroupID(),
+            placement_group->GetPlacementGroupID());
+  mock_placement_group_scheduler_->placement_groups_.pop_back();
+  ASSERT_EQ(placement_group->GetState(), rpc::PlacementGroupTableData::RESCHEDULING);
+
+  OnPlacementGroupCreationSuccess(placement_group);
+  ASSERT_EQ(placement_group->GetState(), rpc::PlacementGroupTableData::CREATED);
+}
+
+TEST_F(GcsPlacementGroupManagerTest, TestTwoNodesWithBundlesFromSamePlacementGroupDie1) {
+  ///
+  /// Test the first scenario of the case where two nodes with bundles from the same
+  /// placement group die consecutively.
+  /// pg scheduled -> pg created -> node1 dead -> pg rescheduled
+  /// -> bundles on node1 prepared -> node2 dead -> pg still in prepared state ->
+  /// -> bundles on node1 created -> pg rescheduled (for bundles on node2) -> pg created
+  ///
+
+  auto request1 = Mocker::GenCreatePlacementGroupRequest();
+  std::atomic<int> registered_placement_group_count(0);
+  RegisterPlacementGroup(request1, [&registered_placement_group_count](Status status) {
+    ++registered_placement_group_count;
+  });
+  ASSERT_EQ(registered_placement_group_count, 1);
+  ASSERT_EQ(mock_placement_group_scheduler_->GetPlacementGroupCount(), 1);
+  auto placement_group = mock_placement_group_scheduler_->placement_groups_.back();
+  mock_placement_group_scheduler_->placement_groups_.pop_back();
+  OnPlacementGroupCreationSuccess(placement_group);
+
+  // Node 1 dies. Assuming Node 1 has bundle 0. Node 2 has bundle 1.
+  mock_placement_group_scheduler_->group_on_dead_node_ =
+      placement_group->GetPlacementGroupID();
+  mock_placement_group_scheduler_->bundles_on_dead_node_.push_back(0);
+  gcs_placement_group_manager_->OnNodeDead(NodeID::FromRandom());
+  RunIOService();
+  ASSERT_EQ(mock_placement_group_scheduler_->placement_groups_[0]->GetPlacementGroupID(),
+            placement_group->GetPlacementGroupID());
+  mock_placement_group_scheduler_->placement_groups_.pop_back();
+  const auto &bundles1 = placement_group->GetBundles();
+  EXPECT_TRUE(NodeID::FromBinary(bundles1[0]->GetMessage().node_id()).IsNil());
+  EXPECT_FALSE(NodeID::FromBinary(bundles1[1]->GetMessage().node_id()).IsNil());
+  ASSERT_EQ(placement_group->GetState(), rpc::PlacementGroupTableData::RESCHEDULING);
+
+  // Bundles on node1 are prepared.
+  PrepareBundleResourcesWithIndex(placement_group, {0});
+  ASSERT_EQ(placement_group->GetState(), rpc::PlacementGroupTableData::PREPARED);
+
+  // Node 2 dies.
+  mock_placement_group_scheduler_->group_on_dead_node_ =
+      placement_group->GetPlacementGroupID();
+  mock_placement_group_scheduler_->bundles_on_dead_node_.pop_back();
+  mock_placement_group_scheduler_->bundles_on_dead_node_.push_back(1);
+  gcs_placement_group_manager_->OnNodeDead(NodeID::FromRandom());
+  RunIOService();
+  const auto &bundles2 = placement_group->GetBundles();
+  EXPECT_FALSE(NodeID::FromBinary(bundles2[0]->GetMessage().node_id()).IsNil());
+  EXPECT_TRUE(NodeID::FromBinary(bundles2[1]->GetMessage().node_id()).IsNil());
+  ASSERT_EQ(placement_group->GetState(), rpc::PlacementGroupTableData::PREPARED);
+
+  // Complete the placement group creation for bundles in node1
+  // Placement group state should be set to RESCHEDULING to reschedule bundles on node2
+  CommitBundleResources(placement_group);
+  ASSERT_EQ(mock_placement_group_scheduler_->placement_groups_[0]->GetPlacementGroupID(),
+            placement_group->GetPlacementGroupID());
+  mock_placement_group_scheduler_->placement_groups_.pop_back();
+  ASSERT_EQ(placement_group->GetState(), rpc::PlacementGroupTableData::RESCHEDULING);
+
+  // Complete the placement group creation for bundles in node2
+  OnPlacementGroupCreationSuccess(placement_group);
+  ASSERT_EQ(placement_group->GetState(), rpc::PlacementGroupTableData::CREATED);
+}
+
+TEST_F(GcsPlacementGroupManagerTest, TestTwoNodesWithBundlesFromSamePlacementGroupDie2) {
+  ///
+  /// Test the second scenario of the case where two nodes with bundles from the same
+  /// placement group die consecutively.
+  /// pg scheduled -> pg created -> node1 dead -> pg rescheduled
+  /// -> all prepare requests returned -> node2 dead -> pg still in rescheduled state
+  /// -> pg prepared -> bundles on node1 created -> pg rescheduled (for bundles on node2)
+  /// -> pg created
+  ///
+  auto request1 = Mocker::GenCreatePlacementGroupRequest();
+  std::atomic<int> registered_placement_group_count(0);
+  RegisterPlacementGroup(request1, [&registered_placement_group_count](Status status) {
+    ++registered_placement_group_count;
+  });
+  ASSERT_EQ(registered_placement_group_count, 1);
+  ASSERT_EQ(mock_placement_group_scheduler_->GetPlacementGroupCount(), 1);
+  auto placement_group = mock_placement_group_scheduler_->placement_groups_.back();
+  mock_placement_group_scheduler_->placement_groups_.pop_back();
+  OnPlacementGroupCreationSuccess(placement_group);
+
+  // Node 1 dies. Assuming Node 1 has bundle 0. Node 2 has bundle 1.
+  mock_placement_group_scheduler_->group_on_dead_node_ =
+      placement_group->GetPlacementGroupID();
+  mock_placement_group_scheduler_->bundles_on_dead_node_.push_back(0);
+  gcs_placement_group_manager_->OnNodeDead(NodeID::FromRandom());
+  RunIOService();
+  ASSERT_EQ(mock_placement_group_scheduler_->placement_groups_[0]->GetPlacementGroupID(),
+            placement_group->GetPlacementGroupID());
+  mock_placement_group_scheduler_->placement_groups_.pop_back();
+  const auto &bundles1 = placement_group->GetBundles();
+  EXPECT_TRUE(NodeID::FromBinary(bundles1[0]->GetMessage().node_id()).IsNil());
+  EXPECT_FALSE(NodeID::FromBinary(bundles1[1]->GetMessage().node_id()).IsNil());
+  ASSERT_EQ(placement_group->GetState(), rpc::PlacementGroupTableData::RESCHEDULING);
+
+  // All prepare requests returned.
+  MockReceivePrepareRequestWithBundleIndexes(placement_group, {0});
+
+  // Node 2 dies.
+  mock_placement_group_scheduler_->group_on_dead_node_ =
+      placement_group->GetPlacementGroupID();
+  mock_placement_group_scheduler_->bundles_on_dead_node_.pop_back();
+  mock_placement_group_scheduler_->bundles_on_dead_node_.push_back(1);
+  gcs_placement_group_manager_->OnNodeDead(NodeID::FromRandom());
+  RunIOService();
+  ASSERT_EQ(mock_placement_group_scheduler_->placement_groups_.size(), 0);
+  const auto &bundles2 = placement_group->GetBundles();
+  EXPECT_FALSE(NodeID::FromBinary(bundles2[0]->GetMessage().node_id()).IsNil());
+  EXPECT_TRUE(NodeID::FromBinary(bundles2[1]->GetMessage().node_id()).IsNil());
+  ASSERT_EQ(placement_group->GetState(), rpc::PlacementGroupTableData::RESCHEDULING);
+
+  // Complete the placement group creation for bundles in Node 1
+  placement_group->UpdateState(rpc::PlacementGroupTableData::PREPARED);
+  ASSERT_EQ(placement_group->GetState(), rpc::PlacementGroupTableData::PREPARED);
+  CommitBundleResources(placement_group);
+  ASSERT_EQ(mock_placement_group_scheduler_->placement_groups_[0]->GetPlacementGroupID(),
+            placement_group->GetPlacementGroupID());
+  mock_placement_group_scheduler_->placement_groups_.pop_back();
+  ASSERT_EQ(placement_group->GetState(), rpc::PlacementGroupTableData::RESCHEDULING);
+
+  // Complete the placement group creation for bundles in Node 2
+  OnPlacementGroupCreationSuccess(placement_group);
+  ASSERT_EQ(placement_group->GetState(), rpc::PlacementGroupTableData::CREATED);
+}
+
+TEST_F(GcsPlacementGroupManagerTest, TestTwoNodesWithBundlesFromSamePlacementGroupDie3) {
+  ///
+  /// Test the third scenario of the case where two nodes with bundles from the same
+  /// placement group die consecutively.
+  /// pg scheduled -> pg created -> node1 dead -> pg rescheduled -> node2 dead
+  /// -> pg still in rescheduled state -> pg prepared -> pg created
+  ///
+  auto request1 = Mocker::GenCreatePlacementGroupRequest();
+  std::atomic<int> registered_placement_group_count(0);
+  RegisterPlacementGroup(request1, [&registered_placement_group_count](Status status) {
+    ++registered_placement_group_count;
+  });
+  ASSERT_EQ(registered_placement_group_count, 1);
+  ASSERT_EQ(mock_placement_group_scheduler_->GetPlacementGroupCount(), 1);
+  auto placement_group = mock_placement_group_scheduler_->placement_groups_.back();
+  mock_placement_group_scheduler_->placement_groups_.pop_back();
+  OnPlacementGroupCreationSuccess(placement_group);
+
+  // Node 1 dies. Assuming Node 1 has bundle 0. Node 2 has bundle 1.
+  mock_placement_group_scheduler_->group_on_dead_node_ =
+      placement_group->GetPlacementGroupID();
+  mock_placement_group_scheduler_->bundles_on_dead_node_.push_back(0);
+  gcs_placement_group_manager_->OnNodeDead(NodeID::FromRandom());
+  RunIOService();
+  ASSERT_EQ(mock_placement_group_scheduler_->placement_groups_[0]->GetPlacementGroupID(),
+            placement_group->GetPlacementGroupID());
+  mock_placement_group_scheduler_->placement_groups_.pop_back();
+  const auto &bundles1 = placement_group->GetBundles();
+  EXPECT_TRUE(NodeID::FromBinary(bundles1[0]->GetMessage().node_id()).IsNil());
+  EXPECT_FALSE(NodeID::FromBinary(bundles1[1]->GetMessage().node_id()).IsNil());
+  ASSERT_EQ(placement_group->GetState(), rpc::PlacementGroupTableData::RESCHEDULING);
+
+  // Node 2 dies.
+  mock_placement_group_scheduler_->group_on_dead_node_ =
+      placement_group->GetPlacementGroupID();
+  mock_placement_group_scheduler_->bundles_on_dead_node_.pop_back();
+  mock_placement_group_scheduler_->bundles_on_dead_node_.push_back(1);
+  gcs_placement_group_manager_->OnNodeDead(NodeID::FromRandom());
+  RunIOService();
+  ASSERT_EQ(mock_placement_group_scheduler_->placement_groups_.size(), 0);
+  const auto &bundles2 = placement_group->GetBundles();
+  EXPECT_TRUE(NodeID::FromBinary(bundles2[0]->GetMessage().node_id()).IsNil());
+  EXPECT_TRUE(NodeID::FromBinary(bundles2[1]->GetMessage().node_id()).IsNil());
+  ASSERT_EQ(placement_group->GetState(), rpc::PlacementGroupTableData::RESCHEDULING);
+
+  // Complete the placement group creation for both bundles
   OnPlacementGroupCreationSuccess(placement_group);
   ASSERT_EQ(placement_group->GetState(), rpc::PlacementGroupTableData::CREATED);
 }

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -139,11 +139,11 @@ enum class RayLogLevel {
 
 #define RAY_IGNORE_EXPR(expr) ((void)(expr))
 
-#define RAY_CHECK_WITH_DISPLAY(condition, display)                                \
-  RAY_PREDICT_TRUE((condition))                                                   \
-  ? RAY_IGNORE_EXPR(0)                                                            \
-  : ::ray::Voidify() & ::ray::RayLog(__FILE__, __LINE__, ray::RayLogLevel::FATAL) \
-                           << " Check failed: " display " "
+#define RAY_CHECK_WITH_DISPLAY(condition, display)                                 \
+  RAY_PREDICT_TRUE((condition))                                                    \
+  ? RAY_IGNORE_EXPR(0)                                                             \
+  : ::ray::Voidify() & (::ray::RayLog(__FILE__, __LINE__, ray::RayLogLevel::FATAL) \
+                        << " Check failed: " display " ")
 
 #define RAY_CHECK(condition) RAY_CHECK_WITH_DISPLAY(condition, #condition)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When debugging a recent check failure, we found that when multiple nodes with the bundles from the same placement group dies at the same time, the placement group rescheduling process of the 2 nodes will interleave with each other and thus causes check failure. 

To be specific, under the above scenario, the following happens:
1. Node 1 with bundle 1 of placement group pg dies
2. pg is set to `RESCHEDULING` state and pg is added to the placement group pending scheduling queue.
3. `SchedulePendingPlacementGroups` is called to fetch the placement groups in the pending queue and schedule them
4. pg is fetched from the queue. Prepare resources requests for bundle 1 received with success state. pg's state is updated to `PREPARED`.
5. Node 2 with bundle 2 of pg dies
6. pg is then set to `RESCHEDULING` state and the pg is added to the placement group pending scheduling queue
7. Resource commit responses for bundle 1 is received. GCS tries to update pg's state to CREATED. 
8. However, when the state update, GCS checks whether the current pg state is PREPARED. Since the pg state is updated to RESCHEDULING in 6, the check fails and thus the job fails. 

The above issue happens mainly because 2 placement group scheduling processes of the same placement group happens in an interleaved way and we should avoid that by making the scheduling of the same placement group in a sequential manner.

The fix of the issue is updating the `OnNodeDead` logic in the placement group management logic to only update the placement group state, add the placement group to the pending queue and trigger scheduling, when the placement group is in `CREATED` state. In this way, if the placement group state is already in `RESCHEDULING` or in `PREPARED` state (meaning the scheduling process in progress), we will not update the placement group state and trigger another scheduling process. 

At the same time, in the current placement group scheduling process, we already have the logic to check whether all placement group bundles are placed after a placement group is created. In this sense, if the node dies during the placement group scheduling process, the rescheduling of the bundles on the dead node will happen there.  

This PR also added corresponding tests as well. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
N/A
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
