### PR TITLE
[Data] Properly shutdown executor after fetching schema

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/executor.py
+++ b/python/ray/data/_internal/execution/interfaces/executor.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Iterable, Iterator, Optional
+from typing import Iterable, Iterator, Optional, ContextManager
 
 from .execution_options import ExecutionOptions
 from .physical_operator import PhysicalOperator
@@ -38,7 +38,7 @@ class OutputIterator(Iterator[RefBundle]):
         return self.get_next()
 
 
-class Executor(ABC):
+class Executor(ContextManager, ABC):
     """Abstract class for executors, which implement physical operator execution.
 
     Subclasses:
@@ -82,3 +82,10 @@ class Executor(ABC):
         while iterating over `execute` results for streaming execution.
         """
         ...
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback, /):
+        self.shutdown(exception=exc_value)
+

--- a/python/ray/data/_internal/execution/interfaces/executor.py
+++ b/python/ray/data/_internal/execution/interfaces/executor.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Iterable, Iterator, Optional, ContextManager
+from typing import Iterator, Optional, ContextManager
 
 from .execution_options import ExecutionOptions
 from .physical_operator import PhysicalOperator

--- a/python/ray/data/_internal/execution/interfaces/executor.py
+++ b/python/ray/data/_internal/execution/interfaces/executor.py
@@ -84,4 +84,3 @@ class Executor(ContextManager, ABC):
 
     def __exit__(self, exc_type, exc_value, traceback, /):
         self.shutdown(exception=exc_value)
-

--- a/python/ray/data/_internal/execution/interfaces/executor.py
+++ b/python/ray/data/_internal/execution/interfaces/executor.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from typing import Iterable, Iterator, Optional
 
 from .execution_options import ExecutionOptions
@@ -37,7 +38,7 @@ class OutputIterator(Iterator[RefBundle]):
         return self.get_next()
 
 
-class Executor:
+class Executor(ABC):
     """Abstract class for executors, which implement physical operator execution.
 
     Subclasses:
@@ -49,6 +50,7 @@ class Executor:
         options.validate()
         self._options = options
 
+    @abstractmethod
     def execute(
         self, dag: PhysicalOperator, initial_stats: Optional[DatasetStats] = None
     ) -> OutputIterator:
@@ -59,7 +61,7 @@ class Executor:
             initial_stats: The DatasetStats to prepend to the stats returned by the
                 executor. These stats represent actions done to compute inputs.
         """
-        raise NotImplementedError
+        ...
 
     def shutdown(self, exception: Optional[Exception] = None):
         """Shutdown an executor, which may still be running.
@@ -72,10 +74,11 @@ class Executor:
         """
         pass
 
+    @abstractmethod
     def get_stats(self) -> DatasetStats:
         """Return stats for the execution so far.
 
         This is generally called after `execute` has completed, but may be called
         while iterating over `execute` results for streaming execution.
         """
-        raise NotImplementedError
+        ...

--- a/python/ray/data/_internal/execution/interfaces/executor.py
+++ b/python/ray/data/_internal/execution/interfaces/executor.py
@@ -7,16 +7,14 @@ from .ref_bundle import RefBundle
 from ray.data._internal.stats import DatasetStats
 
 
-class OutputIterator(Iterator[RefBundle]):
+class OutputIterator(Iterator[RefBundle], ABC):
     """Iterator used to access the output of an Executor execution.
 
     This is a blocking iterator. Datasets guarantees that all its iterators are
     thread-safe (i.e., multiple threads can block on them at the same time).
     """
 
-    def __init__(self, base: Iterable[RefBundle]):
-        self._it = iter(base)
-
+    @abstractmethod
     def get_next(self, output_split_idx: Optional[int] = None) -> RefBundle:
         """Can be used to pull outputs by a specified output index.
 
@@ -30,9 +28,7 @@ class OutputIterator(Iterator[RefBundle]):
         Raises:
             StopIteration if there are no more outputs to return.
         """
