### PR TITLE
[Core] Limit the number of nodes in ClusterResourceManager::DebugString

### DIFF
--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -267,11 +267,18 @@ bool ClusterResourceManager::UpdateNodeNormalTaskResources(
   return false;
 }
 
-std::string ClusterResourceManager::DebugString() const {
+std::string ClusterResourceManager::DebugString(
+    std::optional<size_t> max_num_nodes_to_include) const {
   std::stringstream buffer;
+  size_t num_nodes_included = 0;
   for (auto &node : GetResourceView()) {
+    if (max_num_nodes_to_include.has_value() &&
+        num_nodes_included >= max_num_nodes_to_include.value()) {
+      break;
+    }
     buffer << "node id: " << node.first.ToInt();
     buffer << node.second.GetLocalView().DebugString();
+    ++num_nodes_included;
   }
   buffer << " " << bundle_location_index_.DebugString();
   return buffer.str();

--- a/src/ray/raylet/scheduling/cluster_resource_manager.h
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.h
@@ -130,7 +130,10 @@ class ClusterResourceManager {
     return node.GetLocalView().is_draining;
   }
 
-  std::string DebugString() const;
+  /// @param max_num_nodes_to_include Max number of nodes to include in the debug string.
+  ///   If not specified, all nodes will be included.
+  std::string DebugString(
+      std::optional<size_t> max_num_nodes_to_include = std::nullopt) const;
 
   BundleLocationIndex &GetBundleLocationIndex();
 

--- a/src/ray/raylet/scheduling/cluster_resource_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager_test.cc
@@ -60,6 +60,26 @@ struct ClusterResourceManagerTest : public ::testing::Test {
   std::unique_ptr<ClusterResourceManager> manager;
 };
 
+TEST_F(ClusterResourceManagerTest, DebugStringTest) {
+  // Test max_num_nodes_to_include parameter is working.
+  ASSERT_EQ(std::vector<std::string>(absl::StrSplit(manager->DebugString(), "node id:"))
+                    .size() -
+                1,
+            3);
+  ASSERT_EQ(std::vector<std::string>(
+                absl::StrSplit(manager->DebugString(/*max_num_nodes_to_include=*/5),
+                               "node id:"))
+                    .size() -
+                1,
+            3);
+  ASSERT_EQ(std::vector<std::string>(
+                absl::StrSplit(manager->DebugString(/*max_num_nodes_to_include=*/2),
+                               "node id:"))
+                    .size() -
+                1,
+            2);
+}
+
 TEST_F(ClusterResourceManagerTest, HasFeasibleResourcesTest) {
   ASSERT_FALSE(manager->HasFeasibleResources(node3, {}));
   ASSERT_FALSE(manager->HasFeasibleResources(

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -255,7 +255,8 @@ std::string ClusterResourceScheduler::DebugString(void) const {
   std::stringstream buffer;
   buffer << "\nLocal id: " << local_node_id_.ToInt();
   buffer << " Local resources: " << local_resource_manager_->DebugString();
-  buffer << " Cluster resources: " << cluster_resource_manager_->DebugString();
+  buffer << " Cluster resources (at most 20 nodes are shown): "
+         << cluster_resource_manager_->DebugString(/*max_num_nodes_to_include=*/20);
   return buffer.str();
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
For large cluster with lots of nodes, this can be a very long string in the log message.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
