### PR TITLE
[core][autoscaler] make ready/infeasible/backlog counts clear in the autoscaler status verbose report

### DIFF
--- a/python/ray/autoscaler/v2/schema.py
+++ b/python/ray/autoscaler/v2/schema.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, List, Optional, Tuple
 
+from ray.autoscaler._private.util import ResourceDemandCounts
 from ray.autoscaler.v2.instance_manager.common import InstanceUtil
 from ray.core.generated.autoscaler_pb2 import NodeState, NodeStatus
 from ray.core.generated.instance_manager_pb2 import Instance
@@ -204,6 +205,10 @@ class ClusterStatus:
     # Demand summary.
     resource_demands: ResourceDemandSummary = field(
         default_factory=ResourceDemandSummary
+    )
+    # Resource demand counts.
+    resource_demand_counts: ResourceDemandCounts = field(
+        default_factory=ResourceDemandCounts
     )
     # Query metics
     stats: Stats = field(default_factory=Stats)

--- a/python/ray/autoscaler/v2/tests/test_utils.py
+++ b/python/ray/autoscaler/v2/tests/test_utils.py
@@ -6,6 +6,7 @@ from typing import Dict
 import pytest  # noqa
 from google.protobuf.json_format import ParseDict
 
+from ray.autoscaler._private.util import ResourceDemandCounts
 from ray.autoscaler.v2.schema import (
     ClusterConstraintDemand,
     ClusterStatus,
@@ -537,6 +538,11 @@ def test_cluster_status_formatter():
             cluster_resource_state_version="20",
             request_ts_s=775303535,
         ),
+        resource_demand_counts=ResourceDemandCounts(
+            num_ready_requests_queued=1,
+            num_infeasible_requests_queued=2,
+            backlog_size=3,
+        ),
     )
     actual = ClusterStatusFormatter.format(state, verbose=True)
 
@@ -573,6 +579,10 @@ Total Demands:
  {'CPU': 1, 'GPU': 1}: 11+ pending tasks/actors
  {'CPU': 1, 'GPU': 1} * 1 (STRICT_SPREAD): 1+ pending placement groups
  {'GPU': 2} * 1 (STRICT_PACK): 2+ pending placement groups
+Total Demands (by count):
+ 1 ready requests queued
+ 2 infeasible requests queued
+ 3 total backlog queued
 
 Node: instance1 (head_node)
  Id: fffffffffffffffffffffffffffffffffffffffffffffffffff00001

--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -3268,6 +3268,11 @@ def test_info_string_verbose():
                 "object_store_memory": (0, 2**32),
             },
         },
