### PR TITLE
[core] Avoid infinite recursion when an ActorHandle fails to unpickle

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -1545,6 +1545,15 @@ class ActorHandle:
         return object_refs
 
     def __getattr__(self, item):
+        try:
+            self.__getattribute__("_ray_is_cross_language")
+        except AttributeError:
+            raise AttributeError(
+                f"'{type(self).__name__}' object has no attribute '{item}' "
+                f"and '_ray_is_cross_language'. It seems that unpickling "
+                f"has failed."
+            )
+
         if not self._ray_is_cross_language:
             raise AttributeError(
                 f"'{type(self).__name__}' object has " f"no attribute '{item}'"

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -1549,8 +1549,8 @@ class ActorHandle:
             self.__getattribute__("_ray_is_cross_language")
         except AttributeError:
             raise AttributeError(
-                f"'{type(self).__name__}' object has no attribute '{item}' "
-                f"and '_ray_is_cross_language'. It seems that unpickling "
+                f"'{type(self).__name__}' object has neither attribute '{item}' "
+                f"nor '_ray_is_cross_language'. It seems that unpickling "
                 f"has failed."
             )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

### Without this PR

When developing Ray, I somehow forget to update some Cython code, causing the actor handle to fail to deserialize.

* `ActorHandle.__del__` is called. However, `self._ray_weak_ref` doesn't exist in `__dict__`, so `__getattr__` is invoked.
  https://github.com/ray-project/ray/blob/0a8063f40c0befdb1d5d1f3e007165e920409009/python/ray/actor.py#L1417

* Then, `__getattr__` attempts to access `self._ray_is_cross_language`, which also isn't present in `__dict__`. This results in another call to `__getattr__`, causing infinite recursion.

```python
import ray


python_descriptor = ray._raylet.PythonFunctionDescriptor(
    "module_name", "function_name", "class_name", "function_hash"
)

actor_handle = ray.actor.ActorHandle(
    ray.Language.PYTHON,
    "test",
    0,  # max_task_retries
    True,  # enable_task_events
    {},  # method is_generator
    {},  # method decorators
    {},  # method signatures
    {},  # method num_returns
    {},  # method max_task_retries
    {},  # method retry_exceptions
    {},  # generator_backpressure_num_objects
    {},  # enable_task_events
    0,  # actor method cpu
    python_descriptor,
    None,
    False,
)

# Simulate fails to unpickle
del actor_handle._ray_weak_ref
del actor_handle._ray_is_cross_language

del actor_handle
```

<img width="543" alt="Screenshot 2025-04-16 at 12 57 18 AM" src="https://github.com/user-attachments/assets/4871f9c3-40ee-493e-bb3a-564d83060402" />

### With this PR

<img width="836" alt="image" src="https://github.com/user-attachments/assets/6b3d31f6-7586-45cf-a878-21873620fc31" />



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
