### PR TITLE
[train] fix rank_zero_only logic

### DIFF
--- a/python/ray/air/integrations/wandb.py
+++ b/python/ray/air/integrations/wandb.py
@@ -125,8 +125,11 @@ def setup_wandb(
 
     # Do a try-catch here if we are not in a train session
     session = get_session()
-    if session and rank_zero_only and session.world_rank in (None, 0):
-        return RunDisabled()
+
+    if rank_zero_only:
+        # Check if we are in a train session and if we are not the rank 0 worker
+        if session and session.world_rank is not None and session.world_rank != 0:
+            return RunDisabled()
 
     if session:
         default_trial_id = session.trial_id

--- a/python/ray/air/tests/test_integration_wandb.py
+++ b/python/ray/air/tests/test_integration_wandb.py
@@ -546,6 +546,11 @@ def test_wandb_logging_process_run_info_hook(monkeypatch):
 def test_wandb_logger_rank_zero_only(trial, monkeypatch):
     """Test that logging is disabled for non-rank-0 workers when rank_zero_only is True."""
 
+    monkeypatch.setenv(
+        WANDB_ENV_VAR,
+        "abcde",
+    )
+
     mock_session = Mock()
     mock_session.experiment_name = "test_project"
     mock_session.trial_name = "trial_0"

--- a/python/ray/air/tests/test_integration_wandb.py
+++ b/python/ray/air/tests/test_integration_wandb.py
@@ -559,24 +559,24 @@ def test_wandb_logger_rank_zero_only(trial, monkeypatch):
     # Test case 1: rank_zero_only=True, rank 0
     mock_session.world_rank = 0
     with patch("ray.air.integrations.wandb.get_session", return_value=mock_session):
-        run = setup_wandb(project="test_project", rank_zero_only=True)
+        run = setup_wandb(project="test_project", rank_zero_only=True, _wandb=Mock())
         assert not isinstance(run, RunDisabled)
 
     # Test case 2: rank_zero_only=True, non-rank-0
     mock_session.world_rank = 1
     with patch("ray.air.integrations.wandb.get_session", return_value=mock_session):
-        run = setup_wandb(project="test_project", rank_zero_only=True)
+        run = setup_wandb(project="test_project", rank_zero_only=True, _wandb=Mock())
         assert isinstance(run, RunDisabled)
 
     # Test case 3: rank_zero_only=False, any rank
     mock_session.world_rank = 1
     with patch("ray.air.integrations.wandb.get_session", return_value=mock_session):
-        run = setup_wandb(project="test_project", rank_zero_only=False)
+        run = setup_wandb(project="test_project", rank_zero_only=False, _wandb=Mock())
         assert not isinstance(run, RunDisabled)
 
     # Test case 4: rank_zero_only=True, no session
     with patch("ray.air.integrations.wandb.get_session", return_value=None):
-        run = setup_wandb(project="test_project", rank_zero_only=True)
+        run = setup_wandb(project="test_project", rank_zero_only=True, _wandb=Mock())
         assert not isinstance(run, RunDisabled)
 
 


### PR DESCRIPTION

## Why are these changes needed?

Fixes a bug that was introduced [here](https://github.com/ray-project/ray/commit/2b31d11ca62f510950caf36d5d789352f8c8f2b2#diff-ea9057a769fe63a8ca56e01a232337311b443dfc361250733afcc4fda5beb69d).

Also making the logic a little clearer:

```python
    if rank_zero_only: # Only if this flag is set
        if session  # In Ray Train/Tune
            and session.world_rank is not None # Not Ray Tune (so Ray Train)
            and session.world_rank != 0: # Not Rank 0 Worker
                return RunDisabled()
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
