### PR TITLE
[docstring][rllib] fix indentation errors in docstrings

### DIFF
--- a/rllib/algorithms/dqn/default_dqn_rl_module.py
+++ b/rllib/algorithms/dqn/default_dqn_rl_module.py
@@ -196,7 +196,7 @@ class DefaultDQNRLModule(RLModule, InferenceOnlyAPI, TargetNetworkAPI, QNetAPI):
                 for all heads (Q or advantages and value in case of a dueling
                 architecture).
             head: Either a head model or a dictionary of head model (dueling
-            architecture) containing advantage and value stream heads.
+                architecture) containing advantage and value stream heads.
 
         Returns:
             In case of expectation learning the Q-value predictions ("qf_preds")

--- a/rllib/algorithms/dqn/torch/default_dqn_torch_rl_module.py
+++ b/rllib/algorithms/dqn/torch/default_dqn_torch_rl_module.py
@@ -242,7 +242,7 @@ class DefaultDQNTorchRLModule(TorchRLModule, DefaultDQNRLModule):
                 for all heads (Q or advantages and value in case of a dueling
                 architecture).
             head: Either a head model or a dictionary of head model (dueling
-            architecture) containing advantage and value stream heads.
+                architecture) containing advantage and value stream heads.
 
         Returns:
             In case of expectation learning the Q-value predictions ("qf_preds")

--- a/rllib/algorithms/impala/impala_tf_policy.py
+++ b/rllib/algorithms/impala/impala_tf_policy.py
@@ -139,7 +139,7 @@ def _make_time_major(policy, seq_lens, tensor):
         policy: Policy reference
         seq_lens: Sequence lengths if recurrent or None
         tensor: A tensor or list of tensors to reshape.
-        trajectory item.
+            trajectory item.
 
     Returns:
         res: A tensor with swapped axes or a list of tensors with
@@ -258,6 +258,7 @@ def get_impala_tf_policy(name: str, base: TFPolicyV2Type) -> TFPolicyV2Type:
     Returns:
         A TF Policy to be used with Impala.
     """
+
     # VTrace mixins are placed in front of more general mixins to make sure
     # their functions like optimizer() overrides all the other implementations
     # (e.g., LearningRateSchedule.optimizer())

--- a/rllib/benchmarks/torch_compile/utils.py
+++ b/rllib/benchmarks/torch_compile/utils.py
@@ -14,8 +14,8 @@ def get_ppo_batch_for_env(env: Union[str, gym.Env], batch_size):
 
     Args:
         env: The environment to create a sample batch for. If a string is given,
-        it is assumed to be a gym environment ID.
-        batch_size: The batch size to use.
+            it is assumed to be a gym environment ID.
+            batch_size: The batch size to use.
 
     Returns:
         A sample batch for the given environment.

--- a/rllib/connectors/connector.py
+++ b/rllib/connectors/connector.py
@@ -269,7 +269,7 @@ class AgentConnector(Connector):
 
         Args:
             data: Env and agent IDs, plus arbitrary data item from a single agent
-            of an environment.
+                of an environment.
 
         Returns:
             A transformed piece of agent connector data.

--- a/rllib/env/multi_agent_episode.py
+++ b/rllib/env/multi_agent_episode.py
@@ -467,7 +467,6 @@ class MultiAgentEpisode:
                 v is not None
                 for v in [_observation, _action, _reward, _infos, _extra_model_outputs]
             ):
-
                 raise MultiAgentEnvError(
                     f"Agent {agent_id} already had its `SingleAgentEpisode.is_done` "
                     f"set to True, but still received data in a following step! "
@@ -808,7 +807,8 @@ class MultiAgentEpisode:
         Args:
             other: The other `MultiAgentEpisode` to be concatenated to this one.
 
-        Returns: A `MultiAgentEpisode` instance containing the concatenated data
+        Returns:
+            A `MultiAgentEpisode` instance containing the concatenated data
             from both episodes (`self` and `other`).
         """
         # Make sure the IDs match.

--- a/rllib/env/single_agent_episode.py
+++ b/rllib/env/single_agent_episode.py
@@ -608,7 +608,8 @@ class SingleAgentEpisode:
         Args:
             other: The other `SingleAgentEpisode` to be concatenated to this one.
 
-        Returns: A `SingleAgentEpisode` instance containing the concatenated data
+        Returns:
+            A `SingleAgentEpisode` instance containing the concatenated data
             from both episodes (`self` and `other`).
         """
         assert other.id_ == self.id_

--- a/rllib/evaluation/collectors/agent_collector.py
+++ b/rllib/evaluation/collectors/agent_collector.py
@@ -402,8 +402,8 @@ class AgentCollector:
 
         Args:
             view_requirements: The viewrequirements dict needed to build the
-            SampleBatch from the raw buffers (which may have data shifts as well as
-            mappings from view-col to data-col in them).
+                SampleBatch from the raw buffers, which may have data shifts as well as
+                mappings from view-col to data-col in them.
 
         Returns:
             SampleBatch: The built SampleBatch for this agent, ready to go into

--- a/rllib/execution/minibatch_buffer.py
+++ b/rllib/execution/minibatch_buffer.py
@@ -23,13 +23,13 @@ class MinibatchBuffer:
 
         Args:
            inqueue (queue.Queue): Queue to populate the internal ring buffer
-           from.
+              from.
            size: Max number of data items to buffer.
            timeout: Queue timeout
            num_passes: Max num times each data item should be emitted.
            init_num_passes: Initial passes for each data item.
-           Maxiumum number of passes per item are increased to num_passes over
-           time.
+              Maxiumum number of passes per item are increased to num_passes over
+              time.
         """
         self.inqueue = inqueue
         self.size = size

