### PR TITLE
[Data] Cleaning up streaming executor

### DIFF
--- a/python/ray/data/_internal/execution/autoscaler/default_autoscaler.py
+++ b/python/ray/data/_internal/execution/autoscaler/default_autoscaler.py
@@ -70,7 +70,7 @@ class DefaultAutoscaler(Autoscaler):
         if not op_state._scheduling_status.under_resource_limits:
             return False
         # Do not scale up, if the op has enough free slots for the existing inputs.
-        if op_state.num_queued() <= actor_pool.num_free_task_slots():
+        if op_state.total_input_enqueued() <= actor_pool.num_free_task_slots():
             return False
         # Determine whether to scale up based on the actor pool utilization.
         util = self._calculate_actor_pool_util(actor_pool)
@@ -138,11 +138,12 @@ class DefaultAutoscaler(Autoscaler):
         # Scale up the cluster, if no ops are allowed to run, but there are still data
         # in the input queues.
         no_runnable_op = all(
-            op_state._scheduling_status.runnable is False
+            not op_state._scheduling_status.runnable
             for _, op_state in self._topology.items()
         )
         any_has_input = any(
-            op_state.num_queued() > 0 for _, op_state in self._topology.items()
+            op_state.total_input_enqueued() > 0
+            for _, op_state in self._topology.items()
         )
         if not (no_runnable_op and any_has_input):
             return
@@ -167,7 +168,7 @@ class DefaultAutoscaler(Autoscaler):
             resource_request.extend([task_bundle] * op.num_active_tasks())
             # Only include incremental resource usage for ops that are ready for
             # dispatch.
-            if state.num_queued() > 0:
+            if state.total_input_enqueued() > 0:
                 # TODO(Clark): Scale up more aggressively by adding incremental resource
                 # usage for more than one bundle in the queue for this op?
                 resource_request.append(task_bundle)

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -11,7 +11,6 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
 
 import ray
