### PR TITLE
[core] Reset `next_task_reply_position` when the actor restarts to avoid submitting the same task twice

### DIFF
--- a/doc/source/cluster/kubernetes/index.md
+++ b/doc/source/cluster/kubernetes/index.md
@@ -41,7 +41,7 @@ See [Getting Started](kuberay-quickstart) to learn the basics of KubeRay and fol
 * [RayJob Quick Start](kuberay-rayjob-quickstart)
 * [RayService Quick Start](kuberay-rayservice-quickstart)
 
-Additionally, [Anyscale](https://www.anyscale.com/ray-on-anyscale?utm_source=ray_docs&utm_medium=docs&utm_campaign=ray-doc-upsell&utm_content=deploy-ray-on-k8s) is the managed Ray platform developed by the creators of Ray. It offers an easy path to deploy Ray clusters on your existing Kubernetes infrastructure, including EKS, GEK, AKS, or self-hosted Kubernetes.
+Additionally, [Anyscale](https://www.anyscale.com/ray-on-anyscale?utm_source=ray_docs&utm_medium=docs&utm_campaign=ray-doc-upsell&utm_content=deploy-ray-on-k8s) is the managed Ray platform developed by the creators of Ray. It offers an easy path to deploy Ray clusters on your existing Kubernetes infrastructure, including EKS, GKE, AKS, or self-hosted Kubernetes.
 
 ## Learn More
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -732,6 +732,7 @@ CoreWorker::CoreWorker(CoreWorkerOptions options, const WorkerID &worker_id)
           to_resubmit_.push(std::move(task_to_retry));
         } else {
           if (spec.IsActorTask()) {
+            RAY_LOG(INFO) << "[debug] TaskManager retry_task_callback SubmitTask";
             auto actor_handle = actor_manager_->GetActorHandle(spec.ActorId());
             actor_handle->SetResubmittedActorTaskSpec(spec);
             RAY_CHECK_OK(actor_task_submitter_->SubmitTask(spec));

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -1061,10 +1061,14 @@ void TaskManager::FailPendingTask(const TaskID &task_id,
       // to exit and not be marked as failure.
       SetTaskStatus(it->second, rpc::TaskStatus::FINISHED);
     } else {
-      auto state_update = worker::TaskStatusEvent::TaskStateUpdate(gcs::GetRayErrorInfo(
-          error_type, (status != nullptr ? status->ToString() : "")));
-
-      SetTaskStatus(it->second, rpc::TaskStatus::FAILED, state_update);
+      auto error_info =
+          (ray_error_info == nullptr
+               ? gcs::GetRayErrorInfo(error_type,
+                                      (status != nullptr ? status->ToString() : ""))
+               : *ray_error_info);
+      SetTaskStatus(it->second,
+                    rpc::TaskStatus::FAILED,
+                    worker::TaskStatusEvent::TaskStateUpdate(error_info));
     }
     submissible_tasks_.erase(it);
     num_pending_tasks_--;

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -888,10 +888,11 @@ void TaskManager::CompletePendingTask(const TaskID &task_id,
     it->second.num_successful_executions++;
 
     if (is_application_error) {
-      SetTaskStatus(it->second,
-                    rpc::TaskStatus::FAILED,
-                    gcs::GetRayErrorInfo(rpc::ErrorType::TASK_EXECUTION_EXCEPTION,
-                                         reply.task_execution_error()));
+      SetTaskStatus(
+          it->second,
+          rpc::TaskStatus::FAILED,
+          worker::TaskStatusEvent::TaskStateUpdate(gcs::GetRayErrorInfo(
+              rpc::ErrorType::TASK_EXECUTION_EXCEPTION, reply.task_execution_error())));
     } else {
       SetTaskStatus(it->second, rpc::TaskStatus::FINISHED);
     }
@@ -1060,12 +1061,10 @@ void TaskManager::FailPendingTask(const TaskID &task_id,
       // to exit and not be marked as failure.
       SetTaskStatus(it->second, rpc::TaskStatus::FINISHED);
     } else {
-      SetTaskStatus(it->second,
-                    rpc::TaskStatus::FAILED,
-                    (ray_error_info == nullptr
-                         ? gcs::GetRayErrorInfo(
-                               error_type, (status != nullptr ? status->ToString() : ""))
-                         : *ray_error_info));
+      auto state_update = worker::TaskStatusEvent::TaskStateUpdate(gcs::GetRayErrorInfo(
+          error_type, (status != nullptr ? status->ToString() : "")));
+
+      SetTaskStatus(it->second, rpc::TaskStatus::FAILED, state_update);
     }
     submissible_tasks_.erase(it);
     num_pending_tasks_--;
@@ -1417,15 +1416,9 @@ void TaskManager::MarkTaskWaitingForExecution(const TaskID &task_id,
   RAY_CHECK(it->second.GetStatus() == rpc::TaskStatus::PENDING_NODE_ASSIGNMENT)
       << ", task ID = " << it->first << ", status = " << it->second.GetStatus();
   it->second.SetNodeId(node_id);
-  it->second.SetStatus(rpc::TaskStatus::SUBMITTED_TO_WORKER);
-  RAY_UNUSED(task_event_buffer_.RecordTaskStatusEventIfNeeded(
-      it->second.spec.TaskId(),
-      it->second.spec.JobId(),
-      it->second.spec.AttemptNumber(),
-      it->second.spec,
-      rpc::TaskStatus::SUBMITTED_TO_WORKER,
-      /* include_task_info */ false,
-      worker::TaskStatusEvent::TaskStateUpdate(node_id, worker_id)));
+  SetTaskStatus(it->second,
+                rpc::TaskStatus::SUBMITTED_TO_WORKER,
+                worker::TaskStatusEvent::TaskStateUpdate(node_id, worker_id));
 }
 
 void TaskManager::MarkTaskRetryOnResubmit(TaskEntry &task_entry) {
@@ -1435,17 +1428,15 @@ void TaskManager::MarkTaskRetryOnResubmit(TaskEntry &task_entry) {
   task_entry.MarkRetry();
 
   // Mark the new status and also include task spec info for the new attempt.
-  task_entry.SetStatus(rpc::TaskStatus::PENDING_ARGS_AVAIL);
+  //
   // NOTE(rickyx): We only increment the AttemptNumber on the task spec when
   // `retry_task_callback_` is invoked. In order to record the correct status change for
   // the new task attempt, we pass the the attempt number explicitly.
-  RAY_UNUSED(task_event_buffer_.RecordTaskStatusEventIfNeeded(
-      task_entry.spec.TaskId(),
-      task_entry.spec.JobId(),
-      task_entry.spec.AttemptNumber() + 1,
-      task_entry.spec,
-      rpc::TaskStatus::PENDING_ARGS_AVAIL,
-      /* include_task_info */ true));
+  SetTaskStatus(task_entry,
+                rpc::TaskStatus::PENDING_ARGS_AVAIL,
+                /* state_update */ std::nullopt,
+                /* include_task_info */ true,
+                task_entry.spec.AttemptNumber() + 1);
 }
 
 void TaskManager::MarkTaskRetryOnFailed(TaskEntry &task_entry,
@@ -1453,33 +1444,40 @@ void TaskManager::MarkTaskRetryOnFailed(TaskEntry &task_entry,
   RAY_CHECK(task_entry.IsPending());
 
   // Record the old attempt status as FAILED.
-  SetTaskStatus(task_entry, rpc::TaskStatus::FAILED, error_info);
+  SetTaskStatus(task_entry,
+                rpc::TaskStatus::FAILED,
+                worker::TaskStatusEvent::TaskStateUpdate(error_info));
   task_entry.MarkRetry();
 
   // Mark the new status and also include task spec info for the new attempt.
-  task_entry.SetStatus(rpc::TaskStatus::PENDING_ARGS_AVAIL);
-  RAY_UNUSED(task_event_buffer_.RecordTaskStatusEventIfNeeded(
-      task_entry.spec.TaskId(),
-      task_entry.spec.JobId(),
-      task_entry.spec.AttemptNumber() + 1,
-      task_entry.spec,
-      rpc::TaskStatus::PENDING_ARGS_AVAIL,
-      /* include_task_info */ true));
+  SetTaskStatus(task_entry,
+                rpc::TaskStatus::PENDING_ARGS_AVAIL,
+                /* state_update */ std::nullopt,
+                /* include_task_info */ true,
+                task_entry.spec.AttemptNumber() + 1);
 }
 
 void TaskManager::SetTaskStatus(
     TaskEntry &task_entry,
     rpc::TaskStatus status,
-    const std::optional<const rpc::RayErrorInfo> &error_info) {
+    std::optional<worker::TaskStatusEvent::TaskStateUpdate> state_update,
+    bool include_task_info,
+    std::optional<int32_t> attempt_number) {
+  RAY_LOG(DEBUG).WithField(task_entry.spec.TaskId())
+      << "Setting task status from " << task_entry.GetStatus() << " to " << status;
   task_entry.SetStatus(status);
-  RAY_UNUSED(task_event_buffer_.RecordTaskStatusEventIfNeeded(
-      task_entry.spec.TaskId(),
-      task_entry.spec.JobId(),
-      task_entry.spec.AttemptNumber(),
-      task_entry.spec,
-      status,
-      /* include_task_info */ false,
-      worker::TaskStatusEvent::TaskStateUpdate(error_info)));
+
+  int32_t attempt_number_to_record =
+      attempt_number.value_or(task_entry.spec.AttemptNumber());
+  auto state_update_to_record =
+      state_update.value_or(worker::TaskStatusEvent::TaskStateUpdate());
+  RAY_UNUSED(task_event_buffer_.RecordTaskStatusEventIfNeeded(task_entry.spec.TaskId(),
+                                                              task_entry.spec.JobId(),
+                                                              attempt_number_to_record,
+                                                              task_entry.spec,
+                                                              status,
+                                                              include_task_info,
+                                                              state_update_to_record));
 }
 
 std::unordered_map<rpc::LineageReconstructionTask, uint64_t>

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -734,11 +734,18 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
   ///
   /// \param task_entry corresponding TaskEntry of a task to record the event.
   /// \param status new status.
-  /// \param error_info Optional error info for task execution.
+  /// \param state_update The state update for the task status change event.
+  /// \param include_task_info Whether to include task info in the task status change
+  /// event.
+  /// \param attempt_number The attempt number to record the task status change
+  /// event. If not specified, the attempt number will be the current attempt number of
+  /// the task.
   void SetTaskStatus(
       TaskEntry &task_entry,
       rpc::TaskStatus status,
-      const std::optional<const rpc::RayErrorInfo> &error_info = absl::nullopt);
+      std::optional<worker::TaskStatusEvent::TaskStateUpdate> state_update = std::nullopt,
+      bool include_task_info = false,
+      std::optional<int32_t> attempt_number = std::nullopt);
 
   /// Update the task entry for the task attempt to reflect retry on resubmit.
   ///

--- a/src/ray/core_worker/transport/actor_submit_queue.h
+++ b/src/ray/core_worker/transport/actor_submit_queue.h
@@ -74,6 +74,8 @@ class IActorSubmitQueue {
   /// On client connect/reconnect, find all the tasks that's known to be
   /// executed out of order. This is specific to SequentialActorSubmitQueue.
   virtual std::map<uint64_t, TaskSpecification> PopAllOutOfOrderCompletedTasks() = 0;
+  /// On client connected.
+  virtual void OnClientConnected() = 0;
   /// Get the sequence number of the task to send according to the protocol.
   virtual uint64_t GetSequenceNumber(const TaskSpecification &task_spec) const = 0;
   /// Mark a task has been executed on the receiver side.

--- a/src/ray/core_worker/transport/actor_task_submitter.cc
+++ b/src/ray/core_worker/transport/actor_task_submitter.cc
@@ -189,6 +189,7 @@ Status ActorTaskSubmitter::SubmitTask(TaskSpecification task_spec) {
       // backpressure. The receiving actor will execute the tasks according to
       // this sequence number.
       send_pos = task_spec.ActorCounter();
+      RAY_LOG(INFO) << "[debug] SubmitTask Emplace sequence_no: " << send_pos;
       RAY_CHECK(queue->second.actor_submit_queue->Emplace(send_pos, task_spec));
       queue->second.cur_pending_calls++;
       task_queued = true;
@@ -330,6 +331,7 @@ void ActorTaskSubmitter::ConnectActor(const ActorID &actor_id,
     queue->second.worker_id = address.worker_id();
     // Create a new connection to the actor.
     queue->second.rpc_client = core_worker_client_pool_.GetOrConnect(address);
+    queue->second.actor_submit_queue->OnClientConnected();
 
     ResendOutOfOrderCompletedTasks(actor_id);
     SendPendingTasks(actor_id);
@@ -522,6 +524,7 @@ void ActorTaskSubmitter::CheckTimeoutTasks() {
 }
 
 void ActorTaskSubmitter::SendPendingTasks(const ActorID &actor_id) {
+  RAY_LOG(INFO) << "SendPendingTasks";
   auto it = client_queues_.find(actor_id);
   RAY_CHECK(it != client_queues_.end());
   auto &client_queue = it->second;
@@ -569,6 +572,7 @@ void ActorTaskSubmitter::SendPendingTasks(const ActorID &actor_id) {
 }
 
 void ActorTaskSubmitter::ResendOutOfOrderCompletedTasks(const ActorID &actor_id) {
+  RAY_LOG(INFO) << "ResendOutOfOrderCompletedTasks";
   auto it = client_queues_.find(actor_id);
   RAY_CHECK(it != client_queues_.end());
   if (!it->second.rpc_client) {

--- a/src/ray/core_worker/transport/out_of_order_actor_submit_queue.cc
+++ b/src/ray/core_worker/transport/out_of_order_actor_submit_queue.cc
@@ -102,6 +102,8 @@ OutofOrderActorSubmitQueue::PopAllOutOfOrderCompletedTasks() {
   return {};
 }
 
+void OutofOrderActorSubmitQueue::OnClientConnected() {}
+
 uint64_t OutofOrderActorSubmitQueue::GetSequenceNumber(
     const TaskSpecification &task_spec) const {
   return task_spec.ActorCounter();

--- a/src/ray/core_worker/transport/out_of_order_actor_submit_queue.h
+++ b/src/ray/core_worker/transport/out_of_order_actor_submit_queue.h
@@ -62,6 +62,8 @@ class OutofOrderActorSubmitQueue : public IActorSubmitQueue {
   /// On client connect/reconnect, find all the TASK that's known to be
   /// executed out of order. This ALWAYS RETURNS empty.
   std::map<uint64_t, TaskSpecification> PopAllOutOfOrderCompletedTasks() override;
+  /// On client connected, noop.
+  void OnClientConnected() override;
   /// Get the sequence number of the task to send.
   /// This is ignored by the receivier but only for debugging purpose.
   uint64_t GetSequenceNumber(const TaskSpecification &task_spec) const override;

--- a/src/ray/core_worker/transport/sequential_actor_submit_queue.h
+++ b/src/ray/core_worker/transport/sequential_actor_submit_queue.h
@@ -58,6 +58,9 @@ class SequentialActorSubmitQueue : public IActorSubmitQueue {
   /// On client connect/reconnect, find all the tasks which are known to be
   /// executed out of order.
   std::map<uint64_t, TaskSpecification> PopAllOutOfOrderCompletedTasks() override;
+  /// Called when client is connected/reconnected. Resets `next_task_reply_position` to
+  /// the smallest sequence number of the tasks in `requests`.
+  void OnClientConnected() override;
   /// Get the task's sequence number according to the internal offset.
   uint64_t GetSequenceNumber(const TaskSpecification &task_spec) const override;
   /// Mark a task has been executed on the receiver side.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

https://gist.github.com/kevin85421/43833b55181ee174503999ca1659657f

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
