### PR TITLE
[core][metri-agg/1] recommended level for last-value data

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -92,7 +92,6 @@ python/ray/_private/internal_api.py
 python/ray/_private/metrics_agent.py
     DOC101: Method `OpenCensusProxyCollector.__init__`: Docstring contains fewer arguments than in function signature.
     DOC103: Method `OpenCensusProxyCollector.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [component_timeout_s: int].
-    DOC201: Method `OpenCensusProxyCollector.to_metrics` does not have a return section in docstring
     DOC201: Method `MetricsAgent.proxy_export_metrics` does not have a return section in docstring
     DOC106: Method `PrometheusServiceDiscoveryWriter.__init__`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
     DOC107: Method `PrometheusServiceDiscoveryWriter.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
@@ -282,9 +281,7 @@ python/ray/_private/test_utils.py
     DOC101: Function `run_string_as_driver_nonblocking`: Docstring contains fewer arguments than in function signature.
     DOC107: Function `run_string_as_driver_nonblocking`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
     DOC103: Function `run_string_as_driver_nonblocking`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [env: Dict].
-    DOC101: Function `wait_for_condition`: Docstring contains fewer arguments than in function signature.
     DOC107: Function `wait_for_condition`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
-    DOC103: Function `wait_for_condition`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: Any].
     DOC201: Function `wait_for_condition` does not have a return section in docstring
     DOC101: Function `async_wait_for_condition`: Docstring contains fewer arguments than in function signature.
     DOC107: Function `async_wait_for_condition`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
@@ -831,13 +828,6 @@ python/ray/client_builder.py
     DOC111: Method `ClientBuilder.env`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
     DOC201: Method `ClientBuilder.env` does not have a return section in docstring
     DOC201: Method `ClientBuilder.namespace` does not have a return section in docstring
