### PR TITLE
[core] Speed up, split, and deflake `test_multiprocessing.py`

### DIFF
--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -83,21 +83,15 @@ def make_global_state_accessor(ray_context):
     return global_state_accessor
 
 
-def enable_external_redis():
-    import os
-
+def external_redis_test_enabled():
     return os.environ.get("TEST_EXTERNAL_REDIS") == "1"
 
 
 def redis_replicas():
-    import os
-
     return int(os.environ.get("TEST_EXTERNAL_REDIS_REPLICAS", "1"))
 
 
 def redis_sentinel_replicas():
-    import os
-
     return int(os.environ.get("TEST_EXTERNAL_REDIS_SENTINEL_REPLICAS", "2"))
 
 

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -38,7 +38,7 @@ from ray.serve.schema import ServeApplicationSchema, ServeDeploySchema
 # Explicitly importing it here because it is a ray core tests utility (
 # not in the tree)
 from ray.tests.conftest import (
-    maybe_external_redis,  # noqa: F401
+    maybe_setup_external_redis,  # noqa: F401
     ray_start_with_dashboard,  # noqa: F401
 )
 from ray.util.state import list_actors

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -62,6 +62,8 @@ py_test_module_list(
         "test_kill_raylet_signal_log.py",
         "test_metrics_agent.py",
         "test_metrics_head.py",
+        "test_multiprocessing.py",
+        "test_multiprocessing_standalone.py",
         "test_node_label_scheduling_strategy.py",
         "test_protobuf_compatibility.py",
     ],
