### PR TITLE
[pydoclint] dashboard docstring minimal format errors

### DIFF
--- a/python/ray/dashboard/modules/log/log_manager.py
+++ b/python/ray/dashboard/modules/log/log_manager.py
@@ -201,18 +201,19 @@ class LogsManager:
         suffix: str,
         timeout: int,
     ):
-        """
-        Resolve actor log file
-            Args:
-                actor_id: The actor id.
-                get_actor_fn: The function to get actor information.
-                suffix: The suffix of the log file.
-                timeout: Timeout in seconds.
-            Returns:
-                The log file name and node id.
+        """Resolve actor log file.
 
-            Raises:
-                ValueError if actor data is not found or get_actor_fn is not provided.
+        Args:
+            actor_id: The actor id.
+            get_actor_fn: The function to get actor information.
+            suffix: The suffix of the log file.
+            timeout: Timeout in seconds.
+
+        Returns:
+            The log file name and node id.
+
+        Raises:
+            ValueError: If actor data is not found or get_actor_fn is not provided.
         """
         if get_actor_fn is None:
             raise ValueError("get_actor_fn needs to be specified for actor_id")
@@ -249,13 +250,12 @@ class LogsManager:
     async def _resolve_task_filename(
         self, task_id: str, attempt_number: int, suffix: str, timeout: int
     ):
-        """
-        Resolve log file for a task.
+        """Resolve log file for a task.
 
         Args:
             task_id: The task id.
             attempt_number: The attempt number.
-            suffix: The suffix of the log file, e.g. out or err
+            suffix: The suffix of the log file, e.g. out or err.
             timeout: Timeout in seconds.
 
         Returns:
@@ -263,9 +263,8 @@ class LogsManager:
             corresponding task log in the file.
 
         Raises:
-            FileNotFoundError if the log file is not found.
-            ValueError if the suffix is not out or err.
-
+            FileNotFoundError: If the log file is not found.
+            ValueError: If the suffix is not out or err.
         """
         log_filename = None
         node_id = None

--- a/python/ray/dashboard/modules/reporter/reporter_head.py
+++ b/python/ray/dashboard/modules/reporter/reporter_head.py
@@ -214,7 +214,9 @@ class ReportHead(SubprocessModule):
         return pid, worker_id
 
     @routes.get("/task/traceback")
