### PR TITLE
[core][cgraph] Separate metadata and data in cross-node shared memory transport

### DIFF
--- a/python/ray/dag/tests/experimental/test_multi_node_dag.py
+++ b/python/ray/dag/tests/experimental/test_multi_node_dag.py
@@ -187,6 +187,79 @@ def test_pp(ray_start_cluster, single_fetch):
     time.sleep(2)
 
 
+@pytest.mark.parametrize("single_fetch", [True, False])
+def test_pp_exception(ray_start_cluster, single_fetch):
+    """
+    This test is to verify that the exception can be passed properly
+    through pipeline parallel workers on different nodes.
+    """
+    cluster = ray_start_cluster
+    # This node is for the driver.
+    cluster.add_node(num_cpus=0)
+    ray.init(address=cluster.address)
+    TP = 2
+    # This node is for the PP stage 1.
+    cluster.add_node(resources={"pp1": TP})
+    # This node is for the PP stage 2.
+    cluster.add_node(resources={"pp2": TP})
+    # This node is for the PP stage 3.
+    cluster.add_node(resources={"pp3": TP})
+
+    # Simulate a large error message (e.g., those with a long stack trace)
+    large_error_message = "Model execution failed" * 10000
+
+    @ray.remote
+    class Worker:
+        def __init__(self):
+            pass
+
+        def execute_model(self, val):
+            if val == "exception_trigger":
+                # Simulate an exception happened during model execution
+                raise RuntimeError(large_error_message)
+            return val
+
+    pp1_workers = [
+        Worker.options(num_cpus=0, resources={"pp1": 1}).remote() for _ in range(TP)
+    ]
+    pp2_workers = [
+        Worker.options(num_cpus=0, resources={"pp2": 1}).remote() for _ in range(TP)
+    ]
+    pp3_workers = [
+        Worker.options(num_cpus=0, resources={"pp3": 1}).remote() for _ in range(TP)
+    ]
+
+    with InputNode() as inp:
+        outputs = [inp for _ in range(TP)]
+        outputs = [pp1_workers[i].execute_model.bind(outputs[i]) for i in range(TP)]
+        outputs = [pp2_workers[i].execute_model.bind(outputs[i]) for i in range(TP)]
+        outputs = [pp3_workers[i].execute_model.bind(outputs[i]) for i in range(TP)]
+        dag = MultiOutputNode(outputs)
+
+    compiled_dag = dag.experimental_compile()
+    refs = compiled_dag.execute("exception_trigger")
+
+    # Without the fix in this PR, we will encounter the following exception:
+    # File "/Users/ruiqiao/repos2/ray/python/ray/_private/serialization.py",
+    # line 460, in deserialize_objects
+    #     obj = self._deserialize_object(data, metadata, object_ref)
+    #     raise Exception(
+    #     Exception: Can't deserialize object:
+    #       ObjectRef(00a33d534c5b0ce51bdf175790467da3114801680100000002e1f505), metadata: b'\x00'
+    # With this fix, the original exception will be propagated.
+    if single_fetch:
+        for i in range(TP):
+            with pytest.raises(RuntimeError) as exc_info:
+                ray.get(refs[i])
+            assert "Can't deserialize object" not in str(exc_info.value)
+            assert large_error_message in str(exc_info.value)
+    else:
+        with pytest.raises(RuntimeError) as exc_info:
+            ray.get(refs)
+        assert "Can't deserialize object" not in str(exc_info.value)
+        assert large_error_message in str(exc_info.value)
+
+
 def test_payload_large(ray_start_cluster, monkeypatch):
     GRPC_MAX_SIZE = 1024 * 1024 * 5
     monkeypatch.setenv("RAY_max_grpc_message_size", str(GRPC_MAX_SIZE))
