### PR TITLE
[CI] Re-enable isort for python/ray/tests/test_[a-d]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
         args: [ --fix, --exit-non-zero-on-fix ]
       - id: ruff
         args: [ --select, "I", --fix, --exit-non-zero-on-fix ]
-        files: '^python/ray/serve/|^python/ray/train|^python/ray/data'
+        files: '^python/ray/serve/|^python/ray/train|^python/ray/data|^python/ray/tests/test_[a-d]'
 
   - repo: https://github.com/cpplint/cpplint
     rev: 2.0.0

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -7,27 +7,25 @@ import tempfile
 import numpy as np
 import pytest
 
+# NOTE: We have to import setproctitle after ray because we bundle setproctitle
+# with ray.
+import setproctitle  # noqa
+
 import ray
 from ray import cloudpickle as pickle
 from ray._private import ray_constants
+from ray._private.state_api_test_utils import invoke_state_api, invoke_state_api_n
 from ray._private.test_utils import (
+    SignalActor,
     client_test_enabled,
     wait_for_condition,
     wait_for_pid_to_exit,
 )
-from ray.actor import ActorClassInheritanceException
-from ray.tests.client_test_utils import create_remote_signal_actor
-from ray._private.test_utils import SignalActor
-from ray.core.generated import gcs_pb2
 from ray._private.utils import hex_to_binary
-from ray._private.state_api_test_utils import invoke_state_api, invoke_state_api_n
-
+from ray.actor import ActorClassInheritanceException
+from ray.core.generated import gcs_pb2
+from ray.tests.client_test_utils import create_remote_signal_actor
 from ray.util.state import list_actors
-
-
-# NOTE: We have to import setproctitle after ray because we bundle setproctitle
-# with ray.
-import setproctitle  # noqa
 
 
 @pytest.mark.parametrize("set_enable_auto_connect", [True, False], indirect=True)

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -10,8 +10,8 @@ import pytest
 
 import ray
 import ray._private.gcs_utils as gcs_utils
-from ray.util.state import list_actors
 import ray.cluster_utils
+from ray._private.ray_constants import gcs_actor_scheduling_enabled
 from ray._private.test_utils import (
     SignalActor,
     convert_actor_state,
@@ -21,8 +21,8 @@ from ray._private.test_utils import (
     wait_for_condition,
     wait_for_pid_to_exit,
 )
-from ray._private.ray_constants import gcs_actor_scheduling_enabled
 from ray.experimental.internal_kv import _internal_kv_get, _internal_kv_put
+from ray.util.state import list_actors
 
 
 def test_remote_functions_not_scheduled_on_actors(ray_start_regular):

--- a/python/ray/tests/test_actor_bounded_threads.py
+++ b/python/ray/tests/test_actor_bounded_threads.py
@@ -1,12 +1,12 @@
-import sys
-import os
-
-import ray
 import logging
-from typing import Dict
+import os
+import sys
 from collections import Counter
+from typing import Dict
 
 import pytest
+
+import ray
 
 logger = logging.getLogger(__name__)
 

--- a/python/ray/tests/test_actor_cancel.py
+++ b/python/ray/tests/test_actor_cancel.py
@@ -1,8 +1,8 @@
 import asyncio
+import concurrent.futures
 import os
 import sys
 import time
-import concurrent.futures
 from collections import defaultdict
 
 import pytest

--- a/python/ray/tests/test_actor_failures.py
+++ b/python/ray/tests/test_actor_failures.py
@@ -1,23 +1,24 @@
-import atexit
 import asyncio
+import atexit
 import collections
-import numpy as np
 import os
-import pytest
 import signal
 import sys
 import time
 
+import numpy as np
+import pytest
+
 import ray
-from ray.actor import exit_actor
-from ray.exceptions import AsyncioActorExit
 import ray.cluster_utils
 from ray._private.test_utils import (
+    SignalActor,
+    generate_system_config_map,
     wait_for_condition,
     wait_for_pid_to_exit,
-    generate_system_config_map,
-    SignalActor,
 )
+from ray.actor import exit_actor
+from ray.exceptions import AsyncioActorExit
 
 SIGKILL = signal.SIGKILL if sys.platform != "win32" else signal.SIGTERM
 

--- a/python/ray/tests/test_actor_lifetime.py
+++ b/python/ray/tests/test_actor_lifetime.py
@@ -1,18 +1,17 @@
-import ray
 import os
-import time
 import signal
 import sys
+import time
+
 import pytest
 
-from ray.job_config import JobConfig
-
+import ray
 from ray._private.test_utils import (
     wait_for_condition,
     wait_for_pid_to_exit,
 )
-
 from ray.exceptions import RayActorError
+from ray.job_config import JobConfig
 
 SIGKILL = signal.SIGKILL if sys.platform != "win32" else signal.SIGTERM
 
@@ -81,8 +80,9 @@ def test_default_actor_lifetime(default_actor_lifetime, child_actor_lifetime):
 
 
 if __name__ == "__main__":
-    import pytest
     import sys
+
+    import pytest
 
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))