---------------------
-python/ray/cloudpickle/cloudpickle.py
-    DOC101: Function `_find_imported_submodules`: Docstring contains fewer arguments than in function signature.
-    DOC106: Function `_find_imported_submodules`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
-    DOC107: Function `_find_imported_submodules`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
-    DOC103: Function `_find_imported_submodules`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [code: , top_level_dependencies: ].
-    DOC201: Function `_find_imported_submodules` does not have a return section in docstring
 --------------------
 python/ray/cluster_utils.py
     DOC101: Method `AutoscalingCluster.__init__`: Docstring contains fewer arguments than in function signature.

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -579,3 +579,11 @@ RAY_EXPORT_EVENT_MAX_BACKUP_COUNT = env_bool("RAY_EXPORT_EVENT_MAX_BACKUP_COUNT"
 # and call ray._private.runtime_env.uv_runtime_env_hook.hook manually in your hook or
 # manually set the py_executable in your runtime environment hook.
 RAY_ENABLE_UV_RUN_RUNTIME_ENV = env_bool("RAY_ENABLE_UV_RUN_RUNTIME_ENV", True)
+
+# Prometheus metric cardinality level setting, either "legacy" or "recommended".
+#
+# Legacy: report all metrics to prometheus with the set of labels that are reported by
+#   the component, including WorkerId, (task or actor) Name, etc. This is the default.
+# Recommended: report only the node level metrics to prometheus. This means that the
+#   WorkerId will be removed from all metrics.
+RAY_METRIC_CARDINALITY_LEVEL = os.environ.get("RAY_metric_cardinality_level", "legacy")

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -44,6 +44,7 @@ py_test_module_list(
         "test_advanced_7.py",
         "test_advanced_8.py",
         "test_advanced_9.py",
+        "test_aggregated_prometheus_metrics.py",
         "test_async.py",
         "test_component_failures_2.py",
         "test_component_failures_3.py",

--- a/python/ray/tests/test_aggregated_prometheus_metrics.py
+++ b/python/ray/tests/test_aggregated_prometheus_metrics.py
@@ -1,0 +1,113 @@
+# isort: skip_file
+# ruff: noqa: E402
+import sys
+import requests
+import os
+
+import pytest
+
+import ray
+from ray._private.test_utils import (
+    fetch_prometheus_metrics,
+    wait_for_assertion,
+)
+from ray._private.metrics_agent import WORKER_ID_TAG_KEY
+
+
+try:
+    import prometheus_client
+except ImportError:
+    prometheus_client = None
+
+
+_TO_TEST_METRICS = ["ray_tasks", "ray_actors"]
+
+
+@pytest.fixture
+def _setup_cluster_for_test(request, ray_start_cluster):
+    core_metric_cardinality_level = request.param
+    os.environ["RAY_metric_cardinality_level"] = core_metric_cardinality_level
+    cluster = ray_start_cluster
+    cluster.add_node(
+        _system_config={
+            "metrics_report_interval_ms": 1000,
+            "enable_metrics_collection": True,
+            "metric_cardinality_level": core_metric_cardinality_level,
+        }
+    )
+    cluster.wait_for_nodes()
+    ray_context = ray.init(
+        address=cluster.address,
+    )
+
+    @ray.remote
+    def t():
+        print("task")
+
+    @ray.remote
+    class A:
+        async def run(self):
+            print("actor")
+
+    a = A.remote()
+    obj_refs = [t.remote(), a.run.remote()]
+
+    # Make a request to the dashboard to produce some dashboard metrics
+    requests.get(f"http://{ray_context.dashboard_url}/nodes")
+
+    node_info_list = ray.nodes()
+    prom_addresses = []
+    for node_info in node_info_list:
+        prom_addresses.append(
+            f"{node_info['NodeManagerAddress']}:{node_info['MetricsExportPort']}"
+        )
+    yield prom_addresses
+
+    ray.get(obj_refs)
+
+
+@pytest.mark.skipif(prometheus_client is None, reason="Prometheus not installed")
+@pytest.mark.parametrize(
+    "_setup_cluster_for_test,cardinality_level",
+    [("recommended", "recommended"), ("legacy", "legacy")],
+    indirect=["_setup_cluster_for_test"],
+)
+def test_cardinality_levels(_setup_cluster_for_test, cardinality_level):
+    """
+    Test that the ray_tasks and ray_actors metric are reported with the expected cardinality level
+    """
+    TEST_TIMEOUT_S = 30
+    prom_addresses = _setup_cluster_for_test
+
+    def _validate():
+        metric_samples = fetch_prometheus_metrics(prom_addresses)
+        for metric in _TO_TEST_METRICS:
+            samples = metric_samples.get(metric)
+            assert samples, f"Metric {metric} not found in samples"
+            for sample in samples:
+                if cardinality_level == "recommended":
+                    # If the cardinality level is recommended, the WorkerId tag should
+                    # be removed
+                    assert (
+                        sample.labels.get(WORKER_ID_TAG_KEY) is None
+                    ), f"Sample {sample} contains WorkerId tag"
+                elif cardinality_level == "legacy":
+                    # If the cardinality level is legacy, the WorkerId tag should be
+                    # present
+                    assert (
+                        sample.labels.get(WORKER_ID_TAG_KEY) is not None
+                    ), f"Sample {sample} does not contain WorkerId tag"
+                else:
+                    raise ValueError(f"Unknown cardinality level: {cardinality_level}")
+
+    wait_for_assertion(
+        _validate,
+        timeout=TEST_TIMEOUT_S,
+        retry_interval_ms=1000,  # Yield resource for other processes
+    )
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -542,6 +542,11 @@ RAY_CONFIG(uint64_t, gcs_mark_task_failed_on_worker_dead_delay_ms, /*  1 secs */
 /// Whether or not we enable metrics collection.
 RAY_CONFIG(bool, enable_metrics_collection, true)
 
+/// Determine if the high cardinality labels such as WorkerId, task and actor Name
+/// should be used in the metrics. For the complete definition, see
+/// RAY_METRIC_CARDINALITY_LEVEL in ray_constants.py
+RAY_CONFIG(std::string, metric_cardinality_level, "legacy")
+
 /// Comma separated list of components we enable grpc metrics collection for.
 /// Only effective if `enable_metrics_collection` is also true. Will have some performance
 /// degredations.

--- a/src/ray/stats/tag_defs.cc
+++ b/src/ray/stats/tag_defs.cc
@@ -32,6 +32,7 @@ const TagKeyType DriverPidKey = TagKeyType::Register("DriverPid");
 
 const TagKeyType ActorIdKey = TagKeyType::Register("ActorId");
 
+// Keep in sync with the WORKER_ID_TAG_KEY in python/ray/_private/metrics_agent.py
 const TagKeyType WorkerIdKey = TagKeyType::Register("WorkerId");
 
 const TagKeyType JobIdKey = TagKeyType::Register("JobId");


### PR DESCRIPTION
This series of PR addresses https://github.com/ray-project/ray/issues/47289. The context is that there are metrics such as `ray_tasks` and `ray_actors` produce a high volume of time series on prometheus. Our inspection indicates that  this is because the high cardinality of the `WorkerId` field in these metrics in a high scale cluster. See https://docs.google.com/document/d/1AZVZQGGroSbV1w4KG4Vncc0L_tVdpfkM3ueGo_fD9-M/edit?tab=t.0 for the proposed solution.

This PR:
- Add RAY_core_metric_cardinality_level which can be set to LEGACY, RECOMMENDED or LOW as proposed in the google doc solution
- Implemented the RECOMMENDED cardinality for all metrics of type LastValueAggregationData
- Add test cases

Subsequent PRs will implement additional features to fill the other missing pieces. The PR is safe to merged in pieces because it does not change the default behaviors (and the additional features are not communicated publicly yet so will only be controlled by us).

Test:
- CI (test cases)
- e2e test in production as well