### PR TITLE
Add perf metrics for 2.45.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 408.977408,
+    "_dashboard_memory_usage_mb": 113.983488,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.77,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n2052\t7.08GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3587\t1.87GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4527\t0.84GiB\tpython distributed/test_many_actors.py\n3117\t0.34GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3703\t0.32GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n584\t0.19GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n2844\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3896\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3898\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru\n4309\t0.07GiB\tray::JobSupervisor",
-    "actors_per_second": 556.7424300497004,
+    "_peak_memory": 4.3,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1164\t4.36GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3402\t1.76GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5359\t0.89GiB\tpython distributed/test_many_actors.py\n2875\t0.37GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3604\t0.3GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n586\t0.18GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3518\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n4123\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n2789\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4125\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
+    "actors_per_second": 584.7284406495273,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 556.7424300497004
+            "perf_metric_value": 584.7284406495273
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 109.45
+            "perf_metric_value": 7.272
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2657.411
+            "perf_metric_value": 2276.06
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3654.592
+            "perf_metric_value": 4501.941
         }
     ],
     "success": "1",
-    "time": 17.96162724494934
+    "time": 17.101955890655518
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 258.248704,
+    "_dashboard_memory_usage_mb": 96.99328,
     "_dashboard_test_success": true,
-    "_peak_memory": 1.74,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n6317\t0.51GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2737\t0.29GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n6433\t0.25GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n9543\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n1975\t0.13GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n6626\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n2893\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n9846\t0.08GiB\tray::StateAPIGeneratorActor.start\n9754\t0.07GiB\tray::DashboardTester.run\n6628\t0.07GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
+    "_peak_memory": 2.29,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3929\t0.51GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2756\t0.29GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n7430\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n4128\t0.13GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n1129\t0.13GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4657\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n4126\t0.1GiB\tray-dashboard-EventHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import sp\n4045\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n2670\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n7648\t0.09GiB\tray::StateAPIGeneratorActor.start",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 173.3593587739248
+            "perf_metric_value": 184.76609554410751
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.388
+            "perf_metric_value": 6.661
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 43.569
+            "perf_metric_value": 42.609
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 87.305
+            "perf_metric_value": 52.83
         }
     ],
     "success": "1",
-    "tasks_per_second": 173.3593587739248,
-    "time": 305.76836466789246,
+    "tasks_per_second": 184.76609554410751,
+    "time": 305.4122483730316,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 177.385472,
+    "_dashboard_memory_usage_mb": 88.485888,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.15,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1124\t7.27GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3548\t0.92GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4653\t0.37GiB\tpython distributed/test_many_pgs.py\n2883\t0.3GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n583\t0.18GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3664\t0.14GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n2811\t0.1GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l\n3857\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n2959\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3859\t0.07GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
+    "_peak_memory": 2.7,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1160\t7.23GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3407\t0.96GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2568\t0.43GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4802\t0.36GiB\tpython distributed/test_many_pgs.py\n583\t0.18GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3606\t0.1GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n2727\t0.09GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l\n4137\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n2491\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3523\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13.476595071248589
+            "perf_metric_value": 13.498456472943806
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4.052
+            "perf_metric_value": 4.438
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 14.408
+            "perf_metric_value": 7.748
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 284.202
+            "perf_metric_value": 324.348
         }
     ],
-    "pgs_per_second": 13.476595071248589,
+    "pgs_per_second": 13.498456472943806,
     "success": "1",
-    "time": 74.20271921157837
+    "time": 74.08254432678223
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 980.299776,
+    "_dashboard_memory_usage_mb": 105.558016,
     "_dashboard_test_success": true,
-    "_peak_memory": 4.15,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3570\t1.56GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n3686\t0.9GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n4588\t0.74GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3050\t0.25GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1129\t0.12GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3880\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n2958\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4885\t0.08GiB\tray::StateAPIGeneratorActor.start\n4821\t0.08GiB\tray::DashboardTester.run\n3882\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
+    "_peak_memory": 3.87,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3410\t1.1GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4831\t0.75GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3614\t0.46GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n2828\t0.27GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3617\t0.18GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import sp\n1128\t0.12GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4136\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3526\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n2727\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n5059\t0.08GiB\tray::StateAPIGeneratorActor.start",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 396.2437230530813
+            "perf_metric_value": 386.57760124343247
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 147.409
+            "perf_metric_value": 4.972
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 644.873
+            "perf_metric_value": 498.863
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 992.107
+            "perf_metric_value": 773.119
         }
     ],
     "success": "1",
