### PR TITLE
[core][refactor] Remove `caller_starts_at` from SequentialActorSubmitQueue

### DIFF
--- a/src/ray/core_worker/transport/sequential_actor_submit_queue.cc
+++ b/src/ray/core_worker/transport/sequential_actor_submit_queue.cc
@@ -93,9 +93,7 @@ SequentialActorSubmitQueue::PopAllOutOfOrderCompletedTasks() {
 
 uint64_t SequentialActorSubmitQueue::GetSequenceNumber(
     const TaskSpecification &task_spec) const {
-  RAY_CHECK(task_spec.ActorCounter() >= caller_starts_at)
-      << "actor counter " << task_spec.ActorCounter() << " " << caller_starts_at;
-  return task_spec.ActorCounter() - caller_starts_at;
+  return task_spec.ActorCounter();
 }
 
 void SequentialActorSubmitQueue::MarkSeqnoCompleted(uint64_t sequence_no,

--- a/src/ray/core_worker/transport/sequential_actor_submit_queue.h
+++ b/src/ray/core_worker/transport/sequential_actor_submit_queue.h
@@ -69,58 +69,23 @@ class SequentialActorSubmitQueue : public IActorSubmitQueue {
   /// The ID of the actor.
   ActorID actor_id;
 
-  /// The actor's pending requests, ordered by the task number (see below
-  /// diagram) in the request. The bool indicates whether the dependencies
-  /// for that task have been resolved yet. A task will be sent after its
-  /// dependencies have been resolved and its task number matches
-  /// next_send_position.
+  /// The actor's pending requests, ordered by the sequence number in the request.
+  /// The bool indicates whether the dependencies for that task have been resolved yet.
+  /// A task will be sent after its dependencies have been resolved and its sequence
+  /// number matches next_send_position.
   std::map<uint64_t, std::pair<TaskSpecification, bool>> requests;
 
-  /// Diagram of the sequence numbers assigned to actor tasks during actor
-  /// crash and restart:
-  ///
-  /// The actor starts, and 10 tasks are submitted. We have sent 6 tasks
-  /// (0-5) so far, and have received a successful reply for 4 tasks (0-3).
-  /// 0 1 2 3 4 5 6 7 8 9
-  ///             ^ next_send_position
-  ///         ^ next_task_reply_position
-  /// ^ caller_starts_at
-  ///
-  /// Suppose the actor crashes and recovers. Then, caller_starts_at is reset
-  /// to the current next_task_reply_position. caller_starts_at is then subtracted
-  /// from each task's counter, so the recovered actor will receive the
-  /// sequence numbers 0, 1, 2 (and so on) for tasks 4, 5, 6, respectively.
-  /// Therefore, the recovered actor will restart execution from task 4.
-  /// 0 1 2 3 4 5 6 7 8 9
-  ///             ^ next_send_position
-  ///         ^ next_task_reply_position
-  ///         ^ caller_starts_at
-  ///
-  /// New actor tasks will continue to be sent even while tasks are being
-  /// resubmitted, but the receiving worker will only execute them after the
-  /// resent tasks. For example, this diagram shows what happens if task 6 is
-  /// sent for the first time, tasks 4 and 5 have been resent, and we have
-  /// received a successful reply for task 4.
-  /// 0 1 2 3 4 5 6 7 8 9
-  ///               ^ next_send_position
-  ///           ^ next_task_reply_position
-  ///         ^ caller_starts_at
-  ///
-  /// The send position of the next task to send to this actor. This sequence
-  /// number increases monotonically.
-  ///
+  /// All tasks with sequence numbers less than next_send_position have already been
+  /// sent to the actor.
+  uint64_t next_send_position = 0;
+
   /// If a task raised a retryable user exception, it's marked as "completed" via
   /// `MarkSeqnoCompleted` and `next_task_reply_position` may be updated. Afterwards Ray
   /// retries by creating another task pushed to the back of the queue, making it executes
   /// later than all tasks pending in the queue.
-  uint64_t next_send_position = 0;
-  /// The offset at which the the actor should start its counter for this
-  /// caller. This is used for actors that can be restarted, so that the new
-  /// instance of the actor knows from which task to start executing.
-  uint64_t caller_starts_at = 0;
+  ///
   /// Out of the tasks sent by this worker to the actor, the number of tasks
-  /// that we will never send to the actor again. This is used to reset
-  /// caller_starts_at if the actor dies and is restarted. We only include
+  /// that we will never send to the actor again. We only include
   /// tasks that will not be sent again, to support automatic task retry on
   /// actor failure. This value only tracks consecutive tasks that are completed.
   /// Tasks completed out of order will be cached in out_of_completed_tasks first.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
A follow up of #51904. After #51904 was merged, `caller_starts_at` is always 0, so this PR removes it.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
