### PR TITLE
[build] warning when username or homedir include @ character

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -599,6 +599,14 @@ def build(build_python, build_java, build_cpp):
             + runtime_env_agent_pip_packages
         )
 
+    username = os.environ.get("USER", "")
+    home_path = os.environ.get("HOME", "")
+    if "@" in username or "@" in home_path:
+        warnings.warn(
+            "WARNING: Your username or HOME path contains '@' which can cause issues "
+            "during bazel build. Use a different user account without '@' characters is recommend\n",
+        )
+
     bazel_flags = ["--verbose_failures"]
     if BAZEL_ARGS:
         bazel_flags.extend(shlex.split(BAZEL_ARGS))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

I encountered a build error as below due to the @ character in the username. It would be helpful to add a warning to check for the presence of @ in the username or home directory
https://discuss.ray.io/t/build-error-in-local/22286

## Related issue number


## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
