### PR TITLE
[data.dashboard][log/02] dataset log for all roots

### DIFF
--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -87,6 +87,12 @@ class StreamingExecutor(Executor, threading.Thread):
         self._num_errored_blocks = 0
 
         self._last_debug_log_time = 0
+        self._dataset_log_handler = SessionFileHandler(
+            filename=f"ray-data-{self._dataset_id}.log",
+        )
+        self._dataset_log_handler.setLevel(logging.DEBUG)
+        self._dataset_log_handler.setFormatter(get_default_formatter())
+        logger.addHandler(self._dataset_log_handler)
 
         register_dataset_logger(self._dataset_id)
         Executor.__init__(self, self._data_context.execution_options)

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -87,12 +87,6 @@ class StreamingExecutor(Executor, threading.Thread):
         self._num_errored_blocks = 0
 
         self._last_debug_log_time = 0
-        self._dataset_log_handler = SessionFileHandler(
-            filename=f"ray-data-{self._dataset_id}.log",
-        )
-        self._dataset_log_handler.setLevel(logging.DEBUG)
-        self._dataset_log_handler.setFormatter(get_default_formatter())
-        logger.addHandler(self._dataset_log_handler)
 
         register_dataset_logger(self._dataset_id)
         Executor.__init__(self, self._data_context.execution_options)

--- a/python/ray/data/_internal/logging.py
+++ b/python/ray/data/_internal/logging.py
@@ -1,7 +1,7 @@
 import logging
 import logging.config
 import os
-from typing import Optional
+from typing import Optional, List
 
 import yaml
 
@@ -147,17 +147,7 @@ class SessionFileHandler(logging.Handler):
             self._handler.setFormatter(self._formatter)
 
 
-def configure_logging() -> None:
-    """Configure the Python logger named 'ray.data'.
-
-    This function loads the configration YAML specified by "RAY_DATA_LOGGING_CONFIG"
-    environment variable. If the variable isn't set, this function loads the default
-    "logging.yaml" file that is adjacent to this module.
-
-    If "RAY_DATA_LOG_ENCODING" is specified as "JSON" we will enable JSON logging mode
-    if using the default logging config.
-    """
-
+def _get_logging_config() -> Optional[dict]:
     def _load_logging_config(config_path: str):
         with open(config_path) as file:
             config = yaml.safe_load(file)
@@ -179,6 +169,31 @@ def configure_logging() -> None:
                 ) in RAY_DATA_LOG_HANDLER_JSON_SUBSTITUTIONS.items():
                     logger["handlers"].remove(old_handler_name)
                     logger["handlers"].append(new_handler_name)
+
+    return config
+
+
+def _get_logger_names() -> List[str]:
+    logger_config = _get_logging_config().get("loggers", {})
+
+    return list(logger_config.keys())
+
+
+def configure_logging() -> None:
+    """Configure the Python logger named 'ray.data'.
+
+    This function loads the configration YAML specified by "RAY_DATA_LOGGING_CONFIG"
+    environment variable. If the variable isn't set, this function loads the default
+    "logging.yaml" file that is adjacent to this module.
+
+    If "RAY_DATA_LOG_ENCODING" is specified as "JSON" we will enable JSON logging mode
+    if using the default logging config.
+    """
+
+    # Dynamically load env vars
+    config_path = os.environ.get(RAY_DATA_LOGGING_CONFIG_ENV_VAR_NAME)
+    log_encoding = os.environ.get(RAY_DATA_LOG_ENCODING_ENV_VAR_NAME)
+    config = _get_logging_config()
 
     logging.config.dictConfig(config)
 
@@ -248,7 +263,7 @@ def register_dataset_logger(dataset_id: str) -> None:
     """
     global _DATASET_LOGGER_HANDLER
     global _ACTIVE_DATASET
-    logger = logging.getLogger("ray.data")
+    loggers = [logging.getLogger(name) for name in _get_logger_names()]
     log_handler = _create_dataset_log_handler(dataset_id)
 
     # The per-dataset log will always have the full context about its registration,
@@ -260,7 +275,8 @@ def register_dataset_logger(dataset_id: str) -> None:
     _DATASET_LOGGER_HANDLER[dataset_id] = log_handler
     if not _ACTIVE_DATASET:
         _ACTIVE_DATASET = dataset_id
-        logger.addHandler(log_handler)
+        for logger in loggers:
+            logger.addHandler(log_handler)
     else:
         local_logger.info(
             f"{dataset_id} registers for logging while another dataset "
@@ -278,7 +294,7 @@ def unregister_dataset_logger(dataset_id: str) -> None:
     """
     global _DATASET_LOGGER_HANDLER
     global _ACTIVE_DATASET
-    logger = logging.getLogger("ray.data")
+    loggers = [logging.getLogger(name) for name in _get_logger_names()]
 
     log_handler = _DATASET_LOGGER_HANDLER.pop(dataset_id, None)
 
@@ -289,5 +305,6 @@ def unregister_dataset_logger(dataset_id: str) -> None:
             register_dataset_logger(next(iter(_DATASET_LOGGER_HANDLER.keys())))
 
     if log_handler:
-        logger.removeHandler(log_handler)
+        for logger in loggers:
+            logger.removeHandler(log_handler)
         log_handler.close()


### PR DESCRIPTION
https://github.com/ray-project/ray/pull/52103 added the ability to split `ray.data` logs into per-dataset logs. However, ray data has other namespaces in addition to just `ray.data`. This PR supports splitting logs from other name spaces as well.

Test:
- CI