### PR TITLE
[data] skip tfx-bsl tests on premerge

### DIFF
--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -143,6 +143,7 @@ steps:
     tags:
       - python
       - data
+      - skip-on-premerge
     instance_type: medium
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/data/... data


### PR DESCRIPTION
the base image is not resolving dependencies any more.
