### PR TITLE
[core] No need to resend out of order completed tasks

### DIFF
--- a/src/ray/core_worker/test/actor_submit_queue_test.cc
+++ b/src/ray/core_worker/test/actor_submit_queue_test.cc
@@ -75,8 +75,6 @@ TEST(OutofOrderActorSubmitQueueTest, PassThroughTest) {
   EXPECT_EQ(queue.PopNextTaskToSend()->first.ActorCounter(), 3);
   EXPECT_FALSE(queue.PopNextTaskToSend().has_value());
 
-  EXPECT_TRUE(queue.PopAllOutOfOrderCompletedTasks().empty());
-
   // only contains task 2 and 4.
   for (uint64_t i = 0; i < 5; i++) {
     if (i == 0 || i == 2) {

--- a/src/ray/core_worker/test/direct_actor_transport_test.cc
+++ b/src/ray/core_worker/test/direct_actor_transport_test.cc
@@ -521,22 +521,12 @@ TEST_P(ActorTaskSubmitterTest, TestActorRestartOutOfOrderRetry) {
   addr.set_port(1);
   submitter_.ConnectActor(actor_id, addr, 1);
 
-  if (execute_out_of_order) {
-    // Upon re-connect, task 2 (failed) should be both retried.
-    // Retry task 2 manually (simulating task_finisher and SendPendingTask's behavior)
-    ASSERT_TRUE(CheckSubmitTask(task2));
+  // Upon re-connect, task 2 (failed) should be retried.
+  // Retry task 2 manually (simulating task_finisher and SendPendingTask's behavior)
+  ASSERT_TRUE(CheckSubmitTask(task2));
 
-    // Only task2 should be submitted.
-    ASSERT_EQ(worker_client_->callbacks.size(), 1);
-  } else {
-    // Upon re-connect, task 2 (failed) and 3 (completed) should be both retried.
-    // Retry task 2 manually (simulating task_finisher and SendPendingTask's behavior)
-    // Retry task 3 should happen via event loop
-    ASSERT_TRUE(CheckSubmitTask(task2));
-
-    // Both task2 and task3 should be submitted.
-    ASSERT_EQ(worker_client_->callbacks.size(), 2);
-  }
+  // Only task2 should be submitted. task 3 (completed) should not be retried.
+  ASSERT_EQ(worker_client_->callbacks.size(), 1);
 
   // Finishes all task
   while (!worker_client_->callbacks.empty()) {

--- a/src/ray/core_worker/transport/actor_submit_queue.h
+++ b/src/ray/core_worker/transport/actor_submit_queue.h
@@ -32,15 +32,10 @@ namespace core {
  * The task is not ready until it's being marked as
  * MarkDependencyResolved; and being removed from the queue if it's beking marked as
  * MarkDependencyFailed.
- * The caller should call PopNextTaskToSend to find next task to send; and once the
- * task is known to send, MarkSeqnoCompleted is expected to be called to remove
- * the task from sending queue.
+ * The caller should call PopNextTaskToSend to find next task to send.
  * This queue is also aware of client connection/reconnection, so it needs to
  * call OnClientConnected whenever client is connected, and use GetSequenceNumber
  * to know the actual sequence_no to send over the network.
- * For some of the implementation (such as SequentialActorSubmitQueue), it guarantees
- * the sequential order between client and server and works with retry/actor restart,
- * so PopAllOutOfOrderCompletedTasks is called during actor restart.
  *
  * This class is not thread safe.
  * TODO(scv119): the protocol could be improved.
@@ -71,14 +66,8 @@ class IActorSubmitQueue {
   ///   - a pair of task and bool represents the task to be send and if the receiver
   ///     should SKIP THE SCHEDULING QUEUE while executing it.
   virtual std::optional<std::pair<TaskSpecification, bool>> PopNextTaskToSend() = 0;
-  /// On client connect/reconnect, find all the tasks that's known to be
-  /// executed out of order. This is specific to SequentialActorSubmitQueue.
-  virtual std::map<uint64_t, TaskSpecification> PopAllOutOfOrderCompletedTasks() = 0;
   /// Get the sequence number of the task to send according to the protocol.
   virtual uint64_t GetSequenceNumber(const TaskSpecification &task_spec) const = 0;
-  /// Mark a task has been executed on the receiver side.
-  virtual void MarkSeqnoCompleted(uint64_t sequence_no,
-                                  const TaskSpecification &task_spec) = 0;
   virtual bool Empty() = 0;
 };
 }  // namespace core

--- a/src/ray/core_worker/transport/actor_task_submitter.h
+++ b/src/ray/core_worker/transport/actor_task_submitter.h
@@ -397,18 +397,6 @@ class ActorTaskSubmitter : public ActorTaskSubmitterInterface {
   /// \return Void.
   void SendPendingTasks(const ActorID &actor_id) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
-  /// Resend all previously-received, out-of-order, received tasks for an actor.
-  /// When sending these tasks, the tasks will have the flag skip_execution=true.
-  ///
-  /// This is useful because we want the replies to be in-order. For the out of order
-  /// completed tasks we resend them to the new restarted actor with skip_execution=True
-  /// and expect those tasks replies to fill the seqno.
-  ///
-  /// \param[in] actor_id Actor ID.
-  /// \return Void.
-  void ResendOutOfOrderCompletedTasks(const ActorID &actor_id)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
-
   /// Disconnect the RPC client for an actor.
   void DisconnectRpcClient(ClientQueue &queue) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
 

--- a/src/ray/core_worker/transport/out_of_order_actor_submit_queue.cc
+++ b/src/ray/core_worker/transport/out_of_order_actor_submit_queue.cc
@@ -97,18 +97,10 @@ OutofOrderActorSubmitQueue::PopNextTaskToSend() {
   return std::make_pair(std::move(task_spec), /*skip_queue*/ true);
 }
 
-std::map<uint64_t, TaskSpecification>
-OutofOrderActorSubmitQueue::PopAllOutOfOrderCompletedTasks() {
-  return {};
-}
-
 uint64_t OutofOrderActorSubmitQueue::GetSequenceNumber(
     const TaskSpecification &task_spec) const {
   return task_spec.ActorCounter();
 }
-
-void OutofOrderActorSubmitQueue::MarkSeqnoCompleted(uint64_t position,
-                                                    const TaskSpecification &task_spec) {}
 
 }  // namespace core
 }  // namespace ray

--- a/src/ray/core_worker/transport/out_of_order_actor_submit_queue.h
+++ b/src/ray/core_worker/transport/out_of_order_actor_submit_queue.h
@@ -59,14 +59,9 @@ class OutofOrderActorSubmitQueue : public IActorSubmitQueue {
   ///   - a pair of task and bool represents the task to be send and if the receiver
   ///     should SKIP THE SCHEDULING QUEUE while executing it.
   std::optional<std::pair<TaskSpecification, bool>> PopNextTaskToSend() override;
-  /// On client connect/reconnect, find all the TASK that's known to be
-  /// executed out of order. This ALWAYS RETURNS empty.
-  std::map<uint64_t, TaskSpecification> PopAllOutOfOrderCompletedTasks() override;
   /// Get the sequence number of the task to send.
   /// This is ignored by the receivier but only for debugging purpose.
   uint64_t GetSequenceNumber(const TaskSpecification &task_spec) const override;
-  /// Mark a task has been executed on the receiver side.
-  void MarkSeqnoCompleted(uint64_t position, const TaskSpecification &task_spec) override;
   bool Empty() override;
 
  private:

--- a/src/ray/core_worker/transport/sequential_actor_submit_queue.h
+++ b/src/ray/core_worker/transport/sequential_actor_submit_queue.h
@@ -55,14 +55,8 @@ class SequentialActorSubmitQueue : public IActorSubmitQueue {
   ///   - a pair of task and bool represents the task to be send and if the receiver
   ///     should SKIP THE SCHEDULING QUEUE while executing it.
   std::optional<std::pair<TaskSpecification, bool>> PopNextTaskToSend() override;
-  /// On client connect/reconnect, find all the tasks which are known to be
-  /// executed out of order.
-  std::map<uint64_t, TaskSpecification> PopAllOutOfOrderCompletedTasks() override;
   /// Get the task's sequence number according to the internal offset.
   uint64_t GetSequenceNumber(const TaskSpecification &task_spec) const override;
-  /// Mark a task has been executed on the receiver side.
-  void MarkSeqnoCompleted(uint64_t sequence_no,
-                          const TaskSpecification &task_spec) override;
   bool Empty() override;
 
  private:
@@ -78,27 +72,6 @@ class SequentialActorSubmitQueue : public IActorSubmitQueue {
   /// All tasks with sequence numbers less than next_send_position have already been
   /// sent to the actor.
   uint64_t next_send_position = 0;
-
-  /// If a task raised a retryable user exception, it's marked as "completed" via
-  /// `MarkSeqnoCompleted` and `next_task_reply_position` may be updated. Afterwards Ray
-  /// retries by creating another task pushed to the back of the queue, making it executes
-  /// later than all tasks pending in the queue.
-  ///
-  /// Out of the tasks sent by this worker to the actor, the number of tasks
-  /// that we will never send to the actor again. We only include
-  /// tasks that will not be sent again, to support automatic task retry on
-  /// actor failure. This value only tracks consecutive tasks that are completed.
-  /// Tasks completed out of order will be cached in out_of_completed_tasks first.
-  uint64_t next_task_reply_position = 0;
-
-  /// The temporary container for tasks completed out of order. It can happen in
-  /// async or threaded actor mode. This map is used to store the seqno and task
-  /// spec for (1) increment next_task_reply_position later when the in order tasks are
-  /// returned (2) resend the tasks to restarted actor so retried tasks can maintain
-  /// ordering.
-  // NOTE(simon): consider absl::btree_set for performance, but it requires updating
-  // abseil.
-  std::map<uint64_t, TaskSpecification> out_of_order_completed_tasks;
 };
 }  // namespace core
 }  // namespace ray


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Prior to https://github.com/ray-project/ray/pull/51904, when an actor restarted, its new task sequence numbers were computed as `old_seq_no - caller_starts_at`. Hence, resending out-of-order tasks is required to fill in the sequence numbers for the actors.

https://github.com/ray-project/ray/pull/51904/files#r2029996454

For example,
* Submit 10 tasks (task0 ~ task9)
* Receive the responses of task0, task4, task5. (4 and 5 are out of order)
* Actor crashes and restarts.
* The sequence numbers of task1, task2, task3, and task6 through task9 will each be decremented by 1. That is, 0, 1, 2, 5, 6, 7, 8.
* Hence, if we don't resend task4 and task5, the actor will hang forever before executing task 6.

After #51904, 
* Submit 10 tasks (task0 ~ task9)
* Receive the responses of task0, task4, task5. (4 and 5 are out of order)
* Actor crashes and restarts.
* The sequence numbers of task1, task2, task3, and task6 through task9 will be updated to 10, 11, 12, 13, 14, 15, 16. => No need to resend task 4 and task 5 to update the sequence number.

This PR is meant to eliminate unnecessary behavior (i.e., resending completed tasks out of order). It’s unnecessary because it only causes the actor to update its sequence number, and the tasks won’t be executed again. However, it's not necessary to resend out of order completed tasks after #51904. That is, the resent tasks will neither be executed nor will they update the sequence number. In addition, this redundant behavior causes Ray task state machine has invalid state transition. See #52759 for more details.

## Related issue number

This PR also fixes the same issue #52759 tries to fix.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
