### PR TITLE
[Fix][Core/Dashboard] Make named pipe name unique between sessions

### DIFF
--- a/python/ray/dashboard/modules/train/train_head.py
+++ b/python/ray/dashboard/modules/train/train_head.py
@@ -333,7 +333,7 @@ class TrainHead(SubprocessModule):
     async def _get_actor_infos(self, actor_ids: List[str]):
         if self._node_head_http_session is None:
             self._node_head_http_session = get_http_session_to_module(
-                "NodeHead", self._config.socket_dir
+                "NodeHead", self._config.socket_dir, self._config.session_name
             )
         actor_ids_qs_str = ",".join(actor_ids)
         url = f"http://localhost/logical/actors?ids={actor_ids_qs_str}&nocache=1"

--- a/python/ray/dashboard/subprocesses/handle.py
+++ b/python/ray/dashboard/subprocesses/handle.py
@@ -147,7 +147,7 @@ class SubprocessModuleHandle:
 
         module_name = self.module_cls.__name__
         self.http_client_session = get_http_session_to_module(
-            module_name, self.config.socket_dir
+            module_name, self.config.socket_dir, self.config.session_name
         )
 
         self.health_check_task = self.loop.create_task(self._do_periodic_health_check())

--- a/python/ray/dashboard/subprocesses/module.py
+++ b/python/ray/dashboard/subprocesses/module.py
@@ -131,7 +131,9 @@ class SubprocessModule(abc.ABC):
 
         module_name = self.__class__.__name__
         if sys.platform == "win32":
-            named_pipe_path = get_named_pipe_path(module_name)
+            named_pipe_path = get_named_pipe_path(
+                module_name, self._config.session_name
+            )
             site = aiohttp.web.NamedPipeSite(runner, named_pipe_path)
             logger.info(f"Started aiohttp server over {named_pipe_path}.")
         else:

--- a/python/ray/dashboard/subprocesses/utils.py
+++ b/python/ray/dashboard/subprocesses/utils.py
@@ -47,18 +47,18 @@ def get_socket_path(socket_dir: str, module_name: str) -> str:
     return socket_path
 
 
-def get_named_pipe_path(module_name: str) -> str:
-    return r"\\.\pipe\dash_" + module_name
+def get_named_pipe_path(module_name: str, session_name: str) -> str:
+    return r"\\.\pipe\dash_" + module_name + "_" + session_name
 
 
 def get_http_session_to_module(
-    module_name: str, socket_dir: str
+    module_name: str, socket_dir: str, session_name: str
 ) -> aiohttp.ClientSession:
     """
     Get the aiohttp http client session to the subprocess module.
     """
     if sys.platform == "win32":
-        named_pipe_path = get_named_pipe_path(module_name)
+        named_pipe_path = get_named_pipe_path(module_name, session_name)
         connector = aiohttp.NamedPipeConnector(named_pipe_path)
     else:
         socket_path = get_socket_path(socket_dir, module_name)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Might be the reason for the permission issue in https://github.com/ray-project/ray/issues/52132#issuecomment-2814085020. Unlike the socket files in Linux and macOS, which are located under the session directory so their full file paths are unique, Windows named pipe names are currently not unique. This PR makes them unique between sessions by appending the session name.

## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
