### PR TITLE
[data/docs] fix docs for Ray data vectorizers

### DIFF
--- a/.vale/styles/config/vocabularies/Data/accept.txt
+++ b/.vale/styles/config/vocabularies/Data/accept.txt
@@ -7,6 +7,7 @@ Dask
 [Dd]iscretizer(s)?
 dtype
 [Gg]roupby
+[Hh]asher(s)?
 [Hh]udi
 [Ii]ndexable
 [Ii]ngest

--- a/doc/source/data/api/preprocessor.rst
+++ b/doc/source/data/api/preprocessor.rst
@@ -40,6 +40,7 @@ Generic Preprocessors
 
     ~preprocessors.Concatenator
     ~preprocessors.SimpleImputer
+    ~preprocessors.Chain
 
 Categorical Encoders
 --------------------
@@ -77,3 +78,23 @@ K-Bins Discretizers
 
     ~preprocessors.CustomKBinsDiscretizer
     ~preprocessors.UniformKBinsDiscretizer
+
+Feature Hashers and Vectorizers
+-------------------------------
+
+.. autosummary::
+    :nosignatures:
+    :toctree: doc/
+
+    ~preprocessors.FeatureHasher
+    ~preprocessors.CountVectorizer
+    ~preprocessors.HashingVectorizer
+
+Specialized Preprocessors
+-------------------------
+
+.. autosummary::
+    :nosignatures:
+    :toctree: doc/
+
+    ~preprocessors.TorchVisionPreprocessor


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

It turns out a few preprocessors were missing in the documentation. The full list of APIs can be found in `ray/data/preprocessors/__init__.py`. 

![image](https://github.com/user-attachments/assets/9a1eab0f-2c5b-47bf-9739-c4bbf5467ecd)

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #52349

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