@@ -285,7 +358,7 @@ def test_multi_node_multi_reader_large_payload(
         # In the CI environment, the object store may use /tmp instead of /dev/shm
         # due to limited size of /tmp/shm and therefore has degraded performance.
         # Therefore, we use a longer timeout to avoid flakiness.
-        result = ray.get(ref, timeout=50)
+        result = ray.get(ref, timeout=100)
         assert result == [val for _ in range(ACTORS_PER_NODE * (NUM_REMOTE_NODES + 1))]
 
 

--- a/python/ray/dag/tests/experimental/test_multi_node_dag.py
+++ b/python/ray/dag/tests/experimental/test_multi_node_dag.py
@@ -358,7 +358,7 @@ def test_multi_node_multi_reader_large_payload(
         # In the CI environment, the object store may use /tmp instead of /dev/shm
         # due to limited size of /tmp/shm and therefore has degraded performance.
         # Therefore, we use a longer timeout to avoid flakiness.
-        result = ray.get(ref, timeout=100)
+        result = ray.get(ref, timeout=50)
         assert result == [val for _ in range(ACTORS_PER_NODE * (NUM_REMOTE_NODES + 1))]
 
 

--- a/src/mock/ray/raylet_client/raylet_client.h
+++ b/src/mock/ray/raylet_client/raylet_client.h
@@ -110,6 +110,7 @@ class MockRayletClientInterface : public RayletClientInterface {
                uint64_t data_size,
                uint64_t metadata_size,
                void *data,
+               void *metadata,
                const rpc::ClientCallback<ray::rpc::PushMutableObjectReply> &callback),
               (override));
   MOCK_METHOD(void,

--- a/src/ray/core_worker/experimental_mutable_object_provider.cc
+++ b/src/ray/core_worker/experimental_mutable_object_provider.cc
@@ -131,7 +131,6 @@ void MutableObjectProvider::HandlePushMutableObject(
   }
   size_t total_data_size = request.total_data_size();
   size_t total_metadata_size = request.total_metadata_size();
-  size_t total_size = total_data_size + total_metadata_size;
 
   uint64_t offset = request.offset();
   uint64_t chunk_size = request.chunk_size();
@@ -142,7 +141,7 @@ void MutableObjectProvider::HandlePushMutableObject(
 
     tmp_written_so_far = written_so_far_[writer_object_id];
     written_so_far_[writer_object_id] += chunk_size;
-    if (written_so_far_[writer_object_id] == total_size) {
+    if (written_so_far_[writer_object_id] == total_data_size) {
       written_so_far_.erase(written_so_far_.find(writer_object_id));
     }
   }
@@ -150,9 +149,7 @@ void MutableObjectProvider::HandlePushMutableObject(
   std::shared_ptr<Buffer> object_backing_store;
   if (tmp_written_so_far == 0u) {
     // We set `metadata` to nullptr since the metadata is at the end of the object, which
-    // we will not have until the last chunk is received (or until the two last chunks are
-    // received, if the metadata happens to span both). The metadata will end up being
-    // written along with the data as the chunks are written.
+    // we will not have until the last chunk is received.
     RAY_CHECK_OK(object_manager_->WriteAcquire(info.local_object_id,
                                                total_data_size,
                                                /*metadata=*/nullptr,
@@ -167,14 +164,14 @@ void MutableObjectProvider::HandlePushMutableObject(
   }
   RAY_CHECK(object_backing_store);
 
-  // The buffer has the data immediately followed by the metadata. `WriteAcquire()`
-  // above checks that the buffer size is large enough to hold both the data and the
-  // metadata.
-  memcpy(object_backing_store->Data() + offset, request.payload().data(), chunk_size);
-
+  memcpy(object_backing_store->Data() + offset, request.data().data(), chunk_size);
   size_t total_written = tmp_written_so_far + chunk_size;
-  RAY_CHECK_LE(total_written, total_size);
-  if (total_written == total_size) {
+  RAY_CHECK_LE(total_written, total_data_size);
+  if (total_written == total_data_size) {
+    // Copy the metadata to the end of the object.
+    memcpy(object_backing_store->Data() + total_data_size,
+           request.metadata().data(),
+           total_metadata_size);
     // The entire object has been written, so call `WriteRelease()`.
     RAY_CHECK_OK(object_manager_->WriteRelease(info.local_object_id));
     reply->set_done(true);
@@ -245,6 +242,7 @@ void MutableObjectProvider::PollWriterClosure(
         object->GetData()->Size(),
         object->GetMetadata()->Size(),
         object->GetData()->Data(),
+        object->GetMetadata()->Data(),
         [this, &io_context, writer_object_id, remote_readers, num_replied](
             const Status &status, const rpc::PushMutableObjectReply &reply) {
           *num_replied += 1;

--- a/src/ray/core_worker/test/mutable_object_provider_test.cc
+++ b/src/ray/core_worker/test/mutable_object_provider_test.cc
@@ -121,6 +121,7 @@ class TestInterface : public MutableObjectReaderInterface {
       uint64_t data_size,
       uint64_t metadata_size,
       void *data,
+      void *metadata,
       const rpc::ClientCallback<rpc::PushMutableObjectReply> &callback) override {
     absl::MutexLock guard(&lock_);
     pushed_objects_.push_back(object_id);

--- a/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
+++ b/src/ray/gcs/gcs_server/test/gcs_server_test_util.h
@@ -157,6 +157,7 @@ struct GcsServerMocker {
         uint64_t data_size,
         uint64_t metadata_size,
         void *data,
+        void *metadata,
         const rpc::ClientCallback<rpc::PushMutableObjectReply> &callback) override {}
 
     // Trigger reply to RequestWorkerLease.

--- a/src/ray/protobuf/node_manager.proto
+++ b/src/ray/protobuf/node_manager.proto
@@ -364,12 +364,14 @@ message PushMutableObjectRequest {
   // The total size of the metadata (across all chunks).
   uint64 total_metadata_size = 3;
 
-  // The offset of the chunk (in bytes) within the object.
+  // The offset of the chunk (in bytes) within the object's data.
   uint64 offset = 4;
-  // The size of this chunk. Note that this size could include both data and metadata.
+  // The size of data payload chunk.
   uint64 chunk_size = 5;
-  // The chunk payload. Note that this could include both data and metadata.
-  bytes payload = 6;
+  // The data payload.
+  bytes data = 6;
+  // The metadata payload. Note that the size of metadata is minimal.
+  bytes metadata = 7;
 }
 
 message PushMutableObjectReply {

--- a/src/ray/raylet_client/raylet_client.cc
+++ b/src/ray/raylet_client/raylet_client.cc
@@ -330,15 +330,15 @@ void RayletClient::PushMutableObject(
     uint64_t data_size,
     uint64_t metadata_size,
     void *data,
+    void *metadata,
     const ray::rpc::ClientCallback<ray::rpc::PushMutableObjectReply> &callback) {
   // Ray sets the gRPC max payload size to ~512 MiB. We set the max chunk size to a
   // slightly lower value to allow extra padding just in case.
   uint64_t kMaxGrpcPayloadSize = RayConfig::instance().max_grpc_message_size() * 0.98;
-  uint64_t total_size = data_size + metadata_size;
-  uint64_t total_num_chunks = total_size / kMaxGrpcPayloadSize;
-  // If `total_size` is not a multiple of `kMaxGrpcPayloadSize`, then we need to send an
+  uint64_t total_num_chunks = data_size / kMaxGrpcPayloadSize;
+  // If `data_size` is not a multiple of `kMaxGrpcPayloadSize`, then we need to send an
   // extra chunk with the remaining data.
-  if (total_size % kMaxGrpcPayloadSize) {
+  if (data_size % kMaxGrpcPayloadSize) {
     total_num_chunks++;
   }
 
@@ -349,13 +349,14 @@ void RayletClient::PushMutableObject(
     request.set_total_metadata_size(metadata_size);
 
     uint64_t chunk_size = (i < total_num_chunks - 1) ? kMaxGrpcPayloadSize
-                                                     : (total_size % kMaxGrpcPayloadSize);
+                                                     : (data_size % kMaxGrpcPayloadSize);
     uint64_t offset = i * kMaxGrpcPayloadSize;
     request.set_offset(offset);
     request.set_chunk_size(chunk_size);
-    // This assumes that the format of the object is a contiguous buffer of (data |
-    // metadata).
-    request.set_payload(static_cast<char *>(data) + offset, chunk_size);
+    request.set_data(static_cast<char *>(data) + offset, chunk_size);
+    // Set metadata for each message so on the receiver side
+    // metadata from any message can be used.
+    request.set_metadata(static_cast<char *>(metadata), metadata_size);
 
     // TODO(jackhumphries): Add failure recovery, retries, and timeout.
     grpc_client_->PushMutableObject(

--- a/src/ray/raylet_client/raylet_client.h
+++ b/src/ray/raylet_client/raylet_client.h
@@ -211,7 +211,8 @@ class MutableObjectReaderInterface {
   /// node.
   /// \param metadata_size The size of the metadata to write to the mutable object on this
   /// local node.
-  /// \param data The data and metadata to write. This is formatted as (data | metadata).
+  /// \param data The data to write to the mutable object on this local node.
+  /// \param metadata The metadata to write to the mutable object on this local node.
   /// \param callback This callback is executed to send a reply to the remote node once
   /// the mutable object is transferred.
   virtual void PushMutableObject(
@@ -219,6 +220,7 @@ class MutableObjectReaderInterface {
       uint64_t data_size,
       uint64_t metadata_size,
       void *data,
+      void *metadata,
       const rpc::ClientCallback<rpc::PushMutableObjectReply> &callback) = 0;
 };
 
@@ -448,6 +450,7 @@ class RayletClient : public RayletClientInterface {
                          uint64_t data_size,
                          uint64_t metadata_size,
                          void *data,
+                         void *metadata,
                          const ray::rpc::ClientCallback<ray::rpc::PushMutableObjectReply>
                              &callback) override;
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

In https://github.com/vllm-project/vllm/issues/15333 , when insufficient spare memory is configured, vLLM worker ran into an OutOfMemoryError. However, this error does not propagate properly down to the driver. Instead, an ObjectRef deserialization exception is reported, example:

```
(RayWorkerWrapper pid=362, ip=10.99.48.141) Can't deserialize object: ObjectRef(00f70cd4dc4a5093b6e418c01fc7b425c87053d30100000002e1f505), metadata: b'\x00'
(RayWorkerWrapper pid=362, ip=10.99.48.141) Traceback (most recent call last):
(RayWorkerWrapper pid=362, ip=10.99.48.141)   File "/usr/local/lib/python3.12/dist-packages/ray/_private/serialization.py", line 331, in _deserialize_object
(RayWorkerWrapper pid=362, ip=10.99.48.141)     error_type = int(metadata_fields[0])
(RayWorkerWrapper pid=362, ip=10.99.48.141)                  ^^^^^^^^^^^^^^^^^^^^^^^
(RayWorkerWrapper pid=362, ip=10.99.48.141) ValueError: invalid literal for int() with base 10: b'\x00'
```

The bug that caused this is:
* `PushMutableObject()` assumes that the data and metadata of a Ray Object is contiguous in memory, however,
* This is not the case for exceptions: https://github.com/ray-project/ray/blob/7faa62a8c92dbc253586ce43b976332e6755086e/src/ray/core_worker/experimental_mutable_object_manager.cc#L384

As a result, incorrect "metadata" is copied and deserialized.

This PR fixes the issue by removing the assumption that Ray Object data and metadata are contiguous, which makes the implementation more robust. It also separates the data and metadata into different fields in protobuf message so that their copying can happen independently. Note that metadata is a few bytes, and the `PushMutableObject()` chunk size is more than 10MB smaller than gRPC payload limit, so it will not overflow the message.

## Related issue number

<!-- For example: "Closes #1234" -->
Closes https://github.com/vllm-project/vllm/issues/15333
Closes https://github.com/vllm-project/vllm/issues/15769

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Tested with vLLM workload
   - [ ] Release tests
   - [ ] This PR is not tested :(