--- a/python/ray/tests/test_actor_lineage_reconstruction.py
+++ b/python/ray/tests/test_actor_lineage_reconstruction.py
@@ -1,13 +1,12 @@
-import os
 import gc
+import os
 import sys
 
 import pytest
 
 import ray
 from ray._private.test_utils import wait_for_condition
-from ray.core.generated import gcs_pb2
-from ray.core.generated import common_pb2
+from ray.core.generated import common_pb2, gcs_pb2
 
 
 def test_actor_reconstruction_triggered_by_lineage_reconstruction(ray_start_cluster):

--- a/python/ray/tests/test_actor_out_of_order.py
+++ b/python/ray/tests/test_actor_out_of_order.py
@@ -51,6 +51,7 @@ def test_async_actor_execute_out_of_order(shutdown_only):
 
 if __name__ == "__main__":
     import os
+
     import pytest
 
     # Test suite is timing out. Disable on windows for now.

--- a/python/ray/tests/test_actor_pool.py
+++ b/python/ray/tests/test_actor_pool.py
@@ -2,6 +2,7 @@ import asyncio
 import sys
 import time
 from unittest.mock import MagicMock
+
 import pytest
 
 import ray

--- a/python/ray/tests/test_actor_state_metrics.py
+++ b/python/ray/tests/test_actor_state_metrics.py
@@ -1,19 +1,19 @@
 import asyncio
-from collections import defaultdict
-import pytest
 import time
+from collections import defaultdict
 from typing import Dict
 
-import ray
-from ray._private.utils import hex_to_binary
+import pytest
 
-from ray.util.state import list_actors
+import ray
 from ray._private.test_utils import (
     raw_metrics,
-    wait_for_condition,
     run_string_as_driver,
+    wait_for_condition,
 )
+from ray._private.utils import hex_to_binary
 from ray._private.worker import RayContext
+from ray.util.state import list_actors
 
 _SYSTEM_CONFIG = {
     "metrics_report_interval_ms": 200,
@@ -317,8 +317,8 @@ def test_get_all_actors_info(shutdown_only):
 
 
 if __name__ == "__main__":
-    import sys
     import os
+    import sys
 
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))

--- a/python/ray/tests/test_advanced.py
+++ b/python/ray/tests/test_advanced.py
@@ -11,15 +11,15 @@ import pytest
 import ray._private.profiling as profiling
 import ray.cluster_utils
 from ray._private.internal_api import (
-    memory_summary,
     get_local_ongoing_lineage_reconstruction_tasks,
+    memory_summary,
 )
 from ray._private.test_utils import (
     client_test_enabled,
     wait_for_condition,
 )
-from ray.exceptions import ObjectFreedError
 from ray.core.generated import common_pb2
+from ray.exceptions import ObjectFreedError
 
 if client_test_enabled():
     from ray.util.client import ray

--- a/python/ray/tests/test_advanced_2.py
+++ b/python/ray/tests/test_advanced_2.py
@@ -10,8 +10,8 @@ import pytest
 import ray
 import ray.cluster_utils
 from ray._private.test_utils import wait_for_condition
-from ray.util.placement_group import placement_group
 from ray.util.accelerators import AWS_NEURON_CORE
+from ray.util.placement_group import placement_group
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 logger = logging.getLogger(__name__)

--- a/python/ray/tests/test_advanced_3.py
+++ b/python/ray/tests/test_advanced_3.py
@@ -1,14 +1,15 @@
 # coding: utf-8
+import importlib
 import logging
 import os
 import pickle
 import socket
 import sys
 import time
-import importlib
 
 import numpy as np
 import pytest
+import setproctitle
 
 import ray
 import ray._private.ray_constants
@@ -16,8 +17,6 @@ import ray._private.utils
 import ray.cluster_utils
 import ray.util.accelerators
 from ray._private.test_utils import check_call_ray, wait_for_num_actors
-
-import setproctitle
 
 logger = logging.getLogger(__name__)
 

--- a/python/ray/tests/test_advanced_4.py
+++ b/python/ray/tests/test_advanced_4.py
@@ -7,8 +7,8 @@ import ray
 from ray._private.test_utils import (
     Semaphore,
     client_test_enabled,
-    wait_for_condition,
     get_gcs_memory_used,
+    wait_for_condition,
 )
 from ray.experimental.internal_kv import _internal_kv_list
 
@@ -268,6 +268,7 @@ def test_function_table_gc_actor(call_ray_start):
 
 if __name__ == "__main__":
     import os
+
     import pytest
 
     if os.environ.get("PARALLEL_CI"):

--- a/python/ray/tests/test_advanced_5.py
+++ b/python/ray/tests/test_advanced_5.py
@@ -228,6 +228,7 @@ def test_worker_lease_reply_with_resources(ray_start_cluster_enabled):
 
 if __name__ == "__main__":
     import os
+
     import pytest
 
     if os.environ.get("PARALLEL_CI"):

