### PR TITLE
Remove BUILDKITE_TOKEN env var path

### DIFF
--- a/release/release_logs/fetch_release_logs.py
+++ b/release/release_logs/fetch_release_logs.py
@@ -6,9 +6,7 @@ Specifically, this will loop through all release test pipeline builds for the
 specified Ray version and fetch the latest available results from the respective
 tests. It will then write these to the directory in `ray/release/release_logs`.
 
-To use this script, either set the BUILDKITE_TOKEN environment variable to a
-valid Buildkite API token with read access, or authenticate in AWS with the
-OSS CI account.
+To use this script authenticate in AWS with the OSS CI account.
 
 Usage:
 
@@ -85,18 +83,12 @@ class Artifact:
 
 def get_buildkite_api() -> Buildkite:
     bk = Buildkite()
-    buildkite_token = maybe_fetch_buildkite_token()
+    buildkite_token = fetch_buildkite_token()
     bk.set_access_token(buildkite_token)
     return bk
 
 
-def maybe_fetch_buildkite_token() -> str:
-    buildkite_token = os.environ.get("BUILDKITE_TOKEN", None)
-
-    if buildkite_token:
-        return buildkite_token
-
-    print("Missing BUILDKITE_TOKEN, retrieving from AWS secrets store")
+def fetch_buildkite_token() -> str:
     buildkite_token = boto3.client(
         "secretsmanager", region_name="us-west-2"
     ).get_secret_value(


### PR DESCRIPTION
## Why are these changes needed?

Using environment variables for secrets is a little dangerous, lets just stick with the already supported safer option :D

## Related issue number

n/a

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
