### PR TITLE
[core] Add grpc server success and fail count metric

### DIFF
--- a/src/ray/rpc/server_call.h
+++ b/src/ray/rpc/server_call.h
@@ -296,6 +296,7 @@ class ServerCallImpl : public ServerCall {
   void OnReplySent() override {
     if (record_metrics_) {
       ray::stats::STATS_grpc_server_req_finished.Record(1.0, call_name_);
+      ray::stats::STATS_grpc_server_req_succeeded.Record(1.0, call_name_);
     }
     if (send_reply_success_callback_ && !io_service_.stopped()) {
       auto callback = std::move(send_reply_success_callback_);
@@ -307,6 +308,7 @@ class ServerCallImpl : public ServerCall {
   void OnReplyFailed() override {
     if (record_metrics_) {
       ray::stats::STATS_grpc_server_req_finished.Record(1.0, call_name_);
+      ray::stats::STATS_grpc_server_req_failed.Record(1.0, call_name_);
     }
     if (send_reply_failure_callback_ && !io_service_.stopped()) {
       auto callback = std::move(send_reply_failure_callback_);

--- a/src/ray/stats/metric_defs.cc
+++ b/src/ray/stats/metric_defs.cc
@@ -188,6 +188,16 @@ DEFINE_stats(grpc_server_req_finished,
              ("Method"),
              (),
              ray::stats::COUNT);
+DEFINE_stats(grpc_server_req_succeeded,
+             "Succeeded request count in grpc server",
+             ("Method"),
+             (),
+             ray::stats::COUNT);
+DEFINE_stats(grpc_server_req_failed,
+             "Failed request count in grpc server",
+             ("Method"),
+             (),
+             ray::stats::COUNT);
 
 /// Object Manager.
 DEFINE_stats(object_manager_bytes,

--- a/src/ray/stats/metric_defs.h
+++ b/src/ray/stats/metric_defs.h
@@ -70,6 +70,8 @@ DECLARE_stats(grpc_server_req_process_time_ms);
 DECLARE_stats(grpc_server_req_new);
 DECLARE_stats(grpc_server_req_handling);
 DECLARE_stats(grpc_server_req_finished);
+DECLARE_stats(grpc_server_req_succeeded);
+DECLARE_stats(grpc_server_req_failed);
 
 /// Object Manager.
 DECLARE_stats(object_manager_bytes);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Add a grpc server success and failure count, so we know which + how many replies failed to make it.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
