### PR TITLE
[Data] Fix or mitigate failing release tests

### DIFF
--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -162,7 +162,10 @@
 
   matrix:
     setup:
-      scaling: [fixed_size, autoscaling]
+      scaling:
+        # This test consistently fails on a fixed-size cluster due to head OOMs. So,
+        # we only run it on autoscaling clusters.
+        - autoscaling
       shuffle_strategy: [sort_shuffle_pull_based]
       columns:
         - "column08 column13 column14"   # 84 groups
@@ -316,7 +319,7 @@
 
   matrix:
     setup:
-      scaling: [fixed_size, autoscaling]
+      scaling: [fixed_size]
 
   cluster:
     byod:
@@ -355,6 +358,9 @@
 
 
 - name: "sort_{{scaling}}"
+  # This test intermittently fails due to Arrow offset overflow errors, or OOD from
+  # overly-conservative autoscaling.
+  stable: False
 
   matrix:
     setup:

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -162,10 +162,10 @@
 
   matrix:
     setup:
-      scaling:
-        # This test consistently fails on a fixed-size cluster due to head OOMs. So,
-        # we only run it on autoscaling clusters.
-        - autoscaling
+      # This test consistently fails on fixed-size clusters due to head OOM from
+      # too many objects references on the head node. So, we only run it on
+      # autoscaling clusters.
+      scaling: [autoscaling]
       shuffle_strategy: [sort_shuffle_pull_based]
       columns:
         - "column08 column13 column14"   # 84 groups
@@ -319,6 +319,8 @@
 
   matrix:
     setup:
+      # This release test consistently fails on autoscaling clusters. So, we only run
+      # it on fixed-size clusters. The reason for the failure is unclear.
       scaling: [fixed_size]
 
   cluster:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Some of our release tests are failing or flaky. This PR fixes them, disables them, or marks them as unstable.

**tpch_q1_autoscaling**
Fails because row-by-row filtering is too slow and hits a timeout.

**random_shuffle_autoscaling**
Fails for unclear reasons — needs more digging (though it's been failing since December or longer).

**map_groups_fixed_size_sort_shuffle_pull_based_column02 / column14**
Fails due to too many object references on the head node. The autoscaling variant doesn't fail because it launches fewer map and reduce tasks.

**sort_autoscaling / sort_fixed**
Fails due to Arrow offset errors or OOD from overly-conservative autoscaling.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
