### PR TITLE
[Serve.llm] made Ray Serve LLM compatible with vLLM v1

### DIFF
--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
@@ -75,7 +75,7 @@ time_in_queue_histogram = metrics.Histogram(
 )
 
 V1_TOO_LONG_PATTERN = re.compile(
-    r"Prompt length of (\d+) is longer than the maximum model length of (\d+)."
+    r".* (\d+).* is longer than the maximum model length of (\d+).*"
 )
 
 

--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
@@ -95,6 +95,7 @@ def _get_async_engine_args(llm_config: LLMConfig) -> "AsyncEngineArgs":
         **{
             "model": model,
             "distributed_executor_backend": "ray",
+            "guided_decoding_backend": "xgrammar",
             "disable_log_stats": False,
             **engine_config.get_initialization_kwargs(),
         }

--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
@@ -95,7 +95,7 @@ def _get_async_engine_args(llm_config: LLMConfig) -> "AsyncEngineArgs":
         **{
             "model": model,
             "distributed_executor_backend": "ray",
-            "guided_decoding_backend": "xgrammar",
+            "guided_decoding_backend": RAYLLM_GUIDED_DECODING_BACKEND,
             "disable_log_stats": False,
             **engine_config.get_initialization_kwargs(),
         }

--- a/python/requirements/llm/llm-test-requirements.txt
+++ b/python/requirements/llm/llm-test-requirements.txt
@@ -6,4 +6,3 @@ pynvml>=12.0.0
 xgrammar>=0.1.11, !=0.1.13, !=0.1.12
 jupytext>1.13.6
 sphinx==6.2.1
-vllm==0.8.5

--- a/python/requirements/llm/llm-test-requirements.txt
+++ b/python/requirements/llm/llm-test-requirements.txt
@@ -6,3 +6,4 @@ pynvml>=12.0.0
 xgrammar>=0.1.11, !=0.1.13, !=0.1.12
 jupytext>1.13.6
 sphinx==6.2.1
+vllm==0.8.5

--- a/release/llm_tests/serve/configs/model_config/llama_3dot1_8b_quantized_tp1.yaml
+++ b/release/llm_tests/serve/configs/model_config/llama_3dot1_8b_quantized_tp1.yaml
@@ -6,7 +6,7 @@ accelerator_type: A10G
 # Test V1 at the same time
 runtime_env:
   env_vars:
-    USE_VLLM_V1: "1"
+    VLLM_USE_V1: "1"
 
 engine_kwargs:
   max_model_len: 8192

--- a/release/llm_tests/serve/probes/test_json_mode.py
+++ b/release/llm_tests/serve/probes/test_json_mode.py
@@ -4,6 +4,7 @@ from typing import List
 
 import openai
 import pytest
+import vllm
 from pydantic import BaseModel, Field
 
 from probes.messages import messages, system, user
@@ -133,6 +134,9 @@ async def query_json_model(
     return response_str, expected_type
 
 
+@pytest.mark.skipif(
+    "0.8.2" <= vllm.__version__ < "0.8.5", reason="vllm will hang for json requests"
+)
 @pytest.mark.asyncio
 @pytest.mark.parametrize("model", MODEL_IDS)
 # @pytest.mark.parametrize("response_type", ["basic", "array", "nested"])
@@ -165,6 +169,9 @@ async def test_json_mode(
         expected_type(**json.loads(response_str))
 
 
+@pytest.mark.skipif(
+    "0.8.2" <= vllm.__version__ < "0.8.5", reason="vllm will hang for json requests"
+)
 @pytest.mark.parametrize("model", MODEL_IDS)
 @pytest.mark.parametrize("response_format", get_response_formats())
 @pytest.mark.parametrize("stream", [True, False])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Enable vLLM v1 engine in the release test and fixes:
- catch v1 engine input too long error and return the expected error
- set the `guided_decoding_backend` on the engine as the v1 engine no longer support request level backend selection

Also note the current vLLM version (0.8.2) has bug that will have json request hangs. Skip those test for now until the vllm is upgraded to 0.8.5 or later

## Related issue number

Closes https://anyscale1.atlassian.net/browse/LLM-1865?atlOrigin=eyJpIjoiMTFhMTFiYTA2MzVmNDVhOTkxMWRjZDA1NzQzMjhhYjAiLCJwIjoiaiJ9

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
