### PR TITLE
[serve][P0] fix await deployment response hanging issue

### DIFF
--- a/python/ray/serve/_private/replica_result.py
+++ b/python/ray/serve/_private/replica_result.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 import threading
 import time
@@ -62,6 +63,7 @@ class ActorReplicaResult(ReplicaResult):
         self._is_streaming: bool = metadata.is_streaming
         self._request_id: str = metadata.request_id
         self._object_ref_or_gen_sync_lock = threading.Lock()
+        self.__lazy_object_ref_or_gen_asyncio_lock = None
 
         if isinstance(obj_ref_or_gen, ray.ObjectRefGenerator):
             self._obj_ref_gen = obj_ref_or_gen
@@ -72,6 +74,14 @@ class ActorReplicaResult(ReplicaResult):
             assert (
                 self._obj_ref_gen is not None
             ), "An ObjectRefGenerator must be passed for streaming requests."
+
+    @property
+    def _object_ref_or_gen_asyncio_lock(self) -> asyncio.Lock:
+        """Lazy `asyncio.Lock` object."""
+        if self.__lazy_object_ref_or_gen_asyncio_lock is None:
+            self.__lazy_object_ref_or_gen_asyncio_lock = asyncio.Lock()
+
+        return self.__lazy_object_ref_or_gen_asyncio_lock
 
     def _process_response(f: Union[Callable, Coroutine]):
         @wraps(f)
@@ -174,7 +184,7 @@ class ActorReplicaResult(ReplicaResult):
         # object ref cached in order to avoid calling `__anext__()` to
         # resolve to the underlying object ref more than once.
         # See: https://github.com/ray-project/ray/issues/43879.
-        with self._object_ref_or_gen_sync_lock:
+        async with self._object_ref_or_gen_asyncio_lock:
             if self._obj_ref is None:
                 self._obj_ref = await self._obj_ref_gen.__anext__()
 

--- a/python/ray/serve/_private/replica_result.py
+++ b/python/ray/serve/_private/replica_result.py
@@ -63,7 +63,7 @@ class ActorReplicaResult(ReplicaResult):
         self._is_streaming: bool = metadata.is_streaming
         self._request_id: str = metadata.request_id
         self._object_ref_or_gen_sync_lock = threading.Lock()
-        self.__lazy_object_ref_or_gen_asyncio_lock = None
+        self._lazy_object_ref_or_gen_asyncio_lock = None
 
         if isinstance(obj_ref_or_gen, ray.ObjectRefGenerator):
             self._obj_ref_gen = obj_ref_or_gen
@@ -78,10 +78,10 @@ class ActorReplicaResult(ReplicaResult):
     @property
     def _object_ref_or_gen_asyncio_lock(self) -> asyncio.Lock:
         """Lazy `asyncio.Lock` object."""
-        if self.__lazy_object_ref_or_gen_asyncio_lock is None:
-            self.__lazy_object_ref_or_gen_asyncio_lock = asyncio.Lock()
+        if self._lazy_object_ref_or_gen_asyncio_lock is None:
+            self._lazy_object_ref_or_gen_asyncio_lock = asyncio.Lock()
 
-        return self.__lazy_object_ref_or_gen_asyncio_lock
+        return self._lazy_object_ref_or_gen_asyncio_lock
 
     def _process_response(f: Union[Callable, Coroutine]):
         @wraps(f)


### PR DESCRIPTION
## Why are these changes needed?

If the user passes a `DeploymentResponse` object directly into a deployment handle, we will resolve it to the object ref under the hood before scheduling the request. But we were incorrectly using a threading.Lock when getting the object ref so this can cause deadlock if the same `DeploymentResponse` object is used for multiple downstream calls. Instead we should be using an asyncio lock.

## Related issue number

closes https://github.com/ray-project/ray/issues/51190