### PR TITLE
[pydoclint] workflow docstring minimal format errors

### DIFF
--- a/python/ray/workflow/http_event_provider.py
+++ b/python/ray/workflow/http_event_provider.py
@@ -248,11 +248,13 @@ class HTTPListener(EventListener):
     async def poll_for_event(self, event_key: str = None) -> Event:
         """workflow.wait_for_event calls this method to subscribe to the
         HTTPEventProvider and return the received external event
+
         Args:
             event_key: a unique identifier to the receiving node in a workflow;
-            if missing, default to current workflow task id
+                if missing, default to current workflow task id
+
         Returns:
-            tuple(event_key, event_payload)
+            Tuple[event_key: str, event_payload: Event]'
         """
         workflow_id = workflow_context.get_current_workflow_id()
         if event_key is None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This changes are part a batch effort to rewrite Ray's docstrings to be minimally pydoclint compliant. This PR focuses on making them at least pass basic formatting checks

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
