### PR TITLE
[Data] Added support for Joins (using hash-shuffle)

### DIFF
--- a/python/ray/data/BUILD
+++ b/python/ray/data/BUILD
@@ -311,6 +311,21 @@ py_test(
 )
 
 py_test(
+    name = "test_join",
+    size = "medium",
+    srcs = ["tests/test_join.py"],
+    tags = [
+        "data_non_parallel",
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_binary",
     size = "small",
     srcs = ["tests/test_binary.py"],
@@ -580,20 +595,6 @@ py_test(
     name = "test_path_util",
     size = "small",
     srcs = ["tests/test_path_util.py"],
-    tags = [
-        "exclusive",
-        "team:data",
-    ],
-    deps = [
-        ":conftest",
-        "//:ray_lib",
-    ],
-)
-
-py_test(
-    name = "test_task_pool_map_operator",
-    size = "small",
-    srcs = ["tests/test_task_pool_map_operator.py"],
     tags = [
         "exclusive",
         "team:data",

--- a/python/ray/data/BUILD
+++ b/python/ray/data/BUILD
@@ -606,6 +606,20 @@ py_test(
 )
 
 py_test(
+    name = "test_task_pool_map_operator",
+    size = "small",
+    srcs = ["tests/test_task_pool_map_operator.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_tensor",
     size = "small",
     srcs = ["tests/test_tensor.py"],

--- a/python/ray/data/_internal/execution/operators/join.py
+++ b/python/ray/data/_internal/execution/operators/join.py
@@ -1,0 +1,241 @@
+import logging
+import math
+from typing import Any, Dict, List, Optional, Tuple
+
+from ray.data._internal.execution.operators.hash_shuffle import (
+    HashShufflingOperatorBase,
+    StatefulShuffleAggregation,
+)
+from ray.data._internal.logical.operators.join_operator import JoinType
+from ray.data import DataContext
+from ray.data._internal.arrow_block import ArrowBlockBuilder
+from ray.data._internal.execution.interfaces import PhysicalOperator
+from ray.data._internal.util import GiB
+from ray.data.block import Block
+
+_JOIN_TYPE_TO_ARROW_JOIN_VERB_MAP = {
+    JoinType.INNER: "inner",
+    JoinType.LEFT_OUTER: "left outer",
+    JoinType.RIGHT_OUTER: "right outer",
+    JoinType.FULL_OUTER: "full outer",
+}
+
+
+logger = logging.getLogger(__name__)
+
+
+class JoiningShuffleAggregation(StatefulShuffleAggregation):
+    """Aggregation performing distributed joining of the 2 sequences,
+    by utilising hash-based shuffling.
+
+    Hash-based shuffling applied to 2 input sequences and employing the same
+    partitioning scheme allows to
+
+        - Accumulate identical keys from both sequences into the same
+        (numerical) partition. In other words, all keys such that
+
+            hash(key) % num_partitions = partition_id
+
+        - Perform join on individual partitions independently (from other partitions)
+
+    For actual joining Pyarrow native joining functionality is utilised, providing
+    incredible performance while allowing keep the data from being deserialized.
+    """
+
+    def __init__(
+        self,
+        *,
+        aggregator_id: int,
+        join_type: JoinType,
+        left_key_col_names: Tuple[str],
+        right_key_col_names: Tuple[str],
+        target_partition_ids: List[int],
+        left_columns_suffix: Optional[str] = None,
+        right_columns_suffix: Optional[str] = None,
+    ):
+        super().__init__(aggregator_id)
+
+        assert (
+            len(left_key_col_names) > 0
+        ), "At least 1 column to join on has to be provided"
+        assert len(right_key_col_names) == len(
+            left_key_col_names
+        ), "Number of column for both left and right join operands has to match"
+
+        assert join_type in _JOIN_TYPE_TO_ARROW_JOIN_VERB_MAP, (
+            f"Join type is not currently supported (got: {join_type}; "  # noqa: C416
+            f"supported: {[jt for jt in JoinType]})"  # noqa: C416
+        )
+
+        self._left_key_col_names: Tuple[str] = left_key_col_names
+        self._right_key_col_names: Tuple[str] = right_key_col_names
+        self._join_type: JoinType = join_type
+
+        self._left_columns_suffix: Optional[str] = left_columns_suffix
+        self._right_columns_suffix: Optional[str] = right_columns_suffix
+
+        # Partition builders for the partition corresponding to
+        # left and right input sequences respectively
+        self._left_input_seq_partition_builders: Dict[int, ArrowBlockBuilder] = {
+            partition_id: ArrowBlockBuilder() for partition_id in target_partition_ids
+        }
+
+        self._right_input_seq_partition_builders: Dict[int, ArrowBlockBuilder] = {
+            partition_id: ArrowBlockBuilder() for partition_id in target_partition_ids
+        }
+
+    def accept(self, input_seq_id: int, partition_id: int, partition_shard: Block):
+        assert 0 <= input_seq_id < 2
+
+        partition_builder = self._get_partition_builder(
+            input_seq_id=input_seq_id,
+            partition_id=partition_id,
+        )
+
+        partition_builder.add_block(partition_shard)
+
+    def finalize(self, partition_id: int) -> Block:
+        import pyarrow as pa
+
+        left_seq_partition: pa.Table = self._get_partition_builder(
+            input_seq_id=0, partition_id=partition_id
+        ).build()
+        right_seq_partition: pa.Table = self._get_partition_builder(
+            input_seq_id=1, partition_id=partition_id
+        ).build()
+
+        arrow_join_type = _JOIN_TYPE_TO_ARROW_JOIN_VERB_MAP[self._join_type]
+
+        joined = left_seq_partition.join(
+            right_seq_partition,
+            join_type=arrow_join_type,
+            keys=list(self._left_key_col_names),
+            right_keys=(list(self._right_key_col_names)),
+            left_suffix=self._left_columns_suffix,
+            right_suffix=self._right_columns_suffix,
+        )
+
+        return joined
+
+    def clear(self, partition_id: int):
+        self._left_input_seq_partition_builders.pop(partition_id)
+        self._right_input_seq_partition_builders.pop(partition_id)
+
+    def _get_partition_builder(self, *, input_seq_id: int, partition_id: int):
+        if input_seq_id == 0:
+            partition_builder = self._left_input_seq_partition_builders[partition_id]
+        elif input_seq_id == 1:
+            partition_builder = self._right_input_seq_partition_builders[partition_id]
+        else:
+            raise ValueError(
+                f"Unexpected inpt sequence id of '{input_seq_id}' (expected 0 or 1)"
+            )
+        return partition_builder
+
+
+class JoinOperator(HashShufflingOperatorBase):
+    def __init__(
+        self,
+        data_context: DataContext,
+        left_input_op: PhysicalOperator,
+        right_input_op: PhysicalOperator,
+        left_key_columns: Tuple[str],
+        right_key_columns: Tuple[str],
+        join_type: JoinType,
+        *,
+        num_partitions: int,
+        left_columns_suffix: Optional[str] = None,
+        right_columns_suffix: Optional[str] = None,
+        partition_size_hint: Optional[int] = None,
+        aggregator_ray_remote_args_override: Optional[Dict[str, Any]] = None,
+    ):
+        super().__init__(
+            name=f"Join(num_partitions={num_partitions})",
+            input_ops=[left_input_op, right_input_op],
+            data_context=data_context,
+            key_columns=[left_key_columns, right_key_columns],
+            num_partitions=num_partitions,
+            partition_size_hint=partition_size_hint,
+            partition_aggregation_factory=(
+                lambda aggregator_id, target_partition_ids: JoiningShuffleAggregation(
+                    aggregator_id=aggregator_id,
+                    left_key_col_names=left_key_columns,
+                    right_key_col_names=right_key_columns,
+                    join_type=join_type,
+                    target_partition_ids=target_partition_ids,
+                    left_columns_suffix=left_columns_suffix,
+                    right_columns_suffix=right_columns_suffix,
+                )
+            ),
+            aggregator_ray_remote_args_override=aggregator_ray_remote_args_override,
+        )
+
+    def _get_default_num_cpus_per_partition(self) -> int:
+        """
+        CPU allocation for aggregating actors of Join operator is calculated as:
+        num_cpus (per partition) = CPU budget / # partitions
+
+        Assuming:
+        - Default number of partitions: 64
+        - Total operator's CPU budget with default settings: 8 cores
+        - Number of CPUs per partition: 8 / 64 = 0.125
+
+        These CPU budgets are derived such that Ray Data pipeline could run on a
+        single node (using the default settings).
+        """
+        return 0.125
+
+    def _get_operator_num_cpus_per_partition_override(self) -> int:
+        return self.data_context.join_operator_actor_num_cpus_per_partition_override
+
+    @classmethod
+    def _estimate_aggregator_memory_allocation(
+        cls,
+        *,
+        num_aggregators: int,
+        num_partitions: int,
+        partition_byte_size_estimate: int,
+    ) -> int:
+        dataset_size = num_partitions * partition_byte_size_estimate
+        # Estimate of object store memory required to accommodate all partitions
+        # handled by a single aggregator
+        #
+        # NOTE: x2 due to 2 sequences involved in joins
+        aggregator_shuffle_object_store_memory_required: int = math.ceil(
+            2 * dataset_size / num_aggregators
+        )
+        # Estimate of memory required to perform actual (in-memory) join
+        # operation (inclusive of 50% overhead allocated for Pyarrow join
+        # implementation)
+        #
+        # NOTE:
+        #   - x2 due to 2 partitions (from left/right sequences)
+        #   - x1.5 due to 50% overhead of in-memory join
+        join_memory_required: int = math.ceil(partition_byte_size_estimate * 3)
+        # Estimate of memory required to accommodate single partition as an output
+        # (inside Object Store)
+        #
+        # NOTE: x2 due to 2 sequences involved in joins
+        output_object_store_memory_required: int = 2 * partition_byte_size_estimate
+
+        aggregator_total_memory_required: int = (
+            # Inputs (object store)
+            aggregator_shuffle_object_store_memory_required
+            +
+            # Join (heap)
+            join_memory_required
+            +
+            # Output (object store)
+            output_object_store_memory_required
+        )
+
+        logger.debug(
+            f"Estimated memory requirement for joining aggregator "
+            f"(partitions={num_partitions}, aggregators={num_aggregators}): "
+            f"shuffle={aggregator_shuffle_object_store_memory_required / GiB:.2f}GiB, "
+            f"joining={join_memory_required / GiB:.2f}GiB, "
+            f"output={output_object_store_memory_required / GiB:.2f}GiB, "
+            f"total={aggregator_total_memory_required / GiB:.2f}GiB, "
+        )
+
+        return aggregator_total_memory_required

--- a/python/ray/data/_internal/logical/operators/join_operator.py
+++ b/python/ray/data/_internal/logical/operators/join_operator.py
@@ -1,0 +1,116 @@
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Tuple
+
+from ray.data._internal.logical.interfaces import LogicalOperator
+from ray.data._internal.logical.operators.n_ary_operator import NAry
+
+if TYPE_CHECKING:
+    from ray.data import Schema
+
+
+class JoinType(Enum):
+    INNER = "inner"
+    LEFT_OUTER = "left_outer"
+    RIGHT_OUTER = "right_outer"
+    FULL_OUTER = "full_outer"
+
+
+class Join(NAry):
+    """Logical operator for join."""
+
+    def __init__(
+        self,
+        left_input_op: LogicalOperator,
+        right_input_op: LogicalOperator,
+        join_type: str,
+        left_key_columns: Tuple[str],
+        right_key_columns: Tuple[str],
+        *,
+        num_partitions: int,
+        left_columns_suffix: Optional[str] = None,
+        right_columns_suffix: Optional[str] = None,
+        partition_size_hint: Optional[int] = None,
+        aggregator_ray_remote_args: Optional[Dict[str, Any]] = None,
+    ):
+        """
+        Args:
+            left_input_op: The input operator at left hand side.
+            right_input_op: The input operator at right hand side.
+            join_type: The kind of join that should be performed, one of (“inner”,
+               “left_outer”, “right_outer”, “full_outer”).
+            left_key_columns: The columns from the left Dataset that should be used as
+              keys of the join operation.
+            right_key_columns: The columns from the right Dataset that should be used as
+              keys of the join operation.
+            partition_size_hint: Hint to joining operator about the estimated
+              avg expected size of the resulting partition (in bytes)
+            num_partitions: Total number of expected blocks outputted by this
+                operator.
+        """
+
+        try:
+            join_type_enum = JoinType(join_type)
+        except ValueError:
+            raise ValueError(
+                f"Invalid join type: '{join_type}'. "
+                f"Supported join types are: {', '.join(jt.value for jt in JoinType)}."
+            )
+
+        super().__init__(left_input_op, right_input_op, num_outputs=num_partitions)
+
+        self._left_key_columns = left_key_columns
+        self._right_key_columns = right_key_columns
+        self._join_type = join_type_enum
+
+        self._left_columns_suffix = left_columns_suffix
+        self._right_columns_suffix = right_columns_suffix
+
+        self._partition_size_hint = partition_size_hint
+        self._aggregator_ray_remote_args = aggregator_ray_remote_args
+
+    @staticmethod
+    def _validate_schemas(
+        left_op_schema: "Schema",
+        right_op_schema: "Schema",
+        left_key_column_names: Tuple[str],
+        right_key_column_names: Tuple[str],
+    ):
+        def _col_names_as_str(keys: Sequence[str]):
+            keys_joined = ", ".join(map(lambda k: f"'{k}'", keys))
+            return f"[{keys_joined}]"
+
+        if len(left_key_column_names) < 1:
+            raise ValueError(
+                f"At least 1 column name to join on has to be provided (got "
+                f"{_col_names_as_str(left_key_column_names)})"
+            )
+
+        if len(left_key_column_names) != len(right_key_column_names):
+            raise ValueError(
+                f"Number of columns provided for left and right datasets has to match "
+                f"(got {_col_names_as_str(left_key_column_names)} and "
+                f"{_col_names_as_str(right_key_column_names)})"
+            )
+
+        def _get_key_column_types(schema: "Schema", keys: Tuple[str]):
+            return (
+                [
+                    _type
+                    for name, _type in zip(schema.names, schema.types)
+                    if name in keys
+                ]
+                if schema
+                else None
+            )
+
+        right_op_key_cols = _get_key_column_types(
+            right_op_schema, left_key_column_names
+        )
+        left_op_key_cols = _get_key_column_types(left_op_schema, right_key_column_names)
+
+        if left_op_key_cols != right_op_key_cols:
+            raise ValueError(
+                f"Key columns are expected to be present and have the same types "
+                "in both left and right operands of the join operation: "
+                f"left has {left_op_schema}, but right has {right_op_schema}"
+            )

--- a/python/ray/data/_internal/planner/planner.py
+++ b/python/ray/data/_internal/planner/planner.py
@@ -1,11 +1,13 @@
 from typing import Callable, Dict, List, Tuple, Type, TypeVar
 
 from ray.data._internal.execution.interfaces import PhysicalOperator
+from ray.data._internal.execution.operators.join import JoinOperator
 from ray.data._internal.logical.interfaces import (
     LogicalOperator,
     LogicalPlan,
     PhysicalPlan,
 )
+from ray.data._internal.logical.operators.join_operator import Join
 from ray.data.context import DataContext
 from ray.util.annotations import DeveloperAPI
 
@@ -122,6 +124,30 @@ def _register_default_plan_logical_op_fns():
     register_plan_logical_op_fn(Project, plan_project_op)
 
     register_plan_logical_op_fn(StreamingRepartition, plan_streaming_repartition_op)
+
+    def plan_join_op(
+        logical_op: Join,
+        physical_children: List[PhysicalOperator],
+        data_context: DataContext,
+    ) -> PhysicalOperator:
+        assert len(physical_children) == 2
+        assert logical_op._num_outputs is not None
+
+        return JoinOperator(
+            data_context=data_context,
+            left_input_op=physical_children[0],
+            right_input_op=physical_children[1],
+            join_type=logical_op._join_type,
+            left_key_columns=logical_op._left_key_columns,
+            right_key_columns=logical_op._right_key_columns,
+            left_columns_suffix=logical_op._left_columns_suffix,
+            right_columns_suffix=logical_op._right_columns_suffix,
+            num_partitions=logical_op._num_outputs,
+            partition_size_hint=logical_op._partition_size_hint,
+            aggregator_ray_remote_args_override=logical_op._aggregator_ray_remote_args,
+        )
+
+    register_plan_logical_op_fn(Join, plan_join_op)
 
 
 _register_default_plan_logical_op_fns()

--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -432,9 +432,6 @@ class AbsMax(AggregateFnV2):
             zero_factory=lambda: 0,
         )
 
-    def combine(self, current_accumulator: AggType, new: AggType) -> AggType:
-        return max(current_accumulator, new)
-
     def aggregate_block(self, block: Block) -> AggType:
         block_accessor = BlockAccessor.for_block(block)
 
@@ -448,6 +445,9 @@ class AbsMax(AggregateFnV2):
             abs(max_),
             abs(min_),
         )
+
+    def combine(self, current_accumulator: AggType, new: AggType) -> AggType:
+        return max(current_accumulator, new)
 
 
 @PublicAPI

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -146,9 +146,8 @@ CollatedData = TypeVar("CollatedData")
 TorchBatchType = Union[Dict[str, "torch.Tensor"], CollatedData]
 
 BT_API_GROUP = "Basic Transformations"
-J_API_GROUP = "Joining Operation APIs"
 SSR_API_GROUP = "Sorting, Shuffling and Repartitioning"
-SMD_API_GROUP = "Splitting and Merging datasets"
+SMJ_API_GROUP = "Splitting, Merging, Joining datasets"
 GGA_API_GROUP = "Grouped and Global aggregations"
 CD_API_GROUP = "Consuming Data"
 IOC_API_GROUP = "I/O and Conversion"
@@ -1709,7 +1708,7 @@ class Dataset:
         )
 
     @ConsumptionAPI
-    @PublicAPI(api_group=SMD_API_GROUP)
+    @PublicAPI(api_group=SMJ_API_GROUP)
     def streaming_split(
         self,
         n: int,
@@ -1803,7 +1802,7 @@ class Dataset:
         return StreamSplitDataIterator.create(self, n, equal, locality_hints)
 
     @ConsumptionAPI
-    @PublicAPI(api_group=SMD_API_GROUP)
+    @PublicAPI(api_group=SMJ_API_GROUP)
     def split(
         self, n: int, *, equal: bool = False, locality_hints: Optional[List[Any]] = None
     ) -> List["MaterializedDataset"]:
@@ -2026,7 +2025,7 @@ class Dataset:
         return split_datasets
 
     @ConsumptionAPI
-    @PublicAPI(api_group=SMD_API_GROUP)
+    @PublicAPI(api_group=SMJ_API_GROUP)
     def split_at_indices(self, indices: List[int]) -> List["MaterializedDataset"]:
         """Materialize and split the dataset at the given indices (like ``np.split``).
 
@@ -2101,7 +2100,7 @@ class Dataset:
         return splits
 
     @ConsumptionAPI
-    @PublicAPI(api_group=SMD_API_GROUP)
+    @PublicAPI(api_group=SMJ_API_GROUP)
     def split_proportionately(
         self, proportions: List[float]
     ) -> List["MaterializedDataset"]:
@@ -2182,7 +2181,7 @@ class Dataset:
         return self.split_at_indices(split_indices)
 
     @ConsumptionAPI
-    @PublicAPI(api_group=SMD_API_GROUP)
+    @PublicAPI(api_group=SMJ_API_GROUP)
     def train_test_split(
         self,
         test_size: Union[int, float],
@@ -2244,7 +2243,7 @@ class Dataset:
                 )
             return ds.split_at_indices([ds_length - test_size])
 
-    @PublicAPI(api_group=SMD_API_GROUP)
+    @PublicAPI(api_group=SMJ_API_GROUP)
     def union(self, *other: List["Dataset"]) -> "Dataset":
         """Concatenate :class:`Datasets <ray.data.Dataset>` across rows.
 
@@ -2291,7 +2290,7 @@ class Dataset:
         )
 
     @AllToAllAPI
-    @PublicAPI(api_group=J_API_GROUP)
+    @PublicAPI(api_group=SMJ_API_GROUP)
     def join(
         self,
         ds: "Dataset",
@@ -2868,7 +2867,7 @@ class Dataset:
         logical_plan = LogicalPlan(op, self.context)
         return Dataset(plan, logical_plan)
 
-    @PublicAPI(api_group=SMD_API_GROUP)
+    @PublicAPI(api_group=SMJ_API_GROUP)
     def zip(self, other: "Dataset") -> "Dataset":
         """Zip the columns of this dataset with the columns of another.
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2339,8 +2339,8 @@ class Dataset:
                 false, since obtaining schemas could be prohibitively expensive).
 
         Returns:
-            A :class:`Dataset` that holds join of input left Dataset with the right
-              Dataset based on join type and keys.
+            A :class:`Dataset` that holds rows of input left Dataset joined with the
+            right Dataset based on join type and keys.
 
         Examples:
 

--- a/python/ray/data/tests/test_join.py
+++ b/python/ray/data/tests/test_join.py
@@ -1,10 +1,11 @@
-from typing import Optional
 from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
-
 import ray
+
+from typing import Optional
+
 from ray.data._internal.execution.operators.join import JoinOperator
 from ray.data._internal.logical.operators.join_operator import JoinType
 from ray.data import Dataset, DataContext
@@ -46,6 +47,11 @@ def test_simple_inner_join(
     num_rows_right: int,
     partition_size_hint: Optional[int],
 ):
+    # NOTE: We override max-block size to make sure that in cases when a partition
+    #       size hint is not provided, we're not over-estimating amount of memory
+    #       required for the aggregators
+    DataContext.get_current().target_max_block_size = 1 * MiB
+
     doubles = ray.data.range(num_rows_left).map(
         lambda row: {"id": row["id"], "double": int(row["id"]) * 2}
     )
@@ -104,6 +110,11 @@ def test_simple_left_right_outer_join(
     num_rows_left,
     num_rows_right,
 ):
+    # NOTE: We override max-block size to make sure that in cases when a partition
+    #       size hint is not provided, we're not over-estimating amount of memory
+    #       required for the aggregators
+    DataContext.get_current().target_max_block_size = 1 * MiB
+
     doubles = ray.data.range(num_rows_left).map(
         lambda row: {"id": row["id"], "double": int(row["id"]) * 2}
     )
@@ -162,6 +173,11 @@ def test_simple_full_outer_join(
     num_rows_left,
     num_rows_right,
 ):
+    # NOTE: We override max-block size to make sure that in cases when a partition
+    #       size hint is not provided, we're not over-estimating amount of memory
+    #       required for the aggregators
+    DataContext.get_current().target_max_block_size = 1 * MiB
+
     doubles = ray.data.range(num_rows_left).map(
         lambda row: {"id": row["id"], "double": int(row["id"]) * 2}
     )
@@ -200,6 +216,11 @@ def test_simple_full_outer_join(
 @pytest.mark.parametrize("left_suffix", [None, "_left"])
 @pytest.mark.parametrize("right_suffix", [None, "_right"])
 def test_simple_self_join(ray_start_regular_shared_2_cpus, left_suffix, right_suffix):
+    # NOTE: We override max-block size to make sure that in cases when a partition
+    #       size hint is not provided, we're not over-estimating amount of memory
+    #       required for the aggregators
+    DataContext.get_current().target_max_block_size = 1 * MiB
+
     doubles = ray.data.range(100).map(
         lambda row: {"id": row["id"], "double": int(row["id"]) * 2}
     )

--- a/python/ray/data/tests/test_join.py
+++ b/python/ray/data/tests/test_join.py
@@ -1,0 +1,381 @@
+from typing import Optional
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+import ray
+from ray.anyscale.data._internal.execution.operators.join import JoinOperator
+from ray.anyscale.data._internal.logical.operators.join_operator import JoinType
+from ray.data import Dataset, DataContext
+from ray.data._internal.execution.interfaces import PhysicalOperator
+from ray.data._internal.util import MiB, GiB
+from ray.exceptions import RayTaskError
+from ray.tests.conftest import *  # noqa
+
+
+@pytest.fixture
+def nullify_shuffle_aggregator_num_cpus():
+    ctx = ray.data.context.DataContext.get_current()
+
+    original = ctx.join_operator_actor_num_cpus_per_partition_override
+    # NOTE: We override this to reduce hardware requirements
+    #       for every aggregator
+    ctx.join_operator_actor_num_cpus_per_partition_override = 0.001
+
+    yield
+
+    ctx.join_operator_actor_num_cpus_per_partition_override = original
+
+
+@pytest.mark.parametrize(
+    "num_rows_left,num_rows_right,partition_size_hint",
+    [
+        (32, 32, 1 * MiB),
+        (32, 16, None),
+        (16, 32, None),
+        # "Degenerate" cases with mostly empty partitions
+        (32, 1, None),
+        (1, 32, None),
+    ],
+)
+def test_simple_inner_join(
+    ray_start_regular_shared_2_cpus,
+    nullify_shuffle_aggregator_num_cpus,
+    num_rows_left: int,
+    num_rows_right: int,
+    partition_size_hint: Optional[int],
+):
+    doubles = ray.data.range(num_rows_left).map(
+        lambda row: {"id": row["id"], "double": int(row["id"]) * 2}
+    )
+
+    squares = ray.data.range(num_rows_right).map(
+        lambda row: {"id": row["id"], "square": int(row["id"]) ** 2}
+    )
+
+    doubles_pd = doubles.to_pandas()
+    squares_pd = squares.to_pandas()
+
+    # Join using Pandas (to assert against)
+    expected_pd = doubles_pd.join(squares_pd.set_index("id"), on="id", how="inner")
+    expected_pd_sorted = expected_pd.sort_values(by=["id"]).reset_index(drop=True)
+
+    # Join using Ray Data
+    joined: Dataset = doubles.join(
+        squares,
+        join_type="inner",
+        num_partitions=16,
+        on=("id",),
+        partition_size_hint=partition_size_hint,
+    )
+
+    # TODO use native to_pandas() instead
+    joined_pd = pd.DataFrame(joined.take_all())
+
+    # Sort resulting frame and reset index (to be able to compare with expected one)
+    joined_pd_sorted = joined_pd.sort_values(by=["id"]).reset_index(drop=True)
+
+    pd.testing.assert_frame_equal(expected_pd_sorted, joined_pd_sorted)
+
+
+@pytest.mark.parametrize(
+    "join_type",
+    [
+        "left_outer",
+        "right_outer",
+    ],
+)
+@pytest.mark.parametrize(
+    "num_rows_left,num_rows_right",
+    [
+        (32, 32),
+        (32, 16),
+        (16, 32),
+        # "Degenerate" cases with mostly empty partitions
+        (1, 32),
+        (32, 1),
+    ],
+)
+def test_simple_left_right_outer_join(
+    ray_start_regular_shared_2_cpus,
+    nullify_shuffle_aggregator_num_cpus,
+    join_type,
+    num_rows_left,
+    num_rows_right,
+):
+    doubles = ray.data.range(num_rows_left).map(
+        lambda row: {"id": row["id"], "double": int(row["id"]) * 2}
+    )
+
+    squares = ray.data.range(num_rows_right).map(
+        lambda row: {"id": row["id"], "square": int(row["id"]) ** 2}
+    )
+
+    doubles_pd = doubles.to_pandas()
+    squares_pd = squares.to_pandas()
+
+    # Join using Pandas (to assert against)
+    if join_type == "left_outer":
+        pd_join_type = "left"
+        squares_pd = squares_pd.set_index("id")
+    elif join_type == "right_outer":
+        pd_join_type = "right"
+        doubles_pd = doubles_pd.set_index("id")
+    else:
+        raise ValueError(f"Unsupported join type: {join_type}")
+
+    expected_pd = doubles_pd.join(squares_pd, on="id", how=pd_join_type).reset_index(
+        drop=True
+    )
+
+    # Join using Ray Data
+    joined: Dataset = doubles.join(
+        squares,
+        join_type=join_type,
+        num_partitions=16,
+        on=("id",),
+    )
+
+    joined_pd = pd.DataFrame(joined.take_all())
+
+    # Sort resulting frame and reset index (to be able to compare with expected one)
+    joined_pd_sorted = joined_pd.sort_values(by=["id"]).reset_index(drop=True)
+
+    pd.testing.assert_frame_equal(expected_pd, joined_pd_sorted)
+
+
+@pytest.mark.parametrize(
+    "num_rows_left,num_rows_right",
+    [
+        (32, 32),
+        (32, 16),
+        (16, 32),
+        # # "Degenerate" cases with mostly empty partitions
+        (1, 32),
+        (32, 1),
+    ],
+)
+def test_simple_full_outer_join(
+    ray_start_regular_shared_2_cpus,
+    nullify_shuffle_aggregator_num_cpus,
+    num_rows_left,
+    num_rows_right,
+):
+    doubles = ray.data.range(num_rows_left).map(
+        lambda row: {"id": row["id"], "double": int(row["id"]) * 2}
+    )
+
+    squares = ray.data.range(num_rows_right).map(
+        lambda row: {"id": row["id"] + num_rows_left, "square": int(row["id"]) ** 2}
+    )
+
+    doubles_pd = doubles.to_pandas()
+    squares_pd = squares.to_pandas()
+
+    # Join using Pandas (to assert against)
+    expected_pd = doubles_pd.join(
+        squares_pd.set_index("id"), on="id", how="outer"
+    ).reset_index(drop=True)
+
+    # Join using Ray Data
+    joined: Dataset = doubles.join(
+        squares,
+        join_type="full_outer",
+        num_partitions=16,
+        on=("id",),
+        # NOTE: We override this to reduce hardware requirements
+        #       for every aggregator (by default requiring 1 logical CPU)
+        aggregator_ray_remote_args={"num_cpus": 0.01},
+    )
+
+    joined_pd = pd.DataFrame(joined.take_all())
+
+    # Sort resulting frame and reset index (to be able to compare with expected one)
+    joined_pd_sorted = joined_pd.sort_values(by=["id"]).reset_index(drop=True)
+
+    pd.testing.assert_frame_equal(expected_pd, joined_pd_sorted)
+
+
+@pytest.mark.parametrize("left_suffix", [None, "_left"])
+@pytest.mark.parametrize("right_suffix", [None, "_right"])
+def test_simple_self_join(ray_start_regular_shared_2_cpus, left_suffix, right_suffix):
+    doubles = ray.data.range(100).map(
+        lambda row: {"id": row["id"], "double": int(row["id"]) * 2}
+    )
+
+    doubles_pd = doubles.to_pandas()
+
+    # Self-join
+    joined: Dataset = doubles.join(
+        doubles,
+        join_type="inner",
+        num_partitions=16,
+        on=("id",),
+        left_suffix=left_suffix,
+        right_suffix=right_suffix,
+        # NOTE: We override this to reduce hardware requirements
+        #       for every aggregator (by default requiring 1 logical CPU)
+        aggregator_ray_remote_args={"num_cpus": 0.01},
+    )
+
+    if left_suffix is None and right_suffix is None:
+        with pytest.raises(RayTaskError) as exc_info:
+            joined.count()
+
+        assert 'Field "double" exists 2 times' in str(exc_info.value.cause)
+    else:
+
+        joined_pd = pd.DataFrame(joined.take_all())
+
+        # Sort resulting frame and reset index (to be able to compare with expected one)
+        joined_pd_sorted = joined_pd.sort_values(by=["id"]).reset_index(drop=True)
+
+        # Join using Pandas (to assert against)
+        expected_pd = doubles_pd.join(
+            doubles_pd.set_index("id"),
+            on="id",
+            how="inner",
+            lsuffix=left_suffix,
+            rsuffix=right_suffix,
+        ).reset_index(drop=True)
+
+        pd.testing.assert_frame_equal(expected_pd, joined_pd_sorted)
+
+
+def test_invalid_join_config(ray_start_regular_shared_2_cpus):
+    ds = ray.data.range(32)
+
+    with pytest.raises(ValueError) as exc_info:
+        ds.join(
+            ds,
+            "inner",
+            num_partitions=16,
+            on="id",  # has to be tuple/list
+            validate_schemas=True,
+        )
+
+    assert str(exc_info.value) == "Expected tuple or list as `on` (got str)"
+
+    with pytest.raises(ValueError) as exc_info:
+        ds.join(
+            ds,
+            "inner",
+            num_partitions=16,
+            on=("id",),
+            right_on="id",  # has to be tuple/list
+            validate_schemas=True,
+        )
+
+    assert str(exc_info.value) == "Expected tuple or list as `right_on` (got str)"
+
+
+@pytest.mark.parametrize("join_type", [jt for jt in JoinType])  # noqa: C416
+def test_invalid_join_not_matching_key_columns(
+    ray_start_regular_shared_2_cpus, join_type
+):
+    # Case 1: Check on missing key column
+    empty_ds = ray.data.range(0)
+
+    non_empty_ds = ray.data.range(32)
+
+    with pytest.raises(ValueError) as exc_info:
+        empty_ds.join(
+            non_empty_ds,
+            join_type,
+            num_partitions=16,
+            on=("id",),
+            validate_schemas=True,
+        )
+
+    assert (
+        str(exc_info.value)
+        == "Key columns are expected to be present and have the same types in both "
+           "left and right operands of the join operation: left has None, but right "
+           "has Column  Type\n------  ----\nid      int64"
+    )
+
+    # Case 2: Check mismatching key column
+    id_int_type_ds = ray.data.range(32).map(lambda row: {"id": int(row["id"])})
+
+    id_float_type_ds = ray.data.range(32).map(lambda row: {"id": float(row["id"])})
+
+    with pytest.raises(ValueError) as exc_info:
+        id_int_type_ds.join(
+            id_float_type_ds,
+            join_type,
+            num_partitions=16,
+            on=("id",),
+            validate_schemas=True,
+        )
+
+    assert (
+        str(exc_info.value)
+        == "Key columns are expected to be present and have the same types in both "
+           "left and right operands of the join operation: left has "
+           "Column  Type\n------  ----\nid      int64, but right has "
+           "Column  Type\n------  ----\nid      double"
+    )
+
+
+def test_default_shuffle_aggregator_args():
+    parent_op_mock = MagicMock(PhysicalOperator)
+    parent_op_mock._output_dependencies = []
+
+    op = JoinOperator(
+        left_input_op=parent_op_mock,
+        right_input_op=parent_op_mock,
+        data_context=DataContext.get_current(),
+        left_key_columns=("id",),
+        right_key_columns=("id",),
+        join_type=JoinType.INNER,
+        num_partitions=16,
+    )
+
+    # - 1 partition per aggregator
+    # - No partition size hint
+    args = op._get_default_aggregator_ray_remote_args(
+        num_partitions=16,
+        num_aggregators=16,
+        partition_size_hint=None,
+    )
+
+    assert {
+               "num_cpus": 0.125,
+               "memory": 939524096,
+               "scheduling_strategy": "SPREAD",
+           } == args
+
+    # - 4 partitions per aggregator
+    # - No partition size hint
+    args = op._get_default_aggregator_ray_remote_args(
+        num_partitions=64,
+        num_aggregators=16,
+        partition_size_hint=None,
+    )
+
+    assert {
+               "num_cpus": 0.5,
+               "memory": 1744830464,
+               "scheduling_strategy": "SPREAD",
+           } == args
+
+    # - 4 partitions per aggregator
+    # - No partition size hint
+    args = op._get_default_aggregator_ray_remote_args(
+        num_partitions=64,
+        num_aggregators=16,
+        partition_size_hint=1 * GiB,
+    )
+
+    assert {
+               "num_cpus": 0.5,
+               "memory": 13958643712,
+               "scheduling_strategy": "SPREAD",
+           } == args
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/tests/test_join.py
+++ b/python/ray/data/tests/test_join.py
@@ -5,8 +5,8 @@ import pandas as pd
 import pytest
 
 import ray
-from ray.anyscale.data._internal.execution.operators.join import JoinOperator
-from ray.anyscale.data._internal.logical.operators.join_operator import JoinType
+from ray.data._internal.execution.operators.join import JoinOperator
+from ray.data._internal.logical.operators.join_operator import JoinType
 from ray.data import Dataset, DataContext
 from ray.data._internal.execution.interfaces import PhysicalOperator
 from ray.data._internal.util import MiB, GiB

--- a/python/ray/data/tests/test_join.py
+++ b/python/ray/data/tests/test_join.py
@@ -291,8 +291,8 @@ def test_invalid_join_not_matching_key_columns(
     assert (
         str(exc_info.value)
         == "Key columns are expected to be present and have the same types in both "
-           "left and right operands of the join operation: left has None, but right "
-           "has Column  Type\n------  ----\nid      int64"
+        "left and right operands of the join operation: left has None, but right "
+        "has Column  Type\n------  ----\nid      int64"
     )
 
     # Case 2: Check mismatching key column
@@ -312,9 +312,9 @@ def test_invalid_join_not_matching_key_columns(
     assert (
         str(exc_info.value)
         == "Key columns are expected to be present and have the same types in both "
-           "left and right operands of the join operation: left has "
-           "Column  Type\n------  ----\nid      int64, but right has "
-           "Column  Type\n------  ----\nid      double"
+        "left and right operands of the join operation: left has "
+        "Column  Type\n------  ----\nid      int64, but right has "
+        "Column  Type\n------  ----\nid      double"
     )
 
 
@@ -341,10 +341,10 @@ def test_default_shuffle_aggregator_args():
     )
 
     assert {
-               "num_cpus": 0.125,
-               "memory": 939524096,
-               "scheduling_strategy": "SPREAD",
-           } == args
+        "num_cpus": 0.125,
+        "memory": 939524096,
+        "scheduling_strategy": "SPREAD",
+    } == args
 
     # - 4 partitions per aggregator
     # - No partition size hint
@@ -355,10 +355,10 @@ def test_default_shuffle_aggregator_args():
     )
 
     assert {
-               "num_cpus": 0.5,
-               "memory": 1744830464,
-               "scheduling_strategy": "SPREAD",
-           } == args
+        "num_cpus": 0.5,
+        "memory": 1744830464,
+        "scheduling_strategy": "SPREAD",
+    } == args
 
     # - 4 partitions per aggregator
     # - No partition size hint
@@ -369,10 +369,10 @@ def test_default_shuffle_aggregator_args():
     )
 
     assert {
-               "num_cpus": 0.5,
-               "memory": 13958643712,
-               "scheduling_strategy": "SPREAD",
-           } == args
+        "num_cpus": 0.5,
+        "memory": 13958643712,
+        "scheduling_strategy": "SPREAD",
+    } == args
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR adds `Dataset.join` operator allowing 2 datasets to be joined using previously added [Hash-shuffle implementation](https://github.com/ray-project/ray/pull/52664).

Currently following types of joins are supported:

 - Inner (left/right)
 - Outer (left/right)

In the future we'll be adding support for more join types.

Changes
---

 - Added `JoinOperator`
 - Added `Dataset.join`
 - Added tests

## Related issue number

Closes https://github.com/ray-project/ray/issues/18911 (Finally!!!)

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
