### PR TITLE
[RLlib] Episode API: Add `custom_data` property and deprecate `add|get_temporary_timestep_data()` APIs.

### DIFF
--- a/doc/source/rllib/metrics-logger.rst
+++ b/doc/source/rllib/metrics-logger.rst
@@ -370,7 +370,7 @@ only the :py:class:`~ray.rllib.utils.metrics.metrics_logger.MetricsLogger` aspec
 
     class LogAcrobotAngle(RLlibCallback):
 
-        def on_episode_created(self, *, episode, **kwargs)
+        def on_episode_created(self, *, episode, **kwargs):
             # Initialize an empty list in the `custom_data` property of `episode`.
             episode.custom_data["theta1"] = []
 

--- a/doc/source/rllib/metrics-logger.rst
+++ b/doc/source/rllib/metrics-logger.rst
@@ -348,7 +348,8 @@ to access the throughput value. For example:
 Example 1: How to use MetricsLogger in EnvRunner callbacks
 ----------------------------------------------------------
 
-To demonstrate how to use the :py:class:`~ray.rllib.utils.metrics.metrics_logger.MetricsLogger` on an :py:class:`~ray.rllib.env.env_runner.EnvRunner`, take a look at this end-to-end example here, which
+To demonstrate how to use the :py:class:`~ray.rllib.utils.metrics.metrics_logger.MetricsLogger` on an :py:class:`~ray.rllib.env.env_runner.EnvRunner`,
+take a look at this end-to-end example here, which
 makes use of the :py:class:`~ray.rllib.callbacks.callbacks.RLlibCallback` API to inject custom code into the RL environment loop.
 
 The example computes the average "first-joint angle" of the
@@ -366,15 +367,21 @@ only the :py:class:`~ray.rllib.utils.metrics.metrics_logger.MetricsLogger` aspec
     from ray.rllib.callbacks.callbacks import RLlibCallback
 
     # Define a custom RLlibCallback.
+
     class LogAcrobotAngle(RLlibCallback):
+
+        def on_episode_created(self, *, episode, **kwargs)
+            # Initialize an empty list in the `custom_data` property of `episode`.
+            episode.custom_data["theta1"] = []
+
         def on_episode_step(self, *, episode, env, **kwargs):
             # Compute the angle at every episode step and store it temporarily in episode:
             state = env.envs[0].unwrapped.state
             deg_theta1 = math.degrees(math.atan2(state[1], state[0]))
-            episode.add_temporary_timestep_data("theta1", deg_theta1)
+            episode.custom_data["theta1"].append(deg_theta1)
 
         def on_episode_end(self, *, episode, metrics_logger, **kwargs):
-            theta1s = episode.get_temporary_timestep_data("theta1")
+            theta1s = episode.custom_data["theta1"]
             avg_theta1 = np.mean(theta1s)
 
             # Log the resulting average angle - per episode - to the MetricsLogger.

--- a/doc/source/rllib/package_ref/env/multi_agent_episode.rst
+++ b/doc/source/rllib/package_ref/env/multi_agent_episode.rst
@@ -60,7 +60,6 @@ Getting environment data
     ~MultiAgentEpisode.get_extra_model_outputs
     ~MultiAgentEpisode.get_terminateds
     ~MultiAgentEpisode.get_truncateds
-    ~MultiAgentEpisode.get_temporary_timestep_data
 
 Adding data
 ~~~~~~~~~~~
@@ -70,7 +69,6 @@ Adding data
 
     ~MultiAgentEpisode.add_env_reset
     ~MultiAgentEpisode.add_env_step
-    ~MultiAgentEpisode.add_temporary_timestep_data
 
 Creating and handling episode chunks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/rllib/package_ref/env/single_agent_episode.rst
+++ b/doc/source/rllib/package_ref/env/single_agent_episode.rst
@@ -47,7 +47,6 @@ Getting environment data
     ~SingleAgentEpisode.get_actions
     ~SingleAgentEpisode.get_rewards
     ~SingleAgentEpisode.get_extra_model_outputs
-    ~SingleAgentEpisode.get_temporary_timestep_data
 
 Adding data
 ~~~~~~~~~~~
@@ -57,7 +56,6 @@ Adding data
 
     ~SingleAgentEpisode.add_env_reset
     ~SingleAgentEpisode.add_env_step
-    ~SingleAgentEpisode.add_temporary_timestep_data
 
 Creating and handling episode chunks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/rllib/rllib-callback.rst
