### PR TITLE
test_deployment_scheduler with compact scheduling take more than 5 …

### DIFF
--- a/python/ray/serve/tests/BUILD
+++ b/python/ray/serve/tests/BUILD
@@ -330,7 +330,6 @@ py_test_module_list(
     files = [
         "test_cluster.py",
         "test_controller_recovery.py",
-        "test_deployment_scheduler.py",
         "test_gcs_failure.py",
         "test_max_replicas_per_node.py",
         "test_replica_placement_group.py",
@@ -374,6 +373,7 @@ py_test_module_list(
     data = glob(["test_config_files/**/*"]),
     env = {"RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY": "1"},
     files = [
+        "test_deployment_scheduler.py",
         "test_standalone_2.py",
     ],
     name_suffix = "_with_compact_scheduling",


### PR DESCRIPTION
on turbo

```

[2025-04-14T10:58:12Z]   Stats over 3 runs: max = 315.0s, min = 315.0s, avg = 315.0s, dev = 0.0s
--
  | [2025-04-14T10:58:12Z]   /root/.cache/bazel/_bazel_root/1df605deb6d24fc8068f6e25793ec703/execroot/com_github_ray_project_ray/bazel-out/k8-opt/testlogs/python/ray/anyscale/serve/tests/test_deployment_scheduler/test.log
  | [2025-04-14T10:58:12Z]   /root/.cache/bazel/_bazel_root/1df605deb6d24fc8068f6e25793ec703/execroot/com_github_ray_project_ray/bazel-out/k8-opt/testlogs/python/ray/anyscale/serve/tests/test_deployment_scheduler/test_attempts/attempt_1.log
  | [2025-04-14T10:58:12Z]   /root/.cache/bazel/_bazel_root/1df605deb6d24fc8068f6e25793ec703/execroot/com_github_ray_project_ray/bazel-out/k8-opt/testlogs/python/ray/anyscale/serve/tests/test_deployment_scheduler/test_attempts/attempt_2.log
```

but surprising on OSS this runs under 3 mins
```

[2025-04-14T21:58:30Z] (14:58:30) [51 / 65] 7 / 14 tests; Testing //python/ray/serve/tests:test_model_composition; 24s local
--
  | [2025-04-14T21:58:41Z] (14:58:41) [335 / 393] 51 / 94 tests; Testing //python/ray/serve/tests:test_controller_recovery_with_compact_scheduling; 62s local
  | [2025-04-14T21:59:00Z] (14:59:00) [336 / 394] 52 / 94 tests; Testing //python/ray/serve/tests:test_deployment_scheduler; 19s local
  | [2025-04-14T21:59:09Z] (14:59:09) [51 / 65] 7 / 14 tests; Testing //python/ray/serve/tests:test_model_composition; 64s local
  | [2025-04-14T21:59:15Z] (14:59:15) [337 / 395] 53 / 94 tests; Testing //python/ray/serve/tests:test_deployment_scheduler_with_compact_scheduling; 15s local
  | [2025-04-14T21:59:30Z] (14:59:30) [52 / 66] 8 / 14 tests; Testing //python/ray/serve/tests:test_standalone; 20s local
  | [2025-04-14T22:01:01Z] (15:01:01) [337 / 395] 53 / 94 tests; Testing //python/ray/serve/tests:test_deployment_scheduler_with_compact_scheduling; 121s local
  | [2025-04-14T22:01:23Z] (15:01:23) [338 / 396] 54 / 94 tests; Testing //python/ray/serve/tests:test_deployment_version; 21s local
  | [2025-04-14T22:01:40Z] (15:01:40) [340 / 398] 56 / 94 tests; Testing //python/ray/serve/tests:test_expected_versions; 2s local
  | [2025-04-14T22:02:00Z] (15:02:00) [341 / 399] 57 / 94 tests; Testing //python/ray/serve/tests:test_failure; 20s local


```