### PR TITLE
[ray.data.llm] Lazy import engines in stages

### DIFF
--- a/python/ray/llm/_internal/batch/stages/sglang_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/sglang_engine_stage.py
@@ -391,9 +391,9 @@ class SGLangEngineStage(StatefulStage):
         ret = {"prompt": "The text prompt (str)."}
         task_type = self.fn_constructor_kwargs.get("task_type", SGLangTaskType.GENERATE)
         if task_type == SGLangTaskType.GENERATE:
-            ret["sampling_params"] = (
-                "The sampling parameters. See https://docs.sglang.ai/backend/sampling_params.htmlfor details."
-            )
+            ret[
+                "sampling_params"
+            ] = "The sampling parameters. See https://docs.sglang.ai/backend/sampling_params.htmlfor details."
         return ret
 
     def get_optional_input_keys(self) -> Dict[str, str]:

--- a/python/ray/llm/_internal/batch/stages/sglang_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/sglang_engine_stage.py
@@ -9,14 +9,11 @@ from enum import Enum
 from pydantic import BaseModel, root_validator
 from typing import Any, Dict, AsyncIterator, Optional, List, Tuple, Type
 
-from ray.llm._internal.utils import try_import
 from ray.llm._internal.batch.stages.base import (
     StatefulStage,
     StatefulStageUDF,
 )
 from ray.llm._internal.batch.stages.common import maybe_convert_ndarray_to_list
-
-sgl = try_import("sglang")
 
 logger = logging.getLogger(__name__)
 
@@ -120,14 +117,16 @@ class SGLangEngineWrapper:
         self.skip_tokenizer_init = kwargs.pop("skip_tokenizer_init", True)
         kwargs["skip_tokenizer_init"] = self.skip_tokenizer_init
 
-        if sgl is None:
+        try:
+            import sglang
+        except ImportError as e:
             raise ImportError(
                 "SGLang is not installed or failed to import. Please run "
                 "`pip install sglang[all]` to install required dependencies."
-            )
+            ) from e
 
         # Initialize the SGLang engine
-        self.engine = sgl.Engine(**kwargs)
+        self.engine = sglang.Engine(**kwargs)
 
         # The performance gets really bad if there are too many requests in the pending queue.
         # We work around it with semaphore to limit the number of concurrent requests in the engine.
@@ -392,9 +391,9 @@ class SGLangEngineStage(StatefulStage):
         ret = {"prompt": "The text prompt (str)."}
         task_type = self.fn_constructor_kwargs.get("task_type", SGLangTaskType.GENERATE)
         if task_type == SGLangTaskType.GENERATE:
-            ret[
-                "sampling_params"
-            ] = "The sampling parameters. See https://docs.sglang.ai/backend/sampling_params.htmlfor details."
+            ret["sampling_params"] = (
+                "The sampling parameters. See https://docs.sglang.ai/backend/sampling_params.htmlfor details."
+            )
         return ret
 
     def get_optional_input_keys(self) -> Dict[str, str]:

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -25,10 +25,7 @@ from ray.llm._internal.common.utils.download_utils import (
     download_model_files,
     NodeModelDownloadable,
 )
-from ray.llm._internal.utils import try_import
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
-
-vllm = try_import("vllm")
 
 
 logger = logging.getLogger(__name__)
@@ -101,6 +98,7 @@ class vLLMOutputData(BaseModel):
             num_input_tokens=len(prompt_token_ids),
         )
 
+        import vllm
         if isinstance(output, vllm.outputs.RequestOutput):
             metrics = {}
             if output.metrics is not None:
@@ -157,11 +155,13 @@ class vLLMEngineWrapper:
         # Convert the task type back to a string to pass to the engine.
         kwargs["task"] = self.task_type.value
 
-        if vllm is None:
+        try:
+            import vllm
+        except ImportError as e:
             raise ImportError(
                 "vLLM is not installed or failed to import. Please run "
                 "`pip install ray[llm]` to install required dependencies."
-            )
+            ) from e
 
         # Construct PoolerConfig if override_pooler_config is specified.
         if self.task_type == vLLMTaskType.EMBED and "override_pooler_config" in kwargs:
@@ -208,6 +208,7 @@ class vLLMEngineWrapper:
             or None if there is no LoRA. We use Any in type hint to
             pass doc build in the environment without vLLM.
         """
+        import vllm
         lora_request = None
         if "model" in row and row["model"] != self.model:
             if self.vllm_use_v1:
@@ -267,6 +268,7 @@ class vLLMEngineWrapper:
         lora_request = await self._maybe_get_lora_request(row)
 
         # Prepare sampling parameters.
+        import vllm
         if self.task_type == vLLMTaskType.GENERATE:
             sampling_params = row.pop("sampling_params")
             if "guided_decoding" in sampling_params:
@@ -330,6 +332,7 @@ class vLLMEngineWrapper:
             The output of the request.
         """
 
+        import vllm
         if request.images:
             # FIXME: The latest vLLM does not support multi-modal inputs
             # with tokenized prompt.
@@ -380,6 +383,7 @@ class vLLMEngineWrapper:
         # in a separate process, the benefit of decoupling them in the Processor
         # may be limited.
         assert request.prompt
+        import vllm
         multi_modal_data = {"image": request.images} if request.images else None
         llm_prompt = vllm.inputs.data.TextPrompt(
             prompt=request.prompt, multi_modal_data=multi_modal_data

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -99,6 +99,7 @@ class vLLMOutputData(BaseModel):
         )
 
         import vllm