-        if output_split_idx is not None:
-            raise NotImplementedError()
-        return next(self._it)
+        ...
 
     def __next__(self) -> RefBundle:
         return self.get_next()

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -32,9 +32,12 @@ class OpTask(ABC):
     def __init__(
         self,
         task_index: int,
+        *,
+        is_actor_task: bool = False,
         task_resource_bundle: Optional[ExecutionResources] = None,
     ):
         self._task_index: int = task_index
+        self._is_actor_task: bool = is_actor_task
         self._task_resource_bundle: Optional[ExecutionResources] = task_resource_bundle
 
     def task_index(self) -> int:
@@ -59,6 +62,8 @@ class DataOpTask(OpTask):
         streaming_gen: ObjectRefGenerator,
         output_ready_callback: Callable[[RefBundle], None],
         task_done_callback: Callable[[Optional[Exception]], None],
+        *,
+        is_actor_task: bool = False,
         task_resource_bundle: Optional[ExecutionResources] = None,
     ):
         """
@@ -130,6 +135,8 @@ class MetadataOpTask(OpTask):
         task_index: int,
         object_ref: ray.ObjectRef,
         task_done_callback: Callable[[], None],
+        *,
+        is_actor_task: bool = False,
         task_resource_bundle: Optional[ExecutionResources] = None,
     ):
         """

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -32,12 +32,9 @@ class OpTask(ABC):
     def __init__(
         self,
         task_index: int,
-        *,
-        is_actor_task: bool = False,
         task_resource_bundle: Optional[ExecutionResources] = None,
     ):
         self._task_index: int = task_index
-        self._is_actor_task: bool = is_actor_task
         self._task_resource_bundle: Optional[ExecutionResources] = task_resource_bundle
 
     def task_index(self) -> int:
@@ -62,8 +59,6 @@ class DataOpTask(OpTask):
         streaming_gen: ObjectRefGenerator,
         output_ready_callback: Callable[[RefBundle], None],
         task_done_callback: Callable[[Optional[Exception]], None],
-        *,
-        is_actor_task: bool = False,
         task_resource_bundle: Optional[ExecutionResources] = None,
     ):
         """
@@ -135,8 +130,6 @@ class MetadataOpTask(OpTask):
         task_index: int,
         object_ref: ray.ObjectRef,
         task_done_callback: Callable[[], None],
-        *,
-        is_actor_task: bool = False,
         task_resource_bundle: Optional[ExecutionResources] = None,
     ):
         """

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -66,7 +66,6 @@ class OpTask(ABC):
         )
 
 
-
 class DataOpTask(OpTask):
     """Represents an OpTask that handles Block data."""
 

--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -92,8 +92,7 @@ def execute_to_legacy_bundle_iterator(
             )
             return bundle
 
