### PR TITLE
[core] Add deterministic failure option to rpc failure testing

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -863,6 +863,10 @@ RAY_CONFIG(std::string, testing_asio_delay_us, "")
 ///      export
 ///      RAY_testing_rpc_failure="method1=max_num_failures,method2=max_num_failures"
 RAY_CONFIG(std::string, testing_rpc_failure, "")
+/// If you want the rpc to fail deterministically num_failures times on the sending the
+/// request, set this to "request". If you want the failure to happen on sending the
+/// response, set this to "response".
+RAY_CONFIG(std::string, testing_rpc_failure_deterministic, "")
 
 /// The following are configs for the health check. They are borrowed
 /// from k8s health probe (shorturl.at/jmTY3)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The current rpc failure testing only has one option that will give you a 25% chance request failure or 25% chance of response failure. With this deterministic option, we can have more concise tests that test the behavior of the request or response failing, and we know the first request or response of that rpc will fail every time we run the test.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
