### PR TITLE
[Serve.llm] fix getting prompt limit for input too long error

### DIFF
--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
@@ -276,6 +276,7 @@ class VLLMEngine:
         self.running = False
         self.model_config: "ModelConfig" = None
         self.engine = None
+        self.vllm_config: "VllmConfig" = None
 
     @staticmethod
     async def initialize_node(llm_config: LLMConfig) -> InitializeNodeOutput:
@@ -380,6 +381,10 @@ class VLLMEngine:
             engine_args, engine_config = ray.get(ref)
         else:
             engine_args, engine_config = _get_vllm_engine_config(self.llm_config)
+
+        # Note (genesu): vllm_config is used to extract the scheduler config for
+        # computing the correct prompt limit.
+        self.vllm_config = engine_config
         return engine_args, engine_config, node_initialization
 
     async def _start_engine_v1(self) -> "EngineClient":
@@ -662,6 +667,24 @@ class VLLMEngine:
             # phase
             await self.engine.abort(vllm_generation_request.request_id)
 
+    def _get_prompt_limit(self) -> int:
+        """Helper to get the prompt limit from scheduler config
+
+        Port from https://github.com/vllm-project/vllm/blob/7b5ecf79bd94aab0d782c70126d0dcc37c16bc60/vllm/core/scheduler.py#L939
+        """
+        scheduler_config = self.vllm_config.scheduler_config
+        if (
+            scheduler_config.chunked_prefill_enabled
+            and not scheduler_config.is_multi_step
+        ):
+            prompt_limit = scheduler_config.max_model_len
+        else:
+            prompt_limit = min(
+                scheduler_config.max_model_len,
+                scheduler_config.max_num_batched_tokens,
+            )
+        return prompt_limit
+
     def _handle_input_too_long(
         self, request_output: "RequestOutput", finish_reason: Optional[FinishReason]
     ):
@@ -672,7 +695,7 @@ class VLLMEngine:
         ):
             # This means that the prompt was too long and we did not generate anything.
             raise InputTooLong(
-                len(request_output.prompt_token_ids), self.model_config.max_model_len
+                len(request_output.prompt_token_ids), self._get_prompt_limit()
             ).exception
 
     async def check_health(self):

