### PR TITLE
[data][train] Fix compute config for local_fs + jpeg image classification benchmark

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2160,8 +2160,6 @@
       run:
         timeout: 1200
         script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification_jpeg --dataloader_type=torch --num_workers=16 --num_torch_workers=16 --skip_train_step --skip_validation_at_epoch_end
-      cluster:
-        cluster_compute: compute_configs/compute_gpu_1x1_aws.yaml
 
     - __suffix__: skip_training.jpeg.local_fs
       run:
@@ -2174,6 +2172,8 @@
       run:
         timeout: 1200
         script: bash image_classification/localfs_image_classification_jpeg/download_input_data_from_s3.sh && RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=localfs_image_classification_jpeg --dataloader_type=torch --num_workers=1 --num_torch_workers=32 --skip_train_step --skip_validation_at_epoch_end
+      cluster:
+        cluster_compute: compute_configs/compute_gpu_1x1_aws.yaml
 
 
 - name: train_horovod_multi_node_test


### PR DESCRIPTION
Fix the misconfigured compute config introduced by https://github.com/ray-project/ray/pull/52453