### PR TITLE
Actors tab does not list actors after gcs reboot

### DIFF
--- a/python/ray/includes/unique_ids.pxi
+++ b/python/ray/includes/unique_ids.pxi
@@ -300,6 +300,12 @@ cdef class ActorID(BaseID):
                                parent_task_counter).Binary())
 
     @classmethod
+    def from_binary(cls, id_bytes):
+        if not isinstance(id_bytes, bytes):
+            raise TypeError("Expect bytes, got " + str(type(id_bytes)))
+        return cls(id_bytes)
+
+    @classmethod
     def from_hex(cls, hex_id):
         binary_id = CActorID.FromHex(<c_string>hex_id).Binary()
         return cls(binary_id)

--- a/python/ray/includes/unique_ids.pxi
+++ b/python/ray/includes/unique_ids.pxi
@@ -301,8 +301,6 @@ cdef class ActorID(BaseID):
 
     @classmethod
     def from_binary(cls, id_bytes):
-        if not isinstance(id_bytes, bytes):
-            raise TypeError("Expect bytes, got " + str(type(id_bytes)))
         return cls(id_bytes)
 
     @classmethod

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -3750,10 +3750,10 @@ def test_actor_id_from_binary():
     assert "Expect bytes, got" in str(exc_info.value)
     assert "<class 'str'>" in str(exc_info.value)
 
-    # Test with empty bytes
-    empty_actor_id = ActorID.from_binary(b"")
-    assert empty_actor_id.binary() == b""
-    assert empty_actor_id.hex() == ""
+    # Test with empty bytes - should raise ValueError due to length validation
+    with pytest.raises(ValueError) as exc_info:
+        ActorID.from_binary(b"")
+    assert "ID string needs to have length" in str(exc_info.value)
 
     # Test with None
     with pytest.raises(TypeError) as exc_info:

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -3733,6 +3733,33 @@ def test_hang_driver_has_no_is_running_task(monkeypatch, ray_start_cluster):
     assert list(all_job_info.keys()) == [my_job_id]
     assert not all_job_info[my_job_id].HasField("is_running_tasks")
 
+def test_actor_id_from_binary():
+    # Test with valid binary data
+    binary_data = b"1234567890abcdef"
+    actor_id = ActorID.from_binary(binary_data)
+    assert isinstance(actor_id, ActorID)
+    assert actor_id.binary() == binary_data
+
+    # Test with hex conversion
+    actor_id_hex = actor_id.hex()
+    assert actor_id_hex == binary_data.hex()
+
+    # Test with invalid data type
+    with pytest.raises(TypeError) as exc_info:
+        ActorID.from_binary("not_bytes")
+    assert "Expect bytes, got" in str(exc_info.value)
+    assert "<class 'str'>" in str(exc_info.value)
+
+    # Test with empty bytes
+    empty_actor_id = ActorID.from_binary(b"")
+    assert empty_actor_id.binary() == b""
+    assert empty_actor_id.hex() == ""
+
+    # Test with None
+    with pytest.raises(TypeError) as exc_info:
+        ActorID.from_binary(None)
+    assert "Expect bytes, got" in str(exc_info.value)
+    assert "<class 'NoneType'>" in str(exc_info.value)
 
 if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -3747,19 +3747,17 @@ def test_actor_id_from_binary():
     # Test with invalid data type
     with pytest.raises(TypeError) as exc_info:
         ActorID.from_binary("not_bytes")
-    assert "Expect bytes, got" in str(exc_info.value)
-    assert "<class 'str'>" in str(exc_info.value)
+    assert "Unsupported type: <class 'str'>" in str(exc_info.value)
 
-    # Test with empty bytes - should raise ValueError due to length validation
+    # Test with incorrect length
     with pytest.raises(ValueError) as exc_info:
-        ActorID.from_binary(b"")
+        ActorID.from_binary(b"tooshort")
     assert "ID string needs to have length" in str(exc_info.value)
 
     # Test with None
     with pytest.raises(TypeError) as exc_info:
         ActorID.from_binary(None)
-    assert "Expect bytes, got" in str(exc_info.value)
-    assert "<class 'NoneType'>" in str(exc_info.value)
+    assert "Unsupported type: <class 'NoneType'>" in str(exc_info.value)
 
 if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):


### PR DESCRIPTION
## Why are these changes needed?

After a GCS reboot, the Actors tab fails to list actors (with gcs FT enabled). The root cause is that actors cannot be correctly deserialized due to the absence of the from_binary function. See error message from dashboard.log:

```
2025-04-27 11:38:06,471	INFO actor_head.py:142 -- Getting all actor info from GCS.
2025-04-27 11:38:06,472	ERROR actor_head.py:162 -- Error Getting all actor info from GCS.
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/ray/dashboard/modules/actor/actor_head.py", line 144, in _update_actors
    actors = await self.get_all_actor_info(timeout=5)
  File "/usr/local/lib/python3.10/dist-packages/ray/dashboard/modules/actor/actor_head.py", line 102, in __call__
    return await self.gcs_aio_client.get_all_actor_info(timeout=timeout)
  File "python/ray/includes/gcs_client.pxi", line 656, in ray._raylet.convert_get_all_actor_info
AttributeError: type object 'ray._raylet.ActorID' has no attribute 'from_binary'
```

## Related issue number

https://github.com/ray-project/ray/issues/47447

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