-    bundle_iter = CacheMetadataIterator(bundle_iter)
-    return bundle_iter
+    return CacheMetadataIterator(bundle_iter)
 
 
 def execute_to_legacy_block_list(

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -191,6 +191,7 @@ class ActorPoolMapOperator(MapOperator):
         self._submit_metadata_task(
             res_ref,
             lambda: _task_done_callback(res_ref),
+            is_actor_task=True,
         )
         return actor, res_ref
 
@@ -245,7 +246,10 @@ class ActorPoolMapOperator(MapOperator):
             from functools import partial
 
             self._submit_data_task(
-                gen, bundle, partial(_task_done_callback, actor_to_return=actor)
+                gen,
+                bundle,
+                is_actor_task=True,
+                task_done_callback=partial(_task_done_callback, actor_to_return=actor),
             )
 
     def _refresh_actor_cls(self):

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -191,7 +191,6 @@ class ActorPoolMapOperator(MapOperator):
         self._submit_metadata_task(
             res_ref,
             lambda: _task_done_callback(res_ref),
-            is_actor_task=True,
         )
         return actor, res_ref
 
@@ -246,10 +245,7 @@ class ActorPoolMapOperator(MapOperator):
             from functools import partial
 
             self._submit_data_task(
-                gen,
-                bundle,
-                is_actor_task=True,
-                task_done_callback=partial(_task_done_callback, actor_to_return=actor),
+                gen, bundle, partial(_task_done_callback, actor_to_return=actor)
             )
 
     def _refresh_actor_cls(self):

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -475,8 +475,8 @@ class MapOperator(OneToOneOperator, ABC):
 
     def shutdown(self, force: bool = False):
         if force:
-            tasks: List[OpTask] = (
-                list(self._data_tasks.values()) + list(self._metadata_tasks.values())
+            tasks: List[OpTask] = list(self._data_tasks.values()) + list(
+                self._metadata_tasks.values()
             )
 
             # Interrupt all (still) running tasks immediately

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -365,8 +365,6 @@ class MapOperator(OneToOneOperator, ABC):
         self,
         gen: ObjectRefGenerator,
         inputs: RefBundle,
-        *,
-        is_actor_task: bool,
         task_done_callback: Optional[Callable[[], None]] = None,
     ):
         """Submit a new data-handling task."""
@@ -425,10 +423,7 @@ class MapOperator(OneToOneOperator, ABC):
         )
 
     def _submit_metadata_task(
-        self,
-        result_ref: ObjectRef,
-        task_done_callback: Callable[[], None],
-        is_actor_task: bool,
+        self, result_ref: ObjectRef, task_done_callback: Callable[[], None]
     ):
         """Submit a new metadata-handling task."""
         # TODO(hchen): Move this to the base PhyscialOperator class.
@@ -440,10 +435,7 @@ class MapOperator(OneToOneOperator, ABC):
             task_done_callback()
 
         self._metadata_tasks[task_index] = MetadataOpTask(
-            task_index,
-            result_ref,
-            _task_done_callback,
-            is_actor_task=is_actor_task,
+            task_index, result_ref, _task_done_callback
         )
 
     def get_active_tasks(self) -> List[OpTask]:
@@ -486,8 +478,6 @@ class MapOperator(OneToOneOperator, ABC):
             tasks: List[OpTask] = list(self._data_tasks.values()) + list(
                 self._metadata_tasks.values()
             )
-
-            force_cancel = not isinstance(ActorPoolMapOperator)
 
             # Interrupt all (still) running tasks immediately
             for task in tasks:

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -365,6 +365,8 @@ class MapOperator(OneToOneOperator, ABC):
         self,
         gen: ObjectRefGenerator,
         inputs: RefBundle,
+        *,
+        is_actor_task: bool,
         task_done_callback: Optional[Callable[[], None]] = None,
     ):
         """Submit a new data-handling task."""
@@ -423,7 +425,10 @@ class MapOperator(OneToOneOperator, ABC):
         )
 
     def _submit_metadata_task(
-        self, result_ref: ObjectRef, task_done_callback: Callable[[], None]
+        self,
+        result_ref: ObjectRef,
+        task_done_callback: Callable[[], None],
+        is_actor_task: bool,
     ):
         """Submit a new metadata-handling task."""
         # TODO(hchen): Move this to the base PhyscialOperator class.
@@ -435,7 +440,10 @@ class MapOperator(OneToOneOperator, ABC):
             task_done_callback()
 
         self._metadata_tasks[task_index] = MetadataOpTask(
-            task_index, result_ref, _task_done_callback
+            task_index,
+            result_ref,
+            _task_done_callback,
+            is_actor_task=is_actor_task,
         )
 
     def get_active_tasks(self) -> List[OpTask]:
@@ -478,6 +486,8 @@ class MapOperator(OneToOneOperator, ABC):
             tasks: List[OpTask] = list(self._data_tasks.values()) + list(
                 self._metadata_tasks.values()
             )
