### PR TITLE
[Data]: fix write_parquet to allow row_group_size

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -87,7 +87,9 @@ class ParquetDatasink(_FileDatasink):
                 output_schema = user_schema
 
             if not self.partition_cols:
-                self._write_single_file(tables, filename, output_schema, write_kwargs)
+                self._write_single_file(
+                    self.path, tables, filename, output_schema, write_kwargs
+                )
             else:  # partition writes
                 self._write_partition_files(
                     tables, filename, output_schema, write_kwargs
@@ -105,6 +107,7 @@ class ParquetDatasink(_FileDatasink):
 
     def _write_single_file(
         self,
+        path: str,
         tables: List["pyarrow.Table"],
         filename: str,
         output_schema: "pyarrow.Schema",
@@ -112,12 +115,16 @@ class ParquetDatasink(_FileDatasink):
     ) -> None:
         import pyarrow.parquet as pq
 
-        write_path = posixpath.join(self.path, filename)
+        # We extract 'row_group_size' for write_table() and
+        # keep the rest for ParquetWriter()
+        row_group_size = write_kwargs.pop("row_group_size", None)
+
+        write_path = posixpath.join(path, filename)
         with self.open_output_stream(write_path) as file:
             with pq.ParquetWriter(file, output_schema, **write_kwargs) as writer:
                 for table in tables:
                     table = table.cast(output_schema)
-                    writer.write_table(table)
+                    writer.write_table(table, row_group_size=row_group_size)
 
     def _write_partition_files(
         self,
@@ -127,7 +134,6 @@ class ParquetDatasink(_FileDatasink):
         write_kwargs: Dict[str, Any],
     ) -> None:
         import pyarrow as pa
-        import pyarrow.parquet as pq
         import pyarrow.compute as pc
 
         table = concat(tables, promote_types=False)
@@ -156,10 +162,13 @@ class ParquetDatasink(_FileDatasink):
             )
             write_path = posixpath.join(self.path, partition_path)
             self._create_dir(write_path)
-            write_path = posixpath.join(write_path, filename)
-            with self.open_output_stream(write_path) as file:
-                with pq.ParquetWriter(file, output_schema, **write_kwargs) as writer:
-                    writer.write_table(group_table)
+            self._write_single_file(
+                write_path,
+                [group_table],
+                filename,
+                output_schema,
+                write_kwargs,
+            )
 
     @property
     def min_rows_per_write(self) -> Optional[int]:

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3237,11 +3237,16 @@ class Dataset:
                 implementation. Use this parameter to customize what your filenames
                 look like.
             arrow_parquet_args_fn: Callable that returns a dictionary of write
-                arguments that are provided to `pyarrow.parquet.write_table() <https:/\
+                arguments that are provided to `pyarrow.parquet.ParquetWriter() <https:/\
                     /arrow.apache.org/docs/python/generated/\
-                        pyarrow.parquet.write_table.html#pyarrow.parquet.write_table>`_
+                        pyarrow.parquet.ParquetWriter.html>`_
                 when writing each block to a file. Overrides
-                any duplicate keys from ``arrow_parquet_args``. Use this argument
+                any duplicate keys from ``arrow_parquet_args``. If `row_group_size` is
+                provided, it will be passed to
+                `pyarrow.parquet.ParquetWriter.write_table() <https:/\
+                    /arrow.apache.org/docs/python/generated/pyarrow\
+                        .parquet.ParquetWriter.html\
+                        #pyarrow.parquet.ParquetWriter.write_table>`_. Use this argument
                 instead of ``arrow_parquet_args`` if any of your write arguments
                 can't pickled, or if you'd like to lazily resolve the write
                 arguments for each dataset block.
@@ -3258,10 +3263,10 @@ class Dataset:
                 decided based on the available resources.
             num_rows_per_file: [Deprecated] Use min_rows_per_file instead.
             arrow_parquet_args: Options to pass to
-                `pyarrow.parquet.write_table() <https://arrow.apache.org/docs/python\
-                    /generated/pyarrow.parquet.write_table.html\
-                        #pyarrow.parquet.write_table>`_, which is used to write out each
-                block to a file.
+                `pyarrow.parquet.ParquetWriter() <https:/\
+                    /arrow.apache.org/docs/python/generated/\
+                        pyarrow.parquet.ParquetWriter.html>`_, which is used to write
+                out each block to a file. See `arrow_parquet_args_fn` for more detail.
         """  # noqa: E501
         if arrow_parquet_args_fn is None:
             arrow_parquet_args_fn = lambda: {}  # noqa: E731

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
+from packaging.version import parse as parse_version
 import pyarrow as pa
 import pyarrow.dataset as pds
 import pyarrow.parquet as pq
@@ -1502,7 +1503,14 @@ def test_parquet_row_group_size_001(ray_start_regular_shared, tmp_path):
         )
     )
 
-    ds = pq.ParquetDataset(tmp_path / "test_row_group_5k.parquet")
+    # Since version 15, use_legacy_dataset is deprecated.
+    if parse_version(pa.__version__) >= parse_version("15.0.0"):
+        ds = pq.ParquetDataset(tmp_path / "test_row_group_5k.parquet")
+    else:
+        ds = pq.ParquetDataset(
+            tmp_path / "test_row_group_5k.parquet",
+            use_legacy_dataset=False,  # required for .fragments attribute
+        )
     assert ds.fragments[0].num_row_groups == 2
 
 
@@ -1520,7 +1528,14 @@ def test_parquet_row_group_size_002(ray_start_regular_shared, tmp_path):
         )
     )
 
-    ds = pq.ParquetDataset(tmp_path / "test_row_group_1k.parquet")
+    # Since version 15, use_legacy_dataset is deprecated.
+    if parse_version(pa.__version__) >= parse_version("15.0.0"):
+        ds = pq.ParquetDataset(tmp_path / "test_row_group_1k.parquet")
+    else:
+        ds = pq.ParquetDataset(
+            tmp_path / "test_row_group_1k.parquet",
+            use_legacy_dataset=False,
+        )
     assert ds.fragments[0].num_row_groups == 10
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->


## Why are these changes needed?

To fix:
1. The doc string for the `write_parquet` says `**arrow_parquet_args` is for `pyarrow.parquet.write_table()`, but in the code they are actually fed into `ParquetWriter`.

2. `ParquetWriter` accepts a lot of options except row_group_size, which is a parameter for `ParquetWriter.write_table`. So `row_group_size` is a special case...

https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetWriter.html#pyarrow.parquet.ParquetWriter.write_table

Changes:
- updated docstring
- slightly refactored write_single_file / write_partitioned_files to use the same write_table logic


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes #52481

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