-    "tasks_per_second": 396.2437230530813,
-    "time": 325.23699283599854,
+    "tasks_per_second": 386.57760124343247,
+    "time": 325.8680274486542,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.44.1"}
+{"release_version": "2.45.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8120.290523884843,
-        158.34851735338898
+        8444.076833431887,
+        109.8906193815417
     ],
     "1_1_actor_calls_concurrent": [
-        5395.777383657067,
-        138.88384775053822
+        5197.977170580825,
+        212.32480863999945
     ],
     "1_1_actor_calls_sync": [
-        2042.7849558989133,
-        12.95298675392439
+        1970.1890755785905,
+        6.279095946464738
     ],
     "1_1_async_actor_calls_async": [
-        4826.01449586604,
-        303.1526382315391
+        4690.27307407808,
+        157.5633963254943
     ],
     "1_1_async_actor_calls_sync": [
-        1422.8840037746545,
-        17.9650251370281
+        1484.8537560953,
+        14.429707731927486
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2890.5921527302953,
-        227.22632962757234
+        2887.305655540158,
+        91.9412027571407
     ],
     "1_n_actor_calls_async": [
-        8163.666025779943,
-        250.39413803718676
+        8442.314246687905,
+        243.43825734663986
     ],
     "1_n_async_actor_calls_async": [
-        7146.829366873446,
-        187.12801670230965
+        7800.885681170592,
+        55.298699777675175
     ],
     "client__1_1_actor_calls_async": [
-        1046.3302124868333,
-        14.243246105452002
+        1086.8894650569318,
+        8.834625415868556
     ],
     "client__1_1_actor_calls_concurrent": [
-        1034.573173870887,
-        15.294615369682713
+        1095.8599860679442,
+        21.582794027321686
     ],
     "client__1_1_actor_calls_sync": [
-        518.0227400935812,
-        11.048383029520352
+        502.66993358678155,
+        27.959156824946863
     ],
     "client__get_calls": [
-        1059.14110418216,
-        89.536111176003
+        1166.944263833784,
+        26.80854064375958
     ],
     "client__put_calls": [
-        791.0601747873669,
-        27.32350428360487
+        806.8522252791361,
+        23.443214568427795
     ],
     "client__put_gigabytes": [
-        0.15530413946824417,
-        0.00035613100412910714
+        0.15539024775670351,
+        0.00048357711627779805
     ],
     "client__tasks_and_get_batch": [
-        0.9491360325704473,
-        0.01677407195154065
+        0.9736693864062806,
+        0.03368042368433273
     ],
     "client__tasks_and_put_batch": [
-        13875.973034658084,
-        114.745521620451
+        14921.634990237624,
+        90.2201928263096
     ],
     "multi_client_put_calls_Plasma_Store": [
-        16995.36748607658,
-        348.3512318633828
+        17225.275033455742,
+        400.51249084082644
     ],
     "multi_client_put_gigabytes": [
-        39.223735897953496,
-        1.2527003826588554
+        42.63542976122483,
+        2.956413982171539
     ],
     "multi_client_tasks_async": [
-        22746.78742695212,
-        2034.6339587892833
+        21993.93553882069,
+        504.6647568032584
     ],
     "n_n_actor_calls_async": [
-        27272.98195341939,
-        686.2097246898552
+        28201.299272185486,
+        222.0619153083122
     ],
     "n_n_actor_calls_with_arg_async": [
-        2540.930797772458,
-        60.02705978070071
+        2763.4671549404156,
+        25.273747830075962
     ],
     "n_n_async_actor_calls_async": [
-        23807.96024799393,
-        598.9144362661533
+        24305.549204990766,
+        935.8864435970182
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10427.64803464464
+            "perf_metric_value": 10749.987511970474
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4968.428055166902
+            "perf_metric_value": 5074.5127405902585
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 16995.36748607658
+            "perf_metric_value": 17225.275033455742
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 19.43618272983129
+            "perf_metric_value": 18.986090199611898
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.794726688358455
+            "perf_metric_value": 6.137193762523237
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 39.223735897953496
+            "perf_metric_value": 42.63542976122483
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.733366171990253
+            "perf_metric_value": 12.909895729510396
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4.7662393041672
+            "perf_metric_value": 4.997131305946631
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 963.0702098697656
+            "perf_metric_value": 967.6915002044169
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7293.311601095812
+            "perf_metric_value": 8007.8439530065825
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22746.78742695212
+            "perf_metric_value": 21993.93553882069
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2042.7849558989133
+            "perf_metric_value": 1970.1890755785905
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8120.290523884843
+            "perf_metric_value": 8444.076833431887
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5395.777383657067
+            "perf_metric_value": 5197.977170580825
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8163.666025779943
+            "perf_metric_value": 8442.314246687905
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 27272.98195341939
+            "perf_metric_value": 28201.299272185486
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2540.930797772458
+            "perf_metric_value": 2763.4671549404156
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1422.8840037746545
+            "perf_metric_value": 1484.8537560953
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4826.01449586604
+            "perf_metric_value": 4690.27307407808
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2890.5921527302953
+            "perf_metric_value": 2887.305655540158
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7146.829366873446
+            "perf_metric_value": 7800.885681170592
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23807.96024799393
+            "perf_metric_value": 24305.549204990766
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 752.4419303065624
+            "perf_metric_value": 777.3138561777844
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1059.14110418216
+            "perf_metric_value": 1166.944263833784
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 791.0601747873669
+            "perf_metric_value": 806.8522252791361
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.15530413946824417
+            "perf_metric_value": 0.15539024775670351
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13875.973034658084
+            "perf_metric_value": 14921.634990237624
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 518.0227400935812
+            "perf_metric_value": 502.66993358678155
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1046.3302124868333
+            "perf_metric_value": 1086.8894650569318
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1034.573173870887
+            "perf_metric_value": 1095.8599860679442
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.9491360325704473
+            "perf_metric_value": 0.9736693864062806
         }
     ],
     "placement_group_create/removal": [
-        752.4419303065624,
-        9.075848365096016
+        777.3138561777844,
+        7.184681487591427
     ],
     "single_client_get_calls_Plasma_Store": [
-        10427.64803464464,
-        415.4616837187185
+        10749.987511970474,
+        229.21715536154238
     ],
     "single_client_get_object_containing_10k_refs": [
-        12.733366171990253,
-        0.11955773247701625
+        12.909895729510396,
+        0.47897759652596766
     ],
     "single_client_put_calls_Plasma_Store": [
-        4968.428055166902,
-        71.1678398323514
+        5074.5127405902585,
+        108.08357883333088
     ],
     "single_client_put_gigabytes": [
-        19.43618272983129,
-        7.67756536646069
+        18.986090199611898,
+        7.817017632873358
     ],
     "single_client_tasks_and_get_batch": [
-        5.794726688358455,
-        2.806943552011234
+        6.137193762523237,
+        3.0715095947610935
     ],
     "single_client_tasks_async": [
-        7293.311601095812,
-        429.5735687315323
+        8007.8439530065825,
+        480.716877038182
     ],
     "single_client_tasks_sync": [
-        963.0702098697656,
-        8.340313742090311
+        967.6915002044169,
+        9.187667657445576
     ],
     "single_client_wait_1k_refs": [
-        4.7662393041672,
-        0.08896451807860041
+        4.997131305946631,
+        0.13212779524383766
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 16.360440398999998,
+    "broadcast_time": 12.626934259999999,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 16.360440398999998
+            "perf_metric_value": 12.626934259999999
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 19.557518630999994,
-    "get_time": 23.901681492999998,
+    "args_time": 19.189307459,
+    "get_time": 22.656893267,
     "large_object_size": 107374182400,
-    "large_object_time": 29.71225567700003,
+    "large_object_time": 28.701530757,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 19.557518630999994
+            "perf_metric_value": 19.189307459
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.692964964000012
+            "perf_metric_value": 5.785791095999997
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.901681492999998
+            "perf_metric_value": 22.656893267
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 201.25853992100002
+            "perf_metric_value": 188.94385793700002
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 29.71225567700003
+            "perf_metric_value": 28.701530757
         }
     ],
