### PR TITLE
[data] optimize PandasBlock.size_bytes

### DIFF
--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -15,6 +15,7 @@ from typing import (
 
 import numpy as np
 
+from pandas.api.types import is_string_dtype
 from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.air.util.tensor_extensions.utils import _should_convert_to_tensor
 from ray.data._internal.numpy_support import convert_to_numpy
@@ -41,7 +42,7 @@ if TYPE_CHECKING:
 
 T = TypeVar("T")
 # Max number of samples used to estimate the Pandas block size.
-_PANDAS_SIZE_BYTES_MAX_SAMPLE_COUNT = 50
+_PANDAS_SIZE_BYTES_MAX_SAMPLE_COUNT = 200
 
 logger = logging.getLogger(__name__)
 
@@ -447,8 +448,10 @@ class PandasBlockAccessor(TableBlockAccessor):
                     objects.extend(current.to_numpy())
             return total_size
 
-        # Get initial memory usage including deep introspection
-        memory_usage = self._table.memory_usage(index=True, deep=True)
+        # Get initial memory usage.
+        # No need for deep inspection here, as we will handle the str, object and
+        # extension columns separately.
+        memory_usage = self._table.memory_usage(index=True, deep=False)
 
         # TensorDtype for ray.air.util.tensor_extensions.pandas.TensorDtype
         object_need_check = (TensorDtype,)
@@ -456,9 +459,13 @@ class PandasBlockAccessor(TableBlockAccessor):
 
         # Handle object columns separately
         for column in self._table.columns:
-            # Check pandas object dtype and the extension dtype
-            if is_object_dtype(self._table[column].dtype) or isinstance(
-                self._table[column].dtype, object_need_check
+            # For str, object and extension dtypes, we calculate the size
+            # by sampling the data.
+            dtype = self._table[column].dtype
+            if (
+                is_string_dtype(dtype)
+                or is_object_dtype(dtype)
+                or isinstance(dtype, object_need_check)
             ):
                 total_size = len(self._table[column])
 
@@ -479,7 +486,8 @@ class PandasBlockAccessor(TableBlockAccessor):
                         )
                     # Scale back to the full column size if we sampled
                     column_memory = column_memory_sample * (total_size / sample_size)
-                    memory_usage[column] = int(column_memory)
+                    # Add the data memory usage on top of the index memory usage.
+                    memory_usage[column] += int(column_memory)
                 except Exception as e:
                     # Handle or log the exception as needed
                     logger.warning(f"Error calculating size for column '{column}': {e}")

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -15,7 +15,7 @@ from typing import (
 
 import numpy as np
 
-from pandas.api.types import is_string_dtype
+from pandas.api.types import is_string_dtype, is_object_dtype
 from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.air.util.tensor_extensions.utils import _should_convert_to_tensor
 from ray.data._internal.numpy_support import convert_to_numpy
@@ -397,8 +397,6 @@ class PandasBlockAccessor(TableBlockAccessor):
         return self._table.shape[0]
 
     def size_bytes(self) -> int:
-        from pandas.api.types import is_object_dtype
-
         from ray.air.util.tensor_extensions.pandas import TensorArray
         from ray.data.extensions import TensorArrayElement, TensorDtype
 

--- a/python/ray/data/tests/test_pandas_block.py
+++ b/python/ray/data/tests/test_pandas_block.py
@@ -450,7 +450,9 @@ class TestSizeBytes:
         block_accessor = PandasBlockAccessor.for_block(block)
         bytes_size = block_accessor.size_bytes()
 
-        true_size = block.memory_usage(index=True, deep=True).sum()
+        true_size = block.memory_usage(index=True, deep=False).sum() + sum(
+            sys.getsizeof(x) for x in data
+        )
         assert bytes_size == pytest.approx(true_size, rel=0.1), (bytes_size, true_size)
 
 

--- a/python/ray/data/tests/test_pandas_block.py
+++ b/python/ray/data/tests/test_pandas_block.py
@@ -275,7 +275,10 @@ class TestSizeBytes:
         block_accessor = PandasBlockAccessor.for_block(block)
         bytes_size = block_accessor.size_bytes()
 
-        memory_usage = sum([sys.getsizeof(animal) for animal in animals])
+        # The actual usage should be the index usage + the string data usage.
+        memory_usage = block.memory_usage(index=True, deep=False).sum() + sum(
+            [sys.getsizeof(animal) for animal in animals]
+        )
 
         assert bytes_size == pytest.approx(memory_usage, rel=0.1), (
             bytes_size,


### PR DESCRIPTION
## Why are these changes needed?

`PandasBlock.size_bytes` is expensive for DataFrames with string data, because of the deep inspection. 
And this is the main overheads for the pandas format map_batches benchmark. (See the following screenshot.)

* This PR fixes the issue by also sampling string columns. 
* Also makes the size estimation more accurate by including the index usage. 
* Slightly bump up _PANDAS_SIZE_BYTES_MAX_SAMPLE_COUNT

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/61c85f54-2ba8-4d3c-9437-3ea5415fa015" />

