### PR TITLE
[Serve.llm] add doc example on using `tokenizer_pool_size`

### DIFF
--- a/doc/source/serve/llm/serving-llms.rst
+++ b/doc/source/serve/llm/serving-llms.rst
@@ -69,7 +69,7 @@ Deployment through ``LLMRouter``
     .. tab-item:: Builder Pattern
         :sync: builder
 
-        .. code-block:: python 
+        .. code-block:: python
 
             from ray import serve
             from ray.serve.llm import LLMConfig, build_openai_app
@@ -212,7 +212,7 @@ For deploying multiple models, you can pass a list of ``LLMConfig`` objects to t
         :sync: bind
 
         .. code-block:: python
-            
+
             from ray import serve
             from ray.serve.llm import LLMConfig, LLMServer, LLMRouter
 
@@ -511,7 +511,7 @@ For structured output, you can use JSON mode similar to OpenAI's API:
         If you want, you can also specify the schema you want for the response, using pydantic models:
 
         .. code-block:: python
-            
+
             from openai import OpenAI
             from typing import List, Literal
             from pydantic import BaseModel
@@ -529,7 +529,7 @@ For structured output, you can use JSON mode similar to OpenAI's API:
                 response_format={
                     "type": "json_schema",
                     "json_schema": Color.model_json_schema()
-                    
+
                 },
                 messages=[
                     {
@@ -673,6 +673,29 @@ You can then specify the `bucket_uri` in the `model_loading_config` to point to 
       name: llm_app
       route_prefix: "/"
 
+Configure tokenizer pool size
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When using `tokenizer_pool_size` in vLLM's engine keyargs, `tokenizer_pool_size` is also
+required to configure together in order to have the tokenizer group scheduled correctly.
+
+An example config is shown below:
+
+.. code-block:: yaml
+
+    # config.yaml
+    applications:
+    - args:
+        llm_configs:
+            - engine_kwargs:
+                max_model_len: 1000
+                tokenizer_pool_size: 2
+                tokenizer_pool_extra_config: "{\"runtime_env\": {}}"
+              model_loading_config:
+                model_id: Qwen/Qwen2.5-7B-Instruct
+      import_path: ray.serve.llm:build_openai_app
+      name: llm_app
+      route_prefix: "/"
 
 Frequently Asked Questions
 --------------------------

--- a/doc/source/serve/llm/serving-llms.rst
+++ b/doc/source/serve/llm/serving-llms.rst
@@ -753,8 +753,9 @@ If you are using huggingface models, you can enable fast download by setting `HF
 How to configure tokenizer pool size so it doesn't hang?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When using `tokenizer_pool_size` in vLLM's engine keyargs, `tokenizer_pool_size` is also
-required to configure together in order to have the tokenizer group scheduled correctly.
+When using `tokenizer_pool_size` in vLLM's `engine_kwargs`,
+`tokenizer_pool_size` is also required to configure together in order to have
+the tokenizer group scheduled correctly.
 
 An example config is shown below:
 

--- a/doc/source/serve/llm/serving-llms.rst
+++ b/doc/source/serve/llm/serving-llms.rst
@@ -673,30 +673,6 @@ You can then specify the `bucket_uri` in the `model_loading_config` to point to 
       name: llm_app
       route_prefix: "/"
 
-Configure tokenizer pool size
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-When using `tokenizer_pool_size` in vLLM's engine keyargs, `tokenizer_pool_size` is also
-required to configure together in order to have the tokenizer group scheduled correctly.
-
-An example config is shown below:
-
-.. code-block:: yaml
-
-    # config.yaml
-    applications:
-    - args:
-        llm_configs:
-            - engine_kwargs:
-                max_model_len: 1000
-                tokenizer_pool_size: 2
-                tokenizer_pool_extra_config: "{\"runtime_env\": {}}"
-              model_loading_config:
-                model_id: Qwen/Qwen2.5-7B-Instruct
-      import_path: ray.serve.llm:build_openai_app
-      name: llm_app
-      route_prefix: "/"
-
 Frequently Asked Questions
 --------------------------
 
@@ -773,6 +749,30 @@ If you are using huggingface models, you can enable fast download by setting `HF
     deployment = LLMServer.as_deployment(llm_config.get_serve_options(name_prefix="vLLM:")).bind(llm_config)
     llm_app = LLMRouter.as_deployment().bind([deployment])
     serve.run(llm_app, blocking=True)
+
+How to configure tokenizer pool size so it doesn't hang?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When using `tokenizer_pool_size` in vLLM's engine keyargs, `tokenizer_pool_size` is also
+required to configure together in order to have the tokenizer group scheduled correctly.
+
+An example config is shown below:
+
+.. code-block:: yaml
+
+    # config.yaml
+    applications:
+    - args:
+        llm_configs:
+            - engine_kwargs:
+                max_model_len: 1000
+                tokenizer_pool_size: 2
+                tokenizer_pool_extra_config: "{\"runtime_env\": {}}"
+              model_loading_config:
+                model_id: Qwen/Qwen2.5-7B-Instruct
+      import_path: ray.serve.llm:build_openai_app
+      name: llm_app
+      route_prefix: "/"
 
 Usage Data Collection
 --------------------------


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Re: https://anyscaleteam.slack.com/archives/C05N9KFPUR3/p1743711740430689

Turns out when using `tokenizer_pool_size` on vllm's engine kwargs, `tokenizer_pool_extra_config` also needs to be configured together in order to have the tokenizer group scheduled onto the cluster. This PR adds that note and an usage example.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
