### PR TITLE
[Dashboard] Remove millisecond padding in DurationText component

### DIFF
--- a/python/ray/dashboard/client/src/common/DurationText/DurationText.component.test.tsx
+++ b/python/ray/dashboard/client/src/common/DurationText/DurationText.component.test.tsx
@@ -13,11 +13,11 @@ describe("DurationText", () => {
     rerender(
       <DurationText startTime={new Date(100000)} endTime={new Date(105000)} />,
     );
-    expect(await screen.findByText("5s 000ms")).toBeInTheDocument();
+    expect(await screen.findByText("5s 0ms")).toBeInTheDocument();
     rerender(
       <DurationText startTime={new Date(100000)} endTime={new Date(110000)} />,
     );
-    expect(await screen.findByText("10s 000ms")).toBeInTheDocument();
+    expect(await screen.findByText("10s 0ms")).toBeInTheDocument();
     rerender(
       <DurationText startTime={new Date(100000)} endTime={new Date(200000)} />,
     );
@@ -69,13 +69,13 @@ describe("DurationText", () => {
 
     MockDate.set(mockDate1);
     const { rerender } = render(<DurationText startTime={startTime} />);
-    expect(await screen.findByText("5s 000ms")).toBeInTheDocument();
+    expect(await screen.findByText("5s 0ms")).toBeInTheDocument();
 
     MockDate.set(mockDate2);
     act(() => {
       jest.advanceTimersByTime(1000);
     });
-    expect(await screen.findByText("6s 000ms")).toBeInTheDocument();
+    expect(await screen.findByText("6s 0ms")).toBeInTheDocument();
 
     MockDate.set(mockDate3);
     act(() => {

--- a/python/ray/dashboard/client/src/common/DurationText/DurationText.tsx
+++ b/python/ray/dashboard/client/src/common/DurationText/DurationText.tsx
@@ -28,9 +28,10 @@ export const DurationText = ({ startTime, endTime }: DurationTextProps) => {
   let durationText: string;
   let refreshInterval = 1000;
   if (duration.asSeconds() < 1) {
-    durationText = duration.format("SSS[ms]");
+    durationText = duration.milliseconds() + "ms";
   } else if (duration.asMinutes() < 1) {
-    durationText = duration.format("s[s] SSS[ms]");
+    durationText =
+      duration.format("s[s]") + " " + duration.milliseconds() + "ms";
   } else if (duration.asHours() < 1) {
     durationText = duration.format("m[m] s[s]");
   } else if (duration.asDays() < 1) {


### PR DESCRIPTION
## Why are these changes needed?

The Ray dashboard currently displays millisecond durations with unnecessary leading zeros (e.g., "076ms"). This PR removes the padding to improve readability and make the display more natural (e.g., "76ms"). 

The change affects durations less than 1 minute in the DurationText component, specifically:
- For durations < 1s: Changes from "076ms" to "76ms"
- For durations < 1m: Changes from "5s 076ms" to "5s 76ms"

## Visual Changes

Before and after screenshots show the formatting changes using the reproduction script provided in issue #52345.

Before:
![Before](https://github.com/user-attachments/assets/02495c5d-f858-4585-b1f5-55236c5748ed)

After:
![After](https://github.com/user-attachments/assets/4e1be32c-61c6-4716-b9c1-9f47d10df2b8)


## Related issue number

Closes #52345

## Checks

- [x] I've signed off every commit (by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference.
- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested