### PR TITLE
[pydoclint] train docstring minimal format errors

### DIFF
--- a/python/ray/train/v2/_internal/execution/worker_group/worker_group.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/worker_group.py
@@ -791,7 +791,7 @@ class WorkerGroup:
         that should be propagated from the driver to worker processes.
 
         Args:
-            The custom runtime env dict passed in by the user.
+            custom_runtime_env: The custom runtime env dict passed in by the user.
 
         Returns:
             A copy of the custom runtime env dict updated with internal


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This changes are part a batch effort to rewrite Ray's docstrings to be minimally pydoclint compliant. This PR focuses on making them at least pass basic formatting checks


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
