### PR TITLE
[ray.data.llm] Update release test: enforce pp_backend

### DIFF
--- a/release/llm_tests/batch/test_batch_vllm.py
+++ b/release/llm_tests/batch/test_batch_vllm.py
@@ -11,6 +11,7 @@ def test_chat_template_with_vllm():
     processor_config = vLLMEngineProcessorConfig(
         model_source="unsloth/Llama-3.2-1B-Instruct",
         engine_kwargs=dict(
+            distributed_executor_backend="ray",
             max_model_len=16384,
             enable_chunked_prefill=True,
             max_num_batched_tokens=2048,
@@ -131,6 +132,7 @@ def test_vllm_llama_lora():
         model_source=model_source,
         dynamic_lora_loading_path=lora_path,
         engine_kwargs=dict(
+            distributed_executor_backend="ray",
             max_model_len=4096,
             enable_chunked_prefill=True,
             enable_lora=True,

--- a/release/llm_tests/batch/test_batch_vllm.py
+++ b/release/llm_tests/batch/test_batch_vllm.py
@@ -61,7 +61,6 @@ def test_vllm_llama_parallel(tp_size, pp_size, concurrency, vllm_use_v1):
         runtime_env = dict(
             env_vars=dict(
                 VLLM_USE_V1="1",
-                VLLM_WORKER_MULTIPROC_METHOD="spawn",
             ),
         )
         # vLLM v1 does not support decoupled tokenizer,
@@ -145,7 +144,6 @@ def test_vllm_llama_lora():
             "env_vars": {
                 # TODO(lk-chen): Remove this once ray.data.llm enables LoRA in v1.
                 "VLLM_USE_V1": "0",
-                "VLLM_WORKER_MULTIPROC_METHOD": "spawn",
             }
         },
     )
@@ -198,7 +196,6 @@ def test_vllm_vision_language_models(
         runtime_env = dict(
             env_vars=dict(
                 VLLM_USE_V1="1",
-                VLLM_WORKER_MULTIPROC_METHOD="spawn",
             ),
         )
         # vLLM v1 does not support decoupled tokenizer,

--- a/release/llm_tests/batch/test_batch_vllm.py
+++ b/release/llm_tests/batch/test_batch_vllm.py
@@ -61,6 +61,7 @@ def test_vllm_llama_parallel(tp_size, pp_size, concurrency, vllm_use_v1):
         runtime_env = dict(
             env_vars=dict(
                 VLLM_USE_V1="1",
+                VLLM_WORKER_MULTIPROC_METHOD="spawn",
             ),
         )
         # vLLM v1 does not support decoupled tokenizer,
@@ -78,6 +79,7 @@ def test_vllm_llama_parallel(tp_size, pp_size, concurrency, vllm_use_v1):
         engine_kwargs=dict(
             tensor_parallel_size=tp_size,
             pipeline_parallel_size=pp_size,
+            distributed_executor_backend="ray",
             max_model_len=16384,
             enable_chunked_prefill=True,
             max_num_batched_tokens=2048,
@@ -141,7 +143,9 @@ def test_vllm_llama_lora():
         concurrency=1,
         runtime_env={
             "env_vars": {
+                # TODO(lk-chen): Remove this once ray.data.llm enables LoRA in v1.
                 "VLLM_USE_V1": "0",
+                "VLLM_WORKER_MULTIPROC_METHOD": "spawn",
             }
         },
     )
@@ -194,6 +198,7 @@ def test_vllm_vision_language_models(
         runtime_env = dict(
             env_vars=dict(
                 VLLM_USE_V1="1",
+                VLLM_WORKER_MULTIPROC_METHOD="spawn",
             ),
         )
         # vLLM v1 does not support decoupled tokenizer,
@@ -212,6 +217,7 @@ def test_vllm_vision_language_models(
         engine_kwargs=dict(
             tensor_parallel_size=tp_size,
             pipeline_parallel_size=pp_size,
+            distributed_executor_backend="ray",
             max_model_len=4096,
             enable_chunked_prefill=True,
         ),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

PP backend argument is defaulted to "mp", but as of vLLM 0.8.5, vLLM V1 does not accept "mp" and [requires "ray"](https://github.com/vllm-project/vllm/blob/v0.8.5/vllm/engine/arg_utils.py#L1345), otherwise it will fall back to V0.

There's recent https://github.com/vllm-project/vllm/pull/14219 to come up in next release, to support "mp" in V1.

Our release test should catch "ray" backend only, hence this PR.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