+++ b/doc/source/rllib/rllib-callback.rst
@@ -310,7 +310,7 @@ Also, see this more complex example that
     from ray.rllib.callbacks.callbacks import RLlibCallback
 
     class LogAcrobotAngle(RLlibCallback):
-        def on_episode_created(self, *, episode, **kwargs)
+        def on_episode_created(self, *, episode, **kwargs):
             # Initialize an empty list in the `custom_data` property of `episode`.
             episode.custom_data["theta1"] = []
 

--- a/doc/source/rllib/rllib-callback.rst
+++ b/doc/source/rllib/rllib-callback.rst
@@ -310,6 +310,10 @@ Also, see this more complex example that
     from ray.rllib.callbacks.callbacks import RLlibCallback
 
     class LogAcrobotAngle(RLlibCallback):
+        def on_episode_created(self, *, episode, **kwargs)
+            # Initialize an empty list in the `custom_data` property of `episode`.
+            episode.custom_data["theta1"] = []
+
         def on_episode_step(self, *, episode, env, **kwargs):
             # First get the angle from the env (note that `env` is a VectorEnv).
             # See https://github.com/Farama-Foundation/Gymnasium/blob/main/gymnasium/envs/classic_control/acrobot.py
@@ -319,11 +323,11 @@ Also, see this more complex example that
             deg_theta1 = math.degrees(math.atan2(sin_theta1, cos_theta1))
 
             # Log the theta1 degree value in the episode object, temporarily.
-            episode.add_temporary_timestep_data("theta1", deg_theta1)
+            episode.custom_data["theta1"].append(deg_theta1)
 
         def on_episode_end(self, *, episode, metrics_logger, **kwargs):
             # Get all the logged theta1 degree values and average them.
-            theta1s = episode.get_temporary_timestep_data("theta1")
+            theta1s = episode.custom_data["theta1"]
             avg_theta1 = np.mean(theta1s)
 
             # Log the final result - per episode - to the MetricsLogger.

--- a/rllib/env/multi_agent_episode.py
+++ b/rllib/env/multi_agent_episode.py
@@ -79,7 +79,7 @@ class MultiAgentEpisode:
         "_last_step_time",
         "_len_lookback_buffers",
         "_start_time",
-        "_temporary_timestep_data",
+        "custom_data",
     )
 
     SKIP_ENV_TS_TAG = "S"
@@ -285,9 +285,9 @@ class MultiAgentEpisode:
             extra_model_outputs=extra_model_outputs,
         )
 
-        # Caches for temporary per-timestep data. May be used to store custom metrics
-        # from within a callback for the ongoing episode (e.g. render images).
-        self._temporary_timestep_data = defaultdict(list)
+        # Cache for custom data. May be used to store custom metrics from within a
+        # callback for the ongoing episode (e.g. render images).
+        self.custom_data = {}
 
         # Keep timer stats on deltas between steps.
         self._start_time = None
@@ -792,7 +792,7 @@ class MultiAgentEpisode:
         return self
 
     def concat_episode(self, other: "MultiAgentEpisode") -> None:
-        """Adds the given `other` MultiAgentEpisode to the right side of self.
+        """Adds the given `other` MultiAgentEpisode to the right side of `self`.
 
         In order for this to work, both chunks (`self` and `other`) must fit
         together. This is checked by the IDs (must be identical), the time step counters
@@ -888,8 +888,10 @@ class MultiAgentEpisode:
         elif other.is_truncated:
             self.is_truncated = True
 
-        # Erase all temporary timestep data caches.
-        self._temporary_timestep_data.clear()
+        # Merge with `other`'s custom_data, but give `other` priority b/c we assume
+        # that as a follow-up chunk of `self` other has a more complete version of
+        # `custom_data`.
+        self.custom_data.update(other.custom_data)
 
         # Validate.
         self.validate()
@@ -967,6 +969,7 @@ class MultiAgentEpisode:
             indices=indices_rest,
             return_list=True,
         )
+
         successor = MultiAgentEpisode(
             # Same ID.
             id_=self.id_,
@@ -998,9 +1001,12 @@ class MultiAgentEpisode:
             len_lookback_buffer="auto",
         )
 
-        # Copy over the hanging (end) values into the hanging (begin) chaches of the
+        # Copy over the hanging (end) values into the hanging (begin) caches of the
         # successor.
         successor._hanging_rewards_begin = self._hanging_rewards_end.copy()
+
+        # Deepcopy all custom data in `self` to be continued in the cut episode.
+        successor.custom_data = copy.deepcopy(self.custom_data)
 
         return successor
 
@@ -1433,48 +1439,6 @@ class MultiAgentEpisode:
         }
         truncateds.update({"__all__": self.is_terminated})
         return truncateds
