### PR TITLE
[Core] Cancel tasks when the owner dies

### DIFF
--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -431,6 +431,10 @@ WorkerID TaskSpecification::CallerWorkerId() const {
   return WorkerID::FromBinary(message_->caller_address().worker_id());
 }
 
+NodeID TaskSpecification::CallerNodeId() const {
+  return NodeID::FromBinary(message_->caller_address().raylet_id());
+}
+
 // === Below are getter methods specific to actor tasks.
 
 ActorID TaskSpecification::ActorId() const {

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -456,6 +456,8 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
 
   WorkerID CallerWorkerId() const;
 
+  NodeID CallerNodeId() const;
+
   uint64_t ActorCounter() const;
 
   ObjectID ActorCreationDummyObjectId() const;

--- a/src/ray/common/test/task_spec_test.cc
+++ b/src/ray/common/test/task_spec_test.cc
@@ -220,6 +220,41 @@ TEST(TaskSpecTest, TestTaskSpecBuilderRootDetachedActorId) {
   }
 }
 
+TEST(TaskSpecTest, TestCallerAddress) {
+  rpc::Address caller_address;
+  NodeID caller_node_id = NodeID::FromRandom();
+  WorkerID caller_worker_id = WorkerID::FromRandom();
+  caller_address.set_raylet_id(caller_node_id.Binary());
+  caller_address.set_worker_id(caller_worker_id.Binary());
+  TaskSpecBuilder task_spec_builder;
+  task_spec_builder.SetCommonTaskSpec(
+      TaskID::Nil(),
+      "dummy_task",
+      Language::PYTHON,
+      FunctionDescriptorBuilder::BuildPython("", "", "", ""),
+      JobID::Nil(),
+      rpc::JobConfig(),
+      TaskID::Nil(),
+      0,
+      TaskID::Nil(),
+      caller_address,
+      1,
+      false,
+      false,
+      -1,
+      {},
+      {},
+      "",
+      0,
+      TaskID::Nil(),
+      "");
+  task_spec_builder.SetNormalTaskSpec(
+      0, false, "", rpc::SchedulingStrategy(), ActorID::Nil());
+  TaskSpecification task_spec = std::move(task_spec_builder).ConsumeAndBuild();
+  ASSERT_EQ(task_spec.CallerNodeId(), caller_node_id);
+  ASSERT_EQ(task_spec.CallerWorkerId(), caller_worker_id);
+}
+
 TEST(TaskSpecTest, TestNodeLabelSchedulingStrategy) {
   rpc::SchedulingStrategy scheduling_strategy_1;
   auto expr_1 = scheduling_strategy_1.mutable_node_label_scheduling_strategy()

--- a/src/ray/raylet/local_task_manager.cc
+++ b/src/ray/raylet/local_task_manager.cc
@@ -35,7 +35,6 @@ LocalTaskManager::LocalTaskManager(
     const NodeID &self_node_id,
     ClusterResourceScheduler &cluster_resource_scheduler,
     TaskDependencyManagerInterface &task_dependency_manager,
-    std::function<bool(const WorkerID &, const NodeID &)> is_owner_alive,
     internal::NodeInfoGetter get_node_info,
     WorkerPoolInterface &worker_pool,
     absl::flat_hash_map<WorkerID, std::shared_ptr<WorkerInterface>> &leased_workers,
@@ -49,7 +48,6 @@ LocalTaskManager::LocalTaskManager(
       self_scheduling_node_id_(self_node_id.Binary()),
       cluster_resource_scheduler_(cluster_resource_scheduler),
       task_dependency_manager_(task_dependency_manager),
-      is_owner_alive_(is_owner_alive),
       get_node_info_(get_node_info),
       max_resource_shapes_per_load_report_(
           RayConfig::instance().max_resource_shapes_per_load_report()),
@@ -331,22 +329,6 @@ void LocalTaskManager::DispatchScheduledTasksToWorkers() {
         continue;
       }
 
-      const auto owner_worker_id = WorkerID::FromBinary(spec.CallerAddress().worker_id());
-      const auto owner_node_id = NodeID::FromBinary(spec.CallerAddress().raylet_id());
-
-      // If the owner has died since this task was queued, cancel the task by
-      // killing the worker (unless this task is for a detached actor).
-      if (!spec.IsDetachedActor() && !is_owner_alive_(owner_worker_id, owner_node_id)) {
-        RAY_LOG(WARNING) << "RayTask: " << task.GetTaskSpecification().TaskId()
-                         << "'s caller is no longer running. Cancelling task.";
-        if (!spec.GetDependencies().empty()) {
-          task_dependency_manager_.RemoveTaskDependencies(task_id);
-        }
-        ReleaseTaskArgs(task_id);
-        work_it = dispatch_queue.erase(work_it);
-        continue;
-      }
-
       // Check if the node is still schedulable. It may not be if dependency resolution
       // took a long time.
       auto allocated_instances = std::make_shared<TaskResourceInstances>();
@@ -543,17 +525,9 @@ bool LocalTaskManager::PoppedWorkerHandler(
     const std::string &runtime_env_setup_error_message) {
   const auto &reply = work->reply;
   const auto &callback = work->callback;
-  bool canceled = work->GetState() == internal::WorkStatus::CANCELLED;
+  const bool canceled = work->GetState() == internal::WorkStatus::CANCELLED;
   const auto &task = work->task;
   bool dispatched = false;
-
-  // Check whether owner worker or owner node dead.
-  bool not_detached_with_owner_failed = false;
-  const auto owner_worker_id = WorkerID::FromBinary(owner_address.worker_id());
-  const auto owner_node_id = NodeID::FromBinary(owner_address.raylet_id());
-  if (!is_detached_actor && !is_owner_alive_(owner_worker_id, owner_node_id)) {
-    not_detached_with_owner_failed = true;
-  }
 
   if (!canceled) {
     const auto &required_resource =
@@ -610,14 +584,7 @@ bool LocalTaskManager::PoppedWorkerHandler(
     return false;
   }
 
-  if (!worker || not_detached_with_owner_failed) {
-    // There are two cases that will not dispatch the task at this time:
-    // Case 1: Empty worker popped.
-    // Case 2: The task owner failed (not alive), except the creation task of
-    // detached actor.
-    // In that two case, we should also release worker resources, release task
-    // args.
-
+  if (!worker) {
     dispatched = false;
     // We've already acquired resources so we need to release them.
     cluster_resource_scheduler_.GetLocalResourceManager().ReleaseWorkerResources(
@@ -627,45 +594,39 @@ bool LocalTaskManager::PoppedWorkerHandler(
     ReleaseTaskArgs(task_id);
     RemoveFromRunningTasksIfExists(task);
 
-    if (!worker) {
-      // Empty worker popped.
-      RAY_LOG(DEBUG) << "This node has available resources, but no worker processes "
-                        "to grant the lease "
-                     << task_id;
-      if (status == PopWorkerStatus::RuntimeEnvCreationFailed) {
-        // In case of runtime env creation failed, we cancel this task
-        // directly and raise a `RuntimeEnvSetupError` exception to user
-        // eventually. The task will be removed from dispatch queue in
-        // `CancelTask`.
-        CancelTask(
-            task_id,
-            rpc::RequestWorkerLeaseReply::SCHEDULING_CANCELLED_RUNTIME_ENV_SETUP_FAILED,
-            /*scheduling_failure_message*/ runtime_env_setup_error_message);
-      } else if (status == PopWorkerStatus::JobFinished) {
-        // The task job finished.
-        // Just remove the task from dispatch queue.
-        RAY_LOG(DEBUG) << "Call back to a job finished task, task id = " << task_id;
-        erase_from_dispatch_queue_fn(work, scheduling_class);
-      } else {
-        // In other cases, set the work status `WAITING` to make this task
-        // could be re-dispatched.
-        internal::UnscheduledWorkCause cause =
-            internal::UnscheduledWorkCause::WORKER_NOT_FOUND_JOB_CONFIG_NOT_EXIST;
-        if (status == PopWorkerStatus::JobConfigMissing) {
-          cause = internal::UnscheduledWorkCause::WORKER_NOT_FOUND_JOB_CONFIG_NOT_EXIST;
-        } else if (status == PopWorkerStatus::WorkerPendingRegistration) {
-          cause = internal::UnscheduledWorkCause::WORKER_NOT_FOUND_REGISTRATION_TIMEOUT;
-        } else {
-          RAY_LOG(FATAL) << "Unexpected state received for the empty pop worker. Status: "
-                         << status;
-        }
-        work->SetStateWaiting(cause);
-      }
-    } else if (not_detached_with_owner_failed) {
-      // The task owner failed.
+    // Empty worker popped.
+    RAY_LOG(DEBUG).WithField(task_id)
+        << "This node has available resources, but no worker processes "
+           "to grant the lease: status "
+        << status;
+    if (status == PopWorkerStatus::RuntimeEnvCreationFailed) {
+      // In case of runtime env creation failed, we cancel this task
+      // directly and raise a `RuntimeEnvSetupError` exception to user
+      // eventually. The task will be removed from dispatch queue in
+      // `CancelTask`.
+      CancelTask(
+          task_id,
+          rpc::RequestWorkerLeaseReply::SCHEDULING_CANCELLED_RUNTIME_ENV_SETUP_FAILED,
+          /*scheduling_failure_message*/ runtime_env_setup_error_message);
+    } else if (status == PopWorkerStatus::JobFinished) {
+      // The task job finished.
       // Just remove the task from dispatch queue.
-      RAY_LOG(DEBUG) << "Call back to an owner failed task, task id = " << task_id;
+      RAY_LOG(DEBUG) << "Call back to a job finished task, task id = " << task_id;
       erase_from_dispatch_queue_fn(work, scheduling_class);
+    } else {
+      // In other cases, set the work status `WAITING` to make this task
+      // could be re-dispatched.
+      internal::UnscheduledWorkCause cause =
+          internal::UnscheduledWorkCause::WORKER_NOT_FOUND_JOB_CONFIG_NOT_EXIST;
+      if (status == PopWorkerStatus::JobConfigMissing) {
+        cause = internal::UnscheduledWorkCause::WORKER_NOT_FOUND_JOB_CONFIG_NOT_EXIST;
+      } else if (status == PopWorkerStatus::WorkerPendingRegistration) {
+        cause = internal::UnscheduledWorkCause::WORKER_NOT_FOUND_REGISTRATION_TIMEOUT;
+      } else {
+        RAY_LOG(FATAL) << "Unexpected state received for the empty pop worker. Status: "
+                       << status;
+      }
+      work->SetStateWaiting(cause);
     }
   } else {
     // A worker has successfully popped for a valid task. Dispatch the task to

--- a/src/ray/raylet/local_task_manager.h
+++ b/src/ray/raylet/local_task_manager.h
@@ -68,8 +68,6 @@ class LocalTaskManager : public ILocalTaskManager {
   /// \param cluster_resource_scheduler: The resource scheduler which contains
   ///                                    the state of the cluster.
   /// \param task_dependency_manager_ Used to fetch task's dependencies.
-  /// \param is_owner_alive: A callback which returns if the owner process is alive
-  ///                        (according to our ownership model).
   /// \param get_node_info: Function that returns the node info for a node.
   /// \param worker_pool: A reference to the worker pool.
   /// \param leased_workers: A reference to the leased workers map.
@@ -85,7 +83,6 @@ class LocalTaskManager : public ILocalTaskManager {
       const NodeID &self_node_id,
       ClusterResourceScheduler &cluster_resource_scheduler,
       TaskDependencyManagerInterface &task_dependency_manager,
-      std::function<bool(const WorkerID &, const NodeID &)> is_owner_alive,
       internal::NodeInfoGetter get_node_info,
       WorkerPoolInterface &worker_pool,
       absl::flat_hash_map<WorkerID, std::shared_ptr<WorkerInterface>> &leased_workers,
@@ -289,8 +286,6 @@ class LocalTaskManager : public ILocalTaskManager {
   ClusterResourceScheduler &cluster_resource_scheduler_;
   /// Class to make task dependencies to be local.
   TaskDependencyManagerInterface &task_dependency_manager_;
-  /// Function to check if the owner is alive on a given node.
-  std::function<bool(const WorkerID &, const NodeID &)> is_owner_alive_;
   /// Function to get the node information of a given node id.
   internal::NodeInfoGetter get_node_info_;
 

--- a/src/ray/raylet/local_task_manager_test.cc
+++ b/src/ray/raylet/local_task_manager_test.cc
@@ -204,8 +204,7 @@ class LocalTaskManagerTest : public ::testing::Test {
         local_task_manager_(std::make_shared<LocalTaskManager>(
             id_,
             *scheduler_,
-            dependency_manager_, /* is_owner_alive= */
-            [](const WorkerID &worker_id, const NodeID &node_id) { return true; },
+            dependency_manager_,
             /* get_node_info= */
             [this](const NodeID &node_id) -> const rpc::GcsNodeInfo * {
               if (node_info_.count(node_id) != 0) {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1034,8 +1034,6 @@ void NodeManager::NodeAdded(const GcsNodeInfo &node_info) {
 }
 
 void NodeManager::NodeRemoved(const NodeID &node_id) {
-  // TODO(swang): If we receive a notification for our own death, clean up and
-  // exit immediately.
   RAY_LOG(DEBUG).WithField(node_id) << "[NodeRemoved] Received callback from node id ";
   failed_nodes_cache_.insert(node_id);
 

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -262,7 +262,9 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   /// Handle an unexpected failure notification from GCS pubsub.
   ///
   /// \param data The data of the worker that died.
-  void HandleUnexpectedWorkerFailure(const rpc::WorkerDeltaData &data);
+  void HandleUnexpectedWorkerFailure(const WorkerID &worker_id);
+
+  void HandleNodeRemoved(const NodeID &node_id);
 
   /// Handler for the addition of a new node.
   ///

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -264,8 +264,6 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   /// \param data The data of the worker that died.
   void HandleUnexpectedWorkerFailure(const WorkerID &worker_id);
 
-  void HandleNodeRemoved(const NodeID &node_id);
-
   /// Handler for the addition of a new node.
   ///
   /// \param data Data associated with the new node.

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -764,10 +764,6 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   std::unique_ptr<AgentManager> CreateRuntimeEnvAgentManager(
       const NodeID &self_node_id, const NodeManagerConfig &config);
 
-  /// If Node Manager already knows this (worker, node) is dead, return true.
-  /// Otherwise returns false.
-  bool IsWorkerDead(const WorkerID &worker_id, const NodeID &node_id) const;
-
   /// Creates a Raylet client. Used by `mutable_object_provider_` when a new writer
   /// channel is registered.
   std::shared_ptr<raylet::RayletClient> CreateRayletClient(

--- a/src/ray/raylet/scheduling/cluster_task_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager.cc
@@ -169,7 +169,21 @@ bool ClusterTaskManager::IsWorkWithResourceShape(
   return false;
 }
 
-bool ClusterTaskManager::CancelAllTaskOwnedBy(
+bool ClusterTaskManager::CancelAllTasksOwnedBy(
+    const NodeID &node_id,
+    rpc::RequestWorkerLeaseReply::SchedulingFailureType failure_type,
+    const std::string &scheduling_failure_message) {
+  // Only tasks and regular actors are canceled because their lifetime is
+  // the same as the owner.
+  auto predicate = [node_id](const std::shared_ptr<internal::Work> &work) {
+    return !work->task.GetTaskSpecification().IsDetachedActor() &&
+           work->task.GetTaskSpecification().CallerNodeId() == node_id;
+  };
+
+  return CancelTasks(predicate, failure_type, scheduling_failure_message);
+}
+
+bool ClusterTaskManager::CancelAllTasksOwnedBy(
     const WorkerID &worker_id,
     rpc::RequestWorkerLeaseReply::SchedulingFailureType failure_type,
     const std::string &scheduling_failure_message) {

--- a/src/ray/raylet/scheduling/cluster_task_manager.h
+++ b/src/ray/raylet/scheduling/cluster_task_manager.h
@@ -88,7 +88,6 @@ class ClusterTaskManager : public ClusterTaskManagerInterface {
                       rpc::RequestWorkerLeaseReply::SCHEDULING_CANCELLED_INTENDED,
                   const std::string &scheduling_failure_message = "") override;
 
-  /// Cancel all tasks owned by a specific worker.
   bool CancelAllTasksOwnedBy(
       const WorkerID &worker_id,
       rpc::RequestWorkerLeaseReply::SchedulingFailureType failure_type =

--- a/src/ray/raylet/scheduling/cluster_task_manager.h
+++ b/src/ray/raylet/scheduling/cluster_task_manager.h
@@ -89,8 +89,14 @@ class ClusterTaskManager : public ClusterTaskManagerInterface {
                   const std::string &scheduling_failure_message = "") override;
 
   /// Cancel all tasks owned by a specific worker.
-  bool CancelAllTaskOwnedBy(
+  bool CancelAllTasksOwnedBy(
       const WorkerID &worker_id,
+      rpc::RequestWorkerLeaseReply::SchedulingFailureType failure_type =
+          rpc::RequestWorkerLeaseReply::SCHEDULING_CANCELLED_INTENDED,
+      const std::string &scheduling_failure_message = "") override;
+
+  bool CancelAllTasksOwnedBy(
+      const NodeID &node_id,
       rpc::RequestWorkerLeaseReply::SchedulingFailureType failure_type =
           rpc::RequestWorkerLeaseReply::SCHEDULING_CANCELLED_INTENDED,
       const std::string &scheduling_failure_message = "") override;

--- a/src/ray/raylet/scheduling/cluster_task_manager_interface.h
+++ b/src/ray/raylet/scheduling/cluster_task_manager_interface.h
@@ -51,12 +51,14 @@ class ClusterTaskManagerInterface {
           rpc::RequestWorkerLeaseReply::SCHEDULING_CANCELLED_INTENDED,
       const std::string &scheduling_failure_message = "") = 0;
 
+  /// Cancel all tasks owned by a specific worker.
   virtual bool CancelAllTasksOwnedBy(
       const WorkerID &worker_id,
       rpc::RequestWorkerLeaseReply::SchedulingFailureType failure_type =
           rpc::RequestWorkerLeaseReply::SCHEDULING_CANCELLED_INTENDED,
       const std::string &scheduling_failure_message = "") = 0;
 
+  /// Cancel all tasks owned by a worker on the specific node.
   virtual bool CancelAllTasksOwnedBy(
       const NodeID &node_id,
       rpc::RequestWorkerLeaseReply::SchedulingFailureType failure_type =

--- a/src/ray/raylet/scheduling/cluster_task_manager_interface.h
+++ b/src/ray/raylet/scheduling/cluster_task_manager_interface.h
@@ -51,8 +51,14 @@ class ClusterTaskManagerInterface {
           rpc::RequestWorkerLeaseReply::SCHEDULING_CANCELLED_INTENDED,
       const std::string &scheduling_failure_message = "") = 0;
 
-  virtual bool CancelAllTaskOwnedBy(
+  virtual bool CancelAllTasksOwnedBy(
       const WorkerID &worker_id,
+      rpc::RequestWorkerLeaseReply::SchedulingFailureType failure_type =
+          rpc::RequestWorkerLeaseReply::SCHEDULING_CANCELLED_INTENDED,
+      const std::string &scheduling_failure_message = "") = 0;
+
+  virtual bool CancelAllTasksOwnedBy(
+      const NodeID &node_id,
       rpc::RequestWorkerLeaseReply::SchedulingFailureType failure_type =
           rpc::RequestWorkerLeaseReply::SCHEDULING_CANCELLED_INTENDED,
       const std::string &scheduling_failure_message = "") = 0;

--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -254,15 +254,11 @@ class ClusterTaskManagerTest : public ::testing::Test {
         id_(NodeID::FromRandom()),
         scheduler_(CreateSingleNodeScheduler(
             id_.Binary(), num_cpus_at_head, num_gpus_at_head, *gcs_client_)),
-        is_owner_alive_(true),
         dependency_manager_(missing_objects_),
         local_task_manager_(std::make_unique<LocalTaskManager>(
             id_,
             *scheduler_,
-            dependency_manager_, /* is_owner_alive= */
-            [this](const WorkerID &worker_id, const NodeID &node_id) {
-              return is_owner_alive_;
-            },
+            dependency_manager_,
             /* get_node_info= */
             [this](const NodeID &node_id) -> const rpc::GcsNodeInfo * {
               node_info_calls_++;
@@ -386,7 +382,6 @@ class ClusterTaskManagerTest : public ::testing::Test {
   absl::flat_hash_map<WorkerID, std::shared_ptr<WorkerInterface>> leased_workers_;
   std::unordered_set<ObjectID> missing_objects_;
 
-  bool is_owner_alive_ = false;
   int default_arg_size_ = 10;
 
   int node_info_calls_ = 0;
@@ -1621,6 +1616,7 @@ TEST_F(ClusterTaskManagerTest, BacklogReportTest) {
 }
 
 TEST_F(ClusterTaskManagerTest, OwnerDeadTest) {
+  // TODO(jjyao) revamp the test
   /*
     Test the race condition in which the owner of a task dies while the task is pending.
     This is the essence of test_actor_advanced.py::test_pending_actor_removed_by_owner
@@ -1638,7 +1634,6 @@ TEST_F(ClusterTaskManagerTest, OwnerDeadTest) {
       std::make_shared<MockWorker>(WorkerID::FromRandom(), 1234);
   pool_.PushWorker(std::static_pointer_cast<WorkerInterface>(worker));
 
-  is_owner_alive_ = false;
   task_manager_.QueueAndScheduleTask(task, false, false, &reply, callback);
   pool_.TriggerCallbacks();
 
@@ -1646,7 +1641,6 @@ TEST_F(ClusterTaskManagerTest, OwnerDeadTest) {
   ASSERT_EQ(leased_workers_.size(), 0);
   ASSERT_EQ(pool_.workers.size(), 1);
 
-  is_owner_alive_ = true;
   task_manager_.ScheduleAndDispatchTasks();
   pool_.TriggerCallbacks();
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR makes sure when the task owner worker or node dies, the task is cancelled and the RequestWorkerLease rpc is replied.

We also make sure there is no tasks in cluster_task_manager or local_task_manager has dead owner because:
1. We immediately cancel all tasks owned by the dead worker or node.
2. We reject all future RequestWorkerLease RPCs from the dead owner. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
