### PR TITLE
Update ray server documents

### DIFF
--- a/doc/source/serve/production-guide/kubernetes.md
+++ b/doc/source/serve/production-guide/kubernetes.md
@@ -57,7 +57,7 @@ Learn more about how to configure KubeRay clusters [here](kuberay-config).
 :::
 
 ```console
-$ curl -o ray-service.text-ml.yaml https://raw.githubusercontent.com/ray-project/kuberay/5b1a5a11f5df76db2d66ed332ff0802dc3bbff76/ray-operator/config/samples/ray-service.text-ml.yaml
+$ curl -o ray-service.text-ml.yaml https://raw.githubusercontent.com/ray-project/kuberay/2ba0dd7bea387ac9df3681666bab3d622e89846c/ray-operator/config/samples/ray-service.text-ml.yaml
 ```
 
 To deploy the example, we simply `kubectl apply` the CR.
@@ -67,21 +67,19 @@ This creates the underlying Ray cluster, consisting of a head and worker node po
 $ kubectl apply -f ray-service.text-ml.yaml
 
 $ kubectl get rayservices
-NAME                AGE
-rayservice-sample   7s
+NAME                SERVICE STATUS   NUM SERVE ENDPOINTS
+rayservice-sample   Running          1
 
 $ kubectl get pods
-NAME                                                      READY   STATUS    RESTARTS   AGE
-service-sample-raycluster-454c4-worker-small-group-b6mmg  1/1     Running   0          XXs
-kuberay-operator-7fbdbf8c89-4lrnr                         1/1     Running   0          XXs
-rayservice-sample-raycluster-454c4-head-krk9d             1/1     Running   0          XXs
+NAME                                                          READY   STATUS    RESTARTS   AGE
+rayservice-sample-raycluster-7wlx2-head-hr8mg                 1/1     Running   0          XXs
+rayservice-sample-raycluster-7wlx2-small-group-worker-tb8nn   1/1     Running   0          XXs
 
 $ kubectl get services
