### PR TITLE
[train] add initial Train Grafana dashboard

### DIFF
--- a/python/ray/dashboard/modules/metrics/dashboards/train_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/train_dashboard_panels.py
@@ -1,0 +1,59 @@
+# flake8: noqa E501
+from ray.dashboard.modules.metrics.dashboards.common import (
+    DashboardConfig,
+    Panel,
+    Target,
+)
+
+TRAIN_GRAFANA_PANELS = [
+    # Ray Train Metrics (Worker)
+    Panel(
+        id=1,
+        title="Checkpoint Report Time",
+        description="Time taken to report a checkpoint to storage.",
+        unit="seconds",
+        targets=[
+            Target(
+                expr="sum(ray_train_report_total_blocked_time_s{{{global_filters}}}) by (ray_train_run_name, ray_train_worker_world_rank)",
+                legend="Run Name: {{ray_train_run_name}}, World Rank: {{ray_train_worker_world_rank}}",
+            )
+        ],
+        fill=0,
+        stack=False,
+    ),
+    # Ray Train Metrics (Controller)
+    Panel(
+        id=2,
+        title="Train Controller Operation Time",
+        description="Time taken by the controller to perform various operations.",
+        unit="seconds",
+        targets=[
+            Target(
+                expr="sum(ray_train_worker_group_start_total_time_s{{{global_filters}}}) by (ray_train_run_name)",
+                legend="Run Name: {{ray_train_run_name}}, Worker Group Start Time",
+            ),
+            Target(
+                expr="sum(ray_train_worker_group_shutdown_total_time_s{{{global_filters}}}) by (ray_train_run_name)",
+                legend="Run Name: {{ray_train_run_name}}, Worker Group Shutdown Time",
+            ),
+        ],
+        fill=0,
+        stack=False,
+    ),
+]
+
+ids = [panel.id for panel in TRAIN_GRAFANA_PANELS]
+assert len(ids) == len(
+    set(ids)
+), f"Duplicated id found. Use unique id for each panel. {ids}"
+
+train_dashboard_config = DashboardConfig(
+    name="TRAIN",
+    default_uid="rayTrainDashboard",
+    panels=TRAIN_GRAFANA_PANELS,
+    standard_global_filters=[
+        'SessionName=~"$SessionName"',
+        'ray_train_run_name=~"$TrainRunName"',
+    ],
+    base_json_file_name="train_grafana_dashboard_base.json",
+)

