### PR TITLE
Train Tests: Update Image classification map fn

### DIFF
--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -17,7 +17,7 @@ from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.air.util.tensor_extensions.arrow import ArrowTensorArray
 from ray.data import Schema
 from ray.data.block import BlockExecStats, BlockMetadata
-from ray.data.context import ShuffleStrategy, DataContext
+from ray.data.context import DataContext, ShuffleStrategy
 from ray.data.tests.mock_server import *  # noqa
 
 # Trigger pytest hook to automatically zip test cluster logs to archive dir on failure

--- a/release/train_tests/benchmark/image_classification/image_classification_jpeg/imagenet.py
+++ b/release/train_tests/benchmark/image_classification/image_classification_jpeg/imagenet.py
@@ -1,6 +1,7 @@
 import torch
 import numpy as np
 from typing import Dict, Union, Callable
+from PIL import Image
 
 from constants import DatasetKey
 from image_classification.imagenet import (
@@ -33,7 +34,7 @@ def get_preprocess_map_fn(
     The output is a dict with "image" and "label" keys.
     """
     crop_resize_transform = get_transform(
-        to_torch_tensor=False, random_transforms=random_transforms
+        to_torch_tensor=True, random_transforms=random_transforms
     )
 
     def map_fn(row: Dict[str, Union[np.ndarray, str]]) -> Dict[str, torch.Tensor]:
@@ -45,10 +46,10 @@ def get_preprocess_map_fn(
         Returns:
             Dict with "image" and "label" keys
         """
-        # Convert to CHW format and normalize
-        image = torch.from_numpy(row["image"].transpose(2, 0, 1)).float() / 255.0
-        # Apply transforms
-        image = crop_resize_transform(image)
+        # Convert NumPy HWC image to PIL
+        image_pil = Image.fromarray(row["image"])
+        # Apply transform (includes ToTensor + Normalize)
+        image = crop_resize_transform(image_pil)
         # Convert label
         label = IMAGENET_WNID_TO_ID[row["class"]]
         return {"image": image, "label": label}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Train Tests: Update Image classification map fn.

- Current Image processing does np->tensor conversion with transpose to CHW and normalization.
```

 'train/epoch-avg': 37.75413007199859,
 'train/epoch-max': 37.75413007199859,
 'train/epoch-min': 37.75413007199859,
 'train/epoch-total': 37.75413007199859,
 'train/global_throughput': 3495.5491702359923,
 'train/iter_batch-avg': 0.03661318445453074,
 'train/iter_batch-max': 0.6135890130008193,
 'train/iter_batch-min': 1.593200067873113e-05,
 'train/iter_batch-total': 18.526271333992554,
 'train/iter_first_batch-avg': 19.143331854998905,
 'train/iter_first_batch-max': 19.143331854998905,
 'train/iter_first_batch-min': 19.143331854998905,
 'train/iter_first_batch-total': 19.143331854998905,
 'train/iter_skip_batch-avg': inf,
 'train/iter_skip_batch-max': 0,
 'train/iter_skip_batch-min': inf,
 'train/iter_skip_batch-total': 0,
 'train/local_throughput': 873.8872925589981,
 'train/rows_processed-avg': 32.0,
 'train/rows_processed-max': 32,
 'train/rows_processed-min': 32,
 'train/rows_processed-total': 16192,
 'train/step-avg': 4.809962454802502e-06,
 'train/step-max': 2.1455998648889363e-05,
 'train/step-min': 5.109995981911197e-07,
 'train/step-total': 0.002433841002130066,
 'validation/iter_batch-avg': inf,
 'validation/iter_batch-max': 0,
 'validation/iter_batch-min': inf,
 'validation/iter_batch-total': 0,
 'validation/step-avg': inf,
 'validation/step-max': 0,
 'validation/step-min': inf,
 'validation/step-total': 0}
--------------------------------------------------------------------------------
2025-05-07 12:12:11,659 INFO test_utils.py:1953 -- Wrote results to /tmp/release_test_output.json
2025-05-07 12:12:11,660 INFO test_utils.py:1954 -- {"train/epoch-avg": 37.75413007199859, "train/epoch-min": 37.75413007199859, "train/epoch-max": 37.75413007199859, "train/epoch-total": 37.75413007199859, "train/iter_first_batch-avg": 19.143331854998905, "train/iter_first_batch-min": 19.143331854998905, "train/iter_first_batch-max": 19.143331854998905, "train/iter_first_batch-total": 19.143331854998905, "train/step-avg": 4.809962454802502e-06, "train/step-min": 5.109995981911197e-07, "train/step-max": 2.1455998648889363e-05, "train/step-total": 0.002433841002130066, "train/rows_processed-avg": 32.0, "train/rows_processed-min": 32, "train/rows_processed-max": 32, "train/rows_processed-total": 16192, "train/iter_batch-avg": 0.03661318445453074, "train/iter_batch-min": 1.593200067873113e-05, "train/iter_batch-max": 0.6135890130008193, "train/iter_batch-total": 18.526271333992554, "validation/step-avg": Infinity, "validation/step-min": Infinity, "validation/step-max": 0, "validation/step-total": 0, "validation/iter_batch-avg": Infinity, "validation/iter_batch-min": Infinity, "validation/iter_batch-max": 0, "validation/iter_batch-total": 0, "checkpoint/download-avg": Infinity, "checkpoint/download-min": Infinity, "checkpoint/download-max": 0, "checkpoint/download-total": 0, "checkpoint/load-avg": Infinity, "checkpoint/load-min": Infinity, "checkpoint/load-max": 0, "checkpoint/load-total": 0, "train/iter_skip_batch-avg": Infinity, "train/iter_skip_batch-min": Infinity, "train/iter_skip_batch-max": 0, "train/iter_skip_batch-total": 0, "train/local_throughput": 873.8872925589981, "train/global_throughput": 3495.5491702359923, "dataloader/train": {"producer_throughput": 1946.112621486268, "iter_stats": {"prefetch_block-avg": Infinity, "prefetch_block-min": Infinity, "prefetch_block-max": 0, "prefetch_block-total": 0, "fetch_block-avg": 0.0027022377159291976, "fetch_block-min": 0.0005052189990237821, "fetch_block-max": 0.0197697479998169, "fetch_block-total": 0.218881254990265, "block_to_batch-avg": 0.001253903843829141, "block_to_batch-min": 1.9893001081072725e-05, "block_to_batch-max": 0.01351481799974863, "block_to_batch-total": 0.6344753449775453, "format_batch-avg": 3.4910411080130395e-05, "format_batch-min": 9.00899976841174e-06, "format_batch-max": 0.0005209999999351567, "format_batch-total": 0.01766466800654598, "collate-avg": 0.0019578944209519855, "collate-min": 0.00021700100114685483, "collate-max": 0.013516342000002624, "collate-total": 0.9906945770017046, "finalize-avg": 0.011252377077071, "finalize-min": 0.004483607999645756, "finalize-max": 0.03162657899883925, "finalize-total": 5.693702800997926, "time_spent_blocked-avg": 0.0742146621321331, "time_spent_blocked-min": 6.807998943259008e-06, "time_spent_blocked-max": 19.143022770000243, "time_spent_blocked-total": 37.62683370099148, "time_spent_training-avg": 0.00021408673321073962, "time_spent_training-min": 9.916999260894954e-06, "time_spent_training-max": 0.009087054999326938, "time_spent_training-total": 0.10832788700463425}}}
```

- Updated Image processing does np->PIL->Tensor.

```
 'train/epoch-avg': 30.73613611499968,
 'train/epoch-max': 30.73613611499968,
 'train/epoch-min': 30.73613611499968,
 'train/epoch-total': 30.73613611499968,
 'train/global_throughput': 5434.769027373354,
 'train/iter_batch-avg': 0.023547696209505146,
 'train/iter_batch-max': 0.3791560619993106,
 'train/iter_batch-min': 1.732300006551668e-05,
 'train/iter_batch-total': 11.915134282009603,
 'train/iter_first_batch-avg': 18.71798381300141,
 'train/iter_first_batch-max': 18.71798381300141,
 'train/iter_first_batch-min': 18.71798381300141,
 'train/iter_first_batch-total': 18.71798381300141,
 'train/iter_skip_batch-avg': inf,
 'train/iter_skip_batch-max': 0,
 'train/iter_skip_batch-min': inf,
 'train/iter_skip_batch-total': 0,
 'train/local_throughput': 1358.6922568433386,
 'train/rows_processed-avg': 32.0,
 'train/rows_processed-max': 32,
 'train/rows_processed-min': 32,
 'train/rows_processed-total': 16192,
 'train/step-avg': 4.362646225640153e-06,
 'train/step-max': 2.6562000130070373e-05,
 'train/step-min': 4.579997039400041e-07,
 'train/step-total': 0.0022074989901739173,
 'validation/iter_batch-avg': inf,
 'validation/iter_batch-max': 0,
 'validation/iter_batch-min': inf,
 'validation/iter_batch-total': 0,
 'validation/step-avg': inf,
 'validation/step-max': 0,
 'validation/step-min': inf,
 'validation/step-total': 0}
--------------------------------------------------------------------------------
2025-05-07 12:32:57,439 INFO test_utils.py:1953 -- Wrote results to /tmp/release_test_output.json
2025-05-07 12:32:57,439 INFO test_utils.py:1954 -- {"train/epoch-avg": 30.73613611499968, "train/epoch-min": 30.73613611499968, "train/epoch-max": 30.73613611499968, "train/epoch-total": 30.73613611499968, "train/iter_first_batch-avg": 18.71798381300141, "train/iter_first_batch-min": 18.71798381300141, "train/iter_first_batch-max": 18.71798381300141, "train/iter_first_batch-total": 18.71798381300141, "train/step-avg": 4.362646225640153e-06, "train/step-min": 4.579997039400041e-07, "train/step-max": 2.6562000130070373e-05, "train/step-total": 0.0022074989901739173, "train/rows_processed-avg": 32.0, "train/rows_processed-min": 32, "train/rows_processed-max": 32, "train/rows_processed-total": 16192, "train/iter_batch-avg": 0.023547696209505146, "train/iter_batch-min": 1.732300006551668e-05, "train/iter_batch-max": 0.3791560619993106, "train/iter_batch-total": 11.915134282009603, "validation/step-avg": Infinity, "validation/step-min": Infinity, "validation/step-max": 0, "validation/step-total": 0, "validation/iter_batch-avg": Infinity, "validation/iter_batch-min": Infinity, "validation/iter_batch-max": 0, "validation/iter_batch-total": 0, "checkpoint/download-avg": Infinity, "checkpoint/download-min": Infinity, "checkpoint/download-max": 0, "checkpoint/download-total": 0, "checkpoint/load-avg": Infinity, "checkpoint/load-min": Infinity, "checkpoint/load-max": 0, "checkpoint/load-total": 0, "train/iter_skip_batch-avg": Infinity, "train/iter_skip_batch-min": Infinity, "train/iter_skip_batch-max": 0, "train/iter_skip_batch-total": 0, "train/local_throughput": 1358.6922568433386, "train/global_throughput": 5434.769027373354, "dataloader/train": {"producer_throughput": 2485.456671547162, "iter_stats": {"prefetch_block-avg": Infinity, "prefetch_block-min": Infinity, "prefetch_block-max": 0, "prefetch_block-total": 0, "fetch_block-avg": 0.0023951276418054837, "fetch_block-min": 0.0004556420008157147, "fetch_block-max": 0.009860608999588294, "fetch_block-total": 0.19400533898624417, "block_to_batch-avg": 0.0011380414249187495, "block_to_batch-min": 1.991700082726311e-05, "block_to_batch-max": 0.02047159200083115, "block_to_batch-total": 0.5758489610088873, "format_batch-avg": 2.7870620556763306e-05, "format_batch-min": 9.097000656765886e-06, "format_batch-max": 0.00015905799955362454, "format_batch-total": 0.014102534001722233, "collate-avg": 0.0019216830711812067, "collate-min": 0.00023257399880094454, "collate-max": 0.021248375000141095, "collate-total": 0.9723716340176907, "finalize-avg": 0.008927913114603718, "finalize-min": 0.0044454970011429396, "finalize-max": 0.020735431000503013, "finalize-total": 4.5175240359894815, "time_spent_blocked-avg": 0.0603644016410606, "time_spent_blocked-min": 7.908000043244101e-06, "time_spent_blocked-max": 18.717657721999785, "time_spent_blocked-total": 30.604751632017724, "time_spent_training-avg": 0.00022997682214121696, "time_spent_training-min": 1.0375999409006909e-05, "time_spent_training-max": 0.013436835000902647, "time_spent_training-total": 0.11636827200345579}}}
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