--- a/python/ray/llm/tests/BUILD
+++ b/python/ray/llm/tests/BUILD
@@ -107,6 +107,7 @@ py_test_module_list(
     size = "large",
     data = glob(["serve/**/*.yaml"]),
     files = [
+        "serve/deployments/llm/vllm/test_vllm_engine_gpu.py",
         "serve/integration/test_openai_compatibility.py",
         "serve/integration/test_openai_compatibility_no_accelerator_type.py",
     ],

--- a/python/ray/llm/tests/serve/deployments/llm/vllm/test_vllm_engine.py
+++ b/python/ray/llm/tests/serve/deployments/llm/vllm/test_vllm_engine.py
@@ -10,7 +10,6 @@ from ray.llm._internal.serve.configs.server_models import FinishReason
 from ray.llm._internal.serve.deployments.llm.vllm.vllm_engine import (
     BatchLLMRawResponses,
     VLLMEngine,
-    _get_vllm_engine_config,
 )
 from ray.llm._internal.serve.deployments.llm.vllm.vllm_models import (
     VLLMGenerationRequest,
@@ -194,60 +193,6 @@ class TestVLLMEngine:
         guided_json = json.loads(parsed_params.guided_decoding.json)
         assert guided_json == sampling_params.response_format.json_schema
         assert getattr(parsed_params, "response_format", None) is None
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "engine_kwargs, expected_prompt_limit",
-        [
-            ({"enable_chunked_prefill": True, "device": "cpu"}, 1024000),
-            (
-                {
-                    "enable_chunked_prefill": True,
-                    "device": "cpu",
-                    "max_model_len": 999,
-                },
-                999,
-            ),
-            (
-                {
-                    "enable_chunked_prefill": True,
-                    "device": "cpu",
-                    "max_num_batched_tokens": 888,
-                },
-                1024000,
-            ),
-            (
-                {
-                    "enable_chunked_prefill": True,
-                    "device": "cpu",
-                    "max_model_len": 999,
-                    "max_num_batched_tokens": 888,
-                    "enforce_eager": True,
-                },
-                999,
-            ),
-            ({"enable_chunked_prefill": False, "device": "cpu"}, 1024000),
-            (
-                {
-                    "enable_chunked_prefill": False,
-                    "device": "cpu",
-                    "max_model_len": 999,
-                },
-                999,
-            ),
-        ],
-    )
-    async def test_get_prompt_limit(
-        self, llm_config: LLMConfig, engine_kwargs: dict, expected_prompt_limit: int
-    ):
-        llm_config = llm_config.model_copy(deep=True)
-        vllm_engine = VLLMEngine(llm_config)
-
-        # Test with default engine kwargs
-        llm_config.engine_kwargs = engine_kwargs
-        _, vllm_config = _get_vllm_engine_config(llm_config)
-        vllm_engine.vllm_config = vllm_config
-        assert vllm_engine._get_prompt_limit() == expected_prompt_limit
 
 
 TEXT_VALUE = "foo"

--- a/python/ray/llm/tests/serve/deployments/llm/vllm/test_vllm_engine.py
+++ b/python/ray/llm/tests/serve/deployments/llm/vllm/test_vllm_engine.py
@@ -199,11 +199,11 @@ class TestVLLMEngine:
     @pytest.mark.parametrize(
         "engine_kwargs, expected_prompt_limit",
         [
-            ({"enable_chunked_prefill": True, "trust_remote_code": True}, 1024000),
+            ({"enable_chunked_prefill": True, "device": "cpu"}, 1024000),
             (
                 {
                     "enable_chunked_prefill": True,
-                    "trust_remote_code": True,
+                    "device": "cpu",
                     "max_model_len": 999,
                 },
                 999,
@@ -211,7 +211,7 @@ class TestVLLMEngine:
             (
                 {
                     "enable_chunked_prefill": True,
-                    "trust_remote_code": True,
+                    "device": "cpu",
                     "max_num_batched_tokens": 888,
                 },
                 1024000,
@@ -219,18 +219,18 @@ class TestVLLMEngine:
             (
                 {
                     "enable_chunked_prefill": True,
-                    "trust_remote_code": True,
+                    "device": "cpu",
                     "max_model_len": 999,
                     "max_num_batched_tokens": 888,
                     "enforce_eager": True,
                 },
                 999,
             ),
-            ({"enable_chunked_prefill": False, "trust_remote_code": True}, 1024000),
+            ({"enable_chunked_prefill": False, "device": "cpu"}, 1024000),
             (
                 {
                     "enable_chunked_prefill": False,
-                    "trust_remote_code": True,
+                    "device": "cpu",
                     "max_model_len": 999,
                 },
                 999,

--- a/python/ray/llm/tests/serve/deployments/llm/vllm/test_vllm_engine_gpu.py
+++ b/python/ray/llm/tests/serve/deployments/llm/vllm/test_vllm_engine_gpu.py
@@ -1,0 +1,68 @@
+import sys
+import pytest
+
+from ray.llm._internal.serve.deployments.llm.vllm.vllm_engine import (
+    VLLMEngine,
+    _get_vllm_engine_config,
+)
+from ray.llm._internal.serve.configs.server_models import (
+    LLMConfig,
+)
+
+
+class TestVLLMEngine:
+    """Test the VLLMEngine."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "engine_kwargs, expected_prompt_limit",
+        [
+            ({"enable_chunked_prefill": True}, 1024000),
+            (
+                {
+                    "enable_chunked_prefill": True,
+                    "max_model_len": 999,
+                },
+                999,
+            ),
+            (
+                {
+                    "enable_chunked_prefill": True,
+                    "max_num_batched_tokens": 888,
+                },
+                1024000,
+            ),
+            (
+                {
+                    "enable_chunked_prefill": True,
+                    "max_model_len": 999,
+                    "max_num_batched_tokens": 888,
+                    "enforce_eager": True,
+                },
+                999,
+            ),
+            ({"enable_chunked_prefill": False}, 1024000),
+            (
+                {
+                    "enable_chunked_prefill": False,
+                    "max_model_len": 999,
+                },
+                999,
+            ),
+        ],
+    )
+    async def test_get_prompt_limit(
+        self, llm_config: LLMConfig, engine_kwargs: dict, expected_prompt_limit: int
+    ):
+        llm_config = llm_config.model_copy(deep=True)
+        vllm_engine = VLLMEngine(llm_config)
+
+        # Test with default engine kwargs
+        llm_config.engine_kwargs = engine_kwargs
+        _, vllm_config = _get_vllm_engine_config(llm_config)
+        vllm_engine.vllm_config = vllm_config
+        assert vllm_engine._get_prompt_limit() == expected_prompt_limit
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Re: https://anyscaleteam.slack.com/archives/C05N9KFPUR3/p1744305618896659

In Ray Serve LLM we always use `max_model_len` as the prompt limit when logging the message for token too long error. However, in VLLM there are a lot more goes into determining whether the prompt went over the limit. Port over the [vllm logics](https://github.com/vllm-project/vllm/blob/7b5ecf79bd94aab0d782c70126d0dcc37c16bc60/vllm/core/scheduler.py#L939) so we will log the correct limit.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
