### PR TITLE
[data] Tweak mock pipeline to avoid deadlock

### DIFF
--- a/release/nightly_tests/dataset/batch_inference_mock_image_pipeline.py
+++ b/release/nightly_tests/dataset/batch_inference_mock_image_pipeline.py
@@ -180,6 +180,7 @@ def main(scale_factor: int):
             ray.data.from_pandas(metadata, override_num_blocks=OVERRIDE_NUM_BLOCKS)
             .map(
                 LoadImage,
+                # TODO(mowen): When we fix the deadlocking bug we should increase this to 800.
                 compute=ActorPoolStrategy(min_size=1, max_size=700),
                 max_concurrency=4,  # needed to prevent image loading from becoming the bottleneck
             )

--- a/release/nightly_tests/dataset/batch_inference_mock_image_pipeline.py
+++ b/release/nightly_tests/dataset/batch_inference_mock_image_pipeline.py
@@ -180,7 +180,7 @@ def main(scale_factor: int):
             ray.data.from_pandas(metadata, override_num_blocks=OVERRIDE_NUM_BLOCKS)
             .map(
                 LoadImage,
-                compute=ActorPoolStrategy(min_size=1, max_size=800),
+                compute=ActorPoolStrategy(min_size=1, max_size=700),
                 max_concurrency=4,  # needed to prevent image loading from becoming the bottleneck
             )
             .filter(lambda row: row["image"].size != 0)


### PR DESCRIPTION
## Why are these changes needed?
Until we fix issues with deadlocking actor pools, we should just have a lower max size. Nudging down for now.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
