### PR TITLE
[docs][tune]: fix import & replace `session.report` with `tune.report`

### DIFF
--- a/doc/source/tune/doc_code/key_concepts.py
+++ b/doc/source/tune/doc_code/key_concepts.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 
 # __function_api_start__
-from ray import train
+from ray import tune
 
 
 def objective(x, a, b):  # Define an objective function.

--- a/doc/source/tune/key-concepts.rst
+++ b/doc/source/tune/key-concepts.rst
@@ -51,11 +51,11 @@ Given concrete choices for ``a``, ``b`` and ``x`` we can evaluate the objective 
             :start-after: __function_api_start__
             :end-before: __function_api_end__
 
-        Note that we use ``session.report(...)`` to report the intermediate ``score`` in the training loop, which can be useful
+        Note that we use ``tune.report(...)`` to report the intermediate ``score`` in the training loop, which can be useful
         in many machine learning tasks.
         If you just want to report the final ``score`` outside of this loop, you can simply return the score at the
         end of the ``trainable`` function with ``return {"score": score}``.
-        You can also use ``yield {"score": score}`` instead of ``session.report()``.
+        You can also use ``yield {"score": score}`` instead of ``tune.report()``.
 
     .. tab-item:: Class API
 
@@ -66,7 +66,7 @@ Given concrete choices for ``a``, ``b`` and ``x`` we can evaluate the objective 
             :start-after: __class_api_start__
             :end-before: __class_api_end__
 
-        .. tip:: ``session.report`` can't be used within a ``Trainable`` class.
+        .. tip:: ``tune.report`` can't be used within a ``Trainable`` class.
 
 Learn more about the details of :ref:`Trainables here <trainable-docs>`
 and :ref:`have a look at our examples <tune-examples-others>`.
@@ -248,7 +248,7 @@ Tune Schedulers
 ---------------
 
 To make your training process more efficient, you can use a :ref:`Trial Scheduler <tune-schedulers>`.
-For instance, in our ``trainable`` example minimizing a function in a training loop, we used ``session.report()``.
+For instance, in our ``trainable`` example minimizing a function in a training loop, we used ``tune.report()``.
 This reported `incremental` results, given a hyperparameter configuration selected by a search algorithm.
 Based on these reported results, a Tune scheduler can decide whether to stop the trial early or not.
 If you don't specify a scheduler, Tune will use a first-in-first-out (FIFO) scheduler by default, which simply


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Updated the documentation to improve clarity.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
