### PR TITLE
[tune] change `test_train_v2_integration` test size to medium

### DIFF
--- a/python/ray/tune/BUILD
+++ b/python/ray/tune/BUILD
@@ -403,7 +403,7 @@ py_test(
 
 py_test(
     name = "test_train_v2_integration",
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_train_v2_integration.py"],
     env = {"RAY_TRAIN_V2_ENABLED": "1"},
     tags = [


### PR DESCRIPTION
it takes 51s to finish on an idle machine, and often times out when running on CI (small tests has timeout of 60s), which runs with other tests in parallel
