### PR TITLE
Add perf metrics for 2.46.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 113.983488,
+    "_dashboard_memory_usage_mb": 83.984384,
     "_dashboard_test_success": true,
-    "_peak_memory": 4.3,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1164\t4.36GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3402\t1.76GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5359\t0.89GiB\tpython distributed/test_many_actors.py\n2875\t0.37GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3604\t0.3GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n586\t0.18GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3518\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n4123\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n2789\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4125\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
-    "actors_per_second": 584.7284406495273,
+    "_peak_memory": 4.21,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1129\t6.64GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3412\t1.72GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4757\t0.95GiB\tpython distributed/test_many_actors.py\n2692\t0.44GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3612\t0.22GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n583\t0.18GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n4124\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n2914\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3528\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n4126\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
+    "actors_per_second": 634.2824761754516,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 584.7284406495273
+            "perf_metric_value": 634.2824761754516
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 7.272
+            "perf_metric_value": 8.293
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2276.06
+            "perf_metric_value": 2283.949
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4501.941
+            "perf_metric_value": 4974.655
         }
     ],
     "success": "1",
-    "time": 17.101955890655518
+    "time": 15.765846252441406
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 96.99328,
+    "_dashboard_memory_usage_mb": 93.069312,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.29,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3929\t0.51GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2756\t0.29GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n7430\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n4128\t0.13GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n1129\t0.13GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4657\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n4126\t0.1GiB\tray-dashboard-EventHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import sp\n4045\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n2670\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n7648\t0.09GiB\tray::StateAPIGeneratorActor.start",
+    "_peak_memory": 2.2,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3564\t0.51GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2570\t0.27GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4982\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3763\t0.13GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n1062\t0.13GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4270\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n2625\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3680\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n5279\t0.08GiB\tray::StateAPIGeneratorActor.start\n3766\t0.08GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import sp",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 184.76609554410751
+            "perf_metric_value": 221.2222291023174
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 6.661
+            "perf_metric_value": 5.658
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 42.609
+            "perf_metric_value": 16.67
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 52.83
+            "perf_metric_value": 51.794
         }
     ],
     "success": "1",
-    "tasks_per_second": 184.76609554410751,
-    "time": 305.4122483730316,
+    "tasks_per_second": 221.2222291023174,
+    "time": 304.5203413963318,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 88.485888,
+    "_dashboard_memory_usage_mb": 85.512192,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.7,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1160\t7.23GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3407\t0.96GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2568\t0.43GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4802\t0.36GiB\tpython distributed/test_many_pgs.py\n583\t0.18GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3606\t0.1GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n2727\t0.09GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l\n4137\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n2491\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3523\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash",
+    "_peak_memory": 2.72,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n2059\t7.21GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3429\t0.96GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2686\t0.43GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4793\t0.37GiB\tpython distributed/test_many_pgs.py\n583\t0.19GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3627\t0.1GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n2527\t0.1GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l\n4136\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n2951\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3545\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13.498456472943806
+            "perf_metric_value": 13.650631601393242
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4.438
+            "perf_metric_value": 3.856
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 7.748
+            "perf_metric_value": 6.696
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 324.348
+            "perf_metric_value": 275.082
         }
     ],
-    "pgs_per_second": 13.498456472943806,
+    "pgs_per_second": 13.650631601393242,
     "success": "1",
-    "time": 74.08254432678223
+    "time": 73.25668358802795
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 105.558016,
+    "_dashboard_memory_usage_mb": 92.213248,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.87,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3410\t1.1GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4831\t0.75GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3614\t0.46GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n2828\t0.27GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3617\t0.18GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import sp\n1128\t0.12GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4136\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3526\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n2727\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n5059\t0.08GiB\tray::StateAPIGeneratorActor.start",
+    "_peak_memory": 3.85,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3411\t1.09GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n6752\t0.75GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3611\t0.45GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n2810\t0.28GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3614\t0.17GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import sp\n1134\t0.12GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4128\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3527\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n2907\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n6977\t0.08GiB\tray::StateAPIGeneratorActor.start",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 386.57760124343247
+            "perf_metric_value": 350.23203445104895
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4.972
+            "perf_metric_value": 5.941
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 498.863
+            "perf_metric_value": 437.195
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 773.119
+            "perf_metric_value": 675.061
         }
     ],
     "success": "1",
