### PR TITLE
[release test] fix twine version contraint in setup.py

### DIFF
--- a/release/setup.py
+++ b/release/setup.py
@@ -30,7 +30,7 @@ setup(
         "pydantic >= 2.5.0",
         "PyGithub",
         "requests",
-        "twine == 5.0.0",
+        "twine == 6.1.0",
         "docker >= 7.1.0",
     ],
 )


### PR DESCRIPTION
fixes release test launching; it needs to be consistent with the stand-alone constraint file.