-
-rayservice-sample-head-svc                         ClusterIP   ...        8080/TCP,6379/TCP,8265/TCP,10001/TCP,8000/TCP,52365/TCP   XXs
-rayservice-sample-raycluster-454c4-dashboard-svc   ClusterIP   ...        52365/TCP                                                 XXs
-rayservice-sample-raycluster-454c4-head-svc        ClusterIP   ...        8000/TCP,52365/TCP,8080/TCP,6379/TCP,8265/TCP,10001/TCP   XXs
-rayservice-sample-serve-svc                        ClusterIP   ...        8000/TCP                                                  XXs
+NAME                                          TYPE        CLUSTER-IP        EXTERNAL-IP   PORT(S)                                         AGE
+rayservice-sample-head-svc                    ClusterIP   None              <none>        10001/TCP,8265/TCP,6379/TCP,8080/TCP,8000/TCP   XXs
+rayservice-sample-raycluster-7wlx2-head-svc   ClusterIP   None              <none>        10001/TCP,8265/TCP,6379/TCP,8080/TCP,8000/TCP   XXs
+rayservice-sample-serve-svc                   ClusterIP   192.168.145.219   <none>        8000/TCP                                        XXs
 ```
 
 Note that the `rayservice-sample-serve-svc` above is the one that can be used to send queries to the Serve application -- this will be used in the next section.
@@ -113,31 +111,47 @@ $ kubectl describe rayservice rayservice-sample
 ...
 Status:
   Active Service Status:
+    Ray Cluster Status:
+      Available Worker Replicas:  1
+      Desired CPU:                2500m
+      Desired GPU:                0
+      Desired Memory:             4Gi
+      Desired TPU:                0
+      Desired Worker Replicas:    1
+      Endpoints:
+        Client:     10001
+        Dashboard:  8265
+        Metrics:    8080
+        Redis:      6379
+        Serve:      8000
+      Head:
+        Pod IP:             10.48.99.153
+        Pod Name:           rayservice-sample-raycluster-7wlx2-head-dqv7t
+        Service IP:         10.48.99.153
+        Service Name:       rayservice-sample-raycluster-7wlx2-head-svc
+      Last Update Time:     2025-04-28T06:32:13Z
+      Max Worker Replicas:  5
+      Min Worker Replicas:  1
+      Observed Generation:  1
+  Observed Generation:      1
+  Pending Service Status:
     Application Statuses:
       text_ml_app:
-        Health Last Update Time:  2023-09-07T01:21:30Z
-        Last Update Time:         2023-09-07T01:21:30Z
+        Health Last Update Time:  2025-04-28T06:39:02Z
         Serve Deployment Statuses:
-          text_ml_app_Summarizer:
-            Health Last Update Time:  2023-09-07T01:21:30Z
-            Last Update Time:         2023-09-07T01:21:30Z
+          Summarizer:
+            Health Last Update Time:  2025-04-28T06:39:02Z
             Status:                   HEALTHY
-          text_ml_app_Translator:
-            Health Last Update Time:  2023-09-07T01:21:30Z
-            Last Update Time:         2023-09-07T01:21:30Z
+          Translator:
+            Health Last Update Time:  2025-04-28T06:39:02Z
             Status:                   HEALTHY
         Status:                       RUNNING
-    Dashboard Status:
-      Health Last Update Time:  2023-09-07T01:21:30Z
-      Is Healthy:               true
-      Last Update Time:         2023-09-07T01:21:30Z
-    Ray Cluster Name:           rayservice-sample-raycluster-kkd2p
+    Ray Cluster Name:                 rayservice-sample-raycluster-7wlx2
     Ray Cluster Status:
-      Head:
-  Observed Generation:  1
-  Pending Service Status:
-    Dashboard Status:
-    Ray Cluster Status:
+      Desired CPU:     0
+      Desired GPU:     0
+      Desired Memory:  0
+      Desired TPU:     0
       Head:
   Service Status:  Running
 Events:

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -17,7 +17,7 @@ from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.air.util.tensor_extensions.arrow import ArrowTensorArray
 from ray.data import Schema
 from ray.data.block import BlockExecStats, BlockMetadata
-from ray.data.context import ShuffleStrategy, DataContext
+from ray.data.context import DataContext, ShuffleStrategy
 from ray.data.tests.mock_server import *  # noqa
 
 # Trigger pytest hook to automatically zip test cluster logs to archive dir on failure


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Example in this document is about ray 2.6.3, whose apis are not compatible with the latest KuberayOperator.

Version of KuberayOperator: 1.2.1

Operator will call /api/serve/applications

RayServices:

```
➜  kuberay-serve cat ray-service.text-ml1.yaml
# Make sure to increase resource requests and limits before using this example in production.
# For examples with more realistic resource configuration, see
# ray-cluster.complete.large.yaml and
# ray-cluster.autoscaler.large.yaml.
apiVersion: ray.io/v1alpha1
kind: RayService
metadata:
  name: rayservice-sample
