### PR TITLE
[core] More moves and less locking on task receiving path

### DIFF
--- a/src/ray/core_worker/context.cc
+++ b/src/ray/core_worker/context.cc
@@ -194,13 +194,16 @@ ObjectIDIndexType WorkerContext::GetNextPutIndex() {
 
 void WorkerContext::MaybeInitializeJobInfo(const JobID &job_id,
                                            const rpc::JobConfig &job_config) {
+  {
+    absl::ReaderMutexLock lock(&mutex_);
+    if (!current_job_id_.IsNil() && job_config_.has_value()) {
+      RAY_CHECK(current_job_id_ == job_id);
+      return;
+    }
+  }
   absl::WriterMutexLock lock(&mutex_);
-  if (current_job_id_.IsNil()) {
-    current_job_id_ = job_id;
-  }
-  if (!job_config_.has_value()) {
-    job_config_ = job_config;
-  }
+  current_job_id_ = job_id;
+  job_config_ = job_config;
   RAY_CHECK(current_job_id_ == job_id);
 }
 

--- a/src/ray/core_worker/transport/task_receiver.cc
+++ b/src/ray/core_worker/transport/task_receiver.cc
@@ -16,13 +16,10 @@
 
 #include <memory>
 #include <string>
-#include <thread>
 #include <utility>
 #include <vector>
 
 #include "ray/common/task/task.h"
-
-using ray::rpc::ActorTableData;
 
 namespace ray {
 namespace core {
@@ -31,18 +28,15 @@ void TaskReceiver::Init(std::shared_ptr<rpc::CoreWorkerClientPool> client_pool,
                         rpc::Address rpc_address,
                         DependencyWaiter *dependency_waiter) {
   waiter_ = dependency_waiter;
-  rpc_address_ = rpc_address;
-  client_pool_ = client_pool;
+  rpc_address_ = std::move(rpc_address);
+  client_pool_ = std::move(client_pool);
 }
 
-void TaskReceiver::HandleTask(const rpc::PushTaskRequest &request,
+void TaskReceiver::HandleTask(rpc::PushTaskRequest request,
                               rpc::PushTaskReply *reply,
                               rpc::SendReplyCallback send_reply_callback) {
   RAY_CHECK(waiter_ != nullptr) << "Must call init() prior to use";
-  // Use `mutable_task_spec()` here as `task_spec()` returns a const reference
-  // which doesn't work with std::move.
-  TaskSpecification task_spec(
-      std::move(*(const_cast<rpc::PushTaskRequest &>(request).mutable_task_spec())));
+  TaskSpecification task_spec(std::move(*request.mutable_task_spec()));
 
   // If GCS server is restarted after sending an actor creation task to this core worker,
   // the restarted GCS server will send the same actor creation task to the core worker
@@ -80,7 +74,7 @@ void TaskReceiver::HandleTask(const rpc::PushTaskRequest &request,
 
   auto accept_callback = [this, reply, resource_ids = std::move(resource_ids)](
                              const TaskSpecification &task_spec,
-                             rpc::SendReplyCallback send_reply_callback) {
+                             const rpc::SendReplyCallback &send_reply_callback) mutable {
     if (task_spec.GetMessage().skip_execution()) {
       send_reply_callback(Status::OK(), nullptr, nullptr);
       return;
@@ -93,7 +87,7 @@ void TaskReceiver::HandleTask(const rpc::PushTaskRequest &request,
     std::vector<std::pair<ObjectID, std::shared_ptr<RayObject>>> dynamic_return_objects;
     std::vector<std::pair<ObjectID, bool>> streaming_generator_returns;
     bool is_retryable_error = false;
-    std::string application_error = "";
+    std::string application_error;
     auto status = task_handler_(task_spec,
                                 std::move(resource_ids),
                                 &return_objects,
@@ -135,7 +129,7 @@ void TaskReceiver::HandleTask(const rpc::PushTaskRequest &request,
 
     bool objects_valid = return_objects.size() == num_returns;
     for (const auto &return_object : return_objects) {
-      if (return_object.second == NULL) {
+      if (return_object.second == nullptr) {
         objects_valid = false;
       }
     }
@@ -220,7 +214,7 @@ void TaskReceiver::HandleTask(const rpc::PushTaskRequest &request,
 
   auto cancel_callback = [reply](const TaskSpecification &task_spec,
                                  const Status &status,
-                                 rpc::SendReplyCallback send_reply_callback) {
+                                 const rpc::SendReplyCallback &send_reply_callback) {
     if (task_spec.IsActorTask()) {
       // We consider cancellation of actor tasks to be a push task RPC failure.
       send_reply_callback(status, nullptr, nullptr);

--- a/src/ray/core_worker/transport/task_receiver.h
+++ b/src/ray/core_worker/transport/task_receiver.h
@@ -90,7 +90,7 @@ class TaskReceiver {
   /// \param[in] request The request message.
   /// \param[out] reply The reply message.
   /// \param[in] send_reply_callback The callback to be called when the request is done.
-  void HandleTask(const rpc::PushTaskRequest &request,
+  void HandleTask(rpc::PushTaskRequest request,
                   rpc::PushTaskReply *reply,
                   rpc::SendReplyCallback send_reply_callback);
 
@@ -163,7 +163,7 @@ class TaskReceiver {
   bool execute_out_of_order_ = false;
   /// The repr name of the actor instance for an anonymous actor.
   /// This is only available after the actor creation task.
-  std::string actor_repr_name_ = "";
+  std::string actor_repr_name_;
 };
 
 }  // namespace core


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Some extra moves and linting around task receiver and core worker files. Also reader locking instead of writer locking on the job config setup on every task.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
