### PR TITLE
[Data] Re-enable Actor locality-based scheduling

### DIFF
--- a/python/ray/data/BUILD
+++ b/python/ray/data/BUILD
@@ -1044,6 +1044,20 @@ py_test(
 )
 
 py_test(
+    name = "test_ref_bundle",
+    size = "small",
+    srcs = ["tests/test_ref_bundle.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_resource_manager",
     size = "medium",
     srcs = ["tests/test_resource_manager.py"],

--- a/python/ray/data/_internal/execution/interfaces/execution_options.py
+++ b/python/ray/data/_internal/execution/interfaces/execution_options.py
@@ -305,9 +305,7 @@ class ExecutionOptions:
         exclude_resources: Optional[ExecutionResources] = None,
         locality_with_output: Union[bool, List[NodeIdStr]] = False,
         preserve_order: bool = False,
-        # TODO(hchen): Re-enable `actor_locality_enabled` by default after fixing
-        # https://github.com/ray-project/ray/issues/43466
-        actor_locality_enabled: bool = False,
+        actor_locality_enabled: bool = True,
         verbose_progress: Optional[bool] = None,
     ):
         if resource_limits is None:

--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -1,5 +1,6 @@
+from collections import defaultdict
 from dataclasses import dataclass
-from typing import Iterator, List, Optional, Tuple
+from typing import Dict, Iterator, List, Optional, Tuple
 
 import ray
 from ray.data._internal.memory_tracing import trace_deallocation
@@ -38,8 +39,13 @@ class RefBundle:
     # output splits. It is otherwise None.
     output_split_idx: Optional[int] = None
 
-    # Cached location, used for get_cached_location().
-    _cached_location: Optional[NodeIdStr] = None
+    # Object metadata (size, locations, spilling status)
+    _cached_object_meta: Optional[Dict[ObjectRef, "_ObjectMetadata"]] = None
+
+    # Preferred locations for this bundle determined based on the locations
+    # of individual objects and their corresponding size, ie location with the
+    # largest total number of bytes present there has the highest preference.
+    _cached_preferred_locations: Optional[Dict[NodeIdStr, int]] = None
 
     def __post_init__(self):
         if not isinstance(self.blocks, tuple):
@@ -96,27 +102,43 @@ class RefBundle:
             )
         return self.size_bytes() if should_free else 0
 
-    def get_cached_location(self) -> Optional[NodeIdStr]:
-        """Return a location for this bundle's data, if possible.
+    def get_preferred_object_locations(self) -> Dict[NodeIdStr, int]:
+        """Returns a mapping of node IDs to total bytes stored on each node.
 
-        Caches the resolved location so multiple calls to this are efficient.
+        Returns:
+            Dict mapping node ID to total bytes stored on that node
         """
-        if self._cached_location is None:
-            # Only consider the first block in the bundle for now. TODO(ekl) consider
-            # taking into account other blocks.
-            ref = self.block_refs[0]
+        meta = self._get_cached_metadata()
+
+        if self._cached_preferred_locations is None:
+            preferred_locs: Dict[NodeIdStr, int] = defaultdict(int)
+
+            for ref, obj_meta in meta.items():
+                for loc in obj_meta.locs:
+                    preferred_locs[loc] += obj_meta.size
+
+            self._cached_preferred_locations = preferred_locs
+
+        return self._cached_preferred_locations
+
+    def _get_cached_metadata(self) -> Dict[ObjectRef, "_ObjectMetadata"]:
+        if self._cached_object_meta is None:
             # This call is pretty fast for owned objects (~5k/s), so we don't need to
             # batch it for now.
-            locs = ray.experimental.get_local_object_locations([ref])
-            nodes = locs[ref]["node_ids"]
-            if nodes:
-                self._cached_location = nodes[0]
-            else:
-                self._cached_location = ""
-        if self._cached_location:
-            return self._cached_location
-        else:
-            return None  # Return None if cached location is "".
+            meta = ray.experimental.get_local_object_locations(self.block_refs)
+            # Extract locations
+            object_metas: Dict[ObjectRef, _ObjectMetadata] = {
+                ref: _ObjectMetadata(
+                    size=meta[ref]["object_size"],
+                    spilled=meta[ref]["did_spill"],
+                    locs=meta[ref]["node_ids"],
+                )
+                for ref in self.block_refs
+            }
+
+            self._cached_object_meta = object_metas
+
+        return self._cached_object_meta
 
     def __eq__(self, other) -> bool:
         return self is other
@@ -126,6 +148,16 @@ class RefBundle:
 
     def __len__(self) -> int:
         return len(self.blocks)
+
+
+@dataclass
+class _ObjectMetadata:
+    # Object size in bytes
+    size: int
+    # Flag whether object has been spilled
+    spilled: bool
+    # List of nodes object exists on
+    locs: List[NodeIdStr] = None
 
 
 def _ref_bundles_iterator_to_block_refs_list(

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -23,6 +23,7 @@ from ray.data._internal.remote_fn import _add_system_error_to_retry_exceptions
 from ray.data.block import Block, BlockMetadata
 from ray.data.context import DataContext
 from ray.types import ObjectRef
+from ray.util.common import INT32_MAX
 
 logger = logging.getLogger(__name__)
 
@@ -631,7 +632,7 @@ class _ActorPool(AutoscalingActorPool):
         return True
 
     def pick_actor(
-        self, locality_hint: Optional[RefBundle] = None
+        self, bundle: Optional[RefBundle] = None
     ) -> Optional[ray.actor.ActorHandle]:
         """Picks an actor for task submission based on busyness and locality.
 