-from ray.data._internal.execution.autoscaler import Autoscaler
 from ray.data._internal.execution.backpressure_policy import BackpressurePolicy
 from ray.data._internal.execution.bundle_queue import create_bundle_queue
 from ray.data._internal.execution.interfaces import (
@@ -155,9 +154,6 @@ class OpSchedulingStatus:
     call.
     """
 
-    # Whether the op was selected to run in the last scheduling
-    # decision.
-    selected: bool = False
     # Whether the op was considered runnable in the last scheduling
     # decision.
     runnable: bool = False
@@ -177,16 +173,15 @@ class OpState:
     """
 
     def __init__(self, op: PhysicalOperator, inqueues: List[OpBufferQueue]):
-        # Each inqueue is connected to another operator's outqueue.
+        # Each input queue is connected to another operator's output queue.
         assert len(inqueues) == len(op.input_dependencies), (op, inqueues)
-        self.inqueues: List[OpBufferQueue] = inqueues
-        # The outqueue is connected to another operator's inqueue (they physically
-        # share the same Python list reference).
+        self.input_queues: List[OpBufferQueue] = inqueues
+        # The output queue is connected to another operator's input queue (same object).
         #
         # Note: this queue is also accessed concurrently from the consumer thread.
         # (in addition to the streaming executor thread). Hence, it must be a
         # thread-safe type such as `deque`.
-        self.outqueue: OpBufferQueue = OpBufferQueue()
+        self.output_queue: OpBufferQueue = OpBufferQueue()
         self.op = op
         self.progress_bar = None
         self.num_completed_tasks = 0
@@ -236,17 +231,17 @@ class OpState:
             if isinstance(self.op, AllToAllOperator):
                 self.op.close_sub_progress_bars()
 
-    def num_queued(self) -> int:
-        """Return the number of queued bundles across all inqueues."""
-        return sum(len(q) for q in self.inqueues)
+    def total_input_enqueued(self) -> int:
+        """Return the number of enqueued bundles across all input queues."""
+        return sum(len(q) for q in self.input_queues)
 
-    def num_processing(self):
-        """Return the number of bundles currently in processing for this operator."""
-        return self.op.num_active_tasks() + self.op.internal_queue_size()
+    def total_output_enqueued(self) -> int:
+        """Return the number of enqueued bundles across all input queues."""
+        return len(self.output_queue)
 
     def add_output(self, ref: RefBundle) -> None:
         """Move a bundle produced by the operator to its outqueue."""
-        self.outqueue.append(ref)
+        self.output_queue.append(ref)
         self.num_completed_tasks += 1
         if self.progress_bar:
             assert (
@@ -285,7 +280,7 @@ class OpState:
         desc += self.op.actor_info_progress_str()
 
         # Queued blocks
-        queued = self.num_queued() + self.op.internal_queue_size()
+        queued = self.total_input_enqueued() + self.op.internal_queue_size()
         desc += f"; Queued blocks: {queued}"
         desc += f"; Resources: {resource_manager.get_op_usage_str(self.op)}"
 
@@ -298,7 +293,7 @@ class OpState:
 
     def dispatch_next_task(self) -> None:
         """Move a bundle from the operator inqueue to the operator itself."""
-        for i, inqueue in enumerate(self.inqueues):
+        for i, inqueue in enumerate(self.input_queues):
             ref = inqueue.pop()
             if ref is not None:
                 self.op.add_input(ref, input_index=i)
@@ -319,9 +314,9 @@ class OpState:
             # Check if StreamingExecutor has caught an exception or is done execution.
             if self._exception is not None:
                 raise self._exception
-            elif self._finished and not self.outqueue.has_next(output_split_idx):
+            elif self._finished and not self.output_queue.has_next(output_split_idx):
                 raise StopIteration()
-            ref = self.outqueue.pop(output_split_idx)
+            ref = self.output_queue.pop(output_split_idx)
             if ref is not None:
                 return ref
             time.sleep(0.01)
@@ -329,7 +324,7 @@ class OpState:
     def inqueue_memory_usage(self) -> int:
         """Return the object store memory of this operator's inqueue."""
         total = 0
-        for op, inq in zip(self.op.input_dependencies, self.inqueues):
+        for op, inq in zip(self.op.input_dependencies, self.input_queues):
             # Exclude existing input data items from dynamic memory usage.
             if not isinstance(op, InputDataBuffer):
                 total += inq.memory_usage
@@ -337,11 +332,11 @@ class OpState:
 
     def outqueue_memory_usage(self) -> int:
         """Return the object store memory of this operator's outqueue."""
-        return self.outqueue.memory_usage
+        return self.output_queue.memory_usage
 
     def outqueue_num_blocks(self) -> int:
         """Return the number of blocks in this operator's outqueue."""
-        return self.outqueue.num_blocks
+        return self.output_queue.num_blocks
 
     def mark_finished(self, exception: Optional[Exception] = None):
         """Marks this operator as finished. Used for exiting get_output_blocking."""
@@ -380,7 +375,7 @@ def build_streaming_topology(
         inqueues = []
         for i, parent in enumerate(op.input_dependencies):
             parent_state = setup_state(parent)
-            inqueues.append(parent_state.outqueue)
+            inqueues.append(parent_state.output_queue)
 
         # Create state.
         op_state = OpState(op, inqueues)
@@ -515,7 +510,7 @@ def update_operator_states(topology: Topology) -> None:
             continue
         all_inputs_done = True
         for idx, dep in enumerate(op.input_dependencies):
-            if dep.completed() and not topology[dep].outqueue:
+            if dep.completed() and not topology[dep].output_queue:
                 if not op_state.input_done_called[idx]:
                     op.input_done(idx)
                     op_state.input_done_called[idx] = True
@@ -539,48 +534,60 @@ def update_operator_states(topology: Topology) -> None:
             op.mark_execution_finished()
 
 
-def select_operator_to_run(
+def get_eligible_operators(
     topology: Topology,
-    resource_manager: ResourceManager,
     backpressure_policies: List[BackpressurePolicy],
-    autoscaler: Autoscaler,
-    ensure_at_least_one_running: bool,
-) -> Optional[PhysicalOperator]:
-    """Select an operator to run, if possible.
+    resource_manager: ResourceManager,
+    *,
+    ensure_liveness: bool,
+) -> List[PhysicalOperator]:
+    """This method returns all operators that are eligible for execution in the current state
+    of the pipeline.
 
-    The objective of this function is to maximize the throughput of the overall
-    pipeline, subject to defined memory and parallelism limits.
+    Operator is considered eligible for execution iff:
 
-    This is currently implemented by applying backpressure on operators that are
-    producing outputs faster than they are consuming them `len(outqueue)`, as well as
-    operators with a large number of running tasks `num_processing()`.
+        1. It's NOT completed
+        2. It has at least 1 input block (in the input queue)
+        3. It can accept new inputs
+        4. It's not currently throttled (for task-submission)
 
-    Note that memory limits also apply to the outqueue of the output operator. This
-    provides backpressure if the consumer is slow. However, once a bundle is returned
-    to the user, it is no longer tracked.
     """
+
     # Filter to ops that are eligible for execution.
-    ops = []
+    eligible_ops: List[PhysicalOperator] = []
     for op, state in topology.items():
         assert resource_manager.op_resource_allocator_enabled(), topology
+
+        # Check whether the operator is under its limits imposed by the
+        # resource manager
         under_resource_limits = (
             resource_manager.op_resource_allocator.can_submit_new_task(op)
         )
-        in_backpressure = not under_resource_limits or any(
-            not p.can_add_input(op) for p in backpressure_policies
+        # Operator is considered being in task-submission back-pressure if
+        # both of the following holds true:
+        #   - It's exceeding its resource limits
+        #   - At least one of the back-pressure policies are violated
+        in_backpressure = not under_resource_limits or not all(
+            p.can_add_input(op) for p in backpressure_policies
         )
+
         op_runnable = False
+
+        # Check whether operator could start executing immediately:
+        #   - It's not completed
+        #   - It can accept at least one input
+        #   - Its input queue is not empty
         if (
-            not in_backpressure
-            and not op.completed()
-            and state.num_queued() > 0
+            not op.completed()
             and op.should_add_input()
+            and state.total_input_enqueued() > 0
+            and not in_backpressure
         ):
-            ops.append(op)
             op_runnable = True
+            eligible_ops.append(op)
+
         # Update scheduling status
         state._scheduling_status = OpSchedulingStatus(
-            selected=False,
             runnable=op_runnable,
             under_resource_limits=under_resource_limits,
         )
@@ -588,31 +595,98 @@ def select_operator_to_run(
         # Signal whether op in backpressure for stats collections
         op.notify_in_task_submission_backpressure(in_backpressure)
 
-    # To ensure liveness, allow at least 1 op to run regardless of limits. This is
-    # gated on `ensure_at_least_one_running`, which is set if the consumer is blocked.
+    # To ensure liveness, allow at least 1 operator to schedule tasks regardless of
+    # limits in case when topology is entirely idle (no active tasks running)
     if (
-        ensure_at_least_one_running
-        and not ops
+        not eligible_ops
+        and ensure_liveness
         and all(op.num_active_tasks() == 0 for op in topology)
     ):
-        # The topology is entirely idle, so choose from all ready ops ignoring limits.
-        ops = [
+        eligible_ops = [
             op
             for op, state in topology.items()
-            if state.num_queued() > 0 and not op.completed()
+            # Pick only operators that have a non-empty input queue
+            if state.total_input_enqueued() > 0 and not op.completed()
         ]
 
-    selected_op = None
-    if ops:
-        # Run metadata-only operators first. After that, choose the operator with the
-        # least memory usage.
-        selected_op = min(
-            ops,
-            key=lambda op: (
-                not op.throttling_disabled(),
-                resource_manager.get_op_usage(op).object_store_memory,
-            ),
+    return eligible_ops
+
+
+def select_operator_to_run(
+    topology: Topology,
+    resource_manager: ResourceManager,
+    backpressure_policies: List[BackpressurePolicy],
+    ensure_liveness: bool,
+) -> Optional[PhysicalOperator]:
+    """Select next operator to launch new tasks.
+
+    The objective of this method is to maximize the throughput of the overall
+    pipeline, subject to defined memory, parallelism and other constraints.
+
+    To achieve that this method implements following protocol:
+
+        1. Collects all _eligible_ to run operators (check `_get_eligible_ops`
+           for more details)
+        2. Applies stack-ranking algorithm to select the best operator (check
+           `_create_eligible_ops_ranker` for more details)
+
+    """
+    eligible_ops = get_eligible_operators(
+        topology,
+        backpressure_policies,
+        resource_manager,
+        ensure_liveness=ensure_liveness,
+    )
+
+    if not eligible_ops:
+        return None
+
+    ranks = _rank_operators(eligible_ops, resource_manager)
+
+    assert len(eligible_ops) == len(ranks), (eligible_ops, ranks)
+
+    next_op, _ = min(zip(eligible_ops, ranks), key=lambda t: t[1])
+
+    return next_op
+
+
+def _rank_operators(
+    ops: List[PhysicalOperator], resource_manager: ResourceManager
+) -> List[Tuple]:
+    """Picks operator to run according to the following semantic:
+
+    Operator to run next is selected as the one with the *smallest* value
+    of the lexicographically ordered ranks composed of (in order):
+
+        1. Whether operator's could be throttled (bool)
+        2. Operators' object store utilization
+
+    Consider following examples:
+
+    Example 1:
+
+        Operator 1 with rank (True, 1024 bytes)
+        Operator 2 with rank (False, 2048 bytes)
+
+    In that case Operator 2 will be selected.
+
+    Example 2:
+
+        Operator 1 with rank (True, 1024 bytes)
+        Operator 2 with rank (True, 2048 bytes)
+
+    In that case Operator 1 will be selected.
+    """
+
+    assert len(ops) > 0, ops
+
+    def _ranker(op):
+        # Rank composition:
+        #   1. Whether throttling is enabled
+        #   2. Estimated Object Store usage
+        return (
+            not op.throttling_disabled(),
+            resource_manager.get_op_usage(op).object_store_memory,
         )
-        topology[selected_op]._scheduling_status.selected = True
-    autoscaler.try_trigger_scaling()
-    return selected_op
+
+    return [_ranker(op) for op in ops]

--- a/python/ray/data/tests/test_autoscaler.py
+++ b/python/ray/data/tests/test_autoscaler.py
@@ -33,7 +33,7 @@ def test_actor_pool_scaling():
         _inputs_complete=False,
         internal_queue_size=MagicMock(return_value=1),
     )
-    op_state = MagicMock(num_queued=MagicMock(return_value=10))
+    op_state = MagicMock(total_input_enqueued=MagicMock(return_value=10))
     op_scheduling_status = MagicMock(under_resource_limits=True)
     op_state._scheduling_status = op_scheduling_status
 
@@ -96,7 +96,7 @@ def test_actor_pool_scaling():
 
     # Shouldn't scale up since the op has enough free slots for
     # the existing inputs.
-    with patch(op_state, "num_queued", 5):
+    with patch(op_state, "total_input_enqueued", 5):
         assert_should_scale_up(False)
 
     # === Test scaling down ===
@@ -146,7 +146,7 @@ def test_cluster_scaling():
         num_active_tasks=MagicMock(return_value=1),
     )
     op_state1 = MagicMock(
-        num_queued=MagicMock(return_value=0),
+        total_input_enqueued=MagicMock(return_value=0),
         _scheduling_status=MagicMock(
             runnable=False,
         ),
@@ -159,7 +159,7 @@ def test_cluster_scaling():
         num_active_tasks=MagicMock(return_value=1),
     )
     op_state2 = MagicMock(
-        num_queued=MagicMock(return_value=1),
+        total_input_enqueued=MagicMock(return_value=1),
         _scheduling_status=MagicMock(
             runnable=False,
         ),

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -290,7 +290,7 @@ class TestResourceManager:
         assert resource_manager.get_op_usage(o3).object_store_memory == 0
 
         o2.metrics.on_output_dequeued(input)
-        topo[o2].outqueue.append(input)
+        topo[o2].output_queue.append(input)
         resource_manager.update_usages()
         assert resource_manager.get_op_usage(o1).object_store_memory == 0
         assert resource_manager.get_op_usage(o2).object_store_memory == 1
@@ -298,7 +298,7 @@ class TestResourceManager:
 
         # Objects in the current operator's internal inqueue count towards the previous
         # operator's object store memory usage.
-        o3.metrics.on_input_queued(topo[o2].outqueue.pop())
+        o3.metrics.on_input_queued(topo[o2].output_queue.pop())
         resource_manager.update_usages()
         assert resource_manager.get_op_usage(o1).object_store_memory == 0
         assert resource_manager.get_op_usage(o2).object_store_memory == 1

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -24,6 +24,7 @@ from ray.data._internal.execution.interfaces import (
 )
 from ray.data._internal.execution.interfaces.physical_operator import MetadataOpTask
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
+from ray.data._internal.execution.operators.limit_operator import LimitOperator
 from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.execution.operators.map_transformer import (
     create_map_transformer_from_block_fn,
@@ -41,6 +42,8 @@ from ray.data._internal.execution.streaming_executor_state import (
     process_completed_tasks,
     select_operator_to_run,
     update_operator_states,
+    get_eligible_operators,
+    _rank_operators,
 )
 from ray.data._internal.execution.util import make_ref_bundles
 from ray.data._internal.logical.operators.map_operator import MapRows
@@ -112,9 +115,9 @@ def test_build_streaming_topology(verbose_progress):
     else:
         assert num_progress_bars == 1, num_progress_bars
     assert o1 in topo, topo
-    assert not topo[o1].inqueues, topo
-    assert topo[o1].outqueue == topo[o2].inqueues[0], topo
-    assert topo[o2].outqueue == topo[o3].inqueues[0], topo
+    assert not topo[o1].input_queues, topo
+    assert topo[o1].output_queue == topo[o2].input_queues[0], topo
+    assert topo[o2].output_queue == topo[o3].input_queues[0], topo
     assert list(topo) == [o1, o2, o3]
 
 
@@ -153,11 +156,11 @@ def test_process_completed_tasks():
     topo, _ = build_streaming_topology(o2, ExecutionOptions(verbose_progress=True))
 
     # Test processing output bundles.
-    assert len(topo[o1].outqueue) == 0, topo
+    assert len(topo[o1].output_queue) == 0, topo
     resource_manager = mock_resource_manager()
     process_completed_tasks(topo, resource_manager, 0)
     update_operator_states(topo)
-    assert len(topo[o1].outqueue) == 20, topo
+    assert len(topo[o1].output_queue) == 20, topo
 
     # Test processing completed work items.
     sleep_task = MetadataOpTask(0, sleep.remote(), lambda: None)
@@ -179,7 +182,7 @@ def test_process_completed_tasks():
     o2.all_inputs_done = MagicMock()
     o1.mark_execution_finished = MagicMock()
     o1.completed = MagicMock(return_value=True)
-    topo[o1].outqueue.clear()
+    topo[o1].output_queue.clear()
     process_completed_tasks(topo, resource_manager, 0)
     update_operator_states(topo)
     done_task_callback.assert_called_once()
@@ -207,17 +210,23 @@ def test_process_completed_tasks():
     o2.mark_execution_finished.assert_called_once()
 
 
-def test_select_operator_to_run():
-    opt = ExecutionOptions()
+def test_get_eligible_operators_to_run():
+    opts = ExecutionOptions()
     inputs = make_ref_bundles([[x] for x in range(1)])
     o1 = InputDataBuffer(DataContext.get_current(), inputs)
     o2 = MapOperator.create(
-        make_map_transformer(lambda block: block), o1, DataContext.get_current()
+        make_map_transformer(lambda block: block),
+        o1,
+        DataContext.get_current(),
+        name="O2",
     )
     o3 = MapOperator.create(
-        make_map_transformer(lambda block: block), o2, DataContext.get_current()
+        make_map_transformer(lambda block: block),
+        o2,
+        DataContext.get_current(),
+        name="O3",
     )
-    topo, _ = build_streaming_topology(o3, opt)
+    topo, _ = build_streaming_topology(o3, opts)
 
     resource_manager = mock_resource_manager(
         global_limits=ExecutionResources.for_limits(1, 1, 1),
@@ -230,32 +239,144 @@ def test_select_operator_to_run():
         return_value=True
     )
 
-    def _select_op_to_run():
-        return select_operator_to_run(
-            topo, resource_manager, [], mock_autoscaler(), True
+    def _get_eligible_ops_to_run(ensure_liveness: bool):
+        return get_eligible_operators(
+            topo, [], resource_manager, ensure_liveness=ensure_liveness
         )
 
     # Test empty.
-    assert _select_op_to_run() is None
+    assert _get_eligible_ops_to_run(ensure_liveness=False) == []
 
     # `o2` is the only operator with at least one input.
-    topo[o1].outqueue.append(make_ref_bundle("dummy1"))
+    topo[o1].output_queue.append(make_ref_bundle("dummy1"))
     memory_usage[o1] += 1
-    assert _select_op_to_run() == o2
 
-    # `o2` is still the only operator with at least one input.
-    topo[o1].outqueue.append(make_ref_bundle("dummy2"))
-    memory_usage[o1] += 1
-    assert _select_op_to_run() == o2
+    assert _get_eligible_ops_to_run(ensure_liveness=False) == [o2]
 
     # Both `o2` and `o3` have at least one input, but `o3` has less memory usage.
-    topo[o2].outqueue.append(make_ref_bundle("dummy3"))
+    topo[o2].output_queue.append(make_ref_bundle("dummy3"))
     memory_usage[o2] += 1
-    assert _select_op_to_run() == o3
+    assert _get_eligible_ops_to_run(ensure_liveness=False) == [o2, o3]
 
-    # Test prioritization of nothrottle ops.
-    o2.throttling_disabled = MagicMock(return_value=True)
-    assert _select_op_to_run() == o2
+    # `o2`s queue is not empty, but it can't accept new inputs anymore
+    with patch.object(o2, "should_add_input") as _mock:
+        _mock.return_value = False
+        assert _get_eligible_ops_to_run(ensure_liveness=False) == [o3]
+
+    # Completed ops are not eligible
+    with patch.object(o3, "completed") as _mock:
+        _mock.return_value = True
+        assert _get_eligible_ops_to_run(ensure_liveness=False) == [o2]
+
+    # `o2` operator is now back-pressured
+    with patch.object(
+        resource_manager.op_resource_allocator, "can_submit_new_task"
+    ) as _mock:
+        _mock.side_effect = lambda op: False if op is o2 else True
+        assert _get_eligible_ops_to_run(ensure_liveness=False) == [o3]
+
+        # Complete `o3`
+        with patch.object(o3, "completed") as _mock:
+            _mock.return_value = True
+            # Clear up input queue
+            topo[o3].input_queues[0].clear()
+
+            # To ensure liveness back-pressure limits will be ignored
+            assert _get_eligible_ops_to_run(ensure_liveness=True) == [o2]
+
+
+def test_rank_operators():
+    inputs = make_ref_bundles([[x] for x in range(1)])
+
+    o1 = InputDataBuffer(DataContext.get_current(), inputs)
+    o2 = MapOperator.create(
+        make_map_transformer(lambda block: block), o1, DataContext.get_current()
+    )
+    o3 = MapOperator.create(
+        make_map_transformer(lambda block: block), o2, DataContext.get_current()
+    )
+    o4 = LimitOperator(1, o3, DataContext.get_current())
+
+    resource_manager = mock_resource_manager(
+        global_usage=ExecutionResources(cpu=1),
+        global_limits=ExecutionResources.for_limits(cpu=1),
+    )
+
+    def _get_op_usage_mocked(op):
+        if op is o1:
+            return ExecutionResources(object_store_memory=1024)
+        elif op is o2:
+            return ExecutionResources(object_store_memory=2048)
+        elif op is o3:
+            return ExecutionResources(object_store_memory=4096)
+
+        return ExecutionResources(object_store_memory=8092)
+
+    resource_manager.get_op_usage.side_effect = _get_op_usage_mocked
+
+    ranks = _rank_operators([o1, o2, o3, o4], resource_manager)
+
+    assert [(True, 1024), (True, 2048), (True, 4096), (False, 8092)] == ranks
+
+
+def test_select_ops_to_run():
+    opts = ExecutionOptions()
+
+    inputs = make_ref_bundles([[x] for x in range(1)])
+
+    o1 = InputDataBuffer(DataContext.get_current(), inputs)
+    o2 = MapOperator.create(
+        make_map_transformer(lambda block: block), o1, DataContext.get_current()
+    )
+    o3 = MapOperator.create(
+        make_map_transformer(lambda block: block), o2, DataContext.get_current()
+    )
+    o4 = LimitOperator(1, o3, DataContext.get_current())
+
+    resource_manager = mock_resource_manager(
+        global_usage=ExecutionResources(cpu=1),
+        global_limits=ExecutionResources.for_limits(cpu=1),
+    )
+
+    def _get_op_usage_mocked(op):
+        if op is o1:
+            return ExecutionResources(object_store_memory=1024)
+        elif op is o2:
+            return ExecutionResources(object_store_memory=2048)
+        elif op is o3:
+            return ExecutionResources(object_store_memory=4096)
+
+        return ExecutionResources(object_store_memory=8092)
+
+    resource_manager.get_op_usage.side_effect = _get_op_usage_mocked
+
+    # NOTE: This value is irrelevant since we mock out get_eligible_operators
+    ensure_liveness = False
+
+    with patch(
+        "ray.data._internal.execution.streaming_executor_state.get_eligible_operators"
+    ) as _mock:
+        # Case 1: Should pick the `o4` since it has throttling disabled
+        _mock.return_value = [o1, o2, o3, o4]
+
+        topo, _ = build_streaming_topology(o4, opts)
+
+        selected = select_operator_to_run(
+            topo, resource_manager, [], ensure_liveness=ensure_liveness
+        )
+
+        assert selected is o4
+
+        # Case 2: Should pick the `o1` since it has lowest object store usage
+        _mock.return_value = [o1, o2, o3]
+
+        topo, _ = build_streaming_topology(o3, opts)
+
+        selected = select_operator_to_run(
+            topo, resource_manager, [], ensure_liveness=ensure_liveness
+        )
+
+        assert selected is o1
 
 
 def test_dispatch_next_task():
@@ -267,13 +388,13 @@ def test_dispatch_next_task():
         o1,
         DataContext.get_current(),
     )
-    op_state = OpState(o2, [o1_state.outqueue])
+    op_state = OpState(o2, [o1_state.output_queue])
 
     # TODO: test multiple inqueues with the union operator.
     ref1 = make_ref_bundle("dummy1")
     ref2 = make_ref_bundle("dummy2")
-    op_state.inqueues[0].append(ref1)
-    op_state.inqueues[0].append(ref2)
+    op_state.input_queues[0].append(ref1)
+    op_state.input_queues[0].append(ref2)
 
     o2.add_input = MagicMock()
     op_state.dispatch_next_task()
@@ -330,45 +451,6 @@ def test_validate_dag():
     _validate_dag(o3, ExecutionResources.for_limits(gpu=0))
     with pytest.raises(ValueError):
         _validate_dag(o3, ExecutionResources.for_limits(cpu=10))
-
-
-def test_select_ops_ensure_at_least_one_live_operator():
-    opt = ExecutionOptions()
-    inputs = make_ref_bundles([[x] for x in range(1)])
-    o1 = InputDataBuffer(DataContext.get_current(), inputs)
-    o2 = MapOperator.create(
-        make_map_transformer(lambda block: block), o1, DataContext.get_current()
-    )
-    o3 = MapOperator.create(
-        make_map_transformer(lambda block: block), o2, DataContext.get_current()
-    )
-    topo, _ = build_streaming_topology(o3, opt)
-    resource_manager = mock_resource_manager(
-        global_usage=ExecutionResources(cpu=1),
-        global_limits=ExecutionResources.for_limits(cpu=1),
-    )
-    resource_manager.get_op_usage = MagicMock(return_value=ExecutionResources(0, 0, 0))
-
-    def _select_op_to_run(ensure_at_least_one_running):
-        return select_operator_to_run(
-            topo, resource_manager, [], mock_autoscaler(), ensure_at_least_one_running
-        )
-
-    topo[o2].outqueue.append(make_ref_bundle("dummy1"))
-    resource_manager.op_resource_allocator.can_submit_new_task = MagicMock(
-        return_value=False
-    )
-
-    # Because `o1` has an active task, `select_operator_to_run` returns `None`.
-    o1.num_active_tasks = MagicMock(return_value=1)
-    assert _select_op_to_run(True) is None
-
-    # No operator can submit a new task, but because there are no active tasks, select
-    # from the operators that have at least one input.
-    o1.num_active_tasks = MagicMock(return_value=0)
-    assert _select_op_to_run(True) is o3
-
-    assert _select_op_to_run(False) is None
 
 
 def test_configure_output_locality():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Cleaning up operator scheduling sequence in preparation for subsequent evolution of operator ranking and scheduling prioritization.

Changes
---

 - Removing code duplication
 - Breaking down scheduling sequence into 2 -- extracting elgigible ops and ranking them
 - Making sure there's complete branch coverage

Additionally, this change is cleaning up the code, adding full branch coverage (in preparation to evolve the ranker).
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
