### PR TITLE
Deflake Core dashboard test

### DIFF
--- a/python/ray/dashboard/client/src/pages/overview/OverviewPage.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/overview/OverviewPage.component.test.tsx
@@ -3,12 +3,22 @@ import React, { PropsWithChildren } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { GlobalContext } from "../../App";
 import { STYLE_WRAPPER } from "../../util/test-utils";
+import { useRayStatus } from "../job/hook/useClusterStatus";
 import { useJobList } from "../job/hook/useJobList";
 import { OverviewPage } from "./OverviewPage";
 
 jest.mock("../job/hook/useJobList");
+jest.mock("../job/hook/useClusterStatus");
+
+const mockedUseRayStatus = jest.mocked(useRayStatus);
 
 describe("OverviewPage", () => {
+  beforeEach(() => {
+    mockedUseRayStatus.mockReturnValue({
+      clusterStatus: undefined,
+    });
+  });
+
   it("renders", async () => {
     expect.assertions(3);
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
There are test failures with this error:
```
[2025-04-21T14:53:55Z] FAIL src/pages/overview/OverviewPage.component.test.tsx
[2025-04-21T14:53:55Z]   ● OverviewPage › renders
[2025-04-21T14:53:55Z]
[2025-04-21T14:53:55Z]     TypeError: Cannot read property 'visibilityState' of null
[2025-04-21T14:53:55Z]
[2025-04-21T14:53:55Z]       at Object.isVisible (node_modules/swr/_internal/dist/index.js:134:57)
[2025-04-21T14:53:55Z]       at isActive (node_modules/swr/core/dist/index.js:42:38)
[2025-04-21T14:53:55Z]       at node_modules/swr/core/dist/index.js:293:17
```

This is thrown by SWR in some cases. https://github.com/vercel/swr/issues/2373
These dashboard tests are supposed to mock out API responses anyways, this test did not mock out one of API calls. We'll mock it out and this should deflake this test.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
