### PR TITLE
[Dashboard] Add `flush()` after `job_id` is populated

### DIFF
--- a/python/ray/dashboard/modules/job/cli.py
+++ b/python/ray/dashboard/modules/job/cli.py
@@ -302,6 +302,7 @@ def submit(
             cli_logger.print(cf.bold(f"ray job stop {job_id}"))
 
     cli_logger.newline()
+    cli_logger.flush()
     sdk_version = client.get_version()
     # sdk version 0 does not have log streaming
     if not no_wait:

--- a/python/ray/dashboard/modules/job/cli.py
+++ b/python/ray/dashboard/modules/job/cli.py
@@ -302,6 +302,8 @@ def submit(
             cli_logger.print(cf.bold(f"ray job stop {job_id}"))
 
     cli_logger.newline()
+    # Flush stdout to ensure the Ray job ID is output immediately
+    # for the kubectl plugin, ref PR #52780, Issue kuberay/#3508.
     cli_logger.flush()
     sdk_version = client.get_version()
     # sdk version 0 does not have log streaming


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
See the issue description and [debugging details](https://github.com/ray-project/kuberay/issues/3508#issuecomment-2849349686) in [ray-project/kuberay#3508](https://github.com/ray-project/kuberay/issues/3508).

## Manual Test
command : 
```bash
kubectl ray job submit\         
  --working-dir . \
  --name my-rayjob \
  --runtime-env-json='{"excludes":[
      "ray-operator/bin",
      "ray-operator/bin/k8s",
      ".git",
      "apiserver/pkg/swagger/datafile.go"
    ]}' \
  -- python task.py | ts '[%Y-%m-%d %H:%M:%S]'
```
`task.py` :
```python
import time
import ray

ray.init(address="auto")

@ray.remote
def f():
    for i in range(20):
        print(i)
        time.sleep(1)
    return 1

print(ray.get([f.remote()]))
``` 

**Result before adding `flush()`** 
Log output is delayed until after `task.py` completes : 
![before](https://github.com/user-attachments/assets/554a80a3-b4df-4e1f-a483-ff5a24428d5f)

`my-rayjob` remains in the `Waiting` state until the script finishes :
![image](https://github.com/user-attachments/assets/b4035dc9-02d9-41ed-b522-f1fbfafa257f)

**Result after adding `flush()`**
Log output appears immediately after submission :
![after](https://github.com/user-attachments/assets/acf792ea-9008-48ae-9daa-d65e6932e998)
`my-rayjob` transitions to `Running` state right after submission.
![image](https://github.com/user-attachments/assets/801f1fb4-995d-4601-9706-dc51fcf7e5a6)



## Related issue number

Closes ray-project/kuberay#3508
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
