### PR TITLE
[train ingest benchmark] separate prefetch_batches and prefetch_factor

### DIFF
--- a/release/train_tests/benchmark/config.py
+++ b/release/train_tests/benchmark/config.py
@@ -13,12 +13,12 @@ class DataloaderType(enum.Enum):
 class DataLoaderConfig(BaseModel):
     train_batch_size: int = 32
     validation_batch_size: int = 256
-    prefetch_batches: int = 1
 
 
 class RayDataConfig(DataLoaderConfig):
     # NOTE: Optional[int] doesn't play well with argparse.
     local_buffer_shuffle_size: int = -1
+    ray_data_prefetch_batches: int = 4
 
 
 class TorchConfig(DataLoaderConfig):
@@ -26,6 +26,7 @@ class TorchConfig(DataLoaderConfig):
     torch_dataloader_timeout_seconds: int = 300
     torch_pin_memory: bool = True
     torch_non_blocking: bool = True
+    torch_prefetch_factor: int = -1
 
 
 class BenchmarkConfig(BaseModel):

--- a/release/train_tests/benchmark/ray_dataloader_factory.py
+++ b/release/train_tests/benchmark/ray_dataloader_factory.py
@@ -54,7 +54,7 @@ class RayDataLoaderFactory(BaseDataLoaderFactory):
                     else None
                 ),
                 collate_fn=self.collate_fn,
-                prefetch_batches=dataloader_config.prefetch_batches,
+                prefetch_batches=dataloader_config.ray_data_prefetch_batches,
             )
         )
 
@@ -65,7 +65,7 @@ class RayDataLoaderFactory(BaseDataLoaderFactory):
             ds_iterator.iter_torch_batches(
                 batch_size=dataloader_config.validation_batch_size,
                 collate_fn=self.collate_fn,
-                prefetch_batches=dataloader_config.prefetch_batches,
+                prefetch_batches=dataloader_config.ray_data_prefetch_batches,
             )
         )
 

--- a/release/train_tests/benchmark/torch_dataloader_factory.py
+++ b/release/train_tests/benchmark/torch_dataloader_factory.py
@@ -115,10 +115,11 @@ class TorchDataLoaderFactory(BaseDataLoaderFactory, ABC):
         persistent_workers = num_workers > 0
         pin_memory = dataloader_config.torch_pin_memory
 
-        # Only set prefetch_factor and timeout when using workers
-        prefetch_factor = (
-            dataloader_config.prefetch_batches if num_workers > 0 else None
-        )
+        if dataloader_config.prefetch_factor >= 0:
+            prefetch_factor = dataloader_config.torch_prefetch_factor
+        else:
+            prefetch_factor = None
+
         timeout = (
             dataloader_config.torch_dataloader_timeout_seconds if num_workers > 0 else 0
         )


### PR DESCRIPTION
prefetch_batches serves as 2 different purposes for torch data loader and ray data. Spilt into 2 different args.