--- a/python/ray/tests/test_advanced_7.py
+++ b/python/ray/tests/test_advanced_7.py
@@ -264,6 +264,7 @@ def test_task_output_inline_bytes_limit(ray_start_cluster_enabled):
 
 if __name__ == "__main__":
     import os
+
     import pytest
 
     if os.environ.get("PARALLEL_CI"):

--- a/python/ray/tests/test_advanced_9.py
+++ b/python/ray/tests/test_advanced_9.py
@@ -1,24 +1,24 @@
 import os
+import subprocess
 import sys
 import time
 
+import psutil
 import pytest
 
 import ray
 import ray._private.ray_constants as ray_constants
 from ray._private.test_utils import (
     Semaphore,
-    external_redis_test_enabled,
     client_test_enabled,
-    run_string_as_driver,
-    wait_for_condition,
+    external_redis_test_enabled,
     get_gcs_memory_used,
+    run_string_as_driver,
     run_string_as_driver_nonblocking,
+    wait_for_condition,
 )
 from ray.experimental.internal_kv import _internal_kv_list
 from ray.tests.conftest import call_ray_start
-import subprocess
-import psutil
 
 
 @pytest.fixture

--- a/python/ray/tests/test_annotations.py
+++ b/python/ray/tests/test_annotations.py
@@ -3,10 +3,10 @@ import warnings
 
 import pytest
 
-from ray.util.annotations import Deprecated
 from ray._private.test_utils import (
     run_string_as_driver,
 )
+from ray.util.annotations import Deprecated
 
 
 # Use default filterwarnings behavior for this test

--- a/python/ray/tests/test_args.py
+++ b/python/ray/tests/test_args.py
@@ -80,9 +80,10 @@ def test_args_intertwined(ray_start_regular):
 
 
 if __name__ == "__main__":
-    import pytest
     import os
     import sys
+
+    import pytest
 
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))

--- a/python/ray/tests/test_array.py
+++ b/python/ray/tests/test_array.py
@@ -1,13 +1,14 @@
-from importlib import reload
-import numpy as np
-from numpy.testing import assert_equal, assert_almost_equal
-import pytest
 import sys
+from importlib import reload
+
+import numpy as np
+import pytest
+from numpy.testing import assert_almost_equal, assert_equal
 
 import ray
-import ray.experimental.array.remote as ra
-import ray.experimental.array.distributed as da
 import ray.cluster_utils
+import ray.experimental.array.distributed as da
+import ray.experimental.array.remote as ra
 
 
 @pytest.fixture
@@ -244,6 +245,7 @@ def test_distributed_array_methods(ray_start_cluster_2_nodes, reload_modules):
 
 if __name__ == "__main__":
     import os
+
     import pytest
 
     if os.environ.get("PARALLEL_CI"):

--- a/python/ray/tests/test_async.py
+++ b/python/ray/tests/test_async.py
@@ -4,7 +4,6 @@ import sys
 import time
 
 import numpy as np
-
 import pytest
 
 import ray

--- a/python/ray/tests/test_asyncio_cluster.py
+++ b/python/ray/tests/test_asyncio_cluster.py
@@ -2,8 +2,8 @@
 import asyncio
 import sys
 
-import pytest
 import numpy as np
+import pytest
 
 import ray
 from ray.cluster_utils import Cluster, cluster_not_supported
@@ -32,6 +32,7 @@ async def test_asyncio_cluster_wait():
 
 if __name__ == "__main__":
     import os
+
     import pytest
 
     if os.environ.get("PARALLEL_CI"):

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -1,10 +1,10 @@
 import copy
-import logging
-import sys
 import json
+import logging
 import os
 import re
 import shutil
+import sys
 import tempfile
 import time
 import unittest
@@ -20,11 +20,6 @@ import yaml
 from jsonschema.exceptions import ValidationError
 
 import ray
-from ray.tests.autoscaler_test_utils import (
-    MockNode,
-    MockProcessRunner,
-    MockProvider,
-)
 from ray.autoscaler._private import commands
 from ray.autoscaler._private.autoscaler import NonTerminatedNodes, StandardAutoscaler
 from ray.autoscaler._private.commands import get_or_create_head_node
@@ -61,13 +56,16 @@ from ray.autoscaler.tags import (
     TAG_RAY_NODE_STATUS,
     TAG_RAY_USER_NODE_TYPE,
 )
+from ray.core.generated import common_pb2, gcs_pb2
+from ray.exceptions import RpcError
+from ray.tests.autoscaler_test_utils import (
+    MockNode,
+    MockProcessRunner,
+    MockProvider,
+)
 from ray.tests.test_batch_node_provider_unit import (
     MockBatchingNodeProvider,
 )
-from ray.exceptions import RpcError
-
-from ray.core.generated import gcs_pb2, common_pb2
-
 
 WORKER_FILTER = {TAG_RAY_NODE_KIND: NODE_KIND_WORKER}
 