-
-    def add_temporary_timestep_data(self, key: str, data: Any) -> None:
-        """Temporarily adds (until `to_numpy()` called) per-timestep data to self.
-
-        The given `data` is appended to a list (`self._temporary_timestep_data`), which
-        is cleared upon calling `self.to_numpy()`. To get the thus-far accumulated
-        temporary timestep data for a certain key, use the `get_temporary_timestep_data`
-        API.
-        Note that the size of the per timestep list is NOT checked or validated against
-        the other, non-temporary data in this episode (like observations).
-
-        Args:
-            key: The key under which to find the list to append `data` to. If `data` is
-                the first data to be added for this key, start a new list.
-            data: The data item (representing a single timestep) to be stored.
-        """
-        if self.is_numpy:
-            raise ValueError(
-                "Cannot use the `add_temporary_timestep_data` API on an already "
-                f"numpy'ized {type(self).__name__}!"
-            )
-        self._temporary_timestep_data[key].append(data)
-
-    def get_temporary_timestep_data(self, key: str) -> List[Any]:
-        """Returns all temporarily stored data items (list) under the given key.
-
-        Note that all temporary timestep data is erased/cleared when calling
-        `self.to_numpy()`.
-
-        Returns:
-            The current list storing temporary timestep data under `key`.
-        """
-        if self.is_numpy:
-            raise ValueError(
-                "Cannot use the `get_temporary_timestep_data` API on an already "
-                f"numpy'ized {type(self).__name__}! All temporary data has been erased "
-                f"upon `{type(self).__name__}.to_numpy()`."
-            )
-        try:
-            return self._temporary_timestep_data[key]
-        except KeyError:
-            raise KeyError(f"Key {key} not found in temporary timestep data!")
 
     def slice(
         self,
@@ -2596,10 +2560,10 @@ class MultiAgentEpisode:
         else:
             return inf_lookback_buffer_or_dict
 
-    @Deprecated(new="MultiAgentEpisode.is_numpy()", error=True)
-    def is_finalized(self):
+    @Deprecated(new="MultiAgentEpisode.custom_data[some-key] = ...", error=True)
+    def add_temporary_timestep_data(self):
         pass
 
-    @Deprecated(new="MultiAgentEpisode.to_numpy()", error=True)
-    def finalize(self):
+    @Deprecated(new="MultiAgentEpisode.custom_data[some-key]", error=True)
+    def get_temporary_timestep_data(self):
         pass

--- a/rllib/env/multi_agent_episode.py
+++ b/rllib/env/multi_agent_episode.py
@@ -79,7 +79,7 @@ class MultiAgentEpisode:
         "_last_step_time",
         "_len_lookback_buffers",
         "_start_time",
-        "custom_data",
+        "_custom_data",
     )
 
     SKIP_ENV_TS_TAG = "S"
@@ -287,7 +287,7 @@ class MultiAgentEpisode:
 
         # Cache for custom data. May be used to store custom metrics from within a
         # callback for the ongoing episode (e.g. render images).
-        self.custom_data = {}
+        self._custom_data = {}
 
         # Keep timer stats on deltas between steps.
         self._start_time = None
@@ -659,6 +659,10 @@ class MultiAgentEpisode:
         #  action/reward caches, etc..
 
     @property
+    def custom_data(self):
+        return self._custom_data
+
+    @property
     def is_reset(self) -> bool:
         """Returns True if `self.add_env_reset()` has already been called."""
         return any(
@@ -1006,7 +1010,7 @@ class MultiAgentEpisode:
         successor._hanging_rewards_begin = self._hanging_rewards_end.copy()
 
         # Deepcopy all custom data in `self` to be continued in the cut episode.
-        successor.custom_data = copy.deepcopy(self.custom_data)
+        successor._custom_data = copy.deepcopy(self.custom_data)
 
         return successor
 
@@ -1737,6 +1741,7 @@ class MultiAgentEpisode:
             ),
             "_start_time": self._start_time,
             "_last_step_time": self._last_step_time,
+            "custom_data": self.custom_data,
         }
 
     @staticmethod
@@ -1780,6 +1785,7 @@ class MultiAgentEpisode:
         }
         episode._start_time = state["_start_time"]
         episode._last_step_time = state["_last_step_time"]
+        episode._custom_data = state.get("custom_data", {})
 
         # Validate the episode.
         episode.validate()

