### PR TITLE
[pydoclint] core/_private docstring minimal format fixes

### DIFF
--- a/python/ray/_private/external_storage.py
+++ b/python/ray/_private/external_storage.py
@@ -187,15 +187,14 @@ class ExternalStorage(metaclass=abc.ABCMeta):
         """Check whether or not the obtained_data_size is as expected.
 
         Args:
-             metadata_len: Actual metadata length of the object.
-             buffer_len: Actual buffer length of the object.
-             obtained_data_size: Data size specified in the
-                url_with_offset.
+            address_len: Length of the address.
+            metadata_len: Actual metadata length of the object.
+            buffer_len: Actual buffer length of the object.
+            obtained_data_size: Data size specified in the url_with_offset.
 
         Raises:
-            ValueError if obtained_data_size is different from
-            address_len + metadata_len + buffer_len +
-            24 (first 8 bytes to store length).
+            ValueError: If obtained_data_size is different from
+                address_len + metadata_len + buffer_len + 24 (first 8 bytes to store length).
         """
         data_size_in_bytes = (
             address_len + metadata_len + buffer_len + self.HEADER_LENGTH

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -1035,12 +1035,13 @@ class Node:
         port isn't already cached, an unused port is generated and cached.
 
         Args:
-            port_name: the name of the port, e.g. metrics_export_port
-            default_port (Optional[int]): The port to return and cache if no
-            port has already been cached for the given port_name.  If None, an
-            unused port is generated and cached.
+            port_name: The name of the port, e.g. metrics_export_port.
+            default_port: The port to return and cache if no port has already been
+                cached for the given port_name. If None, an unused port is generated
+                and cached.
+
         Returns:
-            port: the port number.
+            int: The port number.
         """
         file_path = os.path.join(self.get_session_dir_path(), "ports_by_node.json")
 

--- a/python/ray/_private/resource_isolation_config.py
+++ b/python/ray/_private/resource_isolation_config.py
@@ -21,7 +21,7 @@ class ResourceIsolationConfig:
     Also, converts system_reserved_cpu into cpu.weights for cgroupv2.
 
     Raises:
-        ValueError on invalid inputs.
+        ValueError: On invalid inputs.
 
     Attributes:
         enable_resource_isolation: True if cgroupv2 based isolation of ray
@@ -120,12 +120,15 @@ class ResourceIsolationConfig:
         """Returns the ray_constants.DEFAULT_CGROUP_PATH if cgroup_path is not
         specified. Checks the type of cgroup_path.
 
-        Raises:
-            ValueError if cgroup_path is not a string.
-
-        Attributes:
+        Args:
             cgroup_path: The path for the cgroup the raylet should use to enforce
                 resource isolation.
+
+        Returns:
+            str: The validated cgroup path.
+
+        Raises:
+            ValueError: If cgroup_path is not a string.
         """
         if not cgroup_path:
             cgroup_path = ray_constants.DEFAULT_CGROUP_PATH
@@ -147,13 +150,13 @@ class ResourceIsolationConfig:
         checks the type, makes sure that the value is in range, and converts it into cpu.weights
         for cgroupv2. See https://docs.kernel.org/admin-guide/cgroup-v2.html#weights for more information.
 
-        Raises:
-            ValueError if system_reserved_cpu is specified, but invalid.
-
-        Attributes:
+        Args:
             system_reserved_cpu: The amount of cores reserved for ray system
                 processes. Must be >= ray_constants.MINIMUM_SYSTEM_RESERVED_CPU_CORES
                 and < the total number of cores available.
+
+        Raises:
+            ValueError: If system_reserved_cpu is specified, but invalid.
         """
         available_system_cpus = utils.get_num_cpus()
 
@@ -207,13 +210,16 @@ class ResourceIsolationConfig:
         """If system_reserved_memory is not specified, returns the default value. Otherwise,
         checks the type, makes sure that the value is in range.
 
-        Raises:
-            ValueError if system_reserved_memory is specified, but invalid.
-
-        Attributes:
+        Args:
             system_reserved_memory: The amount of memory in bytes reserved
                 for ray system processes. Must be >= ray_constants.MINIMUM_SYSTEM_RESERVED_MEMORY_BYTES
                 and < the total memory available.
+
+        Returns:
+            int: The validated system reserved memory in bytes.
+
+        Raises:
+            ValueError: If system_reserved_memory is specified, but invalid.
         """
         available_system_memory = utils.get_system_memory()
 

--- a/python/ray/_private/runtime_env/agent/runtime_env_agent.py
+++ b/python/ray/_private/runtime_env/agent/runtime_env_agent.py
@@ -356,18 +356,19 @@ class RuntimeEnvAgent:
             setup_timeout_seconds,
             runtime_env_config: RuntimeEnvConfig,
         ) -> Tuple[bool, str, str]:
