### PR TITLE
Train release test: Exclude warmup from Throughput metric

### DIFF
--- a/release/train_tests/benchmark/train_benchmark.py
+++ b/release/train_tests/benchmark/train_benchmark.py
@@ -288,7 +288,8 @@ class TrainLoopRunner:
         num_workers = ray.train.get_context().get_world_size()
         train_time = (
             self._metrics["train/step"].get()
-            + self._metrics["train/iter_first_batch"].get()
+            # Exclude the time it takes to get the first batch.
+            # + self._metrics["train/iter_first_batch"].get()
             + self._metrics["train/iter_batch"].get()
         )
         if train_time > 0:
@@ -301,7 +302,8 @@ class TrainLoopRunner:
 
         validation_time = (
             self._metrics["validation/step"].get()
-            + self._metrics["validation/iter_first_batch"].get()
+            # Exclude the time it takes to get the first batch.
+            # + self._metrics["validation/iter_first_batch"].get()
             + self._metrics["validation/iter_batch"].get()
         )
         if validation_time > 0:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Train release test: Exclude warmup from Throughput metric

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
