### PR TITLE
[docstring][data] fix indentation errors in docstrings

### DIFF
--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -734,7 +734,7 @@ def combine_chunked_array(
     Args:
         array: The chunked array to be combined into a single contiguous array.
         ensure_copy: Skip copying when ensure_copy is False and there's exactly
-                     1 chunk.
+           1 chunk.
     """
 
     import pyarrow as pa

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -733,8 +733,8 @@ def combine_chunked_array(
 
     Args:
         array: The chunked array to be combined into a single contiguous array.
-        ensure_copy: Skip copying when ensure_copy is False and there is exactly
-        1 chunk.
+        ensure_copy: Skip copying when ensure_copy is False and there's exactly
+                     1 chunk.
     """
 
     import pyarrow as pa

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -587,7 +587,7 @@ class ApplyAdditionalSplitToOutputBlocks(MapTransformFn):
         """
         Args:
           additional_output_splits: The number of additional splits, must be
-                                    greater than 1.
+             greater than 1.
         """
         assert additional_split_factor > 1
         self._additional_split_factor = additional_split_factor

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -587,7 +587,7 @@ class ApplyAdditionalSplitToOutputBlocks(MapTransformFn):
         """
         Args:
           additional_output_splits: The number of additional splits, must be
-          greater than 1.
+                                    greater than 1.
         """
         assert additional_split_factor > 1
         self._additional_split_factor = additional_split_factor

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -322,7 +322,7 @@ class StreamingRepartition(AbstractMap):
     """Logical operator for streaming repartition operation.
     Args:
         target_num_rows_per_block: The target number of rows per block granularity for
-                                   streaming repartition.
+           streaming repartition.
     """
 
     def __init__(

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -321,8 +321,8 @@ class FlatMap(AbstractUDFMap):
 class StreamingRepartition(AbstractMap):
     """Logical operator for streaming repartition operation.
     Args:
-        target_num_rows_per_block: The targetr number of rows per block granularity for
-        streaming repartition.
+        target_num_rows_per_block: The target number of rows per block granularity for
+                                   streaming repartition.
     """
 
     def __init__(

--- a/python/ray/data/_internal/numpy_support.py
+++ b/python/ray/data/_internal/numpy_support.py
@@ -76,7 +76,7 @@ def _convert_to_datetime64(dt: datetime, precision: str) -> np.datetime64:
     Args:
         dt: A datetime object to be converted.
         precision: The desired precision for the datetime64 conversion. Possible
-        values are 'D', 's', 'ms', 'us', 'ns'.
+                   values are 'D', 's', 'ms', 'us', 'ns'.
 
     Returns:
         np.datetime64: A numpy datetime64 object with the specified precision.
@@ -106,8 +106,8 @@ def _convert_datetime_to_np_datetime(datetime_list: List[datetime]) -> np.ndarra
 
     Returns:
         np.ndarray: A NumPy array containing the `datetime64` values of the datetime
-        objects from the input list, with the appropriate precision (e.g., nanoseconds,
-        microseconds, milliseconds, etc.).
+                    objects from the input list, with the appropriate precision (e.g., nanoseconds,
+                    microseconds, milliseconds, etc.).
     """
     # Detect the highest precision for the datetime objects
     precision = _detect_highest_datetime_precision(datetime_list)

--- a/python/ray/data/_internal/numpy_support.py
+++ b/python/ray/data/_internal/numpy_support.py
@@ -76,7 +76,7 @@ def _convert_to_datetime64(dt: datetime, precision: str) -> np.datetime64:
     Args:
         dt: A datetime object to be converted.
         precision: The desired precision for the datetime64 conversion. Possible
-                   values are 'D', 's', 'ms', 'us', 'ns'.
+           values are 'D', 's', 'ms', 'us', 'ns'.
 
     Returns:
         np.datetime64: A numpy datetime64 object with the specified precision.
@@ -106,8 +106,8 @@ def _convert_datetime_to_np_datetime(datetime_list: List[datetime]) -> np.ndarra
 
     Returns:
         np.ndarray: A NumPy array containing the `datetime64` values of the datetime
-                    objects from the input list, with the appropriate precision (e.g., nanoseconds,
-                    microseconds, milliseconds, etc.).
+           objects from the input list, with the appropriate precision (e.g., nanoseconds,
+           microseconds, milliseconds, etc.).
     """
     # Detect the highest precision for the datetime objects
     precision = _detect_highest_datetime_precision(datetime_list)

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -1028,9 +1028,9 @@ class DatasetStatsSummary:
 
         Args:
             already_printed: Set of operator IDs that have already had its stats printed
-                             out.
+               out.
             include_parent: If true, also include parent stats summary; otherwise, only
-                            log stats of the latest operator.
+               log stats of the latest operator.
             add_global_stats: If true, includes global stats to this summary.
         Returns:
             String with summary statistics for executing the Dataset.

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -1028,9 +1028,9 @@ class DatasetStatsSummary:
 
         Args:
             already_printed: Set of operator IDs that have already had its stats printed
-            out.
+                             out.
             include_parent: If true, also include parent stats summary; otherwise, only
-            log stats of the latest operator.
+                            log stats of the latest operator.
             add_global_stats: If true, includes global stats to this summary.
         Returns:
             String with summary statistics for executing the Dataset.

--- a/python/ray/data/_internal/table_block.py
+++ b/python/ray/data/_internal/table_block.py
@@ -333,7 +333,7 @@ class TableBlockAccessor(BlockAccessor):
 
         Args:
             sort_key: A column name or list of column names.
-                      If this is ``None``, place all rows in a single group.
+               If this is ``None``, place all rows in a single group.
 
             aggs: The aggregations to do.
 
@@ -567,7 +567,7 @@ class TableBlockAccessor(BlockAccessor):
         Args:
             blocks: A list of TableBlocks to be normalized.
             target_block_type: The type to normalize the blocks to. If None,
-                Ray Data chooses a type to minimize the amount of data conversions.
+               Ray Data chooses a type to minimize the amount of data conversions.
 
         Returns:
             A list of blocks of the same type.

--- a/python/ray/data/_internal/table_block.py
+++ b/python/ray/data/_internal/table_block.py
@@ -333,7 +333,7 @@ class TableBlockAccessor(BlockAccessor):
 
         Args:
             sort_key: A column name or list of column names.
-            If this is ``None``, place all rows in a single group.
+                      If this is ``None``, place all rows in a single group.
 
             aggs: The aggregations to do.
 
@@ -564,10 +564,10 @@ class TableBlockAccessor(BlockAccessor):
         """Normalize input blocks to the specified `normalize_type`. If the blocks
         are already all of the same type, returns original blocks.
 
-         Args:
+        Args:
             blocks: A list of TableBlocks to be normalized.
             target_block_type: The type to normalize the blocks to. If None,
-                will be chosen such that to minimize amount of data conversions.
+                Ray Data chooses a type to minimize the amount of data conversions.
 
         Returns:
             A list of blocks of the same type.

--- a/python/ray/data/datasource/datasink.py
+++ b/python/ray/data/datasource/datasink.py
@@ -70,7 +70,7 @@ class Datasink(Generic[WriteReturnType]):
 
         Args:
             write_result: Aggregated result of the
-                          Write operator, containing write results and stats.
+               Write operator, containing write results and stats.
         """
         pass
 

--- a/python/ray/data/datasource/datasink.py
+++ b/python/ray/data/datasource/datasink.py
@@ -64,13 +64,13 @@ class Datasink(Generic[WriteReturnType]):
     def on_write_complete(self, write_result: WriteResult[WriteReturnType]):
         """Callback for when a write job completes.
 
-        This can be used to "commit" a write output. This method must
+        This can be used to `commit` a write output. This method must
         succeed prior to ``write_datasink()`` returning to the user. If this
         method fails, then ``on_write_failed()`` is called.
 
         Args:
             write_result: Aggregated result of the
-            the Write operator, containing write results and stats.
+                          Write operator, containing write results and stats.
         """
         pass
 


### PR DESCRIPTION
Public-facing ones weren't rendering correctly and cleaned up internal ones in case of cargo culting.

## Related issue number
https://anyscale1.atlassian.net/browse/MLDX-686

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