-    "tasks_per_second": 386.57760124343247,
-    "time": 325.8680274486542,
+    "tasks_per_second": 350.23203445104895,
+    "time": 328.5524995326996,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.45.0"}
+{"release_version": "2.46.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8444.076833431887,
-        109.8906193815417
+        7484.128019312722,
+        222.23612905590366
     ],
     "1_1_actor_calls_concurrent": [
-        5197.977170580825,
-        212.32480863999945
+        5210.654473422534,
+        148.8482302145678
     ],
     "1_1_actor_calls_sync": [
-        1970.1890755785905,
-        6.279095946464738
+        2020.4236901532247,
+        18.458813788356412
     ],
     "1_1_async_actor_calls_async": [
-        4690.27307407808,
-        157.5633963254943
+        4133.0146320984095,
+        158.06597563376883
     ],
     "1_1_async_actor_calls_sync": [
-        1484.8537560953,
-        14.429707731927486
+        1483.660979687764,
+        23.548334544330253
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2887.305655540158,
-        91.9412027571407
+        2744.6685159840754,
+        60.78673286688515
     ],
     "1_n_actor_calls_async": [
-        8442.314246687905,
-        243.43825734663986
+        8318.094433102775,
+        220.7257975463937
     ],
     "1_n_async_actor_calls_async": [
-        7800.885681170592,
-        55.298699777675175
+        7563.184192111071,
+        157.70699676551294
     ],
     "client__1_1_actor_calls_async": [
-        1086.8894650569318,
-        8.834625415868556
+        1069.1602586173547,
+        8.291193112362643
     ],
     "client__1_1_actor_calls_concurrent": [
-        1095.8599860679442,
-        21.582794027321686
+        1050.6282351078878,
+        11.652242761910356
     ],
     "client__1_1_actor_calls_sync": [
-        502.66993358678155,
-        27.959156824946863
+        525.9274124240096,
+        3.4715440434472495
     ],
     "client__get_calls": [
-        1166.944263833784,
-        26.80854064375958
+        1160.5254002780266,
+        16.558088205324744
     ],
     "client__put_calls": [
-        806.8522252791361,
-        23.443214568427795
+        790.7920510051757,
+        21.308859484909945
     ],
     "client__put_gigabytes": [
-        0.15539024775670351,
-        0.00048357711627779805
+        0.1529268174148042,
+        0.0010070926819979113
     ],
     "client__tasks_and_get_batch": [
-        0.9736693864062806,
-        0.03368042368433273
+        0.9480091293556955,
+        0.07641810889693526
     ],
     "client__tasks_and_put_batch": [
-        14921.634990237624,
-        90.2201928263096
+        14569.862277318796,
+        259.9296680300632
     ],
     "multi_client_put_calls_Plasma_Store": [
-        17225.275033455742,
-        400.51249084082644
+        15796.693450669514,
+        300.97046947045953
     ],
     "multi_client_put_gigabytes": [
-        42.63542976122483,
-        2.956413982171539
+        39.896743394372585,
+        2.347460003874646
     ],
     "multi_client_tasks_async": [
-        21993.93553882069,
-        504.6647568032584
+        21959.60128713229,
+        815.6916566872305
     ],
     "n_n_actor_calls_async": [
-        28201.299272185486,
-        222.0619153083122
+        27465.39608393524,
+        762.3570217280651
     ],
     "n_n_actor_calls_with_arg_async": [
-        2763.4671549404156,
-        25.273747830075962
+        2709.168840517713,
+        50.58648732986629
     ],
     "n_n_async_actor_calls_async": [
-        24305.549204990766,
-        935.8864435970182
+        23716.451989299432,
+        762.9269367240967
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10749.987511970474
+            "perf_metric_value": 10723.171694846082
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5074.5127405902585
+            "perf_metric_value": 5113.112753017668
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 17225.275033455742
+            "perf_metric_value": 15796.693450669514
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 18.986090199611898
+            "perf_metric_value": 20.105537951105227
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 6.137193762523237
+            "perf_metric_value": 5.997593980449436
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 42.63542976122483
+            "perf_metric_value": 39.896743394372585
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.909895729510396
+            "perf_metric_value": 12.796724102063072
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4.997131305946631
+            "perf_metric_value": 4.773703805756311
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 967.6915002044169
+            "perf_metric_value": 969.5757440611114
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8007.8439530065825
+            "perf_metric_value": 8081.168521067462
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 21993.93553882069
+            "perf_metric_value": 21959.60128713229
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1970.1890755785905
+            "perf_metric_value": 2020.4236901532247
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8444.076833431887
+            "perf_metric_value": 7484.128019312722
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5197.977170580825
+            "perf_metric_value": 5210.654473422534
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8442.314246687905
+            "perf_metric_value": 8318.094433102775
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 28201.299272185486
+            "perf_metric_value": 27465.39608393524
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2763.4671549404156
+            "perf_metric_value": 2709.168840517713
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1484.8537560953
+            "perf_metric_value": 1483.660979687764
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4690.27307407808
+            "perf_metric_value": 4133.0146320984095
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2887.305655540158
+            "perf_metric_value": 2744.6685159840754
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7800.885681170592
+            "perf_metric_value": 7563.184192111071
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 24305.549204990766
+            "perf_metric_value": 23716.451989299432
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 777.3138561777844
+            "perf_metric_value": 768.9082534403586
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1166.944263833784
+            "perf_metric_value": 1160.5254002780266
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 806.8522252791361
+            "perf_metric_value": 790.7920510051757
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.15539024775670351
+            "perf_metric_value": 0.1529268174148042
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 14921.634990237624
+            "perf_metric_value": 14569.862277318796
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 502.66993358678155
+            "perf_metric_value": 525.9274124240096
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1086.8894650569318
+            "perf_metric_value": 1069.1602586173547
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1095.8599860679442
+            "perf_metric_value": 1050.6282351078878
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.9736693864062806
+            "perf_metric_value": 0.9480091293556955
         }
     ],
     "placement_group_create/removal": [
-        777.3138561777844,
-        7.184681487591427
+        768.9082534403586,
+        7.490796352327158
     ],
     "single_client_get_calls_Plasma_Store": [
-        10749.987511970474,
-        229.21715536154238
+        10723.171694846082,
+        273.67271154030044
     ],
     "single_client_get_object_containing_10k_refs": [
-        12.909895729510396,
-        0.47897759652596766
+        12.796724102063072,
+        0.24376172143785838
     ],
     "single_client_put_calls_Plasma_Store": [
-        5074.5127405902585,
-        108.08357883333088
+        5113.112753017668,
+        59.15893774584755
     ],
     "single_client_put_gigabytes": [
-        18.986090199611898,
-        7.817017632873358
+        20.105537951105227,
+        6.880575059253889
     ],
     "single_client_tasks_and_get_batch": [
-        6.137193762523237,
-        3.0715095947610935
+        5.997593980449436,
+        3.075195708468554
     ],
     "single_client_tasks_async": [
-        8007.8439530065825,
-        480.716877038182
+        8081.168521067462,
+        372.9673263202764
     ],
     "single_client_tasks_sync": [
-        967.6915002044169,
-        9.187667657445576
+        969.5757440611114,
+        8.434453318133698
     ],
     "single_client_wait_1k_refs": [
-        4.997131305946631,
-        0.13212779524383766
+        4.773703805756311,
+        0.0966549450132402
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 12.626934259999999,
+    "broadcast_time": 12.241764013000008,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.626934259999999
+            "perf_metric_value": 12.241764013000008
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 19.189307459,
-    "get_time": 22.656893267,
+    "args_time": 18.764070391999994,
+    "get_time": 24.086921284,
     "large_object_size": 107374182400,
-    "large_object_time": 28.701530757,
+    "large_object_time": 29.323037406000026,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 19.189307459
+            "perf_metric_value": 18.764070391999994
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.785791095999997
+            "perf_metric_value": 5.8424495409999935
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 22.656893267
+            "perf_metric_value": 24.086921284
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 188.94385793700002
+            "perf_metric_value": 199.93470425
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 28.701530757
+            "perf_metric_value": 29.323037406000026
         }
     ],
