### PR TITLE
[core] Reuse serialization threadpool

### DIFF
--- a/src/ray/util/BUILD
+++ b/src/ray/util/BUILD
@@ -177,6 +177,9 @@ ray_cc_library(
     name = "memory",
     srcs = ["memory.cc"],
     hdrs = ["memory.h"],
+    deps = [
+        "@boost//:asio",
+    ],
 )
 
 ray_cc_library(

--- a/src/ray/util/memory.cc
+++ b/src/ray/util/memory.cc
@@ -14,23 +14,47 @@
 
 #include "ray/util/memory.h"
 
+#include <boost/asio/post.hpp>
+#include <boost/asio/thread_pool.hpp>
 #include <cstring>
-#include <thread>
-#include <vector>
+#include <utility>
 
 namespace ray {
 
 uint8_t *pointer_logical_and(const uint8_t *address, uintptr_t bits) {
-  uintptr_t value = reinterpret_cast<uintptr_t>(address);
+  auto value = reinterpret_cast<uintptr_t>(address);
   return reinterpret_cast<uint8_t *>(value & bits);
 }
+
+// TODO(dayshah): Just use absl::NoDestructor when we upgrade absl.
+template <typename T>
+class NoDestructor {
+ public:
+  template <typename... Args>
+  explicit NoDestructor(Args &&...args) {
+    new (storage_) T(std::forward<Args>(args)...);
+  };
+  explicit NoDestructor(const T &x) = delete;
+  explicit NoDestructor(T &&x) = delete;
+  NoDestructor(const NoDestructor &) = delete;
+  NoDestructor &operator=(const NoDestructor &) = delete;
+  ~NoDestructor() = default;
+
+  T &operator*() { return *get(); }
+  T *operator->() { return get(); }
+  T *get() { return reinterpret_cast<T *>(storage_); }
+
+ private:
+  alignas(T) char storage_[sizeof(T)];
+  T *storage_ptr_ = reinterpret_cast<T *>(storage_);
+};
 
 void parallel_memcopy(uint8_t *dst,
                       const uint8_t *src,
                       int64_t nbytes,
-                      uintptr_t block_size,
-                      int num_threads) {
-  std::vector<std::thread> threadpool(num_threads);
+                      uintptr_t block_size) {
+  static constexpr int num_threads = 6;
+  static NoDestructor<boost::asio::thread_pool> pool(num_threads);
   uint8_t *left = pointer_logical_and(src + block_size - 1, ~(block_size - 1));
   uint8_t *right = pointer_logical_and(src + nbytes, ~(block_size - 1));
   int64_t num_blocks = (right - left) / block_size;
@@ -50,18 +74,15 @@ void parallel_memcopy(uint8_t *dst,
 
   // Start all threads first and handle leftovers while threads run.
   for (int i = 0; i < num_threads; i++) {
-    threadpool[i] = std::thread(
-        std::memcpy, dst + prefix + i * chunk_size, left + i * chunk_size, chunk_size);
+    boost::asio::post(*pool, [=]() {
+      std::memcpy(dst + prefix + i * chunk_size, left + i * chunk_size, chunk_size);
+    });
   }
 
   std::memcpy(dst, src, prefix);
   std::memcpy(dst + prefix + num_threads * chunk_size, right, suffix);
 
-  for (auto &t : threadpool) {
-    if (t.joinable()) {
-      t.join();
-    }
-  }
+  pool->join();
 }
 
 }  // namespace ray

--- a/src/ray/util/memory.h
+++ b/src/ray/util/memory.h
@@ -23,7 +23,6 @@ namespace ray {
 void parallel_memcopy(uint8_t *dst,
                       const uint8_t *src,
                       int64_t nbytes,
-                      uintptr_t block_size,
-                      int num_threads);
+                      uintptr_t block_size);
 
 }  // namespace ray


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Instead of restarting this threadpool for every argument we serialize we should just keep it alive for the lifetime of each worker.

No Destructor Impl pulled from https://chromium.googlesource.com/chromium/src/base/+/40343e3fbc1e4835145f125adedcf15a2eb4542f/no_destructor.h

Context here: https://ppwwyyxx.com/blog/2023/Safe-Static-Initialization-No-Destruction/
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
