### PR TITLE
feat(data): Add on_error and error_handler to map_batches

### DIFF
--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union, Literal
 
 import ray
 from ray.actor import ActorHandle
@@ -59,6 +59,8 @@ class ActorPoolMapOperator(MapOperator):
         supports_fusion: bool = True,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         ray_remote_args: Optional[Dict[str, Any]] = None,
+        on_error: Literal["raise", "continue"] = "raise",
+        error_handler: Optional[Callable[[Optional[Any], Exception], None]] = None,
     ):
         """Create an ActorPoolMapOperator instance.
 
@@ -83,6 +85,8 @@ class ActorPoolMapOperator(MapOperator):
                 advanced, experimental feature.
             ray_remote_args: Customize the ray remote args for this op's tasks.
                 See :func:`ray.remote` for details.
+            on_error: The action to take when an error occurs.
+            error_handler: The function to call when an error occurs.
         """
         super().__init__(
             map_transformer,
@@ -94,6 +98,8 @@ class ActorPoolMapOperator(MapOperator):
             supports_fusion,
             ray_remote_args_fn,
             ray_remote_args,
+            on_error=on_error,
+            error_handler=error_handler,
         )
         self._ray_actor_task_remote_args = {}
         actor_task_errors = self.data_context.actor_task_retry_on_errors

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, Literal
 
 from ray.data._internal.execution.interfaces import (
     ExecutionResources,
@@ -27,6 +27,8 @@ class TaskPoolMapOperator(MapOperator):
         supports_fusion: bool = True,
         ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         ray_remote_args: Optional[Dict[str, Any]] = None,
+        on_error: Literal["raise", "continue"] = "raise",
+        error_handler: Optional[Callable[[Optional[Any], Exception], None]] = None,
     ):
         """Create an TaskPoolMapOperator instance.
 
@@ -50,6 +52,8 @@ class TaskPoolMapOperator(MapOperator):
                 always override the args in ``ray_remote_args``. Note: this is an
                 advanced, experimental feature.
             ray_remote_args: Customize the :func:`ray.remote` args for this op's tasks.
+            on_error: The action to take when an error occurs.
+            error_handler: A function to handle errors.
         """
         super().__init__(
             map_transformer,
@@ -61,6 +65,8 @@ class TaskPoolMapOperator(MapOperator):
             supports_fusion,
             ray_remote_args_fn,
             ray_remote_args,
+            on_error=on_error,
+            error_handler=error_handler,
         )
         self._concurrency = concurrency
 


### PR DESCRIPTION
## Why are these changes needed?

This change introduces error handling options (`on_error`, `error_handler`) to `Dataset.map_batches`. Currently, a single failing batch halts the entire job, problematic for long-running tasks or those with transient errors. This PR allows users to configure pipelines to skip faulty batches (`on_error='continue'`) and optionally log errors via a handler. This improves the robustness of Ray Data pipelines against individual batch failures, preventing complete job loss from isolated issues.

## Related issue number

<!-- For example: "Closes #1234" --> Closes #<Insert Original Issue Number Here>

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(