### PR TITLE
[core][refactor] Make `tasks_to_resubmit` more deterministic

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1370,9 +1370,10 @@ void CoreWorker::InternalHeartbeat() {
   // Retry tasks.
   std::vector<TaskToRetry> tasks_to_resubmit;
   {
+    auto current_time_ms = current_time_ms();
     absl::MutexLock lock(&mutex_);
     while (!to_resubmit_.empty() &&
-           current_time_ms() > to_resubmit_.top().execution_time_ms) {
+           current_time_ms > to_resubmit_.top().execution_time_ms) {
       tasks_to_resubmit.emplace_back(to_resubmit_.top());
       to_resubmit_.pop();
     }

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1370,10 +1370,10 @@ void CoreWorker::InternalHeartbeat() {
   // Retry tasks.
   std::vector<TaskToRetry> tasks_to_resubmit;
   {
-    auto current_time_ms = current_time_ms();
     absl::MutexLock lock(&mutex_);
+    auto current_time = current_time_ms();
     while (!to_resubmit_.empty() &&
-           current_time_ms > to_resubmit_.top().execution_time_ms) {
+           current_time > to_resubmit_.top().execution_time_ms) {
       tasks_to_resubmit.emplace_back(to_resubmit_.top());
       to_resubmit_.pop();
     }

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1371,7 +1371,7 @@ void CoreWorker::InternalHeartbeat() {
   std::vector<TaskToRetry> tasks_to_resubmit;
   {
     absl::MutexLock lock(&mutex_);
-    auto current_time = current_time_ms();
+    const auto current_time = current_time_ms();
     while (!to_resubmit_.empty() && current_time > to_resubmit_.top().execution_time_ms) {
       tasks_to_resubmit.emplace_back(to_resubmit_.top());
       to_resubmit_.pop();

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1372,8 +1372,7 @@ void CoreWorker::InternalHeartbeat() {
   {
     absl::MutexLock lock(&mutex_);
     auto current_time = current_time_ms();
-    while (!to_resubmit_.empty() &&
-           current_time > to_resubmit_.top().execution_time_ms) {
+    while (!to_resubmit_.empty() && current_time > to_resubmit_.top().execution_time_ms) {
       tasks_to_resubmit.emplace_back(to_resubmit_.top());
       to_resubmit_.pop();
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, each iteration of the loop that selects `tasks_to_resubmit` uses different values for comparison with `execution_time_ms`. Consequently, some tasks with smaller `execution_time_ms` values might not be selected for resubmission during this call of `InternalHeartbeat`.

Follow up of https://github.com/ray-project/ray/pull/51904#discussion_r2029994867

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