+
+            force_cancel = not isinstance(ActorPoolMapOperator)
 
             # Interrupt all (still) running tasks immediately
             for task in tasks:

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -481,7 +481,7 @@ class MapOperator(OneToOneOperator, ABC):
 
             # Interrupt all (still) running tasks immediately
             for task in tasks:
-                ray.cancel(task.get_waitable(), force=True)
+                task._cancel(force=True)
 
             # Wait for all tasks to get cancelled before returning
             for task in tasks:

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -1,6 +1,5 @@
 from typing import Any, Callable, Dict, Optional
 
-import ray
 from ray.data._internal.execution.interfaces import (
     ExecutionResources,
     PhysicalOperator,

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -106,7 +106,7 @@ class TaskPoolMapOperator(MapOperator):
             *bundle.block_refs,
             **self.get_map_task_kwargs(),
         )
-        self._submit_data_task(gen, bundle, is_actor_task=False)
+        self._submit_data_task(gen, bundle)
 
     def progress_str(self) -> str:
         return ""

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -108,22 +108,6 @@ class TaskPoolMapOperator(MapOperator):
         )
         self._submit_data_task(gen, bundle)
 
-    def shutdown(self, force: bool = False):
-        # Cancel all active tasks.
-        for _, task in self._data_tasks.items():
-            ray.cancel(task.get_waitable())
-        # Wait until all tasks have failed or been cancelled.
-        for _, task in self._data_tasks.items():
-            try:
-                ray.get(task.get_waitable())
-            except ray.exceptions.RayError:
-                # Cancellation either succeeded, or the task had already failed with
-                # a different error, or cancellation failed. In all cases, we
-                # swallow the exception.
-                pass
-
-        super().shutdown(force)
-
     def progress_str(self) -> str:
         return ""
 

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -106,7 +106,7 @@ class TaskPoolMapOperator(MapOperator):
             *bundle.block_refs,
             **self.get_map_task_kwargs(),
         )
-        self._submit_data_task(gen, bundle)
+        self._submit_data_task(gen, bundle, is_actor_task=False)
 
     def progress_str(self) -> str:
         return ""

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -535,9 +535,7 @@ class _ClosingIterator(OutputIterator):
 
         # Have to be BaseException to catch ``KeyboardInterrupt``
         except BaseException as e:
-            self._executor.shutdown(
-                e if not isinstance(e, StopIteration) else None
-            )
+            self._executor.shutdown(e if not isinstance(e, StopIteration) else None)
             raise
 
     def __del__(self):

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -1,7 +1,7 @@
 import logging
 import threading
 import time
