### PR TITLE
[core] Fix stuck of long-time running RayCluster

### DIFF
--- a/python/ray/_private/metrics_agent.py
+++ b/python/ray/_private/metrics_agent.py
@@ -571,7 +571,7 @@ class MetricsAgent:
     def measurement_map_record(self, opencensus_measurement_map, tags):
         """Rewrite the `record` method of `opencensus.stats.measurement_map.MeasurementMap`
          to fix the performance issue[1].
-        [1] https://github.com/issues/mentioned?issue=ray-project%7Cray%7C35202
+        [1] https://github.com/ray-project/ray/issues/35202
 
         Args:
             opencensus_measurement_map: MeasurementMap to record stats

--- a/python/ray/tests/test_metrics_agent_2.py
+++ b/python/ray/tests/test_metrics_agent_2.py
@@ -456,6 +456,38 @@ def test_metrics_agent_export_format_correct(get_agent):
     assert response.count("# TYPE test_test2 gauge") == 1
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
+def test_metrics_agent_record_and_export_performance(get_agent):
+    # export one record.
+    agent, agent_port = get_agent
+
+    # Record a new gauge.
+    metric_name = "test"
+    test_gauge = Gauge(metric_name, "desc", "unit", ["tag"])
+
+    import time
+    t1 = time.time()
+    record_a = Record(
+        gauge=test_gauge,
+        value=3,
+        tags={"tag": "a"},
+    )
+    agent.record_and_export([record_a])
+    t2 = time.time()
+    print(f"\nexport 1 record costs {t2 - t1} seconds")
+
+    # export 10000 records, this should be finished quickly.
+    for i in range(10**3):
+        record_a = Record(
+            gauge=test_gauge,
+            value=i,
+            tags={"tag": str(i)},
+        )
+        agent.record_and_export([record_a])
+    t3 = time.time()
+    print(f"export 1000 record costs {t3 - t2} seconds")
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/tests/test_metrics_agent_2.py
+++ b/python/ray/tests/test_metrics_agent_2.py
@@ -486,7 +486,7 @@ def test_metrics_agent_record_and_export_performance(get_agent):
         )
         agent.record_and_export([record_a])
     t3 = time.time()
-    print(f"export 1000 record costs {t3 - t2} seconds")
+    print(f"export 1000 records costs {t3 - t2} seconds")
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_metrics_agent_2.py
+++ b/python/ray/tests/test_metrics_agent_2.py
@@ -466,6 +466,7 @@ def test_metrics_agent_record_and_export_performance(get_agent):
     test_gauge = Gauge(metric_name, "desc", "unit", ["tag"])
 
     import time
+
     t1 = time.time()
     record_a = Record(
         gauge=test_gauge,


### PR DESCRIPTION
## Why are these changes needed?
For a long-time running RayCluster, the Dashboard Server becomes increasingly slow. As you can see from the following image, after submitting a job-submit request, it takes more than 300 seconds to get response:
 
![image](https://github.com/user-attachments/assets/2b45cb22-9698-4198-be7a-2a978a5ccf57)

 Here are the links to the related issues:
[[1] https://github.com/issues/mentioned?issue=ray-project%7Cray%7C35202](https://github.com/issues/mentioned?issue=ray-project%7Cray%7C35202)

After debugging, I found that the performance bottleneck occurs in the `record_and_export` method of `python/ray/_private/metrics_agent.py`. This is the time consumption of each method in the dashboard server process obtained using py-spy:
![image](https://github.com/user-attachments/assets/27a1372b-f3ac-471f-9df1-20ba02d148ea)



The `metrics_agent.py` uses OpenCensus to report metrics to Prometheus. However, there is a performance issue with OpenCensus: the `measure_to_view_map` stores each record in a map. In a long-running RayCluster, the map in measure_to_view_map gradually increases, causing stuck in reporting. Here is a related link:

[[2] https://github.com/census-instrumentation/opencensus-python/issues/470](https://github.com/census-instrumentation/opencensus-python/issues/470)

Here is a simple code to reproduce the issue, add this method to `python/ray/tests/test_metrics_agent_2.py`:
```python
@pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
def test_metrics_agent_record_and_export_performance(get_agent):
    # export one record.
    agent, agent_port = get_agent

    # Record a new gauge.
    metric_name = "test"
    test_gauge = Gauge(metric_name, "desc", "unit", ["tag"])

    import time
    t1 = time.time()
    record_a = Record(
        gauge=test_gauge,
        value=3,
        tags={"tag": "a"},
    )
    agent.record_and_export([record_a])
    t2 = time.time()
    print(f"\nexport 1 record costs {t2 - t1} seconds")

    # export 10000 records, this should be finished quickly.
    for i in range(10**3):
        record_a = Record(
            gauge=test_gauge,
            value=i,
            tags={"tag": str(i)},
        )
        agent.record_and_export([record_a])
    t3 = time.time()
    print(f"export 1000 record costs {t3 - t2} seconds")
```

Run this code, and you can see the run time of exporting 1000 records is much longer than run time of exporting 1 records * 1000. Here is the result of my test:
```
export 1 record costs 0.0002071857452392578 seconds
export 1000 record costs 3.2115478515625 seconds
```
In fact,  if the number of record is $n$, the time complexity of `record_and_export` is $O(n^2)$.

After debugging, I identified the bottleneck in the performance:
```
|_ metrics_agent.py - record_and_export
    |_ metrics_agent.py - _record_gauge
        |_ measurement_map.py - record
            |_ measure_to_view_map.py - record
                |_ measure_to_view_map.py - export
                    |_ measure_to_view_map.py - copy_and_finalize_view_data
```

The root cause is:   
In  [`measure_to_view_map.py - export`](https://github.com/census-instrumentation/opencensus-python/blob/2275bd06bd56d24e987734d82817bcfca7b5909c/opencensus/stats/measure_to_view_map.py#L128), in order to ensure `view_datas` immutable during  [`e.export(view_datas)`](https://github.com/census-instrumentation/opencensus-python/blob/2275bd06bd56d24e987734d82817bcfca7b5909c/opencensus/stats/measure_to_view_map.py#L135), the original implementation uses [deepcopy](https://github.com/census-instrumentation/opencensus-python/blob/2275bd06bd56d24e987734d82817bcfca7b5909c/opencensus/stats/measure_to_view_map.py#L158) to create a copy of `view_datas`. This means that  in each `metrics_agent.py - record_and_export`, a deepcopy is made to `tag_value_aggregation_data_map`.

 Since`tag_value_aggregation_data_map` within `view_datas` grows continuously during runtime,the deepcopy process resulted in severe performance degradation.
        
However, the `exporter` used by `metrics_agent.py` (located in `python.ray._private.prometheus_exporter.py`) does not modify the values of view_datas, thus the deepcopy process can be safely removed.

## Related issue number

Open #35202 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