-    async def get_task_traceback(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
+    async def get_task_traceback(
+        self, req: aiohttp.web.Request
+    ) -> aiohttp.web.Response:
         """Retrieves the traceback information for a specific task.
         Note that one worker process works on one task at a time
         or one worker works on multiple async tasks.
@@ -304,7 +306,9 @@ class ReportHead(SubprocessModule):
         )
 
     @routes.get("/task/cpu_profile")
-    async def get_task_cpu_profile(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
+    async def get_task_cpu_profile(
+        self, req: aiohttp.web.Request
+    ) -> aiohttp.web.Response:
         """Retrieves the CPU profile for a specific task.
         Note that one worker process works on one task at a time
         or one worker works on multiple async tasks.

--- a/python/ray/dashboard/modules/reporter/reporter_head.py
+++ b/python/ray/dashboard/modules/reporter/reporter_head.py
@@ -173,21 +173,18 @@ class ReportHead(SubprocessModule):
     async def get_worker_details_for_running_task(
         self, task_id: str, attempt_number: int
     ) -> Tuple[Optional[int], Optional[str]]:
-        """
-        Retrieves worker details for a specific task and attempt number.
+        """Retrieves worker details for a specific task and attempt number.
 
         Args:
             task_id: The ID of the task.
             attempt_number: The attempt number of the task.
 
         Returns:
-            Tuple[Optional[int], Optional[str]]: A tuple
-            containing the worker's PID (process ID),
-            and worker's ID.
+            Tuple[Optional[int], Optional[str]]: A tuple containing the worker's PID
+            (process ID), and worker's ID.
 
         Raises:
-            ValueError: If the task attempt is not running or
-            the state APi is not initialized.
+            ValueError: If the task attempt is not running or the state API is not initialized.
         """
         if self._state_api is None:
             raise ValueError("The state API is not initialized yet. Please retry.")
@@ -217,14 +214,10 @@ class ReportHead(SubprocessModule):
         return pid, worker_id
 
     @routes.get("/task/traceback")
-    async def get_task_traceback(self, req) -> aiohttp.web.Response:
-        """
-        Retrieves the traceback information for a specific task.
+    async def get_task_traceback(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
+        """Retrieves the traceback information for a specific task.
         Note that one worker process works on one task at a time
         or one worker works on multiple async tasks.
-
-        Args:
-            req (aiohttp.web.Request): The HTTP request object.
 
         Params:
             task_id: The ID of the task.
@@ -232,20 +225,14 @@ class ReportHead(SubprocessModule):
             node_id: The ID of the node.
 
         Returns:
-            aiohttp.web.Response: The HTTP response containing
-            the traceback information.
+            aiohttp.web.Response: The HTTP response containing the traceback information.
 
         Raises:
-            ValueError: If the "task_id" parameter
-            is missing in the request query.
-            ValueError: If the "attempt_number" parameter
-            is missing in the request query.
-            ValueError: If the worker begins working on
-            another task during the traceback retrieval.
-            aiohttp.web.HTTPInternalServerError: If there is
-            an internal server error during the traceback retrieval.
+            ValueError: If the "task_id" parameter is missing in the request query.
+            ValueError: If the "attempt_number" parameter is missing in the request query.
+            ValueError: If the worker begins working on another task during the traceback retrieval.
+            aiohttp.web.HTTPInternalServerError: If there is an internal server error during the traceback retrieval.
         """
-
         if "task_id" not in req.query:
             raise ValueError("task_id is required")
         if "attempt_number" not in req.query:
@@ -317,30 +304,21 @@ class ReportHead(SubprocessModule):
         )
 
     @routes.get("/task/cpu_profile")
-    async def get_task_cpu_profile(self, req) -> aiohttp.web.Response:
-        """
-        Retrieves the CPU profile for a specific task.
+    async def get_task_cpu_profile(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
+        """Retrieves the CPU profile for a specific task.
         Note that one worker process works on one task at a time
         or one worker works on multiple async tasks.
-
-        Args:
-            req (aiohttp.web.Request): The HTTP request object.
 
         Returns:
             aiohttp.web.Response: The HTTP response containing the CPU profile data.
 
         Raises:
-            ValueError: If the "task_id" parameter is
-            missing in the request query.
-            ValueError: If the "attempt_number" parameter is
-            missing in the request query.
+            ValueError: If the "task_id" parameter is missing in the request query.
+            ValueError: If the "attempt_number" parameter is missing in the request query.
             ValueError: If the maximum duration allowed is exceeded.
-            ValueError: If the worker begins working on
-            another task during the profile retrieval.
-            aiohttp.web.HTTPInternalServerError: If there is
-            an internal server error during the profile retrieval.
-            aiohttp.web.HTTPInternalServerError: If the CPU Flame
-            Graph information for the task is not found.
+            ValueError: If the worker begins working on another task during the profile retrieval.
+            aiohttp.web.HTTPInternalServerError: If there is an internal server error during the profile retrieval.
+            aiohttp.web.HTTPInternalServerError: If the CPU Flame Graph information for the task is not found.
         """
         if "task_id" not in req.query:
             raise ValueError("task_id is required")
@@ -420,8 +398,9 @@ class ReportHead(SubprocessModule):
         )
 
     @routes.get("/worker/traceback")
-    async def get_traceback(self, req) -> aiohttp.web.Response:
-        """
+    async def get_traceback(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
+        """Retrieves the traceback information for a specific worker.
+
         Params:
             pid: Required. The PID of the worker.
             ip: Required. The IP address of the node.
@@ -457,11 +436,21 @@ class ReportHead(SubprocessModule):
             return aiohttp.web.HTTPInternalServerError(text=reply.output)
 
     @routes.get("/worker/cpu_profile")
-    async def cpu_profile(self, req) -> aiohttp.web.Response:
-        """
+    async def cpu_profile(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
+        """Retrieves the CPU profile for a specific worker.
+
         Params:
             pid: Required. The PID of the worker.
             ip: Required. The IP address of the node.
+            duration: Optional. Duration in seconds for profiling (default: 5, max: 60).
+            format: Optional. Output format (default: "flamegraph").
+            native: Optional. Whether to use native profiling (default: false).
+
+        Raises:
+            ValueError: If pid is not provided.
+            ValueError: If ip is not provided.
+            ValueError: If duration exceeds 60 seconds.
+            aiohttp.web.HTTPInternalServerError: If there is an internal server error during the profile retrieval.
         """
         pid = req.query.get("pid")
         ip = req.query.get("ip")
@@ -510,14 +499,10 @@ class ReportHead(SubprocessModule):
             return aiohttp.web.HTTPInternalServerError(text=reply.output)
 
     @routes.get("/memory_profile")
-    async def memory_profile(self, req) -> aiohttp.web.Response:
-        """
-        Retrieves the memory profile for a specific worker or task.
+    async def memory_profile(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
+        """Retrieves the memory profile for a specific worker or task.
         Note that for tasks, one worker process works on one task at a time
         or one worker works on multiple async tasks.
-
-        Args:
-            req (aiohttp.web.Request): The HTTP request object.
 
         Returns:
             aiohttp.web.Response: The HTTP response containing the memory profile data.
@@ -525,6 +510,7 @@ class ReportHead(SubprocessModule):
         Params (1):
             pid: The PID of the worker.
             ip: The IP address of the node.
+
         Params (2):
             task_id: The ID of the task.
             attempt_number: The attempt number of the task.
@@ -538,7 +524,7 @@ class ReportHead(SubprocessModule):
                 or "node id" is missing in the request query.
             aiohttp.web.HTTPInternalServerError: If the maximum
                 duration allowed is exceeded.
-            aiohttp.web.HTTPInternalServerError If requesting task
+            aiohttp.web.HTTPInternalServerError: If requesting task
                 profiling for the worker begins working on another task
                 during the profile retrieval.
             aiohttp.web.HTTPInternalServerError: If there is


### PR DESCRIPTION
## Why are these changes needed?

This changes are part a batch effort to rewrite Ray's docstrings to be minimally pydoclint compliant. This PR focuses on making them at least pass basic formatting checks

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