--- a/python/ray/tests/test_autoscaler_e2e.py
+++ b/python/ray/tests/test_autoscaler_e2e.py
@@ -1,15 +1,16 @@
 import subprocess
-from ray.autoscaler._private.constants import AUTOSCALER_METRIC_PORT
+import sys
 
 import pytest
+
 import ray
-import sys
 from ray._private.test_utils import (
-    wait_for_condition,
-    get_metric_check_condition,
     MetricSamplePattern,
     SignalActor,
+    get_metric_check_condition,
+    wait_for_condition,
 )
+from ray.autoscaler._private.constants import AUTOSCALER_METRIC_PORT
 from ray.autoscaler.node_launch_exception import NodeLaunchException
 
 
@@ -369,6 +370,7 @@ def test_infeasible_task_early_cancellation_actor_creation(
 
 if __name__ == "__main__":
     import os
+
     import pytest
 
     if os.environ.get("PARALLEL_CI"):

--- a/python/ray/tests/test_autoscaler_fake_multinode.py
+++ b/python/ray/tests/test_autoscaler_fake_multinode.py
@@ -1,9 +1,10 @@
-import pytest
 import platform
+import time
+
+import pytest
 
 import ray
 from ray.cluster_utils import AutoscalingCluster
-import time
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="Failing on Windows.")

--- a/python/ray/tests/test_autoscaler_util.py
+++ b/python/ray/tests/test_autoscaler_util.py
@@ -1,7 +1,7 @@
 import os
 import sys
-import pytest
 
+import pytest
 
 from ray.autoscaler._private.util import with_envs, with_head_node_ip
 

--- a/python/ray/tests/test_autoscaler_yaml.py
+++ b/python/ray/tests/test_autoscaler_yaml.py
@@ -3,9 +3,10 @@ import logging
 import os
 import sys
 import tempfile
-from typing import Dict, Any
 import unittest
 import urllib
+from typing import Any, Dict
+from unittest import mock
 from unittest.mock import MagicMock, Mock, patch
 
 import jsonschema
@@ -13,7 +14,6 @@ import pytest
 import yaml
 from click.exceptions import ClickException
 
