### PR TITLE
[data.dashboard.x][04] log the content of data block that failed

### DIFF
--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -1,6 +1,7 @@
 import asyncio
 import collections
 import inspect
+import logging
 import queue
 from threading import Thread
 from types import GeneratorType
@@ -50,6 +51,9 @@ from ray.data.block import (
 from ray.data.context import DataContext
 from ray.data.exceptions import UserCodeException
 from ray.util.rpdb import _is_ray_debugger_post_mortem_enabled
+
+
+logger = logging.getLogger(__name__)
 
 
 class _MapActorContext:
@@ -109,7 +113,7 @@ def plan_project_op(
                 )
             return block
         except Exception as e:
-            _handle_debugger_exception(e)
+            _handle_debugger_exception(e, block)
 
     compute = get_compute(op._compute)
     transform_fn = _generate_transform_fn_for_map_block(fn)
@@ -166,7 +170,7 @@ def plan_filter_op(
             try:
                 return block.filter(expression)
             except Exception as e:
-                _handle_debugger_exception(e)
+                _handle_debugger_exception(e, block)
 
         transform_fn = _generate_transform_fn_for_map_batches(filter_batch_fn)
         map_transformer = _create_map_transformer_for_map_batches_op(
@@ -286,7 +290,7 @@ def _parse_op_fn(op: AbstractUDFMap):
                         **fn_kwargs,
                     )
                 except Exception as e:
-                    _handle_debugger_exception(e)
+                    _handle_debugger_exception(e, item)
 
         else:
 
@@ -300,7 +304,7 @@ def _parse_op_fn(op: AbstractUDFMap):
                         **fn_kwargs,
                     )
                 except Exception as e:
-                    _handle_debugger_exception(e)
+                    _handle_debugger_exception(e, item)
 
     else:
 
@@ -308,7 +312,7 @@ def _parse_op_fn(op: AbstractUDFMap):
             try:
                 return op_fn(item, *fn_args, **fn_kwargs)
             except Exception as e:
-                _handle_debugger_exception(e)
+                _handle_debugger_exception(e, item)
 
         def init_fn():
             pass
@@ -316,15 +320,18 @@ def _parse_op_fn(op: AbstractUDFMap):
     return fn, init_fn
 
 
-def _handle_debugger_exception(e: Exception):
+def _handle_debugger_exception(e: Exception, item: Any = None):
     """If the Ray Debugger is enabled, keep the full stack trace unmodified
     so that the debugger can stop at the initial unhandled exception.
     Otherwise, clear the stack trace to omit noisy internal code path."""
+    error_message = f"Failed to process the following data block: {item}"
+
     ctx = ray.data.DataContext.get_current()
     if _is_ray_debugger_post_mortem_enabled() or ctx.raise_original_map_exception:
+        logger.error(error_message)
         raise e
     else:
-        raise UserCodeException() from e
+        raise UserCodeException(error_message) from e
 
 
 # Following are util functions for converting UDFs to `MapTransformCallable`s.


### PR DESCRIPTION
One small step towards allowing users to inspect the content of their dataset when it fails, this PR prints out the content of the block that it cannot handle.

Test:
- CI
- In this example, the block is an array of one item (number 5)

<img width="824" alt="Screenshot 2025-04-16 at 2 59 35 PM" src="https://github.com/user-attachments/assets/7781fd0b-4261-440b-a747-410ea3533fca" />
