### PR TITLE
[core] Correctly release dynamic generator refs

### DIFF
--- a/python/ray/_private/object_ref_generator.py
+++ b/python/ray/_private/object_ref_generator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from ray.util.annotations import DeveloperAPI
-from typing import Iterator, List, TYPE_CHECKING
+from typing import Iterator, Deque, TYPE_CHECKING
+import collections
 
 if TYPE_CHECKING:
     import ray
@@ -8,15 +9,15 @@ if TYPE_CHECKING:
 
 @DeveloperAPI
 class DynamicObjectRefGenerator:
-    def __init__(self, refs: List["ray.ObjectRef"]):
+    def __init__(self, refs: Deque["ray.ObjectRef"]):
         # TODO(swang): As an optimization, can also store the generator
         # ObjectID so that we don't need to keep individual ref counts for the
         # inner ObjectRefs.
-        self._refs: List["ray.ObjectRef"] = refs
+        self._refs: Deque["ray.ObjectRef"] = collections.deque(refs)
 
     def __iter__(self) -> Iterator("ray.ObjectRef"):
-        for ref in self._refs:
-            yield ref
+        while self._refs:
+            yield self._refs.popleft()
 
     def __len__(self) -> int:
         return len(self._refs)

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -37,6 +37,7 @@ from typing import (
 
 import contextvars
 import concurrent.futures
+import collections
 
 from libc.stdint cimport (
     int32_t,
@@ -2060,7 +2061,7 @@ cdef void execute_task(
                             should_retry_exceptions)
 
                     task_exception = False
-                    dynamic_refs = []
+                    dynamic_refs = collections.deque()
                     for idx in range(dynamic_returns.size()):
                         dynamic_refs.append(ObjectRef(
                             dynamic_returns[0][idx].first.Binary(),

--- a/python/ray/tests/test_generators.py
+++ b/python/ray/tests/test_generators.py
@@ -336,7 +336,10 @@ def test_dynamic_generator(
                 ray.get(ref)
 
 
-def test_dynamic_generator_gc_each_yield(ray_start_regular_shared):
+def test_dynamic_generator_gc_each_yield(ray_start_cluster):
+    # Need to shutdown when going from ray_start_regular_shared to ray_start_cluster
+    ray.shutdown()
+
     num_returns = 5
 
     @ray.remote(num_returns="dynamic")
@@ -361,9 +364,6 @@ def test_dynamic_generator_gc_each_yield(ray_start_regular_shared):
 
 @pytest.mark.parametrize("num_returns_type", ["dynamic", None])
 def test_dynamic_generator_distributed(ray_start_cluster, num_returns_type):
-    # Need to shutdown when going from ray_start_regular_shared to ray_start_cluster
-    ray.shutdown()
-
     cluster = ray_start_cluster
     # Head node with no resources.
     cluster.add_node(num_cpus=0)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
In https://github.com/ray-project/ray/pull/52095, the while loop in DynamicObjectRefGenerator that pops the ref was just changed to a for loop that iterates through the refs. This results in the refs sticking around and using up memory when they can be destroyed.

Also changing the list to a deque for efficiency on popping from the front.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
