### PR TITLE
[ci] add oss and doc tag for doc build on CI

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -49,6 +49,10 @@ steps:
       - bazel run //ci/ray_ci/doc:cmd_build
     depends_on: docbuild
     job_env: docbuild-py3.12
+    tags:
+      - oss
+      - doc
+      - skip-on-premerge
 
   - label: ":tapioca: build: ray py{{matrix}} docker (x86_64)"
     tags:


### PR DESCRIPTION
and also skip on premerge. we have readthedocs running on premerge for doc building
