### PR TITLE
[Data][doc] Update OneHotEncoder docs to fix incorrect output examples and clarify encoding format

### DIFF
--- a/python/ray/data/preprocessors/encoder.py
+++ b/python/ray/data/preprocessors/encoder.py
@@ -187,7 +187,7 @@ class OneHotEncoder(Preprocessor):
         4  [1, 0, 0]
         5  [0, 1, 0]
 
-        :class:`MultiHotEncoder` can also be used in append mode by providing the
+        OneHotEncoder can also be used in append mode by providing the
         name of the output_columns that should hold the encoded values.
 
         >>> encoder = OneHotEncoder(columns=["color"], output_columns=["color_encoded"])
@@ -206,21 +206,21 @@ class OneHotEncoder(Preprocessor):
         >>> df = pd.DataFrame({"color": ["yellow"]})
         >>> batch = ray.data.from_pandas(df)  # doctest: +SKIP
         >>> encoder.transform(batch).to_pandas()  # doctest: +SKIP
-           color_blue  color_green  color_red
-        0           0            0          0
+            color color_encoded
+        0  yellow     [0, 0, 0]
 
         Likewise, if you one-hot encode an infrequent value, then the value is encoded
         with zeros.
 
         >>> encoder = OneHotEncoder(columns=["color"], max_categories={"color": 2})
         >>> encoder.fit_transform(ds).to_pandas()  # doctest: +SKIP
-           color_red  color_green
-        0          1            0
-        1          0            1
-        2          1            0
-        3          1            0
-        4          0            0
-        5          0            1
+            color
+        0  [1, 0]
+        1  [0, 1]
+        2  [1, 0]
+        3  [1, 0]
+        4  [0, 0]
+        5  [0, 1]
 
     Args:
         columns: The columns to separately encode.


### PR DESCRIPTION
## Why are these changes needed?

The current documentation for OneHotEncoder contains:
1. A typo referring to "MultiHotEncoder" in the append mode example when it should be "OneHotEncoder"
2. Inconsistent examples that might confuse users about the actual output format

These changes make the documentation more accurate.

## Related issue number

Closes #52348

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :( (Documentation only changes)