### PR TITLE
[tune][train] update test_train_v2_integration to use correct RunConfig

### DIFF
--- a/python/ray/tune/tests/test_train_v2_integration.py
+++ b/python/ray/tune/tests/test_train_v2_integration.py
@@ -65,7 +65,7 @@ def test_e2e(
             scaling_config=ray.train.ScalingConfig(
                 num_workers=tune_config["num_workers"], use_gpu=True
             ),
-            run_config=ray.tune.RunConfig(
+            run_config=ray.train.RunConfig(
                 storage_path=tmp_path,
                 name=f"train-{ray.tune.get_context().get_trial_id()}",
                 callbacks=[TuneReportCallback()],


### PR DESCRIPTION
Fixes an issue in which the wrong `RunConfig` was being used.

```
  File "/Users/matt/workspace/ray/python/ray/train/v2/_internal/execution/worker_group/worker_group.py", line 133, in create
    worker_group._start()
  File "/Users/matt/workspace/ray/python/ray/train/v2/_internal/execution/worker_group/worker_group.py", line 212, in _start
    raise e
  File "/Users/matt/workspace/ray/python/ray/train/v2/_internal/execution/worker_group/worker_group.py", line 205, in _start
    self._start_impl(
  File "/Users/matt/workspace/ray/python/ray/train/v2/_internal/execution/worker_group/worker_group.py", line 281, in _start_impl
    workers = self._create_workers(
  File "/Users/matt/workspace/ray/python/ray/train/v2/_internal/execution/worker_group/worker_group.py", line 354, in _create_workers
    custom_runtime_env=self._train_run_context.run_config.worker_runtime_env
AttributeError: 'RunConfig' object has no attribute 'worker_runtime_env'
```