-    "queued_time": 201.25853992100002,
-    "returns_time": 5.692964964000012,
+    "queued_time": 188.94385793700002,
+    "returns_time": 5.785791095999997,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.1855878162384033,
-    "max_iteration_time": 4.6709630489349365,
-    "min_iteration_time": 0.048221588134765625,
+    "avg_iteration_time": 1.1924733638763427,
+    "max_iteration_time": 5.366504430770874,
+    "min_iteration_time": 0.05286550521850586,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.1855878162384033
+            "perf_metric_value": 1.1924733638763427
         }
     ],
     "success": 1,
-    "total_time": 118.5589005947113
+    "total_time": 119.24746370315552
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 6.457953453063965
+            "perf_metric_value": 7.069997787475586
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.536348390579224
+            "perf_metric_value": 12.511144208908082
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 39.29103755950928
+            "perf_metric_value": 38.58955483436584
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.700336217880249
+            "perf_metric_value": 1.9198436737060547
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1872.5359020233154
+            "perf_metric_value": 1838.6034362316132
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.5916298288019798
+            "perf_metric_value": 0.5643807586534827
         }
     ],
-    "stage_0_time": 6.457953453063965,
-    "stage_1_avg_iteration_time": 12.536348390579224,
-    "stage_1_max_iteration_time": 13.078275680541992,
-    "stage_1_min_iteration_time": 11.099312543869019,
-    "stage_1_time": 125.3635504245758,
-    "stage_2_avg_iteration_time": 39.29103755950928,
-    "stage_2_max_iteration_time": 39.89809560775757,
-    "stage_2_min_iteration_time": 38.93146586418152,
-    "stage_2_time": 196.4557385444641,
-    "stage_3_creation_time": 1.700336217880249,
-    "stage_3_time": 1872.5359020233154,
-    "stage_4_spread": 0.5916298288019798,
+    "stage_0_time": 7.069997787475586,
+    "stage_1_avg_iteration_time": 12.511144208908082,
+    "stage_1_max_iteration_time": 12.921896934509277,
+    "stage_1_min_iteration_time": 11.234705448150635,
+    "stage_1_time": 125.11151504516602,
+    "stage_2_avg_iteration_time": 38.58955483436584,
+    "stage_2_max_iteration_time": 39.280184507369995,
+    "stage_2_min_iteration_time": 38.13513684272766,
+    "stage_2_time": 192.94836735725403,
+    "stage_3_creation_time": 1.9198436737060547,
+    "stage_3_time": 1838.6034362316132,
+    "stage_4_spread": 0.5643807586534827,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 1.599322591591623,
-    "avg_pg_remove_time_ms": 1.362004578078044,
+    "avg_pg_create_time_ms": 1.4790909474473704,
+    "avg_pg_remove_time_ms": 1.2639661321323425,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.599322591591623
+            "perf_metric_value": 1.4790909474473704
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.362004578078044
+            "perf_metric_value": 1.2639661321323425
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 3.67%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 5395.777383657067 to 5197.977170580825 in microbenchmark.json
REGRESSION 3.55%: 1_1_actor_calls_sync (THROUGHPUT) regresses from 2042.7849558989133 to 1970.1890755785905 in microbenchmark.json
REGRESSION 3.31%: multi_client_tasks_async (THROUGHPUT) regresses from 22746.78742695212 to 21993.93553882069 in microbenchmark.json
REGRESSION 2.96%: client__1_1_actor_calls_sync (THROUGHPUT) regresses from 518.0227400935812 to 502.66993358678155 in microbenchmark.json
REGRESSION 2.81%: 1_1_async_actor_calls_async (THROUGHPUT) regresses from 4826.01449586604 to 4690.27307407808 in microbenchmark.json
REGRESSION 2.44%: tasks_per_second (THROUGHPUT) regresses from 396.2437230530813 to 386.57760124343247 in benchmarks/many_tasks.json
REGRESSION 2.32%: single_client_put_gigabytes (THROUGHPUT) regresses from 19.43618272983129 to 18.986090199611898 in microbenchmark.json
REGRESSION 0.11%: 1_1_async_actor_calls_with_args_async (THROUGHPUT) regresses from 2890.5921527302953 to 2887.305655540158 in microbenchmark.json
REGRESSION 23.63%: dashboard_p50_latency_ms (LATENCY) regresses from 5.388 to 6.661 in benchmarks/many_nodes.json
REGRESSION 23.19%: dashboard_p99_latency_ms (LATENCY) regresses from 3654.592 to 4501.941 in benchmarks/many_actors.json
REGRESSION 14.13%: dashboard_p99_latency_ms (LATENCY) regresses from 284.202 to 324.348 in benchmarks/many_pgs.json
REGRESSION 12.91%: stage_3_creation_time (LATENCY) regresses from 1.700336217880249 to 1.9198436737060547 in stress_tests/stress_test_many_tasks.json
REGRESSION 9.53%: dashboard_p50_latency_ms (LATENCY) regresses from 4.052 to 4.438 in benchmarks/many_pgs.json
REGRESSION 9.48%: stage_0_time (LATENCY) regresses from 6.457953453063965 to 7.069997787475586 in stress_tests/stress_test_many_tasks.json
REGRESSION 1.63%: 3000_returns_time (LATENCY) regresses from 5.692964964000012 to 5.785791095999997 in scalability/single_node.json
REGRESSION 0.58%: avg_iteration_time (LATENCY) regresses from 1.1855878162384033 to 1.1924733638763427 in stress_tests/stress_test_dead_actors.json
```