-            """
-            Create runtime env with retry times. This function won't raise exceptions.
+            """Create runtime env with retry times. This function won't raise exceptions.
 
             Args:
                 runtime_env: The instance of RuntimeEnv class.
                 setup_timeout_seconds: The timeout of runtime environment creation for
-                each attempt.
+                    each attempt.
+                runtime_env_config: The configuration for the runtime environment.
 
             Returns:
-                a tuple which contains result (bool), runtime env context (str), error
-                message(str).
-
+                Tuple[bool, str, str]: A tuple containing:
+                    - result (bool): Whether the creation was successful
+                    - runtime_env_context (str): The serialized context if successful, None otherwise
+                    - error_message (str): Error message if failed, None otherwise
             """
             self._logger.info(
                 f"Creating runtime env: {serialized_env} with timeout "

--- a/python/ray/_private/runtime_env/mpi.py
+++ b/python/ray/_private/runtime_env/mpi.py
@@ -39,20 +39,24 @@ def mpi_init():
 
 
 class MPIPlugin(RuntimeEnvPlugin):
-    """This plugin enable a MPI cluster to run on top of ray.
+    """Plugin for enabling MPI cluster functionality in runtime environments.
 
-    To use this, "mpi" need to be added to the runtime env like following
+    This plugin enables an MPI cluster to run on top of Ray. It handles the setup
+    and configuration of MPI processes for distributed computing tasks.
 
-    @ray.remote(
-        runtime_env={
-            "mpi": {
-                "args": ["-n", "4"],
-                "worker_entry": worker_entry,
+    To use this plugin, add "mpi" to the runtime environment configuration:
+
+    Example:
+        @ray.remote(
+            runtime_env={
+                "mpi": {
+                    "args": ["-n", "4"],
+                    "worker_entry": worker_entry,
+                }
             }
-        }
-    )
-    def calc_pi():
-      ...
+        )
+        def calc_pi():
+            ...
 
     Here worker_entry should be function for the MPI worker to run.
     For example, it should be `'py_module.worker_func'`. The module should be able to

--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -497,7 +497,7 @@ def get_uri_for_file(file: str) -> str:
         URI (str)
 
     Raises:
-        ValueError if the file doesn't exist.
+        ValueError: If the file doesn't exist.
     """
     filepath = Path(file).absolute()
     if not filepath.exists() or not filepath.is_file():
@@ -532,7 +532,7 @@ def get_uri_for_directory(directory: str, excludes: Optional[List[str]] = None) 
         URI (str)
 
     Raises:
-        ValueError if the directory doesn't exist.
+        ValueError: If the directory doesn't exist.
     """
     if excludes is None:
         excludes = []

--- a/python/ray/_private/runtime_env/plugin.py
+++ b/python/ray/_private/runtime_env/plugin.py
@@ -34,10 +34,10 @@ class RuntimeEnvPlugin(ABC):
         The method is invoked upon installation of runtime env.
 
         Args:
-            runtime_env_dict: the user-supplied runtime environment dict.
+            runtime_env_dict: The user-supplied runtime environment dict.
 
         Raises:
-            ValueError: if the validation fails.
+            ValueError: If the validation fails.
         """
         pass
 
@@ -59,13 +59,13 @@ class RuntimeEnvPlugin(ABC):
         Args:
             uri: A URI uniquely describing this resource.
             runtime_env: The RuntimeEnv object.
-            context: auxiliary information supplied by Ray.
+            context: Auxiliary information supplied by Ray.
             logger: A logger to log messages during the context modification.
 
         Returns:
