### PR TITLE
[train] Lazily import torch FSDP for `ray.train.torch` module

### DIFF
--- a/python/ray/train/torch/train_loop_utils.py
+++ b/python/ray/train/torch/train_loop_utils.py
@@ -30,10 +30,6 @@ from ray.train._internal.session import get_accelerator, set_accelerator
 from ray.train.utils import _log_deprecation_warning
 from ray.util.annotations import Deprecated, PublicAPI
 
-try:
-    from torch.profiler import profile
-except ImportError:
-    profile = None
 
 logger = logging.getLogger(__name__)
 

--- a/python/ray/train/torch/train_loop_utils.py
+++ b/python/ray/train/torch/train_loop_utils.py
@@ -30,11 +30,6 @@ from ray.train._internal.session import get_accelerator, set_accelerator
 from ray.train.utils import _log_deprecation_warning
 from ray.util.annotations import Deprecated, PublicAPI
 
-if Version(torch.__version__) < Version("1.11.0"):
-    FullyShardedDataParallel = None
-else:
-    from torch.distributed.fsdp import FullyShardedDataParallel
-
 try:
     from torch.profiler import profile
 except ImportError:
@@ -185,8 +180,7 @@ def prepare_model(
             initialization if ``parallel_strategy`` is set to "ddp"
             or "fsdp", respectively.
     """
-
-    if parallel_strategy == "fsdp" and FullyShardedDataParallel is None:
+    if parallel_strategy == "fsdp" and Version(torch.__version__) < Version("1.11.0"):
         raise ImportError(
             "FullyShardedDataParallel requires torch>=1.11.0. "
             "Run `pip install 'torch>=1.11.0'` to use FullyShardedDataParallel."
@@ -481,6 +475,8 @@ class _TorchAccelerator(Accelerator):
                         "`use_gpu=True` in your Trainer to train with "
                         "GPUs."
                     )
+                from torch.distributed.fsdp import FullyShardedDataParallel
+
                 DataParallel = FullyShardedDataParallel
             if rank == 0:
                 logger.info(f"Wrapping provided model in {DataParallel.__name__}.")
@@ -550,7 +546,7 @@ class _TorchAccelerator(Accelerator):
                 shuffle = not isinstance(loader.sampler, SequentialSampler)
 
                 def seeded_worker_init_fn(
-                    worker_init_fn: Optional[Callable[[int], None]]
+                    worker_init_fn: Optional[Callable[[int], None]],
                 ):
                     def wrapper(worker_id: int):
                         worker_seed = torch.initial_seed() % 2**32

--- a/python/ray/train/v2/torch/train_loop_utils.py
+++ b/python/ray/train/v2/torch/train_loop_utils.py
@@ -20,11 +20,6 @@ from ray._private.usage.usage_lib import TagKey, record_extra_usage_tag
 from ray.train.torch.train_loop_utils import _WrappedDataLoader
 from ray.util.annotations import Deprecated, PublicAPI
 
-if Version(torch.__version__) < Version("1.11.0"):
-    FullyShardedDataParallel = None
-else:
-    from torch.distributed.fsdp import FullyShardedDataParallel
-
 logger = logging.getLogger(__name__)
 
 
@@ -64,7 +59,7 @@ def prepare_model(
             initialization if ``parallel_strategy`` is set to "ddp"
             or "fsdp", respectively.
     """
-    if parallel_strategy == "fsdp" and FullyShardedDataParallel is None:
+    if parallel_strategy == "fsdp" and Version(torch.__version__) < Version("1.11.0"):
         raise ImportError(
             "FullyShardedDataParallel requires torch>=1.11.0. "
             "Run `pip install 'torch>=1.11.0'` to use FullyShardedDataParallel."
@@ -112,6 +107,8 @@ def prepare_model(
                     "`use_gpu=True` in your Trainer to train with "
                     "GPUs."
                 )
+            from torch.distributed.fsdp import FullyShardedDataParallel
+
             DataParallel = FullyShardedDataParallel
         if rank == 0:
             logger.info(f"Wrapping provided model in {DataParallel.__name__}.")


### PR DESCRIPTION
## Summary

Importing `torch.distributed.fsdp` has a dependency chain which causes `transformers` to be imported if it's installed. Importing `ray.train.torch` currently always tries to import FSDP, leading to `transformers` import. This PR lazily imports FSDP if it's used by the `prepare_model` API. (We now recommend users to just wrap their model directly in FSDP.)

The current transformers version tested in CI uses a deprecated torch API, which emits a deprecation warning. Beyond this, the import is unexpected for users and adds extra initialization/import time to each new process that's spawned. Note that the root issue is actually fixed in `torch==2.7.0` (maybe earlier).

## Motivation

With `transformers==4.36.2`,`torch==2.3.0`

```python
>>> import ray.train.torch
/home/ray/anaconda3/lib/python3.9/site-packages/transformers/utils/generic.py:441: UserWarning: torch.utils._pytree._register_pytree_node is deprecated. Please use torch.utils._pytree.register_pytree_node instead.
  _torch_pytree._register_pytree_node(
```

The reason is that `ray.train.torch` imports `torch.distributed.fsdp` somewhere in the `__init__.py` chain:

```python
>>> import torch.distributed.fsdp
/home/ray/anaconda3/lib/python3.9/site-packages/transformers/utils/generic.py:441: UserWarning: torch.utils._pytree._register_pytree_node is deprecated. Please use torch.utils._pytree.register_pytree_node instead.
  _torch_pytree._register_pytree_node(
>>> import sys
>>> "transformers" in sys.modules
True
```