### PR TITLE
[core] Add sync get node info to NodeInfoAccessor

### DIFF
--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -400,9 +400,17 @@ class NodeInfoAccessor {
   /// \param node_id The ID of node to look up in local cache.
   /// \param filter_dead_nodes Whether or not if this method will filter dead nodes.
   /// \return The item returned by GCS. If the item to read doesn't exist or the node is
-  virtual  /// dead, this optional object is empty.
-      const rpc::GcsNodeInfo *
-      Get(const NodeID &node_id, bool filter_dead_nodes = true) const;
+  /// dead, this optional object is empty.
+  virtual const rpc::GcsNodeInfo *GetCached(const NodeID &node_id,
+                                            bool filter_dead_nodes = true) const;
+
+  /// Get node information by making a request to the GCS.
+  /// \param node_id The ID of node.
+  /// \param filter_dead_nodes Whether or not if this method will filter dead nodes.
+  /// \return The item returned by GCS. If the item to read doesn't exist or the node is
+  /// dead, this optional object is empty.
+  virtual std::optional<rpc::GcsNodeInfo> GetSync(const NodeID &node_id,
+                                                  bool filter_dead_nodes = true) const;
 
   /// Get information of all nodes from local cache.
   /// Non-thread safe.

--- a/src/ray/gcs/gcs_client/test/gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/gcs_client_test.cc
@@ -574,8 +574,12 @@ TEST_P(GcsClientTest, TestNodeInfo) {
   // Get information of all nodes from GCS.
   std::vector<rpc::GcsNodeInfo> node_list = GetNodeInfoList();
   EXPECT_EQ(node_list.size(), 2);
-  ASSERT_TRUE(gcs_client_->Nodes().Get(node1_id));
-  ASSERT_TRUE(gcs_client_->Nodes().Get(node2_id));
+  ASSERT_TRUE(gcs_client_->Nodes().GetCached(node1_id) != nullptr);
+  ASSERT_TRUE(gcs_client_->Nodes().GetCached(node2_id) != nullptr);
+
+  ASSERT_TRUE(gcs_client_->Nodes().GetSync(node1_id) != std::nullopt);
+  ASSERT_TRUE(gcs_client_->Nodes().GetSync(node2_id) != std::nullopt);
+
   EXPECT_EQ(gcs_client_->Nodes().GetAll().size(), 2);
 }
 

--- a/src/ray/object_manager/ownership_object_directory.cc
+++ b/src/ray/object_manager/ownership_object_directory.cc
@@ -461,8 +461,8 @@ ray::Status OwnershipBasedObjectDirectory::UnsubscribeObjectLocations(
 
 void OwnershipBasedObjectDirectory::LookupRemoteConnectionInfo(
     RemoteConnectionInfo &connection_info) const {
-  auto node_info = gcs_client_->Nodes().Get(connection_info.node_id);
-  if (node_info) {
+  auto node_info = gcs_client_->Nodes().GetCached(connection_info.node_id);
+  if (node_info != nullptr) {
     NodeID result_node_id = NodeID::FromBinary(node_info->node_id());
     RAY_CHECK(result_node_id == connection_info.node_id);
     connection_info.ip = node_info->node_manager_address();

--- a/src/ray/raylet/local_task_manager_test.cc
+++ b/src/ray/raylet/local_task_manager_test.cc
@@ -135,7 +135,8 @@ std::shared_ptr<ClusterResourceScheduler> CreateSingleNodeScheduler(
       scheduling::NodeID(id),
       local_node_resources,
       /*is_node_available_fn*/ [&gcs_client](scheduling::NodeID node_id) {
-        return gcs_client.Nodes().Get(NodeID::FromBinary(node_id.Binary())) != nullptr;
+        return gcs_client.Nodes().GetCached(NodeID::FromBinary(node_id.Binary())) !=
+               nullptr;
       });
 
   return scheduler;

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -304,7 +304,8 @@ NodeManager::NodeManager(
       config.resource_config.GetResourceMap(),
       /*is_node_available_fn*/
       [this](scheduling::NodeID node_id) {
-        return gcs_client_->Nodes().Get(NodeID::FromBinary(node_id.Binary())) != nullptr;
+        return gcs_client_->Nodes().GetCached(NodeID::FromBinary(node_id.Binary())) !=
+               nullptr;
       },
       /*get_used_object_store_memory*/
       [this]() {
@@ -328,7 +329,7 @@ NodeManager::NodeManager(
       config.labels);
 
   auto get_node_info_func = [this](const NodeID &node_id) {
-    return gcs_client_->Nodes().Get(node_id);
+    return gcs_client_->Nodes().GetCached(node_id);
   };
   auto announce_infeasible_task = [this](const RayTask &task) {
     PublishInfeasibleTaskError(task);
@@ -414,7 +415,7 @@ NodeManager::NodeManager(
 
 std::shared_ptr<raylet::RayletClient> NodeManager::CreateRayletClient(
     const NodeID &node_id, rpc::ClientCallManager &client_call_manager) {
-  const rpc::GcsNodeInfo *node_info = gcs_client_->Nodes().Get(node_id);
+  const rpc::GcsNodeInfo *node_info = gcs_client_->Nodes().GetCached(node_id);
   RAY_CHECK(node_info) << "No GCS info for node " << node_id;
   std::shared_ptr<ray::rpc::NodeManagerWorkerClient> grpc_client =
       rpc::NodeManagerWorkerClient::make(node_info->node_manager_address(),

--- a/src/ray/raylet/placement_group_resource_manager_test.cc
+++ b/src/ray/raylet/placement_group_resource_manager_test.cc
@@ -42,7 +42,8 @@ class NewPlacementGroupResourceManagerTest : public ::testing::Test {
   void SetUp() {
     gcs_client_ = std::make_unique<gcs::MockGcsClient>();
     is_node_available_fn_ = [this](scheduling::NodeID node_id) {
-      return gcs_client_->Nodes().Get(NodeID::FromBinary(node_id.Binary())) != nullptr;
+      return gcs_client_->Nodes().GetCached(NodeID::FromBinary(node_id.Binary())) !=
+             nullptr;
     };
     EXPECT_CALL(*gcs_client_->mock_node_accessor, Get(::testing::_, ::testing::_))
         .WillRepeatedly(::testing::Return(&node_info_));

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler_test.cc
@@ -106,7 +106,8 @@ class ClusterResourceSchedulerTest : public ::testing::Test {
     // policy.
     gcs_client_ = std::make_unique<gcs::MockGcsClient>();
     is_node_available_fn_ = [this](scheduling::NodeID node_id) {
-      return gcs_client_->Nodes().Get(NodeID::FromBinary(node_id.Binary())) != nullptr;
+      return gcs_client_->Nodes().GetCached(NodeID::FromBinary(node_id.Binary())) !=
+             nullptr;
     };
     node_name = NodeID::FromRandom().Binary();
     node_info.set_node_id(node_name);

--- a/src/ray/raylet/scheduling/cluster_task_manager_test.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager_test.cc
@@ -144,7 +144,8 @@ std::shared_ptr<ClusterResourceScheduler> CreateSingleNodeScheduler(
       scheduling::NodeID(id),
       local_node_resources,
       /*is_node_available_fn*/ [&gcs_client](scheduling::NodeID node_id) {
-        return gcs_client.Nodes().Get(NodeID::FromBinary(node_id.Binary())) != nullptr;
+        return gcs_client.Nodes().GetCached(NodeID::FromBinary(node_id.Binary())) !=
+               nullptr;
       });
 
   return scheduler;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Renaming the Get to GetCached, and adding a GetSync to actually make the req to get info for that node.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
