### PR TITLE
[Data] Fixing `FuseOperators` rule to properly handle the case of transformations drastically changing size of the dataset

### DIFF
--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -564,9 +564,9 @@ class _BlockRefBundler:
                 bundle up to this target, but only exceed it if not doing so would
                 result in an empty bundle.
         """
-        assert min_rows_per_bundle is None or min_rows_per_bundle >= 0, (
-            "Min rows per bundle has to be non-negative"
-        )
+        assert (
+            min_rows_per_bundle is None or min_rows_per_bundle >= 0
+        ), "Min rows per bundle has to be non-negative"
 
         self._min_rows_per_bundle = min_rows_per_bundle
         self._bundle_buffer: List[RefBundle] = []

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -564,6 +564,10 @@ class _BlockRefBundler:
                 bundle up to this target, but only exceed it if not doing so would
                 result in an empty bundle.
         """
+        assert min_rows_per_bundle is None or min_rows_per_bundle >= 0, (
+            "Min rows per bundle has to be non-negative"
+        )
+
         self._min_rows_per_bundle = min_rows_per_bundle
         self._bundle_buffer: List[RefBundle] = []
         self._bundle_buffer_size = 0

--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -82,3 +82,7 @@ class LogicalOperator(Operator):
         objects aren't available on the deserialized machine.
         """
         return True
+
+    @classmethod
+    def is_read_op(cls):
+        return False

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -37,8 +37,8 @@ class AbstractMap(AbstractOneToOne):
                 inspecting the logical plan of a Dataset.
             input_op: The operator preceding this operator in the plan DAG. The outputs
                 of `input_op` will be the inputs to this operator.
-            min_rows_per_bundled_input: The target number of rows to pass to
-                ``MapOperator._add_bundled_input()``.
+            min_rows_per_bundled_input: Min number of rows a single bundle of blocks
+                passed on to the task must possess.
             ray_remote_args: Args to provide to :func:`ray.remote`.
             ray_remote_args_fn: A function that returns a dictionary of remote args
                 passed to each map worker. The purpose of this argument is to generate

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -177,7 +177,6 @@ class MapBatches(AbstractUDFMap):
         self._batch_format = batch_format
         self._zero_copy_batch = zero_copy_batch
 
-    @property
     def can_modify_num_rows(self) -> bool:
         return False
 
@@ -210,7 +209,6 @@ class MapRows(AbstractUDFMap):
             ray_remote_args=ray_remote_args,
         )
 
-    @property
     def can_modify_num_rows(self) -> bool:
         return False
 
@@ -249,7 +247,6 @@ class Filter(AbstractUDFMap):
             ray_remote_args=ray_remote_args,
         )
 
-    @property
     def can_modify_num_rows(self) -> bool:
         return True
 
@@ -285,7 +282,6 @@ class Project(AbstractMap):
     def cols_rename(self) -> Optional[Dict[str, str]]:
         return self._cols_rename
 
-    @property
     def can_modify_num_rows(self) -> bool:
         return False
 
@@ -318,7 +314,6 @@ class FlatMap(AbstractUDFMap):
             ray_remote_args=ray_remote_args,
         )
 
-    @property
     def can_modify_num_rows(self) -> bool:
         return True
 
@@ -342,6 +337,5 @@ class StreamingRepartition(AbstractMap):
     def target_num_rows_per_block(self) -> int:
         return self._target_num_rows_per_block
 
-    @property
     def can_modify_num_rows(self) -> bool:
         return False

--- a/python/ray/data/_internal/logical/operators/one_to_one_operator.py
+++ b/python/ray/data/_internal/logical/operators/one_to_one_operator.py
@@ -1,4 +1,3 @@
-import abc
 from typing import Optional
 
 from ray.data._internal.logical.interfaces import LogicalOperator

--- a/python/ray/data/_internal/logical/operators/one_to_one_operator.py
+++ b/python/ray/data/_internal/logical/operators/one_to_one_operator.py
@@ -29,11 +29,10 @@ class AbstractOneToOne(LogicalOperator):
     def input_dependency(self) -> LogicalOperator:
         return self._input_dependencies[0]
 
-    @property
-    @abc.abstractmethod
     def can_modify_num_rows(self) -> bool:
         """Whether this operator can modify the number of rows,
         i.e. number of input rows != number of output rows."""
+        ...
 
 
 class Limit(AbstractOneToOne):
@@ -50,7 +49,6 @@ class Limit(AbstractOneToOne):
         )
         self._limit = limit
 
-    @property
     def can_modify_num_rows(self) -> bool:
         return True
 

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -97,3 +97,9 @@ class Read(AbstractMap):
     @classmethod
     def is_read_op(cls):
         return True
+
+    def can_modify_num_rows(self) -> bool:
+        # NOTE: Returns true, since most of the readers expands its input
+        #       and produce many rows for every single row of the input
+        return True
+

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -102,4 +102,3 @@ class Read(AbstractMap):
         # NOTE: Returns true, since most of the readers expands its input
         #       and produce many rows for every single row of the input
         return True
-

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -93,3 +93,7 @@ class Read(AbstractMap):
             input_files=input_files,
             exec_stats=None,
         )
+
+    @classmethod
+    def is_read_op(cls):
+        return True

--- a/python/ray/data/_internal/logical/rules/limit_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/limit_pushdown.py
@@ -61,7 +61,7 @@ class LimitPushdownRule(Rule):
                 while (
                     isinstance(new_input_into_limit, AbstractOneToOne)
                     and not isinstance(new_input_into_limit, Read)
-                    and not getattr(new_input_into_limit, "can_modify_num_rows", False)
+                    and not new_input_into_limit.can_modify_num_rows()
                 ):
                     new_input_into_limit_copy = copy.copy(new_input_into_limit)
                     ops_between_new_input_and_limit.append(new_input_into_limit_copy)

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -517,6 +517,15 @@ class FuseOperators(Rule):
         upstream_op: AbstractMap,
         downstream_op: AbstractMap,
     ) -> float:
+        """This method derives potential parallelism reduction factor
+        based on `min_rows_per_bundled_input` setting of upstream and downstream
+        operators.
+
+        It returns value in the range [0, 1] that should be interpreted
+        as multiplication factor for estimated parallelism of the upstream
+        operator by potentially fusing the 2 operators.
+        """
+
         us_bundle_min_rows_req = upstream_op._min_rows_per_bundled_input
         ds_bundle_min_rows_req = downstream_op._min_rows_per_bundled_input
 

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -179,9 +179,7 @@ class FuseOperators(Rule):
             (
                 isinstance(up_logical_op, AbstractMap)
                 and isinstance(down_logical_op, AbstractMap)
-                and self._can_fuse_map_ops(
-                    up_logical_op, down_logical_op, up_op.data_context
-                )
+                and self._can_fuse_map_ops(up_logical_op, down_logical_op)
             )
             or (
                 isinstance(up_logical_op, AbstractMap)

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -45,8 +45,6 @@ logger = logging.getLogger(__name__)
 class FuseOperators(Rule):
     """Fuses linear chains of compatible physical operators."""
 
-    _DEFAULT_THRESHOLD_MIN_NUM_ROWS_DS_TO_US_RATIO = 3.0
-
     def apply(self, plan: PhysicalPlan) -> PhysicalPlan:
         self._op_map = plan.op_map.copy()
         # Do DFS fusion on compatible pairwise operators in two passes.
@@ -400,34 +398,11 @@ class FuseOperators(Rule):
         if us_bundle_min_rows_req is None and ds_bundle_min_rows_req is None:
             return None
 
-        # If at least one of the operators has `min_rows_per_bundled_input` specified,
-        # fusion could not proceed unless upstream operator has it specified
-        assert us_bundle_min_rows_req is not None, (
-            "Upstream `_min_rows_per_bundled_input` have to be not None "
-            f"(got {us_bundle_min_rows_req})"
-        )
-
-        ds_bundle_min_rows_req = ds_bundle_min_rows_req or 0
-
-        # NOTE: If ratio of downstream to upstream min num rows requirement is exceeding
-        #       `_DEFAULT_THRESHOLD_MIN_NUM_ROWS_DS_TO_US_RATIO` we log a warning
-        #       as this could potentially lead to substantial parallelism reduction due
-        #       to operator fusion
-        ratio_threshold = cls._DEFAULT_THRESHOLD_MIN_NUM_ROWS_DS_TO_US_RATIO
-        min_num_rows_ratio = ds_bundle_min_rows_req / us_bundle_min_rows_req
-
-        if min_num_rows_ratio > ratio_threshold:
-            logger.warning(
-                f"Value of `min_rows_per_bundled_input` of upstream operator "
-                f"'{up_logical_op}' is increasing from {us_bundle_min_rows_req} "
-                f"to {ds_bundle_min_rows_req} due to operator fusion. This could "
-                f"substantially reduce parallelism level of the operator.")
-
         # Target min bundle size is selected as max of upstream and downstream ones
         # such that it could satisfy both of their requirements
         return max(
-            ds_bundle_min_rows_req,
-            us_bundle_min_rows_req
+            ds_bundle_min_rows_req or 0,
+            us_bundle_min_rows_req or 0,
         )
 
     def _get_fused_all_to_all_operator(

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -391,42 +391,42 @@ class FuseOperators(Rule):
         down_logical_op: AbstractMap,
         up_logical_op: AbstractMap,
     ) -> Optional[int]:
-        us_min_rows_per_bundled_input = up_logical_op._min_rows_per_bundled_input
-        ds_min_rows_per_bundled_input = down_logical_op._min_rows_per_bundled_input
+        us_bundle_min_rows_req = up_logical_op._min_rows_per_bundled_input
+        ds_bundle_min_rows_req = down_logical_op._min_rows_per_bundled_input
 
         # In case neither of the ops specify `min_rows_per_bundled_input`,
         # return None
-        if us_min_rows_per_bundled_input is None and ds_min_rows_per_bundled_input is None:
+        if us_bundle_min_rows_req is None and ds_bundle_min_rows_req is None:
             return None
 
         # If at least one of the operators has `min_rows_per_bundled_input` specified,
         # fusion could not proceed unless upstream operator has it specified
-        assert us_min_rows_per_bundled_input is not None, (
+        assert us_bundle_min_rows_req is not None, (
             "Upstream `_min_rows_per_bundled_input` have to be not None "
-            f"(got {us_min_rows_per_bundled_input})"
+            f"(got {us_bundle_min_rows_req})"
         )
 
-        ds_min_rows_per_bundled_input = ds_min_rows_per_bundled_input or 0
+        ds_bundle_min_rows_req = ds_bundle_min_rows_req or 0
 
         # NOTE: If ratio of downstream to upstream min num rows requirement is exceeding
         #       `_DEFAULT_THRESHOLD_MIN_NUM_ROWS_DS_TO_US_RATIO` we log a warning
         #       as this could potentially lead to substantial parallelism reduction due
         #       to operator fusion
         ratio_threshold = cls._DEFAULT_THRESHOLD_MIN_NUM_ROWS_DS_TO_US_RATIO
-        min_num_rows_ratio = ds_min_rows_per_bundled_input / us_min_rows_per_bundled_input
+        min_num_rows_ratio = ds_bundle_min_rows_req / us_bundle_min_rows_req
 
         if min_num_rows_ratio > ratio_threshold:
             logger.warning(
                 f"Value of `min_rows_per_bundled_input` of upstream operator "
-                f"'{up_logical_op}' is increasing from {us_min_rows_per_bundled_input} "
-                f"to {ds_min_rows_per_bundled_input} due to operator fusion. This could "
+                f"'{up_logical_op}' is increasing from {us_bundle_min_rows_req} "
+                f"to {ds_bundle_min_rows_req} due to operator fusion. This could "
                 f"substantially reduce parallelism level of the operator.")
 
         # Target min bundle size is selected as max of upstream and downstream ones
         # such that it could satisfy both of their requirements
         return max(
-            ds_min_rows_per_bundled_input,
-            us_min_rows_per_bundled_input
+            ds_bundle_min_rows_req,
+            us_bundle_min_rows_req
         )
 
     def _get_fused_all_to_all_operator(

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -412,10 +412,10 @@ class FuseOperators(Rule):
 
         if min_num_rows_ratio > ratio_threshold:
             logger.warning(
-                "Ratio of `min_rows_per_bundled_input` of downstream to upstream map "
-                f"operator is {round(min_num_rows_ratio, 2)} > {ratio_threshold} entailing "
-                f"that operator fusion could potentially reduce parallelism level of the "
-                f"upstream '{up_logical_op}' operator")
+                f"Value of `min_rows_per_bundled_input` of upstream operator "
+                f"'{up_logical_op}' is increasing from {us_min_rows_per_bundled_input} "
+                f"to {ds_min_rows_per_bundled_input} due to operator fusion. This could "
+                f"substantially reduce parallelism level of the operator.")
 
         # Target min bundle size is selected as max of upstream and downstream ones
         # such that it could satisfy both of their requirements

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -497,6 +497,13 @@ class FuseOperators(Rule):
             upstream_op.can_modify_num_rows()
             and downstream_op._min_rows_per_bundled_input is not None
         ):
+            logger.debug(
+                f"Upstream operator '{upstream_op}' could be modifying # of input "
+                f"rows, while downstream operator '{downstream_op}' expects at least "
+                f"{downstream_op._min_rows_per_bundled_input} rows in a batch. "
+                f"Skipping fusion"
+            )
+
             return False
 
         return True

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -494,17 +494,17 @@ class FuseOperators(Rule):
 
         # Avoid fusing operators in cases when doing so would lead to a dramatic parallelism
         # reduction for the upstream operator
-        threshold = context.map_operator_fusion_parallelism_reduction_threshold
-        upstream_parallelism_reduction_ratio = (
-            cls._derive_upstream_parallelism_reduction_ratio(upstream_op, downstream_op)
+        factor_threshold = context.map_operator_fusion_parallelism_reduction_factor_threshold
+        upstream_parallelism_reduction_factor = (
+            cls._derive_upstream_parallelism_reduction_factor(upstream_op, downstream_op)
         )
 
-        if upstream_parallelism_reduction_ratio < threshold:
+        if upstream_parallelism_reduction_factor < factor_threshold:
             logger.warning(
                 f"Fusion of '{upstream_op}' (upstream) with '{downstream_op}' "
-                f"(downstream) will likely lead to parallelism reduction ratio of "
-                f"{round(upstream_parallelism_reduction_ratio, 2)} that's below the "
-                f"threshold of {threshold}. Skipping fusion"
+                f"(downstream) will likely lead to parallelism reduction of "
+                f"{round(upstream_parallelism_reduction_factor, 2)} that's below the "
+                f"threshold of {factor_threshold}. Aborting operator fusion."
             )
 
             return False
@@ -512,7 +512,7 @@ class FuseOperators(Rule):
         return True
 
     @classmethod
-    def _derive_upstream_parallelism_reduction_ratio(
+    def _derive_upstream_parallelism_reduction_factor(
         cls,
         upstream_op: AbstractMap,
         downstream_op: AbstractMap,

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -520,14 +520,17 @@ class FuseOperators(Rule):
         us_bundle_min_rows_req = upstream_op._min_rows_per_bundled_input
         ds_bundle_min_rows_req = downstream_op._min_rows_per_bundled_input
 
-        # If both requirements are None or 0, there's no reduction
-        if not us_bundle_min_rows_req and not ds_bundle_min_rows_req:
+        # If downstream operator's min-rows requirement is None or 0,
+        # there's no reduction
+        if not ds_bundle_min_rows_req:
             return 1.0
 
-        # In case upstream requirement is not specified (or is 0), while downstream
-        # is specifying non-zero one we conservatively assume that downstream's
-        # `min_rows_per_bundled_input` >> than the block size (hence leading to
-        # absolute reduction in parallelism)
+        # In case downstream's requirement is > 0, while upstream's is not specified
+        # (or is 0),we conservatively assume that downstream's
+        #
+        #   `min_rows_per_bundled_input` >> than the input block size
+        #
+        # Hence potentially leading to substantial reduction in parallelism
         elif not us_bundle_min_rows_req:
             return 0.0
 

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -494,9 +494,13 @@ class FuseOperators(Rule):
 
         # Avoid fusing operators in cases when doing so would lead to a dramatic parallelism
         # reduction for the upstream operator
-        factor_threshold = context.map_operator_fusion_parallelism_reduction_factor_threshold
+        factor_threshold = (
+            context.map_operator_fusion_parallelism_reduction_factor_threshold
+        )
         upstream_parallelism_reduction_factor = (
-            cls._derive_upstream_parallelism_reduction_factor(upstream_op, downstream_op)
+            cls._derive_upstream_parallelism_reduction_factor(
+                upstream_op, downstream_op
+            )
         )
 
         if upstream_parallelism_reduction_factor < factor_threshold:

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -484,12 +484,12 @@ class FuseOperators(Rule):
         downstream_op: AbstractMap,
         context: "DataContext",
     ) -> bool:
-        ds_bundle_min_rows_req = downstream_op._min_rows_per_bundled_input
-        us_bundle_min_rows_req = upstream_op._min_rows_per_bundled_input
-
         # Do not fuse read op with downstream map op in case when downstream has
         # `min_rows_per_input_bundle` specified (to avoid reducing reading parallelism)
-        if upstream_op.is_read_op() and ds_bundle_min_rows_req is not None:
+        if (
+            upstream_op.is_read_op()
+            and downstream_op._min_rows_per_bundled_input is not None
+        ):
             return False
 
         # Avoid fusing operators in cases when doing so would lead to a dramatic parallelism

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -190,7 +190,7 @@ class FuseOperators(Rule):
             or (
                 isinstance(up_logical_op, AbstractMap)
                 and isinstance(down_logical_op, Repartition)
-                and not down_logical_op._shuffle
+                and down_logical_op._shuffle
             )
         ):
             return False

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -179,7 +179,9 @@ class FuseOperators(Rule):
             (
                 isinstance(up_logical_op, AbstractMap)
                 and isinstance(down_logical_op, AbstractMap)
-                and self._can_fuse_map_ops(up_logical_op, down_logical_op, up_op.data_context)
+                and self._can_fuse_map_ops(
+                    up_logical_op, down_logical_op, up_op.data_context
+                )
             )
             or (
                 isinstance(up_logical_op, AbstractMap)
@@ -309,8 +311,7 @@ class FuseOperators(Rule):
 
         # Derive min num rows per input bundle
         min_rows_per_bundled_input = self._derive_bundle_min_num_rows(
-            down_logical_op,
-            up_logical_op
+            down_logical_op, up_logical_op
         )
 
         target_max_block_size = self._get_merged_target_max_block_size(
@@ -488,10 +489,7 @@ class FuseOperators(Rule):
 
         # Do not fuse read op with downstream map op in case when downstream has
         # `min_rows_per_input_bundle` specified (to avoid reducing reading parallelism)
-        if (
-            upstream_op.is_read_op()
-            and ds_bundle_min_rows_req is not None
-        ):
+        if upstream_op.is_read_op() and ds_bundle_min_rows_req is not None:
             return False
 
         # Avoid fusing operators in cases when doing so would lead to a dramatic parallelism

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -593,7 +593,8 @@ class ExecutionPlan:
         the LogicalPlan is used."""
         if root_op is None:
             root_op = self._logical_plan.dag
