### PR TITLE
[core] Only get serialization context once for all args

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -875,6 +875,7 @@ cdef prepare_args_internal(
     put_threshold = RayConfig.instance().max_direct_call_object_size()
     total_inlined = 0
     rpc_inline_threshold = RayConfig.instance().task_rpc_inlined_bytes_limit()
+    serialization_context = worker.get_serialization_context()
     for arg in args:
         from ray.experimental.compiled_dag_ref import CompiledDAGRef
         if isinstance(arg, CompiledDAGRef):
@@ -892,8 +893,7 @@ cdef prepare_args_internal(
 
         else:
             try:
-                serialized_arg = worker.get_serialization_context(
-                ).serialize(arg)
+                serialized_arg = serialization_context.serialize(arg)
             except TypeError as e:
                 sio = io.StringIO()
                 ray.util.inspect_serializability(arg, print_file=sio)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We do this get serialization context on every single arg which is pretty expensive. Should only do it once per task. On the same script where we submit 200 small args to a task 1000 times, this cut the percentage taken up by `by get_serialization_context` inside remote invocation  from ~20% to 3%.

Test script
```
@ray.remote
def func(*args):
    num_args = 0
    for arg in args:
        num_args += 1
    return num_args

args = [['a' * 1024] for i in range(250)]
refs = []
for i in range(1000):
    refs.append(func.remote(*args))
```

Before:
<img width="963" alt="Screenshot 2025-04-29 at 4 01 33 PM" src="https://github.com/user-attachments/assets/b4ad5d32-6a6c-425a-ba7a-000ca321e1c0" />

After:
<img width="963" alt="Screenshot 2025-04-29 at 3 58 52 PM" src="https://github.com/user-attachments/assets/2f2e6f38-ce08-4a62-9ee7-b6c5c0e530a4" />

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
