### PR TITLE
[ray.data.llm] Add hint of how to optimize throughput

### DIFF
--- a/python/ray/llm/_internal/batch/processor/base.py
+++ b/python/ray/llm/_internal/batch/processor/base.py
@@ -23,12 +23,12 @@ class ProcessorConfig(BaseModelExtended):
     """The processor configuration."""
 
     batch_size: int = Field(
-        default=64,
+        default=32,
         description="Large batch sizes are likely to saturate the compute resources "
         "and could achieve higher throughput. On the other hand, small batch sizes "
         "are more fault-tolerant and could reduce bubbles in the data pipeline. "
         "You can tune the batch size to balance the throughput and fault-tolerance "
-        "based on your use case. Defaults to 64.",
+        "based on your use case. Defaults to 32.",
     )
     resources_per_bundle: Optional[Dict[str, float]] = Field(
         default=None,

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -172,6 +172,8 @@ class vLLMEngineWrapper:
         engine_args = vllm.AsyncEngineArgs(
             **kwargs,
         )
+        # create_engine_config will set default values including `max_num_seqs`.
+        self._vllm_config = engine_args.create_engine_config()
         self.engine = vllm.AsyncLLMEngine.from_engine_args(engine_args)
 
         # Determine the generate function based on vLLM v0 or v1.
@@ -436,10 +438,7 @@ class vLLMEngineWrapper:
             self.engine.shutdown()
 
     def get_scheduler_config(self) -> vllm.config.SchedulerConfig:
-        if self.vllm_use_v1:
-            return self.engine.vllm_config.scheduler_config
-        else:
-            return self.engine.engine.get_scheduler_config()
+        return self._vllm_config.scheduler_config
 
 
 class vLLMEngineStageUDF(StatefulStageUDF):

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -437,7 +437,7 @@ class vLLMEngineWrapper:
             logger.info("Shutting down vLLM engine")
             self.engine.shutdown()
 
-    def get_scheduler_config(self) -> vllm.config.SchedulerConfig:
+    def get_scheduler_config(self):
         return self._vllm_config.scheduler_config
 
 

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -170,7 +170,6 @@ class vLLMEngineWrapper:
         # Initialize the vLLM engine.
         engine_args = vllm.AsyncEngineArgs(
             **kwargs,
-            disable_log_requests=True,
         )
         self.engine = vllm.AsyncLLMEngine.from_engine_args(engine_args)
 
@@ -490,6 +489,7 @@ class vLLMEngineStageUDF(StatefulStageUDF):
             model_source=model_source,
             idx_in_batch_column=self.IDX_IN_BATCH_COLUMN,
             disable_log_stats=False,
+            disable_log_requests=True,
             max_pending_requests=self.max_pending_requests,
             dynamic_lora_loading_path=dynamic_lora_loading_path,
             **self.engine_kwargs,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

LLM task is usually long-running, and duration varies a lot. This can easily cause long-tail problem if batch size is too large.

For example, within a batch, most prompts finished, while there's one prompt keep decoding, blocking the whole batch to finish. Ray data cannot schedule more batches, if the long-tail happens in all running batches. And vLLM engine is not saturated in this case (only decoding one prompt from each batch, while vLLM could potentially handle 256 sequence concurrently), causing low throughput.

This PR
* changes the default value of certain fields. For LLM batch inference case, we actually want a small `batch_size` to avoid long tail, and large `max_concurrent_batches` to saturate engine.
* log warning if the config cannot saturate engine

Benchmarking on a 10k ShareGPT dataset, on L40S GPU (vLLM 0.8.4, VLLM_USE_V1=0)
| batch_size | concurrent_batches | throughput (req./s) | output_throughput (tk/s) |
|------------|-------------------|-------------------|-------------------|
| 1 | 512 | 12.08 | 2357.43 |
| 2 | 256 | 11.93 | 2350.91 |
| 4 | 128 | 11.86 | 2333.53 |
| 8 | 64 | 12.20 | 2383.35 |
| 16 | 32 | 12.18 | 2404.00 |
| 32 | 16 | 11.94 | 2347.59 |
| 64 | 8 | 11.91 | 2347.94 |
| 128 | 4 | 11.47 | 2272.45 |
| 256 | 2 | 10.48 | 2055.64 |
| 512 | 1 | 8.04 | 1602.82 |
| 1 | 256 | 11.65 | 2318.72 |
| 2 | 128 | 11.90 | 2348.74 |
| 4 | 64 | 12.02 | 2353.33 |
| 8 | 32 | 11.86 | 2315.15 |
| 16 | 16 | 12.10 | 2368.09 |
| 32 | 8 | 11.91 | 2320.09 |
| 64 | 4 | 11.68 | 2280.55 |
| 128 | 2 | 10.30 | 2018.99 |
| 256 | 1 | 7.96 | 1575.01 |

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
