### PR TITLE
[core][autoscaler] bump autoscaler_state_version in a fake request to deflay the test

### DIFF
--- a/python/ray/autoscaler/v2/tests/test_sdk.py
+++ b/python/ray/autoscaler/v2/tests/test_sdk.py
@@ -753,7 +753,9 @@ def test_get_cluster_status(ray_start_cluster):
     stub = _autoscaler_state_service_stub()
     state = autoscaler_pb2.AutoscalingState(
         last_seen_cluster_resource_state_version=0,
-        autoscaler_state_version=10,  # use a large number to avoid flaky.
+        # since the autoscaler will also update the autoscaler_state_version periodically,
+        # we need to use a large number here, such as 10, to override it to avoid flaky test.
+        autoscaler_state_version=10,
         pending_instance_requests=[
             autoscaler_pb2.PendingInstanceRequest(
                 instance_type_name="m5.large",

--- a/python/ray/autoscaler/v2/tests/test_sdk.py
+++ b/python/ray/autoscaler/v2/tests/test_sdk.py
@@ -753,7 +753,7 @@ def test_get_cluster_status(ray_start_cluster):
     stub = _autoscaler_state_service_stub()
     state = autoscaler_pb2.AutoscalingState(
         last_seen_cluster_resource_state_version=0,
-        autoscaler_state_version=1,
+        autoscaler_state_version=10,  # use a large number to avoid flaky.
         pending_instance_requests=[
             autoscaler_pb2.PendingInstanceRequest(
                 instance_type_name="m5.large",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The autoscaler monitor will periodically update the state version number here at:
https://github.com/ray-project/ray/blob/356db5e1d59f6b4ad4dcae1d71809afffed6b1f2/python/ray/autoscaler/v2/monitor.py#L168-L172

Therefore, the grpc stub call with `autoscaler_state_version=1` in the test can sometimes fail if the grpc stub happens after an autoscaler cycle. That's why the test is flaky.

This PR assigns the `autoscaler_state_version` in the stub call with a larger number, 10,  to override the state periodically updated by the autoscaler monitor for this testing purpose. I have run 100 times locally with the updated `autoscaler_state_version`. The test didn't fail.

## Related issue number

Closes https://github.com/ray-project/ray/issues/51843

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
