### PR TITLE
[core] Label selector enum as class to fix windows build

### DIFF
--- a/src/ray/common/scheduling/cluster_resource_data.cc
+++ b/src/ray/common/scheduling/cluster_resource_data.cc
@@ -130,12 +130,12 @@ bool NodeResources::NodeLabelMatchesConstraint(const LabelConstraint &constraint
   const auto &values = constraint.GetLabelValues();
 
   const auto &node_labels = this->labels;
-  if (match_operator == LabelSelectorOperator::IN) {
+  if (match_operator == LabelSelectorOperator::LABEL_IN) {
     // Check for equals or in() labels
     if (node_labels.contains(key) && values.contains(node_labels.at(key))) {
       return true;
     }
-  } else if (match_operator == LabelSelectorOperator::NOT_IN) {
+  } else if (match_operator == LabelSelectorOperator::LABEL_NOT_IN) {
     // Check for not equals (!) or not in (!in()) labels
     if (!(node_labels.contains(key) && values.contains(node_labels.at(key)))) {
       return true;

--- a/src/ray/common/scheduling/label_selector.cc
+++ b/src/ray/common/scheduling/label_selector.cc
@@ -14,6 +14,7 @@
 
 #include "ray/common/scheduling/label_selector.h"
 
+#include "absl/strings/match.h"
 #include "ray/util/logging.h"
 
 namespace ray {
@@ -50,7 +51,7 @@ LabelSelector::ParseLabelSelectorValue(const std::string &key, const std::string
   absl::flat_hash_set<std::string> values;
   LabelSelectorOperator op;
 
-  if (val.rfind("in(", 0) == 0 && val.back() == ')') {
+  if (absl::StartsWith(val, "in(") && val.back() == ')') {
     val.remove_prefix(3);  // Remove "in("
     val.remove_suffix(1);  // Remove ')'
 
@@ -68,10 +69,12 @@ LabelSelector::ParseLabelSelectorValue(const std::string &key, const std::string
       RAY_LOG(ERROR) << "No values provided for Label Selector key: " << key;
     }
 
-    op = is_negated ? LabelSelectorOperator::NOT_IN : LabelSelectorOperator::IN;
+    op = is_negated ? LabelSelectorOperator::LABEL_NOT_IN
+                    : LabelSelectorOperator::LABEL_IN;
   } else {
     values.insert(std::string(val));
-    op = is_negated ? LabelSelectorOperator::NOT_IN : LabelSelectorOperator::IN;
+    op = is_negated ? LabelSelectorOperator::LABEL_NOT_IN
+                    : LabelSelectorOperator::LABEL_IN;
   }
 
   return {op, values};

--- a/src/ray/common/scheduling/label_selector.h
+++ b/src/ray/common/scheduling/label_selector.h
@@ -24,9 +24,9 @@ namespace ray {
 
 enum class LabelSelectorOperator {
   // This is to support equality or in semantics.
-  IN = 0,
+  LABEL_IN = 0,
   // This is to support not equal or not in semantics.
-  NOT_IN = 1
+  LABEL_NOT_IN = 1
 };
 
 // Defines requirements for a label key and value.

--- a/src/ray/common/scheduling/label_selector.h
+++ b/src/ray/common/scheduling/label_selector.h
@@ -57,7 +57,8 @@ class LabelSelector {
  public:
   LabelSelector() = default;
 
-  LabelSelector(const google::protobuf::Map<std::string, std::string> &label_selector);
+  explicit LabelSelector(
+      const google::protobuf::Map<std::string, std::string> &label_selector);
 
   void AddConstraint(const std::string &key, const std::string &value);
 
@@ -65,7 +66,7 @@ class LabelSelector {
     constraints_.push_back(std::move(constraint));
   }
 
-  const std::vector<LabelConstraint> GetConstraints() const { return constraints_; }
+  const std::vector<LabelConstraint> &GetConstraints() const { return constraints_; }
 
   std::pair<LabelSelectorOperator, absl::flat_hash_set<std::string>>
   ParseLabelSelectorValue(const std::string &key, const std::string &value);

--- a/src/ray/common/scheduling/label_selector.h
+++ b/src/ray/common/scheduling/label_selector.h
@@ -22,7 +22,7 @@
 
 namespace ray {
 
-enum LabelSelectorOperator {
+enum class LabelSelectorOperator {
   // This is to support equality or in semantics.
   IN = 0,
   // This is to support not equal or not in semantics.

--- a/src/ray/common/test/label_selector_test.cc
+++ b/src/ray/common/test/label_selector_test.cc
@@ -30,7 +30,7 @@ TEST(LabelSelectorTest, BasicConstruction) {
 
   for (const auto &constraint : constraints) {
     EXPECT_TRUE(label_selector_dict.count(constraint.GetLabelKey()));
-    EXPECT_EQ(constraint.GetOperator(), LabelSelectorOperator::IN);
+    EXPECT_EQ(constraint.GetOperator(), LabelSelectorOperator::LABEL_IN);
     auto values = constraint.GetLabelValues();
     EXPECT_EQ(values.size(), 1);
     EXPECT_EQ(*values.begin(), label_selector_dict[constraint.GetLabelKey()]);
@@ -45,7 +45,7 @@ TEST(LabelSelectorTest, InOperatorParsing) {
   ASSERT_EQ(constraints.size(), 1);
   const auto &constraint = constraints[0];
 
-  EXPECT_EQ(constraint.GetOperator(), LabelSelectorOperator::IN);
+  EXPECT_EQ(constraint.GetOperator(), LabelSelectorOperator::LABEL_IN);
   auto values = constraint.GetLabelValues();
   EXPECT_EQ(values.size(), 3);
   EXPECT_TRUE(values.contains("us-west"));
@@ -61,7 +61,7 @@ TEST(LabelSelectorTest, NotInOperatorParsing) {
   ASSERT_EQ(constraints.size(), 1);
   const auto &constraint = constraints[0];
 
-  EXPECT_EQ(constraint.GetOperator(), LabelSelectorOperator::NOT_IN);
+  EXPECT_EQ(constraint.GetOperator(), LabelSelectorOperator::LABEL_NOT_IN);
   auto values = constraint.GetLabelValues();
   EXPECT_EQ(values.size(), 2);
   EXPECT_TRUE(values.contains("premium"));
@@ -76,7 +76,7 @@ TEST(LabelSelectorTest, SingleValueNotInParsing) {
   ASSERT_EQ(constraints.size(), 1);
   const auto &constraint = constraints[0];
 
-  EXPECT_EQ(constraint.GetOperator(), LabelSelectorOperator::NOT_IN);
+  EXPECT_EQ(constraint.GetOperator(), LabelSelectorOperator::LABEL_NOT_IN);
   auto values = constraint.GetLabelValues();
   EXPECT_EQ(values.size(), 1);
   EXPECT_TRUE(values.contains("dev"));


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
It will break msvc windows build without this because IN is used for something else in windows builds. Maybe there's an IN macro or something. And enum class is the standard in the rest of the codebase anyways. From https://github.com/ray-project/ray/pull/51901/files
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
