### PR TITLE
[ray.data.llm] Add `ClientPayloadError` exception to the retry list in `HTTPRequestUDF`

### DIFF
--- a/python/ray/llm/_internal/batch/stages/http_request_stage.py
+++ b/python/ray/llm/_internal/batch/stages/http_request_stage.py
@@ -4,6 +4,7 @@ import aiohttp
 import asyncio
 import time
 import aiohttp.web_exceptions
+from aiohttp.client_exceptions import ClientPayloadError
 import numpy as np
 import traceback
 from typing import Any, Dict, AsyncIterator, Optional, List, Type, Callable
@@ -131,7 +132,11 @@ class HttpRequestUDF(StatefulStageUDF):
                                     f"the column {self.IDX_IN_BATCH_COLUMN}."
                                 )
                         break
-                    except (asyncio.TimeoutError, aiohttp.ClientConnectionError) as e:
+                    except (
+                        asyncio.TimeoutError,
+                        aiohttp.ClientConnectionError,
+                        ClientPayloadError,
+                    ) as e:
                         last_exception_traceback = traceback.format_exc()
                         last_exception = type(e).__name__
                         wait_time = self.base_retry_wait_time_in_s * (2**retry_count)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Adds `ClientPayloadError` as a retryable error in `HTTPRequestUDF`. 
For a batch inference job with the `HTTPProcessor` and an openai model, I recently got a `ClientPayloadError` likely due to a transient network issue:

```
 File "/home/ray/anaconda3/lib/python3.12/site-packages/ray/data/_internal/execution/operators/map_operato[104/1364]
e 538, in _map_task                                                                                                  
    for b_out in map_transformer.apply_transform(iter(blocks), ctx):                                                 
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                  
  File "/home/ray/anaconda3/lib/python3.12/site-packages/ray/data/_internal/execution/operators/map_transformer.py", 
line 537, in __call__                                                                                                
    for data in iter:        
                ^^^^         
  File "/home/ray/anaconda3/lib/python3.12/site-packages/ray/data/_internal/execution/operators/map_transformer.py", 
line 216, in _udf_timed_iter 
    output = next(input)                                  
             ^^^^^^^^^^^                                  
  File "/home/ray/anaconda3/lib/python3.12/site-packages/ray/data/_internal/execution/operators/map_transformer.py", 
line 332, in __call__        
    yield from self._batch_fn(input, ctx)                 
  File "/home/ray/anaconda3/lib/python3.12/site-packages/ray/data/_internal/planner/plan_udf_map_op.py", line 484, in
 transform_fn                
    raise out_item           
  File "/home/ray/anaconda3/lib/python3.12/site-packages/ray/data/_internal/planner/plan_udf_map_op.py", line 448, in
 process_item                
    async for output_item in output_item_iterator:                                                                   
  File "/home/ray/anaconda3/lib/python3.12/site-packages/ray/llm/_internal/batch/stages/base.py", line 171, in __call
__                           
    async for output in self.udf(inputs):                 
  File "/home/ray/anaconda3/lib/python3.12/site-packages/ray/llm/_internal/batch/stages/http_request_stage.py", line 
127, in udf                  
    resp_json = await response.json()                     
                ^^^^^^^^^^^^^^^^^^^^^                     
  File "/home/ray/anaconda3/lib/python3.12/site-packages/aiohttp/client_reqrep.py", line 1276, in json
    await self.read()        
  File "/home/ray/anaconda3/lib/python3.12/site-packages/aiohttp/client_reqrep.py", line 1218, in read
    self._body = await self.content.read()                
                 ^^^^^^^^^^^^^^^^^^^^^^^^^                
  File "/home/ray/anaconda3/lib/python3.12/site-packages/aiohttp/streams.py", line 418, in read
    block = await self.readany()                          
            ^^^^^^^^^^^^^^^^^^^^                          
  File "/home/ray/anaconda3/lib/python3.12/site-packages/aiohttp/streams.py", line 440, in readany
    await self._wait("readany")                           
  File "/home/ray/anaconda3/lib/python3.12/site-packages/aiohttp/streams.py", line 347, in _wait
    await waiter             
aiohttp.client_exceptions.ClientPayloadError: Response payload is not completed: <TransferEncodingError: 400, message
='Not enough data for satisfy transfer length header.'>   
ray.data.exceptions.SystemException       
```

The request can be safely retried for this error. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
