### PR TITLE
[pydoclint] serve docstring minimal format errors

### DIFF
--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -863,7 +863,7 @@ class ServeController:
             DeploymentRoute's protobuf serialized bytes
 
         Raises:
-            KeyError if the deployment doesn't exist.
+            KeyError: If the deployment doesn't exist.
         """
         id = DeploymentID(name=name, app_name=app_name)
         deployment_info = self.deployment_state_manager.get_deployment(id)

--- a/python/ray/serve/_private/proxy_response_generator.py
+++ b/python/ray/serve/_private/proxy_response_generator.py
@@ -46,9 +46,9 @@ class _ProxyResponseGeneratorBase(ABC):
         """Return the next message in the stream.
 
         Raises:
-            - TimeoutError on timeout.
-            - asyncio.CancelledError on disconnect.
-            - StopAsyncIteration when the stream is completed.
+            TimeoutError: On timeout.
+            asyncio.CancelledError: On disconnect.
+            StopAsyncIteration: When the stream is completed.
         """
         pass
 

--- a/python/ray/serve/_private/storage/kv_store.py
+++ b/python/ray/serve/_private/storage/kv_store.py
@@ -47,8 +47,8 @@ class RayInternalKVStore(KVStoreBase):
         """Put the key-value pair into the store.
 
         Args:
-            key (str)
-            val (bytes)
+            key: The key to store.
+            val: The value to store.
         """
         if not isinstance(key, str):
             raise TypeError("key must be a string, got: {}.".format(type(key)))
@@ -70,10 +70,10 @@ class RayInternalKVStore(KVStoreBase):
         """Get the value associated with the given key from the store.
 
         Args:
-            key (str)
+            key: The key to retrieve.
 
         Returns:
-            The bytes value. If the key wasn't found, returns None.
+            Optional[bytes]: The bytes value. If the key wasn't found, returns None.
         """
         if not isinstance(key, str):
             raise TypeError("key must be a string, got: {}.".format(type(key)))
@@ -91,7 +91,7 @@ class RayInternalKVStore(KVStoreBase):
         """Delete the value associated with the given key from the store.
 
         Args:
-            key (str)
+            key: The key to delete.
         """
 
         if not isinstance(key, str):

--- a/python/ray/serve/context.py
+++ b/python/ray/serve/context.py
@@ -77,8 +77,8 @@ def _get_global_client(
         set to False, returns None.
 
     Raises:
-        RayServeException: if there is no running Serve controller actor
-        and raise_if_no_controller_running is set to True.
+        RayServeException: If there is no running Serve controller actor
+            and raise_if_no_controller_running is set to True.
     """
 
     try:
@@ -127,9 +127,10 @@ def _connect(raise_if_no_controller_running: bool = True) -> ServeControllerClie
         existing Serve application's Serve Controller. None if there is
         no running Serve controller actor and raise_if_no_controller_running
         is set to False.
+
     Raises:
-        RayServeException: if there is no running Serve controller actor
-        and raise_if_no_controller_running is set to True.
+        RayServeException: If there is no running Serve controller actor
+            and raise_if_no_controller_running is set to True.
     """
 
     # Initialize ray if needed.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This changes are part a batch effort to rewrite Ray's docstrings to be minimally pydoclint compliant. This PR focuses on making them at least pass basic formatting checks
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
