### PR TITLE
[Data] Handle Polars sort API change from reverse to descending

### DIFF
--- a/python/ray/data/_internal/arrow_ops/transform_polars.py
+++ b/python/ray/data/_internal/arrow_ops/transform_polars.py
@@ -1,4 +1,5 @@
 from typing import TYPE_CHECKING, List
+from packaging.version import parse as parse_version
 
 try:
     import pyarrow
@@ -10,6 +11,11 @@ if TYPE_CHECKING:
     from ray.data._internal.planner.exchange.sort_task_spec import SortKey
 
 pl = None
+
+# Polars 0.16.8 introduced the `descending` parameter for the `sort` method,
+# replacing `reverse`.
+# See https://github.com/pola-rs/polars/issues/5429 for more details.
+_POLARS_SORT_DESCENDING_MIN_VERSION = parse_version("0.16.8")
 
 
 def check_polars_installed():
@@ -26,7 +32,14 @@ def check_polars_installed():
 def sort(table: "pyarrow.Table", sort_key: "SortKey") -> "pyarrow.Table":
     check_polars_installed()
     df = pl.from_arrow(table)
-    return df.sort(sort_key.get_columns(), reverse=sort_key.get_descending()).to_arrow()
+    if parse_version(pl.__version__) >= _POLARS_SORT_DESCENDING_MIN_VERSION:
+        return df.sort(
+            sort_key.get_columns(), descending=sort_key.get_descending()
+        ).to_arrow()
+    else:
+        return df.sort(
+            sort_key.get_columns(), reverse=sort_key.get_descending()
+        ).to_arrow()
 
 
 def concat_and_sort(
@@ -34,7 +47,12 @@ def concat_and_sort(
 ) -> "pyarrow.Table":
     check_polars_installed()
     blocks = [pl.from_arrow(block) for block in blocks]
-    df = pl.concat(blocks).sort(
-        sort_key.get_columns(), reverse=sort_key.get_descending()
-    )
+    if parse_version(pl.__version__) >= _POLARS_SORT_DESCENDING_MIN_VERSION:
+        df = pl.concat(blocks).sort(
+            sort_key.get_columns(), descending=sort_key.get_descending()
+        )
+    else:
+        df = pl.concat(blocks).sort(
+            sort_key.get_columns(), reverse=sort_key.get_descending()
+        )
     return df.to_arrow()


### PR DESCRIPTION
## Why are these changes needed?

Polars 0.16.8 replaced the `reverse` parameter with `descending` in its sort API.

For reference, see the current Polars sort API documentation: [polars.DataFrame.sort](https://docs.pola.rs/api/python/stable/reference/dataframe/api/polars.DataFrame.sort.html)

This PR adds version-aware handling in Ray Data to maintain compatibility with both older and newer versions of Polars, ensuring sorting operations work correctly regardless of the installed Polars version.

## Related issue number

Closes #52402

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
