### PR TITLE
[docstring][llm] fixing indent errors in docstrings

### DIFF
--- a/python/ray/llm/_internal/batch/stages/base.py
+++ b/python/ray/llm/_internal/batch/stages/base.py
@@ -68,9 +68,9 @@ class StatefulStageUDF:
 
     Args:
         data_column: The internal data column name of the processor. The
-        __call__ method will take the data column as the input of the udf
-        method, and encapsulate the output of the udf method into the data
-        column for the next stage.
+                     __call__ method takes the data column as the input of the UDF
+                     method, and encapsulates the output of the UDF method into the data
+                     column for the next stage.
         expected_input_keys: The expected input keys of the stage.
     """
 

--- a/python/ray/llm/_internal/batch/stages/chat_template_stage.py
+++ b/python/ray/llm/_internal/batch/stages/chat_template_stage.py
@@ -28,8 +28,8 @@ class ChatTemplateUDF(StatefulStageUDF):
             expected_input_keys: The expected input keys of the stage.
             model: The model to use for the chat template.
             chat_template: The chat template in Jinja template format. This is
-            usually not needed if the model checkpoint already contains the
-            chat template.
+                           usually not needed if the model checkpoint already contains the
+                           chat template.
         """
         from transformers import AutoProcessor
 


### PR DESCRIPTION
Public-facing ones weren't rendering correctly and cleaned up internal ones in case of cargo culting.

## Related issue number
https://anyscale1.atlassian.net/browse/MLDX-686

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
