### PR TITLE
[Data] support ray_remote_args for read_tfrecords

### DIFF
--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -1910,6 +1910,7 @@ def read_tfrecords(
     *,
     filesystem: Optional["pyarrow.fs.FileSystem"] = None,
     parallelism: int = -1,
+    ray_remote_args: Dict[str, Any] = None,
     arrow_open_stream_args: Optional[Dict[str, Any]] = None,
     meta_provider: Optional[BaseFileMetadataProvider] = None,
     partition_filter: Optional[PathPartitionFilter] = None,
@@ -1972,6 +1973,7 @@ def read_tfrecords(
             the filesystem is automatically selected based on the scheme of the paths.
             For example, if the path begins with ``s3://``, the `S3FileSystem` is used.
         parallelism: This argument is deprecated. Use ``override_num_blocks`` argument.
+        ray_remote_args: kwargs passed to :func:`ray.remote` in the read tasks.
         arrow_open_stream_args: kwargs passed to
             `pyarrow.fs.FileSystem.open_input_file <https://arrow.apache.org/docs/\
                 python/generated/pyarrow.fs.FileSystem.html\
@@ -2052,6 +2054,7 @@ def read_tfrecords(
     ds = read_datasource(
         datasource,
         parallelism=parallelism,
+        ray_remote_args=ray_remote_args,
         concurrency=concurrency,
         override_num_blocks=override_num_blocks,
     )

--- a/python/ray/data/tests/test_tfrecords.py
+++ b/python/ray/data/tests/test_tfrecords.py
@@ -5,9 +5,11 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
+from unittest.mock import MagicMock
 from pandas.api.types import is_float_dtype, is_int64_dtype, is_object_dtype
 
 import ray
+from ray.data import Dataset
 from ray.data._internal.datasource.tfrecords_datasource import TFXReadOptions
 from ray.tests.conftest import *  # noqa: F401,F403
 
@@ -453,6 +455,37 @@ def test_read_tfrecords(
     assert np.array_equal(df["string_list"][0], np.array([b"xyz", b"999"]))
     assert np.array_equal(df["string_partial"][0], np.array([], dtype=np.bytes_))
     assert np.array_equal(df["string_empty"][0], np.array([], dtype=np.bytes_))
+
+
+@pytest.fixture
+def mock_ray_data_read_tfrecords(mocker):
+    mock_read_tfrecords = mocker.patch("ray.data.read_tfrecords")
+    mock_read_tfrecords.return_value = MagicMock(spec=Dataset)
+    return mock_read_tfrecords
+
+
+@pytest.mark.parametrize("num_cpus", [1, 2, 4])
+def test_read_tfrecords_ray_remote_args(
+    ray_start_regular_shared,
+    mock_ray_data_read_tfrecords,
+    tmp_path,
+    num_cpus,
+):
+    import tensorflow as tf
+
+    example = tf_records_empty()[0]
+    path = os.path.join(tmp_path, "data.tfrecords")
+    with tf.io.TFRecordWriter(path=path) as writer:
+        writer.write(example.SerializeToString())
+    ray_remote_args = {"num_cpus": num_cpus}
+    ds = read_tfrecords_with_tfx_read_override(
+        paths=[path],
+        ray_remote_args=ray_remote_args,
+    )
+    assert isinstance(ds, Dataset)
+    mock_ray_data_read_tfrecords.assert_called_once()
+    args, kwargs = mock_ray_data_read_tfrecords.call_args
+    assert kwargs["ray_remote_args"] == ray_remote_args
 
 
 @pytest.mark.parametrize("ignore_missing_paths", [True, False])

--- a/python/ray/data/tests/test_tfrecords.py
+++ b/python/ray/data/tests/test_tfrecords.py
@@ -485,6 +485,7 @@ def test_read_tfrecords_ray_remote_args(
     assert isinstance(ds, Dataset)
     mock_ray_data_read_tfrecords.assert_called_once()
     args, kwargs = mock_ray_data_read_tfrecords.call_args
+    assert kwargs["paths"] == [path]
     assert kwargs["ray_remote_args"] == ray_remote_args
 
 

--- a/python/requirements/test-requirements.txt
+++ b/python/requirements/test-requirements.txt
@@ -58,6 +58,7 @@ pytest-lazy-fixtures==1.1.2
 pytest-timeout==2.1.0
 pytest-virtualenv==1.7.0; python_version < "3.12"
 pytest-sphinx @ git+https://github.com/ray-project/pytest-sphinx
+pytest-mock==3.14.0
 redis==4.4.2
 scikit-learn==1.3.2
 smart_open[s3]==6.2.0

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -1723,7 +1723,9 @@ pytest-httpserver==1.0.6
 pytest-lazy-fixtures==1.1.2
     # via -r python/requirements/test-requirements.txt
 pytest-mock==3.14.0
-    # via -r python/requirements/ml/data-test-requirements.txt
+    # via
+    #   -r python/requirements/ml/data-test-requirements.txt
+    #   -r python/requirements/test-requirements.txt
 pytest-remotedata==0.3.2
     # via -r python/requirements/ml/tune-test-requirements.txt
 pytest-repeat==0.9.3


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

From https://github.com/ray-project/ray/issues/51379, we noticed that we don't support ray_remote_args for read_tfrecords, and this PR is to fix the issue

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

Closes #51379

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(


Note: I have done manual test

```
In [5]: ray.data.read_tfrecords("s3://anonymous@ray-example-data/iris.tfrecords")
Out[5]: 2025-04-18 17:13:58,893 INFO logging.py:273 -- Registered dataset logger for dataset dataset_None_0
2025-04-18 17:13:58,900 INFO streaming_executor.py:114 -- Starting execution of Dataset dataset_None_0. Full logs are in /tmp/ray/session_2025-04-18_17-12-02_742319_75926/logs/ray-data
2025-04-18 17:13:58,901 INFO streaming_executor.py:115 -- Execution plan of Dataset dataset_None_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ReadTFRecord]
Running Dataset: dataset_None_0. Active & requested resources: 1/10 CPU, 256.0MB/1.0GB object store: : 0.00 row [00:32, ? row/s]2025-04-18 17:14:31,877 INFO streaming_executor.py:230 -- ✔️  Dataset dataset_None_0 execution finished in 32.98 secondsued blocks: 0; Resources: 1.0 CPU, 256.0MB object store: : 0.00 row [00:32, ? row/s]
✔️  Dataset dataset_None_0 execution finished in 32.98 seconds: : 8.00 row [00:32, 4.12s/ row]
- ReadTFRecord->SplitBlocks(20): Tasks: 1; Queued blocks: 0; Resources: 1.0 CPU, 2.1KB object store: : 72.0 row [00:32, 2.18 row/s]

Dataset(
   num_rows=?,
   schema={
      sepal.length: float,
      sepal.width: float,
      petal.length: float,
      petal.width: float,
      label: binary
   }
)

In [6]: ray.data.read_tfrecords("s3://anonymous@ray-example-data/iris.tfrecords", ray_remote_args={"num_cpus": 0.25})
Out[6]: 2025-04-18 17:14:55,906 INFO logging.py:273 -- Registered dataset logger for dataset dataset_None_0
2025-04-18 17:14:55,912 INFO streaming_executor.py:114 -- Starting execution of Dataset dataset_None_0. Full logs are in /tmp/ray/session_2025-04-18_17-12-02_742319_75926/logs/ray-data
2025-04-18 17:14:55,912 INFO streaming_executor.py:115 -- Execution plan of Dataset dataset_None_0: InputDataBuffer[Input] -> TaskPoolMapOperator[ReadTFRecord]
Running Dataset: dataset_None_0. Active & requested resources: 0.25/10 CPU, 256.0MB/1.0GB object store: : 0.00 row [00:03, ? row/s]2025-04-18 17:14:59,245      INFO streaming_executor.py:230 -- ✔️  Dataset dataset_None_0 execution finished in 3.33 secondscks: 0; Resources: 0.2 CPU, 256.0MB object store: : 0.00 row [00:03, ? row/s]
✔️  Dataset dataset_None_0 execution finished in 3.33 seconds: : 8.00 row [00:03, 2.40 row/s]
- ReadTFRecord->SplitBlocks(20): Tasks: 1; Queued blocks: 0; Resources: 0.2 CPU, 1.0KB object store: : 32.0 row [00:03, 9.61 row/s]

Dataset(
   num_rows=?,
   schema={
      sepal.length: float,
      sepal.width: float,
      petal.length: float,
      petal.width: float,
      label: binary
   }
)
```

from `[5]`, we can see we have 1 CPU was used, and from `[6]`, we used 0.25 CPU as we specified.