### PR TITLE
[train] fix error when no args are passed in to TorchTrainer

### DIFF
--- a/python/ray/train/v2/tests/test_torch_trainer.py
+++ b/python/ray/train/v2/tests/test_torch_trainer.py
@@ -22,6 +22,14 @@ def reduce_health_check_interval(monkeypatch):
     yield
 
 
+def test_minimal(ray_start_4_cpus):
+    def train_func():
+        pass
+
+    trainer = TorchTrainer(train_func)
+    trainer.fit()
+
+
 @pytest.mark.parametrize("num_workers", [1, 2])
 def test_torch_linear(ray_start_4_cpus, num_workers):
     def train_func(config):

--- a/python/ray/train/v2/torch/torch_trainer.py
+++ b/python/ray/train/v2/torch/torch_trainer.py
@@ -199,7 +199,8 @@ class TorchTrainer(DataParallelTrainer):
 
         torch_config = torch_config or TorchConfig()
         if not torch_config.backend:
-            torch_config.backend = "nccl" if scaling_config.use_gpu else "gloo"
+            is_gpu_training = scaling_config and scaling_config.use_gpu
+            torch_config.backend = "nccl" if is_gpu_training else "gloo"
 
         super(TorchTrainer, self).__init__(
             train_loop_per_worker=train_loop_per_worker,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Fixes an issue that happens when both `scaling_config` and `torch_config` are not set.

```python
def train_func():
    pass

trainer = TorchTrainer(train_func)
trainer.fit()
```

```python
  File "/Users/matt/miniconda3/envs/ray/lib/python3.10/site-packages/ray/train/v2/torch/torch_trainer.py", line 202, in __init__
    torch_config.backend = "nccl" if scaling_config.use_gpu else "gloo"
AttributeError: 'NoneType' object has no attribute 'use_gpu'
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
