### PR TITLE
[data] Adding in fixed size test variants for new batch inference mock pipeline release tests

### DIFF
--- a/release/nightly_tests/dataset/fixed_size_100_gpu_compute.yaml
+++ b/release/nightly_tests/dataset/fixed_size_100_gpu_compute.yaml
@@ -1,0 +1,20 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west-2
+
+advanced_configurations_json:
+    IamInstanceProfile: {"Name": "ray-autoscaler-v1"}
+
+head_node_type:
+    name: head-node
+    instance_type: m5.2xlarge
+    resources:
+      cpu: 0
+
+worker_node_types:
+    - name: worker-node
+      # Anyscale workspaces use m5.2xlarge worker nodes by default. For consistency, we
+      # use GPU nodes with the same number of vCPUs and memory.
+      instance_type: g4dn.2xlarge
+      min_workers: 100
+      max_workers: 100
+      use_spot: false

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -495,6 +495,23 @@
       run:
         prepare: python setup_chaos.py --chaos TerminateEC2Instance --batch-size-to-kill 10 --max-to-kill 100 --kill-delay 120
 
+- name: batch_inference_mock_image_pipeline_fixed
+  frequency: manual
+  working_dir: nightly_tests
+
+  cluster:
+    cluster_compute: dataset/fixed_size_100_gpu_compute.yaml
+
+  run:
+    timeout: 3600
+    script: >
+      python dataset/batch_inference_mock_image_pipeline.py
+
+  variations:
+    - __suffix__: regular
+    - __suffix__: chaos
+      run:
+        prepare: python setup_chaos.py --chaos TerminateEC2Instance --batch-size-to-kill 10 --max-to-kill 100 --kill-delay 120
 
 ##############
 # TPCH Queries


### PR DESCRIPTION
## Why are these changes needed?
We want to add some release tests that let us benchmark our performance of our mock image pipeline on a fixed sized cluster in addition to the newly added autoscaling variants.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
