### PR TITLE
[core] Deflake `test_runtime_env_3`

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1714,7 +1714,7 @@ def check_local_files_gced(cluster, whitelist=None):
             if whitelist and set(items).issubset(whitelist):
                 continue
             if len(items) > 0:
-                print("Local files not GC'd:", items)
+                print(f"Local files not GC'd from subdir '{subdir}'", items)
                 return False
     return True
 

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1714,6 +1714,7 @@ def check_local_files_gced(cluster, whitelist=None):
             if whitelist and set(items).issubset(whitelist):
                 continue
             if len(items) > 0:
+                print("Local files not GC'd:", items)
                 return False
     return True
 

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1714,7 +1714,7 @@ def check_local_files_gced(cluster, whitelist=None):
             if whitelist and set(items).issubset(whitelist):
                 continue
             if len(items) > 0:
-                print(f"Local files not GC'd from subdir '{subdir}'", items)
+                print(f"runtime_env files not GC'd from subdir '{subdir}': {items}")
                 return False
     return True
 

--- a/python/ray/tests/test_runtime_env_conda_and_pip_3.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_3.py
@@ -1,7 +1,6 @@
 import os
 import pytest
 import sys
-import time
 
 from ray._private.test_utils import (
     wait_for_condition,
@@ -10,7 +9,6 @@ from ray._private.test_utils import (
 )
 import ray
 
-from unittest import mock
 
 if not os.environ.get("CI"):
     # This flags turns on the local development that link against current ray

--- a/python/ray/tests/test_runtime_env_conda_and_pip_3.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_3.py
@@ -145,48 +145,6 @@ class TestGC:
             assert not check_local_files_gced(cluster)
 
 
-# Set scope to "class" to force this to run before start_cluster, whose scope
-# is "function".  We need these env vars to be set before Ray is started.
-@pytest.fixture(scope="class")
-def skip_local_gc():
-    with mock.patch.dict(
-        os.environ,
-        {
-            "RAY_RUNTIME_ENV_SKIP_LOCAL_GC": "1",
-        },
-    ):
-        print("RAY_RUNTIME_ENV_SKIP_LOCAL_GC enabled.")
-        yield
-
-
-class TestSkipLocalGC:
-    @pytest.mark.skipif(
-        os.environ.get("CI") and sys.platform != "linux",
-        reason="Requires PR wheels built in CI, so only run on linux CI machines.",
-    )
-    @pytest.mark.parametrize("field", ["conda", "pip"])
-    def test_skip_local_gc_env_var(self, skip_local_gc, start_cluster, field, tmp_path):
-        cluster, address = start_cluster
-        runtime_env = generate_runtime_env_dict(field, "python_object", tmp_path)
-        ray.init(address, namespace="test", runtime_env=runtime_env)
-
-        @ray.remote
-        def f():
-            import pip_install_test  # noqa: F401
-
-            return True
-
-        assert ray.get(f.remote())
-
-        ray.shutdown()
-
-        # Give enough time for potentially uninstalling a conda env
-        time.sleep(10)
-
-        # Check nothing was GC'ed
-        assert not check_local_files_gced(cluster)
-
-
 if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))

--- a/python/ray/tests/test_runtime_env_working_dir_3.py
+++ b/python/ray/tests/test_runtime_env_working_dir_3.py
@@ -159,16 +159,18 @@ class TestGC:
         wait_for_condition(lambda: check_local_files_gced(cluster, whitelist=whitelist))
         print("check_local_files_gced passed wait_for_condition block.")
 
+    @pytest.mark.parametrize("option", ["working_dir", "py_modules"])
     def test_actor_level_gc(
         self,
         start_cluster,
         working_dir_and_pymodules_disable_URI_cache,
-        disable_temporary_uri_pinning,
+        option: str,
     ):
         """Tests that actor-level working_dir is GC'd when the actor exits."""
         cluster, address = start_cluster
         cluster.add_node(
-            num_cpus=1, runtime_env_dir_name="worker_node_runtime_resources"
+            num_cpus=1, runtime_env_dir_name="worker_node_runtime_resources",
+            dashboard_agent_listen_port=find_free_port(),
         )
         ray.init(address)
 
