### PR TITLE
Fix uv run when use with vllm's Ray backend

### DIFF
--- a/python/ray/_private/runtime_env/uv_runtime_env_hook.py
+++ b/python/ray/_private/runtime_env/uv_runtime_env_hook.py
@@ -74,7 +74,8 @@ def _get_uv_run_cmdline() -> Optional[List[str]]:
     check our parent's parents since the Ray driver might be run as a subprocess
     of the 'uv run' process.
 
-    Return the commandline if any of our ancestors was run with "uv run" and None otherwise.
+    Return the uv run command line if any of our ancestors was run with "uv run"
+    and None otherwise.
     """
     parents = psutil.Process().parents()
     for parent in parents:
@@ -140,6 +141,15 @@ if __name__ == "__main__":
     test_parser = argparse.ArgumentParser()
     test_parser.add_argument("runtime_env")
     args = test_parser.parse_args()
+
+    # If the env variable is set, add one more level of subprocess indirection
+    if os.environ.get("RAY_TEST_UV_ADD_SUBPROCESS_INDIRECTION") == "1":
+        import subprocess
+        env = os.environ.copy()
+        env.pop("RAY_TEST_UV_ADD_SUBPROCESS_INDIRECTION")
+        subprocess.check_call([sys.executable] + sys.argv, env=env)
+        sys.exit(0)
+
     # We purposefully modify sys.argv here to make sure the hook is robust
     # against such modification.
     sys.argv.pop(1)

--- a/python/ray/_private/runtime_env/uv_runtime_env_hook.py
+++ b/python/ray/_private/runtime_env/uv_runtime_env_hook.py
@@ -69,13 +69,12 @@ def _check_working_dir_files(
 
 def _get_uv_run_cmdline() -> Optional[List[str]]:
     """
-    uv spawns the python process as a child process, so to determine if
-    we are running under 'uv run', we check the parent process commandline. We also
-    check our parent's parents since the Ray driver might be run as a subprocess
-    of the 'uv run' process.
+    Return the command line of the first ancestor process that was run with
+    "uv run" and None if there is no such ancestor.
 
-    Return the uv run command line if any of our ancestors was run with "uv run"
-    and None otherwise.
+    uv spawns the python process as a child process, so we first check the
+    parent process command line. We also check our parent's parents since
+    the Ray driver might be run as a subprocess of the 'uv run' process.
     """
     parents = psutil.Process().parents()
     for parent in parents:

--- a/python/ray/_private/runtime_env/uv_runtime_env_hook.py
+++ b/python/ray/_private/runtime_env/uv_runtime_env_hook.py
@@ -65,6 +65,26 @@ def _check_working_dir_files(
             "working directory before running 'uv run', or by using the 'working_dir' "
             "parameter of the runtime_environment."
         )
+    
+
+def _is_running_with_uv_run() -> bool:
+    """
+    uv spawns the python process as a child process, so to determine if
+    we are running under 'uv run', we check the parent process commandline. We also
+    check our parent's parents since the Ray driver might be run as a subprocess.
+    Return True if any of our ancestors was run with "uv run" and False otherwise.
+    """
+    parents = psutil.Process().parents()
+    for parent in parents:
+        try:
+            cmdline = parent.cmdline()
+            if len(cmdline) > 1 and os.path.basename(cmdline[0]) == "uv" and cmdline[1] == "run":
+                return True
+        except psutil.NoSuchProcess:
+            continue
+        except psutil.AccessDenied:
+            continue
+    return False
 
 
 def hook(runtime_env: Optional[Dict[str, Any]]) -> Dict[str, Any]:
@@ -72,12 +92,8 @@ def hook(runtime_env: Optional[Dict[str, Any]]) -> Dict[str, Any]:
 
     runtime_env = copy.deepcopy(runtime_env) or {}
 
-    # uv spawns the python process as a child process, so to determine if
-    # we are running under 'uv run', we check the parent process commandline.
-    parent = psutil.Process().parent()
-    cmdline = parent.cmdline()
-    if os.path.basename(cmdline[0]) != "uv" or cmdline[1] != "run":
-        # This means the driver was not run with 'uv run' -- in this case
+    if not _is_running_with_uv_run():
+        # This means the driver was not run in a 'uv run' environment -- in this case
         # we leave the runtime environment unchanged
         return runtime_env
 

--- a/python/ray/_private/runtime_env/uv_runtime_env_hook.py
+++ b/python/ray/_private/runtime_env/uv_runtime_env_hook.py
@@ -65,7 +65,7 @@ def _check_working_dir_files(
             "working directory before running 'uv run', or by using the 'working_dir' "
             "parameter of the runtime_environment."
         )
-    
+
 
 def _get_uv_run_cmdline() -> Optional[List[str]]:
     """
@@ -81,7 +81,11 @@ def _get_uv_run_cmdline() -> Optional[List[str]]:
     for parent in parents:
         try:
             cmdline = parent.cmdline()
