### PR TITLE
[data] ResourceManager: fix min resource reservation

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/execution_options.py
+++ b/python/ray/data/_internal/execution/interfaces/execution_options.py
@@ -181,15 +181,28 @@ class ExecutionResources:
             ),
         )
 
-    def satisfies_limit(self, limit: "ExecutionResources") -> bool:
+    def satisfies_limit(
+        self,
+        limit: "ExecutionResources",
+        *,
+        exclude_object_store_memory=False,
+    ) -> bool:
         """Return if this resource struct meets the specified limits.
 
         Note that None for a field means no limit.
+
+        Args:
+            limit: The resource limits to check against.
+            exclude_object_store_memory: If True, ignore the object store memory
+                limit when checking if this resource struct meets the limits.
         """
         return (
             self.cpu <= limit.cpu
             and self.gpu <= limit.gpu
-            and self.object_store_memory <= limit.object_store_memory
+            and (
+                exclude_object_store_memory
+                or self.object_store_memory <= limit.object_store_memory
+            )
         )
 
     def scale(self, f: float) -> "ExecutionResources":

--- a/python/ray/data/_internal/execution/interfaces/execution_options.py
+++ b/python/ray/data/_internal/execution/interfaces/execution_options.py
@@ -185,7 +185,7 @@ class ExecutionResources:
         self,
         limit: "ExecutionResources",
         *,