spec:
  serviceUnhealthySecondThreshold: 900 # Config for the health check threshold for Ray Serve applications. Default value is 900.
  deploymentUnhealthySecondThreshold: 300 # Config for the health check threshold for Ray dashboard agent. Default value is 300.
  # serveConfigV2 takes a yaml multi-line scalar, which should be a Ray Serve multi-application config. See https://docs.ray.io/en/latest/serve/multi-app.html.
  # Only one of serveConfig and serveConfigV2 should be used.
  serveConfigV2: |
    applications:
      - name: text_ml_app
        import_path: text_ml.app
        route_prefix: /summarize_translate
        runtime_env:
          working_dir: "https://github.com/ray-project/serve_config_examples/archive/36862c251615e258a58285934c7c41cffd1ee3b7.zip"
          pip:
            - torch
            - transformers
        deployments:
          - name: Translator
            num_replicas: 1
            ray_actor_options:
              num_cpus: 0.2
            user_config:
              language: french
          - name: Summarizer
            num_replicas: 1
            ray_actor_options:
              num_cpus: 0.2
  rayClusterConfig:
    rayVersion: '2.6.3' # should match the Ray version in the image of the containers
    ######################headGroupSpecs#################################
    # Ray head pod template.
    headGroupSpec:
      # The `rayStartParams` are used to configure the `ray start` command.
      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
      rayStartParams:
        dashboard-host: '0.0.0.0'
      #pod template
      template:
        spec:
          containers:
            - name: ray-head
              image: rayproject/ray:2.6.3
              resources:
                limits:
                  cpu: 2
                  memory: 2Gi
                requests:
                  cpu: 2
                  memory: 2Gi
              ports:
                - containerPort: 6379
                  name: gcs-server
                - containerPort: 8265 # Ray dashboard
                  name: dashboard
                - containerPort: 10001
                  name: client
                - containerPort: 8000
                  name: serve
    workerGroupSpecs:
      # the pod replicas in this group typed worker
      - replicas: 1
        minReplicas: 1
        maxReplicas: 5
        # logical group name, for this called small-group, also can be functional
        groupName: small-group
        # The `rayStartParams` are used to configure the `ray start` command.
        # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
        # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
        rayStartParams: {}
        #pod template
        template:
          spec:
            containers:
              - name: ray-worker # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
                image: rayproject/ray:2.6.3
                lifecycle:
                  preStop:
                    exec:
                      command: ["/bin/sh","-c","ray stop"]
                resources:
                  limits:
                    cpu: "1"
                    memory: "2Gi"
                  requests:
                    cpu: "500m"
                    memory: "2Gi"
