### PR TITLE
[doc] Standardize naming to code-output-style in writing code snippets guide

### DIFF
--- a/doc/source/ray-contribute/writing-code-snippets.rst
+++ b/doc/source/ray-contribute/writing-code-snippets.rst
@@ -119,7 +119,7 @@ There's no hard rule about which style you should use. Choose the style that bes
 illustrates your API.
 
 .. tip::
-    If you're not sure which style to use, use *code-block-style*.
+    If you're not sure which style to use, use *code-output-style*.
 
 When to use *doctest-style*
 ===========================
@@ -138,10 +138,10 @@ want to print intermediate objects, use *doctest-style*. ::
         >>> ds.take(5)
         [{'id': 0}, {'id': 1}, {'id': 2}, {'id': 3}, {'id': 4}]
 
-When to use *code-block-style*
+When to use *code-output-style*
 ==============================
 
-If you're writing a longer example, or if object representations aren't relevant to your example, use *code-block-style*. ::
+If you're writing a longer example, or if object representations aren't relevant to your example, use *code-output-style*. ::
 
     .. testcode::
 
@@ -200,10 +200,10 @@ To skip a *doctest-style* example, append `# doctest: +SKIP` to your Python code
         >>> import ray
         >>> ray.data.read_images("s3://private-bucket")  # doctest: +SKIP
 
-Skipping *code-block-style* examples
+Skipping *code-output-style* examples
 ====================================
 
-To skip a *code-block-style* example, add `:skipif: True` to the `testoutput` block. ::
+To skip a *code-output-style* example, add `:skipif: True` to the `testoutput` block. ::
 
     .. testcode::
         :skipif: True
@@ -233,9 +233,9 @@ To ignore parts of a *doctest-style* output, replace problematic sections with e
        schema={image: numpy.ndarray(shape=(32, 32, 3), dtype=uint8)}
     )
 
-To ignore an output altogether, write a *code-block-style* snippet. Don't use `# doctest: +SKIP`.
+To ignore an output altogether, write a *code-output-style* snippet. Don't use `# doctest: +SKIP`.
 
-Ignoring *code-block-style* outputs
+Ignoring *code-output-style* outputs
 ===================================
 
 If parts of your output are long or non-deterministic, replace problematic sections

--- a/doc/source/ray-contribute/writing-code-snippets.rst
+++ b/doc/source/ray-contribute/writing-code-snippets.rst
@@ -139,7 +139,7 @@ want to print intermediate objects, use *doctest-style*. ::
         [{'id': 0}, {'id': 1}, {'id': 2}, {'id': 3}, {'id': 4}]
 
 When to use *code-output-style*
-==============================
+======================================
 
 If you're writing a longer example, or if object representations aren't relevant to your example, use *code-output-style*. ::
 
@@ -201,7 +201,7 @@ To skip a *doctest-style* example, append `# doctest: +SKIP` to your Python code
         >>> ray.data.read_images("s3://private-bucket")  # doctest: +SKIP
 
 Skipping *code-output-style* examples
-====================================
+==========================================
 
 To skip a *code-output-style* example, add `:skipif: True` to the `testcode` block. ::
 
@@ -236,7 +236,7 @@ To ignore parts of a *doctest-style* output, replace problematic sections with e
 To ignore an output altogether, write a *code-output-style* snippet. Don't use `# doctest: +SKIP`.
 
 Ignoring *code-output-style* outputs
-===================================
+========================================
 
 If parts of your output are long or non-deterministic, replace problematic sections
 with ellipses. ::

--- a/doc/source/ray-contribute/writing-code-snippets.rst
+++ b/doc/source/ray-contribute/writing-code-snippets.rst
@@ -203,7 +203,7 @@ To skip a *doctest-style* example, append `# doctest: +SKIP` to your Python code
 Skipping *code-output-style* examples
 ====================================
 
-To skip a *code-output-style* example, add `:skipif: True` to the `testoutput` block. ::
+To skip a *code-output-style* example, add `:skipif: True` to the `testcode` block. ::
 
     .. testcode::
         :skipif: True


### PR DESCRIPTION
## Why are these changes needed?

The documentation for writing code snippets currently uses inconsistent terminology when referring to example styles. This change standardizes the use of "code-output-style" throughout the guide, replacing instances of "code-block-style". It reduces potential confusion and provides clearer guidance to new contributors.

## Related issue number

Closes #52521

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
