### PR TITLE
[Fix][Core/Cluster] Use ray stop command to shutdown for the Cluster class

### DIFF
--- a/python/ray/cluster_utils.py
+++ b/python/ray/cluster_utils.py
@@ -399,7 +399,7 @@ class Cluster:
         return all(node.remaining_processes_alive() for node in self.list_all_nodes())
 
     def shutdown(self):
-        """Removes all nodes."""
+        """Terminate the cluster."""
 
         # We create a list here as a copy because `remove_node`
         # modifies `self.worker_nodes`.
@@ -413,3 +413,6 @@ class Cluster:
         ray.experimental.internal_kv._internal_kv_reset()
         # Delete the cluster address.
         ray._private.utils.reset_ray_address()
+
+        # Call ray stop to make sure all processes are killed.
+        subprocess.check_call(["ray", "stop", "--force"])

--- a/python/ray/dashboard/modules/job/tests/test_sdk.py
+++ b/python/ray/dashboard/modules/job/tests/test_sdk.py
@@ -196,9 +196,7 @@ def get_register_agents_number(gcs_client):
     ],
     indirect=True,
 )
-def test_job_head_choose_job_agent_E2E(
-    ray_start_cluster_head_with_env_vars, call_ray_stop_only
-):
+def test_job_head_choose_job_agent_E2E(ray_start_cluster_head_with_env_vars):
     cluster = ray_start_cluster_head_with_env_vars
     assert wait_until_server_available(cluster.webui_url) is True
     webui_url = cluster.webui_url


### PR DESCRIPTION



<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
See the description in the corresponding issue for details.

Call `ray stop --force` for `Cluster.shutdown` to make sure all ray processes are terminated properly without resource leak in tests.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes: ray-project/ray#52415

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
