### PR TITLE
[docstring] fix indentation of note for Dataset.repartition

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1510,10 +1510,10 @@ class Dataset:
             sort: Whether the blocks should be sorted after repartitioning. Note,
                 that by default blocks will be sorted in the ascending order.
 
-            Note that either `num_blocks` or `target_num_rows_per_block` must be set
-            here, but not both.
-            Additionally, note that, this operation will materialized whole dataset in memory
-            when shuffle is set to True.
+        Note that either `num_blocks` or `target_num_rows_per_block` must be set
+        here, but not both.
+        Additionally, note that, this operation will materialized whole dataset in memory
+        when shuffle is set to True.
 
         Returns:
             The repartitioned :class:`Dataset`.

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1510,10 +1510,10 @@ class Dataset:
             sort: Whether the blocks should be sorted after repartitioning. Note,
                 that by default blocks will be sorted in the ascending order.
 
-        Note that either `num_blocks` or `target_num_rows_per_block` must be set
-        here, but not both.
-        Additionally, note that, this operation will materialized whole dataset in memory
-        when shuffle is set to True.
+        Note that you must set either `num_blocks` or `target_num_rows_per_block`
+        but not both.
+        Additionally note that this operation materializes the entire dataset in memory
+        when you set shuffle to True.
 
         Returns:
             The repartitioned :class:`Dataset`.

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1681,7 +1681,6 @@ class Dataset:
         from ray.data._internal.execution.interfaces.task_context import TaskContext
 
         def random_sample(batch: DataBatch, seed: Optional[int]):
-
             ctx = TaskContext.get_current()
 
             if "rng" in ctx.kwargs:


### PR DESCRIPTION
broken text after Parameters section.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
