### PR TITLE
[pydoclint] core/autoscaler docstring minimal format errors

### DIFF
--- a/python/ray/autoscaler/_private/aws/config.py
+++ b/python/ray/autoscaler/_private/aws/config.py
@@ -959,8 +959,7 @@ def _get_key(key_name, config):
 
 
 def _configure_from_launch_template(config: Dict[str, Any]) -> Dict[str, Any]:
-    """
-    Merges any launch template data referenced by the node config of all
+    """Merges any launch template data referenced by the node config of all
     available node type's into their parent node config. Any parameters
     specified in node config override the same parameters in the launch
     template, in compliance with the behavior of the ec2.create_instances
@@ -968,15 +967,16 @@ def _configure_from_launch_template(config: Dict[str, Any]) -> Dict[str, Any]:
 
     Args:
         config (Dict[str, Any]): config to bootstrap
+
     Returns:
         config (Dict[str, Any]): The input config with all launch template
         data merged into the node config of all available node types. If no
         launch template data is found, then the config is returned
         unchanged.
+
     Raises:
-        ValueError: If no launch template is found for any launch
-        template [name|id] and version, or more than one launch template is
-        found.
+        ValueError: When no launch template is found for the given launch template
+            [name|id] and version, or more than one launch template is found.
     """
     # create a copy of the input config to modify
     config = copy.deepcopy(config)
@@ -991,23 +991,23 @@ def _configure_from_launch_template(config: Dict[str, Any]) -> Dict[str, Any]:
 def _configure_node_type_from_launch_template(
     config: Dict[str, Any], node_type: Dict[str, Any]
 ) -> Dict[str, Any]:
-    """
-    Merges any launch template data referenced by the given node type's
+    """Merges any launch template data referenced by the given node type's
     node config into the parent node config. Any parameters specified in
     node config override the same parameters in the launch template.
 
     Args:
         config (Dict[str, Any]): config to bootstrap
         node_type (Dict[str, Any]): node type config to bootstrap
+
     Returns:
         node_type (Dict[str, Any]): The input config with all launch template
         data merged into the node config of the input node type. If no
         launch template data is found, then the config is returned
         unchanged.
+
     Raises:
-        ValueError: If no launch template is found for the given launch
-        template [name|id] and version, or more than one launch template is
-        found.
+        ValueError: When no launch template is found for the given launch template
+            [name|id] and version, or more than one launch template is found.
     """
     # create a copy of the input config to modify
     node_type = copy.deepcopy(node_type)
