### PR TITLE
[serve] use sys.executable instead of python in tests

### DIFF
--- a/python/ray/serve/tests/test_standalone_2.py
+++ b/python/ray/serve/tests/test_standalone_2.py
@@ -349,14 +349,18 @@ serve.run(B.bind())"""
         f1.write(file1.encode("utf-8"))
         f1.seek(0)
         # Driver 1 (starts Serve controller)
-        output = subprocess.check_output(["python", f1.name], stderr=subprocess.STDOUT)
+        output = subprocess.check_output(
+            [sys.executable, f1.name], stderr=subprocess.STDOUT
+        )
         assert "Connecting to existing Ray cluster" in output.decode("utf-8")
         assert "Adding 1 replica to Deployment(name='A'" in output.decode("utf-8")
 
         f2.write(file2.encode("utf-8"))
         f2.seek(0)
         # Driver 2 (reconnects to the same Serve controller)
-        output = subprocess.check_output(["python", f2.name], stderr=subprocess.STDOUT)
+        output = subprocess.check_output(
+            [sys.executable, f2.name], stderr=subprocess.STDOUT
+        )
         assert "Connecting to existing Ray cluster" in output.decode("utf-8")
         assert "Adding 1 replica to Deployment(name='B'" in output.decode("utf-8")
 
@@ -381,14 +385,18 @@ serve.run(B.bind())"""
     with NamedTemporaryFile() as f1, NamedTemporaryFile() as f2:
         f1.write(file1.encode("utf-8"))
         f1.seek(0)
-        output = subprocess.check_output(["python", f1.name], stderr=subprocess.STDOUT)
+        output = subprocess.check_output(
+            [sys.executable, f1.name], stderr=subprocess.STDOUT
+        )
         print(output.decode("utf-8"))
         assert "Connecting to existing Ray cluster" in output.decode("utf-8")
         subprocess.check_output(["serve", "shutdown", "-y"])
 
         f2.write(file2.encode("utf-8"))
         f2.seek(0)
-        output = subprocess.check_output(["python", f2.name], stderr=subprocess.STDOUT)
+        output = subprocess.check_output(
+            [sys.executable, f2.name], stderr=subprocess.STDOUT
+        )
         print(output.decode("utf-8"))
         assert "Connecting to existing Ray cluster" in output.decode("utf-8")
         assert "Recovering target state for application" not in output.decode("utf-8")

--- a/python/ray/serve/tests/test_standalone_3.py
+++ b/python/ray/serve/tests/test_standalone_3.py
@@ -208,9 +208,9 @@ def test_shutdown_remote(start_and_shutdown_ray_cli_function):
 
         # Ensure Serve can be restarted and shutdown with for loop
         for _ in range(2):
-            subprocess.check_output(["python", deploy_file.name])
+            subprocess.check_output([sys.executable, deploy_file.name])
             assert requests.get("http://localhost:8000/f").text == "got f"
-            subprocess.check_output(["python", shutdown_file.name])
+            subprocess.check_output([sys.executable, shutdown_file.name])
             with pytest.raises(requests.exceptions.ConnectionError):
                 requests.get("http://localhost:8000/f")
     finally:


### PR DESCRIPTION
## Why are these changes needed?

Seeing errors like the following in `test_standalone_2` and `test_standalone_3`:
```
[2025-04-28T18:37:09Z] Traceback (most recent call last):
--
  | [2025-04-28T18:37:09Z]   File "/tmp/tmpwuqkmzo3.py", line 2, in <module>
  | [2025-04-28T18:37:09Z]     from ray import serve
  | [2025-04-28T18:37:09Z]   File "/rayci/python/ray/serve/__init__.py", line 1, in <module>
  | [2025-04-28T18:37:09Z]     import ray._private.worker
  | [2025-04-28T18:37:09Z]   File "/rayci/python/ray/_private/worker.py", line 37, in <module>
  | [2025-04-28T18:37:09Z]     import setproctitle
  | [2025-04-28T18:37:09Z] ModuleNotFoundError: No module named 'setproctitle'
```

`setproctitle` has been a requirement for a while, which seems to imply for some reason launch the subprocess with `"python"` is using the wrong python. Use `sys.executable` instead to guarantee the subprocess uses the same python.
