### PR TITLE
[train] log errors raised by worker

### DIFF
--- a/python/ray/train/v2/_internal/execution/worker_group/thread_runner.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/thread_runner.py
@@ -49,6 +49,7 @@ class ThreadRunner:
                     self._exc = UserExceptionWithTraceback(
                         e, traceback_str=exc_traceback_str
                     )
+
             with self._lock:
                 self._is_running = False
 

--- a/python/ray/train/v2/_internal/execution/worker_group/thread_runner.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/thread_runner.py
@@ -1,3 +1,4 @@
+import logging
 import threading
 import traceback
 from typing import Callable, Optional, TypeVar
@@ -5,6 +6,8 @@ from typing import Callable, Optional, TypeVar
 from ray.train.v2._internal.exceptions import UserExceptionWithTraceback
 
 T = TypeVar("T")
+
+logger = logging.getLogger(__name__)
 
 
 class ThreadRunner:
@@ -42,10 +45,10 @@ class ThreadRunner:
                     exc_traceback_str = traceback.format_exc(
                         limit=-(len(traceback.extract_tb(e.__traceback__)) - 2)
                     )
+                    logger.error(f"Error in training function:\n{exc_traceback_str}")
                     self._exc = UserExceptionWithTraceback(
                         e, traceback_str=exc_traceback_str
                     )
-
             with self._lock:
                 self._is_running = False
 

--- a/python/ray/train/v2/_internal/execution/worker_group/worker.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/worker.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import queue
 import socket
@@ -31,8 +30,6 @@ from ray.train.v2._internal.logging.logging import configure_worker_logger
 from ray.train.v2._internal.logging.patch_print import patch_print_function
 
 T = TypeVar("T")
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -144,8 +141,6 @@ class RayTrainWorker:
             training_result = None
 
         error = execution_context.training_thread_runner.get_error()
-        if error:
-            logger.error(f"Error in training function:\n{error}")
 
         # TODO: The running state should not be conflated with queue flushing.
         # Running should only be true if the user code is still running.

--- a/python/ray/train/v2/_internal/execution/worker_group/worker.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/worker.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import queue
 import socket
@@ -30,6 +31,8 @@ from ray.train.v2._internal.logging.logging import configure_worker_logger
 from ray.train.v2._internal.logging.patch_print import patch_print_function
 
 T = TypeVar("T")
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -141,6 +144,8 @@ class RayTrainWorker:
             training_result = None
 
         error = execution_context.training_thread_runner.get_error()
+        if error:
+            logger.error(f"Error in training function:\n{error}")
 
         # TODO: The running state should not be conflated with queue flushing.
         # Running should only be true if the user code is still running.


### PR DESCRIPTION
## Why are these changes needed?

When an error happens in the user training function, it is raised in a separate thread and not currently logged.

This propagates the error to be logged when the thread completes with an error.

## Checks

```python
from ray.train.v2.api.data_parallel_trainer import DataParallelTrainer

def f():
    1/0

trainer = DataParallelTrainer(f)
trainer.fit()
```

```bash
~ cat /tmp/ray/session_latest/logs/train/ray-train-app-worker-8a2f3e3c1a67ccfd095ea12fe7eb343d0063af1b9cadb55874eed73c.log | jq -r .message           
Error in training function:
Traceback (most recent call last):
  File "/tmp/repro.py", line 4, in f
    1/0
ZeroDivisionError: division by zero
```