### PR TITLE
[data] Fix backpressure for FileBasedDatasource

### DIFF
--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -285,7 +285,6 @@ class FileBasedDatasource(Datasource):
                         read_files,
                         num_workers=num_threads,
                         preserve_ordering=True,
-                        buffer_size=max(len(read_paths) // num_threads, 1),
                     )
                 else:
                     logger.debug(f"Reading {len(read_paths)} files.")


### PR DESCRIPTION
Currently there is no backpressure for FileBasedDatasource, because the `buffer_size` is incorrectly set to the total number of files. 
This issue can lead to OOMs for jobs using `read_images`, `read_video`, `read_audio`, `read_binary`, etc. 