@@ -1023,8 +1023,7 @@ def _configure_node_type_from_launch_template(
 def _configure_node_cfg_from_launch_template(
     config: Dict[str, Any], node_cfg: Dict[str, Any]
 ) -> Dict[str, Any]:
-    """
-    Merges any launch template data referenced by the given node type's
+    """Merges any launch template data referenced by the given node type's
     node config into the parent node config. Any parameters specified in
     node config override the same parameters in the launch template.
 
@@ -1041,14 +1040,15 @@ def _configure_node_cfg_from_launch_template(
     Args:
         config (Dict[str, Any]): config to bootstrap
         node_cfg (Dict[str, Any]): node config to bootstrap
+
     Returns:
         node_cfg (Dict[str, Any]): The input node config merged with all launch
         template data. If no launch template data is found, then the node
         config is returned unchanged.
+
     Raises:
-        ValueError: If no launch template is found for the given launch
-        template [name|id] and version, or more than one launch template is
-        found.
+        ValueError: When no launch template is found for the given launch template
+            [name|id] and version, or more than one launch template is found.
     """
     # create a copy of the input config to modify
     node_cfg = copy.deepcopy(node_cfg)
@@ -1078,22 +1078,23 @@ def _configure_node_cfg_from_launch_template(
 
 
 def _configure_from_network_interfaces(config: Dict[str, Any]) -> Dict[str, Any]:
-    """
-    Copies all network interface subnet and security group IDs up to their
+    """Copies all network interface subnet and security group IDs up to their
     parent node config for each available node type.
 
     Args:
         config (Dict[str, Any]): config to bootstrap
+
     Returns:
         config (Dict[str, Any]): The input config with all network interface
         subnet and security group IDs copied into the node config of all
         available node types. If no network interfaces are found, then the
         config is returned unchanged.
+
     Raises:
         ValueError: If [1] subnet and security group IDs exist at both the
-        node config and network interface levels, [2] any network interface
-        doesn't have a subnet defined, or [3] any network interface doesn't
-        have a security group defined.
+            node config and network interface levels, [2] any network interface
+            doesn't have a subnet defined, or [3] any network interface doesn't
+            have a security group defined.
     """
     # create a copy of the input config to modify
     config = copy.deepcopy(config)
@@ -1107,22 +1108,23 @@ def _configure_from_network_interfaces(config: Dict[str, Any]) -> Dict[str, Any]
 def _configure_node_type_from_network_interface(
     node_type: Dict[str, Any]
 ) -> Dict[str, Any]:
-    """
-    Copies all network interface subnet and security group IDs up to the
+    """Copies all network interface subnet and security group IDs up to the
     parent node config for the given node type.
 
     Args:
         node_type (Dict[str, Any]): node type config to bootstrap
+
     Returns:
         node_type (Dict[str, Any]): The input config with all network interface
         subnet and security group IDs copied into the node config of the
         given node type. If no network interfaces are found, then the
         config is returned unchanged.
+
     Raises:
         ValueError: If [1] subnet and security group IDs exist at both the
-        node config and network interface levels, [2] any network interface
-        doesn't have a subnet defined, or [3] any network interface doesn't
-        have a security group defined.
+            node config and network interface levels, [2] any network interface
+            doesn't have a subnet defined, or [3] any network interface doesn't
+            have a security group defined.
     """
     # create a copy of the input config to modify
     node_type = copy.deepcopy(node_type)
@@ -1138,20 +1140,21 @@ def _configure_node_type_from_network_interface(
 def _configure_subnets_and_groups_from_network_interfaces(
     node_cfg: Dict[str, Any]
 ) -> Dict[str, Any]:
-    """
-    Copies all network interface subnet and security group IDs into their
+    """Copies all network interface subnet and security group IDs into their
     parent node config.
 
     Args:
         node_cfg (Dict[str, Any]): node config to bootstrap
+
     Returns:
         node_cfg (Dict[str, Any]): node config with all copied network
         interface subnet and security group IDs
+
     Raises:
         ValueError: If [1] subnet and security group IDs exist at both the
-        node config and network interface levels, [2] any network interface
-        doesn't have a subnet defined, or [3] any network interface doesn't
-        have a security group defined.
+            node config and network interface levels, [2] any network interface
+            doesn't have a subnet defined, or [3] any network interface doesn't
+            have a security group defined.
     """
     # create a copy of the input config to modify
     node_cfg = copy.deepcopy(node_cfg)

--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -265,9 +265,9 @@ class SSHCommandRunner(CommandRunnerInterface):
             silent: If true, the command output will be silenced.
 
         Raises:
-            ProcessRunnerError if using new log style and disabled
+            ProcessRunnerError: If using new log style and disabled
                 login shells.
-            click.ClickException if using login shells.
+            click.ClickException: If using login shells.
         """
         try:
             # For now, if the output is needed we just skip the new logic.

--- a/python/ray/autoscaler/_private/kuberay/utils.py
+++ b/python/ray/autoscaler/_private/kuberay/utils.py
@@ -16,8 +16,7 @@ gke_tpu_accelerator_to_generation = {
 
 
 def parse_quantity(quantity):
-    """
-    Parse kubernetes canonical form quantity like 200Mi to a decimal number.
+    """Parse kubernetes canonical form quantity like 200Mi to a decimal number.
     Supported SI suffixes:
     base1024: Ki | Mi | Gi | Ti | Pi | Ei
     base1000: n | u | m | "" | k | M | G | T | P | E
@@ -25,14 +24,14 @@ def parse_quantity(quantity):
     See
     https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go
 
-    Input:
-    quantity: string. kubernetes canonical form quantity
+    Args:
+        quantity: string. kubernetes canonical form quantity
 
     Returns:
-    Decimal
+        Decimal: The parsed quantity as a decimal number
 
     Raises:
-    ValueError on invalid or unknown input
+        ValueError: On invalid or unknown input
     """
     if isinstance(quantity, (int, float, Decimal)):
         return Decimal(quantity)

--- a/python/ray/autoscaler/node_provider.py
+++ b/python/ray/autoscaler/node_provider.py
@@ -91,7 +91,7 @@ class NodeProvider:
                 public or private.
 
         Raises:
-            ValueError if not found.
+            ValueError: If not found.
         """
 
         def find_node_id():
@@ -208,18 +208,18 @@ class NodeProvider:
         """Returns the CommandRunner class used to perform SSH commands.
 
         Args:
-        log_prefix: stores "NodeUpdater: {}: ".format(<node_id>). Used
-            to print progress in the CommandRunner.
-        node_id: the node ID.
-        auth_config: the authentication configs from the autoscaler
-            yaml file.
-        cluster_name: the name of the cluster.
-        process_runner: the module to use to run the commands
-            in the CommandRunner. E.g., subprocess.
-        use_internal_ip: whether the node_id belongs to an internal ip
-            or external ip.
-        docker_config: If set, the docker information of the docker
-            container that commands should be run on.
+            log_prefix: stores "NodeUpdater: {}: ".format(<node_id>). Used
+                to print progress in the CommandRunner.
+            node_id: the node ID.
+            auth_config: the authentication configs from the autoscaler
+                yaml file.
+            cluster_name: the name of the cluster.
+            process_runner: the module to use to run the commands
+                in the CommandRunner. E.g., subprocess.
+            use_internal_ip: whether the node_id belongs to an internal ip
+                or external ip.
+            docker_config: If set, the docker information of the docker
+                container that commands should be run on.
         """
         common_args = {
             "log_prefix": log_prefix,

--- a/python/ray/autoscaler/sdk/sdk.py
+++ b/python/ray/autoscaler/sdk/sdk.py
@@ -149,7 +149,7 @@ def rsync(
         should_bootstrap: whether to bootstrap cluster config before syncing
 
     Raises:
-        RuntimeError if the cluster head node is not found.
+        RuntimeError: If the cluster head node is not found.
     """
     with _as_config_file(cluster_config) as config_file:
         return commands.rsync(
@@ -178,7 +178,7 @@ def get_head_node_ip(cluster_config: Union[dict, str]) -> str:
         The ip address of the cluster head node.
 
     Raises:
-        RuntimeError if the cluster is not found.
+        RuntimeError: If the cluster is not found.
     """
     with _as_config_file(cluster_config) as config_file:
         return commands.get_head_node_ip(config_file)
@@ -196,7 +196,7 @@ def get_worker_node_ips(cluster_config: Union[dict, str]) -> List[str]:
         List of worker node ip addresses.
 
     Raises:
-        RuntimeError if the cluster is not found.
+        RuntimeError: If the cluster is not found.
     """
     with _as_config_file(cluster_config) as config_file:
         return commands.get_worker_node_ips(config_file)

--- a/python/ray/autoscaler/v2/autoscaler.py
+++ b/python/ray/autoscaler/v2/autoscaler.py
@@ -153,8 +153,7 @@ class Autoscaler:
     def update_autoscaling_state(
         self,
     ) -> Optional[AutoscalingState]:
-        """
-        Update the autoscaling state of the cluster by reconciling the current
+        """Update the autoscaling state of the cluster by reconciling the current
         state of the cluster resources, the cloud providers as well as instance
         update subscribers with the desired state.
 
@@ -163,7 +162,7 @@ class Autoscaler:
             the state is not updated.
 
         Raises:
-            No exception.
+            None: No exception.
         """
 
         try:


### PR DESCRIPTION
## Why are these changes needed?

This changes are part a batch effort to rewrite Ray's docstrings to be minimally pydoclint compliant. This PR focuses on making them at least pass basic formatting checks

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