@@ -182,6 +184,7 @@ class TestGC:
         A = A.options(
             runtime_env={
                 "working_dir": S3_PACKAGE_URI,
+            } if option == "working_dir" else {
                 "py_modules": [
                     S3_PACKAGE_URI,
                 ],

--- a/python/ray/tests/test_runtime_env_working_dir_3.py
+++ b/python/ray/tests/test_runtime_env_working_dir_3.py
@@ -164,7 +164,6 @@ class TestGC:
         start_cluster,
         working_dir_and_pymodules_disable_URI_cache,
         disable_temporary_uri_pinning,
-        tmp_working_dir,
     ):
         """Tests that actor-level working_dir is GC'd when the actor exits."""
         cluster, address = start_cluster
@@ -182,7 +181,7 @@ class TestGC:
 
         A = A.options(
             runtime_env={
-                "working_dir": tmp_working_dir,
+                "working_dir": S3_PACKAGE_URI,
                 "py_modules": [
                     S3_PACKAGE_URI,
                 ],

--- a/python/ray/tests/test_runtime_env_working_dir_3.py
+++ b/python/ray/tests/test_runtime_env_working_dir_3.py
@@ -169,7 +169,8 @@ class TestGC:
         """Tests that actor-level working_dir is GC'd when the actor exits."""
         cluster, address = start_cluster
         cluster.add_node(
-            num_cpus=1, runtime_env_dir_name="worker_node_runtime_resources",
+            num_cpus=1,
+            runtime_env_dir_name="worker_node_runtime_resources",
             dashboard_agent_listen_port=find_free_port(),
         )
         ray.init(address)
@@ -184,7 +185,9 @@ class TestGC:
         A = A.options(
             runtime_env={
                 "working_dir": S3_PACKAGE_URI,
-            } if option == "working_dir" else {
+            }
+            if option == "working_dir"
+            else {
                 "py_modules": [
                     S3_PACKAGE_URI,
                 ],

--- a/python/ray/tests/test_runtime_env_working_dir_3.py
+++ b/python/ray/tests/test_runtime_env_working_dir_3.py
@@ -242,9 +242,8 @@ class TestGC:
         class A:
             def test_import(self):
                 import test_module
+                import pip_install_test  # noqa: F401
 
-                if option == "py_modules":
-                    import pip_install_test  # noqa: F401
                 test_module.one()
 
         a = A.options(name="test", lifetime="detached").remote()

--- a/python/ray/tests/test_runtime_env_working_dir_3.py
+++ b/python/ray/tests/test_runtime_env_working_dir_3.py
@@ -159,6 +159,11 @@ class TestGC:
         wait_for_condition(lambda: check_local_files_gced(cluster, whitelist=whitelist))
         print("check_local_files_gced passed wait_for_condition block.")
 
+    # NOTE(edoakes): I tried removing the parametrization here and setting working_dir
+    # and py_modules to the same thing, but the test fails. This appears to be due to a
+    # bug in the reference counting logic: we key the reference table on URI only, not
+    # (option, URI), so there is a collision when both options have the same value.
+    # See: https://github.com/ray-project/ray/issues/52578.
     @pytest.mark.parametrize("option", ["working_dir", "py_modules"])
     def test_actor_level_gc(
         self,

--- a/python/ray/tests/test_runtime_env_working_dir_3.py
+++ b/python/ray/tests/test_runtime_env_working_dir_3.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-from pytest_lazy_fixtures import lf as lazy_fixture
 
 import ray
 import ray.experimental.internal_kv as kv
@@ -105,7 +104,7 @@ class TestGC:
         cluster, address = start_cluster
         cluster.add_node(
             num_cpus=1,
-            runtime_env_dir_name=f"worker_node_runtime_resources",
+            runtime_env_dir_name="worker_node_runtime_resources",
             dashboard_agent_listen_port=find_free_port(),
         )
 
@@ -121,7 +120,7 @@ class TestGC:
             },
         )
         assert not check_internal_kv_gced()
-        print(f'kv check 1 passed with source "{source}".')
+        print("kv check 1 passed.")
 
         @ray.remote(num_cpus=1)
         class A:
@@ -141,7 +140,7 @@ class TestGC:
         print("Got responses from all actors.")
 
         assert not check_internal_kv_gced()
-        print(f'kv check 2 passed with source "{source}".')
+        print("kv check 2 passed.")
 
         assert not check_local_files_gced(cluster)
         print("check_local_files_gced() check passed.")
@@ -170,7 +169,7 @@ class TestGC:
         """Tests that actor-level working_dir is GC'd when the actor exits."""
         cluster, address = start_cluster
         cluster.add_node(
-            num_cpus=1, runtime_env_dir_name=f"worker_node_runtime_resources"
+            num_cpus=1, runtime_env_dir_name="worker_node_runtime_resources"
         )
         ray.init(address)
 
@@ -255,7 +254,7 @@ class TestGC:
         print('Got response from "test" actor.')
 
         assert not check_internal_kv_gced()
-        print(f'kv check 2 passed with source "{source}" and option "{option}".')
+        print("kv check 2 passed.")
 
         assert not check_local_files_gced(cluster)
         print("check_local_files_gced() check passed.")
@@ -267,7 +266,7 @@ class TestGC:
         print(f'Reconnected to Ray at address "{address}" and namespace "test".')
 
         assert not check_internal_kv_gced()
-        print(f'kv check 3 passed with source "{source}" and option "{option}".')
+        print("kv check 3 passed.")
 
         assert not check_local_files_gced(cluster)
         print("check_local_files_gced() check passed.")
@@ -294,7 +293,7 @@ class TestGC:
         """Test eviction happens when we exceed a nonzero (10MB) cache size."""
         cluster, address = start_cluster
         cluster.add_node(
-            num_cpus=1, runtime_env_dir_name=f"worker_node_runtime_resources"
+            num_cpus=1, runtime_env_dir_name="worker_node_runtime_resources"
         )
 
         with tempfile.TemporaryDirectory() as tmp_dir, chdir(tmp_dir):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The test is bumping up against the timeout which is causing flakes on macos builds.

Rather than increase the timeout or split the test, I opted to refactor it a bit to reduce the runtime by combining the logic in the tests to avoid "source" and "option" parametrization. Also reduced to a single worker node for each test to reduce overhead in CI.

I've also deleted some tests that have been dead code for a long time (those testing the logic to disable GC, which hasn't existed for years).

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
