### PR TITLE
[core] Deflake sigint cgraph test

### DIFF
--- a/python/ray/dag/tests/experimental/test_dag_error_handling.py
+++ b/python/ray/dag/tests/experimental/test_dag_error_handling.py
@@ -876,8 +876,7 @@ ray.get(ref)
         driver_script, env={"RAY_CGRAPH_teardown_timeout": "0"}
     )
     # wait for graph execution to start
-    while driver_proc.stdout.readline() != b"executing\n":
-        pass
+    assert driver_proc.stdout.readline() == b"executing\n"
     driver_proc.send_signal(signal.SIGINT)  # ctrl+c
     # teardown will kill actors after timeout
     wait_for_pid_to_exit(driver_proc.pid, 10)

--- a/python/ray/dag/tests/experimental/test_dag_error_handling.py
+++ b/python/ray/dag/tests/experimental/test_dag_error_handling.py
@@ -22,9 +22,9 @@ from ray._common.utils import (
 from ray._private.test_utils import (
     run_string_as_driver_nonblocking,
     wait_for_pid_to_exit,
+    SignalActor,
 )
 import signal
-import psutil
 
 from ray.dag.tests.experimental.actor_defs import Actor
 
@@ -315,14 +315,25 @@ def test_buffered_get_timeout(ray_start_regular):
 
 
 def test_get_with_zero_timeout(ray_start_regular):
-    a = Actor.remote(0)
+    @ray.remote
+    class Actor:
+        def __init__(self, signal_actor):
+            self.signal_actor = signal_actor
+
+        def send(self, x):
+            self.signal_actor.send.remote()
+            return x
+
+    signal_actor = SignalActor.remote()
+    a = Actor.remote(signal_actor)
     with InputNode() as inp:
-        dag = a.inc.bind(inp)
+        dag = a.send.bind(inp)
 
     compiled_dag = dag.experimental_compile()
     ref = compiled_dag.execute(1)
     # Give enough time for DAG execution result to be ready
-    time.sleep(2)
+    ray.get(signal_actor.wait.remote())
+    time.sleep(0.1)
     # Use timeout=0 to either get result immediately or raise an exception
     result = ray.get(ref, timeout=0)
     assert result == 1
@@ -840,7 +851,6 @@ def test_missing_input_node():
         dag.experimental_compile()
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Sigint not supported on Windows")
 def test_sigint_get_dagref(ray_start_cluster):
     driver_script = """
 import ray
@@ -852,27 +862,25 @@ ray.init()
 @ray.remote
 class Actor:
     def sleep(self, x):
-        while(True):
-            time.sleep(x)
+        time.sleep(x)
 
 a = Actor.remote()
 with InputNode() as inp:
     dag = a.sleep.bind(inp)
 compiled_dag = dag.experimental_compile()
-ref = compiled_dag.execute(1)
-ray.get(ref, timeout=100)
+ref = compiled_dag.execute(100)
+print("executing", flush=True)
+ray.get(ref)
 """
     driver_proc = run_string_as_driver_nonblocking(
-        driver_script, env={"RAY_CGRAPH_teardown_timeout": "5"}
+        driver_script, env={"RAY_CGRAPH_teardown_timeout": "0"}
     )
-    pid = driver_proc.pid
     # wait for graph execution to start
-    time.sleep(5)
-    proc = psutil.Process(pid)
-    assert proc.status() == psutil.STATUS_RUNNING
-    os.kill(pid, signal.SIGINT)  # ctrl+c
-    # teardown will kill actors after 5 second timeout
-    wait_for_pid_to_exit(pid, 10)
+    while driver_proc.stdout.readline() != b"executing\n":
+        pass
+    driver_proc.send_signal(signal.SIGINT)  # ctrl+c
+    # teardown will kill actors after timeout
+    wait_for_pid_to_exit(driver_proc.pid, 10)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The sigint cgraph test was flaky. Also removed another 2 second sleep from the other test.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
