### PR TITLE
batch_inference_chaos_no_scale_back: Remove chaos-test option

### DIFF
--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -461,7 +461,7 @@
     prepare: python setup_cluster_compute_config_updater.py --updates worker_nodes.0.max_nodes:5:240
     script: >
       python dataset/gpu_batch_inference.py
-      --data-directory 300G-image-data-synthetic-raw-parquet --data-format parquet --chaos-test
+      --data-directory 300G-image-data-synthetic-raw-parquet --data-format parquet
 
 # 10 TB image classification parquet data with autoscaling heterogenous cluster
 # 10 g4dn.12xlarge, 10 m5.16xlarge

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -450,7 +450,6 @@
       --data-directory 300G-image-data-synthetic-raw-parquet --data-format parquet --chaos-test
 
 - name: batch_inference_chaos_no_scale_back
-  stable: False
   working_dir: nightly_tests
 
   cluster:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Given we don't kill nodes in this test, we can't test for dead nodes. So removing the `chaos-test` flag here.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