-    "queued_time": 188.94385793700002,
-    "returns_time": 5.785791095999997,
+    "queued_time": 199.93470425,
+    "returns_time": 5.8424495409999935,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.1924733638763427,
-    "max_iteration_time": 5.366504430770874,
-    "min_iteration_time": 0.05286550521850586,
+    "avg_iteration_time": 1.1950538015365602,
+    "max_iteration_time": 3.303210973739624,
+    "min_iteration_time": 0.09052538871765137,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.1924733638763427
+            "perf_metric_value": 1.1950538015365602
         }
     ],
     "success": 1,
-    "total_time": 119.24746370315552
+    "total_time": 119.50550389289856
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 7.069997787475586
+            "perf_metric_value": 7.1579203605651855
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.511144208908082
+            "perf_metric_value": 12.4845627784729
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 38.58955483436584
+            "perf_metric_value": 33.596983671188354
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.9198436737060547
+            "perf_metric_value": 2.0442848205566406
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1838.6034362316132
+            "perf_metric_value": 1825.3072292804718
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.5643807586534827
+            "perf_metric_value": 0.55708404702971
         }
     ],
-    "stage_0_time": 7.069997787475586,
-    "stage_1_avg_iteration_time": 12.511144208908082,
-    "stage_1_max_iteration_time": 12.921896934509277,
-    "stage_1_min_iteration_time": 11.234705448150635,
-    "stage_1_time": 125.11151504516602,
-    "stage_2_avg_iteration_time": 38.58955483436584,
-    "stage_2_max_iteration_time": 39.280184507369995,
-    "stage_2_min_iteration_time": 38.13513684272766,
-    "stage_2_time": 192.94836735725403,
-    "stage_3_creation_time": 1.9198436737060547,
-    "stage_3_time": 1838.6034362316132,
-    "stage_4_spread": 0.5643807586534827,
+    "stage_0_time": 7.1579203605651855,
+    "stage_1_avg_iteration_time": 12.4845627784729,
+    "stage_1_max_iteration_time": 12.942049741744995,
+    "stage_1_min_iteration_time": 11.020888566970825,
+    "stage_1_time": 124.84568572044373,
+    "stage_2_avg_iteration_time": 33.596983671188354,
+    "stage_2_max_iteration_time": 34.238181352615356,
+    "stage_2_min_iteration_time": 32.854965925216675,
+    "stage_2_time": 167.985454082489,
+    "stage_3_creation_time": 2.0442848205566406,
+    "stage_3_time": 1825.3072292804718,
+    "stage_4_spread": 0.55708404702971,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 1.4790909474473704,
-    "avg_pg_remove_time_ms": 1.2639661321323425,
+    "avg_pg_create_time_ms": 1.5207665240240509,
+    "avg_pg_remove_time_ms": 1.2291068678679091,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.4790909474473704
+            "perf_metric_value": 1.5207665240240509
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.2639661321323425
+            "perf_metric_value": 1.2291068678679091
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 11.88%: 1_1_async_actor_calls_async (THROUGHPUT) regresses from 4690.27307407808 to 4133.0146320984095 in microbenchmark.json
REGRESSION 11.37%: 1_1_actor_calls_async (THROUGHPUT) regresses from 8444.076833431887 to 7484.128019312722 in microbenchmark.json
REGRESSION 9.40%: tasks_per_second (THROUGHPUT) regresses from 386.57760124343247 to 350.23203445104895 in benchmarks/many_tasks.json
REGRESSION 8.29%: multi_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 17225.275033455742 to 15796.693450669514 in microbenchmark.json
REGRESSION 6.42%: multi_client_put_gigabytes (THROUGHPUT) regresses from 42.63542976122483 to 39.896743394372585 in microbenchmark.json
REGRESSION 4.94%: 1_1_async_actor_calls_with_args_async (THROUGHPUT) regresses from 2887.305655540158 to 2744.6685159840754 in microbenchmark.json
REGRESSION 4.47%: single_client_wait_1k_refs (THROUGHPUT) regresses from 4.997131305946631 to 4.773703805756311 in microbenchmark.json
REGRESSION 4.13%: client__1_1_actor_calls_concurrent (THROUGHPUT) regresses from 1095.8599860679442 to 1050.6282351078878 in microbenchmark.json
REGRESSION 3.05%: 1_n_async_actor_calls_async (THROUGHPUT) regresses from 7800.885681170592 to 7563.184192111071 in microbenchmark.json
REGRESSION 2.64%: client__tasks_and_get_batch (THROUGHPUT) regresses from 0.9736693864062806 to 0.9480091293556955 in microbenchmark.json
REGRESSION 2.61%: n_n_actor_calls_async (THROUGHPUT) regresses from 28201.299272185486 to 27465.39608393524 in microbenchmark.json
REGRESSION 2.42%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 24305.549204990766 to 23716.451989299432 in microbenchmark.json
REGRESSION 2.36%: client__tasks_and_put_batch (THROUGHPUT) regresses from 14921.634990237624 to 14569.862277318796 in microbenchmark.json
REGRESSION 2.27%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 6.137193762523237 to 5.997593980449436 in microbenchmark.json
REGRESSION 1.99%: client__put_calls (THROUGHPUT) regresses from 806.8522252791361 to 790.7920510051757 in microbenchmark.json
REGRESSION 1.96%: n_n_actor_calls_with_arg_async (THROUGHPUT) regresses from 2763.4671549404156 to 2709.168840517713 in microbenchmark.json
REGRESSION 1.63%: client__1_1_actor_calls_async (THROUGHPUT) regresses from 1086.8894650569318 to 1069.1602586173547 in microbenchmark.json
REGRESSION 1.59%: client__put_gigabytes (THROUGHPUT) regresses from 0.15539024775670351 to 0.1529268174148042 in microbenchmark.json
REGRESSION 1.47%: 1_n_actor_calls_async (THROUGHPUT) regresses from 8442.314246687905 to 8318.094433102775 in microbenchmark.json
REGRESSION 1.08%: placement_group_create/removal (THROUGHPUT) regresses from 777.3138561777844 to 768.9082534403586 in microbenchmark.json
REGRESSION 0.88%: single_client_get_object_containing_10k_refs (THROUGHPUT) regresses from 12.909895729510396 to 12.796724102063072 in microbenchmark.json
REGRESSION 0.55%: client__get_calls (THROUGHPUT) regresses from 1166.944263833784 to 1160.5254002780266 in microbenchmark.json
REGRESSION 0.25%: single_client_get_calls_Plasma_Store (THROUGHPUT) regresses from 10749.987511970474 to 10723.171694846082 in microbenchmark.json
REGRESSION 0.16%: multi_client_tasks_async (THROUGHPUT) regresses from 21993.93553882069 to 21959.60128713229 in microbenchmark.json
REGRESSION 0.08%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1484.8537560953 to 1483.660979687764 in microbenchmark.json
REGRESSION 19.49%: dashboard_p50_latency_ms (LATENCY) regresses from 4.972 to 5.941 in benchmarks/many_tasks.json
REGRESSION 14.04%: dashboard_p50_latency_ms (LATENCY) regresses from 7.272 to 8.293 in benchmarks/many_actors.json
REGRESSION 10.50%: dashboard_p99_latency_ms (LATENCY) regresses from 4501.941 to 4974.655 in benchmarks/many_actors.json
REGRESSION 6.48%: stage_3_creation_time (LATENCY) regresses from 1.9198436737060547 to 2.0442848205566406 in stress_tests/stress_test_many_tasks.json
REGRESSION 6.31%: 10000_get_time (LATENCY) regresses from 22.656893267 to 24.086921284 in scalability/single_node.json
REGRESSION 5.82%: 1000000_queued_time (LATENCY) regresses from 188.94385793700002 to 199.93470425 in scalability/single_node.json
REGRESSION 2.82%: avg_pg_create_time_ms (LATENCY) regresses from 1.4790909474473704 to 1.5207665240240509 in stress_tests/stress_test_placement_group.json
REGRESSION 2.17%: 107374182400_large_object_time (LATENCY) regresses from 28.701530757 to 29.323037406000026 in scalability/single_node.json
REGRESSION 1.24%: stage_0_time (LATENCY) regresses from 7.069997787475586 to 7.1579203605651855 in stress_tests/stress_test_many_tasks.json
REGRESSION 0.98%: 3000_returns_time (LATENCY) regresses from 5.785791095999997 to 5.8424495409999935 in scalability/single_node.json
REGRESSION 0.35%: dashboard_p95_latency_ms (LATENCY) regresses from 2276.06 to 2283.949 in benchmarks/many_actors.json
REGRESSION 0.22%: avg_iteration_time (LATENCY) regresses from 1.1924733638763427 to 1.1950538015365602 in stress_tests/stress_test_dead_actors.json
```