-        exclude_object_store_memory=False,
+        ignore_object_store_memory=False,
     ) -> bool:
         """Return if this resource struct meets the specified limits.
 
@@ -200,7 +200,7 @@ class ExecutionResources:
             self.cpu <= limit.cpu
             and self.gpu <= limit.gpu
             and (
-                exclude_object_store_memory
+                ignore_object_store_memory
                 or self.object_store_memory <= limit.object_store_memory
             )
         )

--- a/python/ray/data/_internal/execution/interfaces/execution_options.py
+++ b/python/ray/data/_internal/execution/interfaces/execution_options.py
@@ -193,7 +193,7 @@ class ExecutionResources:
 
         Args:
             limit: The resource limits to check against.
-            exclude_object_store_memory: If True, ignore the object store memory
+            ignore_object_store_memory: If True, ignore the object store memory
                 limit when checking if this resource struct meets the limits.
         """
         return (

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -276,6 +276,12 @@ class PhysicalOperator(Operator):
         """Manually mark this operator has completed execution."""
         self._execution_completed = True
 
+    def execution_completed(self) -> bool:
+        """Return True when this operator has completed execution.
+        The outputs may or may not have been taken.
+        """
+        return self._execution_completed
+
     def completed(self) -> bool:
         """Return True when this operator is completed.
 

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -203,7 +203,7 @@ class PhysicalOperator(Operator):
         self._in_task_output_backpressure = False
         self._estimated_num_output_bundles = None
         self._estimated_output_num_rows = None
-        self._execution_completed = False
+        self._execution_finished = False
         # The LogicalOperator(s) which were translated to create this PhysicalOperator.
         # Set via `PhysicalOperator.set_logical_operators()`.
         self._logical_operators: List[LogicalOperator] = []
@@ -272,28 +272,29 @@ class PhysicalOperator(Operator):
         elif self._output_block_size_option is not None:
             self._output_block_size_option = None
 
-    def mark_execution_completed(self):
-        """Manually mark this operator has completed execution."""
-        self._execution_completed = True
+    def mark_execution_finished(self):
+        """Manually mark this operator has finished execution."""
+        self._execution_finished = True
 
-    def execution_completed(self) -> bool:
-        """Return True when this operator has completed execution.
+    def execution_finished(self) -> bool:
+        """Return True when this operator has finished execution.
+
         The outputs may or may not have been taken.
         """
-        return self._execution_completed
+        return self._execution_finished
 
     def completed(self) -> bool:
         """Return True when this operator is completed.
 
-        An operator is completed the operator has stopped execution and all
-        outputs are taken.
+        An operator is completed if the operator has finished execution and all
+        outputs have been taken.
         """
-        if not self._execution_completed:
+        if not self._execution_finished:
             if self._inputs_complete and self.num_active_tasks() == 0:
                 # If all inputs are complete and there are no active tasks,
                 # then the operator has completed execution.
-                self._execution_completed = True
-        return self._execution_completed and not self.has_next()
+                self._execution_finished = True
+        return self._execution_finished and not self.has_next()
 
     def get_stats(self) -> StatsDict:
         """Return recorded execution stats for use with DatasetStats."""

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -273,7 +273,7 @@ class PhysicalOperator(Operator):
             self._output_block_size_option = None
 
     def mark_execution_finished(self):
-        """Manually mark this operator has finished execution."""
+        """Manually mark that this operator has finished execution."""
         self._execution_finished = True
 
     def execution_finished(self) -> bool:
@@ -286,8 +286,9 @@ class PhysicalOperator(Operator):
     def completed(self) -> bool:
         """Return True when this operator is completed.
 
-        An operator is completed if the operator has finished execution and all
-        outputs have been taken.
+        An operator is completed when all these conditions hold true:
+        * The operator has finished execution (i.e., `execution_finished()` is True).
+        * All outputs have been taken (i.e., `has_next()` is False).
         """
         if not self._execution_finished:
             if self._inputs_complete and self.num_active_tasks() == 0:

--- a/python/ray/data/_internal/execution/operators/input_data_buffer.py
+++ b/python/ray/data/_internal/execution/operators/input_data_buffer.py
@@ -44,6 +44,7 @@ class InputDataBuffer(PhysicalOperator):
             self._input_data_factory = input_data_factory
             self._is_input_initialized = False
         self._input_data_index = 0
+        self.mark_execution_completed()
 
     def start(self, options: ExecutionOptions) -> None:
         if not self._is_input_initialized:

--- a/python/ray/data/_internal/execution/operators/input_data_buffer.py
+++ b/python/ray/data/_internal/execution/operators/input_data_buffer.py
@@ -44,7 +44,7 @@ class InputDataBuffer(PhysicalOperator):
             self._input_data_factory = input_data_factory
             self._is_input_initialized = False
         self._input_data_index = 0
-        self.mark_execution_completed()
+        self.mark_execution_finished()
 
     def start(self, options: ExecutionOptions) -> None:
         if not self._is_input_initialized:

--- a/python/ray/data/_internal/execution/operators/limit_operator.py
+++ b/python/ray/data/_internal/execution/operators/limit_operator.py
@@ -114,7 +114,7 @@ class LimitOperator(OneToOneOperator):
     def num_outputs_total(self) -> Optional[int]:
         # Before execution is completed, we don't know how many output
         # bundles we will have. We estimate based off the consumption so far.
-        if self._execution_completed:
+        if self._execution_finished:
             return self._cur_output_bundles
         return self._estimated_num_output_bundles
 

--- a/python/ray/data/_internal/execution/operators/limit_operator.py
+++ b/python/ray/data/_internal/execution/operators/limit_operator.py
@@ -31,7 +31,7 @@ class LimitOperator(OneToOneOperator):
         self._cur_output_bundles = 0
         super().__init__(self._name, input_op, data_context, target_max_block_size=None)
         if self._limit <= 0:
-            self.mark_execution_completed()
+            self.mark_execution_finished()
 
     def _limit_reached(self) -> bool:
         return self._consumed_rows >= self._limit
@@ -81,7 +81,7 @@ class LimitOperator(OneToOneOperator):
         self._buffer.append(out_refs)
         self._metrics.on_output_queued(out_refs)
         if self._limit_reached():
-            self.mark_execution_completed()
+            self.mark_execution_finished()
 
         # We cannot estimate if we have only consumed empty blocks,
         # or if the input dependency's total number of output bundles is unknown.

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -426,7 +426,12 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
 
     def _is_op_eligible(self, op: PhysicalOperator) -> bool:
         """Whether the op is eligible for memory reservation."""
-        return not op.throttling_disabled() and not op.execution_completed()
+        return (
+            not op.throttling_disabled()
+            # As long as the op has finished execution, even if there are still
+            # non-taken outputs, we don't need to allocate resources for it.
+            and not op.execution_completed()
+        )
 
     def _get_eligible_ops(self) -> List[PhysicalOperator]:
         return [

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -430,7 +430,7 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
             not op.throttling_disabled()
             # As long as the op has finished execution, even if there are still
             # non-taken outputs, we don't need to allocate resources for it.
-            and not op.execution_completed()
+            and not op.execution_finished()
         )
 
     def _get_eligible_ops(self) -> List[PhysicalOperator]:

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -479,7 +479,9 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
             min_reserved.object_store_memory += self._reserved_for_op_outputs[op]
             # Total resources we want to reserve for this operator.
             op_total_reserved = default_reserved.max(min_reserved)
-            if op_total_reserved.satisfies_limit(self._total_shared):
+            if op_total_reserved.satisfies_limit(
+                self._total_shared, exclude_object_store_memory=True
+            ):
                 # If the remaining resources are enough to reserve `op_total_reserved`,
                 # subtract it from `self._total_shared` and reserve it for this op.
                 self._reserved_min_resources[op] = True

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -426,7 +426,7 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
 
     def _is_op_eligible(self, op: PhysicalOperator) -> bool:
         """Whether the op is eligible for memory reservation."""
-        return not op.throttling_disabled() and not op.completed()
+        return not op.throttling_disabled() and not op.execution_completed()
 
     def _get_eligible_ops(self) -> List[PhysicalOperator]:
         return [

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -525,7 +525,7 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
                         " The job may hang forever unless the cluster scales up."
                     )
 
-            remaining = self._total_shared.max(ExecutionResources.zero())
+            remaining = remaining.max(ExecutionResources.zero())
         self._total_shared = remaining
 
     def can_submit_new_task(self, op: PhysicalOperator) -> bool:

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -528,7 +528,7 @@ def update_operator_states(topology: Topology) -> None:
 
     # Traverse the topology in reverse topological order.
     # For each op, if all of its downstream operators have completed.
-    # call mark_execution_completed() to also complete this op.
+    # call mark_execution_finished() to also complete this op.
     for op, op_state in reversed(list(topology.items())):
         if op.completed():
             continue

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -536,7 +536,7 @@ def update_operator_states(topology: Topology) -> None:
             dep.completed() for dep in op.output_dependencies
         )
         if dependents_completed:
-            op.mark_execution_completed()
+            op.mark_execution_finished()
 
 
 def select_operator_to_run(

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -711,8 +711,8 @@ def test_limit_operator(ray_start_regular_shared):
         refs = make_ref_bundles([[i] * num_rows_per_block for i in range(num_refs)])
         input_op = InputDataBuffer(DataContext.get_current(), refs)
         limit_op = LimitOperator(limit, input_op, DataContext.get_current())
-        limit_op.mark_execution_completed = MagicMock(
-            wraps=limit_op.mark_execution_completed
+        limit_op.mark_execution_finished = MagicMock(
+            wraps=limit_op.mark_execution_finished
         )
         if limit == 0:
             # If the limit is 0, the operator should be completed immediately.
@@ -731,16 +731,16 @@ def test_limit_operator(ray_start_regular_shared):
                 limit_op.get_next()
             cur_rows += num_rows_per_block
             if cur_rows >= limit:
-                assert limit_op.mark_execution_completed.call_count == 1, limit
+                assert limit_op.mark_execution_finished.call_count == 1, limit
                 assert limit_op.completed(), limit
                 assert limit_op._limit_reached(), limit
                 assert limit_op._execution_completed, limit
             else:
-                assert limit_op.mark_execution_completed.call_count == 0, limit
+                assert limit_op.mark_execution_finished.call_count == 0, limit
                 assert not limit_op.completed(), limit
                 assert not limit_op._limit_reached(), limit
                 assert not limit_op._execution_completed, limit
-        limit_op.mark_execution_completed()
+        limit_op.mark_execution_finished()
         # After inputs done, the number of output bundles
         # should be the same as the number of `add_input`s.
         assert limit_op.num_outputs_total() == loop_count, limit

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -723,7 +723,7 @@ def test_limit_operator(ray_start_regular_shared):
         while input_op.has_next() and not limit_op._limit_reached():
             loop_count += 1
             assert not limit_op.completed(), limit
-            assert not limit_op._execution_completed, limit
+            assert not limit_op._execution_finished, limit
             limit_op.add_input(input_op.get_next(), 0)
             while limit_op.has_next():
                 # Drain the outputs. So the limit operator
@@ -734,12 +734,12 @@ def test_limit_operator(ray_start_regular_shared):
                 assert limit_op.mark_execution_finished.call_count == 1, limit
                 assert limit_op.completed(), limit
                 assert limit_op._limit_reached(), limit
-                assert limit_op._execution_completed, limit
+                assert limit_op._execution_finished, limit
             else:
                 assert limit_op.mark_execution_finished.call_count == 0, limit
                 assert not limit_op.completed(), limit
                 assert not limit_op._limit_reached(), limit
-                assert not limit_op._execution_completed, limit
+                assert not limit_op._execution_finished, limit
         limit_op.mark_execution_finished()
         # After inputs done, the number of output bundles
         # should be the same as the number of `add_input`s.

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -531,7 +531,8 @@ class TestReservationOpResourceAllocator:
         """Test that we only handle non-completed map ops."""
         DataContext.get_current().op_resource_reservation_enabled = True
 
-        o1 = InputDataBuffer(DataContext.get_current(), [])
+        input = make_ref_bundles([[x] for x in range(1)])
+        o1 = InputDataBuffer(DataContext.get_current(), input)
         o2 = mock_map_op(o1)
         o3 = LimitOperator(1, o2, DataContext.get_current())
         topo, _ = build_streaming_topology(o3, ExecutionOptions())
@@ -551,10 +552,11 @@ class TestReservationOpResourceAllocator:
         assert isinstance(allocator, ReservationOpResourceAllocator)
 
         allocator.update_usages()
+        assert o1 not in allocator._op_budgets
         assert o2 in allocator._op_budgets
         assert o3 not in allocator._op_budgets
 
-        o2.execution_completed = MagicMock(return_value=True)
+        o2.mark_execution_completed()
         allocator.update_usages()
         assert o2 not in allocator._op_budgets
 

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -575,7 +575,7 @@ class TestReservationOpResourceAllocator:
         assert o2 in allocator._op_budgets
         assert o3 not in allocator._op_budgets
 
-        o2.mark_execution_completed()
+        o2.mark_execution_finished()
         allocator.update_usages()
         assert o2 not in allocator._op_budgets
 

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -554,7 +554,7 @@ class TestReservationOpResourceAllocator:
         assert o2 in allocator._op_budgets
         assert o3 not in allocator._op_budgets
 
-        o2.completed = MagicMock(return_value=True)
+        o2.execution_completed = MagicMock(return_value=True)
         allocator.update_usages()
         assert o2 not in allocator._op_budgets
 

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -470,13 +470,15 @@ class TestReservationOpResourceAllocator:
         DataContext.get_current().op_resource_reservation_enabled = True
         DataContext.get_current().op_resource_reservation_ratio = 0.5
 
-        global_limits = ExecutionResources(cpu=6, gpu=0, object_store_memory=1600)
+        global_limits = ExecutionResources(cpu=7, gpu=0, object_store_memory=800)
         incremental_usage = ExecutionResources(cpu=3, gpu=0, object_store_memory=500)
 
         o1 = InputDataBuffer(DataContext.get_current(), [])
         o2 = mock_map_op(o1, incremental_resource_usage=incremental_usage)
         o3 = mock_map_op(o2, incremental_resource_usage=incremental_usage)
-        topo, _ = build_streaming_topology(o3, ExecutionOptions())
+        o4 = mock_map_op(o3, incremental_resource_usage=incremental_usage)
+        o5 = mock_map_op(o4, incremental_resource_usage=incremental_usage)
+        topo, _ = build_streaming_topology(o5, ExecutionOptions())
 
         resource_manager = ResourceManager(
             topo, ExecutionOptions(), MagicMock(), DataContext.get_current()
@@ -490,10 +492,27 @@ class TestReservationOpResourceAllocator:
         assert isinstance(allocator, ReservationOpResourceAllocator)
 
         allocator.update_usages()
+        # incremental_usage should be reserved for o2.
         assert allocator._op_reserved[o2] == incremental_usage
+        # Remaining resources are CPU = 7 - 3 = 4, object_store_memory = 800 - 500 = 300.
+        # We have enough CPUs for o3's incremental_usage, but not enough
+        # object_store_memory. We'll still reserve the incremental_usage by
+        # oversubscribing object_store_memory.
         assert allocator._op_reserved[o3] == incremental_usage
-        assert allocator._reserved_for_op_outputs[o2] == 200
-        assert allocator._reserved_for_op_outputs[o2] == 200
+        # Now the remaining resources are CPU = 4 - 3 = 1,
+        # object_store_memory = 300 - 500 = -200.
+        # We don't oversubscribing CPUs, we'll only reserve
+        # incremental_usage.object_store_memory.
+        assert allocator._op_reserved[o4] == ExecutionResources(
+            0, 0, incremental_usage.object_store_memory
+        )
+        # Same for o5
+        assert allocator._op_reserved[o5] == ExecutionResources(
+            0, 0, incremental_usage.object_store_memory
+        )
+        assert allocator._total_shared == ExecutionResources(1, 0, 0)
+        for op in [o2, o3, o4]:
+            assert allocator._reserved_for_op_outputs[op] == 50
 
     def test_reserve_min_resources_for_gpu_ops(self, restore_data_context):
         """Test that we'll reserve enough resources for ActorPoolMapOperator

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -164,26 +164,26 @@ def test_process_completed_tasks():
     done_task = MetadataOpTask(0, ray.put("done"), done_task_callback)
     o2.get_active_tasks = MagicMock(return_value=[sleep_task, done_task])
     o2.all_inputs_done = MagicMock()
-    o1.mark_execution_completed = MagicMock()
+    o1.mark_execution_finished = MagicMock()
     process_completed_tasks(topo, resource_manager, 0)
     update_operator_states(topo)
     done_task_callback.assert_called_once()
     o2.all_inputs_done.assert_not_called()
-    o1.mark_execution_completed.assert_not_called()
+    o1.mark_execution_finished.assert_not_called()
 
     # Test input finalization.
     done_task_callback = MagicMock()
     done_task = MetadataOpTask(0, ray.put("done"), done_task_callback)
     o2.get_active_tasks = MagicMock(return_value=[done_task])
     o2.all_inputs_done = MagicMock()
-    o1.mark_execution_completed = MagicMock()
+    o1.mark_execution_finished = MagicMock()
     o1.completed = MagicMock(return_value=True)
     topo[o1].outqueue.clear()
     process_completed_tasks(topo, resource_manager, 0)
     update_operator_states(topo)
     done_task_callback.assert_called_once()
     o2.all_inputs_done.assert_called_once()
-    o1.mark_execution_completed.assert_not_called()
+    o1.mark_execution_finished.assert_not_called()
 
     # Test dependents completed.
     o1 = InputDataBuffer(DataContext.get_current(), inputs)
@@ -199,11 +199,11 @@ def test_process_completed_tasks():
     )
     topo, _ = build_streaming_topology(o3, ExecutionOptions(verbose_progress=True))
 
-    o3.mark_execution_completed()
-    o2.mark_execution_completed = MagicMock()
+    o3.mark_execution_finished()
+    o2.mark_execution_finished = MagicMock()
     process_completed_tasks(topo, resource_manager, 0)
     update_operator_states(topo)
-    o2.mark_execution_completed.assert_called_once()
+    o2.mark_execution_finished.assert_called_once()
 
 
 def test_select_operator_to_run():


### PR DESCRIPTION
* When calculating the minimum resource reservation, we can over-subscribe object store memory, but not CPU. Without this fix, a dataset can hang on a small cluster where CPUs are sufficient but object store is small. 
* Also add an optimization to exclude operators as soon as they've finished execution, instead of util all outputs are taken.