### PR TITLE
[pydoclint] tune docstring minimal format errors

### DIFF
--- a/python/ray/tune/examples/hyperopt_conditional_search_space_example.py
+++ b/python/ray/tune/examples/hyperopt_conditional_search_space_example.py
@@ -20,20 +20,17 @@ from ray.tune.search.hyperopt import HyperOptSearch
 
 
 def f_unpack_dict(dct):
-    """
-    Unpacks all sub-dictionaries in given dictionary recursively.
+    """Unpacks all sub-dictionaries in given dictionary recursively.
     There should be no duplicated keys across all nested
     subdictionaries, or some instances will be lost without warning
 
     Source: https://www.kaggle.com/fanvacoolt/tutorial-on-hyperopt
 
-    Parameters:
-    ----------------
-    dct : dictionary to unpack
+    Args:
+        dct: dictionary to unpack
 
     Returns:
-    ----------------
-    : unpacked dictionary
+        dict: unpacked dictionary
     """
 
     res = {}

--- a/python/ray/tune/integration/pytorch_lightning.py
+++ b/python/ray/tune/integration/pytorch_lightning.py
@@ -55,9 +55,9 @@ class TuneCallback(Callback):
     """Base class for Tune's PyTorch Lightning callbacks.
 
     Args:
-        When to trigger checkpoint creations. Must be one of
-        the PyTorch Lightning event hooks (less the ``on_``), e.g.
-        "train_batch_start", or "train_end". Defaults to "validation_end"
+        on: When to trigger checkpoint creations. Must be one of
+            the PyTorch Lightning event hooks (less the ``on_``), e.g.
+            "train_batch_start", or "train_end". Defaults to "validation_end"
     """
 
     def __init__(self, on: Union[str, List[str]] = "validation_end"):

--- a/python/ray/tune/registry.py
+++ b/python/ray/tune/registry.py
@@ -230,8 +230,13 @@ class _Registry:
     def register(self, category, key, value):
         """Registers the value with the global registry.
 
+        Args:
+            category: The category to register under.
+            key: The key to register under.
+            value: The value to register.
+
         Raises:
-            PicklingError if unable to pickle to provided file.
+            PicklingError: If unable to pickle to provided file.
         """
         if category not in KNOWN_CATEGORIES:
             from ray.tune import TuneError


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This changes are part a batch effort to rewrite Ray's docstrings to be minimally pydoclint compliant. This PR focuses on making them at least pass basic formatting checks
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
