### PR TITLE
[core][autoscaler] make cluster constraints clear in the autoscaler status report

### DIFF
--- a/python/ray/autoscaler/_private/util.py
+++ b/python/ray/autoscaler/_private/util.py
@@ -724,9 +724,19 @@ def format_resource_demand_summary(
     return demand_lines
 
 
-def get_constraints_report(lm_summary: LoadMetricsSummary):
+def get_constraint_report(request_demand: List[DictCount]):
+    """Returns a formatted string describing the resource constraints from request_resources().
+
+    Args:
+        request_demand: List of tuples containing resource bundle dictionaries and counts
+            from request_resources() calls.
+
+    Returns:
+        String containing the formatted constraints report, either listing each constraint
+        and count or indicating no constraints exist.
+    """
     constraint_lines = []
-    for bundle, count in lm_summary.request_demand:
+    for bundle, count in request_demand:
         line = f" {bundle}: {count} from request_resources()"
         constraint_lines.append(line)
     if len(constraint_lines) > 0:
@@ -902,7 +912,7 @@ def format_info_string(
         failure_report += " (no failures)"
 
     usage_report = get_usage_report(lm_summary, verbose)
-    constraints_report = get_constraints_report(lm_summary)
+    constraints_report = get_constraint_report(lm_summary.request_demand)
     demand_report = get_demand_report(lm_summary)
     formatted_output = f"""{header}
 Node status

--- a/python/ray/autoscaler/_private/util.py
+++ b/python/ray/autoscaler/_private/util.py
@@ -727,7 +727,7 @@ def format_resource_demand_summary(
 def get_constraints_report(lm_summary: LoadMetricsSummary):
     constraint_lines = []
     for bundle, count in lm_summary.request_demand:
-        line = f" {bundle}: {count}+ from request_resources()"
+        line = f" {bundle}: {count} from request_resources()"
         constraint_lines.append(line)
     if len(constraint_lines) > 0:
         constraints_report = "\n".join(constraint_lines)

--- a/python/ray/autoscaler/_private/util.py
+++ b/python/ray/autoscaler/_private/util.py
@@ -724,6 +724,18 @@ def format_resource_demand_summary(
     return demand_lines
 
 
+def get_constraints_report(lm_summary: LoadMetricsSummary):
+    constraint_lines = []
+    for bundle, count in lm_summary.request_demand:
+        line = f" {bundle}: {count}+ from request_resources()"
+        constraint_lines.append(line)
+    if len(constraint_lines) > 0:
+        constraints_report = "\n".join(constraint_lines)
+    else:
+        constraints_report = " (no cluster constraints)"
+    return constraints_report
+
+
 def get_demand_report(lm_summary: LoadMetricsSummary):
     demand_lines = []
     if lm_summary.resource_demand:
@@ -732,9 +744,6 @@ def get_demand_report(lm_summary: LoadMetricsSummary):
         pg, count = entry
         pg_str = format_pg(pg)
         line = f" {pg_str}: {count}+ pending placement groups"
-        demand_lines.append(line)
-    for bundle, count in lm_summary.request_demand:
-        line = f" {bundle}: {count}+ from request_resources()"
         demand_lines.append(line)
     if len(demand_lines) > 0:
         demand_report = "\n".join(demand_lines)
@@ -893,6 +902,7 @@ def format_info_string(
         failure_report += " (no failures)"
 
     usage_report = get_usage_report(lm_summary, verbose)
+    constraints_report = get_constraints_report(lm_summary)
     demand_report = get_demand_report(lm_summary)
     formatted_output = f"""{header}
 Node status
@@ -914,6 +924,8 @@ Resources
 {separator}
 {"Total " if verbose else ""}Usage:
 {usage_report}
+{"Total " if verbose else ""}Constraints:
+{constraints_report}
 {"Total " if verbose else ""}Demands:
 {demand_report}"""
 

--- a/python/ray/autoscaler/_private/util.py
+++ b/python/ray/autoscaler/_private/util.py
@@ -734,6 +734,14 @@ def get_constraint_report(request_demand: List[DictCount]):
     Returns:
         String containing the formatted constraints report, either listing each constraint
         and count or indicating no constraints exist.
+
+    Example:
+        >>> request_demand = [
+        ...     ({"CPU": 4}, 2),
+        ...     ({"GPU": 1}, 1)
+        ... ]
+        >>> get_constraint_report(request_demand)
+        " {'CPU': 4}: 2 from request_resources()\\n {'GPU': 1}: 1 from request_resources()"
     """
     constraint_lines = []
     for bundle, count in request_demand:

--- a/python/ray/autoscaler/_private/util.py
+++ b/python/ray/autoscaler/_private/util.py
@@ -732,7 +732,7 @@ def get_constraints_report(lm_summary: LoadMetricsSummary):
     if len(constraint_lines) > 0:
         constraints_report = "\n".join(constraint_lines)
     else:
-        constraints_report = " (no cluster constraints)"
+        constraints_report = " (no request_resources() constraints)"
     return constraints_report
 
 

--- a/python/ray/autoscaler/v2/tests/test_utils.py
+++ b/python/ray/autoscaler/v2/tests/test_utils.py
@@ -568,7 +568,7 @@ Total Usage:
  5.42KiB/10.04KiB object_store_memory
 
 Total Constraints:
- {'GPU': 2, 'CPU': 100}: 2+ from request_resources()
+ {'GPU': 2, 'CPU': 100}: 2 from request_resources()
 Total Demands:
  {'CPU': 1, 'GPU': 1}: 11+ pending tasks/actors
  {'CPU': 1, 'GPU': 1} * 1 (STRICT_SPREAD): 1+ pending placement groups

--- a/python/ray/autoscaler/v2/tests/test_utils.py
+++ b/python/ray/autoscaler/v2/tests/test_utils.py
@@ -567,11 +567,12 @@ Total Usage:
  0.0/4.0 GPU
  5.42KiB/10.04KiB object_store_memory
 
+Total Constraints:
+ {'GPU': 2, 'CPU': 100}: 2+ from request_resources()
 Total Demands:
  {'CPU': 1, 'GPU': 1}: 11+ pending tasks/actors
  {'CPU': 1, 'GPU': 1} * 1 (STRICT_SPREAD): 1+ pending placement groups
  {'GPU': 2} * 1 (STRICT_PACK): 2+ pending placement groups
- {'GPU': 2, 'CPU': 100}: 2+ from request_resources()
 
 Node: instance1 (head_node)
  Id: fffffffffffffffffffffffffffffffffffffffffffffffffff00001

--- a/python/ray/autoscaler/v2/utils.py
+++ b/python/ray/autoscaler/v2/utils.py
@@ -552,7 +552,7 @@ class ClusterStatusFormatter:
             for bc in constraint_demand.bundles_by_count
         ]
         for bundle, count in request_demand:
-            constraint_lines.append(f" {bundle}: {count}+ from request_resources()")
+            constraint_lines.append(f" {bundle}: {count} from request_resources()")
         if constraint_lines:
             return "\n".join(constraint_lines)
         return " (no cluster constraints)"

--- a/python/ray/autoscaler/v2/utils.py
+++ b/python/ray/autoscaler/v2/utils.py
@@ -555,7 +555,7 @@ class ClusterStatusFormatter:
             constraint_lines.append(f" {bundle}: {count} from request_resources()")
         if constraint_lines:
             return "\n".join(constraint_lines)
-        return " (no cluster constraints)"
+        return " (no request_resources() constraints)"
 
     @staticmethod
     def _demand_report(data: ClusterStatus) -> str:

--- a/python/ray/autoscaler/v2/utils.py
+++ b/python/ray/autoscaler/v2/utils.py
@@ -319,7 +319,7 @@ class ClusterStatusFormatter:
         pending_report = cls._pending_node_report(data)
         failure_report = cls._failed_node_report(data, verbose)
         cluster_usage_report = cls._cluster_usage_report(data, verbose)
-        constraints_report = cls._constraints_report(data)
+        constraints_report = cls._constraint_report(data)
         demand_report = cls._demand_report(data)
         node_usage_report = (
             ""
@@ -543,8 +543,16 @@ class ClusterStatusFormatter:
         return " (no pending nodes)"
 
     @staticmethod
-    def _constraints_report(data: ClusterStatus) -> str:
-        # Process cluster constraint demand
+    def _constraint_report(data: ClusterStatus) -> str:
+        """Returns a formatted string describing the resource constraints from request_resources().
+
+        Args:
+            data: ClusterStatus object containing resource demand information.
+
+        Returns:
+            String containing the formatted constraints report, either listing each constraint
+            and count or indicating no constraints exist.
+        """
         constraint_lines = []
         request_demand = [
             (bc.bundle, bc.count)

--- a/python/ray/autoscaler/v2/utils.py
+++ b/python/ray/autoscaler/v2/utils.py
@@ -319,7 +319,9 @@ class ClusterStatusFormatter:
         pending_report = cls._pending_node_report(data)
         failure_report = cls._failed_node_report(data, verbose)
         cluster_usage_report = cls._cluster_usage_report(data, verbose)
-        constraints_report = cls._constraint_report(data)
+        constraints_report = cls._constraint_report(
+            data.resource_demands.cluster_constraint_demand
+        )
         demand_report = cls._demand_report(data)
         node_usage_report = (
             ""
@@ -543,7 +545,9 @@ class ClusterStatusFormatter:
         return " (no pending nodes)"
 
     @staticmethod
-    def _constraint_report(data: ClusterStatus) -> str:
+    def _constraint_report(
+        cluster_constraint_demand: List[ClusterConstraintDemand],
+    ) -> str:
         """Returns a formatted string describing the resource constraints from request_resources().
 
         Args:
@@ -552,11 +556,21 @@ class ClusterStatusFormatter:
         Returns:
             String containing the formatted constraints report, either listing each constraint
             and count or indicating no constraints exist.
+
+        Example:
+            >>> cluster_constraint_demand = [
+            ...     ClusterConstraintDemand(bundles_by_count=[
+            ...         ResourceRequestByCount(bundle={"CPU": 4}, count=2),
+            ...         ResourceRequestByCount(bundle={"GPU": 1}, count=1)
+            ...     ])
+            ... ]
+            >>> ClusterStatusFormatter._constraint_report(cluster_constraint_demand)
+            " {'CPU': 4}: 2 from request_resources()\\n {'GPU': 1}: 1 from request_resources()"
         """
         constraint_lines = []
         request_demand = [
             (bc.bundle, bc.count)
-            for constraint_demand in data.resource_demands.cluster_constraint_demand
+            for constraint_demand in cluster_constraint_demand
             for bc in constraint_demand.bundles_by_count
         ]
         for bundle, count in request_demand:

--- a/python/ray/tests/test_cli_patterns/test_ray_status.txt
+++ b/python/ray/tests/test_cli_patterns/test_ray_status.txt
@@ -18,6 +18,6 @@ Usage:
  0.+
 
 Constraints:
- \(no cluster constraints\)
+ \(no request_resources\(\) constraints\)
 Demands:
  \(no resource demands\)

--- a/python/ray/tests/test_cli_patterns/test_ray_status.txt
+++ b/python/ray/tests/test_cli_patterns/test_ray_status.txt
@@ -17,5 +17,7 @@ Usage:
  0.+
  0.+
 
+Constraints:
+ \(no cluster constraints\)
 Demands:
  \(no resource demands\)

--- a/python/ray/tests/test_cli_patterns/test_ray_status_multinode.txt
+++ b/python/ray/tests/test_cli_patterns/test_ray_status_multinode.txt
@@ -21,6 +21,6 @@ Usage:
  0.+
 
 Constraints:
- \(no cluster constraints\)
+ \(no request_resources\(\) constraints\)
 Demands:
  \(no resource demands\)

--- a/python/ray/tests/test_cli_patterns/test_ray_status_multinode.txt
+++ b/python/ray/tests/test_cli_patterns/test_ray_status_multinode.txt
@@ -20,5 +20,7 @@ Usage:
  0.+
  0.+
 
+Constraints:
+ \(no cluster constraints\)
 Demands:
  \(no resource demands\)

--- a/python/ray/tests/test_cli_patterns/test_ray_status_multinode_v1.txt
+++ b/python/ray/tests/test_cli_patterns/test_ray_status_multinode_v1.txt
@@ -19,6 +19,6 @@ Usage:
  0.+
 
 Constraints:
- \(no cluster constraints\)
+ \(no request_resources\(\) constraints\)
 Demands:
  \(no resource demands\)

--- a/python/ray/tests/test_cli_patterns/test_ray_status_multinode_v1.txt
+++ b/python/ray/tests/test_cli_patterns/test_ray_status_multinode_v1.txt
@@ -18,5 +18,7 @@ Usage:
  0.+
  0.+
 
+Constraints:
+ \(no cluster constraints\)
 Demands:
  \(no resource demands\)

--- a/python/ray/tests/test_cli_patterns/test_ray_status_v1.txt
+++ b/python/ray/tests/test_cli_patterns/test_ray_status_v1.txt
@@ -15,5 +15,7 @@ Usage:
  0.+
  0.+
 
+Constraints:
+ \(no cluster constraints\)
 Demands:
  \(no resource demands\)

--- a/python/ray/tests/test_cli_patterns/test_ray_status_v1.txt
+++ b/python/ray/tests/test_cli_patterns/test_ray_status_v1.txt
@@ -16,6 +16,6 @@ Usage:
  0.+
 
 Constraints:
- \(no cluster constraints\)
+ \(no request_resources\(\) constraints\)
 Demands:
  \(no resource demands\)

--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -3166,10 +3166,11 @@ Usage:
  2.00GiB/8.00GiB memory
  3.14GiB/16.00GiB object_store_memory
 
+Constraints:
+ {'CPU': 16}: 100+ from request_resources()
 Demands:
  {'CPU': 1}: 150+ pending tasks/actors
  {'CPU': 4} * 5 (PACK): 420+ pending placement groups
- {'CPU': 16}: 100+ from request_resources()
 """.strip()
     actual = format_info_string(
         lm_summary,
@@ -3256,10 +3257,11 @@ Total Usage:
  2.00GiB/8.00GiB memory
  3.14GiB/16.00GiB object_store_memory
 
+Total Constraints:
+ {'CPU': 16}: 100+ from request_resources()
 Total Demands:
  {'CPU': 1}: 150+ pending tasks/actors
  {'CPU': 4} * 5 (PACK): 420+ pending placement groups
- {'CPU': 16}: 100+ from request_resources()
 
 Node: 192.168.1.1
  Usage:
@@ -3370,10 +3372,11 @@ Total Usage:
  2.00GiB/8.00GiB memory
  3.14GiB/16.00GiB object_store_memory
 
+Total Constraints:
+ {'CPU': 16}: 100+ from request_resources()
 Total Demands:
  {'CPU': 1}: 150+ pending tasks/actors
  {'CPU': 4} * 5 (PACK): 420+ pending placement groups
- {'CPU': 16}: 100+ from request_resources()
 
 Node: 192.168.1.1 (head-node)
  Usage:
@@ -3461,10 +3464,11 @@ Total Usage:
  2.00GiB/8.00GiB memory
  3.14GiB/16.00GiB object_store_memory
 
+Total Constraints:
+ {'CPU': 16}: 100+ from request_resources()
 Total Demands:
  {'CPU': 1}: 150+ pending tasks/actors
  {'CPU': 4} * 5 (PACK): 420+ pending placement groups
- {'CPU': 16}: 100+ from request_resources()
 """.strip()
     actual = format_info_string(
         lm_summary,
@@ -3555,10 +3559,11 @@ Usage:
  2.00GiB/8.00GiB memory
  3.14GiB/16.00GiB object_store_memory
 
+Constraints:
+ {'CPU': 16}: 100+ from request_resources()
 Demands:
  {'CPU': 1}: 150+ pending tasks/actors
  {'CPU': 4} * 5 (PACK): 420+ pending placement groups
- {'CPU': 16}: 100+ from request_resources()
 """.strip()
     actual = format_info_string(
         lm_summary,
@@ -3647,10 +3652,11 @@ Total Usage:
  2.00GiB/8.00GiB memory
  3.14GiB/16.00GiB object_store_memory
 
+Total Constraints:
+ {'CPU': 16}: 100+ from request_resources()
 Total Demands:
  {'CPU': 1}: 150+ pending tasks/actors
  {'CPU': 4} * 5 (PACK): 420+ pending placement groups
- {'CPU': 16}: 100+ from request_resources()
 """.strip()
     actual = format_info_string(
         lm_summary,
@@ -3735,11 +3741,12 @@ Usage:
  2.00GiB/8.00GiB memory
  3.14GiB/16.00GiB object_store_memory
 
+Constraints:
+ {'CPU': 16}: 100+ from request_resources()
 Demands:
  {'CPU': 2.0}: 153+ pending tasks/actors (3+ using placement groups)
  {'GPU': 0.5}: 100+ pending tasks/actors (100+ using placement groups)
  {'CPU': 4} * 5 (PACK): 420+ pending placement groups
- {'CPU': 16}: 100+ from request_resources()
 """
 
     actual = format_info_string(

--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -3167,7 +3167,7 @@ Usage:
  3.14GiB/16.00GiB object_store_memory
 
 Constraints:
- {'CPU': 16}: 100+ from request_resources()
+ {'CPU': 16}: 100 from request_resources()
 Demands:
  {'CPU': 1}: 150+ pending tasks/actors
  {'CPU': 4} * 5 (PACK): 420+ pending placement groups
@@ -3258,7 +3258,7 @@ Total Usage:
  3.14GiB/16.00GiB object_store_memory
 
 Total Constraints:
- {'CPU': 16}: 100+ from request_resources()
+ {'CPU': 16}: 100 from request_resources()
 Total Demands:
  {'CPU': 1}: 150+ pending tasks/actors
  {'CPU': 4} * 5 (PACK): 420+ pending placement groups
@@ -3373,7 +3373,7 @@ Total Usage:
  3.14GiB/16.00GiB object_store_memory
 
 Total Constraints:
- {'CPU': 16}: 100+ from request_resources()
+ {'CPU': 16}: 100 from request_resources()
 Total Demands:
  {'CPU': 1}: 150+ pending tasks/actors
  {'CPU': 4} * 5 (PACK): 420+ pending placement groups
@@ -3465,7 +3465,7 @@ Total Usage:
  3.14GiB/16.00GiB object_store_memory
 
 Total Constraints:
- {'CPU': 16}: 100+ from request_resources()
+ {'CPU': 16}: 100 from request_resources()
 Total Demands:
  {'CPU': 1}: 150+ pending tasks/actors
  {'CPU': 4} * 5 (PACK): 420+ pending placement groups
@@ -3560,7 +3560,7 @@ Usage:
  3.14GiB/16.00GiB object_store_memory
 
 Constraints:
- {'CPU': 16}: 100+ from request_resources()
+ {'CPU': 16}: 100 from request_resources()
 Demands:
  {'CPU': 1}: 150+ pending tasks/actors
  {'CPU': 4} * 5 (PACK): 420+ pending placement groups
@@ -3653,7 +3653,7 @@ Total Usage:
  3.14GiB/16.00GiB object_store_memory
 
 Total Constraints:
- {'CPU': 16}: 100+ from request_resources()
+ {'CPU': 16}: 100 from request_resources()
 Total Demands:
  {'CPU': 1}: 150+ pending tasks/actors
  {'CPU': 4} * 5 (PACK): 420+ pending placement groups
@@ -3742,7 +3742,7 @@ Usage:
  3.14GiB/16.00GiB object_store_memory
 
 Constraints:
- {'CPU': 16}: 100+ from request_resources()
+ {'CPU': 16}: 100 from request_resources()
 Demands:
  {'CPU': 2.0}: 153+ pending tasks/actors (3+ using placement groups)
  {'GPU': 0.5}: 100+ pending tasks/actors (100+ using placement groups)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

As requested in the https://github.com/ray-project/ray/issues/37959. Make the cluster constraints clear in the autoscaler status report by not showing them with normal demands together but showing them in an explicit section.

## Before
```sh
Resources
---------------------------------------------------------------
Usage:
 0B/8.21GiB memory
 0B/2.00GiB object_store_memory

Demands:
 {'CPU': 3.0}: 3+ pending tasks/actors
 {'CPU': 2.0}: 3+ pending tasks/actors
 {'CPU': 1}: 1000+ from request_resources()
```

## After
```sh
Resources
---------------------------------------------------------------
Usage:
 0B/8.21GiB memory
 0B/2.00GiB object_store_memory

Constraints:
 {'CPU': 1}: 1000 from request_resources()
Demands:
 {'CPU': 3.0}: 3+ pending tasks/actors
 {'CPU': 2.0}: 3+ pending tasks/actors
```

Note that this change is also reflected in the dashboard:
<img width="552" alt="image" src="https://github.com/user-attachments/assets/478218e8-73e7-4ecd-a5a7-fe3df6e5da76" />


## Related issue number

Closes https://github.com/ray-project/ray/issues/37959

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