-        return root_op.is_read()
+
+        return root_op.is_read_op()
 
     def has_computed_output(self) -> bool:
         """Whether this plan has a computed snapshot for the final operator, i.e. for

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -259,7 +259,7 @@ class ExecutionPlan:
                         chars_left_for_col_name = max(
                             SCHEMA_LINE_CHAR_LIMIT - len(shortened_suffix),
                             MIN_FIELD_LENGTH,
-                            )
+                        )
                         col_str = (
                             f"{col_str[:chars_left_for_col_name]}{shortened_suffix}"
                         )

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -10,8 +10,6 @@ from ray._private.internal_api import get_memory_info_reply, get_state_from_addr
 from ray.data._internal.execution.interfaces import RefBundle
 from ray.data._internal.logical.interfaces.logical_operator import LogicalOperator
 from ray.data._internal.logical.interfaces.logical_plan import LogicalPlan
-from ray.data._internal.logical.operators.from_operators import AbstractFrom
-from ray.data._internal.logical.operators.input_data_operator import InputData
 from ray.data._internal.logical.operators.read_operator import Read
 from ray.data._internal.stats import DatasetStats
 from ray.data._internal.util import unify_block_metadata_schema
@@ -136,7 +134,7 @@ class ExecutionPlan:
             ):
                 """Traverse (DFS) the LogicalPlan DAG and
                 return a string representation of the operators."""
-                if isinstance(op, (Read, InputData, AbstractFrom)):
+                if not op.input_dependencies or op.is_read_op():
                     return curr_str, depth
 
                 curr_max_depth = depth
@@ -168,19 +166,27 @@ class ExecutionPlan:
                 count = self._snapshot_metadata.num_rows
             else:
                 # This plan hasn't executed any operators.
-                sources = self._logical_plan.sources()
+                has_n_ary_operator = False
+                dag = self._logical_plan.dag
+
+                while not dag.is_read_op() and dag.input_dependencies:
+                    if len(dag.input_dependencies) > 1:
+                        has_n_ary_operator = True
+                        break
+
+                    dag = dag.input_dependencies[0]
+
                 # TODO(@bveeramani): Handle schemas for n-ary operators like `Union`.
-                if len(sources) > 1:
-                    # Multiple sources, cannot determine schema.
+                if has_n_ary_operator:
                     schema = None
                     count = None
                 else:
-                    assert len(sources) == 1
+                    assert dag.is_read_op() or not dag.input_dependencies, dag
                     plan = ExecutionPlan(
                         DatasetStats(metadata={}, parent=None),
                         self._context,
                     )
-                    plan.link_logical_plan(LogicalPlan(sources[0], plan._context))
+                    plan.link_logical_plan(LogicalPlan(dag, plan._context))
                     schema = plan.schema()
                     count = plan.meta_count()
         else:
@@ -253,7 +259,7 @@ class ExecutionPlan:
                         chars_left_for_col_name = max(
                             SCHEMA_LINE_CHAR_LIMIT - len(shortened_suffix),
                             MIN_FIELD_LENGTH,
-                        )
+                            )
                         col_str = (
                             f"{col_str[:chars_left_for_col_name]}{shortened_suffix}"
                         )
@@ -587,7 +593,7 @@ class ExecutionPlan:
         the LogicalPlan is used."""
         if root_op is None:
             root_op = self._logical_plan.dag