-            the disk space taken up by this plugin installation for this
-            environment. e.g. for working_dir, this downloads the files to the
-            local node.
+            float: The disk space taken up by this plugin installation for this
+                environment. e.g. for working_dir, this downloads the files to the
+                local node.
         """
         return 0
 
@@ -78,7 +78,7 @@ class RuntimeEnvPlugin(ABC):
     ) -> None:
         """Modify context to change worker startup behavior.
 
-        For example, you can use this to preprend "cd <dir>" command to worker
+        For example, you can use this to prepend "cd <dir>" command to worker
         startup, or add new environment variables.
 
         Args:
@@ -90,13 +90,14 @@ class RuntimeEnvPlugin(ABC):
         return
 
     def delete_uri(self, uri: str, logger: logging.Logger) -> float:
-        """Delete the the runtime environment given uri.
+        """Delete the runtime environment given uri.
 
         Args:
-            uri: a URI uniquely describing this resource.
+            uri: A URI uniquely describing this resource.
+            logger: The logger used to log messages during the deletion.
 
         Returns:
-            the amount of space reclaimed by the deletion.
+            float: The amount of space reclaimed by the deletion.
         """
         return 0
 

--- a/python/ray/_private/runtime_env/protocol.py
+++ b/python/ray/_private/runtime_env/protocol.py
@@ -36,7 +36,16 @@ class ProtocolsProvider:
 
     @classmethod
     def download_remote_uri(cls, protocol: str, source_uri: str, dest_file: str):
-        """Download file from remote URI to dest file"""
+        """Download file from remote URI to destination file.
+
+        Args:
+            protocol: The protocol to use for downloading (e.g., 's3', 'https').
+            source_uri: The source URI to download from.
+            dest_file: The destination file path to save to.
+
+        Raises:
+            ImportError: If required dependencies for the protocol are not installed.
+        """
         assert protocol in cls.get_remote_protocols()
 
         tp = None

--- a/python/ray/_private/runtime_env/uri_cache.py
+++ b/python/ray/_private/runtime_env/uri_cache.py
@@ -7,17 +7,15 @@ DEFAULT_MAX_URI_CACHE_SIZE_BYTES = (1024**3) * 10  # 10 GB
 
 
 class URICache:
-    """
-    Caches URIs up to a specified total size limit.
+    """Caches URIs up to a specified total size limit.
 
-    URIs are represented by strings.  Each URI has an associated size on disk.
-
+    URIs are represented by strings. Each URI has an associated size on disk.
     When a URI is added to the URICache, it is marked as "in use".
     When a URI is no longer in use, the user of this class should call
     `mark_unused` to signal that the URI is safe for deletion.
 
     URIs in the cache can be marked as "in use" by calling `mark_used`.
-
+    
     Deletion of URIs on disk does not occur until the size limit is exceeded.
     When this happens, URIs that are not in use are deleted randomly until the
     size limit is satisfied, or there are no more URIs that are not in use.
@@ -61,7 +59,7 @@ class URICache:
         self._check_valid()
 
     def mark_used(self, uri: str, logger: logging.Logger = default_logger):
-        """Mark a URI as in use.  URIs in use will not be deleted."""
+        """Mark a URI as in use. URIs in use will not be deleted."""
         if uri in self._used_uris:
             return
         elif uri in self._unused_uris:

--- a/python/ray/_private/runtime_env/uri_cache.py
+++ b/python/ray/_private/runtime_env/uri_cache.py
@@ -15,7 +15,7 @@ class URICache:
     `mark_unused` to signal that the URI is safe for deletion.
 
     URIs in the cache can be marked as "in use" by calling `mark_used`.
-    
+
     Deletion of URIs on disk does not occur until the size limit is exceeded.
     When this happens, URIs that are not in use are deleted randomly until the
     size limit is satisfied, or there are no more URIs that are not in use.

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -785,7 +785,9 @@ def create_redis_client(redis_address, password=None, username=None):
     """Create a Redis client.
 
     Args:
-        The IP address, port, username, and password of the Redis server.
+        redis_address: The IP address and port of the Redis server.
+        password: The password for Redis authentication.
+        username: The username for Redis authentication.
 
     Returns:
         A Redis client.

