### PR TITLE
[pydoclint] llm docstring minimal format errors

### DIFF
--- a/python/ray/llm/_internal/serve/configs/server_models.py
+++ b/python/ray/llm/_internal/serve/configs/server_models.py
@@ -877,7 +877,8 @@ def merge_dicts(base: Dict, overwrite: Dict) -> Dict:
 
 
 class SamplingParams(BaseModelExtended):
-    """
+    """Parameters for controlling text generation sampling.
+
     Args:
         max_tokens: The maximum number of tokens to generate. Defaults to inf.
         temperature: What sampling temperature to use.
@@ -902,7 +903,6 @@ class SamplingParams(BaseModelExtended):
             the completion.
         response_format: Format to return the final response in. Can be for ex:
             response_format={"type": "json", "schema": "{...}"}
-
     """
 
     _ignored_fields: Set[str] = set()

--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_models.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_models.py
@@ -206,7 +206,8 @@ class VLLMEngineConfig(BaseModelExtended):
 
 
 class VLLMSamplingParams(SamplingParams):
-    """
+    """Sampling parameters specific to vLLM engine.
+
     Args:
         top_k: The number of highest probability vocabulary tokens to keep for top-k-filtering.
         seed: Seed for deterministic sampling with temperature>0.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This changes are part a batch effort to rewrite Ray's docstrings to be minimally pydoclint compliant. This PR focuses on making them at least pass basic formatting checks

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
