### PR TITLE
[core][refactor] Remove `OnClientConnected`

### DIFF
--- a/src/ray/core_worker/transport/actor_submit_queue.h
+++ b/src/ray/core_worker/transport/actor_submit_queue.h
@@ -74,8 +74,6 @@ class IActorSubmitQueue {
   /// On client connect/reconnect, find all the tasks that's known to be
   /// executed out of order. This is specific to SequentialActorSubmitQueue.
   virtual std::map<uint64_t, TaskSpecification> PopAllOutOfOrderCompletedTasks() = 0;
-  /// On client connected.
-  virtual void OnClientConnected() = 0;
   /// Get the sequence number of the task to send according to the protocol.
   virtual uint64_t GetSequenceNumber(const TaskSpecification &task_spec) const = 0;
   /// Mark a task has been executed on the receiver side.

--- a/src/ray/core_worker/transport/actor_task_submitter.cc
+++ b/src/ray/core_worker/transport/actor_task_submitter.cc
@@ -324,7 +324,6 @@ void ActorTaskSubmitter::ConnectActor(const ActorID &actor_id,
     queue->second.worker_id = address.worker_id();
     // Create a new connection to the actor.
     queue->second.rpc_client = core_worker_client_pool_.GetOrConnect(address);
-    queue->second.actor_submit_queue->OnClientConnected();
 
     ResendOutOfOrderCompletedTasks(actor_id);
     SendPendingTasks(actor_id);

--- a/src/ray/core_worker/transport/out_of_order_actor_submit_queue.cc
+++ b/src/ray/core_worker/transport/out_of_order_actor_submit_queue.cc
@@ -102,8 +102,6 @@ OutofOrderActorSubmitQueue::PopAllOutOfOrderCompletedTasks() {
   return {};
 }
 
-void OutofOrderActorSubmitQueue::OnClientConnected() {}
-
 uint64_t OutofOrderActorSubmitQueue::GetSequenceNumber(
     const TaskSpecification &task_spec) const {
   return task_spec.ActorCounter();

--- a/src/ray/core_worker/transport/out_of_order_actor_submit_queue.h
+++ b/src/ray/core_worker/transport/out_of_order_actor_submit_queue.h
@@ -62,8 +62,6 @@ class OutofOrderActorSubmitQueue : public IActorSubmitQueue {
   /// On client connect/reconnect, find all the TASK that's known to be
   /// executed out of order. This ALWAYS RETURNS empty.
   std::map<uint64_t, TaskSpecification> PopAllOutOfOrderCompletedTasks() override;
-  /// On client connected, noop.
-  void OnClientConnected() override;
   /// Get the sequence number of the task to send.
   /// This is ignored by the receivier but only for debugging purpose.
   uint64_t GetSequenceNumber(const TaskSpecification &task_spec) const override;

--- a/src/ray/core_worker/transport/sequential_actor_submit_queue.cc
+++ b/src/ray/core_worker/transport/sequential_actor_submit_queue.cc
@@ -91,8 +91,6 @@ SequentialActorSubmitQueue::PopAllOutOfOrderCompletedTasks() {
   return result;
 }
 
-void SequentialActorSubmitQueue::OnClientConnected() {}
-
 uint64_t SequentialActorSubmitQueue::GetSequenceNumber(
     const TaskSpecification &task_spec) const {
   RAY_CHECK(task_spec.ActorCounter() >= caller_starts_at)

--- a/src/ray/core_worker/transport/sequential_actor_submit_queue.h
+++ b/src/ray/core_worker/transport/sequential_actor_submit_queue.h
@@ -58,9 +58,6 @@ class SequentialActorSubmitQueue : public IActorSubmitQueue {
   /// On client connect/reconnect, find all the tasks which are known to be
   /// executed out of order.
   std::map<uint64_t, TaskSpecification> PopAllOutOfOrderCompletedTasks() override;
-  /// Called on client connected/reconnected. This reset the offset for
-  /// sequence number.
-  void OnClientConnected() override;
   /// Get the task's sequence number according to the internal offset.
   uint64_t GetSequenceNumber(const TaskSpecification &task_spec) const override;
   /// Mark a task has been executed on the receiver side.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

All `OnClientConnected` implementations are empty after #51904.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
