### PR TITLE
reclassify test as medium

### DIFF
--- a/python/ray/serve/tests/BUILD
+++ b/python/ray/serve/tests/BUILD
@@ -34,7 +34,6 @@ py_test_module_list(
 py_test_module_list(
     size = "small",
     files = [
-        "test_actor_replica_wrapper.py",
         "test_advanced.py",
         "test_batching.py",
         "test_cluster_node_info_cache.py",
@@ -65,6 +64,7 @@ py_test_module_list(
 py_test_module_list(
     size = "medium",
     files = [
+        "test_actor_replica_wrapper.py",
         "test_backpressure.py",
         "test_callback.py",
         "test_cluster.py",


### PR DESCRIPTION
test takes over a min on local
```
❯ pytest python/ray/serve/tests/test_actor_replica_wrapper.py
Test session starts (platform: linux, Python 3.9.21, pytest 7.4.4, pytest-sugar 0.9.5)
rootdir: /home/ubuntu/ray
configfile: pytest.ini
plugins: docker-tools-3.1.3, timeout-2.1.0, asyncio-0.17.2, forked-1.4.0, virtualenv-1.7.0, sugar-0.9.5, shutil-1.7.0, aiohttp-1.1.0, httpserver-1.0.6, nbval-0.11.0, anyio-3.7.1, sphinx-0.5.1.dev0, rerunfailures-11.1.2, lazy-fixture-0.6.3
timeout: 180.0s
timeout method: signal
timeout func_only: False
asyncio: mode=auto
collecting ...
 python/ray/serve/tests/test_actor_replica_wrapper.py ✓✓✓✓✓✓✓                                                                                                                                                                                                                                                                                              100% ██████████

Results (74.46s):
       7 passed
```

so it makes sense that we should bump it up as medium test

fixes: https://github.com/ray-project/ray/issues/46014
failing build: https://buildkite.com/ray-project/postmerge/builds/9856#019688b9-45fe-4e5b-b951-344188fdf3e9