### PR TITLE
[release] Upgrade twine to 6.1.0 and skip python 3.13 wheel for Windows

### DIFF
--- a/ci/ray_ci/automation/ray_wheels_lib.py
+++ b/ci/ray_ci/automation/ray_wheels_lib.py
@@ -53,6 +53,8 @@ def _get_wheel_names(ray_version: str) -> List[str]:
     for python_version in PYTHON_VERSIONS:
         for platform in ALL_PLATFORMS:
             for ray_type in RAY_TYPES:
+                if python_version == "cp313-cp313" and platform == "win_amd64":
+                    continue
                 wheel_name = f"{ray_type}-{ray_version}-{python_version}-{platform}"
                 wheel_names.append(wheel_name)
     return wheel_names

--- a/ci/ray_ci/automation/test_ray_wheels_lib.py
+++ b/ci/ray_ci/automation/test_ray_wheels_lib.py
@@ -30,9 +30,10 @@ def test_get_wheel_names():
     ray_version = "1.11.0"
     wheel_names = _get_wheel_names(ray_version)
 
-    assert len(wheel_names) == len(PYTHON_VERSIONS) * len(ALL_PLATFORMS) * len(
-        RAY_TYPES
-    )
+    assert (
+        len(wheel_names)
+        == len(PYTHON_VERSIONS) * len(ALL_PLATFORMS) * len(RAY_TYPES) - 2
+    )  # Except for the win_amd64 wheel for cp313 on ray and ray-cpp
 
     for wheel_name in wheel_names:
         assert len(wheel_name.split("-")) == 5

--- a/release/requirements_buildkite.in
+++ b/release/requirements_buildkite.in
@@ -14,7 +14,7 @@ pyyaml
 pybuildkite
 PyGithub
 requests
-twine == 5.0.0
+twine == 6.1.0
 docker >= 7.1.0
 aws_requests_auth
 

--- a/release/requirements_buildkite.txt
+++ b/release/requirements_buildkite.txt
@@ -726,6 +726,10 @@ humanize==4.9.0 \
     --hash=sha256:582a265c931c683a7e9b8ed9559089dea7edcf6cc95be39a3cbc2c5d5ac2bcfa \
     --hash=sha256:ce284a76d5b1377fd8836733b983bfb0b76f1aa1c090de2566fcf008d7f6ab16
     # via anyscale
+id==1.5.0 \
+    --hash=sha256:292cb8a49eacbbdbce97244f47a97b4c62540169c976552e497fd57df0734c1d \
+    --hash=sha256:f1434e1cef91f2cbb8a4ec64663d5a23b9ed43ef44c4c957d02583d61714c658
+    # via twine
 idna==3.7 \
     --hash=sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc \
     --hash=sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0
@@ -1094,6 +1098,7 @@ packaging==24.0 \
     #   pydata-sphinx-theme
     #   pytest
     #   sphinx
+    #   twine
 parso==0.8.4 \
     --hash=sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18 \
     --hash=sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d
@@ -1106,10 +1111,6 @@ pexpect==4.9.0 \
     --hash=sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523 \
     --hash=sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f
     # via ipython
-pkginfo==1.10.0 \
-    --hash=sha256:5df73835398d10db79f8eecd5cd86b1f6d29317589ea70796994d49399af6297 \
-    --hash=sha256:889a6da2ed7ffc58ab5b900d888ddce90bce912f2d2de1dc1c26f4cb9fe65097
-    # via twine
 platformdirs==4.2.2 \
     --hash=sha256:2d7a1657e36a80ea911db832a8a6ece5ee53d8de21edd5cc5879af6530b1bfee \
     --hash=sha256:38b7b51f512eed9e84a22788b4bce1de17c0adb134d6becb09836e37d8654cd3
@@ -1521,6 +1522,7 @@ requests==2.32.3 \
     #   docker
     #   google-api-core
     #   google-cloud-storage
+    #   id
     #   pybuildkite
     #   pygithub
     #   requests-toolbelt
@@ -1880,9 +1882,9 @@ traitlets==5.14.3 \
     #   matplotlib-inline
     #   nbclient
     #   nbformat
-twine==5.0.0 \
-    --hash=sha256:89b0cc7d370a4b66421cc6102f269aa910fe0f1861c124f573cf2ddedbc10cf4 \
-    --hash=sha256:a262933de0b484c53408f9edae2e7821c1c45a3314ff2df9bdd343aa7ab8edc0
+twine==6.1.0 \
+    --hash=sha256:a47f973caf122930bf0fbbf17f80b83bc1602c9ce393c7845f289a3001dc5384 \
+    --hash=sha256:be324f6272eff91d07ee93f251edf232fc647935dd585ac003539b42404a8dbd
     # via -r release/requirements_buildkite.in
 typing-extensions==4.11.0 \
     --hash=sha256:83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0 \


### PR DESCRIPTION
- Upgrade `twine` to `6.1.0` in Buildkite dependencies
- Skip fetching 3.13 wheels for Windows because we are not building them yet