```

Result:

![image](https://github.com/user-attachments/assets/66251482-315f-48c9-af32-74adb0e1a631)

Log of dashboard:

```
2025-04-28 19:05:19,363	INFO head.py:150 -- Dashboard head grpc address: 0.0.0.0:43059
2025-04-28 19:05:19,372	INFO head.py:254 -- Starting dashboard metrics server on port 44227
2025-04-28 19:05:19,375	INFO utils.py:112 -- Get all modules by type: DashboardHeadModule
2025-04-28 19:05:19,671	INFO utils.py:145 -- Available modules: [<class 'ray.dashboard.modules.actor.actor_head.ActorHead'>, <class 'ray.dashboard.modules.event.event_head.EventHead'>, <class 'ray.dashboard.modules.healthz.healthz_head.HealthzHead'>, <class 'ray.dashboard.modules.job.job_head.JobHead'>, <class 'ray.dashboard.modules.log.log_head.LogHead'>, <class 'ray.dashboard.modules.metrics.metrics_head.MetricsHead'>, <class 'ray.dashboard.modules.node.node_head.NodeHead'>, <class 'ray.dashboard.modules.reporter.reporter_head.ReportHead'>, <class 'ray.dashboard.modules.serve.serve_head.ServeHead'>, <class 'ray.dashboard.modules.snapshot.snapshot_head.APIHead'>, <class 'ray.dashboard.modules.state.state_head.StateHead'>, <class 'ray.dashboard.modules.usage_stats.usage_stats_head.UsageStatsHead'>]
2025-04-28 19:05:19,671	INFO head.py:223 -- Modules to load: {'NodeHead', 'JobHead', 'ReportHead', 'ActorHead', 'UsageStatsHead', 'ServeHead', 'StateHead', 'MetricsHead', 'EventHead', 'APIHead', 'LogHead', 'HealthzHead'}
2025-04-28 19:05:19,672	INFO head.py:226 -- Loading DashboardHeadModule: <class 'ray.dashboard.modules.actor.actor_head.ActorHead'>
2025-04-28 19:05:19,672	INFO head.py:226 -- Loading DashboardHeadModule: <class 'ray.dashboard.modules.event.event_head.EventHead'>
2025-04-28 19:05:19,672	INFO head.py:226 -- Loading DashboardHeadModule: <class 'ray.dashboard.modules.healthz.healthz_head.HealthzHead'>
2025-04-28 19:05:19,672	INFO head.py:226 -- Loading DashboardHeadModule: <class 'ray.dashboard.modules.job.job_head.JobHead'>
2025-04-28 19:05:19,672	INFO head.py:226 -- Loading DashboardHeadModule: <class 'ray.dashboard.modules.log.log_head.LogHead'>
2025-04-28 19:05:19,672	INFO head.py:226 -- Loading DashboardHeadModule: <class 'ray.dashboard.modules.metrics.metrics_head.MetricsHead'>
2025-04-28 19:05:19,673	INFO head.py:226 -- Loading DashboardHeadModule: <class 'ray.dashboard.modules.node.node_head.NodeHead'>
2025-04-28 19:05:19,673	INFO head.py:226 -- Loading DashboardHeadModule: <class 'ray.dashboard.modules.reporter.reporter_head.ReportHead'>
2025-04-28 19:05:19,673	INFO head.py:226 -- Loading DashboardHeadModule: <class 'ray.dashboard.modules.serve.serve_head.ServeHead'>
2025-04-28 19:05:19,673	INFO head.py:226 -- Loading DashboardHeadModule: <class 'ray.dashboard.modules.snapshot.snapshot_head.APIHead'>
2025-04-28 19:05:19,673	INFO head.py:226 -- Loading DashboardHeadModule: <class 'ray.dashboard.modules.state.state_head.StateHead'>
2025-04-28 19:05:19,673	INFO head.py:226 -- Loading DashboardHeadModule: <class 'ray.dashboard.modules.usage_stats.usage_stats_head.UsageStatsHead'>
2025-04-28 19:05:19,673	INFO head.py:239 -- Loaded 12 modules. [<ray.dashboard.modules.actor.actor_head.ActorHead object at 0x7f96dc1dc0a0>, <ray.dashboard.modules.event.event_head.EventHead object at 0x7f96dc51f4c0>, <ray.dashboard.modules.healthz.healthz_head.HealthzHead object at 0x7f96dc51f430>, <ray.dashboard.modules.job.job_head.JobHead object at 0x7f96aa3c4d90>, <ray.dashboard.modules.log.log_head.LogHead object at 0x7f96aa3c4df0>, <ray.dashboard.modules.metrics.metrics_head.MetricsHead object at 0x7f96aa3c4e80>, <ray.dashboard.modules.node.node_head.NodeHead object at 0x7f96aa3d5340>, <ray.dashboard.modules.reporter.reporter_head.ReportHead object at 0x7f96aa3d5310>, <ray.dashboard.modules.serve.serve_head.ServeHead object at 0x7f96aa3d55b0>, <ray.dashboard.modules.snapshot.snapshot_head.APIHead object at 0x7f96aa3d5790>, <ray.dashboard.modules.state.state_head.StateHead object at 0x7f96aa3d5760>, <ray.dashboard.modules.usage_stats.usage_stats_head.UsageStatsHead object at 0x7f96aa3d5910>]
2025-04-28 19:05:19,673	INFO head.py:326 -- Initialize the http server.
2025-04-28 19:05:19,674	INFO http_server_head.py:82 -- Setup static dir for dashboard: /home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/client/build
2025-04-28 19:05:19,679	INFO http_server_head.py:201 -- Dashboard head http address: 10.48.99.156:8265
2025-04-28 19:05:19,679	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /logical/actors> -> <function ActorHead.get_all_actors[cache ttl=2, max_size=128] at 0x7f96cc211af0>
2025-04-28 19:05:19,679	INFO http_server_head.py:207 -- <ResourceRoute [GET] <DynamicResource  /logical/actors/{actor_id}> -> <function ActorHead.get_actor[cache ttl=2, max_size=128] at 0x7f96cc211ca0>
2025-04-28 19:05:19,679	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /events> -> <function EventHead.get_event[cache ttl=2, max_size=128] at 0x7f96cc00e5e0>
2025-04-28 19:05:19,680	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /api/gcs_healthz> -> <function HealthzHead.health_check at 0x7f96cc015280>
2025-04-28 19:05:19,680	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /api/version> -> <function JobHead.get_version at 0x7f96aa7cce50>
2025-04-28 19:05:19,680	INFO http_server_head.py:207 -- <ResourceRoute [GET] <DynamicResource  /api/packages/{protocol}/{package_name}> -> <function JobHead.get_package at 0x7f96aa7ccf70>
2025-04-28 19:05:19,680	INFO http_server_head.py:207 -- <ResourceRoute [PUT] <DynamicResource  /api/packages/{protocol}/{package_name}> -> <function JobHead.upload_package at 0x7f96aa7d50d0>
2025-04-28 19:05:19,680	INFO http_server_head.py:207 -- <ResourceRoute [POST] <PlainResource  /api/jobs/> -> <function JobHead.submit_job at 0x7f96aa7d51f0>
2025-04-28 19:05:19,680	INFO http_server_head.py:207 -- <ResourceRoute [POST] <DynamicResource  /api/jobs/{job_or_submission_id}/stop> -> <function JobHead.stop_job at 0x7f96aa7d5310>
2025-04-28 19:05:19,680	INFO http_server_head.py:207 -- <ResourceRoute [DELETE] <DynamicResource  /api/jobs/{job_or_submission_id}> -> <function JobHead.delete_job at 0x7f96aa7d5430>
2025-04-28 19:05:19,680	INFO http_server_head.py:207 -- <ResourceRoute [GET] <DynamicResource  /api/jobs/{job_or_submission_id}> -> <function JobHead.get_job_info at 0x7f96aa7d5550>
2025-04-28 19:05:19,680	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /api/jobs/> -> <function JobHead.list_jobs at 0x7f96aa7d5670>
2025-04-28 19:05:19,680	INFO http_server_head.py:207 -- <ResourceRoute [GET] <DynamicResource  /api/jobs/{job_or_submission_id}/logs> -> <function JobHead.get_job_logs at 0x7f96aa7d5790>
2025-04-28 19:05:19,680	INFO http_server_head.py:207 -- <ResourceRoute [GET] <DynamicResource  /api/jobs/{job_or_submission_id}/logs/tail> -> <function JobHead.tail_job_logs at 0x7f96aa7d58b0>
2025-04-28 19:05:19,680	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /log_index> -> <function LogHead.get_log_index at 0x7f96aa7f4f70>
2025-04-28 19:05:19,680	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /log_proxy> -> <function LogHead.get_log_from_proxy at 0x7f96aa7f80d0>
2025-04-28 19:05:19,680	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /api/grafana_health> -> <function MetricsHead.grafana_health at 0x7f96aa696310>
2025-04-28 19:05:19,680	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /api/prometheus_health> -> <function MetricsHead.prometheus_health at 0x7f96aa696430>
2025-04-28 19:05:19,680	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /internal/node_module> -> <function NodeHead.get_node_module_internal_state at 0x7f96aa69b160>
2025-04-28 19:05:19,680	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /nodes> -> <function NodeHead.get_all_nodes[cache ttl=2, max_size=128] at 0x7f96aa69b280>
2025-04-28 19:05:19,680	INFO http_server_head.py:207 -- <ResourceRoute [GET] <DynamicResource  /nodes/{node_id}> -> <function NodeHead.get_node[cache ttl=2, max_size=128] at 0x7f96aa69b430>
2025-04-28 19:05:19,680	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /api/v0/cluster_metadata> -> <function ReportHead.get_cluster_metadata at 0x7f96aa3f8d30>
2025-04-28 19:05:19,680	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /api/cluster_status> -> <function ReportHead.get_cluster_status at 0x7f96aa3f8e50>
2025-04-28 19:05:19,680	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /worker/traceback> -> <function ReportHead.get_traceback at 0x7f96aa3f8f70>
2025-04-28 19:05:19,681	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /worker/cpu_profile> -> <function ReportHead.cpu_profile at 0x7f96aa3fc0d0>
2025-04-28 19:05:19,681	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /api/serve_head/applications/> -> <function ServeHead.get_serve_instance_details at 0x7f96aa411940>
2025-04-28 19:05:19,681	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /api/actors/kill> -> <function APIHead.kill_actor_gcs at 0x7f96aa41d310>
2025-04-28 19:05:19,681	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /api/snapshot> -> <function APIHead.snapshot at 0x7f96aa41d430>
2025-04-28 19:05:19,681	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /api/component_activities> -> <function APIHead.get_component_activities at 0x7f96aa41d550>
2025-04-28 19:05:19,681	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /api/v0/actors> -> <function RateLimitedModule.enforce_max_concurrent_calls.<locals>.async_wrapper at 0x7f96aa3b2670>
2025-04-28 19:05:19,681	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /api/v0/jobs> -> <function RateLimitedModule.enforce_max_concurrent_calls.<locals>.async_wrapper at 0x7f96aa3b2820>
2025-04-28 19:05:19,681	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /api/v0/nodes> -> <function RateLimitedModule.enforce_max_concurrent_calls.<locals>.async_wrapper at 0x7f96aa3b29d0>
2025-04-28 19:05:19,681	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /api/v0/placement_groups> -> <function RateLimitedModule.enforce_max_concurrent_calls.<locals>.async_wrapper at 0x7f96aa3b2b80>
2025-04-28 19:05:19,681	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /api/v0/workers> -> <function RateLimitedModule.enforce_max_concurrent_calls.<locals>.async_wrapper at 0x7f96aa3b2d30>
2025-04-28 19:05:19,681	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /api/v0/tasks> -> <function RateLimitedModule.enforce_max_concurrent_calls.<locals>.async_wrapper at 0x7f96aa3b2ee0>
2025-04-28 19:05:19,681	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /api/v0/objects> -> <function RateLimitedModule.enforce_max_concurrent_calls.<locals>.async_wrapper at 0x7f96aa3b50d0>
2025-04-28 19:05:19,681	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /api/v0/runtime_envs> -> <function RateLimitedModule.enforce_max_concurrent_calls.<locals>.async_wrapper at 0x7f96aa3b5280>
2025-04-28 19:05:19,681	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /api/v0/cluster_events> -> <function RateLimitedModule.enforce_max_concurrent_calls.<locals>.async_wrapper at 0x7f96aa3b5430>
2025-04-28 19:05:19,681	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /api/v0/logs> -> <function RateLimitedModule.enforce_max_concurrent_calls.<locals>.async_wrapper at 0x7f96aa3b55e0>
2025-04-28 19:05:19,681	INFO http_server_head.py:207 -- <ResourceRoute [GET] <DynamicResource  /api/v0/logs/{media_type}> -> <function RateLimitedModule.enforce_max_concurrent_calls.<locals>.async_wrapper at 0x7f96aa3b5790>
2025-04-28 19:05:19,681	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /api/v0/tasks/summarize> -> <function RateLimitedModule.enforce_max_concurrent_calls.<locals>.async_wrapper at 0x7f96aa3b59d0>
2025-04-28 19:05:19,681	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /api/v0/actors/summarize> -> <function RateLimitedModule.enforce_max_concurrent_calls.<locals>.async_wrapper at 0x7f96aa3b5b80>
2025-04-28 19:05:19,681	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /api/v0/objects/summarize> -> <function RateLimitedModule.enforce_max_concurrent_calls.<locals>.async_wrapper at 0x7f96aa3b5d30>
2025-04-28 19:05:19,681	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /api/v0/tasks/timeline> -> <function RateLimitedModule.enforce_max_concurrent_calls.<locals>.async_wrapper at 0x7f96aa3b5ee0>
2025-04-28 19:05:19,681	INFO http_server_head.py:207 -- <ResourceRoute [GET] <DynamicResource  /api/v0/delay/{delay_s}> -> <function StateHead.delayed_response at 0x7f96aa3ba040>
2025-04-28 19:05:19,682	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /usage_stats_enabled> -> <function UsageStatsHead.get_usage_stats_enabled at 0x7f96aa3cb040>
2025-04-28 19:05:19,682	INFO http_server_head.py:207 -- <ResourceRoute [GET] <StaticResource  /logs -> PosixPath('/tmp/ray/session_2025-04-28_19-05-17_318142_8/logs')> -> <bound method StaticResource._handle of <StaticResource  /logs -> PosixPath('/tmp/ray/session_2025-04-28_19-05-17_318142_8/logs')>>
2025-04-28 19:05:19,682	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /> -> <function HttpServerDashboardHead.get_index at 0x7f96aa3cb820>
2025-04-28 19:05:19,682	INFO http_server_head.py:207 -- <ResourceRoute [GET] <PlainResource  /favicon.ico> -> <function HttpServerDashboardHead.get_favicon at 0x7f96aa3cb940>
2025-04-28 19:05:19,682	INFO http_server_head.py:207 -- <ResourceRoute [GET] <StaticResource  /static -> PosixPath('/home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/client/build/static')> -> <bound method StaticResource._handle of <StaticResource  /static -> PosixPath('/home/ray/anaconda3/lib/python3.8/site-packages/ray/dashboard/client/build/static')>>
2025-04-28 19:05:19,682	INFO http_server_head.py:208 -- Registered 50 routes.
2025-04-28 19:05:19,682	INFO head.py:329 -- http server initialized at 10.48.99.156:8265
2025-04-28 19:05:19,684	INFO event_utils.py:132 -- Monitor events logs modified after 1745890519.5241358 on /tmp/ray/session_2025-04-28_19-05-17_318142_8/logs/events, the source types are all.
2025-04-28 19:05:19,702	INFO usage_stats_head.py:171 -- Usage reporting is enabled.
2025-04-28 19:05:19,703	INFO actor_head.py:102 -- Getting all actor info from GCS.
2025-04-28 19:05:19,708	INFO actor_head.py:124 -- Received 0 actor info from GCS.
2025-04-28 19:05:28,020	INFO web_log.py:206 -- 127.0.0.1 [29/Apr/2025:02:05:28 +0000] 'GET /api/gcs_healthz HTTP/1.1' 200 163 bytes 1924 us '-' 'Wget/1.20.3 (linux-gnu)'
2025-04-28 19:05:28,654	INFO web_log.py:206 -- 10.9.7.102 [29/Apr/2025:02:05:28 +0000] 'PUT /api/serve/applications/ HTTP/1.1' 404 172 bytes 1056 us '-' 'kuberay-operator/v1.2.1'
2025-04-28 19:05:30,674	INFO web_log.py:206 -- 10.9.7.102 [29/Apr/2025:02:05:30 +0000] 'PUT /api/serve/applications/ HTTP/1.1' 404 172 bytes 956 us '-' 'kuberay-operator/v1.2.1'
2025-04-28 19:05:32,693	INFO web_log.py:206 -- 10.9.7.102 [29/Apr/2025:02:05:32 +0000] 'PUT /api/serve/applications/ HTTP/1.1' 404 172 bytes 916 us '-' 'kuberay-operator/v1.2.1'
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
