### PR TITLE
[train] Deserialize the user-defined training function directly on workers

### DIFF
--- a/python/ray/train/v2/BUILD
+++ b/python/ray/train/v2/BUILD
@@ -230,6 +230,22 @@ py_test(
 )
 
 py_test(
+    name = "test_serialization",
+    size = "small",
+    srcs = ["tests/test_serialization.py"],
+    env = {"RAY_TRAIN_V2_ENABLED": "1"},
+    tags = [
+        "exclusive",
+        "team:ml",
+        "train_v2",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_state",
     size = "medium",
     srcs = ["tests/test_state.py"],

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -3,7 +3,7 @@ import os
 import time
 import uuid
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional
+from typing import Callable, List, Optional
 
 import pandas as pd
 
@@ -60,7 +60,7 @@ from ray.train.v2._internal.execution.worker_group.worker_group import (
     WorkerGroupContext,
 )
 from ray.train.v2._internal.logging.logging import configure_controller_logger
-from ray.train.v2._internal.util import time_monotonic
+from ray.train.v2._internal.util import time_monotonic, ObjectRefWrapper
 from ray.train.v2.api.callback import RayTrainCallback
 from ray.train.v2.api.exceptions import TrainingFailedError
 from ray.train.v2.api.result import Result
@@ -103,7 +103,7 @@ class TrainController:
 
     def __init__(
         self,
-        train_fn: Callable[[Dict[str, Any]], None],
+        train_fn_ref: ObjectRefWrapper[Callable[[], None]],
         train_run_context: TrainRunContext,
         scaling_policy: ScalingPolicy,
         failure_policy: FailurePolicy,
@@ -111,7 +111,7 @@ class TrainController:
     ):
         self._train_run_context = train_run_context
         configure_controller_logger(self._train_run_context)
-        self._train_fn = train_fn
+        self._train_fn_ref = train_fn_ref
         self._scaling_policy = scaling_policy
         self._failure_policy = failure_policy
         self._run_config = self._train_run_context.run_config
@@ -270,7 +270,7 @@ class TrainController:
 
         worker_group_context = WorkerGroupContext(
             run_attempt_id=self._get_run_attempt_id(),
-            train_fn=self._train_fn,
+            train_fn_ref=self._train_fn_ref,
             num_workers=num_workers,
             resources_per_worker=resources_per_worker,
             placement_strategy=placement_strategy,

--- a/python/ray/train/v2/_internal/execution/worker_group/worker.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/worker.py
@@ -1,9 +1,10 @@
+from dataclasses import dataclass
+from functools import cached_property
+import logging
 import os
 import queue
 import socket
-from dataclasses import dataclass
-from functools import cached_property
-from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
+from typing import Callable, Dict, List, Optional, TypeVar, Union
 
 import ray
 from ray.types import ObjectRef
@@ -30,7 +31,10 @@ from ray.train.v2._internal.logging.logging import configure_worker_logger
 from ray.train.v2._internal.logging.patch_print import patch_print_function
 from ray.train.v2._internal.util import ObjectRefWrapper
 
+
 T = TypeVar("T")
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -112,13 +116,17 @@ class RayTrainWorker:
     def execute(self, fn: Callable[..., T], *fn_args, **fn_kwargs) -> T:
         return fn(*fn_args, **fn_kwargs)
 
-    def run_train_fn(self, train_fn_ref: ObjectRefWrapper[Callable[[], Any]]):
+    def run_train_fn(self, train_fn_ref: ObjectRefWrapper[Callable[[], None]]):
         """Run the training function in a separate thread.
 
         This function should return immediately, freeing up the main actor thread
         to perform other tasks such as polling the status.
         """
-        train_fn = train_fn_ref.get()
+        try:
+            train_fn = train_fn_ref.get()
+        except Exception as e:
+            logger.error(f"Error deserializing the training function: {e}")
+            raise
 
         # Create and start the training thread.
         get_train_context().execution_context.training_thread_runner.run(train_fn)

--- a/python/ray/train/v2/_internal/execution/worker_group/worker.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/worker.py
@@ -28,6 +28,7 @@ from ray.train.v2._internal.execution.storage import StorageContext
 from ray.train.v2._internal.execution.worker_group.poll import WorkerStatus
 from ray.train.v2._internal.logging.logging import configure_worker_logger
 from ray.train.v2._internal.logging.patch_print import patch_print_function
+from ray.train.v2._internal.util import ObjectRefWrapper
 
 T = TypeVar("T")
 
@@ -111,12 +112,14 @@ class RayTrainWorker:
     def execute(self, fn: Callable[..., T], *fn_args, **fn_kwargs) -> T:
         return fn(*fn_args, **fn_kwargs)
 
-    def run_train_fn(self, train_fn: Callable[[], Any]):
+    def run_train_fn(self, train_fn_ref: ObjectRefWrapper[Callable[[], Any]]):
         """Run the training function in a separate thread.
 
         This function should return immediately, freeing up the main actor thread
         to perform other tasks such as polling the status.
         """
+        train_fn = train_fn_ref.get()
+
         # Create and start the training thread.
         get_train_context().execution_context.training_thread_runner.run(train_fn)
 

--- a/python/ray/train/v2/_internal/execution/worker_group/worker_group.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/worker_group.py
@@ -57,6 +57,7 @@ from ray.train.v2._internal.util import (
     invoke_context_managers,
     ray_get_safe,
     time_monotonic,
+    ObjectRefWrapper,
 )
 from ray.types import ObjectRef
 from ray.util.placement_group import (
@@ -82,7 +83,7 @@ class WorkerGroupContext:
 
     Attributes:
         run_attempt_id: The ID of the run attempt.
-        train_fn: The training function to execute.
+        train_fn_ref: An object store reference to the training function to execute.
         num_workers: The number of workers in the worker group.
         resources_per_worker: The resources per worker.
         placement_strategy: Strategy for placing workers.
@@ -90,7 +91,7 @@ class WorkerGroupContext:
     """
 
     run_attempt_id: str
-    train_fn: Callable[[], None]
+    train_fn_ref: ObjectRefWrapper[Callable[[], None]]
     num_workers: int
     resources_per_worker: Dict[str, float]
     placement_strategy: str = "PACK"
@@ -320,7 +321,7 @@ class WorkerGroup:
         # This task should start a worker thread and return immediately.
         ray_get_safe(
             [
-                worker.actor.run_train_fn.remote(worker_group_context.train_fn)
+                worker.actor.run_train_fn.remote(worker_group_context.train_fn_ref)
                 for worker in workers
             ]
         )

--- a/python/ray/train/v2/_internal/util.py
+++ b/python/ray/train/v2/_internal/util.py
@@ -8,6 +8,7 @@ from typing import (
     ContextManager,
     Dict,
     Generator,
+    Generic,
     List,
     Optional,
     TypeVar,
@@ -42,7 +43,7 @@ def construct_train_func(
     train_func: Union[Callable[[], T], Callable[[Dict[str, Any]], T]],
     config: Optional[Dict[str, Any]],
     train_func_context: ContextManager,
-    fn_arg_name: Optional[str] = "train_func",
+    fn_arg_name: Optional[str] = "train_loop_per_worker",
 ) -> Callable[[], T]:
     """Validates and constructs the training function to execute.
     Args:
@@ -84,6 +85,16 @@ def construct_train_func(
                 return train_func()
 
     return train_fn
+
+
+class ObjectRefWrapper(Generic[T]):
+    """Thin wrapper around ray.put to manually control dereferencing."""
+
+    def __init__(self, obj: T):
+        self._ref = ray.put(obj)
+
+    def get(self) -> T:
+        return ray.get(self._ref)
 
 
 def date_str(include_ms: bool = False):

--- a/python/ray/train/v2/api/data_parallel_trainer.py
+++ b/python/ray/train/v2/api/data_parallel_trainer.py
@@ -43,7 +43,7 @@ from ray.train.v2._internal.execution.context import TrainRunContext
 from ray.train.v2._internal.execution.controller import TrainController
 from ray.train.v2._internal.execution.failure_handling import create_failure_policy
 from ray.train.v2._internal.execution.scaling_policy import create_scaling_policy
-from ray.train.v2._internal.util import construct_train_func
+from ray.train.v2._internal.util import construct_train_func, ObjectRefWrapper
 from ray.train.v2.api.callback import UserCallback
 from ray.util.annotations import Deprecated, DeveloperAPI
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
@@ -110,9 +110,10 @@ class DataParallelTrainer:
             train_func_context=self.backend_config.train_func_context,
             fn_arg_name="train_loop_per_worker",
         )
+        train_fn_ref = ObjectRefWrapper(train_fn)
 
         result = self._initialize_and_run_controller(
-            train_fn=train_fn,
+            train_fn_ref=train_fn_ref,
             scaling_policy=create_scaling_policy(self.scaling_config),
             failure_policy=create_failure_policy(self.run_config.failure_config),
             train_run_context=self.train_run_context,

--- a/python/ray/train/v2/tests/test_accelerator_utils.py
+++ b/python/ray/train/v2/tests/test_accelerator_utils.py
@@ -12,6 +12,7 @@ from ray.train.v2._internal.callbacks.accelerators import (
     _get_visible_accelerator_ids_per_worker,
 )
 from ray.train.v2._internal.execution.context import TrainRunContext
+from ray.train.v2._internal.util import ObjectRefWrapper
 from ray.train.v2._internal.execution.worker_group import ActorMetadata, WorkerGroup
 from ray.train.v2._internal.execution.worker_group.worker_group import (
     WorkerGroupContext,
@@ -116,7 +117,7 @@ def test_accelerator_setup_callback(mock_gpu_cluster):
 
     worker_group_context = WorkerGroupContext(
         run_attempt_id="attempt_1",
-        train_fn=lambda: None,
+        train_fn_ref=ObjectRefWrapper(lambda: None),
         num_workers=scaling_config.num_workers,
         resources_per_worker=scaling_config._resources_per_worker_not_none,
     )

--- a/python/ray/train/v2/tests/test_controller.py
+++ b/python/ray/train/v2/tests/test_controller.py
@@ -21,125 +21,20 @@ from ray.train.v2._internal.execution.controller.state import (
     ErroredState,
     TrainControllerState,
 )
-from ray.train.v2._internal.execution.failure_handling import (
-    FailureDecision,
-    FailurePolicy,
-)
+from ray.train.v2._internal.execution.failure_handling import FailureDecision
 from ray.train.v2._internal.execution.scaling_policy import (
     NoopDecision,
     ResizeDecision,
     ScalingDecision,
-    ScalingPolicy,
 )
-from ray.train.v2._internal.execution.worker_group import (
-    WorkerGroup,
-    WorkerGroupContext,
-    WorkerGroupPollStatus,
-    WorkerGroupState,
-    WorkerStatus,
-)
-from ray.train.v2._internal.util import time_monotonic
 from ray.train.v2.api.config import RunConfig, ScalingConfig
 
-
-class DummyWorkerGroup(WorkerGroup):
-
-    _start_failure = None
-
-    # TODO: Clean this up and use Mocks instead.
-    def __init__(
-        self,
-        train_run_context: TrainRunContext,
-        worker_group_context: WorkerGroupContext,
-        callbacks=None,
-    ):
-        self._num_workers = worker_group_context.num_workers
-        self._worker_group_state = None
-        self._worker_statuses = {}
-
-    def poll_status(self, *args, **kwargs) -> WorkerGroupPollStatus:
-        return WorkerGroupPollStatus(
-            worker_statuses=self._worker_statuses,
-        )
-
-    def _start(self):
-        num_workers = self._num_workers
-        if self._start_failure:
-            raise self._start_failure
-
-        self._worker_group_state = WorkerGroupState(
-            start_time=time_monotonic(),
-            workers=[MagicMock() for i in range(num_workers)],
-            placement_group=MagicMock(),
-            sync_actor=None,
-        )
-
-        self._worker_statuses = {
-            i: WorkerStatus(running=True, error=None) for i in range(num_workers)
-        }
-
-    def shutdown(self):
-        self._worker_group_state = None
-
-    # === Test methods ===
-    def error_worker(self, worker_index):
-        status = self._worker_statuses[worker_index]
-        status.error = RuntimeError(f"Worker {worker_index} failed")
-
-    def finish_worker(self, worker_index):
-        status = self._worker_statuses[worker_index]
-        status.running = False
-
-    @classmethod
-    def set_start_failure(cls, start_failure):
-        cls._start_failure = start_failure
-
-
-class MockScalingPolicy(ScalingPolicy):
-    def __init__(self, scaling_config):
-        self._recovery_decision_queue = []
-        self._monitor_decision_queue = []
-
-        super().__init__(scaling_config)
-
-    def make_decision_for_non_running_worker_group(self) -> ScalingDecision:
-        if self._recovery_decision_queue:
-            return self._recovery_decision_queue.pop(0)
-        return NoopDecision()
-
-    def make_decision_for_running_worker_group(
-        self,
-        worker_group_state: WorkerGroupState,
-        worker_group_status: WorkerGroupPollStatus,
-    ) -> ScalingDecision:
-        if self._monitor_decision_queue:
-            return self._monitor_decision_queue.pop(0)
-        return NoopDecision()
-
-    # === Test methods ===
-    def queue_recovery_decision(self, decision):
-        self._recovery_decision_queue.append(decision)
-
-    def queue_monitor_decision(self, decision):
-        self._monitor_decision_queue.append(decision)
-
-
-class MockFailurePolicy(FailurePolicy):
-    def __init__(self, failure_config):
-        self._decision_queue = []
-
-        super().__init__(failure_config)
-
-    def make_decision(
-        self, worker_group_status: WorkerGroupPollStatus
-    ) -> FailureDecision:
-        if self._decision_queue:
-            return self._decision_queue.pop(0)
-        return FailureDecision.NOOP
-
-    # === Test methods ===
-    def queue_decision(self, decision):
-        self._decision_queue.append(decision)
+from ray.train.v2.tests.util import (
+    DummyWorkerGroup,
+    DummyObjectRefWrapper,
+    MockScalingPolicy,
+    MockFailurePolicy,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -161,7 +56,7 @@ def test_resize():
     scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
     train_run_context = TrainRunContext(run_config=RunConfig())
     controller = TrainController(
-        train_fn=lambda: None,
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
         train_run_context=train_run_context,
         scaling_policy=scaling_policy,
         failure_policy=MockFailurePolicy(failure_config=None),
@@ -234,7 +129,7 @@ def test_failure_handling():
     failure_policy = MockFailurePolicy(failure_config=None)
     train_run_context = TrainRunContext(run_config=RunConfig())
     controller = TrainController(
-        train_fn=lambda: None,
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
         train_run_context=train_run_context,
         scaling_policy=scaling_policy,
         failure_policy=failure_policy,
@@ -277,7 +172,7 @@ def test_worker_group_start_failure(monkeypatch, error_type):
     failure_policy = MockFailurePolicy(failure_config=None)
     train_run_context = TrainRunContext(run_config=RunConfig())
     controller = TrainController(
-        train_fn=lambda: None,
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
         train_run_context=train_run_context,
         scaling_policy=scaling_policy,
         failure_policy=failure_policy,
@@ -321,7 +216,7 @@ def test_poll_frequency(monkeypatch):
     train_run_context = TrainRunContext(run_config=RunConfig())
 
     controller = TrainController(
-        train_fn=lambda: None,
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
         train_run_context=train_run_context,
         scaling_policy=None,
         failure_policy=None,
@@ -380,7 +275,7 @@ def test_controller_callback():
     train_run_context = TrainRunContext(run_config=RunConfig())
 
     controller = TrainController(
-        train_fn=lambda: None,
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
         train_run_context=train_run_context,
         scaling_policy=scaling_policy,
         failure_policy=failure_policy,

--- a/python/ray/train/v2/tests/test_data_integration.py
+++ b/python/ray/train/v2/tests/test_data_integration.py
@@ -12,6 +12,7 @@ from ray.train.v2._internal.execution.worker_group.worker_group import (
     WorkerGroupContext,
 )
 from ray.train.v2.api.data_parallel_trainer import DataParallelTrainer
+from ray.train.v2._internal.util import ObjectRefWrapper
 from ray.train.v2.tests.test_controller import DummyWorkerGroup
 
 # TODO(justinvyu): Bring over more tests from ray/air/tests/test_new_dataset_config.py
@@ -71,7 +72,7 @@ def test_dataset_setup_callback(ray_start_4_cpus):
 
     worker_group_context = WorkerGroupContext(
         run_attempt_id="attempt_1",
-        train_fn=lambda: None,
+        train_fn_ref=ObjectRefWrapper(lambda: None),
         num_workers=scaling_config.num_workers,
         resources_per_worker=scaling_config.resources_per_worker,
     )

--- a/python/ray/train/v2/tests/test_data_integration.py
+++ b/python/ray/train/v2/tests/test_data_integration.py
@@ -12,8 +12,7 @@ from ray.train.v2._internal.execution.worker_group.worker_group import (
     WorkerGroupContext,
 )
 from ray.train.v2.api.data_parallel_trainer import DataParallelTrainer
-from ray.train.v2._internal.util import ObjectRefWrapper
-from ray.train.v2.tests.test_controller import DummyWorkerGroup
+from ray.train.v2.tests.util import DummyWorkerGroup, DummyObjectRefWrapper
 
 # TODO(justinvyu): Bring over more tests from ray/air/tests/test_new_dataset_config.py
 
@@ -72,7 +71,7 @@ def test_dataset_setup_callback(ray_start_4_cpus):
 
     worker_group_context = WorkerGroupContext(
         run_attempt_id="attempt_1",
-        train_fn_ref=ObjectRefWrapper(lambda: None),
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
         num_workers=scaling_config.num_workers,
         resources_per_worker=scaling_config.resources_per_worker,
     )

--- a/python/ray/train/v2/tests/test_report_handler.py
+++ b/python/ray/train/v2/tests/test_report_handler.py
@@ -21,7 +21,8 @@ from ray.train.v2._internal.execution.worker_group import (
 from ray.train.v2._internal.execution.worker_group.worker_group import (
     WorkerGroupContext,
 )
-from ray.train.v2.tests.test_controller import DummyWorkerGroup
+
+from ray.train.v2.tests.util import DummyWorkerGroup, DummyObjectRefWrapper
 
 
 def generate_worker_group_poll_status(num_workers, num_ckpt, num_dummy, num_none):
@@ -67,7 +68,7 @@ def test_report_handler(tmp_path, num_workers, num_ckpt, num_dummy, num_none, ex
 
     worker_group_context = WorkerGroupContext(
         run_attempt_id="test_run_attempt_id",
-        train_fn=lambda: None,
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
         num_workers=10,
         resources_per_worker={"CPU": 1},
     )

--- a/python/ray/train/v2/tests/test_serialization.py
+++ b/python/ray/train/v2/tests/test_serialization.py
@@ -1,0 +1,27 @@
+import sys
+
+import ray.train
+from ray.train.v2.api.data_parallel_trainer import DataParallelTrainer
+from ray.train.v2._internal.execution.callback import ControllerCallback
+
+
+def test_captured_imports(ray_start_4_cpus):
+    import torch
+
+    def train_fn():
+        # torch is captured in the closure of the train_fn
+        # and should be re-imported on each worker.
+        torch.ones(1)
+
+    class AssertImportsCallback(ControllerCallback):
+        def after_controller_start(self):
+            # Check that torch is not imported in the controller process.
+            # The train_fn should be deserialized directly on the workers.
+            assert "torch" not in sys.modules
+
+    trainer = DataParallelTrainer(
+        train_fn,
+        run_config=ray.train.RunConfig(callbacks=[AssertImportsCallback()]),
+        scaling_config=ray.train.ScalingConfig(num_workers=2),
+    )
+    trainer.fit()

--- a/python/ray/train/v2/tests/test_serialization.py
+++ b/python/ray/train/v2/tests/test_serialization.py
@@ -2,15 +2,31 @@ import sys
 
 import pytest
 
-import ray.train
+import ray
 from ray.train.v2.api.data_parallel_trainer import DataParallelTrainer
-from ray.train.v2._internal.execution.callback import ControllerCallback
+from ray.train.v2._internal.execution.callback import (
+    ControllerCallback,
+    WorkerGroupCallback,
+)
+
+
+def block_import(import_name):
+    import sys
+
+    class BlockTorchImport:
+        def find_spec(self, fullname, path, target=None):
+            if fullname == import_name or fullname.startswith(import_name + "."):
+                raise ImportError(
+                    f"Test error: {import_name} not installed on this node"
+                )
+
+    sys.meta_path.insert(0, BlockTorchImport())
 
 
 def test_captured_imports(ray_start_4_cpus):
     import torch
 
-    def train_fn():
+    def capture_torch_import_fn():
         # torch is captured in the closure of the train_fn
         # and should be re-imported on each worker.
         torch.ones(1)
@@ -22,11 +38,38 @@ def test_captured_imports(ray_start_4_cpus):
             assert "torch" not in sys.modules
 
     trainer = DataParallelTrainer(
-        train_fn,
+        capture_torch_import_fn,
         run_config=ray.train.RunConfig(callbacks=[AssertImportsCallback()]),
         scaling_config=ray.train.ScalingConfig(num_workers=2),
     )
     trainer.fit()
+
+
+def test_deserialization_error(ray_start_4_cpus):
+    """Test that train_fn deserialization errors are propagated properly.
+
+    This test showcases a common deserialization error example, where
+    the the driver script successfully imports torch, but torch is not
+    installed on the worker nodes.
+    """
+    import torch
+
+    def capture_torch_import_fn():
+        torch.ones(1)
+
+    class BlockTorchImportCallback(WorkerGroupCallback):
+        def after_worker_group_start(self, worker_group):
+            # Make it so that the torch import that happens on
+            # train_fn deserialization will fail on workers.
+            worker_group.execute(block_import, "torch")
+
+    trainer = DataParallelTrainer(
+        capture_torch_import_fn,
+        run_config=ray.train.RunConfig(callbacks=[BlockTorchImportCallback()]),
+        scaling_config=ray.train.ScalingConfig(num_workers=2),
+    )
+    with pytest.raises(ray.exceptions.RayTaskError, match="torch not installed"):
+        trainer.fit()
 
 
 if __name__ == "__main__":

--- a/python/ray/train/v2/tests/test_serialization.py
+++ b/python/ray/train/v2/tests/test_serialization.py
@@ -1,5 +1,7 @@
 import sys
 
+import pytest
+
 import ray.train
 from ray.train.v2.api.data_parallel_trainer import DataParallelTrainer
 from ray.train.v2._internal.execution.callback import ControllerCallback
@@ -25,3 +27,9 @@ def test_captured_imports(ray_start_4_cpus):
         scaling_config=ray.train.ScalingConfig(num_workers=2),
     )
     trainer.fit()
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", "-x", __file__]))

--- a/python/ray/train/v2/tests/test_worker_group.py
+++ b/python/ray/train/v2/tests/test_worker_group.py
@@ -28,6 +28,8 @@ from ray.train.v2._internal.execution.worker_group import (
 )
 from ray.train.v2.api.config import RunConfig
 
+from ray.train.v2.tests.util import DummyObjectRefWrapper
+
 
 @pytest.fixture(autouse=True, scope="module")
 def ray_start_4_cpus():
@@ -49,7 +51,7 @@ def _default_inactive_worker_group(**kwargs):
 def _default_worker_group_context(**kwargs):
     default_config = {
         "run_attempt_id": "test_run_attempt_id",
-        "train_fn": lambda: None,
+        "train_fn_ref": DummyObjectRefWrapper(lambda: None),
         "num_workers": 4,
         "resources_per_worker": {"CPU": 1},
     }
@@ -127,11 +129,8 @@ def test_start_timeout(monkeypatch):
 
 
 def test_poll_status_running():
-    worker_group_context = WorkerGroupContext(
-        run_attempt_id="test_run_attempt_id",
-        train_fn=lambda: time.sleep(60),
-        num_workers=4,
-        resources_per_worker={"CPU": 1},
+    worker_group_context = _default_worker_group_context(
+        train_fn_ref=DummyObjectRefWrapper(lambda: time.sleep(60)),
     )
     wg = _default_inactive_worker_group(worker_group_context=worker_group_context)
     wg._start()
@@ -144,11 +143,8 @@ def test_poll_status_running():
 
 
 def test_poll_status_finished():
-    worker_group_context = WorkerGroupContext(
-        run_attempt_id="test_run_attempt_id",
-        train_fn=lambda: "done",
-        num_workers=4,
-        resources_per_worker={"CPU": 1},
+    worker_group_context = _default_worker_group_context(
+        train_fn_ref=DummyObjectRefWrapper(lambda: "done"),
     )
     wg = _default_inactive_worker_group(worker_group_context=worker_group_context)
     wg._start()
@@ -180,11 +176,8 @@ def test_poll_status_failures(monkeypatch, training_failure, poll_failure):
 
         monkeypatch.setattr(RayTrainWorker, "poll_status", patched_poll_status)
 
-    worker_group_context = WorkerGroupContext(
-        run_attempt_id="test_run_attempt_id",
-        train_fn=train_fn,
-        num_workers=4,
-        resources_per_worker={"CPU": 1},
+    worker_group_context = _default_worker_group_context(
+        train_fn_ref=DummyObjectRefWrapper(train_fn),
     )
     wg = _default_inactive_worker_group(worker_group_context=worker_group_context)
     wg._start()

--- a/python/ray/train/v2/tests/util.py
+++ b/python/ray/train/v2/tests/util.py
@@ -1,0 +1,130 @@
+from unittest.mock import MagicMock
+
+from ray.train.v2._internal.execution.context import TrainRunContext
+from ray.train.v2._internal.execution.failure_handling import (
+    FailureDecision,
+    FailurePolicy,
+)
+from ray.train.v2._internal.execution.scaling_policy import (
+    NoopDecision,
+    ScalingDecision,
+    ScalingPolicy,
+)
+from ray.train.v2._internal.execution.worker_group import (
+    WorkerGroup,
+    WorkerGroupContext,
+    WorkerGroupPollStatus,
+    WorkerGroupState,
+    WorkerStatus,
+)
+from ray.train.v2._internal.util import time_monotonic, ObjectRefWrapper
+
+
+class DummyWorkerGroup(WorkerGroup):
+
+    _start_failure = None
+
+    # TODO: Clean this up and use Mocks instead.
+    def __init__(
+        self,
+        train_run_context: TrainRunContext,
+        worker_group_context: WorkerGroupContext,
+        callbacks=None,
+    ):
+        self._num_workers = worker_group_context.num_workers
+        self._worker_group_state = None
+        self._worker_statuses = {}
+
+    def poll_status(self, *args, **kwargs) -> WorkerGroupPollStatus:
+        return WorkerGroupPollStatus(
+            worker_statuses=self._worker_statuses,
+        )
+
+    def _start(self):
+        num_workers = self._num_workers
+        if self._start_failure:
+            raise self._start_failure
+
+        self._worker_group_state = WorkerGroupState(
+            start_time=time_monotonic(),
+            workers=[MagicMock() for i in range(num_workers)],
+            placement_group=MagicMock(),
+            sync_actor=None,
+        )
+
+        self._worker_statuses = {
+            i: WorkerStatus(running=True, error=None) for i in range(num_workers)
+        }
+
+    def shutdown(self):
+        self._worker_group_state = None
+
+    # === Test methods ===
+    def error_worker(self, worker_index):
+        status = self._worker_statuses[worker_index]
+        status.error = RuntimeError(f"Worker {worker_index} failed")
+
+    def finish_worker(self, worker_index):
+        status = self._worker_statuses[worker_index]
+        status.running = False
+
+    @classmethod
+    def set_start_failure(cls, start_failure):
+        cls._start_failure = start_failure
+
+
+class MockScalingPolicy(ScalingPolicy):
+    def __init__(self, scaling_config):
+        self._recovery_decision_queue = []
+        self._monitor_decision_queue = []
+
+        super().__init__(scaling_config)
+
+    def make_decision_for_non_running_worker_group(self) -> ScalingDecision:
+        if self._recovery_decision_queue:
+            return self._recovery_decision_queue.pop(0)
+        return NoopDecision()
+
+    def make_decision_for_running_worker_group(
+        self,
+        worker_group_state: WorkerGroupState,
+        worker_group_status: WorkerGroupPollStatus,
+    ) -> ScalingDecision:
+        if self._monitor_decision_queue:
+            return self._monitor_decision_queue.pop(0)
+        return NoopDecision()
+
+    # === Test methods ===
+    def queue_recovery_decision(self, decision):
+        self._recovery_decision_queue.append(decision)
+
+    def queue_monitor_decision(self, decision):
+        self._monitor_decision_queue.append(decision)
+
+
+class MockFailurePolicy(FailurePolicy):
+    def __init__(self, failure_config):
+        self._decision_queue = []
+
+        super().__init__(failure_config)
+
+    def make_decision(
+        self, worker_group_status: WorkerGroupPollStatus
+    ) -> FailureDecision:
+        if self._decision_queue:
+            return self._decision_queue.pop(0)
+        return FailureDecision.NOOP
+
+    # === Test methods ===
+    def queue_decision(self, decision):
+        self._decision_queue.append(decision)
+
+
+class DummyObjectRefWrapper(ObjectRefWrapper):
+    """Mock object that returns the object passed in without going through ray.put."""
+
+    def __init__(self, obj):
+        self._obj = obj
+
+    def get(self):
+        return self._obj


### PR DESCRIPTION
## Summary

Serialize the user-defined training function to the object store on the driver process, and deserialize the function along with any captured imports directly on the train worker processes.

Previously, the function was passed directly to the controller process, then again to the workers. This causes the train function to be deserialized on the controller process, which adds a bunch of captured modules which are unnecessary since the controller is not running user code.

This PR also introduces a lightweight `ObjectRefWrapper` that is used to manually dereference an object reference, since Ray Core's default behavior is to dereference an object ref if passed to a Ray actor constructor/method.

## Motivation

The Train controller process is a CPU actor. Even if it's running on a GPU node, `CUDA_VISIBLE_DEVICES` is not set. This causes some issues with packages such as `triton` that error when importing on a process without any CUDA devices available. This PR reduces the risk of similar issues in the future by removing these unnecessary imports on the controller.

See the related issues.

## Related issues

Closes https://github.com/ray-project/ray/issues/50406