### PR TITLE
[Dashboard] Allow getting dashboard URL via RuntimeContext

### DIFF
--- a/doc/source/ray-observability/getting-started.rst
+++ b/doc/source/ray-observability/getting-started.rst
@@ -48,6 +48,10 @@ You can capture the context object returned by `ray.init()` and access the URL t
     context = ray.init()
     print(context.dashboard_url)
 
+..
+    This test output is flaky. If Ray isn't completely shutdown, the port can be
+    "8266" instead of "8265".
+
 .. testoutput::
     :options: +MOCK
 
@@ -70,6 +74,10 @@ A more convenient way to get the dashboard URL *after* Ray has been initialized 
     ray.init()
     ctx = ray.get_runtime_context()
     print(ctx.get_dashboard_url())
+
+..
+    This test output is flaky. If Ray isn't completely shutdown, the port can be
+    "8266" instead of "8265".
 
 .. testoutput::
     :options: +MOCK

--- a/doc/source/ray-observability/getting-started.rst
+++ b/doc/source/ray-observability/getting-started.rst
@@ -23,7 +23,17 @@ To access the dashboard, use `ray[default]` or :ref:`other installation commands
 
   pip install -U "ray[default]"
 
-When you start a single-node Ray Cluster on your laptop, access the dashboard with the URL that Ray prints when it initializes (the default URL is **http://localhost:8265**) or with the context object returned by `ray.init`.
+When you start a single-node Ray Cluster on your laptop, access the dashboard with the URL that Ray prints when it initializes (the default URL is **http://localhost:8265**).
+
+.. code-block:: text
+
+   INFO worker.py:1487 -- Connected to Ray cluster. View the dashboard at 127.0.0.1:8265.
+
+There are two ways to get the dashboard URL programmatically:
+
+**1. Using the Context from `ray.init()`**
+
+You can capture the context object returned by `ray.init()` and access the URL through its `dashboard_url` property.
 
 .. testcode::
   :hide:
@@ -38,24 +48,37 @@ When you start a single-node Ray Cluster on your laptop, access the dashboard wi
     context = ray.init()
     print(context.dashboard_url)
 
-..
-    This test output is flaky. If Ray isn't completely shutdown, the port can be
-    "8266" instead of "8265".
+.. testoutput::
+    :options: +MOCK
+
+   127.0.0.1:8265
+
+**2. Using the Runtime Context**
+
+A more convenient way to get the dashboard URL *after* Ray has been initialized is to use the :meth:`ray.get_runtime_context().get_dashboard_url() <ray.runtime_context.RuntimeContext.get_dashboard_url>` method. This works even if you didn't store the initial context from `ray.init()`.
+
+.. testcode::
+  :hide:
+
+  import ray
+  ray.shutdown()
+
+.. testcode::
+
+    import ray
+
+    ray.init()
+    ctx = ray.get_runtime_context()
+    print(ctx.get_dashboard_url())
 
 .. testoutput::
     :options: +MOCK
 
    127.0.0.1:8265
 
-.. code-block:: text
-
-  INFO worker.py:1487 -- Connected to Ray cluster. View the dashboard at 127.0.0.1:8265.
-
 .. note::
 
-    If you start Ray in a docker container, ``--dashboard-host`` is a required parameter. For example, ``ray start --head --dashboard-host=0.0.0.0``.
-
-
+    If you start Ray in a docker container, `--dashboard-host` is a required parameter. For example, `ray start --head --dashboard-host=0.0.0.0`.
 
 When you start a remote Ray Cluster with the :ref:`VM Cluster Launcher <vm-cluster-quick-start>`, :ref:`KubeRay operator <kuberay-quickstart>`, or manual configuration, Ray Dashboard launches on the head node but the dashboard port may not be publicly exposed. View :ref:`configuring the dashboard <dashboard-in-browser>` for how to view Dashboard from outside the Head Node.
 

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1916,6 +1916,7 @@ def init(
     for hook in _post_init_hooks:
         hook()
 
+    global_worker._dashboard_url = dashboard_url
     node_id = global_worker.core_worker.get_current_node_id()
     global_node_address_info = _global_node.address_info.copy()
     global_node_address_info["webui_url"] = _remove_protocol_from_url(dashboard_url)

--- a/python/ray/runtime_context.py
+++ b/python/ray/runtime_context.py
@@ -533,6 +533,24 @@ class RuntimeContext(object):
             ids_dict[accelerator_resource_name] = [str(id) for id in accelerator_ids]
         return ids_dict
 
+    def get_dashboard_url(self) -> Optional[str]:
+        """
+        Get the dashboard URL of the ray cluster.
+
+        This URL can be used to access the Ray Dashboard web UI. It refers
+        to the same URL that is printed when `ray.init()` connects or starts
+        a cluster.
+
+        Returns:
+            The dashboard URL string if the dashboard is running and enabled for the cluster,
+            otherwise None. Returns None if Ray is not initialized.
+        """
+        assert ray.is_initialized(), "Ray is not initialized. Cannot get dashboard URL."
+
+        url = getattr(self.worker, "_dashboard_url", None)
+
+        return url if url else None
+
 
 _runtime_context = None
 _runtime_context_lock = threading.Lock()

--- a/python/ray/runtime_context.py
+++ b/python/ray/runtime_context.py
@@ -543,13 +543,12 @@ class RuntimeContext(object):
 
         Returns:
             The dashboard URL string if the dashboard is running and enabled for the cluster,
-            otherwise None. Returns None if Ray is not initialized.
+            otherwise an empty string.
         """
-        assert ray.is_initialized(), "Ray is not initialized. Cannot get dashboard URL."
 
         url = getattr(self.worker, "_dashboard_url", None)
 
-        return url if url else None
+        return url if url else ""
 
 
 _runtime_context = None

--- a/python/ray/tests/test_runtime_context.py
+++ b/python/ray/tests/test_runtime_context.py
@@ -427,7 +427,7 @@ def test_dashboard_url_disabled(shutdown_only):
     ray.init(include_dashboard=False)
     ctx = ray.get_runtime_context()
 
-    assert ctx.get_dashboard_url() is None
+    assert ctx.get_dashboard_url() == ""
 
 
 def test_dashboard_url_override(monkeypatch, ray_start_regular):
@@ -438,7 +438,6 @@ def test_dashboard_url_override(monkeypatch, ray_start_regular):
 
     ray.init()
     ctx = ray.get_runtime_context()
-    print(ctx.get_dashboard_url())
 
     assert ctx.get_dashboard_url() == override_url
 


### PR DESCRIPTION
## Why are these changes needed?
Currently, getting the Ray Dashboard URL programmatically requires capturing the context object returned by `ray.init()`.
This is often inconvenient, especially in interactive environments like Jupyter notebooks, where the initial `ray.init()` call might have occurred in a previous cell and the context object wasn't stored.

This change introduces a more convenient way to access the dashboard URL anytime after Ray has been initialized, directly through the runtime context. This aligns with the purpose of `ray.get_runtime_context()` providing runtime information.

The primary use case is simple access within a script or notebook:
```python
import ray

ctx = ray.get_runtime_context()
print(ctx.get_dashboard_url())
```

This PR implements the `get_dashboard_url()` method on `ray.runtime_context.RuntimeContext`. Corresponding unit tests and documentation updates are included.

## Related issue number
Closes #52629

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
