### PR TITLE
[data] fix test_logging_dataset timedout flakiness

### DIFF
--- a/python/ray/data/_internal/logging.py
+++ b/python/ray/data/_internal/logging.py
@@ -212,9 +212,14 @@ def reset_logging() -> None:
 
     Used for testing.
     """
+    global _DATASET_LOGGER_HANDLER
+    global _ACTIVE_DATASET
     logger = logging.getLogger("ray.data")
     logger.handlers.clear()
     logger.setLevel(logging.NOTSET)
+
+    _DATASET_LOGGER_HANDLER = {}
+    _ACTIVE_DATASET = None
 
 
 def get_log_directory() -> Optional[str]:

--- a/python/ray/data/tests/test_logging_dataset.py
+++ b/python/ray/data/tests/test_logging_dataset.py
@@ -73,10 +73,10 @@ def test_dataset_logging_concurrent(ray_start_regular_shared, reset_logging):
         time.sleep(1)
         return x
 
-    ds01 = ray.data.range(100, override_num_blocks=20).map_batches(_short)
+    ds01 = ray.data.range(1).map_batches(_short)
     ds01.set_name("test_dataset_logging_concurrent_01")
 
-    ds02 = ray.data.range(100, override_num_blocks=20).map_batches(_long)
+    ds02 = ray.data.range(1).map_batches(_long)
     ds02.set_name("test_dataset_logging_concurrent_02")
 
     with ThreadPoolExecutor() as executor:
@@ -106,11 +106,11 @@ def test_dataset_logging_sequential(ray_start_regular_shared, reset_logging):
         time.sleep(1)
         return x
 
-    ds01 = ray.data.range(100, override_num_blocks=20).map_batches(_short)
+    ds01 = ray.data.range(1).map_batches(_short)
     ds01.set_name("test_dataset_logging_sequential_01")
     ds01.materialize()
 
-    ds02 = ray.data.range(100, override_num_blocks=20).map_batches(_long)
+    ds02 = ray.data.range(1).map_batches(_long)
     ds02.set_name("test_dataset_logging_sequential_02")
     ds02.materialize()
 


### PR DESCRIPTION
Fix `test_logging_dataset` timedout flakiness; we don't need to run that many tasks (which have sleeps), just one task is enough.

Test:
- CI