### PR TITLE
Revert "[core][cgraph] Use cord for cgraphs object transfer (#51459)"

### DIFF
--- a/src/ray/core_worker/experimental_mutable_object_provider.cc
+++ b/src/ray/core_worker/experimental_mutable_object_provider.cc
@@ -170,13 +170,7 @@ void MutableObjectProvider::HandlePushMutableObject(
   // The buffer has the data immediately followed by the metadata. `WriteAcquire()`
   // above checks that the buffer size is large enough to hold both the data and the
   // metadata.
-  size_t chunk_offset = 0;
-  for (absl::string_view cord_chunk : request.payload().Chunks()) {
-    memcpy(object_backing_store->Data() + offset + chunk_offset,
-           cord_chunk.data(),
-           cord_chunk.size());
-    chunk_offset += cord_chunk.size();
-  }
+  memcpy(object_backing_store->Data() + offset, request.payload().data(), chunk_size);
 
   size_t total_written = tmp_written_so_far + chunk_size;
   RAY_CHECK_LE(total_written, total_size);

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -123,14 +123,16 @@ message CommitBundleResourcesRequest {
   repeated Bundle bundle_specs = 1;
 }
 
-message CommitBundleResourcesReply {}
+message CommitBundleResourcesReply {
+}
 
 message CancelResourceReserveRequest {
   // Bundle containing the requested resources.
   Bundle bundle_spec = 1;
 }
 
-message CancelResourceReserveReply {}
+message CancelResourceReserveReply {
+}
 
 // Release a worker back to its raylet.
 message ReturnWorkerRequest {
@@ -147,7 +149,8 @@ message ReturnWorkerRequest {
   string disconnect_worker_error_detail = 5;
 }
 
-message ReturnWorkerReply {}
+message ReturnWorkerReply {
+}
 
 message ReleaseUnusedActorWorkersRequest {
   repeated bytes worker_ids_in_use = 1;
@@ -246,9 +249,11 @@ message GetNodeStatsReply {
   ObjectStoreStats store_stats = 6;
 }
 
-message GlobalGCRequest {}
+message GlobalGCRequest {
+}
 
-message GlobalGCReply {}
+message GlobalGCReply {
+}
 
 // Accumulates memory info across all nodes. To access per-node memory info,
 // use GetNodeStats() calls instead.
@@ -273,9 +278,11 @@ message ReleaseUnusedBundlesRequest {
   repeated Bundle bundles_in_use = 1;
 }
 
-message ReleaseUnusedBundlesReply {}
+message ReleaseUnusedBundlesReply {
+}
 
-message GetSystemConfigRequest {}
+message GetSystemConfigRequest {
+}
 
 message GetSystemConfigReply {
   string system_config = 1;
@@ -369,7 +376,7 @@ message PushMutableObjectRequest {
   // The size of this chunk. Note that this size could include both data and metadata.
   uint64 chunk_size = 5;
   // The chunk payload. Note that this could include both data and metadata.
-  bytes payload = 6 [ctype = CORD];
+  bytes payload = 6;
 }
 
 message PushMutableObjectReply {

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -123,16 +123,14 @@ message CommitBundleResourcesRequest {
   repeated Bundle bundle_specs = 1;
 }
 
-message CommitBundleResourcesReply {
-}
+message CommitBundleResourcesReply {}
 
 message CancelResourceReserveRequest {
   // Bundle containing the requested resources.
   Bundle bundle_spec = 1;
 }
 
-message CancelResourceReserveReply {
-}
+message CancelResourceReserveReply {}
 
 // Release a worker back to its raylet.
 message ReturnWorkerRequest {
@@ -149,8 +147,7 @@ message ReturnWorkerRequest {
   string disconnect_worker_error_detail = 5;
 }
 
-message ReturnWorkerReply {
-}
+message ReturnWorkerReply {}
 
 message ReleaseUnusedActorWorkersRequest {
   repeated bytes worker_ids_in_use = 1;
@@ -249,11 +246,9 @@ message GetNodeStatsReply {
   ObjectStoreStats store_stats = 6;
 }
 
-message GlobalGCRequest {
-}
+message GlobalGCRequest {}
 
-message GlobalGCReply {
-}
+message GlobalGCReply {}
 
 // Accumulates memory info across all nodes. To access per-node memory info,
 // use GetNodeStats() calls instead.
@@ -278,11 +273,9 @@ message ReleaseUnusedBundlesRequest {
   repeated Bundle bundles_in_use = 1;
 }
 
-message ReleaseUnusedBundlesReply {
-}
+message ReleaseUnusedBundlesReply {}
 
-message GetSystemConfigRequest {
-}
+message GetSystemConfigRequest {}
 
 message GetSystemConfigReply {
   string system_config = 1;

--- a/src/ray/raylet_client/raylet_client.cc
+++ b/src/ray/raylet_client/raylet_client.cc
@@ -355,8 +355,7 @@ void RayletClient::PushMutableObject(
     request.set_chunk_size(chunk_size);
     // This assumes that the format of the object is a contiguous buffer of (data |
     // metadata).
-    request.set_payload(absl::MakeCordFromExternal(
-        absl::string_view(static_cast<char *>(data) + offset, chunk_size), []() {}));
+    request.set_payload(static_cast<char *>(data) + offset, chunk_size);
 
     // TODO(jackhumphries): Add failure recovery, retries, and timeout.
     grpc_client_->PushMutableObject(


### PR DESCRIPTION
This reverts commit 372acb89be53076fd225aba7e86b0c89f14b33b0.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There's no issue with this, but we still don't want inconsistency since we didn't merge https://github.com/ray-project/ray/pull/51397
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
