### PR TITLE
[core] Synchronize locations with pinned_at_raylet_id

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -4190,7 +4190,11 @@ void CoreWorker::HandleUpdateObjectLocationBatch(
         AddObjectLocationOwner(object_id, node_id);
       } else if (object_location_update.plasma_location_update() ==
                  rpc::ObjectPlasmaLocationUpdate::REMOVED) {
-        RemoveObjectLocationOwner(object_id, node_id);
+        auto reference_exists =
+            reference_counter_->RemoveObjectLocation(object_id, node_id);
+        if (!reference_exists) {
+          RAY_LOG(DEBUG).WithField(object_id) << "Object not found";
+        }
       } else {
         RAY_LOG(FATAL) << "Invalid object plasma location update "
                        << object_location_update.plasma_location_update()
@@ -4262,14 +4266,6 @@ void CoreWorker::AddObjectLocationOwner(const ObjectID &object_id,
       reference_counter_->AddDynamicReturn(object_id, maybe_generator_id);
     }
     RAY_UNUSED(reference_counter_->AddObjectLocation(object_id, node_id));
-  }
-}
-
-void CoreWorker::RemoveObjectLocationOwner(const ObjectID &object_id,
-                                           const NodeID &node_id) {
-  auto reference_exists = reference_counter_->RemoveObjectLocation(object_id, node_id);
-  if (!reference_exists) {
-    RAY_LOG(DEBUG).WithField(object_id) << "Object not found";
   }
 }
 

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1601,8 +1601,6 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
 
   void AddObjectLocationOwner(const ObjectID &object_id, const NodeID &node_id);
 
-  void RemoveObjectLocationOwner(const ObjectID &object_id, const NodeID &node_id);
-
   /// Returns whether the message was sent to the wrong worker. The right error reply
   /// is sent automatically. Messages end up on the wrong worker when a worker dies
   /// and a new one takes its place with the same place. In this situation, we want

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -1601,6 +1601,10 @@ void ReferenceCounter::FillObjectInformation(
 void ReferenceCounter::FillObjectInformationInternal(
     ReferenceTable::iterator it, rpc::WorkerObjectLocationsPubMessage *object_info) {
   for (const auto &node_id : it->second.locations) {
+    // Skip spilled node ID.
+    if (node_id == it->second.spilled_node_id) {
+      continue;
+    }
     object_info->add_node_ids(node_id.Binary());
   }
   int64_t object_size = it->second.object_size;

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -866,6 +866,7 @@ void ReferenceCounter::UpdateObjectPinnedAtRaylet(const ObjectID &object_id,
     if (!it->second.OutOfScope(lineage_pinning_enabled_)) {
       if (check_node_alive_(raylet_id)) {
         it->second.pinned_at_raylet_id = raylet_id;
+        AddObjectLocationInternal(it, raylet_id);
       } else {
         UnsetObjectPrimaryCopy(it);
         objects_to_recover_.push_back(object_id);
@@ -1469,11 +1470,6 @@ std::optional<LocalityData> ReferenceCounter::GetLocalityData(
   // - If we don't own this object, this will contain a snapshot of the object locations
   //   at future resolution time.
   auto node_ids = it->second.locations;
-  // Add location of the primary copy since the object must be there: either in memory or
-  // spilled.
-  if (it->second.pinned_at_raylet_id.has_value()) {
-    node_ids.emplace(it->second.pinned_at_raylet_id.value());
-  }
 
   // We should only reach here if we have valid locality data to return.
   std::optional<LocalityData> locality_data(

--- a/src/ray/core_worker/reference_count.cc
+++ b/src/ray/core_worker/reference_count.cc
@@ -784,7 +784,7 @@ void ReferenceCounter::UnsetObjectPrimaryCopy(ReferenceTable::iterator it) {
   if (!it->second.pinned_at_raylet_id.has_value()) {
     return;
   }
-  RAY_CHECK_GT(it->second.locations.erase(*it->second.pinned_at_raylet_id), 0);
+  RAY_CHECK_GT(it->second.locations.erase(*it->second.pinned_at_raylet_id), 0ul);
   it->second.pinned_at_raylet_id.reset();
   if (it->second.spilled && !it->second.spilled_node_id.IsNil()) {
     it->second.spilled = false;

--- a/src/ray/core_worker/reference_count.h
+++ b/src/ray/core_worker/reference_count.h
@@ -750,7 +750,7 @@ class ReferenceCounter : public ReferenceCounterInterface,
     std::string call_site = "<unknown>";
     /// Object size if known, otherwise -1;
     int64_t object_size = -1;
-    /// If this object is owned by us and stored in plasma, this contains all
+    /// If this object is owned by us and stored in plasma or spill, this contains all
     /// object locations.
     absl::flat_hash_set<NodeID> locations;
     /// The object's owner's address, if we know it. If this process is the
@@ -758,7 +758,7 @@ class ReferenceCounter : public ReferenceCounterInterface,
     /// process is a borrower, the borrower must add the owner's address before
     /// using the ObjectID.
     std::optional<rpc::Address> owner_address;
-    /// If this object is owned by us and stored in plasma, and reference
+    /// If this object is owned by us and stored in plasma or spill, and reference
     /// counting is enabled, then some raylet must be pinning the object value.
     /// This is the address of that raylet.
     std::optional<NodeID> pinned_at_raylet_id;

--- a/src/ray/core_worker/test/reference_count_test.cc
+++ b/src/ray/core_worker/test/reference_count_test.cc
@@ -2668,7 +2668,7 @@ TEST_F(ReferenceCountLineageEnabledTest, TestPlasmaLocation) {
   ASSERT_TRUE(rc->IsPlasmaObjectPinnedOrSpilled(id, &owned_by_us, &pinned_at, &spilled));
   ASSERT_TRUE(owned_by_us);
   ASSERT_FALSE(pinned_at.IsNil());
-  ASSERT_TRUE(rc->GetObjectLocations(id)->empty());
+  ASSERT_EQ(rc->GetObjectLocations(id)->size(), 1);
 
   rc->RemoveLocalReference(id, nullptr);
   ASSERT_FALSE(rc->IsPlasmaObjectPinnedOrSpilled(id, &owned_by_us, &pinned_at, &spilled));


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We should add to locations whenever we set pinned_at_raylet_id instead of having it update through UpdateObjectLocationBatch. This will result in the worker and whoever needs the location to have it earlier since pinned_at_raylet_id gets updated whenever the task finishes. The obod (which does the UpdateObjectLocationBatch to core worker ref count) will get the locations after plasma realizes the object is there and sends an ipc to the raylet.

There's a behavior difference that comes with this though. The pinned_at_raylet_id location is always inside the locations set even if it's been spilled. Before it wouldn't be contained in locations if spilled because the OBOD would send a message when removed from plasma. Therefore, when publishing locations to consumers, we remove the spilled location from locations.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
