### PR TITLE
[Fix][CI] Conditionally Kickoff KubeRay doctests correctly

### DIFF
--- a/.buildkite/kuberay.rayci.yml
+++ b/.buildkite/kuberay.rayci.yml
@@ -21,8 +21,7 @@ steps:
 
   - label: ":kubernetes: kuberay doc tests"
     tags:
-      - python
-      - docker
+      - k8s_doc
     instance_type: medium
     commands:
       - bash ci/k8s/run-kuberay-doc-tests.sh

--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -15,7 +15,7 @@ _ALL_TAGS = set(
     lint python cpp core_cpp java workflow accelerated_dag dashboard
     data serve ml tune train llm rllib rllib_gpu rllib_directly
     linux_wheels macos_wheels docker doc python_dependencies tools
-    release_tests compiled_python
+    release_tests compiled_python k8s_doc
     """.split()
 )
 

--- a/ci/pipeline/test_conditional_testing.py
+++ b/ci/pipeline/test_conditional_testing.py
@@ -55,9 +55,7 @@ docker/Dockerfile.ray: lint docker linux_wheels
 doc/code.py: lint doc
 doc/example.ipynb: lint doc
 doc/tutorial.rst: lint doc
-doc/source/cluster/kubernetes/getting-started.md: lint k8s_doc
 doc/source/cluster/kubernetes/doc_sanitize.cfg: lint k8s_doc
-doc/source/cluster/kubernetes/scripts/doctest-utils.sh: lint k8s_doc
 ci/k8s/run-kuberay-doc-tests.sh: lint k8s_doc
 ci/docker/doctest.build.Dockerfile: lint
 release/requirements_buildkite.txt: lint release_tests

--- a/ci/pipeline/test_conditional_testing.py
+++ b/ci/pipeline/test_conditional_testing.py
@@ -56,6 +56,9 @@ doc/code.py: lint doc
 doc/example.ipynb: lint doc
 doc/tutorial.rst: lint doc
 doc/source/cluster/kubernetes/getting-started.md: lint k8s_doc
+doc/source/cluster/kubernetes/doc_sanitize.cfg: lint k8s_doc
+doc/source/cluster/kubernetes/scripts/doctest-utils.sh: lint k8s_doc
+ci/k8s/run-kuberay-doc-tests.sh: lint k8s_doc
 ci/docker/doctest.build.Dockerfile: lint
 release/requirements_buildkite.txt: lint release_tests
 ci/lint/lint.sh: lint tools

--- a/ci/pipeline/test_conditional_testing.py
+++ b/ci/pipeline/test_conditional_testing.py
@@ -55,6 +55,7 @@ docker/Dockerfile.ray: lint docker linux_wheels
 doc/code.py: lint doc
 doc/example.ipynb: lint doc
 doc/tutorial.rst: lint doc
+doc/source/cluster/kubernetes/getting-started.md: lint k8s_doc
 ci/docker/doctest.build.Dockerfile: lint
 release/requirements_buildkite.txt: lint release_tests
 ci/lint/lint.sh: lint tools

--- a/ci/pipeline/test_rules.txt
+++ b/ci/pipeline/test_rules.txt
@@ -10,6 +10,10 @@
 #
 #   ;  # Semicolon to separate rules
 
+doc/source/cluster/kubernetes/
+ci/k8s/
+@ k8s_doc
+;
 
 python/ray/air/
 @ ml train tune data linux_wheels
@@ -221,9 +225,4 @@ setup_hooks.sh
 .prettierrc.toml
 build.sh
 # pass
-;
-
-doc/source/cluster/kubernetes/
-ci/k8s/
-@ k8s_doc
 ;

--- a/ci/pipeline/test_rules.txt
+++ b/ci/pipeline/test_rules.txt
@@ -10,11 +10,6 @@
 #
 #   ;  # Semicolon to separate rules
 
-doc/source/cluster/kubernetes/
-ci/k8s/
-@ k8s_doc
-;
-
 python/ray/air/
 @ ml train tune data linux_wheels
 ;
@@ -120,6 +115,11 @@ cpp/
 docker/
 .buildkite/pipeline.build_cpp.yml
 @ docker linux_wheels
+;
+
+doc/source/cluster/kubernetes/
+ci/k8s/
+@ k8s_doc
 ;
 
 .readthedocs.yaml

--- a/ci/pipeline/test_rules.txt
+++ b/ci/pipeline/test_rules.txt
@@ -222,3 +222,8 @@ setup_hooks.sh
 build.sh
 # pass
 ;
+
+doc/source/cluster/kubernetes/
+ci/k8s/
+@ k8s_doc
+;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Kick off KubeRay doc tests only when files in `doc/source/cluster/kubernetes/` or `ci/k8s/` are changed.

## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