-from unittest import mock
 from ray._private.test_utils import load_test_config, recursive_fnmatch
 from ray.autoscaler._private._azure.config import (
     _configure_key_pair as _azure_configure_key_pair,

--- a/python/ray/tests/test_autoscaling_policy.py
+++ b/python/ray/tests/test_autoscaling_policy.py
@@ -1,38 +1,39 @@
 import collections
 import copy
 import logging
-import yaml
-import tempfile
-from typing import Dict, Callable, List
 import shutil
-from queue import PriorityQueue
+import tempfile
 import unittest
+from queue import PriorityQueue
+from typing import Callable, Dict, List
+
 import pytest
+import yaml
 
 import ray
-from ray.tests.test_autoscaler import (
-    MockProvider,
-    MockProcessRunner,
-    MockGcsClient,
-    mock_raylet_id,
-    MockAutoscaler,
-)
-from ray.tests.test_resource_demand_scheduler import MULTI_WORKER_CLUSTER
+from ray._private.gcs_utils import PlacementGroupTableData
+from ray.autoscaler._private.cli_logger import cli_logger
+from ray.autoscaler._private.constants import AUTOSCALER_UPDATE_INTERVAL_S
+from ray.autoscaler._private.load_metrics import LoadMetrics
+from ray.autoscaler._private.node_launcher import NodeLauncher
 from ray.autoscaler._private.providers import (
     _NODE_PROVIDERS,
     _clear_provider_cache,
 )
-from ray.autoscaler._private.load_metrics import LoadMetrics
-from ray.autoscaler._private.node_launcher import NodeLauncher
 from ray.autoscaler.tags import (
-    TAG_RAY_USER_NODE_TYPE,
-    TAG_RAY_NODE_KIND,
     NODE_KIND_HEAD,
+    TAG_RAY_NODE_KIND,
+    TAG_RAY_USER_NODE_TYPE,
 )
-from ray.autoscaler._private.constants import AUTOSCALER_UPDATE_INTERVAL_S
-from ray.autoscaler._private.cli_logger import cli_logger
 from ray.core.generated.common_pb2 import Bundle, PlacementStrategy
-from ray._private.gcs_utils import PlacementGroupTableData
+from ray.tests.test_autoscaler import (
+    MockAutoscaler,
+    MockGcsClient,
+    MockProcessRunner,
+    MockProvider,
+    mock_raylet_id,
+)
+from ray.tests.test_resource_demand_scheduler import MULTI_WORKER_CLUSTER
 
 
 class Task:

--- a/python/ray/tests/test_basic_4.py
+++ b/python/ray/tests/test_basic_4.py
@@ -1,20 +1,19 @@
 # coding: utf-8
 import logging
+import os
 import subprocess
 import sys
 import time
 from pathlib import Path
-import os
-
-import pytest
 from unittest import mock
+
+import psutil
+import pytest
 
 import ray
 import ray.cluster_utils
 from ray._private.test_utils import wait_for_condition
 from ray.autoscaler._private.constants import RAY_PROCESSES
-
-import psutil
 
 logger = logging.getLogger(__name__)
 

--- a/python/ray/tests/test_basic_5.py
+++ b/python/ray/tests/test_basic_5.py
@@ -2,22 +2,22 @@
 import gc
 import logging
 import os
+import subprocess
 import sys
 import time
-import subprocess
-from unittest.mock import Mock, patch
 import unittest
+from unittest.mock import Mock, patch
 
 import pytest
 
 import ray
 import ray.cluster_utils
+from ray._private.resource_spec import HEAD_NODE_RESOURCE_NAME
 from ray._private.test_utils import (
+    client_test_enabled,
     run_string_as_driver,
     wait_for_pid_to_exit,
-    client_test_enabled,
 )
-from ray._private.resource_spec import HEAD_NODE_RESOURCE_NAME
 
 logger = logging.getLogger(__name__)
 

--- a/python/ray/tests/test_batch_node_provider_integration.py
+++ b/python/ray/tests/test_batch_node_provider_integration.py
@@ -1,21 +1,21 @@
 """Integration/e2e test for BatchingNodeProvider.
 Adapts FakeMultiNodeProvider tests.
 """
-from copy import deepcopy
+import logging
 import sys
+from copy import deepcopy
 
 import pytest
 
-
 import ray
 from ray._private.test_utils import wait_for_condition
+from ray.autoscaler._private.constants import FOREGROUND_NODE_LAUNCH_KEY
+from ray.autoscaler._private.fake_multi_node.node_provider import FakeMultiNodeProvider
 from ray.autoscaler.batching_node_provider import (
     BatchingNodeProvider,
     NodeData,
     ScaleRequest,
 )
-from ray.autoscaler._private.fake_multi_node.node_provider import FakeMultiNodeProvider
-from ray.autoscaler._private.constants import FOREGROUND_NODE_LAUNCH_KEY
 from ray.autoscaler.tags import (
     NODE_KIND_WORKER,
     STATUS_UP_TO_DATE,
@@ -24,9 +24,6 @@ from ray.autoscaler.tags import (
     TAG_RAY_USER_NODE_TYPE,
 )
 from ray.cluster_utils import AutoscalingCluster
-
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/python/ray/tests/test_batch_node_provider_unit.py
+++ b/python/ray/tests/test_batch_node_provider_unit.py
@@ -1,35 +1,35 @@
 """Unit test for BatchingNodeProvider.
 Validates BatchingNodeProvider's book-keeping logic.
 """
-from copy import copy
-from uuid import uuid4
 import os
 import random
 import sys
-from typing import Any, Dict
 from collections import defaultdict
+from copy import copy
+from typing import Any, Dict
+from uuid import uuid4
 
 import pytest
 
+from ray.autoscaler._private.constants import (
+    DISABLE_LAUNCH_CONFIG_CHECK_KEY,
+    DISABLE_NODE_UPDATERS_KEY,
+    FOREGROUND_NODE_LAUNCH_KEY,
+)
+from ray.autoscaler._private.util import NodeID, NodeType
 from ray.autoscaler.batching_node_provider import (
     BatchingNodeProvider,
     NodeData,
     ScaleRequest,
 )
-from ray.autoscaler._private.util import NodeID, NodeType
 from ray.autoscaler.tags import (
+    NODE_KIND_HEAD,
+    NODE_KIND_WORKER,
     STATUS_UP_TO_DATE,
-    TAG_RAY_USER_NODE_TYPE,
     TAG_RAY_NODE_KIND,
     TAG_RAY_NODE_STATUS,
     TAG_RAY_REPLICA_INDEX,
-    NODE_KIND_HEAD,
-    NODE_KIND_WORKER,
-)
-from ray.autoscaler._private.constants import (
-    DISABLE_LAUNCH_CONFIG_CHECK_KEY,
-    DISABLE_NODE_UPDATERS_KEY,
-    FOREGROUND_NODE_LAUNCH_KEY,
+    TAG_RAY_USER_NODE_TYPE,
 )
 
 

--- a/python/ray/tests/test_bounded_unix_sockets.py
+++ b/python/ray/tests/test_bounded_unix_sockets.py
@@ -1,11 +1,11 @@
-import sys
+import logging
 import os
+import sys
+
+import psutil
+import pytest
 
 import ray
-import logging
-import psutil
-
-import pytest
 
 logger = logging.getLogger(__name__)
 

--- a/python/ray/tests/test_cancel.py
+++ b/python/ray/tests/test_cancel.py
@@ -1,23 +1,23 @@
+import _thread
 import os
 import random
 import signal
 import sys
 import threading
-import _thread
 import time
 
 import pytest
 
 import ray
-from ray.exceptions import (
-    TaskCancelledError,
-    RayTaskError,
-    GetTimeoutError,
-    WorkerCrashedError,
-    ObjectLostError,
-)
-from ray._private.utils import DeferSigint
 from ray._private.test_utils import SignalActor, wait_for_condition
+from ray._private.utils import DeferSigint
+from ray.exceptions import (
+    GetTimeoutError,
+    ObjectLostError,
+    RayTaskError,
+    TaskCancelledError,
+    WorkerCrashedError,
+)
 from ray.util.state import list_tasks
 
 

--- a/python/ray/tests/test_channel.py
+++ b/python/ray/tests/test_channel.py
@@ -1,7 +1,7 @@
 # coding: utf-8
-import pickle
 import logging
 import os
+import pickle
 import sys
 import time
 import traceback
@@ -14,11 +14,11 @@ import ray
 import ray.cluster_utils
 import ray.exceptions
 import ray.experimental.channel as ray_channel
-from ray.experimental.channel.torch_tensor_type import TorchTensorType
-from ray.exceptions import RayChannelError, RayChannelTimeoutError
-from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
-from ray.dag.compiled_dag_node import CompiledDAG
 from ray._private.test_utils import get_actor_node_id
+from ray.dag.compiled_dag_node import CompiledDAG
+from ray.exceptions import RayChannelError, RayChannelTimeoutError
+from ray.experimental.channel.torch_tensor_type import TorchTensorType
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 logger = logging.getLogger(__name__)
 

--- a/python/ray/tests/test_chaos.py
+++ b/python/ray/tests/test_chaos.py
@@ -1,25 +1,24 @@
-import sys
 import random
-
-import ray
-
-import pytest
+import sys
 import time
 
+import pytest
+
+import ray
+from ray._private.test_utils import (
+    RayletKiller,
+    WorkerKillerActor,
+    get_and_run_resource_killer,
+    get_log_message,
+    wait_for_condition,
+)
+from ray.cluster_utils import AutoscalingCluster
+from ray.exceptions import ObjectLostError, RayTaskError
 from ray.experimental import shuffle
 from ray.tests.conftest import _ray_start_chaos_cluster
 from ray.util.placement_group import placement_group
-from ray._private.test_utils import (
-    RayletKiller,
-    get_log_message,
-    get_and_run_resource_killer,
-    WorkerKillerActor,
-    wait_for_condition,
-)
-from ray.exceptions import RayTaskError, ObjectLostError
-from ray.util.state.common import ListApiOptions, StateResource
 from ray.util.state.api import StateApiClient, list_nodes
-from ray.cluster_utils import AutoscalingCluster
+from ray.util.state.common import ListApiOptions, StateResource
 
 
 def assert_no_system_failure(p, timeout):
@@ -318,6 +317,7 @@ def test_node_killer_filter(autoscaler_v2):
 
 if __name__ == "__main__":
     import os
+
     import pytest
 
     if os.environ.get("PARALLEL_CI"):

--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -18,6 +18,7 @@ Note: config cache does not work with AWS mocks since the AWS resource ids are
       randomized each time.
 """
 import glob
+import json
 import multiprocessing as mp
 import multiprocessing.connection
 import os
@@ -25,16 +26,17 @@ import re
 import sys
 import tempfile
 import threading
-import json
 import time
 import uuid
 from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Optional
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import moto
+import psutil
 import pytest
 from click.testing import CliRunner
 from moto import mock_ec2, mock_iam
@@ -42,18 +44,15 @@ from testfixtures import Replacer
 from testfixtures.popen import MockPopen, PopenBehaviour
 
 import ray
+import ray._private.ray_constants as ray_constants
+import ray._private.utils as utils
 import ray.autoscaler._private.aws.config as aws_config
 import ray.autoscaler._private.constants as autoscaler_constants
-import ray._private.ray_constants as ray_constants
 import ray.scripts.scripts as scripts
-import ray._private.utils as utils
-from ray.util.check_open_ports import check_open_ports
 from ray._private.test_utils import wait_for_condition
 from ray.cluster_utils import cluster_not_supported
+from ray.util.check_open_ports import check_open_ports
 from ray.util.state import list_nodes
-from http.server import BaseHTTPRequestHandler, HTTPServer
-
-import psutil
 
 boto3_list = [
     {

--- a/python/ray/tests/test_cli_logger.py
+++ b/python/ray/tests/test_cli_logger.py
@@ -1,7 +1,9 @@
-from ray.autoscaler._private import cli_logger
 import io
 from unittest.mock import patch
+
 import pytest
+
+from ray.autoscaler._private import cli_logger
 
 
 def test_colorful_mock_with_style():

--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -6,8 +6,8 @@ import re
 import sys
 import threading
 import time
-from unittest.mock import Mock
 from typing import Type
+from unittest.mock import Mock
 
 import numpy as np
 import pytest

--- a/python/ray/tests/test_client_builder.py
+++ b/python/ray/tests/test_client_builder.py
@@ -12,8 +12,8 @@ import ray.util.client.server.server as ray_client_server
 from ray._private.test_utils import (
     run_string_as_driver,
     run_string_as_driver_nonblocking,
-    wait_for_condition,
     skip_flaky_core_test_premerge,
+    wait_for_condition,
 )
 from ray.util.state import list_workers
 

--- a/python/ray/tests/test_client_init.py
+++ b/python/ray/tests/test_client_init.py
@@ -1,19 +1,17 @@
 """Client tests that run their own init (as with init_and_serve) live here"""
-import pytest
-
-import time
 import random
-import sys
 import subprocess
+import sys
+import time
 from unittest.mock import patch
 
-import ray.util.client.server.server as ray_client_server
-import ray.core.generated.ray_client_pb2 as ray_client_pb2
-
-from ray.util.client import _ClientContext
-from ray.cluster_utils import cluster_not_supported
+import pytest
 
 import ray
+import ray.core.generated.ray_client_pb2 as ray_client_pb2
+import ray.util.client.server.server as ray_client_server
+from ray.cluster_utils import cluster_not_supported
+from ray.util.client import _ClientContext
 
 
 @ray.remote
@@ -197,6 +195,7 @@ def test_max_clients(init_and_serve):
 
 if __name__ == "__main__":
     import os
+
     import pytest
 
     if os.environ.get("PARALLEL_CI"):

--- a/python/ray/tests/test_client_metadata.py
+++ b/python/ray/tests/test_client_metadata.py
@@ -1,9 +1,8 @@
 import pytest
 
-from ray.util.client.ray_client_helpers import ray_start_client_server
 from ray._raylet import NodeID
-
 from ray.runtime_context import RuntimeContext
+from ray.util.client.ray_client_helpers import ray_start_client_server
 
 
 def test_get_ray_metadata(ray_start_regular_shared):

--- a/python/ray/tests/test_client_multi.py
+++ b/python/ray/tests/test_client_multi.py
@@ -1,6 +1,8 @@
 import os
 import sys
+
 import pytest
+
 import ray
 
 

--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -4,8 +4,8 @@ import random
 import sys
 import time
 from glob import glob
-from unittest.mock import patch, MagicMock
 from itertools import chain
+from unittest.mock import MagicMock, patch
 
 import grpc
 import pytest

--- a/python/ray/tests/test_client_reconnect.py
+++ b/python/ray/tests/test_client_reconnect.py
@@ -1,21 +1,21 @@
-from concurrent import futures
 import contextlib
 import os
-import threading
+import random
 import sys
+import threading
+import time
+from concurrent import futures
+from typing import Any, Callable, Optional
+from unittest.mock import Mock, patch
+
 import grpc
 import numpy as np
-
-import time
-import random
 import pytest
-from typing import Any, Callable, Optional
-from unittest.mock import patch, Mock
 
 import ray
-from ray._common.utils import get_or_create_event_loop
 import ray.core.generated.ray_client_pb2 as ray_client_pb2
 import ray.core.generated.ray_client_pb2_grpc as ray_client_pb2_grpc
+from ray._common.utils import get_or_create_event_loop
 from ray.tests.conftest import call_ray_start_context
 from ray.util.client.common import CLIENT_SERVER_MAX_THREADS, GRPC_OPTIONS
 

--- a/python/ray/tests/test_client_terminate.py
+++ b/python/ray/tests/test_client_terminate.py
@@ -138,9 +138,10 @@ def test_kill_cancel_metadata(ray_start_regular):
 
 
 if __name__ == "__main__":
-    import pytest
     import os
     import sys
+
+    import pytest
 
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))

--- a/python/ray/tests/test_client_warnings.py
+++ b/python/ray/tests/test_client_warnings.py
@@ -1,10 +1,10 @@
-from ray.util.client.ray_client_helpers import ray_start_client_server
-from ray.util.debug import _logged
+import unittest
 
 import numpy as np
 import pytest
 
-import unittest
+from ray.util.client.ray_client_helpers import ray_start_client_server
+from ray.util.debug import _logged
 
 
 @pytest.fixture(autouse=True)
@@ -36,6 +36,7 @@ class LoggerSuite(unittest.TestCase):
 if __name__ == "__main__":
     import os
     import sys
+
     import pytest
 
     if os.environ.get("PARALLEL_CI"):

--- a/python/ray/tests/test_command_runner.py
+++ b/python/ray/tests/test_command_runner.py
@@ -1,15 +1,16 @@
+import hashlib
+from getpass import getuser
+
 import pytest
 
-from ray.tests.test_autoscaler import MockProvider, MockProcessRunner
-from ray.autoscaler.command_runner import CommandRunnerInterface
 from ray.autoscaler._private.command_runner import (
-    SSHCommandRunner,
     DockerCommandRunner,
+    SSHCommandRunner,
     _with_environment_variables,
 )
+from ray.autoscaler.command_runner import CommandRunnerInterface
 from ray.autoscaler.sdk import get_docker_host_mount_location
-from getpass import getuser
-import hashlib
+from ray.tests.test_autoscaler import MockProcessRunner, MockProvider
 
 auth_config = {
     "ssh_user": "ray",

--- a/python/ray/tests/test_component_failures_2.py
+++ b/python/ray/tests/test_component_failures_2.py
@@ -142,6 +142,7 @@ def test_get_node_info_after_raylet_died(ray_start_cluster_head):
 
 if __name__ == "__main__":
     import os
+
     import pytest
 
     if os.environ.get("PARALLEL_CI"):

--- a/python/ray/tests/test_component_failures_3.py
+++ b/python/ray/tests/test_component_failures_3.py
@@ -117,6 +117,7 @@ def test_dying_worker(ray_start_2_cpus):
 
 if __name__ == "__main__":
     import os
+
     import pytest
 
     if os.environ.get("PARALLEL_CI"):

--- a/python/ray/tests/test_coordinator_server.py
+++ b/python/ray/tests/test_coordinator_server.py
@@ -1,31 +1,32 @@
+import json
 import os
 import random
-import unittest
 import socket
-import json
+import unittest
 
-from ray.autoscaler.local.coordinator_server import OnPremCoordinatorServer
-from ray.autoscaler._private.providers import _NODE_PROVIDERS, _get_node_provider
+import pytest
+
+from ray._private.utils import get_ray_temp_dir
 from ray.autoscaler._private.local import config as local_config
-from ray.autoscaler._private.local.node_provider import LocalNodeProvider
-from ray.autoscaler._private.local.node_provider import (
-    record_local_head_state_if_needed,
-)
 from ray.autoscaler._private.local.coordinator_node_provider import (
     CoordinatorSenderNodeProvider,
 )
-from ray.autoscaler.tags import (
-    TAG_RAY_NODE_KIND,
-    TAG_RAY_CLUSTER_NAME,
-    TAG_RAY_NODE_NAME,
-    NODE_KIND_WORKER,
-    NODE_KIND_HEAD,
-    TAG_RAY_USER_NODE_TYPE,
-    TAG_RAY_NODE_STATUS,
-    STATUS_UP_TO_DATE,
+from ray.autoscaler._private.local.node_provider import (
+    LocalNodeProvider,
+    record_local_head_state_if_needed,
 )
-from ray._private.utils import get_ray_temp_dir
-import pytest
+from ray.autoscaler._private.providers import _NODE_PROVIDERS, _get_node_provider
+from ray.autoscaler.local.coordinator_server import OnPremCoordinatorServer
+from ray.autoscaler.tags import (
+    NODE_KIND_HEAD,
+    NODE_KIND_WORKER,
+    STATUS_UP_TO_DATE,
+    TAG_RAY_CLUSTER_NAME,
+    TAG_RAY_NODE_KIND,
+    TAG_RAY_NODE_NAME,
+    TAG_RAY_NODE_STATUS,
+    TAG_RAY_USER_NODE_TYPE,
+)
 
 
 class OnPremCoordinatorServerTest(unittest.TestCase):

--- a/python/ray/tests/test_core_worker_io_thread_stack_size.py
+++ b/python/ray/tests/test_core_worker_io_thread_stack_size.py
@@ -1,6 +1,8 @@
 import os
 import sys
+
 import pytest
+
 import ray
 
 

--- a/python/ray/tests/test_cross_language.py
+++ b/python/ray/tests/test_cross_language.py
@@ -1,5 +1,6 @@
-import pytest
 import sys
+
+import pytest
 
 import ray
 import ray.cluster_utils

--- a/python/ray/tests/test_dashboard_profiler.py
+++ b/python/ray/tests/test_dashboard_profiler.py
@@ -1,8 +1,9 @@
-import pytest
-import subprocess
 import os
-import requests
+import subprocess
 import sys
+
+import pytest
+import requests
 
 import ray
 from ray._private.test_utils import (

--- a/python/ray/tests/test_debug_tools.py
+++ b/python/ray/tests/test_debug_tools.py
@@ -1,15 +1,13 @@
 import os
 import subprocess
 import sys
-
-import pytest
 from pathlib import Path
 
+import pytest
+
 import ray
-
-import ray._private.services as services
 import ray._private.ray_constants as ray_constants
-
+import ray._private.services as services
 from ray._private.test_utils import wait_for_condition
 
 

--- a/python/ray/tests/test_distributed_sort.py
+++ b/python/ray/tests/test_distributed_sort.py
@@ -1,5 +1,6 @@
-import pytest
 import sys
+
+import pytest
 
 from ray.experimental.raysort import main
 

--- a/python/ray/tests/test_draining.py
+++ b/python/ray/tests/test_draining.py
@@ -1,11 +1,12 @@
 import sys
+import time
+
 import pytest
 
 import ray
-import time
+from ray._private.test_utils import wait_for_condition
 from ray._raylet import GcsClient
 from ray.core.generated import autoscaler_pb2, common_pb2
-from ray._private.test_utils import wait_for_condition
 from ray.util.scheduling_strategies import (
     NodeAffinitySchedulingStrategy,
     PlacementGroupSchedulingStrategy,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Follow-up for https://github.com/ray-project/ray/pull/52712

## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
