### PR TITLE
[data.dashboard.x][05] persist task labels into task export events

### DIFF
--- a/python/ray/dashboard/modules/event/tests/test_export_task.py
+++ b/python/ray/dashboard/modules/event/tests/test_export_task.py
@@ -1,0 +1,64 @@
+import json
+import os
+import sys
+
+import pytest
+
+import ray
+from ray._private.test_utils import wait_until_server_available, wait_for_condition
+from ray.dashboard.tests.conftest import *  # noqa
+
+os.environ["RAY_enable_export_api_write"] = "1"
+
+
+@pytest.mark.asyncio
+async def test_task_labels(disable_aiohttp_cache, ray_start_with_dashboard):
+    """
+    Test task events are correctly generated and written to file
+    """
+    assert wait_until_server_available(ray_start_with_dashboard["webui_url"])
+    export_event_path = os.path.join(
+        ray_start_with_dashboard["session_dir"], "logs", "export_events"
+    )
+
+    # A simple task to trigger the export event
+    @ray.remote
+    def hi_w00t_task():
+        return 1
+
+    ray.get(hi_w00t_task.options(_labels={"hi": "w00t"}).remote())
+
+    def _verify():
+        # Verify export events are written
+        events = []
+        for filename in os.listdir(export_event_path):
+            if not filename.startswith("event_EXPORT_TASK"):
+                continue
+            with open(f"{export_event_path}/{filename}", "r") as f:
+                for line in f.readlines():
+                    events.append(json.loads(line))
+
+        hi_w00t_event = next(
+            (
+                event
+                for event in events
+                if event["source_type"] == "EXPORT_TASK"
+                and event["event_data"].get("task_info", {}).get("func_or_class_name")
+                == "hi_w00t_task"
+            ),
+            None,
+        )
+        return (
+            hi_w00t_event is not None
+            and hi_w00t_event["event_data"]
+            .get("task_info", {})
+            .get("labels", {})
+            .get("hi")
+            == "w00t"
+        )
+
+    wait_for_condition(_verify, timeout=30)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -415,6 +415,10 @@ std::vector<std::string> TaskSpecification::DynamicWorkerOptions() const {
       message_->actor_creation_task_spec().dynamic_worker_options());
 }
 
+absl::flat_hash_map<std::string, std::string> TaskSpecification::GetLabels() const {
+  return MapFromProtobuf(message_->labels());
+}
+
 TaskID TaskSpecification::CallerId() const {
   return TaskID::FromBinary(message_->caller_id());
 }

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -444,6 +444,8 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
 
   std::vector<std::string> DynamicWorkerOptionsOrEmpty() const;
 
+  absl::flat_hash_map<std::string, std::string> GetLabels() const;
+
   // Methods specific to actor tasks.
 
   ActorID ActorId() const;

--- a/src/ray/gcs/pb_util.h
+++ b/src/ray/gcs/pb_util.h
@@ -277,6 +277,8 @@ inline void FillExportTaskInfo(rpc::ExportTaskEventData::TaskInfoEntry *task_inf
   const auto &resources_map = task_spec.GetRequiredResources().GetResourceMap();
   task_info->mutable_required_resources()->insert(resources_map.begin(),
                                                   resources_map.end());
+  task_info->mutable_labels()->insert(task_spec.GetLabels().begin(),
+                                      task_spec.GetLabels().end());
 
   auto export_runtime_env_info = task_info->mutable_runtime_env_info();
   export_runtime_env_info->set_serialized_runtime_env(

--- a/src/ray/protobuf/export_api/export_task_event.proto
+++ b/src/ray/protobuf/export_api/export_task_event.proto
@@ -86,6 +86,8 @@ message ExportTaskEventData {
     // If the task/actor is created within a placement group,
     // this value is configured.
     optional bytes placement_group_id = 9;
+    // The key-value labels for task and actor.
+    map<string, string> labels = 10;
   }
 
   message ProfileEventEntry {


### PR DESCRIPTION
Similar to https://github.com/ray-project/ray/pull/51687, we also add the `labels` field to the task export events. This is needed for ray data dashboard to file the corresponding tasks for an operator.

Test:
- CI

```
cat event_EXPORT_TASK_33072.log | grep "labels"
{"event_data":{"attempt_number":0,"job_id":"AQAAAA==","state_updates":{"state_ts_ns":{"8":"1745861181723861455"}},"task_id":"//////////////////////////8BAAAA","task_info":{"func_or_class_name":"","labels":{},"language":"PYTHON","parent_task_id":"////////////////////////////////","required_resources":{},"runtime_env_info":{"runtime_env_config":{"eager_install":false,"log_files":[],"setup_timeout_seconds":0},"serialized_runtime_env":"","uris":{"py_modules_uris":[],"working_dir_uri":""}},"task_id":"//////////////////////////8BAAAA","type":"DRIVER_TASK"}},"event_id":"573ecef0a99ccbc00f1ad993195be64a0b79","source_type":"EXPORT_TASK","timestamp":1745861182}
```