-        return isinstance(root_op, Read) and len(root_op.input_dependencies) == 0
+        return root_op.is_read()
 
     def has_computed_output(self) -> bool:
         """Whether this plan has a computed snapshot for the final operator, i.e. for

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -403,23 +403,6 @@ class DataContext:
     override_object_store_memory_limit_fraction: float = None
     memory_usage_poll_interval_s: Optional[float] = 1
 
-    # Threshold for parallelism reduction ratio between map operators being fused,
-    # below which map operators will stop being fused.
-    #
-    # This entails that for 2 adjacent map operators A and B such that:
-    #
-    #   A's (estimated) parallelism / B's (estimated) parallelism < threshold
-    #
-    # Operator fusion won't happen (as parallelism of one of them will be reduced
-    # by more than 1 / threshold)
-    #
-    # NOTE: This value should be in the range of (0, 1.0] and interpreted
-    #       as a multiplication factor for evaluation of impact on an estimated
-    #       parallelism level. For ex, default threshold of 0.25 entails
-    #       that parallelism reduction of more than 4x will be considered high
-    #       enough to prevent operator fusion from occurring.
-    map_operator_fusion_parallelism_reduction_factor_threshold: float = 0.25
-
     def __post_init__(self):
         # The additonal ray remote args that should be added to
         # the task-pool-based data tasks.

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -418,7 +418,7 @@ class DataContext:
     #       parallelism level. For ex, default threshold of 0.25 entails
     #       that parallelism reduction of more than 4x will be considered high
     #       enough to prevent operator fusion from occurring.
-    map_operator_fusion_parallelism_reduction_threshold: float = 0.25
+    map_operator_fusion_parallelism_reduction_factor_threshold: float = 0.25
 
     def __post_init__(self):
         # The additonal ray remote args that should be added to

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -412,6 +412,12 @@ class DataContext:
     #
     # Operator fusion won't happen (as parallelism of one of them will be reduced
     # by more than 1 / threshold)
+    #
+    # NOTE: This value should be in the range of (0, 1.0] and interpreted
+    #       as a multiplication factor for evaluation of impact on an estimated
+    #       parallelism level. For ex, default threshold of 0.25 entails
+    #       that parallelism reduction of more than 4x will be considered high
+    #       enough to prevent operator fusion from occurring.
     map_operator_fusion_parallelism_reduction_threshold: float = 0.25
 
     def __post_init__(self):

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -403,6 +403,17 @@ class DataContext:
     override_object_store_memory_limit_fraction: float = None
     memory_usage_poll_interval_s: Optional[float] = 1
 
+    # Threshold for parallelism reduction ratio between map operators being fused,
+    # below which map operators will stop being fused.
+    #
+    # This entails that for 2 adjacent map operators A and B such that:
+    #
+    #   A's (estimated) parallelism / B's (estimated) parallelism < threshold
+    #
+    # Operator fusion won't happen (as parallelism of one of them will be reduced
+    # by more than 1 / threshold)
+    map_operator_fusion_parallelism_reduction_threshold: float = 0.25
+
     def __post_init__(self):
         # The additonal ray remote args that should be added to
         # the task-pool-based data tasks.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

These changes are needed to make sure `FuseOperators` is appropriately handling potential impacts of transformations on the dataset sizes and whether fusion should occur in that case. 

For ex, consider following scenarios:

```
ds.filter(...).map_batches(..., bathc_size=1024)
```

Could not be fused as fusing it could potentially violate batching semantic -- fused operator gonna first gonna collect 1024 rows, then apply filter and subsequent transformation (which might expect exactly 1024 rows to be provided in a batch).

```
read_parquet(...).map_batches(..., bathc_size=1024)
```

Also could not be fused in that case, as fusing these 2 operations could lead to drastic reduction of the parallelism of the read operation: fused operator first gonna batch 1024 rows, then apply combined read->map transformation.

This change:

1. Cleans up `can_modify_num_rows` method
2. Makes sure `Read` overrides `can_modify_num_rows` as well
3. Avoids fusion with ops that could be drastically modifying dataset size
4. Cleaning up `FuseOperators` rule
5. Adding telemetry

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