--- a/rllib/offline/estimators/off_policy_estimator.py
+++ b/rllib/offline/estimators/off_policy_estimator.py
@@ -38,8 +38,8 @@ class OffPolicyEstimator(OfflineEvaluator):
             policy: Policy to evaluate.
             gamma: Discount factor of the environment.
             epsilon_greedy: The probability by which we act acording to a fully random
-            policy during deployment. With 1-epsilon_greedy we act according the target
-            policy.
+                policy during deployment. With 1-epsilon_greedy we act according the target
+                policy.
             # TODO (kourosh): convert the input parameters to a config dict.
         """
         super().__init__(policy)
@@ -52,9 +52,9 @@ class OffPolicyEstimator(OfflineEvaluator):
 
         Args:
             batch: The episode to calculate the off-policy estimates (OPE) on. The
-            episode must be a sample batch type that contains the fields "obs",
-            "actions", and "action_prob" and it needs to represent a
-            complete trajectory.
+                episode must be a sample batch type that contains the fields "obs",
+                "actions", and "action_prob" and it needs to represent a
+                complete trajectory.
 
         Returns:
             The off-policy estimates (OPE) calculated on the given episode. The returned
@@ -72,8 +72,8 @@ class OffPolicyEstimator(OfflineEvaluator):
 
         Args:
             batch: The batch to calculate the off-policy estimates (OPE) on. The
-            batch must be a sample batch type that contains the fields "obs",
-            "actions", and "action_prob".
+                batch must be a sample batch type that contains the fields "obs",
+                "actions", and "action_prob".
 
         Returns:
             The off-policy estimates (OPE) calculated on the given batch of single time
@@ -92,7 +92,7 @@ class OffPolicyEstimator(OfflineEvaluator):
 
         Args:
             sample_batch: The batch to split by episode. This contains multiple
-            episodes.
+                episodes.
 
         Returns:
             The modified batch before calling split_by_episode().
@@ -109,7 +109,7 @@ class OffPolicyEstimator(OfflineEvaluator):
 
         Args:
             all_episodes: The list of episodes in the original batch. Each element is a
-            sample batch type that is a single episode.
+                sample batch type that is a single episode.
         """
 
         return all_episodes
@@ -124,7 +124,7 @@ class OffPolicyEstimator(OfflineEvaluator):
 
         Args:
             episode: The episode that is split from the original batch. This is a
-            sample batch type that is a single episode.
+                sample batch type that is a single episode.
         """
         pass
 
@@ -136,8 +136,8 @@ class OffPolicyEstimator(OfflineEvaluator):
 
         Args:
             batch: The batch to calculate the off-policy estimates (OPE) on. The
-            batch must contain the fields "obs", "actions", and "action_prob".
-            split_batch_by_episode: Whether to split the batch by episode.
+                batch must contain the fields "obs", "actions", and "action_prob".
+                split_batch_by_episode: Whether to split the batch by episode.
 
         Returns:
             The off-policy estimates (OPE) calculated on the given batch. The returned

--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -1327,9 +1327,9 @@ class Policy(metaclass=ABCMeta):
             auto_remove_unneeded_view_reqs: Whether to automatically
                 remove those ViewRequirements records from
                 self.view_requirements that are not needed.
-            stats_fn (Optional[Callable[[Policy, SampleBatch], Dict[str,
-                TensorType]]]): An optional stats function to be called after
-                the loss.
+                stats_fn (Optional[Callable[[Policy, SampleBatch], Dict[str,
+                    TensorType]]]): An optional stats function to be called after
+                    the loss.
         """
 
         if self.config.get("_disable_initialize_loss_from_dummy_batch", False):

--- a/rllib/policy/policy_template.py
+++ b/rllib/policy/policy_template.py
@@ -119,7 +119,7 @@ def build_policy_class(
         Callable[[Policy, "torch.optim.Optimizer"], None]
     ] = None,
     mixins: Optional[List[type]] = None,