+        resource_demand_counts={
+            "num_ready_requests_queued": 1,
+            "num_infeasible_requests_queued": 2,
+            "backlog_size": 3,
+        },
     )
     autoscaler_summary = AutoscalerSummary(
         active_nodes=[],
@@ -3320,6 +3325,10 @@ Total Constraints:
 Total Demands:
  {'CPU': 1}: 150+ pending tasks/actors
  {'CPU': 4} * 5 (PACK): 420+ pending placement groups
+Total Demands (by count):
+ 1 ready requests queued
+ 2 infeasible requests queued
+ 3 total backlog queued
 
 Node: 192.168.1.1
  Usage:
@@ -3369,6 +3378,11 @@ def test_info_string_verbose_node_types():
         pg_demand=[({"bundles": [({"CPU": 4}, 5)], "strategy": "PACK"}, 420)],
         request_demand=[({"CPU": 16}, 100)],
         node_types=[],
+        resource_demand_counts={
+            "num_ready_requests_queued": 1,
+            "num_infeasible_requests_queued": 2,
+            "backlog_size": 3,
+        },
         usage_by_node={
             "192.168.1.1": {
                 "CPU": (5.0, 20.0),
@@ -3435,6 +3449,10 @@ Total Constraints:
 Total Demands:
  {'CPU': 1}: 150+ pending tasks/actors
  {'CPU': 4} * 5 (PACK): 420+ pending placement groups
+Total Demands (by count):
+ 1 ready requests queued
+ 2 infeasible requests queued
+ 3 total backlog queued
 
 Node: 192.168.1.1 (head-node)
  Usage:
@@ -3481,6 +3499,11 @@ def test_info_string_verbose_no_breakdown():
         pg_demand=[({"bundles": [({"CPU": 4}, 5)], "strategy": "PACK"}, 420)],
         request_demand=[({"CPU": 16}, 100)],
         node_types=[],
+        resource_demand_counts={
+            "num_ready_requests_queued": 1,
+            "num_infeasible_requests_queued": 2,
+            "backlog_size": 3,
+        },
         usage_by_node=None,
     )
     autoscaler_summary = AutoscalerSummary(
@@ -3527,6 +3550,10 @@ Total Constraints:
 Total Demands:
  {'CPU': 1}: 150+ pending tasks/actors
  {'CPU': 4} * 5 (PACK): 420+ pending placement groups
+Total Demands (by count):
+ 1 ready requests queued
+ 2 infeasible requests queued
+ 3 total backlog queued
 """.strip()
     actual = format_info_string(
         lm_summary,
@@ -3645,6 +3672,11 @@ def test_info_string_with_launch_failures_verbose():
         pg_demand=[({"bundles": [({"CPU": 4}, 5)], "strategy": "PACK"}, 420)],
         request_demand=[({"CPU": 16}, 100)],
         node_types=[],
+        resource_demand_counts={
+            "num_ready_requests_queued": 1,
+            "num_infeasible_requests_queued": 2,
+            "backlog_size": 3,
+        },
     )
     base_timestamp = datetime(
         year=2012, month=12, day=21, hour=13, minute=3, second=1
@@ -3715,6 +3747,10 @@ Total Constraints:
 Total Demands:
  {'CPU': 1}: 150+ pending tasks/actors
  {'CPU': 4} * 5 (PACK): 420+ pending placement groups
+Total Demands (by count):
+ 1 ready requests queued
+ 2 infeasible requests queued
+ 3 total backlog queued
 """.strip()
     actual = format_info_string(
         lm_summary,

--- a/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_autoscaler_state_manager.cc
@@ -310,6 +310,11 @@ void GcsAutoscalerStateManager::GetPendingResourceRequests(
     if (num_pending > 0) {
       auto pending_req = state->add_pending_resource_requests();
       pending_req->set_count(num_pending);
+      auto breakdown = pending_req->mutable_breakdown();
+      breakdown->set_num_ready_requests_queued(demand.num_ready_requests_queued());
+      breakdown->set_num_infeasible_requests_queued(
+          demand.num_infeasible_requests_queued());
+      breakdown->set_backlog_size(demand.backlog_size());
       auto req = pending_req->mutable_request();
       req->mutable_resources_bundle()->insert(shape.begin(), shape.end());
     }

--- a/src/ray/protobuf/autoscaler.proto
+++ b/src/ray/protobuf/autoscaler.proto
@@ -93,9 +93,22 @@ message ResourceRequest {
   repeated LabelSelector label_selectors = 3;
 }
 
+message ResourceRequestByCountBreakdown {
+  // The number of requests that are ready to run (i.e., dependencies have been
+  // fulfilled), but that are waiting for resources.
+  uint64 num_ready_requests_queued = 1;
+  // The number of requests for which there is no node that is a superset of
+  // the requested resource shape.
+  uint64 num_infeasible_requests_queued = 2;
+  // The number of requests of this shape still queued in CoreWorkers that this
+  // raylet knows about.
+  int64 backlog_size = 3;
+}
+
 message ResourceRequestByCount {
   ResourceRequest request = 1;
   int64 count = 2;
+  optional ResourceRequestByCountBreakdown breakdown = 3;
 }
 
 // A bundle selector used to specify the resource bundles that should be


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR is a follow-up for https://github.com/ray-project/ray/issues/37959 to reveal `num_ready_requests_queued`, `num_infeasible_requests_queued`, and `backlog_size` in a new `Total Demands (by count)` section of a verbose `ray status -v` report. For example:

```sh
Resources
---------------------------------------------------------------
Usage:
 0B/8.21GiB memory
 0B/2.00GiB object_store_memory

Total Constraints:
 {'GPU': 2, 'CPU': 100}: 2 from request_resources()
Total Demands:
 {'CPU': 1, 'GPU': 1}: 11+ pending tasks/actors
Total Demands (by count):  # <----- the newly added section.
 5 ready requests queued
 4 infeasible requests queued
 2 total backlog queued
```

With these new counters, we can debug issues like https://github.com/ray-project/ray/issues/48950 and https://github.com/ray-project/ray/issues/47531 more easily in the future because we can identify where the resource leaks happen by checking those counters. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
