### PR TITLE
[pydoclint] util docstring minimal format errors

### DIFF
--- a/python/ray/util/client/worker.py
+++ b/python/ray/util/client/worker.py
@@ -361,7 +361,7 @@ class Worker:
         from being replayed on the server side in the event that the client
         must retry a requsest.
         Args:
-            metadata - the gRPC metadata to append the IDs to
+            metadata: the gRPC metadata to append the IDs to
         """
         if not self._reconnect_enabled:
             # IDs not needed if the reconnects are disabled

--- a/python/ray/util/state/api.py
+++ b/python/ray/util/state/api.py
@@ -273,10 +273,9 @@ class StateApiClient(SubmissionClient):
             Empty list for objects if not found, or list of ObjectState for objects
 
         Raises:
-            This doesn't catch any exceptions raised when the underlying request
-            call raises exceptions. For example, it could raise `requests.Timeout`
-            when timeout occurs.
-
+            Exception: This doesn't catch any exceptions raised when the underlying request
+                call raises exceptions. For example, it could raise `requests.Timeout`
+                when timeout occurs.
             ValueError:
                 if the resource could not be GET by id, i.e. jobs and runtime-envs.
 
@@ -482,9 +481,9 @@ class StateApiClient(SubmissionClient):
             A list of queried result from `ListApiResponse`,
 
         Raises:
-            This doesn't catch any exceptions raised when the underlying request
-            call raises exceptions. For example, it could raise `requests.Timeout`
-            when timeout occurs.
+            Exception: This doesn't catch any exceptions raised when the
+                underlying request call raises exceptions. For example, it could
+                raise `requests.Timeout` when timeout occurs.
 
         """
         if options.has_conflicting_filters():
@@ -530,9 +529,9 @@ class StateApiClient(SubmissionClient):
             A dictionary of queried result from `SummaryApiResponse`.
 
         Raises:
-            This doesn't catch any exceptions raised when the underlying request
-            call raises exceptions. For example, it could raise `requests.Timeout`
-            when timeout occurs.
+            Exception: This doesn't catch any exceptions raised when the
+                underlying request call raises exceptions. For example, it could
+                raise `requests.Timeout` when timeout occurs.
         """
         params = {"timeout": options.timeout}
         endpoint = f"/api/v0/{resource.value}/summarize"

--- a/python/ray/util/state/state_cli.py
+++ b/python/ray/util/state/state_cli.py
@@ -803,7 +803,7 @@ def _get_head_node_ip(address: Optional[str] = None):
         address: ray cluster address, e.g. "auto", "localhost:6379"
 
     Raises:
-        click.UsageError if node ip could not be resolved
+        click.UsageError: if node ip could not be resolved
     """
     try:
         address = services.canonicalize_bootstrap_address_or_die(address)
@@ -1078,7 +1078,7 @@ def log_actor(
     timeout: int,
     err: bool,
 ):
-    """Get/List logs associated with an actor.
+    """Get logs from an actor.
 
     Example:
 
@@ -1103,10 +1103,8 @@ def log_actor(
         ```
 
     Raises:
-        :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
-            if the CLI is failed to query the data.
-        MissingParameter if inputs are missing.
-    """  # noqa: E501
+        MissingParameter: if inputs are missing.
+    """
 
     if pid is None and id is None:
         raise click.MissingParameter(
@@ -1178,7 +1176,7 @@ def log_worker(
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
             if the CLI is failed to query the data.
-        MissingParameter if inputs are missing.
+        MissingParameter: if inputs are missing.
     """  # noqa: E501
 
     _print_log(
@@ -1241,7 +1239,7 @@ def log_job(
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
             if the CLI is failed to query the data.
-        MissingParameter if inputs are missing.
+        MissingParameter: if inputs are missing.
     """  # noqa: E501
 
     _print_log(
@@ -1312,7 +1310,7 @@ def log_task(
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
             if the CLI is failed to query the data.
-        MissingParameter if inputs are missing.
+        MissingParameter: if inputs are missing.
     """  # noqa: E501
 
     _print_log(

--- a/python/ray/util/state/state_cli.py
+++ b/python/ray/util/state/state_cli.py
@@ -1078,7 +1078,7 @@ def log_actor(
     timeout: int,
     err: bool,
 ):
-    """Get logs from an actor.
+    """Get/List logs associated with an actor.
 
     Example:
 
@@ -1103,8 +1103,10 @@ def log_actor(
         ```
 
     Raises:
+        :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
+            if the CLI is failed to query the data.
         MissingParameter: if inputs are missing.
-    """
+    """  # noqa: E501
 
     if pid is None and id is None:
         raise click.MissingParameter(

--- a/python/ray/util/state/state_manager.py
+++ b/python/ray/util/state/state_manager.py
@@ -80,10 +80,13 @@ def handle_grpc_network_errors(func):
         Returns:
             If RPC succeeds, it returns what the original function returns.
             If RPC fails, it raises exceptions.
-        Exceptions:
+
+        Raises:
             DataSourceUnavailable: if the source is unavailable because it is down
                 or there's a slow network issue causing timeout.
-            Otherwise, the raw network exceptions (e.g., gRPC) will be raised.
+
+            Exception: Otherwise, the raw network exceptions (e.g., gRPC) will be
+                raised.
         """
         try:
             return await func(*args, **kwargs)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This changes are part a batch effort to rewrite Ray's docstrings to be minimally pydoclint compliant. This PR focuses on making them at least pass basic formatting checks

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
