### PR TITLE
[core] [docs] Dynamic generator deprecation

### DIFF
--- a/doc/source/ray-core/ray-generator.rst
+++ b/doc/source/ray-core/ray-generator.rst
@@ -210,3 +210,10 @@ Ray generators don't support these features:
 - ``return`` statements from generators.
 - Passing ``ObjectRefGenerator`` to another task or actor.
 - :ref:`Ray Client <ray-client-ref>`
+
+Deprecated Dynamic Generator
+----------------------------
+.. toctree::
+    :maxdepth: 1
+
+    tasks/dynamic_generators.rst

--- a/doc/source/ray-core/tasks.rst
+++ b/doc/source/ray-core/tasks.rst
@@ -307,4 +307,3 @@ More about Ray Tasks
     :maxdepth: 1
 
     tasks/nested-tasks.rst
-    tasks/generators.rst

--- a/doc/source/ray-core/tasks/dynamic_generators.rst
+++ b/doc/source/ray-core/tasks/dynamic_generators.rst
@@ -1,12 +1,13 @@
 .. _dynamic_generators:
 
-.. warning::
-
-    ``num_returns="dynamic"`` :ref:`generator API <dynamic_generators>` is soft deprecated as of Ray 2.8 due to its :ref:`limitation <dynamic-generators-limitation>`. It is hard deprecated as of Ray 2.9.
-    Use the :ref:`streaming generator API<generators>` instead.
-
 Dynamic generators
 ==================
+
+
+.. warning::
+
+    ``num_returns="dynamic"`` :ref:`generator API <dynamic_generators>` is soft deprecated as of Ray 2.8 due to its :ref:`limitation <dynamic-generators-limitation>`.
+    Use the :ref:`streaming generator API<generators>` instead.
 
 Python generators are functions that behave like iterators, yielding one
 value per iteration. Ray supports remote generators for two use cases:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Deprecating the dynamic ref generator.

It was supposed to be deprecated a long time ago in favor of streaming generators but found that the deprecation warning on the docs page was actually never showing https://docs.ray.io/en/releases-2.46.0/ray-core/tasks/generators.html because the warning is above the title of the page.

Moved the dynamic ref generator page under deprecated at the bottom of the ray generators page and outside the tasks subsection.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
