### PR TITLE
[serve] Suppress cancelled errors in proxy

### DIFF
--- a/python/ray/serve/_private/proxy_response_generator.py
+++ b/python/ray/serve/_private/proxy_response_generator.py
@@ -61,7 +61,15 @@ def swallow_cancelled(task: asyncio.Task):
     try:
         task.result()
     except (RequestCancelledError, asyncio.CancelledError):
+        # We expect RequestCancelledError to be raised because for disconnect or
+        # timeouts, we explicitly call resp.cancel(). To avoid "Task exception
+        # was never retrieved" errors from spamming the proxy logs, swallow
+        # them here.
         pass
+    except Exception:
+        # For all other exceptions, do not catch and instead re-raise here so that
+        # they will be logged properly.
+        raise
 
 
 class ProxyResponseGenerator(_ProxyResponseGeneratorBase):


### PR DESCRIPTION
## Why are these changes needed?

If `serve.exceptions.RequestCancelledError` is thrown in `next_result_task` in the proxy, then `Task exception was never retrieved` traceback errors will spam in the proxy. However this is an expected error if we cancel a request. So in this case, suppress the error in a callback.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
