### PR TITLE
[data.dashboard.x][12] print the whole stack trace when dataset fails

### DIFF
--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -491,7 +491,7 @@ def process_completed_tasks(
                                 " To ignore this exception and continue, set"
                                 " DataContext.max_errored_blocks."
                             )
-                            logger.error(error_message)
+                            logger.exception(error_message)
                             raise e from None
                 else:
                     assert isinstance(task, MetadataOpTask)


### PR DESCRIPTION
Currently when `ray.data` hits an exception, it just propagate the exception up without printing the stack trace. This makes the per-dataset-log kind of useless because it doesn't have the stack trace (see the screenshot I attached). This change makes sure `ray.data` prints the stack trace.

Test:
- CI


<img width="1899" alt="Screenshot 2025-04-24 at 5 44 42 PM" src="https://github.com/user-attachments/assets/a50da775-00da-43f2-ad89-14ca607f4107" />
<img width="1894" alt="Screenshot 2025-04-24 at 5 45 07 PM" src="https://github.com/user-attachments/assets/3b5b9453-339f-476b-a7a0-773d3079e6a9" />