--- a/rllib/env/tests/test_single_agent_episode.py
+++ b/rllib/env/tests/test_single_agent_episode.py
@@ -669,7 +669,7 @@ class TestSingelAgentEpisode(unittest.TestCase):
         self.assertEqual(type(episode_2._action_space), type(episode._action_space))
         check(episode_2._start_time, episode._start_time)
         check(episode_2._last_step_time, episode._last_step_time)
-        check(episode_2._temporary_timestep_data, episode._temporary_timestep_data)
+        check(episode_2.custom_data, episode.custom_data)
         self.assertDictEqual(episode_2.extra_model_outputs, episode.extra_model_outputs)
 
     def _create_episode(self, num_data, t_started=None, len_lookback_buffer=0):

--- a/rllib/examples/envs/env_rendering_and_recording.py
+++ b/rllib/examples/envs/env_rendering_and_recording.py
@@ -149,7 +149,9 @@ class EnvRenderCallback(RLlibCallback):
         # See below:
         # `on_episode_end()`: We compile the video and maybe store it).
         # `on_sample_end()` We log the best and worst video to the `MetricsLogger`.
-        episode.add_temporary_timestep_data("render_images", image)
+        if "render_images" not in episode.custom_data:
+            episode.custom_data["render_images"] = []
+        episode.custom_data["render_images"].append(image)
 
     def on_episode_end(
         self,
@@ -183,7 +185,7 @@ class EnvRenderCallback(RLlibCallback):
             or episode_return < self.worst_episode_and_return[1]
         ):
             # Pull all images from the temp. data of the episode.
-            images = episode.get_temporary_timestep_data("render_images")
+            images = episode.custom_data["render_images"]
             # `images` is now a list of 3D ndarrays
 
             # Create a video from the images by simply stacking them AND

--- a/rllib/examples/metrics/custom_metrics_in_env_runners.py
+++ b/rllib/examples/metrics/custom_metrics_in_env_runners.py
@@ -147,6 +147,10 @@ class MsPacmanHeatmapCallback(RLlibCallback):
         yx_pos = self._get_pacman_yx_pos(env)
         self._episode_start_position[episode.id_] = yx_pos
 
+        # Create two lists holding custom per-timestep data.
+        episode.custom_data["pacman_yx_pos"] = []
+        episode.custom_data["pacman_dist_travelled"] = []
+
     def on_episode_step(
         self,
         *,
@@ -168,7 +172,7 @@ class MsPacmanHeatmapCallback(RLlibCallback):
             return
 
         yx_pos = self._get_pacman_yx_pos(env)
-        episode.add_temporary_timestep_data("pacman_yx_pos", yx_pos)
+        episode.custom_data["pacman_yx_pos"].append(yx_pos)
 
         # Compute distance to start position.
         dist_travelled = np.sqrt(
@@ -179,7 +183,7 @@ class MsPacmanHeatmapCallback(RLlibCallback):
                 )
             )
         )
-        episode.add_temporary_timestep_data("pacman_dist_travelled", dist_travelled)
+        episode.custom_data["pacman_dist_travelled"].append(dist_travelled)
 
     def on_episode_end(
         self,
@@ -203,7 +207,7 @@ class MsPacmanHeatmapCallback(RLlibCallback):
         del self._episode_start_position[episode.id_]
 
         # Get all pacman y/x-positions from the episode.
-        yx_positions = episode.get_temporary_timestep_data("pacman_yx_pos")
+        yx_positions = episode.custom_data["pacman_yx_pos"]
         # h x w
         heatmap = np.zeros((80, 100), dtype=np.int32)
         for yx_pos in yx_positions:
@@ -229,7 +233,7 @@ class MsPacmanHeatmapCallback(RLlibCallback):
 
         # Get the max distance travelled for this episode.
         dist_travelled = np.max(
-            episode.get_temporary_timestep_data("pacman_dist_travelled")
+            episode.custom_data["pacman_dist_travelled"]
         )
 
         # Log the max. dist travelled in this episode (window=100).

--- a/rllib/examples/metrics/custom_metrics_in_env_runners.py
+++ b/rllib/examples/metrics/custom_metrics_in_env_runners.py
@@ -232,9 +232,7 @@ class MsPacmanHeatmapCallback(RLlibCallback):
         )
 
         # Get the max distance travelled for this episode.
-        dist_travelled = np.max(
-            episode.custom_data["pacman_dist_travelled"]
-        )
+        dist_travelled = np.max(episode.custom_data["pacman_dist_travelled"])
 
         # Log the max. dist travelled in this episode (window=100).
         metrics_logger.log_value(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Episode API: Add `custom_data` property and deprecate `add|get_temporary_timestep_data()` APIs.

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
