### PR TITLE
[data.dashboard.x][05] add operator queued block metrics

### DIFF
--- a/python/ray/dashboard/modules/data/tests/test_data_head.py
+++ b/python/ray/dashboard/modules/data/tests/test_data_head.py
@@ -36,6 +36,7 @@ RESPONSE_SCHEMA = [
 OPERATOR_SCHEMA = [
     "name",
     "operator",
+    "queued_blocks",
 ] + DATA_SCHEMA
 
 

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -435,6 +435,7 @@ class StreamingExecutor(Executor, threading.Thread):
                     "progress": op_state.num_completed_tasks,
                     "total": op.num_outputs_total(),
                     "total_rows": op.num_output_rows_total(),
+                    "queued_blocks": op.internal_queue_size() + op_state.num_queued(),
                     "state": DatasetState.FINISHED.name
                     if op.execution_finished()
                     else state,

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -313,6 +313,11 @@ class _StatsActor:
             description="Total work units in rows for operator",
             tag_keys=operator_tags,
         )
+        self.data_operator_queued_blocks = Gauge(
+            "data_operator_queued_blocks",
+            description="Number of queued blocks for operator",
+            tag_keys=operator_tags,
+        )
         self.data_operator_state = Gauge(
             "data_operator_state",
             description=f"State of operator ({', '.join([f'{s.value}={s.name}' for s in DatasetState])})",
@@ -487,6 +492,7 @@ class _StatsActor:
                     "state": DatasetState.RUNNING.name,
                     "progress": 0,
                     "total": 0,
+                    "queued_blocks": 0,
                 }
                 for operator in operator_tags
             },
@@ -526,6 +532,9 @@ class _StatsActor:
             )
             self.data_operator_estimated_total_rows.set(
                 op_state.get("total_rows", 0), operator_tags
+            )
+            self.data_operator_queued_blocks.set(
+                op_state.get("queued_blocks", 0), operator_tags
             )
 
             # Get state code directly from enum


### PR DESCRIPTION
Add operator queued block metrics. The formula is the same as how the progress bar is computed (https://github.com/ray-project/ray/blob/master/python/ray/data/_internal/execution/streaming_executor_state.py#L288)

Test:
- CI