### PR TITLE
[core] `SetTaskStatus` should only be called within the same lock scope where `task_entry` is retrieved

### DIFF
--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -314,7 +314,6 @@ bool TaskManager::ResubmitTask(const TaskID &task_id, std::vector<ObjectID> *tas
   RAY_CHECK(task_deps->empty());
 
   TaskSpecification spec;
-  TaskEntry *task_entry = nullptr;
   bool resubmit = false;
   {
     absl::MutexLock lock(&mu_);
@@ -342,7 +341,6 @@ bool TaskManager::ResubmitTask(const TaskID &task_id, std::vector<ObjectID> *tas
         RAY_CHECK(it->second.num_retries_left == -1);
       }
       spec = it->second.spec;
-      task_entry = &(it->second);
     }
   }
 
@@ -386,7 +384,7 @@ bool TaskManager::ResubmitTask(const TaskID &task_id, std::vector<ObjectID> *tas
                 << spec.AttemptNumber() << ": " << spec.DebugString();
   // We should actually detect if the actor for this task is dead, but let's just assume
   // it's not for now.
-  RetryTask(task_entry, /*object_recovery*/ true, /*delay_ms*/ 0);
+  retry_task_callback_(spec, /*object_recovery*/ true, /*delay_ms*/ 0);
 
   return true;
 }
@@ -967,7 +965,6 @@ void TaskManager::CompletePendingTask(const TaskID &task_id,
 bool TaskManager::RetryTaskIfPossible(const TaskID &task_id,
                                       const rpc::RayErrorInfo &error_info) {
   TaskSpecification spec;
-  TaskEntry *task_entry = nullptr;
   bool will_retry = false;
   int32_t num_retries_left = 0;
   int32_t num_oom_retries_left = 0;
@@ -980,7 +977,6 @@ bool TaskManager::RetryTaskIfPossible(const TaskID &task_id,
     RAY_CHECK(it->second.IsPending())
         << "Tried to retry task that was not pending " << task_id;
     spec = it->second.spec;
-    task_entry = &(it->second);
     num_retries_left = it->second.num_retries_left;
     num_oom_retries_left = it->second.num_oom_retries_left;
     if (task_failed_due_to_oom) {
@@ -1003,7 +999,7 @@ bool TaskManager::RetryTaskIfPossible(const TaskID &task_id,
       }
     }
     if (will_retry) {
-      MarkTaskRetryOnFailed(*task_entry, error_info);
+      MarkTaskRetryOnFailed(it->second, error_info);
     }
   }
 
@@ -1025,25 +1021,13 @@ bool TaskManager::RetryTaskIfPossible(const TaskID &task_id,
                                  spec.AttemptNumber(),
                                  RayConfig::instance().task_oom_retry_delay_base_ms())
                            : RayConfig::instance().task_retry_delay_ms();
-    RetryTask(task_entry, /*object_recovery*/ false, delay_ms);
+    retry_task_callback_(spec, /*object_recovery*/ false, delay_ms);
     return true;
   } else {
     RAY_LOG(INFO) << "No retries left for task " << spec.TaskId()
                   << ", not going to resubmit.";
     return false;
   }
-}
-
-void TaskManager::RetryTask(TaskEntry *task_entry,
-                            bool object_recovery,
-                            uint32_t delay_ms) {
-  RAY_CHECK(task_entry != nullptr);
-  SetTaskStatus(*task_entry,
-                rpc::TaskStatus::PENDING_ARGS_AVAIL,
-                /* state_update */ std::nullopt,
-                /* include_task_info */ true,
-                task_entry->spec.AttemptNumber() + 1);
-  retry_task_callback_(task_entry->spec, object_recovery, delay_ms);
 }
 
 void TaskManager::FailPendingTask(const TaskID &task_id,
@@ -1446,6 +1430,17 @@ void TaskManager::MarkTaskRetryOnResubmit(TaskEntry &task_entry) {
       << "Only finished tasks can be resubmitted: " << task_entry.spec.TaskId();
 
   task_entry.MarkRetry();
+
+  // Mark the new status and also include task spec info for the new attempt.
+  //
+  // NOTE(rickyx): We only increment the AttemptNumber on the task spec when
+  // `retry_task_callback_` is invoked. In order to record the correct status change for
+  // the new task attempt, we pass the the attempt number explicitly.
+  SetTaskStatus(task_entry,
+                rpc::TaskStatus::PENDING_ARGS_AVAIL,
+                /* state_update */ std::nullopt,
+                /* include_task_info */ true,
+                task_entry.spec.AttemptNumber() + 1);
 }
 
 void TaskManager::MarkTaskRetryOnFailed(TaskEntry &task_entry,
@@ -1457,6 +1452,13 @@ void TaskManager::MarkTaskRetryOnFailed(TaskEntry &task_entry,
                 rpc::TaskStatus::FAILED,
                 worker::TaskStatusEvent::TaskStateUpdate(error_info));
   task_entry.MarkRetry();
+
+  // Mark the new status and also include task spec info for the new attempt.
+  SetTaskStatus(task_entry,
+                rpc::TaskStatus::PENDING_ARGS_AVAIL,
+                /* state_update */ std::nullopt,
+                /* include_task_info */ true,
+                task_entry.spec.AttemptNumber() + 1);
 }
 
 void TaskManager::SetTaskStatus(

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -697,15 +697,6 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
                                  std::vector<ObjectID> *ids_to_release)
       ABSL_LOCKS_EXCLUDED(mu_);
 
-  /// A wrapper of `retry_task_callback_` that sets the task status
-  /// and calls `retry_task_callback_`. This function should be the only
-  /// caller of `retry_task_callback_`.
-  ///
-  /// \param[in] task_entry The task entry to retry.
-  /// \param[in] object_recovery Whether to retry the task for object recovery.
-  /// \param[in] delay_ms The delay in milliseconds before retrying the task.
-  void RetryTask(TaskEntry *task_entry, bool object_recovery, uint32_t delay_ms);
-
   /// Helper function to call RemoveSubmittedTaskReferences on the remaining
   /// dependencies of the given task spec after the task has finished or
   /// failed. The remaining dependencies are plasma objects and any ObjectIDs
@@ -749,6 +740,11 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
   /// \param attempt_number The attempt number to record the task status change
   /// event. If not specified, the attempt number will be the current attempt number of
   /// the task.
+  ///
+  /// \note This function updates `task_entry` in place. Please only call
+  /// this function within the same lock scope where `task_entry` is retrieved from
+  /// `submissible_tasks_`. If not, the task entry may be invalidated if the flat_hash_map
+  /// is rehashed or the element is removed from the map.
   void SetTaskStatus(
       TaskEntry &task_entry,
       rpc::TaskStatus status,

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -750,7 +750,8 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
       rpc::TaskStatus status,
       std::optional<worker::TaskStatusEvent::TaskStateUpdate> state_update = std::nullopt,
       bool include_task_info = false,
-      std::optional<int32_t> attempt_number = std::nullopt) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+      std::optional<int32_t> attempt_number = std::nullopt)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
   /// Update the task entry for the task attempt to reflect retry on resubmit.
   ///

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -750,7 +750,7 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
       rpc::TaskStatus status,
       std::optional<worker::TaskStatusEvent::TaskStateUpdate> state_update = std::nullopt,
       bool include_task_info = false,