+
         if isinstance(output, vllm.outputs.RequestOutput):
             metrics = {}
             if output.metrics is not None:
@@ -209,6 +210,7 @@ class vLLMEngineWrapper:
             pass doc build in the environment without vLLM.
         """
         import vllm
+
         lora_request = None
         if "model" in row and row["model"] != self.model:
             if self.vllm_use_v1:
@@ -269,6 +271,7 @@ class vLLMEngineWrapper:
 
         # Prepare sampling parameters.
         import vllm
+
         if self.task_type == vLLMTaskType.GENERATE:
             sampling_params = row.pop("sampling_params")
             if "guided_decoding" in sampling_params:
@@ -333,6 +336,7 @@ class vLLMEngineWrapper:
         """
 
         import vllm
+
         if request.images:
             # FIXME: The latest vLLM does not support multi-modal inputs
             # with tokenized prompt.
@@ -384,6 +388,7 @@ class vLLMEngineWrapper:
         # may be limited.
         assert request.prompt
         import vllm
+
         multi_modal_data = {"image": request.images} if request.images else None
         llm_prompt = vllm.inputs.data.TextPrompt(
             prompt=request.prompt, multi_modal_data=multi_modal_data

--- a/python/ray/llm/tests/batch/cpu/stages/test_chat_template_stage.py
+++ b/python/ray/llm/tests/batch/cpu/stages/test_chat_template_stage.py
@@ -11,7 +11,8 @@ def mock_tokenizer_setup():
     # triggers lazy module import in transformers/__init__.py. This means the
     # mocking may not work without explicitly importing AutoProcessor, hence
     # the following import.
-    from transformers import AutoProcessor
+    from transformers import AutoProcessor  # noqa: F401
+
     with patch("transformers.AutoProcessor") as mock_auto_processor:
         mock_processor = MagicMock()
         mock_auto_processor.from_pretrained.return_value = mock_processor

--- a/python/ray/llm/tests/batch/cpu/stages/test_chat_template_stage.py
+++ b/python/ray/llm/tests/batch/cpu/stages/test_chat_template_stage.py
@@ -7,6 +7,11 @@ from ray.llm._internal.batch.stages.chat_template_stage import ChatTemplateUDF
 
 @pytest.fixture
 def mock_tokenizer_setup():
+    # As of writing, the test environment does not have TYPE_CHECKING, which
+    # triggers lazy module import in transformers/__init__.py. This means the
+    # mocking may not work without explicitly importing AutoProcessor, hence
+    # the following import.
+    from transformers import AutoProcessor
     with patch("transformers.AutoProcessor") as mock_auto_processor:
         mock_processor = MagicMock()
         mock_auto_processor.from_pretrained.return_value = mock_processor

--- a/python/ray/llm/tests/batch/gpu/stages/test_sglang_engine_stage.py
+++ b/python/ray/llm/tests/batch/gpu/stages/test_sglang_engine_stage.py
@@ -1,4 +1,5 @@
 """This test suite does not need sglang to be installed."""
+
 import asyncio
 import pytest
 import sys
@@ -54,12 +55,17 @@ def mock_sglang_wrapper():
 def mock_sgl_engine():
     """Mock the SGLang engine and its _generate_async method."""
     with (
-        patch("ray.llm._internal.batch.stages.sglang_engine_stage.sgl") as mock_sgl,
         patch(
             "ray.llm._internal.batch.stages.sglang_engine_stage.SGLangEngineWrapper._generate_async"
         ) as mock_generate_async,
     ):
-        mock_sgl.Engine = AsyncMock()
+        try:
+            import sglang  # noqa: F401
+        except ImportError:
+            # Mock sglang module if it's not installed in test env.
+            mock_sgl = MagicMock()
+            mock_sgl.Engine = AsyncMock()
+            sys.modules["sglang"] = mock_sgl
         num_running_requests = 0
         request_lock = asyncio.Lock()
 
@@ -93,7 +99,7 @@ def mock_sgl_engine():
             }
 
         mock_generate_async.side_effect = mock_generate
-        yield mock_sgl, mock_generate_async
+        yield mock_generate_async
 
 
 def test_sglang_engine_stage_post_init(gpu_type, model_llama_3_2_216M):
@@ -187,7 +193,7 @@ async def test_sglang_wrapper(
     mock_sgl_engine, model_llama_3_2_216M, max_pending_requests, batch_size
 ):
     """Test the SGLang wrapper with different configurations."""
-    _, mock_generate_async = mock_sgl_engine
+    mock_generate_async = mock_sgl_engine
 
     # Set the max_pending_requests for assertion in the mock
     mock_generate_async.side_effect.max_pending_requests = max_pending_requests
@@ -228,7 +234,7 @@ async def test_sglang_wrapper(
 @pytest.mark.asyncio
 async def test_sglang_error_handling(model_llama_3_2_216M):
     """Test error handling when SGLang is not available."""
-    with patch("ray.llm._internal.batch.stages.sglang_engine_stage.sgl", None):
+    with patch.dict(sys.modules, {"sglang": None}):
         with pytest.raises(ImportError, match="SGLang is not installed"):
             SGLangEngineWrapper(
                 model=model_llama_3_2_216M,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`import vllm` could take ~7 seconds. This is severe especially in ray data case, because this 7s overhead happens in each actor's `__init__`. [Some test](https://buildkite.com/ray-project/premerge/builds/39250#0196a181-e130-455c-8f43-7a1c08b9aead) times out due to this overhead.

This PR moves `import vllm` out of beginning of file. And since we lazy import vllm, the test needs a fix to explicitly import `AutoProcessor`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
