### PR TITLE
[core][refactor] Unify the code path for setting the task status of retrying tasks

### DIFF
--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -314,6 +314,7 @@ bool TaskManager::ResubmitTask(const TaskID &task_id, std::vector<ObjectID> *tas
   RAY_CHECK(task_deps->empty());
 
   TaskSpecification spec;
+  TaskEntry *task_entry = nullptr;
   bool resubmit = false;
   {
     absl::MutexLock lock(&mu_);
@@ -341,6 +342,7 @@ bool TaskManager::ResubmitTask(const TaskID &task_id, std::vector<ObjectID> *tas
         RAY_CHECK(it->second.num_retries_left == -1);
       }
       spec = it->second.spec;
+      task_entry = &(it->second);
     }
   }
 
@@ -384,7 +386,7 @@ bool TaskManager::ResubmitTask(const TaskID &task_id, std::vector<ObjectID> *tas
                 << spec.AttemptNumber() << ": " << spec.DebugString();
   // We should actually detect if the actor for this task is dead, but let's just assume
   // it's not for now.
-  retry_task_callback_(spec, /*object_recovery*/ true, /*delay_ms*/ 0);
+  RetryTask(task_entry, /*object_recovery*/ true, /*delay_ms*/ 0);
 
   return true;
 }
@@ -965,6 +967,7 @@ void TaskManager::CompletePendingTask(const TaskID &task_id,
 bool TaskManager::RetryTaskIfPossible(const TaskID &task_id,
                                       const rpc::RayErrorInfo &error_info) {
   TaskSpecification spec;
+  TaskEntry *task_entry = nullptr;
   bool will_retry = false;
   int32_t num_retries_left = 0;
   int32_t num_oom_retries_left = 0;
@@ -977,6 +980,7 @@ bool TaskManager::RetryTaskIfPossible(const TaskID &task_id,
     RAY_CHECK(it->second.IsPending())
         << "Tried to retry task that was not pending " << task_id;
     spec = it->second.spec;
+    task_entry = &(it->second);
     num_retries_left = it->second.num_retries_left;
     num_oom_retries_left = it->second.num_oom_retries_left;
     if (task_failed_due_to_oom) {
@@ -999,7 +1003,7 @@ bool TaskManager::RetryTaskIfPossible(const TaskID &task_id,
       }
     }
     if (will_retry) {
-      MarkTaskRetryOnFailed(it->second, error_info);
+      MarkTaskRetryOnFailed(*task_entry, error_info);
     }
   }
 
@@ -1021,13 +1025,25 @@ bool TaskManager::RetryTaskIfPossible(const TaskID &task_id,
                                  spec.AttemptNumber(),
                                  RayConfig::instance().task_oom_retry_delay_base_ms())
                            : RayConfig::instance().task_retry_delay_ms();
-    retry_task_callback_(spec, /*object_recovery*/ false, delay_ms);
+    RetryTask(task_entry, /*object_recovery*/ false, delay_ms);
     return true;
   } else {
     RAY_LOG(INFO) << "No retries left for task " << spec.TaskId()
                   << ", not going to resubmit.";
     return false;
   }
+}
+
+void TaskManager::RetryTask(TaskEntry *task_entry,
+                            bool object_recovery,
+                            uint32_t delay_ms) {
+  RAY_CHECK(task_entry != nullptr);
+  SetTaskStatus(*task_entry,
+                rpc::TaskStatus::PENDING_ARGS_AVAIL,
+                /* state_update */ std::nullopt,
+                /* include_task_info */ true,
+                task_entry->spec.AttemptNumber() + 1);
+  retry_task_callback_(task_entry->spec, object_recovery, delay_ms);
 }
 
 void TaskManager::FailPendingTask(const TaskID &task_id,
@@ -1430,17 +1446,6 @@ void TaskManager::MarkTaskRetryOnResubmit(TaskEntry &task_entry) {
       << "Only finished tasks can be resubmitted: " << task_entry.spec.TaskId();
 
   task_entry.MarkRetry();
-
-  // Mark the new status and also include task spec info for the new attempt.
-  //
-  // NOTE(rickyx): We only increment the AttemptNumber on the task spec when
-  // `retry_task_callback_` is invoked. In order to record the correct status change for
-  // the new task attempt, we pass the the attempt number explicitly.
-  SetTaskStatus(task_entry,
-                rpc::TaskStatus::PENDING_ARGS_AVAIL,
-                /* state_update */ std::nullopt,
-                /* include_task_info */ true,
-                task_entry.spec.AttemptNumber() + 1);
 }
 
 void TaskManager::MarkTaskRetryOnFailed(TaskEntry &task_entry,
@@ -1452,13 +1457,6 @@ void TaskManager::MarkTaskRetryOnFailed(TaskEntry &task_entry,
                 rpc::TaskStatus::FAILED,
                 worker::TaskStatusEvent::TaskStateUpdate(error_info));
   task_entry.MarkRetry();
-
-  // Mark the new status and also include task spec info for the new attempt.
-  SetTaskStatus(task_entry,
-                rpc::TaskStatus::PENDING_ARGS_AVAIL,
-                /* state_update */ std::nullopt,
-                /* include_task_info */ true,
-                task_entry.spec.AttemptNumber() + 1);
 }
 
 void TaskManager::SetTaskStatus(

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -697,6 +697,15 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
                                  std::vector<ObjectID> *ids_to_release)
       ABSL_LOCKS_EXCLUDED(mu_);
 
+  /// A wrapper of `retry_task_callback_` that sets the task status
+  /// and calls `retry_task_callback_`. This function should be the only
+  /// caller of `retry_task_callback_`.
+  ///
+  /// \param[in] task_entry The task entry to retry.
+  /// \param[in] object_recovery Whether to retry the task for object recovery.
+  /// \param[in] delay_ms The delay in milliseconds before retrying the task.
+  void RetryTask(TaskEntry *task_entry, bool object_recovery, uint32_t delay_ms);
+
   /// Helper function to call RemoveSubmittedTaskReferences on the remaining
   /// dependencies of the given task spec after the task has finished or
   /// failed. The remaining dependencies are plasma objects and any ObjectIDs


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Solution 1: Call `SetTaskStatus` inside `retry_task_callback` (core_worker.cc) https://github.com/kevin85421/ray/commit/be51239a330c263a0ec1c0dcd7c3267ca93eb04c

* Make `SetTaskStatus` public so that it can be called inside `core_worker.cc`. => not good
* Move `TaskEntry` out of `class TaskManager`
* Change the interface of `retry_task_manager` to take a task entry instead of a task spec.

Solution 2: Add a function `TaskManager::RetryTask` (this PR)
* Much simpler

## Related issue number

follow up of #52637

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
