### PR TITLE
[Data] Mitigate OOM errors in `gpu_batch_inference.py`

### DIFF
--- a/release/nightly_tests/dataset/gpu_batch_inference.py
+++ b/release/nightly_tests/dataset/gpu_batch_inference.py
@@ -1,12 +1,12 @@
-from typing import Dict
 import argparse
 import time
+from typing import Dict
 
 import numpy as np
 import torch
-from torchvision.models import resnet50, ResNet50_Weights
-
 from benchmark import Benchmark, BenchmarkMetric
+from torchvision.models import ResNet50_Weights, resnet50
+
 import ray
 from ray.data import ActorPoolStrategy
 
@@ -48,8 +48,13 @@ def main(args):
 
     print(f"Running GPU batch prediction with data from {data_url}")
 
+    # The preprocessing UDF converts images from uint8 to float64, which increases
+    # memory usage 8x. Each processed image is about 1.5 MiB (256×256×3×8 bytes). Since
+    # our target block size is 128 MiB, we set the batch size to around 90 images (128
+    # MiB / 1.5) to avoid running out of memory.
+    PREPROCESS_BATCH_SIZE = 90
     # Largest batch that can fit on a T4.
-    BATCH_SIZE = 900
+    INFERENCE_BATCH_SIZE = 900
 
     device = "cpu" if smoke_test else "cuda"
 
@@ -100,10 +105,10 @@ def main(args):
         # Autoscale to use as many GPUs as possible.
         compute = ActorPoolStrategy(min_size=1, max_size=None)
         num_gpus = 1
-    ds = ds.map_batches(preprocess)
+    ds = ds.map_batches(preprocess, batch_size=PREPROCESS_BATCH_SIZE)
     ds = ds.map_batches(
         Predictor,
-        batch_size=BATCH_SIZE,
+        batch_size=INFERENCE_BATCH_SIZE,
         compute=compute,
         num_gpus=num_gpus,
         fn_constructor_kwargs={"model": model_ref},

--- a/release/nightly_tests/dataset/gpu_batch_inference.py
+++ b/release/nightly_tests/dataset/gpu_batch_inference.py
@@ -102,8 +102,7 @@ def main(args):
         compute = ActorPoolStrategy(size=4)
         num_gpus = 0
     else:
-        # Autoscale to use as many GPUs as possible.
-        compute = ActorPoolStrategy(min_size=1, max_size=None)
+        compute = ActorPoolStrategy(min_size=1, max_size=10)
         num_gpus = 1
     ds = ds.map_batches(preprocess, batch_size=PREPROCESS_BATCH_SIZE)
     ds = ds.map_batches(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The preprocessing UDF converts images from uint8 to float64, which increases memory usage 8x. As a result, this script can be prone to OOMs.

To mitigate these OOMs, this PR configures a batch size for the preprocessing UDF.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