-    get_batch_divisibility_req: Optional[Callable[[Policy], int]] = None
+    get_batch_divisibility_req: Optional[Callable[[Policy], int]] = None,
 ) -> Type[TorchPolicy]:
     """Helper function for creating a new Policy class at runtime.
 
@@ -128,111 +128,111 @@ def build_policy_class(
     Args:
         name: name of the policy (e.g., "PPOTorchPolicy")
         framework: Either "jax" or "torch".
-        loss_fn (Optional[Callable[[Policy, ModelV2,
-            Type[TorchDistributionWrapper], SampleBatch], Union[TensorType,
-            List[TensorType]]]]): Callable that returns a loss tensor.
-        get_default_config (Optional[Callable[[None], AlgorithmConfigDict]]):
-            Optional callable that returns the default config to merge with any
-            overrides. If None, uses only(!) the user-provided
-            PartialAlgorithmConfigDict as dict for this Policy.
-        postprocess_fn (Optional[Callable[[Policy, SampleBatch,
-            Optional[Dict[Any, SampleBatch]], Optional[Any]],
-            SampleBatch]]): Optional callable for post-processing experience
-            batches (called after the super's `postprocess_trajectory` method).
-        stats_fn (Optional[Callable[[Policy, SampleBatch],
-            Dict[str, TensorType]]]): Optional callable that returns a dict of
-            values given the policy and training batch. If None,
-            will use `TorchPolicy.extra_grad_info()` instead. The stats dict is
-            used for logging (e.g. in TensorBoard).
-        extra_action_out_fn (Optional[Callable[[Policy, Dict[str, TensorType],
-            List[TensorType], ModelV2, TorchDistributionWrapper]], Dict[str,
-            TensorType]]]): Optional callable that returns a dict of extra
-            values to include in experiences. If None, no extra computations
-            will be performed.
-        extra_grad_process_fn (Optional[Callable[[Policy,
-            "torch.optim.Optimizer", TensorType], Dict[str, TensorType]]]):
-            Optional callable that is called after gradients are computed and
-            returns a processing info dict. If None, will call the
-            `TorchPolicy.extra_grad_process()` method instead.
-        # TODO: (sven) dissolve naming mismatch between "learn" and "compute.."
-        extra_learn_fetches_fn (Optional[Callable[[Policy],
-            Dict[str, TensorType]]]): Optional callable that returns a dict of
-            extra tensors from the policy after loss evaluation. If None,
-            will call the `TorchPolicy.extra_compute_grad_fetches()` method
-            instead.
-        optimizer_fn (Optional[Callable[[Policy, AlgorithmConfigDict],
-            "torch.optim.Optimizer"]]): Optional callable that returns a
-            torch optimizer given the policy and config. If None, will call
-            the `TorchPolicy.optimizer()` method instead (which returns a
-            torch Adam optimizer).
-        validate_spaces (Optional[Callable[[Policy, gym.Space, gym.Space,
-            AlgorithmConfigDict], None]]): Optional callable that takes the
-            Policy, observation_space, action_space, and config to check for
-            correctness. If None, no spaces checking will be done.
-        before_init (Optional[Callable[[Policy, gym.Space, gym.Space,
-            AlgorithmConfigDict], None]]): Optional callable to run at the
-            beginning of `Policy.__init__` that takes the same arguments as
-            the Policy constructor. If None, this step will be skipped.
-        before_loss_init (Optional[Callable[[Policy, gym.spaces.Space,
-            gym.spaces.Space, AlgorithmConfigDict], None]]): Optional callable to
-            run prior to loss init. If None, this step will be skipped.
-        after_init (Optional[Callable[[Policy, gym.Space, gym.Space,
-            AlgorithmConfigDict], None]]): DEPRECATED: Use `before_loss_init`
-            instead.
-        _after_loss_init (Optional[Callable[[Policy, gym.spaces.Space,
-            gym.spaces.Space, AlgorithmConfigDict], None]]): Optional callable to
-            run after the loss init. If None, this step will be skipped.
-            This will be deprecated at some point and renamed into `after_init`
-            to match `build_tf_policy()` behavior.
-        action_sampler_fn (Optional[Callable[[TensorType, List[TensorType]],
-            Tuple[TensorType, TensorType]]]): Optional callable returning a
-            sampled action and its log-likelihood given some (obs and state)
-            inputs. If None, will either use `action_distribution_fn` or
-            compute actions by calling self.model, then sampling from the
-            so parameterized action distribution.
-        action_distribution_fn (Optional[Callable[[Policy, ModelV2, TensorType,
-            TensorType, TensorType], Tuple[TensorType,
-            Type[TorchDistributionWrapper], List[TensorType]]]]): A callable
-            that takes the Policy, Model, the observation batch, an
-            explore-flag, a timestep, and an is_training flag and returns a
-            tuple of a) distribution inputs (parameters), b) a dist-class to
-            generate an action distribution object from, and c) internal-state
-            outputs (empty list if not applicable). If None, will either use
-            `action_sampler_fn` or compute actions by calling self.model,
-            then sampling from the parameterized action distribution.
-        make_model (Optional[Callable[[Policy, gym.spaces.Space,
-            gym.spaces.Space, AlgorithmConfigDict], ModelV2]]): Optional callable
-            that takes the same arguments as Policy.__init__ and returns a
-            model instance. The distribution class will be determined
-            automatically. Note: Only one of `make_model` or
-            `make_model_and_action_dist` should be provided. If both are None,
-            a default Model will be created.
-        make_model_and_action_dist (Optional[Callable[[Policy,
-            gym.spaces.Space, gym.spaces.Space, AlgorithmConfigDict],
-            Tuple[ModelV2, Type[TorchDistributionWrapper]]]]): Optional
-            callable that takes the same arguments as Policy.__init__ and
-            returns a tuple of model instance and torch action distribution
-            class.
-            Note: Only one of `make_model` or `make_model_and_action_dist`
-            should be provided. If both are None, a default Model will be
-            created.
-        compute_gradients_fn (Optional[Callable[
-            [Policy, SampleBatch], Tuple[ModelGradients, dict]]]): Optional
-            callable that the sampled batch an computes the gradients w.r.
-            to the loss function.
-            If None, will call the `TorchPolicy.compute_gradients()` method
-            instead.
-        apply_gradients_fn (Optional[Callable[[Policy,
-            "torch.optim.Optimizer"], None]]): Optional callable that
-            takes a grads list and applies these to the Model's parameters.
-            If None, will call the `TorchPolicy.apply_gradients()` method
-            instead.
-        mixins (Optional[List[type]]): Optional list of any class mixins for
-            the returned policy class. These mixins will be applied in order
-            and will have higher precedence than the TorchPolicy class.
-        get_batch_divisibility_req (Optional[Callable[[Policy], int]]):
-            Optional callable that returns the divisibility requirement for
-            sample batches. If None, will assume a value of 1.
+            loss_fn (Optional[Callable[[Policy, ModelV2,
+                Type[TorchDistributionWrapper], SampleBatch], Union[TensorType,
+                List[TensorType]]]]): Callable that returns a loss tensor.
+            get_default_config (Optional[Callable[[None], AlgorithmConfigDict]]):
+                Optional callable that returns the default config to merge with any
+                overrides. If None, uses only(!) the user-provided
+                PartialAlgorithmConfigDict as dict for this Policy.
+            postprocess_fn (Optional[Callable[[Policy, SampleBatch,
+                Optional[Dict[Any, SampleBatch]], Optional[Any]],
+                SampleBatch]]): Optional callable for post-processing experience
+                batches (called after the super's `postprocess_trajectory` method).
+            stats_fn (Optional[Callable[[Policy, SampleBatch],
+                Dict[str, TensorType]]]): Optional callable that returns a dict of
+                values given the policy and training batch. If None,
+                will use `TorchPolicy.extra_grad_info()` instead. The stats dict is
+                used for logging (e.g. in TensorBoard).
+            extra_action_out_fn (Optional[Callable[[Policy, Dict[str, TensorType],
+                List[TensorType], ModelV2, TorchDistributionWrapper]], Dict[str,
+                TensorType]]]): Optional callable that returns a dict of extra
+                values to include in experiences. If None, no extra computations
+                will be performed.
+            extra_grad_process_fn (Optional[Callable[[Policy,
+                "torch.optim.Optimizer", TensorType], Dict[str, TensorType]]]):
+                Optional callable that is called after gradients are computed and
+                returns a processing info dict. If None, will call the
+                `TorchPolicy.extra_grad_process()` method instead.
+            # TODO: (sven) dissolve naming mismatch between "learn" and "compute.."
+            extra_learn_fetches_fn (Optional[Callable[[Policy],
+                Dict[str, TensorType]]]): Optional callable that returns a dict of
+                extra tensors from the policy after loss evaluation. If None,
+                will call the `TorchPolicy.extra_compute_grad_fetches()` method
+                instead.
+            optimizer_fn (Optional[Callable[[Policy, AlgorithmConfigDict],
+                "torch.optim.Optimizer"]]): Optional callable that returns a
+                torch optimizer given the policy and config. If None, will call
+                the `TorchPolicy.optimizer()` method instead (which returns a
+                torch Adam optimizer).
+            validate_spaces (Optional[Callable[[Policy, gym.Space, gym.Space,
+                AlgorithmConfigDict], None]]): Optional callable that takes the
+                Policy, observation_space, action_space, and config to check for
+                correctness. If None, no spaces checking will be done.
+            before_init (Optional[Callable[[Policy, gym.Space, gym.Space,
+                AlgorithmConfigDict], None]]): Optional callable to run at the
+                beginning of `Policy.__init__` that takes the same arguments as
+                the Policy constructor. If None, this step will be skipped.
+            before_loss_init (Optional[Callable[[Policy, gym.spaces.Space,
+                gym.spaces.Space, AlgorithmConfigDict], None]]): Optional callable to
+                run prior to loss init. If None, this step will be skipped.
+            after_init (Optional[Callable[[Policy, gym.Space, gym.Space,
+                AlgorithmConfigDict], None]]): DEPRECATED: Use `before_loss_init`
+                instead.
+            _after_loss_init (Optional[Callable[[Policy, gym.spaces.Space,
+                gym.spaces.Space, AlgorithmConfigDict], None]]): Optional callable to
+                run after the loss init. If None, this step will be skipped.
+                This will be deprecated at some point and renamed into `after_init`
+                to match `build_tf_policy()` behavior.
+            action_sampler_fn (Optional[Callable[[TensorType, List[TensorType]],
+                Tuple[TensorType, TensorType]]]): Optional callable returning a
+                sampled action and its log-likelihood given some (obs and state)
+                inputs. If None, will either use `action_distribution_fn` or
+                compute actions by calling self.model, then sampling from the
+                so parameterized action distribution.
+            action_distribution_fn (Optional[Callable[[Policy, ModelV2, TensorType,
+                TensorType, TensorType], Tuple[TensorType,
+                Type[TorchDistributionWrapper], List[TensorType]]]]): A callable
+                that takes the Policy, Model, the observation batch, an
+                explore-flag, a timestep, and an is_training flag and returns a
+                tuple of a) distribution inputs (parameters), b) a dist-class to
+                generate an action distribution object from, and c) internal-state
+                outputs (empty list if not applicable). If None, will either use
+                `action_sampler_fn` or compute actions by calling self.model,
+                then sampling from the parameterized action distribution.
+            make_model (Optional[Callable[[Policy, gym.spaces.Space,
+                gym.spaces.Space, AlgorithmConfigDict], ModelV2]]): Optional callable
+                that takes the same arguments as Policy.__init__ and returns a
+                model instance. The distribution class will be determined
+                automatically. Note: Only one of `make_model` or
+                `make_model_and_action_dist` should be provided. If both are None,
+                a default Model will be created.
+            make_model_and_action_dist (Optional[Callable[[Policy,
+                gym.spaces.Space, gym.spaces.Space, AlgorithmConfigDict],
+                Tuple[ModelV2, Type[TorchDistributionWrapper]]]]): Optional
+                callable that takes the same arguments as Policy.__init__ and
+                returns a tuple of model instance and torch action distribution
+                class.
+                Note: Only one of `make_model` or `make_model_and_action_dist`
+                should be provided. If both are None, a default Model will be
+                created.
+            compute_gradients_fn (Optional[Callable[
+                [Policy, SampleBatch], Tuple[ModelGradients, dict]]]): Optional
+                callable that the sampled batch an computes the gradients w.r.
+                to the loss function.
+                If None, will call the `TorchPolicy.compute_gradients()` method
+                instead.
+            apply_gradients_fn (Optional[Callable[[Policy,
+                "torch.optim.Optimizer"], None]]): Optional callable that
+                takes a grads list and applies these to the Model's parameters.
+                If None, will call the `TorchPolicy.apply_gradients()` method
+                instead.
+            mixins (Optional[List[type]]): Optional list of any class mixins for
+                the returned policy class. These mixins will be applied in order
+                and will have higher precedence than the TorchPolicy class.
+            get_batch_divisibility_req (Optional[Callable[[Policy], int]]):
+                Optional callable that returns the divisibility requirement for
+                sample batches. If None, will assume a value of 1.
 
     Returns:
         Type[TorchPolicy]: TorchPolicy child class constructed from the

--- a/rllib/policy/tf_policy_template.py
+++ b/rllib/policy/tf_policy_template.py
@@ -108,89 +108,89 @@ def build_tf_policy(
 
     Args:
         name: Name of the policy (e.g., "PPOTFPolicy").
-        loss_fn (Callable[[
-            Policy, ModelV2, Type[TFActionDistribution], SampleBatch],
-            Union[TensorType, List[TensorType]]]): Callable for calculating a
-            loss tensor.
-        get_default_config (Optional[Callable[[None], AlgorithmConfigDict]]):
-            Optional callable that returns the default config to merge with any
-            overrides. If None, uses only(!) the user-provided
-            PartialAlgorithmConfigDict as dict for this Policy.
-        postprocess_fn (Optional[Callable[[Policy, SampleBatch,
-            Optional[Dict[AgentID, SampleBatch]], Episode], None]]):
-            Optional callable for post-processing experience batches (called
-            after the parent class' `postprocess_trajectory` method).
-        stats_fn (Optional[Callable[[Policy, SampleBatch],
-            Dict[str, TensorType]]]): Optional callable that returns a dict of
-            TF tensors to fetch given the policy and batch input tensors. If
-            None, will not compute any stats.
-        optimizer_fn (Optional[Callable[[Policy, AlgorithmConfigDict],
-            "tf.keras.optimizers.Optimizer"]]): Optional callable that returns
-            a tf.Optimizer given the policy and config. If None, will call
-            the base class' `optimizer()` method instead (which returns a
-            tf1.train.AdamOptimizer).
-        compute_gradients_fn (Optional[Callable[[Policy,
-            "tf.keras.optimizers.Optimizer", TensorType], ModelGradients]]):
-            Optional callable that returns a list of gradients. If None,
-            this defaults to optimizer.compute_gradients([loss]).
-        apply_gradients_fn (Optional[Callable[[Policy,
-            "tf.keras.optimizers.Optimizer", ModelGradients],
-            "tf.Operation"]]): Optional callable that returns an apply
-            gradients op given policy, tf-optimizer, and grads_and_vars. If
-            None, will call the base class' `build_apply_op()` method instead.
-        grad_stats_fn (Optional[Callable[[Policy, SampleBatch, ModelGradients],
-            Dict[str, TensorType]]]): Optional callable that returns a dict of
-            TF fetches given the policy, batch input, and gradient tensors. If
-            None, will not collect any gradient stats.
-        extra_action_out_fn (Optional[Callable[[Policy],
-            Dict[str, TensorType]]]): Optional callable that returns
-            a dict of TF fetches given the policy object. If None, will not
-            perform any extra fetches.
-        extra_learn_fetches_fn (Optional[Callable[[Policy],
-            Dict[str, TensorType]]]): Optional callable that returns a dict of
-            extra values to fetch and return when learning on a batch. If None,
-            will call the base class' `extra_compute_grad_fetches()` method
-            instead.
-        validate_spaces (Optional[Callable[[Policy, gym.Space, gym.Space,
-            AlgorithmConfigDict], None]]): Optional callable that takes the
-            Policy, observation_space, action_space, and config to check
-            the spaces for correctness. If None, no spaces checking will be
-            done.
-        before_init (Optional[Callable[[Policy, gym.Space, gym.Space,
-            AlgorithmConfigDict], None]]): Optional callable to run at the
-            beginning of policy init that takes the same arguments as the
-            policy constructor. If None, this step will be skipped.
-        before_loss_init (Optional[Callable[[Policy, gym.spaces.Space,
-            gym.spaces.Space, AlgorithmConfigDict], None]]): Optional callable to
-            run prior to loss init. If None, this step will be skipped.
-        after_init (Optional[Callable[[Policy, gym.Space, gym.Space,
-            AlgorithmConfigDict], None]]): Optional callable to run at the end of
-            policy init. If None, this step will be skipped.
-        make_model (Optional[Callable[[Policy, gym.spaces.Space,
-            gym.spaces.Space, AlgorithmConfigDict], ModelV2]]): Optional callable
-            that returns a ModelV2 object.
-            All policy variables should be created in this function. If None,
-            a default ModelV2 object will be created.
-        action_sampler_fn (Optional[Callable[[TensorType, List[TensorType]],
-            Tuple[TensorType, TensorType]]]): A callable returning a sampled
-            action and its log-likelihood given observation and state inputs.
-            If None, will either use `action_distribution_fn` or
-            compute actions by calling self.model, then sampling from the
-            so parameterized action distribution.
-        action_distribution_fn (Optional[Callable[[Policy, ModelV2, TensorType,
-            TensorType, TensorType],
-            Tuple[TensorType, type, List[TensorType]]]]): Optional callable
-            returning distribution inputs (parameters), a dist-class to
-            generate an action distribution object from, and internal-state
-            outputs (or an empty list if not applicable). If None, will either
-            use `action_sampler_fn` or compute actions by calling self.model,
-            then sampling from the so parameterized action distribution.
-        mixins (Optional[List[type]]): Optional list of any class mixins for
-            the returned policy class. These mixins will be applied in order
-            and will have higher precedence than the DynamicTFPolicy class.
-        get_batch_divisibility_req (Optional[Callable[[Policy], int]]):
-            Optional callable that returns the divisibility requirement for
-            sample batches. If None, will assume a value of 1.
+            loss_fn (Callable[[
+                Policy, ModelV2, Type[TFActionDistribution], SampleBatch],
+                Union[TensorType, List[TensorType]]]): Callable for calculating a
+                loss tensor.
+            get_default_config (Optional[Callable[[None], AlgorithmConfigDict]]):
+                Optional callable that returns the default config to merge with any
+                overrides. If None, uses only(!) the user-provided
+                PartialAlgorithmConfigDict as dict for this Policy.
+            postprocess_fn (Optional[Callable[[Policy, SampleBatch,
+                Optional[Dict[AgentID, SampleBatch]], Episode], None]]):
+                Optional callable for post-processing experience batches (called
+                after the parent class' `postprocess_trajectory` method).
+            stats_fn (Optional[Callable[[Policy, SampleBatch],
+                Dict[str, TensorType]]]): Optional callable that returns a dict of
+                TF tensors to fetch given the policy and batch input tensors. If
+                None, will not compute any stats.
+            optimizer_fn (Optional[Callable[[Policy, AlgorithmConfigDict],
+                "tf.keras.optimizers.Optimizer"]]): Optional callable that returns
+                a tf.Optimizer given the policy and config. If None, will call
+                the base class' `optimizer()` method instead (which returns a
+                tf1.train.AdamOptimizer).
+            compute_gradients_fn (Optional[Callable[[Policy,
+                "tf.keras.optimizers.Optimizer", TensorType], ModelGradients]]):
+                Optional callable that returns a list of gradients. If None,
+                this defaults to optimizer.compute_gradients([loss]).
+            apply_gradients_fn (Optional[Callable[[Policy,
+                "tf.keras.optimizers.Optimizer", ModelGradients],
+                "tf.Operation"]]): Optional callable that returns an apply
+                gradients op given policy, tf-optimizer, and grads_and_vars. If
+                None, will call the base class' `build_apply_op()` method instead.
+            grad_stats_fn (Optional[Callable[[Policy, SampleBatch, ModelGradients],
+                Dict[str, TensorType]]]): Optional callable that returns a dict of
+                TF fetches given the policy, batch input, and gradient tensors. If
+                None, will not collect any gradient stats.
+            extra_action_out_fn (Optional[Callable[[Policy],
+                Dict[str, TensorType]]]): Optional callable that returns
+                a dict of TF fetches given the policy object. If None, will not
+                perform any extra fetches.
+            extra_learn_fetches_fn (Optional[Callable[[Policy],
+                Dict[str, TensorType]]]): Optional callable that returns a dict of
+                extra values to fetch and return when learning on a batch. If None,
+                will call the base class' `extra_compute_grad_fetches()` method
+                instead.
+            validate_spaces (Optional[Callable[[Policy, gym.Space, gym.Space,
+                AlgorithmConfigDict], None]]): Optional callable that takes the
+                Policy, observation_space, action_space, and config to check
+                the spaces for correctness. If None, no spaces checking will be
+                done.
+            before_init (Optional[Callable[[Policy, gym.Space, gym.Space,
+                AlgorithmConfigDict], None]]): Optional callable to run at the
+                beginning of policy init that takes the same arguments as the
+                policy constructor. If None, this step will be skipped.
+            before_loss_init (Optional[Callable[[Policy, gym.spaces.Space,
+                gym.spaces.Space, AlgorithmConfigDict], None]]): Optional callable to
+                run prior to loss init. If None, this step will be skipped.
+            after_init (Optional[Callable[[Policy, gym.Space, gym.Space,
+                AlgorithmConfigDict], None]]): Optional callable to run at the end of
+                policy init. If None, this step will be skipped.
+            make_model (Optional[Callable[[Policy, gym.spaces.Space,
+                gym.spaces.Space, AlgorithmConfigDict], ModelV2]]): Optional callable
+                that returns a ModelV2 object.
+                All policy variables should be created in this function. If None,
+                a default ModelV2 object will be created.
+            action_sampler_fn (Optional[Callable[[TensorType, List[TensorType]],
+                Tuple[TensorType, TensorType]]]): A callable returning a sampled
+                action and its log-likelihood given observation and state inputs.
+                If None, will either use `action_distribution_fn` or
+                compute actions by calling self.model, then sampling from the
+                so parameterized action distribution.
+            action_distribution_fn (Optional[Callable[[Policy, ModelV2, TensorType,
+                TensorType, TensorType],
+                Tuple[TensorType, type, List[TensorType]]]]): Optional callable
+                returning distribution inputs (parameters), a dist-class to
+                generate an action distribution object from, and internal-state
+                outputs (or an empty list if not applicable). If None, will either
+                use `action_sampler_fn` or compute actions by calling self.model,
+                then sampling from the so parameterized action distribution.
+            mixins (Optional[List[type]]): Optional list of any class mixins for
+                the returned policy class. These mixins will be applied in order
+                and will have higher precedence than the DynamicTFPolicy class.
+            get_batch_divisibility_req (Optional[Callable[[Policy], int]]):
+                Optional callable that returns the divisibility requirement for
+                sample batches. If None, will assume a value of 1.
 
     Returns:
         Type[DynamicTFPolicy]: A child class of DynamicTFPolicy based on the

--- a/rllib/utils/metrics/utils.py
+++ b/rllib/utils/metrics/utils.py
@@ -6,8 +6,8 @@ def to_snake_case(class_name: str) -> str:
 
     This is used to unify metrics names when using class names within.
     Args:
-        class_name: A string defining a class name (usually in camel
-        case).
+        class_name: A string defining a class name usually in camel
+            case.
 
     Returns:
         The class name in snake case.

--- a/rllib/utils/replay_buffers/fifo_replay_buffer.py
+++ b/rllib/utils/replay_buffers/fifo_replay_buffer.py
@@ -104,6 +104,6 @@ class FifoReplayBuffer(ReplayBuffer):
 
         Args:
             state: The new state to set this buffer. Can be obtained by calling
-            `self.get_state()`.
+                `self.get_state()`.
         """
         pass

