### PR TITLE
[core] Further deflake `test_gcs_fault_tolerance.py`

### DIFF
--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -157,7 +157,7 @@ def test_autoscaler_init(
 
     # Fetch the cluster status from the autoscaler and check that it works.
     status = get_cluster_status(cluster.address)
-    assert len(status.active_nodes) + len(status.idle_nodes) == 2
+    wait_for_condition(lambda: len(status.idle_nodes) == 2)
 
 
 @pytest.mark.parametrize(

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -12,6 +12,7 @@ from filelock import FileLock
 import pytest
 
 import ray
+from ray.autoscaler.v2.sdk import get_cluster_status
 from ray.util.placement_group import placement_group
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 import ray._private.gcs_utils as gcs_utils
@@ -150,15 +151,13 @@ def test_autoscaler_init(
     assert len(nodes) == 2
     assert nodes[0]["alive"] and nodes[1]["alive"]
 
-    cluster_kill_gcs_wait(cluster)
-
     # Restart gcs server process.
+    cluster_kill_gcs_wait(cluster)
     cluster.head_node.start_gcs_server()
 
-    from ray.autoscaler.v2.sdk import get_cluster_status
-
-    status = get_cluster_status(ray.get_runtime_context().gcs_address)
-    assert len(status.idle_nodes) == 2
+    # Fetch the cluster status from the autoscaler and check that it works.
+    status = get_cluster_status(cluster.address)
+    assert len(status.active_nodes) + len(status.idle_nodes) == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Recent flake: https://buildkite.com/ray-project/postmerge/builds/9908#01969376-c292-484d-b9d4-abca4fbbd35d/180-1552

Attempting to fix by using `wait_for_condition` instead of an immediate assertion.

If this doesn't work, it might reveal an actual bug in the autoscaler (there's no reason the nodes should be marked as `RUNNING` in this case).