### PR TITLE
[Core] Fix test_python_object_leak

### DIFF
--- a/python/ray/tests/test_streaming_generator_2.py
+++ b/python/ray/tests/test_streaming_generator_2.py
@@ -338,6 +338,7 @@ def test_python_object_leak(shutdown_only):
     class AsyncActor:
         def __init__(self):
             self.gc_garbage_len = 0
+            gc.collect()
 
         def get_gc_garbage_len(self):
             return self.gc_garbage_len
@@ -366,6 +367,7 @@ def test_python_object_leak(shutdown_only):
     class A:
         def __init__(self):
             self.gc_garbage_len = 0
+            gc.collect()
 
         def get_gc_garbage_len(self):
             return self.gc_garbage_len

--- a/python/ray/tests/test_streaming_generator_2.py
+++ b/python/ray/tests/test_streaming_generator_2.py
@@ -337,8 +337,10 @@ def test_python_object_leak(shutdown_only):
     @ray.remote
     class AsyncActor:
         def __init__(self):
-            self.gc_garbage_len = 0
+            # Clear any existing circular references
+            # before testing leaks in actor tasks.
             gc.collect()
+            self.gc_garbage_len = 0
 
         def get_gc_garbage_len(self):
             return self.gc_garbage_len
@@ -366,8 +368,10 @@ def test_python_object_leak(shutdown_only):
     @ray.remote
     class A:
         def __init__(self):
-            self.gc_garbage_len = 0
+            # Clear any existing circular references
+            # before testing leaks in actor tasks.
             gc.collect()
+            self.gc_garbage_len = 0
 
         def get_gc_garbage_len(self):
             return self.gc_garbage_len


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

We are testing to make sure we don't generate circular references in actor tasks but we didn't clear any existing circular references before calling actor tasks. It's not a problem for Python 3.9 since there are no existing circular references but for Python 3.12, there are some so we should clear those first.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
#52350
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