-            if len(cmdline) > 1 and os.path.basename(cmdline[0]) == "uv" and cmdline[1] == "run":
+            if (
+                len(cmdline) > 1
+                and os.path.basename(cmdline[0]) == "uv"
+                and cmdline[1] == "run"
+            ):
                 return cmdline
         except psutil.NoSuchProcess:
             continue
@@ -145,6 +149,7 @@ if __name__ == "__main__":
     # If the env variable is set, add one more level of subprocess indirection
     if os.environ.get("RAY_TEST_UV_ADD_SUBPROCESS_INDIRECTION") == "1":
         import subprocess
+
         env = os.environ.copy()
         env.pop("RAY_TEST_UV_ADD_SUBPROCESS_INDIRECTION")
         subprocess.check_call([sys.executable] + sys.argv, env=env)

--- a/python/ray/tests/test_runtime_env_uv_run.py
+++ b/python/ray/tests/test_runtime_env_uv_run.py
@@ -279,7 +279,9 @@ def test_uv_run_runtime_env_hook(with_uv):
             "py_executable": f"{uv} run --no-project",
             "working_dir": os.getcwd(),
         },
-        subprocess_kwargs={"env": {**os.environ, "RAY_TEST_UV_ADD_SUBPROCESS_INDIRECTION": "1"}}
+        subprocess_kwargs={
+            "env": {**os.environ, "RAY_TEST_UV_ADD_SUBPROCESS_INDIRECTION": "1"}
+        },
     )
 
 

--- a/python/ray/tests/test_runtime_env_uv_run.py
+++ b/python/ray/tests/test_runtime_env_uv_run.py
@@ -167,7 +167,7 @@ def test_uv_run_runtime_env_hook(with_uv):
         )
         output = result.stdout.strip().decode()
         if result.returncode != 0:
-            assert expected_error
+            assert expected_error, result.stderr.decode()
             assert expected_error in result.stderr.decode()
         else:
             assert json.loads(output) == expected_output
@@ -269,6 +269,18 @@ def test_uv_run_runtime_env_hook(with_uv):
     subprocess.check_output(
         [sys.executable, ray._private.runtime_env.uv_runtime_env_hook.__file__, "{}"]
     ).strip().decode() == "{}"
+
+    # Check in the case that there is one more level of subprocess indirection between
+    # the "uv run" process and the process that checks the environment
+    check_uv_run(
+        cmd=[uv, "run", "--no-project"],
+        runtime_env={},
+        expected_output={
+            "py_executable": f"{uv} run --no-project",
+            "working_dir": os.getcwd(),
+        },
+        subprocess_kwargs={"env": {**os.environ, "RAY_TEST_UV_ADD_SUBPROCESS_INDIRECTION": "1"}}
+    )
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Not ported to Windows yet.")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

If vllm's Ray backend is used in the vllm V1 architecture, it will start a subprocess and then call ray.init in that subprocess to launch the actual vllm replicas. This PR makes it so the uv environment still gets propagated correctly in that case.

This change is consistent with the behavior of how uv environments propagate to subprocesses with just vanilla `uv run` without Ray:

```
(base) pcmoritz@pcmoritz-DQ44HV60WX vllm-repro % cat pyproject.toml 
[project]
name = "test"
version = "0.1"
dependencies = [
   "ray",
]
```
```
(base) (base) pcmoritz@pcmoritz-DQ44HV60WX vllm-repro % cat test.py 
import sys

import ray
import subprocess
import psutil

print(sys.executable)
print(ray.__path__)

# avoid fork bomb
if len(psutil.Process().parents()) > 10:
    sys.exit(0)

subprocess.check_call([sys.executable, "test.py"])
```

```
(base) pcmoritz@pcmoritz-DQ44HV60WX vllm-repro % uv run test.py
warning: No `requires-python` value found in the workspace. Defaulting to `>=3.12`.
/private/tmp/vllm-repro/.venv/bin/python3
['/private/tmp/vllm-repro/.venv/lib/python3.12/site-packages/ray']
/private/tmp/vllm-repro/.venv/bin/python3
['/private/tmp/vllm-repro/.venv/lib/python3.12/site-packages/ray']
/private/tmp/vllm-repro/.venv/bin/python3
['/private/tmp/vllm-repro/.venv/lib/python3.12/site-packages/ray']
/private/tmp/vllm-repro/.venv/bin/python3
['/private/tmp/vllm-repro/.venv/lib/python3.12/site-packages/ray']
/private/tmp/vllm-repro/.venv/bin/python3
['/private/tmp/vllm-repro/.venv/lib/python3.12/site-packages/ray']
/private/tmp/vllm-repro/.venv/bin/python3
['/private/tmp/vllm-repro/.venv/lib/python3.12/site-packages/ray']
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