--- a/python/ray/dashboard/modules/metrics/dashboards/train_grafana_dashboard_base.json
+++ b/python/ray/dashboard/modules/metrics/dashboards/train_grafana_dashboard_base.json
@@ -1,0 +1,112 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "iteration": 1667344411089,
+  "links": [],
+  "panels": [],
+  "refresh": false,
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false
+        },
+        "description": "Filter queries of a specific Prometheus type.",
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": ".+",
+        "current": {
+          "selected": false
+        },
+        "datasource": "${datasource}",
+        "definition": "label_values(ray_train_report_total_blocked_time_s{{{global_filters}}}, SessionName)",
+        "description": "Filter queries to specific ray sessions.",
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": false,
+        "name": "SessionName",
+        "options": [],
+        "query": {
+          "query": "label_values(ray_train_report_total_blocked_time_s{{{global_filters}}}, SessionName)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 2,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".+",
+        "current": {
+          "selected": false
+        },
+        "datasource": "${datasource}",
+        "definition": "label_values(ray_train_report_total_blocked_time_s{{{global_filters}}}, ray_train_run_name)",
+        "description": "Filter queries to specific ray sessions.",
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": false,
+        "name": "TrainRunName",
+        "options": [],
+        "query": {
+          "query": "label_values(ray_train_report_total_blocked_time_s{{{global_filters}}}, ray_train_run_name)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 2,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Train Dashboard",
+  "uid": "rayTrainDashboard",
+  "version": 1
+}

--- a/python/ray/dashboard/modules/metrics/grafana_dashboard_factory.py
+++ b/python/ray/dashboard/modules/metrics/grafana_dashboard_factory.py
@@ -18,6 +18,9 @@ from ray.dashboard.modules.metrics.dashboards.serve_dashboard_panels import (
 from ray.dashboard.modules.metrics.dashboards.serve_deployment_dashboard_panels import (
     serve_deployment_dashboard_config,
 )
+from ray.dashboard.modules.metrics.dashboards.train_dashboard_panels import (
+    train_dashboard_config,
+)
 
 GRAFANA_DASHBOARD_UID_OVERRIDE_ENV_VAR_TEMPLATE = "RAY_GRAFANA_{name}_DASHBOARD_UID"
 GRAFANA_DASHBOARD_GLOBAL_FILTERS_OVERRIDE_ENV_VAR_TEMPLATE = (
@@ -209,6 +212,17 @@ def generate_data_grafana_dashboard() -> Tuple[str, str]:
       Tuple with format content, uid
     """
     return _generate_grafana_dashboard(data_dashboard_config)
+
+
+def generate_train_grafana_dashboard() -> Tuple[str, str]:
+    """
+    Generates the dashboard output for the train dashboard and returns
+    both the content and the uid.
+
+    Returns:
+      Tuple with format content, uid
+    """
+    return _generate_grafana_dashboard(train_dashboard_config)
 
 
 def _generate_grafana_dashboard(dashboard_config: DashboardConfig) -> str:

--- a/python/ray/dashboard/modules/metrics/metrics_head.py
+++ b/python/ray/dashboard/modules/metrics/metrics_head.py
@@ -17,6 +17,7 @@ from ray.dashboard.modules.metrics.grafana_dashboard_factory import (
     generate_default_grafana_dashboard,
     generate_serve_deployment_grafana_dashboard,
     generate_serve_grafana_dashboard,
+    generate_train_grafana_dashboard,
 )
 from ray.dashboard.modules.metrics.templates import (
     DASHBOARD_PROVISIONING_TEMPLATE,
@@ -340,6 +341,18 @@ class MetricsHead(SubprocessModule):
                 content,
                 self._dashboard_uids["data"],
             ) = generate_data_grafana_dashboard()
+            f.write(content)
+        with open(
+            os.path.join(
+                self._grafana_dashboard_output_dir,
+                "train_grafana_dashboard.json",
+            ),
+            "w",
+        ) as f:
+            (
+                content,
+                self._dashboard_uids["train"],
+            ) = generate_train_grafana_dashboard()
             f.write(content)
 
     def _create_default_prometheus_configs(self):


### PR DESCRIPTION
This PR adds the Grafana `Train Dashboard`.

This initial version includes 2 metrics:
1. **Checkpoint Report Time:** Time taken to report a checkpoint to storage.
     * This is tracked _per worker_.
3. **Train Controller Operation Time:** Time taken by the controller to perform various operations.
    * This is tracked _per run_.

<img width="1624" alt="Screenshot 2025-04-30 at 12 42 24 PM" src="https://github.com/user-attachments/assets/b81aac8b-2df4-4a96-885d-756960e05acd" />

## Testing

1. Setup Prometheus and Grafana locally following [these instructions](https://docs.ray.io/en/latest/cluster/metrics.html).
2. Ran the following script and verified in the Grafana UI.
```python
import os
import tempfile
import time

import ray.train
from ray.train.torch import TorchTrainer

def train_func():
    for i in range(5):
        time.sleep(10)
        with tempfile.TemporaryDirectory() as temp_checkpoint_dir:
            checkpoint=None
            if ray.train.get_context().get_world_rank() == 0:
                with open(os.path.join(temp_checkpoint_dir, f"file_{i}.bin"), "wb") as f:
                    f.write(b'\0' * (1024 * 1024 * 1024))
                checkpoint = ray.train.Checkpoint.from_directory(temp_checkpoint_dir)
            ray.train.report(metrics={"i": i}, checkpoint=checkpoint)


scaling_config = ray.train.ScalingConfig(num_workers=2)

trainer = TorchTrainer(train_func, scaling_config=scaling_config)
trainer.fit()
```