### PR TITLE
[doc] kuberay: fix persistent gcs yaml config link

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-persistent-ft.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-persistent-ft.md
@@ -110,7 +110,7 @@ to set `appendfsync` to `always` so Redis stores all writes immediately.
 ## Putting it together
 
 Edit
-[the full YAML](https://github.com/ray-project/kuberay/blob/master/config/samples/ray-cluster.persistent-redis.yaml)
+[the full YAML](https://github.com/ray-project/kuberay/blob/release-1.3/ray-operator/config/samples/ray-cluster.persistent-redis.yaml)
 to your satisfaction and apply it:
 
 ```


### PR DESCRIPTION
and using a link to release branch rather than master branch, which is more stable.
