### PR TITLE
[data] Add map transformer wrapper

### DIFF
--- a/python/ray/data/__init__.py
+++ b/python/ray/data/__init__.py
@@ -69,6 +69,7 @@ from ray.data.read_api import (  # noqa: F401
     read_webdataset,
 )
 
+# TODO(mowen): Clean this up
 # Module-level cached global functions for callable classes. It needs to be defined here
 # since it has to be process-global across cloudpickled funcs.
 _map_actor_context = None

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -466,7 +466,7 @@ class _MapWorker:
         Note, this only ensures cleanup is performed when the job exists gracefully.
         If the driver or the actor is forcefully killed, `__del__` will not be called.
         """
-        # TODO(mowen): Clean this up
+        # TODO(mowen): Make this actually delete the UDF object now that we have a wrapper.
         # `_map_actor_context` is a global variable that references the UDF object.
         # Delete it to trigger `UDF.__del__`.
         del ray.data._map_actor_context

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -466,6 +466,7 @@ class _MapWorker:
         Note, this only ensures cleanup is performed when the job exists gracefully.
         If the driver or the actor is forcefully killed, `__del__` will not be called.
         """
+        # TODO(mowen): Clean this up
         # `_map_actor_context` is a global variable that references the UDF object.
         # Delete it to trigger `UDF.__del__`.
         del ray.data._map_actor_context

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -57,7 +57,7 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
-class MapTransformerWrapper: #TODO(mowen): Not sure if I love this name, don't want to overload the MapTransformer class so keeping for now.
+class MapTransformerWrapper:  # TODO(mowen): Not sure if I love this name, don't want to overload the MapTransformer class so keeping for now.
     # Allow all to be None so we don't have to overwrite on construction in _parse_op_fn
     fn: Optional[Callable[[Any], Any]] = None
     init_fn: Optional[Callable[[], None]] = None
@@ -226,7 +226,9 @@ def plan_udf_map_op(
     init_fn = wrapper.init_fn
 
     if isinstance(op, MapBatches):
-        transform_fn = _generate_transform_fn_for_map_batches(fn, wrapper.map_actor_context)
+        transform_fn = _generate_transform_fn_for_map_batches(
+            fn, wrapper.map_actor_context
+        )
         map_transformer = _create_map_transformer_for_map_batches_op(
             transform_fn,
             op._batch_size,
@@ -238,7 +240,9 @@ def plan_udf_map_op(
         if isinstance(op, MapRows):
             transform_fn = _generate_transform_fn_for_map_rows(fn)
         elif isinstance(op, FlatMap):
-            transform_fn = _generate_transform_fn_for_flat_map(fn, wrapper.map_actor_context)
+            transform_fn = _generate_transform_fn_for_flat_map(
+                fn, wrapper.map_actor_context
+            )
         else:
             raise ValueError(f"Found unknown logical operator during planning: {op}")
 
@@ -404,7 +408,9 @@ def _generate_transform_fn_for_map_batches(
 ) -> MapTransformCallable[DataBatch, DataBatch]:
     if inspect.iscoroutinefunction(fn):
         # UDF is a callable class with async generator `__call__` method.
-        transform_fn = _generate_transform_fn_for_async_map(fn, _validate_batch_output, map_actor_context)
+        transform_fn = _generate_transform_fn_for_async_map(
+            fn, _validate_batch_output, map_actor_context
+        )
 
     else:
 
@@ -545,7 +551,9 @@ def _generate_transform_fn_for_flat_map(
 ) -> MapTransformCallable[Row, Row]:
     if inspect.iscoroutinefunction(fn):
         # UDF is a callable class with async generator `__call__` method.
-        transform_fn = _generate_transform_fn_for_async_map(fn, _validate_row_output, map_actor_context)
+        transform_fn = _generate_transform_fn_for_async_map(
+            fn, _validate_row_output, map_actor_context
+        )
 
     else:
 


### PR DESCRIPTION
## Why are these changes needed?
We are seeing some issues with the current implementation of storing map actor context through `ray.data._map_actor_context`. It seems like this stems from the use of the module level assignment, so we move to an implementation where we use a simple wrapper to share context between the `init_fn` and the `fn` without having to use the module level variable. 

An example of the errors is as follows:
```
 2025-05-05 15:32:53,092    ERROR worker.py:421 -- Unhandled error (suppress with 'RAY_IGNORE_UNHANDLED_ERRORS=1'): ray::Map(LoadImage).submit() (pid=3164, ip=10.0.109.31, actor_id=6cd178863b61c1f8c6d275da03000000, repr=MapWorker(Map(LoadImage)))locks: 616; Resources: 0.0 CPU, 90.0 GPU, 474.2MB object store (in=474.2MB,out=0    yield from _map_task(u=inf,obj_store=33.9GB,out=68.4GB); [142/1066 objects local]:  29%|██▉       | 744k/2.53M [08:10<58:56, 504 row/s]
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/execution/operators/map_operator.py", line 543, in _map_task4.4GB,out=68.8GB):  29%|██▉       | 669/2.    for b_out in map_transformer.apply_transform(iter(blocks), ctx):
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/execution/operators/map_transformer.py", line 532, in __call__
    for data in iter:
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/execution/operators/map_transformer.py", line 211, in _udf_timed_iter
    output = next(input)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/execution/operators/map_transformer.py", line 297, in __call__
    yield from self._row_fn(input, ctx)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/planner/plan_udf_map_op.py", line 514, in transform_fn
    out_row = fn(row)
  File "/home/ray/anaconda3/lib/python3.9/site-packages/ray/data/_internal/planner/plan_udf_map_op.py", line 298, in fn
    assert ray.data._map_actor_context is not None
AssertionError
```
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