-from typing import Dict, Iterator, List, Optional
+from typing import Dict, List, Optional
 
 from ray.data._internal.execution.autoscaler import create_autoscaler
 from ray.data._internal.execution.backpressure_policy import (

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -222,6 +222,7 @@ class StreamingExecutor(Executor, threading.Thread):
 
         Results are returned via the output node's outqueue.
         """
+        exc: Optional[Exception] = None
         try:
             # Run scheduling loop until complete.
             while True:
@@ -238,10 +239,10 @@ class StreamingExecutor(Executor, threading.Thread):
                     break
         except Exception as e:
             # Propagate it to the result iterator.
-            self._output_node.mark_finished(e)
+            exc = e
         finally:
             # Signal end of results.
-            self._output_node.mark_finished()
+            self._output_node.mark_finished(exc)
 
     def get_stats(self):
         """Return the stats object for the streaming execution.

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -95,7 +95,7 @@ class StreamingExecutor(Executor, threading.Thread):
 
     def execute(
         self, dag: PhysicalOperator, initial_stats: Optional[DatasetStats] = None
-    ) -> Iterator[RefBundle]:
+    ) -> OutputIterator:
         """Executes the DAG using a streaming execution strategy.
 
         We take an event-loop approach to scheduling. We block on the next scheduling

--- a/python/ray/data/_internal/iterator/iterator_impl.py
+++ b/python/ray/data/_internal/iterator/iterator_impl.py
@@ -24,9 +24,7 @@ class DataIteratorImpl(DataIterator):
     def _to_ref_bundle_iterator(
         self,
     ) -> Tuple[Iterator[RefBundle], Optional[DatasetStats], bool]:
-        ds = self._base_dataset
-        ref_bundles_iterator, stats, executor = ds._plan.execute_to_iterator()
-        ds._current_executor = executor
+        ref_bundles_iterator, stats = self._base_dataset._execute_to_iterator()
         return ref_bundles_iterator, stats, False
 
     def stats(self) -> str:

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -360,36 +360,26 @@ class ExecutionPlan:
             return self._schema
 
         schema = None
+
         if self.has_computed_output():
             schema = unify_block_metadata_schema(self._snapshot_bundle.metadata)
+
         elif self._logical_plan.dag.aggregate_output_metadata().schema is not None:
             schema = self._logical_plan.dag.aggregate_output_metadata().schema
-        elif fetch_if_missing:
-            iter_ref_bundles, _, _ = self.execute_to_iterator()
-            for ref_bundle in iter_ref_bundles:
-                for metadata in ref_bundle.metadata:
-                    if metadata.schema is not None and (
-                        metadata.num_rows is None or metadata.num_rows > 0
-                    ):
-                        schema = metadata.schema
-                        break
-        elif self.is_read_only():
+
+        elif fetch_if_missing or self.is_read_only():
             # For consistency with the previous implementation, we fetch the schema if
             # the plan is read-only even if `fetch_if_missing` is False.
+
             iter_ref_bundles, _, executor = self.execute_to_iterator()
-            try:
-                ref_bundle = next(iter(iter_ref_bundles))
-                for metadata in ref_bundle.metadata:
-                    if metadata.schema is not None:
-                        schema = metadata.schema
-                        break
-            except StopIteration:  # Empty dataset.
-                schema = None
-            finally:
-                # NOTE: Make sure executor is terminated at this point and all
-                #       outstanding tasks are finished (to make sure it won't affect
-                #       subsequent execution)
-                del executor
+
+            # Make sure executor is fully shutdown upon exiting
+            with executor:
+                for ref_bundle in iter_ref_bundles:
+                    for metadata in ref_bundle.metadata:
+                        if metadata.schema is not None:
+                            schema = metadata.schema
+                            break
 
         self._schema = schema
         return self._schema
@@ -424,6 +414,11 @@ class ExecutionPlan:
         """Execute this plan, returning an iterator.
 
         This will use streaming execution to generate outputs.
+
+        NOTE: Executor will be shutdown upon either of the 2 following conditions:
+
+            - Iterator is fully exhausted (ie until StopIteration is raised)
+            - Executor instances is garbage-collected
 
         Returns:
             Tuple of iterator over output RefBundles, DatasetStats, and the executor.

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -376,7 +376,7 @@ class ExecutionPlan:
         elif self.is_read_only():
             # For consistency with the previous implementation, we fetch the schema if
             # the plan is read-only even if `fetch_if_missing` is False.
-            iter_ref_bundles, _, _ = self.execute_to_iterator()
+            iter_ref_bundles, _, executor = self.execute_to_iterator()
             try:
                 ref_bundle = next(iter(iter_ref_bundles))
                 for metadata in ref_bundle.metadata:
@@ -385,6 +385,11 @@ class ExecutionPlan:
                         break
             except StopIteration:  # Empty dataset.
                 schema = None
+            finally:
+                # NOTE: Make sure executor is terminated at this point and all
+                #       outstanding tasks are finished (to make sure it won't affect
+                #       subsequent execution)
+                del executor
 
         self._schema = schema
         return self._schema


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, fetching schemas leaves executor dangling for potentially undefined amount of time until it's collected by GC.

This creates substantial amount of downstream issues as subsequent execution might need to compete for resources with the executor that hasn't been shutdown yet.

Some operations (like `groupby`) actually invoke this API internally exacerbating the problem.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