@@ -639,16 +640,11 @@ class _ActorPool(AutoscalingActorPool):
         max_tasks_in_flight) or are still pending.
 
         Args:
-            locality_hint: Try to pick an actor that is local for this bundle.
+            bundle: Try to pick an actor that is local for this bundle.
         """
         if not self._running_actors:
             # Actor pool is empty or all actors are still pending.
             return None
-
-        if locality_hint:
-            preferred_loc = self._get_location(locality_hint)
-        else:
-            preferred_loc = None
 
         # Filter out actors that are invalid, i.e. actors with number of tasks in
         # flight >= _max_tasks_in_flight or actor_state is not ALIVE.
@@ -664,28 +660,73 @@ class _ActorPool(AutoscalingActorPool):
             # All actors are at capacity or actor state is not ALIVE.
             return None
 
-        def penalty_key(actor):
-            """Returns the key that should be minimized for the best actor.
+        # Rank all valid actors
+        ranks = self._rank_actors(valid_actors, bundle)
 
-            We prioritize actors with argument locality, and those that are not busy,
-            in that order.
-            """
-            busyness = self._running_actors[actor].num_tasks_in_flight
-            requires_remote_fetch = (
-                self._running_actors[actor].actor_location != preferred_loc
+        assert len(ranks) == len(valid_actors), f"{len(ranks)} != {len(valid_actors)}"
+
+        # Pick the actor with the highest rank (lower value, higher rank)
+        target_actor_idx = min(range(len(valid_actors)), key=lambda idx: ranks[idx])
+
+        target_actor = valid_actors[target_actor_idx]
+        locality_rank, _ = ranks[target_actor_idx]
+
+        if bundle and locality_rank != INT32_MAX:
+            self._locality_hits += 1
+        else:
+            self._locality_misses += 1
+
+        self._running_actors[target_actor].num_tasks_in_flight += 1
+
+        return target_actor
+
+    def _rank_actors(
+        self,
+        actors: List[ActorHandle],
+        bundle: Optional[RefBundle],
+    ) -> List[Tuple[int, int]]:
+        """Return ranks for each actor based on node affinity with the blocks in the provided
+        bundle and current Actor's load.
+
+        The rank for each actor is a tuple of
+
+            1. Locality rank: a rank of a node Actor is scheduled on determined based on
+            the ranking of preferred locations for provided ``RefBundle`` (defined by
+            ``RefBundle.get_preferred_locations``). Lower is better.
+            2. Number of tasks currently executed by Actor. Lower is better.
+
+        Args:
+            actors: List of actors to rank
+            bundle: Optional bundle whose locality preferences should be considered
+
+        Returns:
+            List of (locality_rank, num_tasks) tuples, one per input actor
+        """
+        locs_priorities = (
+            {
+                # NOTE: We're negating total bytes to maintain an invariant
+                #       of the rank used -- lower value corresponding to a higher rank
+                node_id: -total_bytes
+                for node_id, total_bytes in bundle.get_preferred_object_locations().items()
+            }
+            if bundle is not None
+            else {}
+        )
+
+        ranks = [
+            (
+                # Priority/rank of the location (based on the object size).
+                # Defaults to int32 max value (ie no rank)
+                locs_priorities.get(
+                    self._running_actors[actor].actor_location, INT32_MAX
+                ),
+                # Number of tasks currently in flight at the given actor
+                self._running_actors[actor].num_tasks_in_flight,
             )
-            return requires_remote_fetch, busyness
+            for actor in actors
+        ]
 
-        # Pick the best valid actor based on the penalty key
-        actor = min(valid_actors, key=penalty_key)
-
-        if locality_hint:
-            if self._running_actors[actor].actor_location == preferred_loc:
-                self._locality_hits += 1
-            else:
-                self._locality_misses += 1
-        self._running_actors[actor].num_tasks_in_flight += 1
-        return actor
+        return ranks
 
     def return_actor(self, actor: ray.actor.ActorHandle):
         """Returns the provided actor to the pool."""
@@ -805,16 +846,6 @@ class _ActorPool(AutoscalingActorPool):
         del self._running_actors[actor]
 
         return ref
-
-    def _get_location(self, bundle: RefBundle) -> Optional[NodeIdStr]:
-        """Ask Ray for the node id of the given bundle.
-
-        This method may be overriden for testing.
-
-        Returns:
-            A node id associated with the bundle, or None if unknown.
-        """
-        return bundle.get_cached_location()
 
     def actor_info_counts(self) -> Tuple[int, int, int]:
         """Returns Actor counts for Alive, Restarting and Pending Actors."""

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -335,9 +335,9 @@ def test_split_operator_locality_hints(ray_start_regular_shared):
     def get_bundle_loc(bundle):
         block = ray.get(bundle.blocks[0][0])
         fval = list(block["id"])[0]
-        return get_fake_loc(fval)
+        return [get_fake_loc(fval)]
 
-    op._get_location = get_bundle_loc
+    op._get_locations = get_bundle_loc
 
     # Feed data and implement streaming exec.
     output_splits = collections.defaultdict(list)

--- a/python/ray/data/tests/test_ref_bundle.py
+++ b/python/ray/data/tests/test_ref_bundle.py
@@ -1,0 +1,55 @@
+from unittest.mock import patch
+
+from ray import ObjectRef
+from ray.data._internal.execution.interfaces import RefBundle
+from ray.data.block import BlockMetadata
+
+
+def test_get_preferred_locations():
+
+    first_block_ref = ObjectRef(b"1" * 28)
+    second_block_ref = ObjectRef(b"2" * 28)
+    third_block_ref = ObjectRef(b"3" * 28)
+
+    meta = BlockMetadata(
+        num_rows=None, size_bytes=1, exec_stats=None, schema=None, input_files=None
+    )
+
+    bundle = RefBundle(
+        blocks=[
+            (first_block_ref, meta),
+            (second_block_ref, meta),
+            (third_block_ref, meta),
+        ],
+        owns_blocks=True,
+    )
+
+    def _get_obj_locs(obj_refs):
+        assert obj_refs == [first_block_ref, second_block_ref, third_block_ref]
+
+        return {
+            first_block_ref: {
+                "object_size": 1024,
+                "did_spill": False,
+                "node_ids": ["1", "2", "3"],
+            },
+            second_block_ref: {
+                "object_size": 2048,
+                "did_spill": False,
+                "node_ids": ["2", "3"],
+            },
+            third_block_ref: {
+                "object_size": 4096,
+                "did_spill": False,
+                "node_ids": ["2"],
+            },
+        }
+
+    with patch("ray.experimental.get_local_object_locations", _get_obj_locs):
+        preferred_object_locs = bundle.get_preferred_object_locations()
+
+    assert {
+        "1": 1024,  # first_block_ref]
+        "2": 7168,  # first_block_ref, second_block_ref, third_block_ref
+        "3": 3072,  # first_block_ref, second_block_ref
+    } == preferred_object_locs


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Context
---

Currently locality-aware scheduling is disabled due to https://github.com/ray-project/ray/issues/43466

However, since we're already using the new API, i've cleaned up the ranking and scheduling sequence and re-enabled locality aware scheduling.

Changes
---

 - Added `RefBundle.get_preferred_object_locations` to compute a mapping of node-ids to total object bytes on the node
 - Added tests
 - Rebased `OutputSplitter` onto the new API
 - Rebased `ActorPool` onto `get_preferred_locations`
 - Re-enable locality hinting for actors by default

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