--- a/python/ray/_private/storage.py
+++ b/python/ray/_private/storage.py
@@ -57,7 +57,7 @@ def get_filesystem() -> ("pyarrow.fs.FileSystem", str):
         be created for this cluster.
 
     Raises:
-        RuntimeError if storage has not been configured or init failed.
+        RuntimeError: If storage has not been configured or init failed.
     """
     return _get_filesystem_internal()
 
@@ -334,8 +334,8 @@ class KVClient:
             List of file-info objects for the directory contents.
 
         Raises:
-            FileNotFoundError if the given path is not found.
-            NotADirectoryError if the given path isn't a valid directory.
+            FileNotFoundError: If the given path is not found.
+            NotADirectoryError: If the given path isn't a valid directory.
         """
         from pyarrow.fs import FileSelector, FileType, LocalFileSystem
 

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -674,16 +674,17 @@ def get_metric_check_condition(
     metrics_to_check: List[MetricSamplePattern], export_addr: Optional[str] = None
 ) -> Callable[[], bool]:
     """A condition to check if a prometheus metrics reach a certain value.
+
     This is a blocking check that can be passed into a `wait_for_condition`
     style function.
 
     Args:
-      metrics_to_check: A list of MetricSamplePattern. The fields that
-      aren't `None` will be matched.
+        metrics_to_check: A list of MetricSamplePattern. The fields that
+            aren't `None` will be matched.
+        export_addr: Optional address to export metrics to.
 
     Returns:
-      A function that returns True if all the metrics are emitted.
-
+        A function that returns True if all the metrics are emitted.
     """
     node_info = ray.nodes()[0]
     metrics_export_port = node_info["MetricsExportPort"]
@@ -1567,7 +1568,6 @@ class WorkerKillerActor(ResourceKillerActor):
                 ("name", "!=", "WorkerKillActor.run"),
             ]
         )
-
     async def _find_resources_to_kill(self):
         from ray.util.state.common import StateResource
 
@@ -2136,3 +2136,4 @@ def check_library_usage_telemetry(
         assert all(
             [extra_usage_tags[k] == v for k, v in expected_extra_usage_tags.items()]
         ), extra_usage_tags
+

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -1568,6 +1568,7 @@ class WorkerKillerActor(ResourceKillerActor):
                 ("name", "!=", "WorkerKillActor.run"),
             ]
         )
+
     async def _find_resources_to_kill(self):
         from ray.util.state.common import StateResource
 
@@ -2136,4 +2137,3 @@ def check_library_usage_telemetry(
         assert all(
             [extra_usage_tags[k] == v for k, v in expected_extra_usage_tags.items()]
         ), extra_usage_tags
-

--- a/python/ray/_private/usage/usage_lib.py
+++ b/python/ray/_private/usage/usage_lib.py
@@ -522,7 +522,7 @@ def put_cluster_metadata(gcs_client, *, ray_init_cluster) -> None:
         ray_init_cluster: Whether the cluster is started by ray.init()
 
     Raises:
-        gRPC exceptions if PUT fails.
+        gRPC exceptions: If PUT fails.
     """
     metadata = _generate_cluster_metadata(ray_init_cluster=ray_init_cluster)
     gcs_client.internal_kv_put(
@@ -798,7 +798,7 @@ def get_cluster_metadata(gcs_client) -> dict:
         The cluster metadata in a dictinoary.
 
     Raises:
-        RuntimeError if it fails to obtain cluster metadata from GCS.
+        RuntimeError: If it fails to obtain cluster metadata from GCS.
     """
     return json.loads(
         gcs_client.internal_kv_get(
@@ -949,7 +949,7 @@ class UsageReportClient:
             data: Data to report.
 
         Raises:
-            requests.HTTPError if requests fails.
+            requests.HTTPError: If requests fails.
         """
         r = requests.request(
             "POST",


### PR DESCRIPTION
## Why are these changes needed?

This changes are part a batch effort to rewrite Ray's docstrings to be minimally pydoclint compliant. This PR focuses on making them at least pass basic formatting checks

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