--- a/rllib/utils/replay_buffers/multi_agent_mixin_replay_buffer.py
+++ b/rllib/utils/replay_buffers/multi_agent_mixin_replay_buffer.py
@@ -117,7 +117,7 @@ class MultiAgentMixInReplayBuffer(MultiAgentPrioritizedReplayBuffer):
         prioritized_replay_alpha: float = 0.6,
         prioritized_replay_beta: float = 0.4,
         prioritized_replay_eps: float = 1e-6,
-        **kwargs
+        **kwargs,
     ):
         """Initializes MultiAgentMixInReplayBuffer instance.
 
@@ -187,7 +187,7 @@ class MultiAgentMixInReplayBuffer(MultiAgentPrioritizedReplayBuffer):
             prioritized_replay_alpha=prioritized_replay_alpha,
             prioritized_replay_beta=prioritized_replay_beta,
             prioritized_replay_eps=prioritized_replay_eps,
-            **kwargs
+            **kwargs,
         )
 
         self.replay_ratio = replay_ratio
@@ -282,7 +282,7 @@ class MultiAgentMixInReplayBuffer(MultiAgentPrioritizedReplayBuffer):
         Args:
             num_items: Number of items to sample from this buffer.
             policy_id: ID of the policy that produced the experiences to be
-            sampled.
+                sampled.
             **kwargs: Forward compatibility kwargs.
 
         Returns:

--- a/rllib/utils/replay_buffers/multi_agent_prioritized_replay_buffer.py
+++ b/rllib/utils/replay_buffers/multi_agent_prioritized_replay_buffer.py
@@ -49,7 +49,7 @@ class MultiAgentPrioritizedReplayBuffer(
         prioritized_replay_alpha: float = 0.6,
         prioritized_replay_beta: float = 0.4,
         prioritized_replay_eps: float = 1e-6,
-        **kwargs
+        **kwargs,
     ):
         """Initializes a MultiAgentReplayBuffer instance.
 
