### PR TITLE
[Core] Revert PR 52045 and don't fail if __init__.py exists

### DIFF
--- a/python/ray/dashboard/tests/conftest.py
+++ b/python/ray/dashboard/tests/conftest.py
@@ -13,10 +13,10 @@ def enable_test_module():
     import ray.dashboard.tests
 
     p = pathlib.Path(ray.dashboard.modules.__path__[0]) / "tests" / "__init__.py"
-    p.touch(exist_ok=False)
+    p.touch()
     yield
     os.environ.pop("RAY_DASHBOARD_MODULE_TEST", None)
-    p.unlink(missing_ok=False)
+    p.unlink()
 
 
 @pytest.fixture

--- a/python/ray/dashboard/tests/conftest.py
+++ b/python/ray/dashboard/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 
 import pytest
 
@@ -9,8 +10,13 @@ from ray.tests.conftest import *  # noqa
 @pytest.fixture
 def enable_test_module():
     os.environ["RAY_DASHBOARD_MODULE_TEST"] = "true"
+    import ray.dashboard.tests
+
+    p = pathlib.Path(ray.dashboard.modules.__path__[0]) / "tests" / "__init__.py"
+    p.touch(exist_ok=False)
     yield
     os.environ.pop("RAY_DASHBOARD_MODULE_TEST", None)
+    p.unlink(missing_ok=False)
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

There's a sizable slowdown in ray startup with the `__init__.py` file added in #52045. See #52289 for details.

This PR reverts #52045 and makes tests not fail if `__init__.py` already exists.

## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
