### PR TITLE
fix bootstrap alert inheritence

### DIFF
--- a/doc/source/_static/css/index.css
+++ b/doc/source/_static/css/index.css
@@ -290,3 +290,8 @@ h4 {
   font-size: 18px;
   font-weight: 600;
 }
+
+/* Restore Bootstrap alert text color inheritance that is overridden by the PyData Sphinx theme */
+.alert p {
+  color: inherit;
+}


### PR DESCRIPTION
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Fixes an issue in bootstrap alerts where the `p` tag text color from pydata sphynx theme was overriding the expected bootstrap alert color making it impossible to read in dark mode

Before:
![Screenshot 2025-04-21 at 6 05 52 PM](https://github.com/user-attachments/assets/66d5c827-4516-45c9-b634-c285d75a56ae)

After:
![Screenshot 2025-04-21 at 6 09 19 PM](https://github.com/user-attachments/assets/39ce29ab-61f5-46a1-a2e7-0cee6bbed437)


## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
