### PR TITLE
[data.llm] Deserialize arrays for sampling_params

### DIFF
--- a/python/ray/llm/_internal/batch/stages/common.py
+++ b/python/ray/llm/_internal/batch/stages/common.py
@@ -1,0 +1,29 @@
+"""
+Shared utilities for stages.
+"""
+
+from typing import Any, Dict, List, Union
+
+import numpy as np
+
+
+def maybe_convert_ndarray_to_list(
+    params: Union[np.ndarray, List[Any], Dict[str, Any]]
+) -> Union[List[Any], Dict[str, Any]]:
+    """Convert all ndarray to list in the params. This is because Ray Data
+    by default converts all lists to ndarrays when passing data around, but
+    vLLM expects lists.
+
+    Args:
+        params: The parameters to convert.
+
+    Returns:
+        The converted parameters.
+    """
+    if isinstance(params, dict):
+        return {k: maybe_convert_ndarray_to_list(v) for k, v in params.items()}
+    elif isinstance(params, list):
+        return [maybe_convert_ndarray_to_list(v) for v in params]
+    elif isinstance(params, np.ndarray):
+        return params.tolist()
+    return params

--- a/python/ray/llm/_internal/batch/stages/sglang_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/sglang_engine_stage.py
@@ -14,6 +14,7 @@ from ray.llm._internal.batch.stages.base import (
     StatefulStage,
     StatefulStageUDF,
 )
+from ray.llm._internal.batch.stages.common import maybe_convert_ndarray_to_list
 
 sgl = try_import("sglang")
 
@@ -155,14 +156,13 @@ class SGLangEngineWrapper:
 
         # Prepare sampling parameters.
         if self.task_type == SGLangTaskType.GENERATE:
-            params = row.pop("sampling_params")
+            params = maybe_convert_ndarray_to_list(row.pop("sampling_params"))
         else:
             raise ValueError(f"Unsupported task type: {self.task_type}")
 
         if tokenized_prompt is not None and not self.skip_tokenizer_init:
             raise ValueError(
-                "To use a token-in-token-out mode of SGLang Engine, "
-                "please set engine_kwargs['skip_tokenizer_init'] to True."
+                "To use a token-in-token-out mode of SGLang Engine, please set engine_kwargs['skip_tokenizer_init'] to True."
             )
 
         request = SGLangEngineRequest(
@@ -220,8 +220,7 @@ class SGLangEngineWrapper:
                 return output
 
         raise RuntimeError(
-            "[SGLang] The request is not finished. This should not happen. "
-            "Please report this issue to the Ray team."
+            "[SGLang] The request is not finished. This should not happen. Please report this issue to the Ray team."
         )
 
     def shutdown(self):
@@ -393,11 +392,9 @@ class SGLangEngineStage(StatefulStage):
         ret = {"prompt": "The text prompt (str)."}
         task_type = self.fn_constructor_kwargs.get("task_type", SGLangTaskType.GENERATE)
         if task_type == SGLangTaskType.GENERATE:
-            ret["sampling_params"] = (
-                "The sampling parameters. See "
-                "https://docs.sglang.ai/backend/sampling_params.html"
-                "for details."
-            )
+            ret[
+                "sampling_params"
+            ] = "The sampling parameters. See https://docs.sglang.ai/backend/sampling_params.htmlfor details."
         return ret
 
     def get_optional_input_keys(self) -> Dict[str, str]:

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -301,7 +301,7 @@ class vLLMEngineWrapper:
             else:
                 guided_decoding = None
             params = vllm.SamplingParams(
-                **sampling_params,
+                **self._maybe_convert_ndarray_to_list(sampling_params),
                 guided_decoding=guided_decoding,
             )
         elif self.task_type == vLLMTaskType.EMBED:


### PR DESCRIPTION
<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This solves the issue described in https://github.com/ray-project/ray/issues/52630
Some vllm sampling params such as `stop_token_ids` are lists and hence get converted to np.arrays when sent from one process to another in ray data. This causes a deserialization error in the vLLM engine since it expects a list, not a np.array.

## Related issue number
Closes #52630 

## Checks
- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [-] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