@@ -156,7 +156,7 @@ class MultiAgentPrioritizedReplayBuffer(
 
         Args:
             policy_id: ID of the policy that corresponds to the underlying
-            buffer
+                buffer
             batch: SampleBatch to add to the underlying buffer
             ``**kwargs``: Forward compatibility kwargs.
         """
@@ -244,7 +244,7 @@ class MultiAgentPrioritizedReplayBuffer(
 
         Args:
             prio_dict: A dictionary containing td_errors for
-            batches saved in underlying replay buffers.
+                batches saved in underlying replay buffers.
         """
         with self.update_priorities_timer:
             for policy_id, (batch_indexes, td_errors) in prio_dict.items():
@@ -259,8 +259,8 @@ class MultiAgentPrioritizedReplayBuffer(
         """Returns the stats of this buffer and all underlying buffers.
 
         Args:
-            debug: If True, stats of underlying replay buffers will
-            be fetched with debug=True.
+            debug: If True, stats of underlying replay buffers are
+                fetched with debug=True.
 
         Returns:
             stat: Dictionary of buffer stats.

--- a/rllib/utils/replay_buffers/multi_agent_replay_buffer.py
+++ b/rllib/utils/replay_buffers/multi_agent_replay_buffer.py
@@ -72,7 +72,7 @@ class MultiAgentReplayBuffer(ReplayBuffer):
         replay_burn_in: int = 0,
         replay_zero_init_states: bool = True,
         underlying_buffer_config: dict = None,
-        **kwargs
+        **kwargs,
     ):
         """Initializes a MultiAgentReplayBuffer instance.
 
@@ -242,7 +242,7 @@ class MultiAgentReplayBuffer(ReplayBuffer):
 
         Args:
             policy_id: ID of the policy that corresponds to the underlying
-            buffer
+                buffer
             batch: SampleBatch to add to the underlying buffer
             ``**kwargs``: Forward compatibility kwargs.
         """
@@ -304,7 +304,7 @@ class MultiAgentReplayBuffer(ReplayBuffer):
         Args:
             num_items: Number of items to sample from a policy's buffer.
             policy_id: ID of the policy that created the experiences we sample. If
-            none is given, sample from all policies.
+                none is given, sample from all policies.
 
         Returns:
             Concatenated MultiAgentBatch of items.
@@ -337,8 +337,8 @@ class MultiAgentReplayBuffer(ReplayBuffer):
         """Returns the stats of this buffer and all underlying buffers.
 
         Args:
-            debug: If True, stats of underlying replay buffers will
-            be fetched with debug=True.
+            debug: If True, stats of underlying replay buffers
+                are fetched with debug=True.
 
         Returns:
             stat: Dictionary of buffer stats.

--- a/rllib/utils/replay_buffers/prioritized_replay_buffer.py
+++ b/rllib/utils/replay_buffers/prioritized_replay_buffer.py
@@ -29,7 +29,7 @@ class PrioritizedReplayBuffer(ReplayBuffer):
         capacity: int = 10000,
         storage_unit: str = "timesteps",
         alpha: float = 1.0,
-        **kwargs
+        **kwargs,
     ):
         """Initializes a PrioritizedReplayBuffer instance.
 
@@ -115,7 +115,7 @@ class PrioritizedReplayBuffer(ReplayBuffer):
         Args:
             num_items: Number of items to sample from this buffer.
             beta: To what degree to use importance weights (0 - no corrections,
-            1 - full correction).
+                1 - full correction).
             ``**kwargs``: Forward compatibility kwargs.
 
         Returns:
@@ -170,7 +170,7 @@ class PrioritizedReplayBuffer(ReplayBuffer):
         Args:
             idxes: List of indices of items
             priorities: List of updated priorities corresponding to items at the
-            idxes denoted by variable `idxes`.
+                idxes denoted by variable `idxes`.
         """
         # Making sure we don't pass in e.g. a torch tensor.
         assert isinstance(
@@ -232,7 +232,7 @@ class PrioritizedReplayBuffer(ReplayBuffer):
 
         Args:
             state: The new state to set this buffer. Can be obtained by calling
-            `self.get_state()`.
+                `self.get_state()`.
         """
         super().set_state(state)
         self._it_sum.set_state(state["sum_segment_tree"])


### PR DESCRIPTION
Public-facing ones weren't rendering correctly and cleaned up internal ones in case of cargo culting.

## Related issue number
https://anyscale1.atlassian.net/browse/MLDX-686

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
