### PR TITLE
Fix is_http_filesystem fsspec circular dependency

### DIFF
--- a/python/ray/data/datasource/path_util.py
+++ b/python/ray/data/datasource/path_util.py
@@ -114,6 +114,7 @@ def _resolve_paths_and_filesystem(
                     # try to use fsspec HTTPFileSystem. This expects fsspec is
                     # installed.
                     try:
+                        import fsspec
                         from fsspec.implementations.http import HTTPFileSystem
                     except ModuleNotFoundError:
                         raise ImportError(

--- a/python/ray/data/datasource/path_util.py
+++ b/python/ray/data/datasource/path_util.py
@@ -148,6 +148,7 @@ def _is_http_filesystem(fs: "pyarrow.fs.FileSystem") -> bool:
     from pyarrow.fs import FSSpecHandler, PyFileSystem
 
     try:
+        import fsspec
         from fsspec.implementations.http import HTTPFileSystem
     except ModuleNotFoundError:
         return False

--- a/python/ray/data/datasource/path_util.py
+++ b/python/ray/data/datasource/path_util.py
@@ -82,7 +82,7 @@ def _resolve_paths_and_filesystem(
             f"filesystem was: {filesystem}"
         )
         try:
-            import fsspec
+            import fsspec  # noqa: F401
             from fsspec.implementations.http import HTTPFileSystem
         except ModuleNotFoundError:
             # If filesystem is not a pyarrow filesystem and fsspec isn't
@@ -114,7 +114,7 @@ def _resolve_paths_and_filesystem(
                     # try to use fsspec HTTPFileSystem. This expects fsspec is
                     # installed.
                     try:
-                        import fsspec
+                        import fsspec  # noqa: F401
                         from fsspec.implementations.http import HTTPFileSystem
                     except ModuleNotFoundError:
                         raise ImportError(
@@ -149,7 +149,7 @@ def _is_http_filesystem(fs: "pyarrow.fs.FileSystem") -> bool:
     from pyarrow.fs import FSSpecHandler, PyFileSystem
 
     try:
-        import fsspec
+        import fsspec  # noqa: F401
         from fsspec.implementations.http import HTTPFileSystem
     except ModuleNotFoundError:
         return False


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Handle circular import issue with `fsspec`.

```
File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/data/datasource/partitioning.py", line 267, in _dir_path_trim_base
    if not path.startswith(self._scheme.normalized_base_dir):
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/data/datasource/partitioning.py", line 108, in normalized_base_dir
    self._normalize_base_dir()
  File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/data/datasource/partitioning.py", line 128, in _normalize_base_dir
    paths, self._resolved_filesystem = _resolve_paths_and_filesystem(
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/data/datasource/path_util.py", line 137, in _resolve_paths_and_filesystem
    if not _is_http_filesystem(filesystem):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/data/datasource/path_util.py", line 151, in _is_http_filesystem
    from fsspec.implementations.http import HTTPFileSystem
  File "/home/ray/anaconda3/lib/python3.11/site-packages/fsspec/__init__.py", line 5, in <module>
    from .compression import available_compressions
  File "/home/ray/anaconda3/lib/python3.11/site-packages/fsspec/compression.py", line 70, in <module>
    register_compression("zip", unzip, "zip")
  File "/home/ray/anaconda3/lib/python3.11/site-packages/fsspec/compression.py", line 46, in register_compression
    if ext in fsspec.utils.compressions and not force:
              ^^^^^^^^^^^^
AttributeError: partially initialized module 'fsspec' has no attribute 'utils' (most likely due to a circular import)

```
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
