### PR TITLE
[data] RetryContextManager should also retry opening files

### DIFF
--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -248,7 +248,7 @@ class FileBasedDatasource(Datasource):
                     partitions = parse(read_path)
 
                 with RetryingContextManager(
-                    self._open_input_source(fs, read_path, **open_stream_args),
+                    lambda: self._open_input_source(fs, read_path, **open_stream_args),
                     context=self._data_context,
                 ) as f:
                     for block in iterate_with_retry(


### PR DESCRIPTION
Fix the following error. 

```
(TrainController pid=6278) ray.exceptions.RayTaskError(OSError): ray::ReadCSV->SplitBlocks(5)() (pid=5940, ip=10.0.128.209) [repeated 15x across cluster]
(TrainController pid=6278)     for b_out in map_transformer.apply_transform(iter(blocks), ctx): [repeated 15x across cluster]
(TrainController pid=6278)   File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/datasource/datasource.py", line 168, in __call__ [repeated 60x across cluster]
(TrainController pid=6278)     for block in blocks: [repeated 15x across cluster]
(TrainController pid=6278)     for data in iter: [repeated 15x across cluster]
(TrainController pid=6278)     yield from self._block_fn(input, ctx) [repeated 15x across cluster]
(TrainController pid=6278)   File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/planner/plan_read_op.py", line 106, in do_read [repeated 15x across cluster]
(TrainController pid=6278)     yield from read_task() [repeated 15x across cluster]
(TrainController pid=6278)     yield from result [repeated 15x across cluster]
(TrainController pid=6278)   File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/datasource/file_based_datasource.py", line 292, in read_task_fn [repeated 15x across cluster]
(TrainController pid=6278)     yield from read_files(read_paths) [repeated 15x across cluster]
(TrainController pid=6278)   File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/datasource/file_based_datasource.py", line 251, in read_files [repeated 15x across cluster]
(TrainController pid=6278)     self._open_input_source(fs, read_path, **open_stream_args), [repeated 15x across cluster]
(TrainController pid=6278)   File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/datasource/file_based_datasource.py", line 369, in _open_input_source [repeated 15x across cluster]
(TrainController pid=6278)     file = filesystem.open_input_stream(path, buffer_size=buffer_size, **open_args) [repeated 15x across cluster]
(TrainController pid=6278)   File "pyarrow/_fs.pyx", line 822, in pyarrow._fs.FileSystem.open_input_stream [repeated 15x across cluster]
(TrainController pid=6278)   File "pyarrow/error.pxi", line 154, in pyarrow.lib.pyarrow_internal_check_status [repeated 15x across cluster]
(TrainController pid=6278)   File "pyarrow/error.pxi", line 91, in pyarrow.lib.check_status [repeated 15x across cluster]
(TrainController pid=6278) OSError: When reading information for key 'criteo/tsv.gz/valid/day_23_bp.tsv.gz' in bucket 'ray-benchmark-data-internal': AWS Error ACCESS_DENIED during HeadObject operation: No response body. [repeated 15x across cluster]
```