### PR TITLE
Added warning for serve config when no config exists

### DIFF
--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -351,7 +351,7 @@ def deploy(
     )
 
 @cli.command(short_help="Get the current Serve application configurations")
-def config(address: str):
+def get_config(address: str):
     """Show the current Serve config (only available if config was provided at startup)."""
     client = ServeSubmissionClient(address)
     try:

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -347,8 +347,27 @@ def deploy(
         "\nSent deploy request successfully.\n "
         "* Use `serve status` to check applications' statuses.\n "
         "* Use `serve config` to see the current application config(s).\n"
+        "(only available if config was provided at startup).\n"
     )
 
+@cli.command(short_help="Get the current Serve application configurations")
+def config(address: str):
+    """Show the current Serve config (only available if config was provided at startup)."""
+    client = ServeSubmissionClient(address)
+    try:
+        config = client.get_serve_config()
+        if not config or not getattr(config, "applications", None):
+            cli_logger.warning(
+                "No configuration available. Note: `serve config` only displays "
+                "configurations that were explicitly provided at startup."
+            )
+            return
+            
+        cli_logger.print("Current Serve configurations:\n")
+        cli_logger.print(yaml.dump(config.dict(exclude_unset=True)))
+    except Exception as e:
+        cli_logger.error(f"Failed to get Serve config: {str(e)}")
+        
 
 @cli.command(
     short_help="Run an application or group of applications.",


### PR DESCRIPTION
Warns users when serve config is called without a user-provided config.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- server config will give a warning. -->

## Related issue number

<!-- 52113 -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
