### PR TITLE
[Feat][Core/Dashboard] Reimplement cross-process synchronization for subprocess module with pipe

### DIFF
--- a/python/ray/dashboard/subprocesses/handle.py
+++ b/python/ray/dashboard/subprocesses/handle.py
@@ -139,7 +139,13 @@ class SubprocessModuleHandle:
         and can be blocking.
         """
         if self.parent_conn.poll(dashboard_consts.SUBPROCESS_MODULE_WAIT_READY_TIMEOUT):
-            self.parent_conn.recv()
+            try:
+                self.parent_conn.recv()
+            except EOFError:
+                raise RuntimeError(
+                    f"Module {self.module_cls.__name__} failed to start. "
+                    "Received EOF from pipe."
+                )
             self.parent_conn.close()
             self.parent_conn = None
         else:

--- a/python/ray/dashboard/subprocesses/module.py
+++ b/python/ray/dashboard/subprocesses/module.py
@@ -210,7 +210,7 @@ async def run_module_inner(
     cls: type[SubprocessModule],
     config: SubprocessModuleConfig,
     incarnation: int,
-    conn_to_parent: multiprocessing.connection.Connection,
+    child_conn: multiprocessing.connection.Connection,
 ):
 
     module_name = cls.__name__
@@ -228,8 +228,8 @@ async def run_module_inner(
             lambda _: sys.exit()
         )
         await module.run()
-        conn_to_parent.send(None)
-        conn_to_parent.close()
+        child_conn.send(None)
+        child_conn.close()
         logger.info(f"Module {module_name} initialized, receiving messages...")
     except Exception as e:
         logger.exception(f"Error creating module {module_name}")
@@ -240,7 +240,7 @@ def run_module(
     cls: type[SubprocessModule],
     config: SubprocessModuleConfig,
     incarnation: int,
-    conn_to_parent: multiprocessing.connection.Connection,
+    child_conn: multiprocessing.connection.Connection,
 ):
     """
     Entrypoint for a subprocess module.
@@ -280,7 +280,7 @@ def run_module(
             cls,
             config,
             incarnation,
-            conn_to_parent,
+            child_conn,
         )
     )
     # TODO: do graceful shutdown.

--- a/python/ray/dashboard/subprocesses/module.py
+++ b/python/ray/dashboard/subprocesses/module.py
@@ -210,7 +210,7 @@ async def run_module_inner(
     cls: type[SubprocessModule],
     config: SubprocessModuleConfig,
     incarnation: int,
-    pipe_writer: multiprocessing.connection.Connection,
+    conn_to_parent: multiprocessing.connection.Connection,
 ):
 
     module_name = cls.__name__
@@ -228,8 +228,8 @@ async def run_module_inner(
             lambda _: sys.exit()
         )
         await module.run()
-        pipe_writer.send(None)
-        pipe_writer.close()
+        conn_to_parent.send(None)
+        conn_to_parent.close()
         logger.info(f"Module {module_name} initialized, receiving messages...")
     except Exception as e:
         logger.exception(f"Error creating module {module_name}")
@@ -240,7 +240,7 @@ def run_module(
     cls: type[SubprocessModule],
     config: SubprocessModuleConfig,
     incarnation: int,
-    pipe_writer: multiprocessing.connection.Connection,
+    conn_to_parent: multiprocessing.connection.Connection,
 ):
     """
     Entrypoint for a subprocess module.
@@ -280,7 +280,7 @@ def run_module(
             cls,
             config,
             incarnation,
-            pipe_writer,
+            conn_to_parent,
         )
     )
     # TODO: do graceful shutdown.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

In the macOS machine in BuildKite CI, there is a limit on the number of semaphores that can be created within a single process. Internally, `multiprocessing.Event` uses semaphores, so we cannot create too many of them. It's unclear whether users' macOS environments also impose this semaphore limit, so it's better to avoid using it. Therefore, this PR changes the implementation of cross-process synchronization to use `multiprocessing.Pipe`.

## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