-      std::optional<int32_t> attempt_number = std::nullopt);
+      std::optional<int32_t> attempt_number = std::nullopt) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
   /// Update the task entry for the task attempt to reflect retry on resubmit.
   ///
@@ -758,7 +758,7 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
   /// the retry counter.
   ///
   /// \param task_entry Task entry for the corresponding task attempt
-  void MarkTaskRetryOnResubmit(TaskEntry &task_entry);
+  void MarkTaskRetryOnResubmit(TaskEntry &task_entry) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
   /// Update the task entry for the task attempt to reflect retry on failure.
   ///
@@ -766,7 +766,8 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
   /// the retry counter.
   ///
   /// \param task_entry Task entry for the corresponding task attempt
-  void MarkTaskRetryOnFailed(TaskEntry &task_entry, const rpc::RayErrorInfo &error_info);
+  void MarkTaskRetryOnFailed(TaskEntry &task_entry, const rpc::RayErrorInfo &error_info)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
   /// Mark the stream is ended.
   /// The end of the stream always contains a "sentinel object" passed


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR reverts https://github.com/ray-project/ray/pull/52695 and adds comments to explain where should `SetTaskStatus` be called.

#52695 updates the value in submissble_tasks_ without acquiring the mutex lock. If multiple threads or coroutines write to the map, a rehash or deletion may occur, causing the pointer to the value to become invalid.

### Outdated PR statement

#### Question

https://github.com/ray-project/ray/pull/52695#discussion_r2072477177

Pointers to values in a `flat_hash_map` become invalid after a rehash. Additionally, we dereference those pointers in `RetryTask`, which doesn’t hold a mutex lock. Hence, it’s possible for the pointers to become invalid when other coroutines or threads insert or delete elements from the map, triggering a rehash.

"Iterators, references, and pointers to elements are invalidated on rehash." ([reference](https://abseil.io/docs/cpp/guides/container))

#### Solution

Changing `submissible_tasks_` from `absl::flat_hash_map<TaskID, TaskEntry>` to `absl::flat_hash_map<TaskID, std::unique_ptr<TaskEntry>>` requires a lot of changes.

Hence, this PR implements a short-term solution by copying the value (i.e., TaskEntry) while holding the mutex lock where rehash will not be triggered by other threads / coroutine.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