@@ -763,7 +765,6 @@ py_test_module_list(
     files = [
         "test_failure_4.py",
         "test_iter.py",
-        "test_multiprocessing.py",
         "test_object_spilling.py",
         "test_object_spilling_2.py",
         "test_object_spilling_3.py",

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -1147,8 +1147,6 @@ py_test(
     ],
 )
 
-# TODO(ekl) we can't currently support tagging these as flaky since there's
-# no way to filter by both flaky and client mode tests in bazel.
 py_test_module_list(
     size = "large",
     env = {

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -32,7 +32,7 @@ from ray._private.test_utils import (
     init_log_pubsub,
     setup_tls,
     teardown_tls,
-    enable_external_redis,
+    external_redis_test_enabled,
     redis_replicas,
     get_redis_cli,
     start_redis_instance,
@@ -454,8 +454,8 @@ def _setup_redis(request, with_sentinel=False):
 
 
 @pytest.fixture
-def maybe_external_redis(request):
-    if enable_external_redis():
+def maybe_setup_external_redis(request):
+    if external_redis_test_enabled():
         with _setup_redis(request):
             yield
     else:
@@ -494,7 +494,7 @@ def local_autoscaling_cluster(request, enable_v2):
 
 
 @pytest.fixture
-def shutdown_only(maybe_external_redis):
+def shutdown_only(maybe_setup_external_redis):
     yield None
     # The code after the yield will run as teardown code.
     ray.shutdown()
@@ -538,7 +538,7 @@ def _ray_start(**kwargs):
 
 
 @pytest.fixture
-def ray_start_with_dashboard(request, maybe_external_redis):
+def ray_start_with_dashboard(request, maybe_setup_external_redis):
     param = getattr(request, "param", {})
     if param.get("num_cpus") is None:
         param["num_cpus"] = 1
@@ -569,7 +569,7 @@ def make_sure_dashboard_http_port_unused():
 
 # The following fixture will start ray with 0 cpu.
 @pytest.fixture
-def ray_start_no_cpu(request, maybe_external_redis):
+def ray_start_no_cpu(request, maybe_setup_external_redis):
     param = getattr(request, "param", {})
     with _ray_start(num_cpus=0, **param) as res:
         yield res
@@ -577,7 +577,7 @@ def ray_start_no_cpu(request, maybe_external_redis):
 
 # The following fixture will start ray with 1 cpu.
 @pytest.fixture
-def ray_start_regular(request, maybe_external_redis):
+def ray_start_regular(request, maybe_setup_external_redis):
     param = getattr(request, "param", {})
     with _ray_start(**param) as res:
         yield res
@@ -615,14 +615,14 @@ def ray_start_shared_local_modes(request):
 
 
 @pytest.fixture
-def ray_start_2_cpus(request, maybe_external_redis):
+def ray_start_2_cpus(request, maybe_setup_external_redis):
     param = getattr(request, "param", {})
     with _ray_start(num_cpus=2, **param) as res:
         yield res
 
 
 @pytest.fixture
-def ray_start_10_cpus(request, maybe_external_redis):
+def ray_start_10_cpus(request, maybe_setup_external_redis):
     param = getattr(request, "param", {})
     with _ray_start(num_cpus=10, **param) as res:
         yield res
@@ -665,14 +665,14 @@ def _ray_start_cluster(**kwargs):
 
 # This fixture will start a cluster with empty nodes.
 @pytest.fixture
-def ray_start_cluster(request, maybe_external_redis):
+def ray_start_cluster(request, maybe_setup_external_redis):
     param = getattr(request, "param", {})
     with _ray_start_cluster(**param) as res:
         yield res
 
 
 @pytest.fixture
-def ray_start_cluster_enabled(request, maybe_external_redis):
+def ray_start_cluster_enabled(request, maybe_setup_external_redis):
     param = getattr(request, "param", {})
     param["skip_cluster"] = False
     with _ray_start_cluster(**param) as res:
@@ -680,14 +680,14 @@ def ray_start_cluster_enabled(request, maybe_external_redis):
 
 
 @pytest.fixture
-def ray_start_cluster_init(request, maybe_external_redis):
+def ray_start_cluster_init(request, maybe_setup_external_redis):
     param = getattr(request, "param", {})
     with _ray_start_cluster(do_init=True, **param) as res:
         yield res
 
 
 @pytest.fixture
-def ray_start_cluster_head(request, maybe_external_redis):
+def ray_start_cluster_head(request, maybe_setup_external_redis):
     param = getattr(request, "param", {})
     with _ray_start_cluster(do_init=True, num_nodes=1, **param) as res:
         yield res
@@ -713,7 +713,9 @@ def ray_start_cluster_head_with_external_redis_sentinel(
 
 
 @pytest.fixture
-def ray_start_cluster_head_with_env_vars(request, maybe_external_redis, monkeypatch):
+def ray_start_cluster_head_with_env_vars(
+    request, maybe_setup_external_redis, monkeypatch
+):
     param = getattr(request, "param", {})
     env_vars = param.pop("env_vars", {})
     for k, v in env_vars.items():
@@ -723,14 +725,14 @@ def ray_start_cluster_head_with_env_vars(request, maybe_external_redis, monkeypa
 
 
 @pytest.fixture
-def ray_start_cluster_2_nodes(request, maybe_external_redis):
+def ray_start_cluster_2_nodes(request, maybe_setup_external_redis):
     param = getattr(request, "param", {})
     with _ray_start_cluster(do_init=True, num_nodes=2, **param) as res:
         yield res
 
 
 @pytest.fixture
-def ray_start_object_store_memory(request, maybe_external_redis):
+def ray_start_object_store_memory(request, maybe_setup_external_redis):
     # Start the Ray processes.
     store_size = request.param
     system_config = get_default_fixure_system_config()

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -596,7 +596,6 @@ def ray_start_regular_with_external_redis(request, external_redis):
 @pytest.fixture(scope="module")
 def ray_start_regular_shared(request):
     param = getattr(request, "param", {})
-    print("PARAM", param)
     with _ray_start(**param) as res:
         yield res
 

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -596,6 +596,7 @@ def ray_start_regular_with_external_redis(request, external_redis):
 @pytest.fixture(scope="module")
 def ray_start_regular_shared(request):
     param = getattr(request, "param", {})
+    print("PARAM", param)
     with _ray_start(**param) as res:
         yield res
 

--- a/python/ray/tests/test_advanced_9.py
+++ b/python/ray/tests/test_advanced_9.py
@@ -8,7 +8,7 @@ import ray
 import ray._private.ray_constants as ray_constants
 from ray._private.test_utils import (
     Semaphore,
-    enable_external_redis,
+    external_redis_test_enabled,
     client_test_enabled,
     run_string_as_driver,
     wait_for_condition,
@@ -215,7 +215,7 @@ def test_worker_oom_score(shutdown_only):
 call_ray_start_2 = call_ray_start
 
 
-@pytest.mark.skipif(not enable_external_redis(), reason="Only valid in redis env")
+@pytest.mark.skipif(not external_redis_test_enabled(), reason="Only valid in redis env")
 @pytest.mark.parametrize(
     "call_ray_start,call_ray_start_2",
     [
@@ -348,7 +348,7 @@ print(ray.get([use_gpu.remote(), use_gpu.remote()]))
     wait_for_condition(lambda: check_demands(1))
 
 
-@pytest.mark.skipif(enable_external_redis(), reason="Only valid in non redis env")
+@pytest.mark.skipif(external_redis_test_enabled(), reason="Only valid in non redis env")
 def test_redis_not_available(monkeypatch, call_ray_stop_only):
     monkeypatch.setenv("RAY_redis_db_connect_retries", "5")
     monkeypatch.setenv("RAY_REDIS_ADDRESS", "localhost:12345")
@@ -363,7 +363,7 @@ def test_redis_not_available(monkeypatch, call_ray_stop_only):
     assert "redis storage is alive or not." in p.stderr.decode()
 
 
-@pytest.mark.skipif(not enable_external_redis(), reason="Only valid in redis env")
+@pytest.mark.skipif(not external_redis_test_enabled(), reason="Only valid in redis env")
 def test_redis_wrong_password(monkeypatch, external_redis, call_ray_stop_only):
     monkeypatch.setenv("RAY_redis_db_connect_retries", "5")
     p = subprocess.run(
@@ -375,7 +375,7 @@ def test_redis_wrong_password(monkeypatch, external_redis, call_ray_stop_only):
     assert "RedisError: ERR AUTH <password> called" in p.stderr.decode()
 
 
-@pytest.mark.skipif(not enable_external_redis(), reason="Only valid in redis env")
+@pytest.mark.skipif(not external_redis_test_enabled(), reason="Only valid in redis env")
 def test_redis_full(ray_start_cluster_head):
     import redis
 

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -19,7 +19,7 @@ import ray._private.gcs_utils as gcs_utils
 from ray._private import ray_constants
 from ray._private.test_utils import (
     convert_actor_state,
-    enable_external_redis,
+    external_redis_test_enabled,
     generate_system_config_map,
     wait_for_condition,
     wait_for_pid_to_exit,
@@ -904,7 +904,7 @@ def test_raylet_fate_sharing(ray_start_regular):
     ray._private.worker._global_node.kill_gcs_server()
     ray._private.worker._global_node.start_gcs_server()
 
-    if not enable_external_redis():
+    if not external_redis_test_enabled():
         # Waiting for raylet to become unhealthy
         wait_for_condition(lambda: not check_raylet_healthy())
     else:
@@ -937,7 +937,7 @@ def test_session_name(ray_start_cluster):
     head_node = cluster.head_node
     new_session_dir = head_node.get_session_dir_path()
 
-    if not enable_external_redis():
+    if not external_redis_test_enabled():
         assert session_dir != new_session_dir
     else:
         assert session_dir == new_session_dir
@@ -1104,7 +1104,7 @@ def raises_exception(exc_type, f):
         {"kill_job": False, "kill_actor": True, "expect_alive": "regular"},
     ],
 )
-@pytest.mark.skipif(not enable_external_redis(), reason="Only valid in redis env")
+@pytest.mark.skipif(not external_redis_test_enabled(), reason="Only valid in redis env")
 def test_gcs_server_restart_destroys_out_of_scope_actors(
     external_redis, ray_start_cluster, case
 ):

--- a/python/ray/tests/test_gcs_utils.py
+++ b/python/ray/tests/test_gcs_utils.py
@@ -11,7 +11,7 @@ import redis
 from ray._raylet import GcsClient
 import ray._private.gcs_utils as gcs_utils
 from ray._private.test_utils import (
-    enable_external_redis,
+    external_redis_test_enabled,
     find_free_port,
     generate_system_config_map,
     async_wait_for_condition,
@@ -180,7 +180,8 @@ async def test_kv_timeout_aio(ray_start_regular):
 
 
 @pytest.mark.skipif(
-    not enable_external_redis(), reason="Only valid when start with an external redis"
+    not external_redis_test_enabled(),
+    reason="Only valid when start with an external redis",
 )
 def test_external_storage_namespace_isolation(shutdown_only):
     addr = ray.init(
@@ -283,7 +284,8 @@ def redis_replicas(request, monkeypatch):
 
 
 @pytest.mark.skipif(
-    not enable_external_redis(), reason="Only valid when start with an external redis"
+    not external_redis_test_enabled(),
+    reason="Only valid when start with an external redis",
 )
 def test_redis_cleanup(redis_replicas, shutdown_only):
     addr = ray.init(

--- a/python/ray/tests/test_joblib.py
+++ b/python/ray/tests/test_joblib.py
@@ -24,7 +24,7 @@ from sklearn.model_selection import cross_val_score
 import ray
 from ray.util.joblib import register_ray
 from ray.util.joblib.ray_backend import RayBackend
-from ray._private.test_utils import SignalActor, wait_for_condition
+from ray._private.test_utils import wait_for_condition
 
 
 def test_register_ray():

--- a/python/ray/tests/test_joblib.py
+++ b/python/ray/tests/test_joblib.py
@@ -1,10 +1,10 @@
-import joblib
 import sys
 import time
 import os
 import pytest
 from unittest import mock
 
+import joblib
 import pickle
 import numpy as np
 
@@ -21,8 +21,10 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.neural_network import MLPClassifier
 from sklearn.model_selection import cross_val_score
 
-from ray.util.joblib import register_ray
 import ray
+from ray.util.joblib import register_ray
+from ray.util.joblib.ray_backend import RayBackend
+from ray._private.test_utils import SignalActor, wait_for_condition
 
 
 def test_register_ray():
@@ -33,7 +35,6 @@ def test_register_ray():
 
 def test_ray_backend(shutdown_only):
     register_ray()
-    from ray.util.joblib.ray_backend import RayBackend
 
     with joblib.parallel_backend("ray"):
         assert type(joblib.parallel.get_active_backend()[0]) is RayBackend
@@ -190,6 +191,52 @@ def test_ray_remote_args(shutdown_only):
         "ray", ray_remote_args={"resources": {"custom_resource": 1}}
     ):
         joblib.Parallel()(joblib.delayed(check_resource)() for i in range(8))
+
+
+def test_task_to_actor_assignment(shutdown_only):
+    ray.init(num_cpus=4)
+
+    @ray.remote(num_cpus=0)
+    class Counter:
+        def __init__(self):
+            self._c = 0
+
+        def inc(self):
+            self._c += 1
+
+        def get(self) -> int:
+            return self._c
+
+    counter = Counter.remote()
+
+    def worker_func(worker_id):
+        launch_time = time.time()
+
+        # Wait for all 4 workers to have started.
+        ray.get(counter.inc.remote())
+        wait_for_condition(lambda: ray.get(counter.get.remote()) == 4)
+
+        return worker_id, launch_time
+
+    output = []
+    num_workers = 4
+    register_ray()
+    with joblib.parallel_backend("ray", n_jobs=-1):
+        output = joblib.Parallel()(
+            joblib.delayed(worker_func)(worker_id) for worker_id in range(num_workers)
+        )
+
+    worker_ids = set()
+    launch_times = []
+    for worker_id, launch_time in output:
+        worker_ids.add(worker_id)
+        launch_times.append(launch_time)
+
+    assert len(worker_ids) == num_workers
+
+    for i in range(num_workers):
+        for j in range(i + 1, num_workers):
+            assert abs(launch_times[i] - launch_times[j]) < 1
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_multiprocessing.py
+++ b/python/ray/tests/test_multiprocessing.py
@@ -1,3 +1,8 @@
+"""Tests for ray.util.multiprocessing that can run on a shared Ray cluster fixture.
+
+Tests that require a standalone Ray cluster (for example, testing ray.init or shutdown
+behavior) should go in test_multiprocessing_standalone.py.
+"""
 import math
 import os
 import platform
@@ -13,9 +18,8 @@ import pytest
 
 
 import ray
-from ray._private.test_utils import external_redis_test_enabled, SignalActor
+from ray._private.test_utils import SignalActor
 from ray.util.multiprocessing import Pool, TimeoutError, JoinableQueue
-from ray.util.joblib import register_ray
 
 
 @pytest.fixture(scope="module")
@@ -37,128 +41,6 @@ def pool_4_processes_python_multiprocessing_lib():
     yield pool
     pool.terminate()
     pool.join()
-
-
-@pytest.mark.skipif(
-    external_redis_test_enabled(),
-    reason="Starts multiple Ray instances in parallel with the same namespace.",
-)
-def test_ray_init(shutdown_only):
-    def getpid(i: int):
-        return os.getpid()
-
-    def check_pool_size(pool, size: int):
-        assert len(set(pool.map(getpid, range(size)))) == size
-
-    # Check that starting a pool starts ray if not initialized.
-    assert not ray.is_initialized()
-    with Pool(processes=4) as pool:
-        assert ray.is_initialized()
-        check_pool_size(pool, 4)
-        assert int(ray.cluster_resources()["CPU"]) == 4
-    pool.join()
-
-    # Check that starting a pool doesn't affect ray if there is a local
-    # ray cluster running.
-    assert ray.is_initialized()
-    assert int(ray.cluster_resources()["CPU"]) == 4
-    with Pool(processes=2) as pool:
-        assert ray.is_initialized()
-        check_pool_size(pool, 2)
-        assert int(ray.cluster_resources()["CPU"]) == 4
-    pool.join()
-
-    # Check that trying to start a pool on an existing ray cluster throws an
-    # error if there aren't enough CPUs for the number of processes.
-    assert ray.is_initialized()
-    assert int(ray.cluster_resources()["CPU"]) == 4
-    with pytest.raises(ValueError):
-        Pool(processes=8)
-        assert int(ray.cluster_resources()["CPU"]) == 4
-
-
-@pytest.mark.skipif(
-    external_redis_test_enabled(),
-    reason="Starts multiple Ray instances in parallel with the same namespace.",
-)
-@pytest.mark.parametrize(
-    "ray_start_cluster",
-    [
-        {
-            "num_cpus": 1,
-            "num_nodes": 1,
-            "do_init": False,
-        }
-    ],
-    indirect=True,
-)
-def test_connect_to_ray(monkeypatch, ray_start_cluster):
-    def getpid(args):
-        return os.getpid()
-
-    def check_pool_size(pool, size):
-        args = [tuple() for _ in range(size)]
-        assert len(set(pool.map(getpid, args))) == size
-
-    # Use different numbers of CPUs to distinguish between starting a local
-    # ray cluster and connecting to an existing one.
-    ray.init(address=ray_start_cluster.address)
-    existing_cluster_cpus = int(ray.cluster_resources()["CPU"])
-    local_cluster_cpus = existing_cluster_cpus + 1
-    ray.shutdown()
-
-    # Check that starting a pool connects to the running ray cluster by default.
-    assert not ray.is_initialized()
-    with Pool() as pool:
-        assert ray.is_initialized()
-        check_pool_size(pool, existing_cluster_cpus)
-        assert int(ray.cluster_resources()["CPU"]) == existing_cluster_cpus
-    pool.join()
-    ray.shutdown()
-
-    # Check that starting a pool connects to a running ray cluster if
-    # ray_address is set to the cluster address.
-    assert not ray.is_initialized()
-    with Pool(ray_address=ray_start_cluster.address) as pool:
-        check_pool_size(pool, existing_cluster_cpus)
-        assert int(ray.cluster_resources()["CPU"]) == existing_cluster_cpus
-    pool.join()
-    ray.shutdown()
-
-    # Check that starting a pool connects to a running ray cluster if
-    # RAY_ADDRESS is set to the cluster address.
-    assert not ray.is_initialized()
-    monkeypatch.setenv("RAY_ADDRESS", ray_start_cluster.address)
-    with Pool() as pool:
-        check_pool_size(pool, existing_cluster_cpus)
-        assert int(ray.cluster_resources()["CPU"]) == existing_cluster_cpus
-    pool.join()
-    ray.shutdown()
-
-    # Check that trying to start a pool on an existing ray cluster throws an
-    # error if there aren't enough CPUs for the number of processes.
-    assert not ray.is_initialized()
-    with pytest.raises(Exception):
-        Pool(processes=existing_cluster_cpus + 1)
-    assert int(ray.cluster_resources()["CPU"]) == existing_cluster_cpus
-    ray.shutdown()
-
-    # Check that starting a pool starts a local ray cluster if ray_address="local".
-    assert not ray.is_initialized()
-    with Pool(processes=local_cluster_cpus, ray_address="local") as pool:
-        check_pool_size(pool, local_cluster_cpus)
-        assert int(ray.cluster_resources()["CPU"]) == local_cluster_cpus
-    pool.join()
-    ray.shutdown()
-
-    # Check that starting a pool starts a local ray cluster if RAY_ADDRESS="local".
-    assert not ray.is_initialized()
-    monkeypatch.setenv("RAY_ADDRESS", "local")
-    with Pool(processes=local_cluster_cpus) as pool:
-        check_pool_size(pool, local_cluster_cpus)
-        assert int(ray.cluster_resources()["CPU"]) == local_cluster_cpus
-    pool.join()
-    ray.shutdown()
 
 
 def test_initializer(ray_init_4_cpu_shared):
@@ -562,7 +444,7 @@ def test_imap_timeout(pool_4_processes, use_iter):
     with pytest.raises(StopIteration):
         result_iter.next()
 
-    wait_index = 23
+    wait_index = 13
     signal = SignalActor.remote()
     if use_iter:
         imap_iterable = iter([(index, wait_index, signal) for index in range(20)])
@@ -586,25 +468,6 @@ def test_imap_timeout(pool_4_processes, use_iter):
 
     with pytest.raises(StopIteration):
         result_iter.next()
-
-
-def test_maxtasksperchild(shutdown_only):
-    with Pool(processes=3, maxtasksperchild=1) as pool:
-        assert len(set(pool.map(lambda _: os.getpid(), range(20)))) == 20
-    pool.join()
-
-
-def test_deadlock_avoidance_in_recursive_tasks(ray_start_1_cpu):
-    def poolit_a(_):
-        with Pool() as pool:
-            return list(pool.map(math.sqrt, range(0, 2, 1)))
-
-    def poolit_b():
-        with Pool() as pool:
-            return list(pool.map(poolit_a, range(2, 4, 1)))
-
-    result = poolit_b()
-    assert result == [[0.0, 1.0], [0.0, 1.0]]
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_multiprocessing.py
+++ b/python/ray/tests/test_multiprocessing.py
@@ -589,7 +589,7 @@ def test_imap_timeout(pool_4_processes, use_iter):
 
 
 def test_maxtasksperchild(shutdown_only):
-    with Pool(processes=5, maxtasksperchild=1) as pool:
+    with Pool(processes=3, maxtasksperchild=1) as pool:
         assert len(set(pool.map(lambda _: os.getpid(), range(20)))) == 20
     pool.join()
 

--- a/python/ray/tests/test_multiprocessing.py
+++ b/python/ray/tests/test_multiprocessing.py
@@ -3,7 +3,6 @@
 Tests that require a standalone Ray cluster (for example, testing ray.init or shutdown
 behavior) should go in test_multiprocessing_standalone.py.
 """
-import math
 import os
 import platform
 import queue

--- a/python/ray/tests/test_multiprocessing.py
+++ b/python/ray/tests/test_multiprocessing.py
@@ -24,6 +24,7 @@ from ray.util.multiprocessing import Pool, TimeoutError, JoinableQueue
 @pytest.fixture(scope="module")
 def ray_init_4_cpu_shared():
     yield ray.init(num_cpus=4)
+    ray.shutdown()
 
 
 @pytest.fixture

--- a/python/ray/tests/test_multiprocessing_standalone.py
+++ b/python/ray/tests/test_multiprocessing_standalone.py
@@ -4,22 +4,15 @@ Tests that can run on a shared Ray cluster fixture should go in test_multiproces
 """
 import math
 import os
-import platform
-import queue
-import random
 import sys
-import tempfile
-import time
 import multiprocessing as mp
-from collections import defaultdict
 
 import pytest
 
 
 import ray
-from ray._private.test_utils import external_redis_test_enabled, SignalActor
-from ray.util.multiprocessing import Pool, TimeoutError, JoinableQueue
-from ray.util.joblib import register_ray
+from ray._private.test_utils import external_redis_test_enabled
+from ray.util.multiprocessing import Pool
 
 
 @pytest.fixture(scope="module")

--- a/python/ray/tests/test_multiprocessing_standalone.py
+++ b/python/ray/tests/test_multiprocessing_standalone.py
@@ -1,0 +1,193 @@
+"""Tests for ray.util.multiprocessing that require a standalone Ray cluster per test.
+
+Tests that can run on a shared Ray cluster fixture should go in test_multiprocessing.py
+"""
+import math
+import os
+import platform
+import queue
+import random
+import sys
+import tempfile
+import time
+import multiprocessing as mp
+from collections import defaultdict
+
+import pytest
+
+
+import ray
+from ray._private.test_utils import external_redis_test_enabled, SignalActor
+from ray.util.multiprocessing import Pool, TimeoutError, JoinableQueue
+from ray.util.joblib import register_ray
+
+
+@pytest.fixture(scope="module")
+def ray_init_4_cpu_shared():
+    yield ray.init(num_cpus=4)
+
+
+@pytest.fixture
+def pool_4_processes(ray_init_4_cpu_shared):
+    pool = Pool(processes=4)
+    yield pool
+    pool.terminate()
+    pool.join()
+
+
+@pytest.fixture
+def pool_4_processes_python_multiprocessing_lib():
+    pool = mp.Pool(processes=4)
+    yield pool
+    pool.terminate()
+    pool.join()
+
+
+@pytest.mark.skipif(
+    external_redis_test_enabled(),
+    reason="Starts multiple Ray instances in parallel with the same namespace.",
+)
+def test_ray_init(shutdown_only):
+    def getpid(i: int):
+        return os.getpid()
+
+    def check_pool_size(pool, size: int):
+        assert len(set(pool.map(getpid, range(size)))) == size
+
+    # Check that starting a pool starts ray if not initialized.
+    assert not ray.is_initialized()
+    with Pool(processes=4) as pool:
+        assert ray.is_initialized()
+        check_pool_size(pool, 4)
+        assert int(ray.cluster_resources()["CPU"]) == 4
+    pool.join()
+
+    # Check that starting a pool doesn't affect ray if there is a local
+    # ray cluster running.
+    assert ray.is_initialized()
+    assert int(ray.cluster_resources()["CPU"]) == 4
+    with Pool(processes=2) as pool:
+        assert ray.is_initialized()
+        check_pool_size(pool, 2)
+        assert int(ray.cluster_resources()["CPU"]) == 4
+    pool.join()
+
+    # Check that trying to start a pool on an existing ray cluster throws an
+    # error if there aren't enough CPUs for the number of processes.
+    assert ray.is_initialized()
+    assert int(ray.cluster_resources()["CPU"]) == 4
+    with pytest.raises(ValueError):
+        Pool(processes=8)
+        assert int(ray.cluster_resources()["CPU"]) == 4
+
+
+@pytest.mark.skipif(
+    external_redis_test_enabled(),
+    reason="Starts multiple Ray instances in parallel with the same namespace.",
+)
+@pytest.mark.parametrize(
+    "ray_start_cluster",
+    [
+        {
+            "num_cpus": 1,
+            "num_nodes": 1,
+            "do_init": False,
+        }
+    ],
+    indirect=True,
+)
+def test_connect_to_ray(monkeypatch, ray_start_cluster):
+    def getpid(args):
+        return os.getpid()
+
+    def check_pool_size(pool, size):
+        args = [tuple() for _ in range(size)]
+        assert len(set(pool.map(getpid, args))) == size
+
+    # Use different numbers of CPUs to distinguish between starting a local
+    # ray cluster and connecting to an existing one.
+    ray.init(address=ray_start_cluster.address)
+    existing_cluster_cpus = int(ray.cluster_resources()["CPU"])
+    local_cluster_cpus = existing_cluster_cpus + 1
+    ray.shutdown()
+
+    # Check that starting a pool connects to the running ray cluster by default.
+    assert not ray.is_initialized()
+    with Pool() as pool:
+        assert ray.is_initialized()
+        check_pool_size(pool, existing_cluster_cpus)
+        assert int(ray.cluster_resources()["CPU"]) == existing_cluster_cpus
+    pool.join()
+    ray.shutdown()
+
+    # Check that starting a pool connects to a running ray cluster if
+    # ray_address is set to the cluster address.
+    assert not ray.is_initialized()
+    with Pool(ray_address=ray_start_cluster.address) as pool:
+        check_pool_size(pool, existing_cluster_cpus)
+        assert int(ray.cluster_resources()["CPU"]) == existing_cluster_cpus
+    pool.join()
+    ray.shutdown()
+
+    # Check that starting a pool connects to a running ray cluster if
+    # RAY_ADDRESS is set to the cluster address.
+    assert not ray.is_initialized()
+    monkeypatch.setenv("RAY_ADDRESS", ray_start_cluster.address)
+    with Pool() as pool:
+        check_pool_size(pool, existing_cluster_cpus)
+        assert int(ray.cluster_resources()["CPU"]) == existing_cluster_cpus
+    pool.join()
+    ray.shutdown()
+
+    # Check that trying to start a pool on an existing ray cluster throws an
+    # error if there aren't enough CPUs for the number of processes.
+    assert not ray.is_initialized()
+    with pytest.raises(Exception):
+        Pool(processes=existing_cluster_cpus + 1)
+    assert int(ray.cluster_resources()["CPU"]) == existing_cluster_cpus
+    ray.shutdown()
+
+    # Check that starting a pool starts a local ray cluster if ray_address="local".
+    assert not ray.is_initialized()
+    with Pool(processes=local_cluster_cpus, ray_address="local") as pool:
+        check_pool_size(pool, local_cluster_cpus)
+        assert int(ray.cluster_resources()["CPU"]) == local_cluster_cpus
+    pool.join()
+    ray.shutdown()
+
+    # Check that starting a pool starts a local ray cluster if RAY_ADDRESS="local".
+    assert not ray.is_initialized()
+    monkeypatch.setenv("RAY_ADDRESS", "local")
+    with Pool(processes=local_cluster_cpus) as pool:
+        check_pool_size(pool, local_cluster_cpus)
+        assert int(ray.cluster_resources()["CPU"]) == local_cluster_cpus
+    pool.join()
+    ray.shutdown()
+
+
+def test_maxtasksperchild(shutdown_only):
+    with Pool(processes=5, maxtasksperchild=1) as pool:
+        assert len(set(pool.map(lambda _: os.getpid(), range(20)))) == 20
+    pool.join()
+
+
+def test_deadlock_avoidance_in_recursive_tasks(shutdown_only):
+    ray.init(num_cpus=1)
+
+    def poolit_a(_):
+        with Pool() as pool:
+            return list(pool.map(math.sqrt, range(0, 2, 1)))
+
+    def poolit_b():
+        with Pool() as pool:
+            return list(pool.map(poolit_a, range(2, 4, 1)))
+
+    result = poolit_b()
+    assert result == [[0.0, 1.0], [0.0, 1.0]]
+
+
+if __name__ == "__main__":
+    if os.environ.get("PARALLEL_CI"):
+        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
+    else:
+        sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -15,7 +15,7 @@ from ray.cluster_utils import Cluster
 from ray.util.client.common import ClientObjectRef
 from ray.util.client.ray_client_helpers import ray_start_client_server
 from ray.util.client.worker import Worker
-from ray._private.test_utils import wait_for_condition, enable_external_redis
+from ray._private.test_utils import wait_for_condition, external_redis_test_enabled
 from ray._private import ray_constants
 
 
@@ -242,7 +242,7 @@ def test_new_ray_instance_new_session_dir(shutdown_only):
     session_dir = ray._private.worker._global_node.get_session_dir_path()
     ray.shutdown()
     ray.init()
-    if enable_external_redis():
+    if external_redis_test_enabled():
         assert ray._private.worker._global_node.get_session_dir_path() == session_dir
     else:
         assert ray._private.worker._global_node.get_session_dir_path() != session_dir
@@ -257,7 +257,7 @@ def test_new_cluster_new_session_dir(ray_start_cluster):
     cluster.shutdown()
     cluster.add_node()
     ray.init(address=cluster.address)
-    if enable_external_redis():
+    if external_redis_test_enabled():
         assert ray._private.worker._global_node.get_session_dir_path() == session_dir
     else:
         assert ray._private.worker._global_node.get_session_dir_path() != session_dir

--- a/python/ray/tests/test_redis_tls.py
+++ b/python/ray/tests/test_redis_tls.py
@@ -1,7 +1,7 @@
 import pytest
 import sys
 import ray
-from ray._private.test_utils import enable_external_redis
+from ray._private.test_utils import external_redis_test_enabled
 
 
 @pytest.fixture
@@ -22,7 +22,9 @@ def setup_replicas(request, monkeypatch):
     yield
 
 
-@pytest.mark.skipif(not enable_external_redis(), reason="Only work for redis mode")
+@pytest.mark.skipif(
+    not external_redis_test_enabled(), reason="Only work for redis mode"
+)
 @pytest.mark.skipif(sys.platform != "linux", reason="Only work in linux")
 @pytest.mark.parametrize("setup_replicas", [1, 3], indirect=True)
 def test_redis_tls(setup_tls, setup_replicas, ray_start_cluster_head):

--- a/python/ray/tests/test_runtime_env_plugin.py
+++ b/python/ray/tests/test_runtime_env_plugin.py
@@ -15,7 +15,7 @@ import ray
 from ray._private import ray_constants
 from ray._private.runtime_env.context import RuntimeEnvContext
 from ray._private.runtime_env.plugin import RuntimeEnvPlugin
-from ray._private.test_utils import enable_external_redis, wait_for_condition
+from ray._private.test_utils import external_redis_test_enabled, wait_for_condition
 from ray.exceptions import RuntimeEnvSetupError
 from ray.runtime_env.runtime_env import RuntimeEnv
 
@@ -210,7 +210,7 @@ class HangPlugin(DummyPlugin):
     ],
     indirect=True,
 )
-@pytest.mark.skipif(enable_external_redis(), reason="Failing in redis mode.")
+@pytest.mark.skipif(external_redis_test_enabled(), reason="Failing in redis mode.")
 def test_plugin_timeout(set_runtime_env_plugins, start_cluster):
     @ray.remote(num_cpus=0.1)
     def f():

--- a/python/ray/util/multiprocessing/pool.py
+++ b/python/ray/util/multiprocessing/pool.py
@@ -605,7 +605,10 @@ class Pool:
                 RAY_ADDRESS_ENV in os.environ
                 or ray._private.utils.read_ray_address() is not None
             ):
-                ray.init()
+                init_kwargs = {}
+                if os.environ.get(RAY_ADDRESS_ENV) == "local":
+                    init_kwargs["num_cpus"] = processes
+                ray.init(**init_kwargs)
             elif ray_address is not None:
                 init_kwargs = {}
                 if ray_address == "local":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

A few bundled changes to speed up these tests and deflake them ([example failure](https://buildkite.com/ray-project/postmerge/builds/9918#01969ed5-bdb5-4f51-9d32-8a1b49bee671/180-2039)):

- Clean up the `test_ray_init` and `test_connect_to_ray` test conditions. Skip the tests that start multiple Ray instances when running on external redis (avoid using the hacky private API that caused flakes). I also found a minor bug from improving the tests that I have fixed (not setting `num_cpus` as expected if `RAY_ADDRESS="local"` was set).
- Renamed the utils around external redis tests for clarity.
- Split the tests into `test_multiprocessing.py` and `test_multiprocessing_standalone.py`, use a shared Ray cluster fixture for the former.
- Reduce the runtime of some individual tests by reducing iterable sizes and sleep times.
- Move out the `joblib` test into `test_joblib.py` and remove the sleep.

## Before
`test_multiprocessing.py`: `21 passed in 105.55s`

## After
`test_multiprocessing.py`: `16 passed in 13.06s`
`test_multiprocessing_standalone.py`: `4 passed in 20.76s`