### PR TITLE
Use large instance for OOM test

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -387,7 +387,7 @@ steps:
     tags:
       - python
       - docker
-    instance_type: medium
+    instance_type: large
     commands:
       - bazel run //ci/ray_ci:build_in_docker -- docker --platform cpu --canonical-tag ha_integration
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... core --only-tags ha_integration

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -156,7 +156,7 @@ steps:
     tags:
       - serve
       - python
-    instance_type: medium
+    instance_type: large
     commands:
       - bazel run //ci/ray_ci:build_in_docker -- docker --platform cpu --canonical-tag ha_integration
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/tests/... serve


### PR DESCRIPTION
## Why are these changes needed?

In https://github.com/ray-project/ray/pull/52250, community contributor does a feature-wise no-op change to split large targets into smaller ones, but CI keeps failing due to OOM.
```sh

[2025-04-17T05:33:59Z] Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
--
  | [2025-04-17T05:33:59Z] gcc: fatal error: Killed signal terminated program cc1plus
```

The reason why splitting targets uses more memory is bazel parallelize compilation on targets level, so smaller targets generally indicates more parallelism, thus more memory consumption.
I also see people increasing resource allocation in another [PR](https://github.com/ray-project/ray/pull/51673), my hunch is we're already at the verge of OOM. :( 

## Related issue number

Closes https://github.com/ray-project/ray/issues/52399