### PR TITLE
make test_backpressure a medium size test

### DIFF
--- a/python/ray/serve/tests/BUILD
+++ b/python/ray/serve/tests/BUILD
@@ -36,7 +36,6 @@ py_test_module_list(
     files = [
         "test_actor_replica_wrapper.py",
         "test_advanced.py",
-        "test_backpressure.py",
         "test_batching.py",
         "test_cluster_node_info_cache.py",
         "test_constructor_failure.py",
@@ -66,6 +65,7 @@ py_test_module_list(
 py_test_module_list(
     size = "medium",
     files = [
+        "test_backpressure.py",
         "test_callback.py",
         "test_cluster.py",
         "test_controller_recovery.py",


### PR DESCRIPTION
as part of this [commit](https://github.com/ray-project/ray/commit/cca67203215351b4bbcd6ba3bc5149d06f12582d) we added more tests to test_backpressure this resulted in the test runtime to creep over 60s causing the build to fail, hence reclassifying the test as medium size.