### PR TITLE
[core] Support streaming arbitrary types to Status messages

### DIFF
--- a/src/ray/common/BUILD
+++ b/src/ray/common/BUILD
@@ -291,6 +291,7 @@ ray_cc_library(
         ":source_location",
         "//src/ray/util:logging",
         "//src/ray/util:macros",
+        "//src/ray/util:type_traits",
         "//src/ray/util:visibility",
         "@boost//:system",
         "@com_google_absl//absl/container:flat_hash_map",

--- a/src/ray/common/status.h
+++ b/src/ray/common/status.h
@@ -111,7 +111,7 @@ class RAY_MUST_USE_RESULT RAY_EXPORT Status;
 #endif
 
 template <typename Arg>
-inline void AppendArgToStatus(std::string *msg_str, Arg &&arg) {
+inline void appendArgToStatus(std::string *msg_str, Arg &&arg) {
   if constexpr (std::is_same_v<std::decay_t<Arg>, std::filesystem::directory_entry>) {
     // Explicitly handle std::filesystem::directory_entry.
     absl::StrAppend(msg_str, arg.path().string());
@@ -352,7 +352,7 @@ class RAY_EXPORT Status {
   template <typename... T>
   Status &operator<<(T &&...msg) {
     if (RAY_PREDICT_FALSE(state_ != nullptr)) {
-      (AppendArgToStatus(&state_->msg, std::forward<T>(msg)), ...);
+      (appendArgToStatus(&state_->msg, std::forward<T>(msg)), ...);
     }
     return *this;
   }

--- a/src/ray/common/status.h
+++ b/src/ray/common/status.h
@@ -111,7 +111,7 @@ class RAY_MUST_USE_RESULT RAY_EXPORT Status;
 #endif
 
 template <typename Arg>
-inline void appendArgToStatus(std::string *msg_str, Arg &&arg) {
+inline void AppendArgToStatus(std::string *msg_str, Arg &&arg) {
   if constexpr (std::is_same_v<std::decay_t<Arg>, std::filesystem::directory_entry>) {
     // Explicitly handle std::filesystem::directory_entry.
     absl::StrAppend(msg_str, arg.path().string());
@@ -352,7 +352,7 @@ class RAY_EXPORT Status {
   template <typename... T>
   Status &operator<<(T &&...msg) {
     if (RAY_PREDICT_FALSE(state_ != nullptr)) {
-      (appendArgToStatus(&state_->msg, std::forward<T>(msg)), ...);
+      (AppendArgToStatus(&state_->msg, std::forward<T>(msg)), ...);
     }
     return *this;
   }

--- a/src/ray/common/test/status_test.cc
+++ b/src/ray/common/test/status_test.cc
@@ -159,6 +159,6 @@ TEST_F(StatusTest, StreamOperatorFallbackPath) {
 
   EXPECT_FALSE(status.ok());
   EXPECT_TRUE(status.IsInvalid());
-  EXPECT_EQ(status.message(), "\".\"");
+  EXPECT_EQ(status.message(), ".");
 }
 }  // namespace ray

--- a/src/ray/common/test/status_test.cc
+++ b/src/ray/common/test/status_test.cc
@@ -152,13 +152,37 @@ TEST_F(StatusTest, StreamOperatorAbslStrAppendTypes) {
 }
 
 TEST_F(StatusTest, StreamOperatorFallbackPath) {
-  Status status = Status::Invalid("");
-  const std::filesystem::directory_entry entry{"."};
+  Status status;
 
-  status << entry;
+  {
+    status = Status::Invalid("");
+    const std::filesystem::directory_entry entry{"."};
+    status << entry;
+    EXPECT_TRUE(status.IsInvalid());
+    EXPECT_EQ(status.message(), ".");
+  }
 
-  EXPECT_FALSE(status.ok());
-  EXPECT_TRUE(status.IsInvalid());
-  EXPECT_EQ(status.message(), ".");
+  {
+    status = Status::Invalid("");
+    const std::filesystem::path path{"/tmp/test"};
+    status << path;
+    EXPECT_TRUE(status.IsInvalid());
+    EXPECT_EQ(status.message(), "\"/tmp/test\"");
+  }
+
+  {
+    status = Status::Invalid("");
+    std::error_code ec(ENOENT, std::system_category());
+    status << ec;
+    EXPECT_TRUE(status.IsInvalid());
+    EXPECT_FALSE(status.message().empty());  // Exact message varies by platform
+  }
+
+  {
+    status = Status::Invalid("");
+    status << std::this_thread::get_id();
+    EXPECT_TRUE(status.IsInvalid());
+    EXPECT_FALSE(status.message().empty());  // Thread ID format varies
+  }
 }
 }  // namespace ray

--- a/src/ray/util/BUILD
+++ b/src/ray/util/BUILD
@@ -182,6 +182,9 @@ ray_cc_library(
 ray_cc_library(
     name = "type_traits",
     hdrs = ["type_traits.h"],
+    deps = [
+        "@com_google_absl//absl/strings",
+    ],
 )
 
 ray_cc_library(

--- a/src/ray/util/type_traits.h
+++ b/src/ray/util/type_traits.h
@@ -14,7 +14,12 @@
 
 #pragma once
 
+#include <sstream>
+#include <string>
 #include <type_traits>
+#include <utility>
+
+#include "absl/strings/str_cat.h"
 
 namespace ray {
 
@@ -38,4 +43,28 @@ struct has_equal_operator<T,
                           std::void_t<decltype(std::declval<T>() == std::declval<T>())>>
     : std::true_type {};
 
+template <typename T, typename = void>
+struct can_absl_str_append : std::false_type {};
+
+template <typename T>
+struct can_absl_str_append<
+    T,
+    std::void_t<decltype(absl::StrAppend(std::declval<std::string *>(),
+                                         std::forward<T>(std::declval<T>())))>>
+    : std::true_type {};
+
+template <typename T>
+inline constexpr bool can_absl_str_append_v = can_absl_str_append<std::decay_t<T>>::value;
+
+template <typename T, typename = void>
+struct is_streamable : std::false_type {};
+
+template <typename T>
+struct is_streamable<
+    T,
+    std::void_t<decltype(std::declval<std::ostringstream &>() << std::declval<T>())>>
+    : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_streamable_v = is_streamable<T>::value;
 }  // namespace ray


### PR DESCRIPTION
## Why are these changes needed?

The current `ray::Status::operator<<` implementation only supports types that work with `absl::StrAppend`. This limits the usability of the Status class when working with types that have `std::ostream` operator overloads but aren't directly supported by `absl::StrAppend`. For example, standard library types like `std::filesystem::directory_entry` cannot be streamed into Status messages.

This PR implements a hybrid approach that:
1. Maintains performance by using `absl::StrAppend` for supported types
2. Adds fallback support for any type with a `std::ostream` operator<< overload
3. Adds test coverage including:
   - Tests for basic types using absl::StrAppend path (strings, numbers, booleans)
   - Tests for types requiring std::ostringstream fallback (filesystem::directory_entry)

## Related issue number

Closes #51695

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
