### PR TITLE
Adds pydoclint to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,30 @@ repos:
         args: [ --select, "I", --fix, --exit-non-zero-on-fix ]
         files: '^python/ray/serve/|^python/ray/train|^python/ray/data'
 
+  - repo: https://github.com/jsh9/pydoclint
+    rev: "0.6.6"
+    hooks:
+      - id: pydoclint
+        args: [
+          python/ray,
+          --style=google,
+          --baseline=ci/lint/pydoclint-baseline.txt,
+          --exclude=thirdparty,
+          # --generate-baseline=True, # Not generally needed, but documenting since this is how we generate the initial baseline
+          --auto-regenerate-baseline=True,
+          # Current settings (not because we think they're right, but because we
+          # don't want a baseline the size of the codebase)
+          --arg-type-hints-in-docstring=False,
+          --skip-checking-raises=True,
+          --check-return-types=False,
+          --allow-init-docstring=True,
+          --check-class-attributes=False,
+          # --check-style-mismatch=True, # Bring this back once things are a bit cleaner
+        ]
+        types: [python]
+        files: '^python/ray/'
+        pass_filenames: false
+
   - repo: https://github.com/cpplint/cpplint
     rev: 2.0.0
     hooks:

--- a/ci/lint/lint.sh
+++ b/ci/lint/lint.sh
@@ -38,6 +38,7 @@ pre_commit() {
     cpplint
     buildifier
     buildifier-lint
+    pydoclint
   )
 
   for HOOK in "${HOOKS[@]}"; do

--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1,0 +1,3077 @@
+python/ray/_common/utils.py
+    DOC101: Function `import_attr`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `import_attr`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [full_path: str, reload_module: bool].
+--------------------
+python/ray/_private/accelerators/neuron.py
+    DOC111: Method `NeuronAcceleratorManager.set_current_process_visible_accelerator_ids`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+--------------------
+python/ray/_private/accelerators/tpu.py
+    DOC111: Method `TPUAcceleratorManager.set_current_process_visible_accelerator_ids`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+--------------------
+python/ray/_private/client_mode_hook.py
+    DOC201: Function `client_mode_hook` does not have a return section in docstring
+--------------------
+python/ray/_private/dict.py
+    DOC111: Function `merge_dicts`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Function `deep_update` does not have a return section in docstring
+    DOC201: Function `unflatten_list_dict` does not have a return section in docstring
+--------------------
+python/ray/_private/event/event_logger.py
+    DOC201: Function `get_event_logger` does not have a return section in docstring
+--------------------
+python/ray/_private/event/export_event_logger.py
+    DOC201: Function `get_export_event_logger` does not have a return section in docstring
+    DOC201: Function `check_export_api_enabled` does not have a return section in docstring
+--------------------
+python/ray/_private/external_storage.py
+    DOC201: Method `ExternalStorage._write_multiple_objects` does not have a return section in docstring
+    DOC106: Method `ExternalStorage._size_check`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `ExternalStorage._size_check`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Method `ExternalStorage.spill_objects`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `ExternalStorage.spill_objects`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC101: Method `FileSystemStorage.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `FileSystemStorage.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [buffer_size: Optional[int], directory_path: Union[str, List[str]], node_id: str].
+    DOC101: Method `ExternalStorageSmartOpenImpl.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC107: Method `ExternalStorageSmartOpenImpl.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `ExternalStorageSmartOpenImpl.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [buffer_size: , node_id: str]. Arguments in the docstring but not in the function signature: [prefix: ].
+    DOC106: Function `spill_objects`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `spill_objects`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC201: Function `restore_spilled_objects` does not have a return section in docstring
+    DOC201: Function `_get_unique_spill_filename` does not have a return section in docstring
+--------------------
+python/ray/_private/function_manager.py
+    DOC101: Method `FunctionActorManager.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `FunctionActorManager.__init__`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `FunctionActorManager.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `FunctionActorManager.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [worker: ].
+    DOC106: Method `FunctionActorManager.compute_collision_identifier`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `FunctionActorManager.compute_collision_identifier`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Method `FunctionActorManager.export`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `FunctionActorManager.export`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC201: Method `FunctionActorManager.export` does not have a return section in docstring
+    DOC106: Method `FunctionActorManager.get_execution_info`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `FunctionActorManager.get_execution_info`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC101: Method `FunctionActorManager._wait_for_function`: Docstring contains fewer arguments than in function signature.
+    DOC107: Method `FunctionActorManager._wait_for_function`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `FunctionActorManager._wait_for_function`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [function_descriptor: , timeout: ]. Arguments in the docstring but not in the function signature: [function_descriptor : ].
+    DOC106: Method `FunctionActorManager.load_actor_class`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `FunctionActorManager.load_actor_class`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC107: Method `FunctionActorManager._make_actor_method_executor`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/_private/gcs_pubsub.py
+    DOC101: Method `GcsAioResourceUsageSubscriber.poll`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `GcsAioResourceUsageSubscriber.poll`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `GcsAioResourceUsageSubscriber.poll`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `GcsAioResourceUsageSubscriber.poll`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [timeout: ].
+    DOC101: Method `GcsAioActorSubscriber.poll`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `GcsAioActorSubscriber.poll`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `GcsAioActorSubscriber.poll`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `GcsAioActorSubscriber.poll`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [batch_size: , timeout: ].
+    DOC101: Method `GcsAioNodeInfoSubscriber.poll`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `GcsAioNodeInfoSubscriber.poll`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `GcsAioNodeInfoSubscriber.poll`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `GcsAioNodeInfoSubscriber.poll`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [batch_size: , timeout: ].
+--------------------
+python/ray/_private/gcs_utils.py
+    DOC107: Function `create_gcs_channel`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC104: Function `cleanup_redis_storage`: Arguments are the same in the docstring and the function signature, but are in a different order.
+    DOC105: Function `cleanup_redis_storage`: Argument names match, but type hints in these args do not match: host, port, password, use_ssl, storage_namespace, username
+    DOC201: Function `cleanup_redis_storage` does not have a return section in docstring
+--------------------
+python/ray/_private/inspect_util.py
+    DOC106: Function `is_function_or_method`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `is_function_or_method`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Function `is_static_method`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `is_static_method`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC201: Function `is_static_method` does not have a return section in docstring
+--------------------
+python/ray/_private/internal_api.py
+    DOC111: Function `free`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Function `free` does not have a return section in docstring
+--------------------
+python/ray/_private/metrics_agent.py
+    DOC101: Method `OpenCensusProxyCollector.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `OpenCensusProxyCollector.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [component_timeout_s: int].
+    DOC201: Method `OpenCensusProxyCollector.to_metrics` does not have a return section in docstring
+    DOC201: Method `MetricsAgent.proxy_export_metrics` does not have a return section in docstring
+    DOC106: Method `PrometheusServiceDiscoveryWriter.__init__`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `PrometheusServiceDiscoveryWriter.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/_private/node.py
+    DOC107: Method `Node.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC201: Method `Node.check_version_info` does not have a return section in docstring
+    DOC111: Method `Node._make_inc_temp`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC101: Method `Node._prepare_socket_file`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Node._prepare_socket_file`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [default_prefix: str].
+    DOC201: Method `Node._prepare_socket_file` does not have a return section in docstring
+    DOC101: Method `Node.start_raylet`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Node.start_raylet`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [fallback_directory: str, object_store_memory: int, plasma_directory: str].
+    DOC107: Method `Node._kill_process_type`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC101: Method `Node.kill_all_processes`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `Node.kill_all_processes`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `Node.kill_all_processes`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `Node.kill_all_processes`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [allow_graceful: ].
+--------------------
+python/ray/_private/parameter.py
+    DOC101: Method `RayParams.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC107: Method `RayParams.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `RayParams.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_system_config: Optional[Dict[str, str]], autoscaling_config: Optional[str], cluster_id: Optional[str], dashboard_agent_listen_port: Optional[int], dashboard_host: Optional[str], dashboard_port: Optional[bool], driver_mode: , enable_object_reconstruction: Optional[bool], env_vars: Optional[Dict[str, str]], external_addresses: Optional[List[str]], gcs_address: Optional[str], gcs_server_port: Optional[int], huge_pages: Optional[bool], include_dashboard: Optional[bool], include_log_monitor: Optional[str], labels: Optional[Dict[str, str]], max_worker_port: Optional[int], memory: Optional[float], metrics_agent_port: Optional[int], metrics_export_port: Optional[int], min_worker_port: Optional[int], no_monitor: Optional[bool], node_id: Optional[str], node_ip_address: Optional[str], node_manager_port: int, node_name: Optional[str], num_cpus: Optional[int], num_gpus: Optional[int], num_redis_shards: Optional[int], object_manager_port: Optional[int], object_ref_seed: Optional[int], object_spilling_directory: Optional[str], object_store_memory: Optional[float], plasma_directory: Optional[str], plasma_store_socket_name: Optional[str], ray_client_server_port: Optional[int], ray_debugger_external: bool, raylet_ip_address: Optional[str], raylet_socket_name: Optional[str], redirect_output: Optional[bool], redis_address: Optional[str], redis_max_clients: Optional[int], redis_password: Optional[str], redis_port: Optional[int], redis_shard_ports: Optional[List[int]], redis_username: Optional[str], resource_isolation_config: Optional[ResourceIsolationConfig], resources: Optional[Dict[str, float]], runtime_env_agent_port: Optional[int], runtime_env_dir_name: Optional[str], session_name: Optional[str], setup_worker_path: Optional[str], storage: Optional[str], temp_dir: Optional[str], tracing_startup_hook: , webui: Optional[str], worker_path: Optional[str], worker_port_list: Optional[List[int]]].
+    DOC106: Method `RayParams.update`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC103: Method `RayParams.update`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ]. Arguments in the docstring but not in the function signature: [kwargs: ].
+    DOC106: Method `RayParams.update_if_absent`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC103: Method `RayParams.update_if_absent`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ]. Arguments in the docstring but not in the function signature: [kwargs: ].
+    DOC202: Method `RayParams.update_pre_selected_port` has a return section in docstring, but there are no return statements or annotations
+--------------------
+python/ray/_private/profiling.py
+    DOC106: Function `profile`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `profile`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/_private/ray_logging/__init__.py
+    DOC107: Function `setup_component_logger`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC101: Function `run_callback_on_events_in_ipython`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `run_callback_on_events_in_ipython`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [event: str].
+--------------------
+python/ray/_private/ray_option_utils.py
+    DOC201: Function `_counting_option` does not have a return section in docstring
+--------------------
+python/ray/_private/resource_isolation_config.py
+    DOC101: Method `ResourceIsolationConfig.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ResourceIsolationConfig.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [cgroup_path: Optional[str], enable_resource_isolation: bool, system_reserved_cpu: Optional[float], system_reserved_memory: Optional[int]].
+    DOC201: Method `ResourceIsolationConfig._validate_and_get_system_reserved_cpu` does not have a return section in docstring
+--------------------
+python/ray/_private/resource_spec.py
+    DOC201: Method `ResourceSpec.resolve` does not have a return section in docstring
+--------------------
+python/ray/_private/runtime_env/agent/runtime_env_agent.py
+    DOC101: Method `RuntimeEnvAgent.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC107: Method `RuntimeEnvAgent.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `RuntimeEnvAgent.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: , gcs_client: GcsClient, logging_params: , runtime_env_agent_port: , runtime_env_dir: , temp_dir: ].
+    DOC107: Function `_create_runtime_env_with_retry`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/_private/runtime_env/conda.py
+    DOC101: Function `current_ray_pip_specifier`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `current_ray_pip_specifier`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [logger: Optional[logging.Logger]].
+    DOC111: Function `inject_dependencies`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+--------------------
+python/ray/_private/runtime_env/conda_utils.py
+    DOC101: Function `create_conda_env_if_needed`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `create_conda_env_if_needed`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [logger: Optional[logging.Logger]].
+    DOC101: Function `exec_cmd`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `exec_cmd`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [logger: Optional[logging.Logger]].
+    DOC201: Function `exec_cmd` does not have a return section in docstring
+--------------------
+python/ray/_private/runtime_env/packaging.py
+    DOC111: Function `_store_package_in_gcs`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Function `_store_package_in_gcs` does not have a return section in docstring
+    DOC201: Function `package_exists` does not have a return section in docstring
+    DOC111: Function `get_uri_for_directory`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC101: Function `upload_package_if_needed`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `upload_package_if_needed`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [logger: Optional[logging.Logger]].
+    DOC201: Function `upload_package_if_needed` does not have a return section in docstring
+    DOC101: Function `delete_package`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `delete_package`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [base_directory: str].
+--------------------
+python/ray/_private/runtime_env/plugin.py
+    DOC107: Method `RuntimeEnvPlugin.create`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `RuntimeEnvPluginManager.create_uri_cache_for_plugin`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [plugin: RuntimeEnvPlugin]. Arguments in the docstring but not in the function signature: [plugin_name: ].
+--------------------
+python/ray/_private/runtime_env/setup_hook.py
+    DOC102: Function `upload_worker_process_setup_hook_if_needed`: Docstring contains more arguments than in function signature.
+    DOC103: Function `upload_worker_process_setup_hook_if_needed`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the docstring but not in the function signature: [decoder: ].
+    DOC201: Function `upload_worker_process_setup_hook_if_needed` does not have a return section in docstring
+--------------------
+python/ray/_private/runtime_env/utils.py
+    DOC103: Function `check_output_cmd`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ]. Arguments in the docstring but not in the function signature: [kwargs: ].
+--------------------
+python/ray/_private/serialization.py
+    DOC106: Method `SerializationContext.serialize`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `SerializationContext.serialize`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC201: Method `SerializationContext.serialize` does not have a return section in docstring
+--------------------
+python/ray/_private/services.py
+    DOC201: Function `_build_python_executable_command_memory_profileable` does not have a return section in docstring
+    DOC101: Function `get_ray_address_from_environment`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `get_ray_address_from_environment`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [addr: str, temp_dir: Optional[str]].
+    DOC201: Function `wait_for_node` does not have a return section in docstring
+    DOC101: Function `canonicalize_bootstrap_address`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `canonicalize_bootstrap_address`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [addr: str, temp_dir: Optional[str]].
+    DOC101: Function `canonicalize_bootstrap_address_or_die`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `canonicalize_bootstrap_address_or_die`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [addr: str, temp_dir: Optional[str]].
+    DOC106: Function `create_redis_client`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `create_redis_client`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC101: Function `start_reaper`: Docstring contains fewer arguments than in function signature.
+    DOC106: Function `start_reaper`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `start_reaper`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `start_reaper`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [fate_share: ].
+    DOC102: Function `start_log_monitor`: Docstring contains more arguments than in function signature.
+    DOC103: Function `start_log_monitor`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the docstring but not in the function signature: [redirect_logging: ].
+    DOC101: Function `start_api_server`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `start_api_server`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [fate_share: Optional[bool]].
+    DOC101: Function `start_gcs_server`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `start_gcs_server`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [fate_share: Optional[bool]].
+    DOC101: Function `start_raylet`: Docstring contains fewer arguments than in function signature.
+    DOC107: Function `start_raylet`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `start_raylet`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [cluster_id: str, socket_to_use: Optional[int]].
+    DOC101: Function `determine_plasma_store_config`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `determine_plasma_store_config`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [temp_dir: str].
+    DOC101: Function `start_monitor`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `start_monitor`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [autoscaler_v2: bool, fate_share: Optional[bool]].
+    DOC101: Function `start_ray_client_server`: Docstring contains fewer arguments than in function signature.
+    DOC111: Function `start_ray_client_server`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Function `start_ray_client_server`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [fate_share: Optional[bool]].
+--------------------
+python/ray/_private/signature.py
+    DOC106: Function `get_signature`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `get_signature`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Function `extract_signature`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `extract_signature`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC107: Function `validate_args`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC107: Function `flatten_args`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Function `recover_args`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `recover_args`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/_private/state.py
+    DOC106: Method `GlobalState._initialize_global_state`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `GlobalState._initialize_global_state`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC101: Method `GlobalState._gen_actor_info`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `GlobalState._gen_actor_info`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `GlobalState._gen_actor_info`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `GlobalState._gen_actor_info`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [actor_table_data: ].
+    DOC106: Method `GlobalState.chrome_tracing_dump`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `GlobalState.chrome_tracing_dump`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Method `GlobalState.chrome_tracing_object_transfer_dump`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `GlobalState.chrome_tracing_object_transfer_dump`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Method `GlobalState.add_worker`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `GlobalState.add_worker`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Method `GlobalState.update_worker_debugger_port`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `GlobalState.update_worker_debugger_port`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Method `GlobalState.get_worker_debugger_port`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `GlobalState.get_worker_debugger_port`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Method `GlobalState.update_worker_num_paused_threads`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `GlobalState.update_worker_num_paused_threads`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Function `timeline`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `timeline`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Function `object_transfer_timeline`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `object_transfer_timeline`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Function `update_worker_debugger_port`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `update_worker_debugger_port`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Function `update_worker_num_paused_threads`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `update_worker_num_paused_threads`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Function `get_worker_debugger_port`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `get_worker_debugger_port`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/_private/state_api_test_utils.py
+    DOC101: Function `invoke_state_api`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `invoke_state_api`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , err_msg: Optional[str], key_suffix: Optional[str], print_result: Optional[bool], state_api_fn: Callable, state_stats: StateAPIStats, verify_cb: Callable]. Arguments in the docstring but not in the function signature: [- kwargs: , - state_api_fn: , - state_stats: , - verify_cb: ].
+    DOC201: Function `invoke_state_api` does not have a return section in docstring
+    DOC103: Method `StateAPIGeneratorActor.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [apis: List[StateAPICallSpec], call_interval_s: float, print_interval_s: float, print_result: bool, wait_after_stop: bool]. Arguments in the docstring but not in the function signature: [- apis: , - call_interval_s: , - print_interval_s: , - print_result: , - wait_after_stop: ].
+    DOC101: Function `verify_tasks_running_or_terminated`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `verify_tasks_running_or_terminated`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [expect_num_tasks: int].
+    DOC201: Function `verify_tasks_running_or_terminated` does not have a return section in docstring
+--------------------
+python/ray/_private/test_utils.py
+    DOC101: Function `start_redis_instance`: Docstring contains fewer arguments than in function signature.
+    DOC107: Function `start_redis_instance`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `start_redis_instance`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [db_dir: , fate_share: Optional[bool], free_port: , leader_id: , replica_of: ].
+    DOC106: Function `_pid_alive`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `_pid_alive`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC101: Function `run_string_as_driver`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `run_string_as_driver`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [encode: str].
+    DOC101: Function `run_string_as_driver_stdout_stderr`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `run_string_as_driver_stdout_stderr`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [encode: str].
+    DOC101: Function `run_string_as_driver_nonblocking`: Docstring contains fewer arguments than in function signature.
+    DOC107: Function `run_string_as_driver_nonblocking`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `run_string_as_driver_nonblocking`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [env: Dict].
+    DOC101: Function `wait_for_condition`: Docstring contains fewer arguments than in function signature.
+    DOC107: Function `wait_for_condition`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `wait_for_condition`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: Any].
+    DOC201: Function `wait_for_condition` does not have a return section in docstring
+    DOC101: Function `async_wait_for_condition`: Docstring contains fewer arguments than in function signature.
+    DOC107: Function `async_wait_for_condition`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `async_wait_for_condition`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: Any].
+    DOC201: Function `async_wait_for_condition` does not have a return section in docstring
+    DOC106: Function `wait_until_succeeded_without_exception`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `wait_until_succeeded_without_exception`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `wait_until_succeeded_without_exception`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [*args: ]. Arguments in the docstring but not in the function signature: [args: ].
+    DOC201: Function `wait_until_succeeded_without_exception` does not have a return section in docstring
+    DOC101: Method `BatchQueue.get_batch`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `BatchQueue.get_batch`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [batch_size: int, first_timeout: Optional[float], total_timeout: Optional[float]].
+    DOC201: Method `BatchQueue.get_batch` does not have a return section in docstring
+    DOC101: Function `monitor_memory_usage`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `monitor_memory_usage`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [print_interval_s: int, record_interval_s: int]. Arguments in the docstring but not in the function signature: [interval_s: ].
+    DOC402: Function `simulate_storage` has "yield" statements, but the docstring does not have a "Yields" section
+    DOC404: Function `simulate_storage` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
+--------------------
+python/ray/_private/usage/usage_lib.py
+    DOC201: Function `record_extra_usage_tag` does not have a return section in docstring
+    DOC201: Function `_generate_cluster_metadata` does not have a return section in docstring
+    DOC106: Function `put_cluster_metadata`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `put_cluster_metadata`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC101: Function `get_extra_usage_tags_to_report`: Docstring contains fewer arguments than in function signature.
+    DOC106: Function `get_extra_usage_tags_to_report`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `get_extra_usage_tags_to_report`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `get_extra_usage_tags_to_report`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [gcs_client: ].
+    DOC106: Function `_get_cluster_status_to_report_v2`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `_get_cluster_status_to_report_v2`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Function `get_cluster_status_to_report`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `get_cluster_status_to_report`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Function `get_cluster_metadata`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `get_cluster_metadata`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/_private/utils.py
+    DOC101: Function `format_error_message`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `format_error_message`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [task_exception: bool].
+    DOC107: Function `push_error_to_driver`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC107: Function `publish_error_to_driver`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC101: Function `decode`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `decode`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [encode_type: str].
+    DOC101: Function `get_system_memory`: Docstring contains fewer arguments than in function signature.
+    DOC106: Function `get_system_memory`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `get_system_memory`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `get_system_memory`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [memory_limit_filename: , memory_limit_filename_v2: ].
+    DOC201: Function `get_num_cpus` does not have a return section in docstring
+    DOC106: Function `set_kill_child_on_death_win32`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `set_kill_child_on_death_win32`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Function `try_to_create_directory`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `try_to_create_directory`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Function `try_to_symlink`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `try_to_symlink`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC201: Function `try_to_symlink` does not have a return section in docstring
+    DOC201: Function `get_call_location` does not have a return section in docstring
+    DOC107: Function `deprecated`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Function `check_version_info`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `check_version_info`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/_private/worker.py
+    DOC106: Method `Worker.set_mode`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `Worker.set_mode`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Method `BaseContext._get_widget_bundle`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC102: Function `init`: Docstring contains more arguments than in function signature.
+    DOC111: Function `init`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Function `init`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ]. Arguments in the docstring but not in the function signature: [_cgroup_path: , _driver_object_store_memory: , _enable_object_reconstruction: , _memory: , _metrics_export_port: , _node_ip_address: , _node_name: , _plasma_directory: , _redis_password: , _redis_username: , _system_config: , _temp_dir: , _tracing_startup_hook: , object_spilling_directory: ].
+    DOC106: Function `listen_error_messages`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `listen_error_messages`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC111: Function `listen_error_messages`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Function `listen_error_messages` does not have a return section in docstring
+    DOC107: Function `connect`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC111: Function `connect`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC111: Function `get`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Function `put`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_owner: Optional['ray.actor.ActorHandle']]. Arguments in the docstring but not in the function signature: [_owner [Experimental]: ].
+    DOC102: Function `remote`: Docstring contains more arguments than in function signature.
+    DOC106: Function `remote`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC111: Function `remote`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Function `remote`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ]. Arguments in the docstring but not in the function signature: [_labels: , _metadata: , accelerator_type: , label_selector: Dict[str, str], max_calls: , max_restarts: , max_retries: , max_task_retries: , memory: , num_cpus: , num_gpus: , num_returns: , resources: Dict[str, float], retry_exceptions: , runtime_env: Dict[str, Any], scheduling_strategy: ].
+    DOC201: Function `remote` does not have a return section in docstring
+--------------------
+python/ray/actor.py
+    DOC101: Function `method`: Docstring contains fewer arguments than in function signature.
+    DOC106: Function `method`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC103: Function `method`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ]. Arguments in the docstring but not in the function signature: [num_returns: ].
+    DOC201: Function `method` does not have a return section in docstring
+    DOC101: Method `ActorMethod.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC107: Method `ActorMethod.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `ActorMethod.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [actor: , decorator: , enable_task_events: bool, generator_backpressure_num_objects: int, hardref: , is_generator: bool, max_task_retries: int, method_name: , num_returns: Optional[Union[int, Literal['streaming']]], retry_exceptions: Union[bool, list, tuple], signature: Optional[List[inspect.Parameter]]].
+    DOC101: Method `ActorMethod.options`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `ActorMethod.options`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC103: Method `ActorMethod.options`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**options: ].
+    DOC201: Method `ActorMethod.options` does not have a return section in docstring
+    DOC101: Method `_ActorClassMetadata.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC107: Method `_ActorClassMetadata.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `_ActorClassMetadata.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [accelerator_type: , actor_creation_function_descriptor: , class_id: , concurrency_groups: , label_selector: , language: , max_restarts: , max_task_retries: , memory: , modified_class: , num_cpus: , num_gpus: , object_store_memory: , resources: , runtime_env: , scheduling_strategy: SchedulingStrategyT].
+    DOC101: Method `ActorClass.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `ActorClass.__init__`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `ActorClass.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `ActorClass.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [attr: , bases: , name: ].
+    DOC101: Method `ActorClass.__call__`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `ActorClass.__call__`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC103: Method `ActorClass.__call__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ].
+    DOC106: Method `ActorClass.remote`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC103: Method `ActorClass.remote`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ]. Arguments in the docstring but not in the function signature: [args: , kwargs: ].
+    DOC102: Method `ActorClass.options`: Docstring contains more arguments than in function signature.
+    DOC106: Method `ActorClass.options`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC111: Method `ActorClass.options`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Method `ActorClass.options`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**actor_options: ]. Arguments in the docstring but not in the function signature: [_metadata: , accelerator_type: , enable_task_events: , label_selector: Dict[str, str], lifetime: , max_concurrency: , max_pending_calls: , max_restarts: , max_task_retries: , memory: , name: , namespace: , num_cpus: , num_gpus: , object_store_memory: , resources: Dict[str, float], runtime_env: Dict[str, Any], scheduling_strategy: ].
+    DOC201: Method `ActorClass.options` does not have a return section in docstring
+    DOC102: Method `ActorClass._remote`: Docstring contains more arguments than in function signature.
+    DOC106: Method `ActorClass._remote`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `ActorClass._remote`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC111: Method `ActorClass._remote`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Method `ActorClass._remote`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**actor_options: ]. Arguments in the docstring but not in the function signature: [_labels: , enable_task_events: , lifetime: , max_concurrency: , max_pending_calls: , memory: , name: , namespace: , num_cpus: , num_gpus: , placement_group: , placement_group_bundle_index: , placement_group_capture_child_tasks: , resources: , runtime_env: Dict[str, Any], scheduling_strategy: ].
+    DOC101: Method `ActorHandle.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC107: Method `ActorHandle.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `ActorHandle.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [actor_creation_function_descriptor: , actor_id: , actor_method_cpus: int, cluster_and_job: , enable_task_events: bool, language: , max_task_retries: Optional[int], method_decorators: , method_enable_task_events: Dict[str, bool], method_generator_backpressure_num_objects: Dict[str, int], method_is_generator: Dict[str, bool], method_max_task_retries: Dict[str, int], method_num_returns: Dict[str, Union[int, Literal['streaming']]], method_retry_exceptions: Dict[str, Union[bool, list, tuple]], method_signatures: , original_handle: , weak_ref: bool].
+    DOC101: Method `ActorHandle._actor_method_call`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ActorHandle._actor_method_call`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [concurrency_group_name: Optional[str], generator_backpressure_num_objects: Optional[int]].
+    DOC107: Method `ActorHandle._deserialization_helper`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC104: Method `ActorHandle._deserialization_helper`: Arguments are the same in the docstring and the function signature, but are in a different order.
+    DOC105: Method `ActorHandle._deserialization_helper`: Argument names match, but type hints in these args do not match: weak_ref
+    DOC201: Method `ActorHandle._deserialization_helper` does not have a return section in docstring
+--------------------
+python/ray/air/_internal/mlflow.py
+    DOC104: Method `_MLflowLoggerUtil.setup_mlflow`: Arguments are the same in the docstring and the function signature, but are in a different order.
+    DOC105: Method `_MLflowLoggerUtil.setup_mlflow`: Argument names match, but type hints in these args do not match: tracking_uri, registry_uri, experiment_id, experiment_name, tracking_token, artifact_location, create_experiment_if_not_exists
+    DOC101: Method `_MLflowLoggerUtil.start_run`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `_MLflowLoggerUtil.start_run`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [run_name: Optional[str]].
+    DOC111: Method `_MLflowLoggerUtil.log_params`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC101: Method `_MLflowLoggerUtil.log_metrics`: Docstring contains fewer arguments than in function signature.
+    DOC107: Method `_MLflowLoggerUtil.log_metrics`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC111: Method `_MLflowLoggerUtil.log_metrics`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Method `_MLflowLoggerUtil.log_metrics`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [step: ].
+    DOC111: Method `_MLflowLoggerUtil.save_artifacts`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC107: Method `_MLflowLoggerUtil.end_run`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC111: Method `_MLflowLoggerUtil.end_run`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+--------------------
+python/ray/air/_internal/tensorflow_utils.py
+    DOC201: Function `convert_ndarray_to_tf_tensor` does not have a return section in docstring
+    DOC103: Function `convert_ndarray_batch_to_tf_tensor_batch`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [dtypes: Optional[Union[tf.dtypes.DType, Dict[str, tf.dtypes.DType]]], ndarrays: Union[np.ndarray, Dict[str, np.ndarray]]]. Arguments in the docstring but not in the function signature: [dtype: , ndarray: ].
+    DOC201: Function `convert_ndarray_batch_to_tf_tensor_batch` does not have a return section in docstring
+--------------------
+python/ray/air/_internal/torch_utils.py
+    DOC103: Function `convert_pandas_to_torch_tensor`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [column_dtypes: Optional[Union[torch.dtype, List[torch.dtype]]]]. Arguments in the docstring but not in the function signature: [column_dtype: ].
+    DOC201: Function `convert_ndarray_to_torch_tensor` does not have a return section in docstring
+    DOC103: Function `convert_ndarray_batch_to_torch_tensor_batch`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [dtypes: Optional[Union[torch.dtype, Dict[str, torch.dtype]]], ndarrays: Union[np.ndarray, Dict[str, np.ndarray]]]. Arguments in the docstring but not in the function signature: [dtype: , ndarray: ].
+    DOC201: Function `convert_ndarray_batch_to_torch_tensor_batch` does not have a return section in docstring
+    DOC201: Function `consume_prefix_in_state_dict_if_present_not_in_place` does not have a return section in docstring
+    DOC201: Function `convert_ndarray_list_to_torch_tensor_list` does not have a return section in docstring
+--------------------
+python/ray/air/_internal/uri_utils.py
+    DOC101: Method `URI.rstrip_subpath`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `URI.rstrip_subpath`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [subpath: Path].
+    DOC201: Method `URI.rstrip_subpath` does not have a return section in docstring
+--------------------
+python/ray/air/_internal/usage.py
+    DOC107: Function `_find_class_name`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC101: Function `tag_callbacks`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `tag_callbacks`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [callbacks: Optional[List['Callback']]].
+--------------------
+python/ray/air/config.py
+    DOC107: Function `_repr_dataclass`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/air/execution/_internal/actor_manager.py
+    DOC201: Method `RayActorManager.is_actor_started` does not have a return section in docstring
+    DOC201: Method `RayActorManager.get_actor_resources` does not have a return section in docstring
+    DOC101: Method `RayActorManager.schedule_actor_task`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `RayActorManager.schedule_actor_task`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_return_future: bool].
+    DOC201: Method `RayActorManager.schedule_actor_task` does not have a return section in docstring
+--------------------
+python/ray/air/execution/_internal/barrier.py
+    DOC106: Method `Barrier.arrive`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+--------------------
+python/ray/air/execution/_internal/tracked_actor.py
+    DOC101: Method `TrackedActor.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TrackedActor.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [actor_id: int, on_error: Optional[Callable[['TrackedActor', Exception], None]], on_start: Optional[Callable[['TrackedActor'], None]], on_stop: Optional[Callable[['TrackedActor'], None]]].
+--------------------
+python/ray/air/execution/resources/request.py
+    DOC201: Function `_sum_bundles` does not have a return section in docstring
+    DOC201: Method `AcquiredResources.annotate_remote_entities` does not have a return section in docstring
+--------------------
+python/ray/air/integrations/keras.py
+    DOC104: Method `ReportCheckpointCallback.__init__`: Arguments are the same in the docstring and the function signature, but are in a different order.
+    DOC105: Method `ReportCheckpointCallback.__init__`: Argument names match, but type hints in these args do not match: checkpoint_on, report_metrics_on, metrics
+--------------------
+python/ray/air/integrations/mlflow.py
+    DOC201: Function `setup_mlflow` does not have a return section in docstring
+--------------------
+python/ray/air/integrations/wandb.py
+    DOC103: Function `setup_wandb`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ]. Arguments in the docstring but not in the function signature: [kwargs: ].
+    DOC201: Function `setup_wandb` does not have a return section in docstring
+    DOC101: Method `WandbLoggerCallback.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `WandbLoggerCallback.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [save_checkpoints: bool, upload_timeout: int].
+--------------------
+python/ray/air/result.py
+    DOC201: Method `Result._read_file_as_str` does not have a return section in docstring
+--------------------
+python/ray/air/util/check_ingest.py
+    DOC101: Method `DummyTrainer.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `DummyTrainer.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: , batch_size: Optional[int]].
+    DOC201: Function `make_local_dataset_iterator` does not have a return section in docstring
+--------------------
+python/ray/air/util/tensor_extensions/arrow.py
+    DOC101: Function `pyarrow_table_from_pydict`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `pyarrow_table_from_pydict`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [pydict: Dict[str, Union[List[Any], pa.Array]]].
+    DOC201: Function `pyarrow_table_from_pydict` does not have a return section in docstring
+    DOC201: Method `ArrowTensorArray._concat_same_type` does not have a return section in docstring
+--------------------
+python/ray/air/util/tensor_extensions/pandas.py
+    DOC101: Method `TensorDtype.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TensorDtype.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [dtype: np.dtype, shape: Tuple[Optional[int], ...]].
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `TensorArray.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TensorArray.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [values: Union[np.ndarray, ABCSeries, Sequence[Union[np.ndarray, TensorArrayElement]], TensorArrayElement, Any]].
+--------------------
+python/ray/air/util/torch_dist.py
+    DOC101: Method `TorchDistributedWorker.execute`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TorchDistributedWorker.execute`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ]. Arguments in the docstring but not in the function signature: [args, kwargs: ].
+    DOC201: Method `TorchDistributedWorker.execute` does not have a return section in docstring
+    DOC103: Function `init_torch_dist_process_group`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**init_process_group_kwargs: ]. Arguments in the docstring but not in the function signature: [init_process_group_kwargs: ].
+--------------------
+python/ray/air/util/transform_pyarrow.py
+    DOC201: Function `_concatenate_extension_column` does not have a return section in docstring
+--------------------
+python/ray/autoscaler/_private/_azure/node_provider.py
+    DOC101: Method `AzureNodeProvider.non_terminated_nodes`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `AzureNodeProvider.non_terminated_nodes`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `AzureNodeProvider.non_terminated_nodes`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `AzureNodeProvider.non_terminated_nodes`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [tag_filters: ].
+    DOC201: Method `AzureNodeProvider.non_terminated_nodes` does not have a return section in docstring
+--------------------
+python/ray/autoscaler/_private/aliyun/utils.py
+    DOC106: Method `AcsClient.__init__`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `AcsClient.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/autoscaler/_private/autoscaler.py
+    DOC104: Method `StandardAutoscaler.__init__`: Arguments are the same in the docstring and the function signature, but are in a different order.
+    DOC105: Method `StandardAutoscaler.__init__`: Argument names match, but type hints in these args do not match: config_reader, load_metrics, gcs_client, session_name, max_launch_batch, max_concurrent_launches, max_failures, process_runner, update_interval_s, prefix_cluster_info, event_summarizer, prom_metrics
+    DOC101: Method `StandardAutoscaler._keep_worker_of_node_type`: Docstring contains fewer arguments than in function signature.
+    DOC111: Method `StandardAutoscaler._keep_worker_of_node_type`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Method `StandardAutoscaler._keep_worker_of_node_type`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [node_id: NodeID].
+--------------------
+python/ray/autoscaler/_private/aws/config.py
+    DOC101: Function `_usable_subnet_ids`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_usable_subnet_ids`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [all_subnets: List[Any], azs: Optional[str], node_type_key: str, use_internal_ips: bool, user_specified_subnets: Optional[List[Any]], vpc_id_of_sg: Optional[str]].
+    DOC111: Function `_configure_from_launch_template`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC111: Function `_configure_node_type_from_launch_template`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC111: Function `_configure_node_cfg_from_launch_template`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC111: Function `_configure_from_network_interfaces`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC111: Function `_configure_node_type_from_network_interface`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC111: Function `_configure_subnets_and_groups_from_network_interfaces`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC111: Function `_subnets_in_network_config`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC111: Function `_security_groups_in_network_config`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+--------------------
+python/ray/autoscaler/_private/aws/node_provider.py
+    DOC101: Function `list_ec2_instances`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `list_ec2_instances`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [aws_credentials: Dict[str, Any]].
+    DOC111: Method `AWSNodeProvider._merge_tag_specs`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+--------------------
+python/ray/autoscaler/_private/cli_logger.py
+    DOC101: Function `_format_msg`: Docstring contains fewer arguments than in function signature.
+    DOC111: Function `_format_msg`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Function `_format_msg`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: Any, msg: str].
+    DOC101: Method `_CliLogger._print`: Docstring contains fewer arguments than in function signature.
+    DOC111: Method `_CliLogger._print`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Method `_CliLogger._print`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_level_str: str, _linefeed: bool, end: str]. Arguments in the docstring but not in the function signature: [linefeed: bool].
+    DOC201: Method `_CliLogger._print` does not have a return section in docstring
+    DOC101: Method `_CliLogger.labeled_value`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `_CliLogger.labeled_value`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: Any, *args: Any, msg: str].
+    DOC101: Method `_CliLogger.doassert`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `_CliLogger.doassert`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: Any, *args: Any, msg: str].
+    DOC101: Method `_CliLogger.confirm`: Docstring contains fewer arguments than in function signature.
+    DOC111: Method `_CliLogger.confirm`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Method `_CliLogger.confirm`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: Any, *args: Any, msg: str].
+    DOC201: Method `_CliLogger.confirm` does not have a return section in docstring
+    DOC101: Method `_CliLogger.prompt`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `_CliLogger.prompt`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ].
+--------------------
+python/ray/autoscaler/_private/cluster_dump.py
+    DOC403: Method `Archive.subdir` has a "Yields" section in the docstring, but there are no "yield" statements, or the return annotation is not a Generator/Iterator/Iterable. (Or it could be because the function lacks a return annotation.)
+    DOC404: Method `Archive.subdir` yield type(s) in docstring not consistent with the return annotation. Return annotation does not exist or is not Generator[...]/Iterator[...]/Iterable[...], but docstring "yields" section has 1 type(s).
+    DOC111: Function `get_local_ray_logs`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Function `get_local_ray_logs`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [session_log_dir: str]. Arguments in the docstring but not in the function signature: [session_dir: ].
+    DOC104: Function `create_and_get_archive_from_remote_node`: Arguments are the same in the docstring and the function signature, but are in a different order.
+    DOC105: Function `create_and_get_archive_from_remote_node`: Argument names match, but type hints in these args do not match: remote_node, parameters, script_path
+    DOC111: Function `create_archive_for_remote_nodes`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC111: Function `create_archive_for_local_and_remote_nodes`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+--------------------
+python/ray/autoscaler/_private/command_runner.py
+    DOC111: Function `_with_environment_variables`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Function `_with_environment_variables` does not have a return section in docstring
+    DOC111: Method `SSHCommandRunner._run_helper`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Method `SSHCommandRunner._run_helper` does not have a return section in docstring
+--------------------
+python/ray/autoscaler/_private/commands.py
+    DOC107: Function `debug_status`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC111: Function `request_resources`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC101: Function `_should_create_new_head`: Docstring contains fewer arguments than in function signature.
+    DOC111: Function `_should_create_new_head`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Function `_should_create_new_head`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [provider: NodeProvider].
+    DOC101: Function `attach_cluster`: Docstring contains fewer arguments than in function signature.
+    DOC111: Function `attach_cluster`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Function `attach_cluster`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [no_config_cache: bool].
+    DOC101: Function `exec_cluster`: Docstring contains fewer arguments than in function signature.
+    DOC111: Function `exec_cluster`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Function `exec_cluster`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [no_config_cache: bool, with_output: bool].
+    DOC201: Function `exec_cluster` does not have a return section in docstring
+    DOC101: Function `rsync`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `rsync`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_runner: ModuleType, no_config_cache: bool].
+    DOC111: Function `_get_running_head_node`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Function `_get_running_head_node` does not have a return section in docstring
+--------------------
+python/ray/autoscaler/_private/event_system.py
+    DOC111: Method `_EventSystem.add_callback_handler`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC111: Method `_EventSystem.execute_callback`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+--------------------
+python/ray/autoscaler/_private/fake_multi_node/node_provider.py
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `FakeMultiNodeProvider.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `FakeMultiNodeProvider.__init__`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `FakeMultiNodeProvider.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `FakeMultiNodeProvider.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [cluster_name: , provider_config: ].
+--------------------
+python/ray/autoscaler/_private/gcp/tpu_command_runner.py
+    DOC106: Method `TPUCommandRunner.run_rsync_down`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC103: Method `TPUCommandRunner.run_rsync_down`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ]. Arguments in the docstring but not in the function signature: [source: , target: ].
+    DOC102: Method `TPUCommandRunner.run_init`: Docstring contains more arguments than in function signature.
+    DOC106: Method `TPUCommandRunner.run_init`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC103: Method `TPUCommandRunner.run_init`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ]. Arguments in the docstring but not in the function signature: [as_head: , file_mounts: , sync_run_yet: ].
+--------------------
+python/ray/autoscaler/_private/kuberay/node_provider.py
+    DOC201: Function `url_from_resource` does not have a return section in docstring
+--------------------
+python/ray/autoscaler/_private/kuberay/utils.py
+    DOC106: Function `parse_quantity`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `parse_quantity`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/autoscaler/_private/load_metrics.py
+    DOC101: Function `add_resources`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `add_resources`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [dict1: Dict[str, float], dict2: Dict[str, float]].
+    DOC107: Function `freq_of_dicts`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC111: Function `freq_of_dicts`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC111: Method `LoadMetrics.prune_active_ips`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Method `LoadMetrics.get_node_resources` does not have a return section in docstring
+    DOC201: Method `LoadMetrics.get_static_node_resources_by_ip` does not have a return section in docstring
+--------------------
+python/ray/autoscaler/_private/monitor.py
+    DOC106: Function `parse_resource_demands`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `parse_resource_demands`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC111: Function `parse_resource_demands`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+--------------------
+python/ray/autoscaler/_private/resource_demand_scheduler.py
+    DOC101: Method `ResourceDemandScheduler.calculate_node_resources`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ResourceDemandScheduler.calculate_node_resources`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [unused_resources_by_ip: Dict[str, ResourceDict]].
+    DOC111: Method `ResourceDemandScheduler.reserve_and_allocate_spread`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC101: Function `_add_min_workers_nodes`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_add_min_workers_nodes`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [head_node_type: NodeType].
+    DOC101: Function `get_nodes_for`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `get_nodes_for`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [head_node_type: NodeType].
+    DOC111: Function `get_bin_pack_residual`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC111: Function `placement_groups_to_resource_demands`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+--------------------
+python/ray/autoscaler/_private/subprocess_output_util.py
+    DOC106: Function `_read_subprocess_stream`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `_read_subprocess_stream`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC111: Function `_read_subprocess_stream`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Function `_read_subprocess_stream` does not have a return section in docstring
+    DOC101: Function `_run_and_process_output`: Docstring contains fewer arguments than in function signature.
+    DOC106: Function `_run_and_process_output`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `_run_and_process_output`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC111: Function `_run_and_process_output`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Function `_run_and_process_output`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [use_login_shells: ].
+    DOC201: Function `_run_and_process_output` does not have a return section in docstring
+    DOC101: Function `run_cmd_redirected`: Docstring contains fewer arguments than in function signature.
+    DOC106: Function `run_cmd_redirected`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `run_cmd_redirected`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC111: Function `run_cmd_redirected`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Function `run_cmd_redirected`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [use_login_shells: ].
+    DOC201: Function `run_cmd_redirected` does not have a return section in docstring
+    DOC106: Function `handle_ssh_fails`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `handle_ssh_fails`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC201: Function `handle_ssh_fails` does not have a return section in docstring
+--------------------
+python/ray/autoscaler/_private/updater.py
+    DOC101: Method `NodeUpdater.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `NodeUpdater.__init__`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `NodeUpdater.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `NodeUpdater.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [cluster_synced_files: , node_labels: , node_resources: ].
+--------------------
+python/ray/autoscaler/_private/util.py
+    DOC111: Function `with_envs`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC101: Function `parse_placement_group_resource_str`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `parse_placement_group_resource_str`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [placement_group_resource_str: str].
+--------------------
+python/ray/autoscaler/command_runner.py
+    DOC111: Method `CommandRunnerInterface.run`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Method `CommandRunnerInterface.run` does not have a return section in docstring
+    DOC101: Method `CommandRunnerInterface.run_rsync_up`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `CommandRunnerInterface.run_rsync_up`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [options: Optional[Dict[str, Any]]].
+    DOC101: Method `CommandRunnerInterface.run_rsync_down`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `CommandRunnerInterface.run_rsync_down`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [options: Optional[Dict[str, Any]]].
+--------------------
+python/ray/autoscaler/launch_and_verify_cluster.py
+    DOC106: Function `get_docker_image`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `get_docker_image`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Function `check_file`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `check_file`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC101: Function `cleanup_cluster`: Docstring contains fewer arguments than in function signature.
+    DOC106: Function `cleanup_cluster`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `cleanup_cluster`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `cleanup_cluster`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [config_yaml: ].
+    DOC201: Function `cleanup_cluster` does not have a return section in docstring
+    DOC101: Function `run_ray_commands`: Docstring contains fewer arguments than in function signature.
+    DOC106: Function `run_ray_commands`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `run_ray_commands`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `run_ray_commands`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [config_yaml: , num_expected_nodes: ].
+--------------------
+python/ray/autoscaler/local/coordinator_server.py
+    DOC106: Method `Handler._do_header`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `Handler._do_header`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC111: Method `Handler._do_header`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+--------------------
+python/ray/autoscaler/node_launch_exception.py
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `NodeLaunchException.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `NodeLaunchException.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [category: str, description: str, src_exc_info: Optional[Tuple[Any, Any, Any]]].
+--------------------
+python/ray/autoscaler/node_provider.py
+    DOC101: Method `NodeProvider.non_terminated_nodes`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `NodeProvider.non_terminated_nodes`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [tag_filters: Dict[str, str]].
+    DOC201: Method `NodeProvider.non_terminated_nodes` does not have a return section in docstring
+    DOC201: Method `NodeProvider.get_node_id` does not have a return section in docstring
+    DOC201: Method `NodeProvider.get_command_runner` does not have a return section in docstring
+--------------------
+python/ray/autoscaler/sdk/sdk.py
+    DOC111: Function `create_or_update_cluster`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Function `create_or_update_cluster` does not have a return section in docstring
+    DOC111: Function `teardown_cluster`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC111: Function `run_on_cluster`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC111: Function `rsync`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Function `rsync` does not have a return section in docstring
+    DOC111: Function `get_head_node_ip`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC111: Function `get_worker_node_ips`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC111: Function `request_resources`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC111: Function `configure_logging`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Function `configure_logging`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [verbosity: Optional[int]]. Arguments in the docstring but not in the function signature: [vebosity: int].
+--------------------
+python/ray/autoscaler/v2/autoscaler.py
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `Autoscaler.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Autoscaler.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [config_reader: IConfigReader, event_logger: Optional[AutoscalerEventLogger], gcs_client: GcsClient, metrics_reporter: Optional[AutoscalerMetricsReporter], session_name: str].
+--------------------
+python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/cloud_provider.py
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `KubeRayProvider.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `KubeRayProvider.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [cluster_name: str, k8s_api_client: Optional[IKubernetesHttpApiClient], provider_config: Dict[str, Any]].
+    DOC101: Method `KubeRayProvider._get_workers_delete_info`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `KubeRayProvider._get_workers_delete_info`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [node_set: Set[CloudInstanceId], ray_cluster_spec: Dict[str, Any]].
+    DOC201: Method `KubeRayProvider._cloud_instance_from_pod` does not have a return section in docstring
+--------------------
+python/ray/autoscaler/v2/instance_manager/common.py
+    DOC201: Method `InstanceUtil.new_instance` does not have a return section in docstring
+    DOC101: Method `InstanceUtil._record_status_transition`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `InstanceUtil._record_status_transition`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [details: str].
+    DOC103: Method `InstanceUtil.has_timeout`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [timeout_s: int]. Arguments in the docstring but not in the function signature: [timeout_seconds: ].
+    DOC201: Method `InstanceUtil.get_status_transitions` does not have a return section in docstring
+    DOC103: Method `InstanceUtil.get_last_status_transition`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [select_instance_status: Optional['Instance.InstanceStatus']]. Arguments in the docstring but not in the function signature: [instance_status: ].
+    DOC201: Method `InstanceUtil.get_last_status_transition` does not have a return section in docstring
+    DOC103: Method `InstanceUtil.get_status_transition_times_ns`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [select_instance_status: Optional['Instance.InstanceStatus']]. Arguments in the docstring but not in the function signature: [instance_status: ].
+--------------------
+python/ray/autoscaler/v2/instance_manager/config.py
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `AutoscalingConfig.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `AutoscalingConfig.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [configs: Dict[str, Any], skip_content_hash: bool].
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `FileConfigReader.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `FileConfigReader.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [config_file: str, skip_content_hash: bool].
+--------------------
+python/ray/autoscaler/v2/instance_manager/instance_storage.py
+    DOC103: Method `InstanceStorage.upsert_instance`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [expected_storage_verison: Optional[int]]. Arguments in the docstring but not in the function signature: [expected_storage_version: ].
+    DOC103: Method `InstanceStorage.batch_delete_instances`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [expected_storage_version: Optional[int], instance_ids: List[str]]. Arguments in the docstring but not in the function signature: [expected_version: , to_delete: ].
+--------------------
+python/ray/autoscaler/v2/instance_manager/node_provider.py
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `NodeProviderAdapter.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `NodeProviderAdapter.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [config_reader: IConfigReader, max_concurrent_launches: int, max_launch_batch_per_type: int, v1_provider: NodeProviderV1].
+--------------------
+python/ray/autoscaler/v2/instance_manager/reconciler.py
+    DOC101: Method `Reconciler.reconcile`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Reconciler.reconcile`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [autoscaling_config: AutoscalingConfig, cloud_provider: ICloudInstanceProvider, scheduler: IResourceScheduler].
+    DOC201: Method `Reconciler.reconcile` does not have a return section in docstring
+    DOC101: Method `Reconciler._sync_from`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Reconciler._sync_from`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [autoscaling_config: AutoscalingConfig].
+    DOC101: Method `Reconciler._step_next`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Reconciler._step_next`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [autoscaling_state: AutoscalingState, cloud_provider: ICloudInstanceProvider].
+    DOC101: Method `Reconciler._handle_ray_stop_failed`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Reconciler._handle_ray_stop_failed`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [ray_nodes: List[NodeState]].
+    DOC101: Method `Reconciler._handle_ray_status_transition`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Reconciler._handle_ray_status_transition`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [autoscaling_config: AutoscalingConfig].
+    DOC101: Method `Reconciler._install_ray`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Reconciler._install_ray`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [non_terminated_cloud_instances: Dict[CloudInstanceId, CloudInstance]].
+    DOC103: Method `Reconciler._handle_stuck_instance`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**update_kwargs: Dict]. Arguments in the docstring but not in the function signature: [update_kwargs: ].
+--------------------
+python/ray/autoscaler/v2/instance_manager/subscribers/cloud_instance_updater.py
+    DOC201: Method `CloudInstanceUpdater._terminate_instances` does not have a return section in docstring
+    DOC201: Method `CloudInstanceUpdater._launch_new_instances` does not have a return section in docstring
+--------------------
+python/ray/autoscaler/v2/instance_manager/subscribers/ray_stopper.py
+    DOC101: Method `RayStopper._drain_ray_node`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `RayStopper._drain_ray_node`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [error_queue: Queue, instance_id: str].
+    DOC101: Method `RayStopper._stop_ray_node`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `RayStopper._stop_ray_node`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [error_queue: Queue, instance_id: str].
+--------------------
+python/ray/autoscaler/v2/scheduler.py
+    DOC201: Method `SchedulingNode.new` does not have a return section in docstring
+    DOC102: Method `SchedulingNode.from_node_config`: Docstring contains more arguments than in function signature.
+    DOC103: Method `SchedulingNode.from_node_config`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ).
+    DOC201: Method `SchedulingNode.from_node_config` does not have a return section in docstring
+    DOC101: Method `SchedulingNode._compute_score`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `SchedulingNode._compute_score`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [resource_request_source: ResourceRequestSource].
+    DOC201: Method `ScheduleContext.from_schedule_request` does not have a return section in docstring
+    DOC103: Method `ResourceDemandScheduler._sched_resource_requests`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [requests: List[ResourceRequest]]. Arguments in the docstring but not in the function signature: [requests_by_count: ].
+    DOC104: Method `ResourceDemandScheduler._try_schedule`: Arguments are the same in the docstring and the function signature, but are in a different order.
+    DOC105: Method `ResourceDemandScheduler._try_schedule`: Argument names match, but type hints in these args do not match: ctx, requests_to_sched, resource_request_source
+--------------------
+python/ray/autoscaler/v2/utils.py
+    DOC103: Function `_count_by`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [key: str]. Arguments in the docstring but not in the function signature: [keys: ].
+    DOC106: Method `ProtobufUtil.to_dict`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `ProtobufUtil.to_dict`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Method `ProtobufUtil.to_dict_list`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `ProtobufUtil.to_dict_list`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC101: Method `ResourceRequestUtil.make`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ResourceRequestUtil.make`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [constraints: Optional[List[Tuple[PlacementConstraintType, str, str]]]].
+    DOC103: Method `ClusterStatusFormatter._constraint_report`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [cluster_constraint_demand: List[ClusterConstraintDemand]]. Arguments in the docstring but not in the function signature: [data: ].
+--------------------
+python/ray/client_builder.py
+    DOC111: Method `ClientBuilder.env`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Method `ClientBuilder.env` does not have a return section in docstring
+    DOC201: Method `ClientBuilder.namespace` does not have a return section in docstring
+--------------------
+python/ray/cloudpickle/cloudpickle.py
+    DOC101: Function `_find_imported_submodules`: Docstring contains fewer arguments than in function signature.
+    DOC106: Function `_find_imported_submodules`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `_find_imported_submodules`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `_find_imported_submodules`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [code: , top_level_dependencies: ].
+    DOC201: Function `_find_imported_submodules` does not have a return section in docstring
+--------------------
+python/ray/cluster_utils.py
+    DOC101: Method `AutoscalingCluster.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `AutoscalingCluster.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**config_kwargs: , autoscaler_v2: bool].
+    DOC103: Method `Cluster.add_node`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**node_args: ]. Arguments in the docstring but not in the function signature: [node_args: ].
+    DOC101: Method `Cluster.remove_node`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `Cluster.remove_node`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `Cluster.remove_node`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `Cluster.remove_node`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [allow_graceful: ].
+    DOC107: Method `Cluster._wait_for_node`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC111: Method `Cluster._wait_for_node`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Method `Cluster.wait_for_nodes` does not have a return section in docstring
+--------------------
+python/ray/cross_language.py
+    DOC201: Function `java_function` does not have a return section in docstring
+    DOC201: Function `cpp_function` does not have a return section in docstring
+    DOC201: Function `java_actor_class` does not have a return section in docstring
+    DOC201: Function `cpp_actor_class` does not have a return section in docstring
+    DOC106: Function `_format_args`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `_format_args`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC107: Function `_get_function_descriptor_for_actor_method`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/dag/compiled_dag_node.py
+    DOC201: Function `_check_unused_dag_input_attributes` does not have a return section in docstring
+    DOC101: Function `do_allocate_channel`: Docstring contains fewer arguments than in function signature.
+    DOC107: Function `do_allocate_channel`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `do_allocate_channel`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [self: ].
+    DOC101: Function `do_exec_tasks`: Docstring contains fewer arguments than in function signature.
+    DOC107: Function `do_exec_tasks`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `do_exec_tasks`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [self: ].
+    DOC101: Function `do_profile_tasks`: Docstring contains fewer arguments than in function signature.
+    DOC107: Function `do_profile_tasks`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `do_profile_tasks`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [self: ].
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `CompiledTask.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `CompiledTask.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [dag_node: 'ray.dag.DAGNode', idx: int].
+    DOC201: Method `_ExecutableTaskInput.resolve` does not have a return section in docstring
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `ExecutableTask.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ExecutableTask.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [resolved_args: List[Any], resolved_kwargs: Dict[str, Any], task: 'CompiledTask'].
+    DOC201: Method `ExecutableTask.prepare` does not have a return section in docstring
+    DOC107: Method `ExecutableTask._compute`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC107: Method `ExecutableTask.exec_operation`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC303: Class `CompiledDAG`: The __init__() docstring does not need a "Returns" section, because it cannot return anything
+    DOC103: Method `CompiledDAG.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [default_communicator: Optional[Union[Communicator, str]]]. Arguments in the docstring but not in the function signature: [_default_communicator: ].
+    DOC302: Class `CompiledDAG`: The class docstring does not need a "Returns" section, because __init__() cannot return anything
+    DOC106: Method `CompiledDAG.execute`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC103: Method `CompiledDAG.execute`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ]. Arguments in the docstring but not in the function signature: [args: , kwargs: ].
+    DOC106: Method `CompiledDAG.execute_async`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC103: Method `CompiledDAG.execute_async`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ]. Arguments in the docstring but not in the function signature: [args: , kwargs: ].
+    DOC106: Method `CompiledDAG.visualize`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `CompiledDAG.visualize`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/dag/dag_node.py
+    DOC201: Method `DAGNode.with_tensor_transport` does not have a return section in docstring
+    DOC101: Method `DAGNode.execute`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `DAGNode.execute`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ].
+    DOC201: Method `DAGNode.execute` does not have a return section in docstring
+    DOC201: Method `DAGNode._get_all_child_nodes` does not have a return section in docstring
+    DOC106: Method `DAGNode._raise_nested_dag_node_error`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `DAGNode._raise_nested_dag_node_error`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/dag/dag_node_operation.py
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `_DAGNodeOperation.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `_DAGNodeOperation.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [exec_task_idx: int, method_name: Optional[str], operation_type: _DAGNodeOperationType].
+    DOC101: Function `_add_edge`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_add_edge`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [control_dependency: bool].
+    DOC201: Function `_actor_viz_label` does not have a return section in docstring
+    DOC201: Function `_node_viz_id_and_label` does not have a return section in docstring
+--------------------
+python/ray/dag/dag_operation_future.py
+    DOC106: Method `ResolvedFuture.__init__`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `ResolvedFuture.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/dag/input_node.py
+    DOC101: Method `InputNode.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC107: Method `InputNode.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `InputNode.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ].
+    DOC101: Method `InputAttributeNode.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `InputAttributeNode.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [accessor_method: str, dag_input_node: InputNode, input_type: str, key: Union[int, str]].
+--------------------
+python/ray/dag/tests/experimental/test_dag_visualization.py
+    DOC106: Method `TestVisualizationAscii.parse_ascii_visualization`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `TestVisualizationAscii.parse_ascii_visualization`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/dag/tests/experimental/test_torch_tensor_dag.py
+    DOC106: Method `TorchTensorWorker.recv_and_matmul`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `TorchTensorWorker.recv_and_matmul`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC201: Method `TorchTensorWorker.recv_and_matmul` does not have a return section in docstring
+--------------------
+python/ray/dag/tests/experimental/test_torch_tensor_transport.py
+    DOC106: Function `run_driver_to_worker_dag`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `run_driver_to_worker_dag`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Function `run_worker_to_worker_dag`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `run_worker_to_worker_dag`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Function `run_worker_to_driver_dag`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `run_worker_to_driver_dag`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/dashboard/dashboard.py
+    DOC101: Method `Dashboard.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Dashboard.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [minimal: bool, modules_to_load: Optional[Set[str]], session_dir: str, temp_dir: str].
+--------------------
+python/ray/dashboard/head.py
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `DashboardHead.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `DashboardHead.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [cluster_id_hex: str, gcs_address: str, http_host: str, http_port: int, http_port_retries: int, log_dir: str, logging_filename: str, logging_format: str, logging_level: int, logging_rotate_backup_count: int, logging_rotate_bytes: int, minimal: bool, modules_to_load: Optional[Set[str]], node_ip_address: str, serve_frontend: bool, session_dir: str, temp_dir: str].
+    DOC103: Method `DashboardHead._load_dashboard_head_modules`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [modules_to_load: Optional[Set[str]]]. Arguments in the docstring but not in the function signature: [modules: ].
+    DOC201: Method `DashboardHead._load_dashboard_head_modules` does not have a return section in docstring
+    DOC103: Method `DashboardHead._load_subprocess_module_handles`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [modules_to_load: Optional[Set[str]]]. Arguments in the docstring but not in the function signature: [modules: ].
+    DOC201: Method `DashboardHead._load_subprocess_module_handles` does not have a return section in docstring
+--------------------
+python/ray/dashboard/modules/dashboard_sdk.py
+    DOC101: Function `get_job_submission_client_cluster_info`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `get_job_submission_client_cluster_info`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_use_tls: Optional[bool], cookies: Optional[Dict[str, Any]], headers: Optional[Dict[str, Any]], metadata: Optional[Dict[str, Any]]].
+--------------------
+python/ray/dashboard/modules/event/event_head.py
+    DOC101: Function `_list_cluster_events_impl`: Docstring contains fewer arguments than in function signature.
+    DOC107: Function `_list_cluster_events_impl`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `_list_cluster_events_impl`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [all_events: , executor: ThreadPoolExecutor, option: ListApiOptions].
+--------------------
+python/ray/dashboard/modules/event/event_utils.py
+    DOC107: Function `monitor_events`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC111: Function `monitor_events`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Function `monitor_events` does not have a return section in docstring
+--------------------
+python/ray/dashboard/modules/job/cli.py
+    DOC101: Function `submit`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `submit`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: Optional[str], entrypoint: Tuple[str], entrypoint_memory: Optional[int], entrypoint_num_cpus: Optional[Union[int, float]], entrypoint_num_gpus: Optional[Union[int, float]], entrypoint_resources: Optional[str], headers: Optional[str], job_id: Optional[str], metadata_json: Optional[str], no_wait: bool, runtime_env: Optional[str], runtime_env_json: Optional[str], submission_id: Optional[str], verify: Union[bool, str], working_dir: Optional[str]].
+    DOC101: Function `status`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `status`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: Optional[str], headers: Optional[str], job_id: str, verify: Union[bool, str]].
+    DOC101: Function `stop`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `stop`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: Optional[str], headers: Optional[str], job_id: str, no_wait: bool, verify: Union[bool, str]].
+    DOC201: Function `stop` does not have a return section in docstring
+    DOC101: Function `delete`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `delete`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: Optional[str], headers: Optional[str], job_id: str, verify: Union[bool, str]].
+    DOC101: Function `logs`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `logs`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: Optional[str], follow: bool, headers: Optional[str], job_id: str, verify: Union[bool, str]].
+    DOC101: Function `list`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `list`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: Optional[str], headers: Optional[str], verify: Union[bool, str]].
+--------------------
+python/ray/dashboard/modules/job/job_log_storage_client.py
+    DOC107: Method `JobLogStorageClient.get_last_n_log_lines`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC201: Method `JobLogStorageClient.get_last_n_log_lines` does not have a return section in docstring
+--------------------
+python/ray/dashboard/modules/job/job_manager.py
+    DOC101: Method `JobManager._get_supervisor_runtime_env`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `JobManager._get_supervisor_runtime_env`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [submission_id: str].
+    DOC101: Method `JobManager.submit_job`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `JobManager.submit_job`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [submission_id: Optional[str]].
+--------------------
+python/ray/dashboard/modules/job/job_supervisor.py
+    DOC101: Method `JobSupervisor._exec_entrypoint`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `JobSupervisor._exec_entrypoint`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [env: dict].
+--------------------
+python/ray/dashboard/modules/job/sdk.py
+    DOC104: Method `JobSubmissionClient.submit_job`: Arguments are the same in the docstring and the function signature, but are in a different order.
+    DOC105: Method `JobSubmissionClient.submit_job`: Argument names match, but type hints in these args do not match: entrypoint, job_id, runtime_env, metadata, submission_id, entrypoint_num_cpus, entrypoint_num_gpus, entrypoint_memory, entrypoint_resources
+    DOC402: Method `JobSubmissionClient.tail_job_logs` has "yield" statements, but the docstring does not have a "Yields" section
+    DOC404: Method `JobSubmissionClient.tail_job_logs` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
+--------------------
+python/ray/dashboard/modules/log/log_agent.py
+    DOC402: Function `_stream_log_in_chunk` has "yield" statements, but the docstring does not have a "Yields" section
+    DOC404: Function `_stream_log_in_chunk` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
+--------------------
+python/ray/dashboard/modules/log/log_manager.py
+    DOC101: Method `LogsManager.stream_logs`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `LogsManager.stream_logs`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [get_actor_fn: Callable[[ActorID], Awaitable[Optional[ActorTableData]]]].
+    DOC402: Method `LogsManager.stream_logs` has "yield" statements, but the docstring does not have a "Yields" section
+    DOC404: Method `LogsManager.stream_logs` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
+    DOC101: Method `LogsManager.resolve_filename`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `LogsManager.resolve_filename`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [attempt_number: Optional[int]].
+    DOC201: Method `LogsManager.resolve_filename` does not have a return section in docstring
+    DOC101: Method `LogsManager._categorize_log_files`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `LogsManager._categorize_log_files`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [log_files: List[str]].
+--------------------
+python/ray/dashboard/modules/metrics/grafana_dashboard_factory.py
+    DOC101: Function `_read_configs_for_dashboard`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_read_configs_for_dashboard`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [dashboard_config: DashboardConfig].
+    DOC101: Function `_generate_grafana_dashboard`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_generate_grafana_dashboard`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [dashboard_config: DashboardConfig].
+--------------------
+python/ray/dashboard/modules/reporter/profile_manager.py
+    DOC111: Method `CpuProfilingManager.trace_dump`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC101: Method `CpuProfilingManager.cpu_profile`: Docstring contains fewer arguments than in function signature.
+    DOC107: Method `CpuProfilingManager.cpu_profile`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC111: Method `CpuProfilingManager.cpu_profile`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Method `CpuProfilingManager.cpu_profile`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [format: ].
+    DOC101: Method `MemoryProfilingManager.get_profile_result`: Docstring contains fewer arguments than in function signature.
+    DOC111: Method `MemoryProfilingManager.get_profile_result`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Method `MemoryProfilingManager.get_profile_result`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [profiler_filename: str].
+    DOC111: Method `MemoryProfilingManager.attach_profiler`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC111: Method `MemoryProfilingManager.detach_profiler`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+--------------------
+python/ray/dashboard/modules/reporter/reporter_agent.py
+    DOC103: Method `ReporterAgent.generate_worker_stats_record`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [worker_stats: List[dict]]. Arguments in the docstring but not in the function signature: [stats: ].
+    DOC201: Method `ReporterAgent.generate_worker_stats_record` does not have a return section in docstring
+--------------------
+python/ray/dashboard/modules/reporter/reporter_head.py
+    DOC102: Method `ReportHead.get_task_traceback`: Docstring contains more arguments than in function signature.
+    DOC103: Method `ReportHead.get_task_traceback`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [req: aiohttp.web.Request]. Arguments in the docstring but not in the function signature: [attempt_number: , node_id: , task_id: ].
+    DOC101: Method `ReportHead.get_task_cpu_profile`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ReportHead.get_task_cpu_profile`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [req: aiohttp.web.Request].
+    DOC102: Method `ReportHead.get_traceback`: Docstring contains more arguments than in function signature.
+    DOC103: Method `ReportHead.get_traceback`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [req: aiohttp.web.Request]. Arguments in the docstring but not in the function signature: [ip: , pid: ].
+    DOC201: Method `ReportHead.get_traceback` does not have a return section in docstring
+    DOC102: Method `ReportHead.cpu_profile`: Docstring contains more arguments than in function signature.
+    DOC103: Method `ReportHead.cpu_profile`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [req: aiohttp.web.Request]. Arguments in the docstring but not in the function signature: [duration: , format: , ip: , native: , pid: ].
+    DOC201: Method `ReportHead.cpu_profile` does not have a return section in docstring
+    DOC101: Method `ReportHead.memory_profile`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ReportHead.memory_profile`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [req: aiohttp.web.Request].
+--------------------
+python/ray/dashboard/modules/train/train_head.py
+    DOC101: Method `TrainHead._decorate_train_runs`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TrainHead._decorate_train_runs`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [train_runs: List['TrainRun']].
+--------------------
+python/ray/dashboard/routes.py
+    DOC101: Function `rest_response`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `rest_response`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ].
+--------------------
+python/ray/dashboard/state_aggregator.py
+    DOC101: Method `StateAPIManager.list_actors`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `StateAPIManager.list_actors`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [option: ListApiOptions].
+    DOC101: Method `StateAPIManager.list_placement_groups`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `StateAPIManager.list_placement_groups`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [option: ListApiOptions].
+    DOC101: Method `StateAPIManager.list_nodes`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `StateAPIManager.list_nodes`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [option: ListApiOptions].
+    DOC101: Method `StateAPIManager.list_workers`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `StateAPIManager.list_workers`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [option: ListApiOptions].
+    DOC101: Method `StateAPIManager.list_tasks`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `StateAPIManager.list_tasks`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [option: ListApiOptions].
+    DOC101: Method `StateAPIManager.list_objects`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `StateAPIManager.list_objects`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [option: ListApiOptions].
+    DOC101: Method `StateAPIManager.list_runtime_envs`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `StateAPIManager.list_runtime_envs`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [option: ListApiOptions].
+--------------------
+python/ray/dashboard/state_api_utils.py
+    DOC101: Function `do_filter`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `do_filter`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [detail: bool].
+--------------------
+python/ray/dashboard/subprocesses/utils.py
+    DOC101: Function `module_logging_filename`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `module_logging_filename`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [extension: str, logging_filename: str, module_name: str].
+    DOC201: Function `module_logging_filename` does not have a return section in docstring
+--------------------
+python/ray/dashboard/utils.py
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `RateLimitedModule.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `RateLimitedModule.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [logger: Optional[logging.Logger], max_num_call: int].
+    DOC201: Function `compose_state_message` does not have a return section in docstring
+--------------------
+python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+    DOC201: Function `combine_chunks` does not have a return section in docstring
+    DOC201: Function `combine_chunked_array` does not have a return section in docstring
+    DOC101: Function `_try_combine_chunks_safe`: Docstring contains fewer arguments than in function signature.
+    DOC107: Function `_try_combine_chunks_safe`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `_try_combine_chunks_safe`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [array: 'pyarrow.ChunkedArray', max_chunk_size: ].
+--------------------
+python/ray/data/_internal/block_batching/iter_batches.py
+    DOC103: Function `_format_in_threadpool`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [batch_iter: Iterator[Batch]]. Arguments in the docstring but not in the function signature: [logical_batch_iterator: ].
+    DOC201: Function `_format_in_threadpool` does not have a return section in docstring
+--------------------
+python/ray/data/_internal/block_batching/util.py
+    DOC402: Function `resolve_block_refs` has "yield" statements, but the docstring does not have a "Yields" section
+    DOC404: Function `resolve_block_refs` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
+    DOC402: Function `blocks_to_batches` has "yield" statements, but the docstring does not have a "Yields" section
+    DOC404: Function `blocks_to_batches` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
+    DOC402: Function `format_batches` has "yield" statements, but the docstring does not have a "Yields" section
+    DOC404: Function `format_batches` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
+    DOC402: Function `collate` has "yield" statements, but the docstring does not have a "Yields" section
+    DOC404: Function `collate` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
+    DOC402: Function `finalize_batches` has "yield" statements, but the docstring does not have a "Yields" section
+    DOC404: Function `finalize_batches` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
+--------------------
+python/ray/data/_internal/datasource/iceberg_datasink.py
+    DOC102: Method `IcebergDatasink.__init__`: Docstring contains more arguments than in function signature.
+    DOC103: Method `IcebergDatasink.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the docstring but not in the function signature: [to an iceberg table, e.g. {"commit_time": ].
+--------------------
+python/ray/data/_internal/datasource/lance_datasink.py
+    DOC101: Method `LanceDatasink.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `LanceDatasink.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: , max_rows_per_file: int, min_rows_per_file: int, mode: Literal['create', 'append', 'overwrite'], schema: Optional[pa.Schema], storage_options: Optional[Dict[str, Any]], uri: str]. Arguments in the docstring but not in the function signature: [max_rows_per_file : , min_rows_per_file : , mode : , schema : , storage_options : , uri : ].
+--------------------
+python/ray/data/_internal/datasource/sql_datasource.py
+    DOC101: Method `SQLDatasource.supports_sharding`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `SQLDatasource.supports_sharding`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [parallelism: int].
+--------------------
+python/ray/data/_internal/datasource/tfrecords_datasource.py
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `TFRecordDatasource.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TFRecordDatasource.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**file_based_datasource_kwargs: , paths: Union[str, List[str]], tf_schema: Optional['schema_pb2.Schema'], tfx_read_options: Optional['TFXReadOptions']].
+--------------------
+python/ray/data/_internal/datasource/webdataset_datasource.py
+    DOC201: Function `_valid_sample` does not have a return section in docstring
+    DOC201: Function `_check_suffix` does not have a return section in docstring
+    DOC101: Function `_tar_file_iterator`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_tar_file_iterator`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [filerename: Optional[Union[bool, callable, list]], verbose_open: bool].
+    DOC402: Function `_tar_file_iterator` has "yield" statements, but the docstring does not have a "Yields" section
+    DOC404: Function `_tar_file_iterator` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
+    DOC402: Function `_group_by_keys` has "yield" statements, but the docstring does not have a "Yields" section
+    DOC404: Function `_group_by_keys` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
+    DOC101: Function `_default_decoder`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_default_decoder`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [format: Optional[Union[bool, str]]].
+    DOC201: Function `_default_decoder` does not have a return section in docstring
+    DOC101: Function `_default_encoder`: Docstring contains fewer arguments than in function signature.
+    DOC111: Function `_default_encoder`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Function `_default_encoder`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [format: Optional[Union[str, bool]]].
+    DOC201: Function `_default_encoder` does not have a return section in docstring
+    DOC102: Method `WebDatasetDatasource._read_stream`: Docstring contains more arguments than in function signature.
+    DOC103: Method `WebDatasetDatasource._read_stream`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the docstring but not in the function signature: [decoder: , fileselect: , suffixes: , verbose_open: ].
+    DOC403: Method `WebDatasetDatasource._read_stream` has a "Yields" section in the docstring, but there are no "yield" statements, or the return annotation is not a Generator/Iterator/Iterable. (Or it could be because the function lacks a return annotation.)
+    DOC404: Method `WebDatasetDatasource._read_stream` yield type(s) in docstring not consistent with the return annotation. Return annotation does not exist or is not Generator[...]/Iterator[...]/Iterable[...], but docstring "yields" section has 1 type(s).
+--------------------
+python/ray/data/_internal/equalize.py
+    DOC101: Function `_equalize`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_equalize`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [owned_by_consumer: bool].
+    DOC103: Function `_shave_all_splits`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [per_split_num_rows: List[List[int]]].
+--------------------
+python/ray/data/_internal/execution/autoscaler/autoscaling_actor_pool.py
+    DOC101: Method `AutoscalingActorPool.scale_up`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `AutoscalingActorPool.scale_up`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [num_actors: int].
+    DOC101: Method `AutoscalingActorPool.scale_down`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `AutoscalingActorPool.scale_down`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [num_actors: int].
+--------------------
+python/ray/data/_internal/execution/bundle_queue/bundle_queue.py
+    DOC201: Method `BundleQueue.pop` does not have a return section in docstring
+--------------------
+python/ray/data/_internal/execution/interfaces/execution_options.py
+    DOC201: Method `ExecutionResources.for_limits` does not have a return section in docstring
+    DOC101: Method `ExecutionResources.add`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ExecutionResources.add`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [other: 'ExecutionResources'].
+    DOC101: Method `ExecutionResources.subtract`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ExecutionResources.subtract`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [other: 'ExecutionResources'].
+    DOC107: Method `ExecutionResources.satisfies_limit`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC201: Method `ExecutionResources.satisfies_limit` does not have a return section in docstring
+    DOC101: Method `ExecutionOptions.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ExecutionOptions.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [actor_locality_enabled: bool, exclude_resources: Optional[ExecutionResources], locality_with_output: Union[bool, List[NodeIdStr]], preserve_order: bool, resource_limits: Optional[ExecutionResources], verbose_progress: Optional[bool]].
+--------------------
+python/ray/data/_internal/execution/interfaces/executor.py
+    DOC201: Method `OutputIterator.get_next` does not have a return section in docstring
+    DOC201: Method `Executor.execute` does not have a return section in docstring
+--------------------
+python/ray/data/_internal/execution/interfaces/physical_operator.py
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `DataOpTask.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `DataOpTask.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [output_ready_callback: Callable[[RefBundle], None], streaming_gen: ObjectRefGenerator, task_done_callback: Callable[[Optional[Exception]], None], task_index: int, task_resource_bundle: Optional[ExecutionResources]].
+    DOC201: Method `DataOpTask.on_data_ready` does not have a return section in docstring
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `MetadataOpTask.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `MetadataOpTask.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [object_ref: ray.ObjectRef, task_done_callback: Callable[[], None], task_index: int, task_resource_bundle: Optional[ExecutionResources]].
+--------------------
+python/ray/data/_internal/execution/interfaces/task_context.py
+    DOC106: Method `TaskContext.set_current`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `TaskContext.set_current`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/data/_internal/execution/legacy_compat.py
+    DOC107: Function `execute_to_legacy_bundle_iterator`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+    DOC103: Method `ActorPoolMapOperator.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [data_context: DataContext, map_transformer: MapTransformer]. Arguments in the docstring but not in the function signature: [init_fn: , transform_fn: ].
+    DOC201: Method `_ActorPool.pick_actor` does not have a return section in docstring
+--------------------
+python/ray/data/_internal/execution/operators/base_physical_operator.py
+    DOC101: Method `OneToOneOperator.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `OneToOneOperator.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [data_context: DataContext].
+    DOC101: Method `AllToAllOperator.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `AllToAllOperator.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [data_context: DataContext, target_max_block_size: Optional[int]].
+    DOC103: Method `NAryOperator.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [*input_ops: LogicalOperator, data_context: DataContext]. Arguments in the docstring but not in the function signature: [input_op: , name: ].
+--------------------
+python/ray/data/_internal/execution/operators/hash_shuffle.py
+    DOC104: Function `_shuffle_block`: Arguments are the same in the docstring and the function signature, but are in a different order.
+    DOC105: Function `_shuffle_block`: Argument names match, but type hints in these args do not match: block, input_index, key_columns, pool, block_transformer, send_empty_blocks, override_partition_id
+--------------------
+python/ray/data/_internal/execution/operators/input_data_buffer.py
+    DOC101: Method `InputDataBuffer.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `InputDataBuffer.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [data_context: DataContext].
+--------------------
+python/ray/data/_internal/execution/operators/map_operator.py
+    DOC103: Method `MapOperator.create`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [data_context: DataContext, map_transformer: MapTransformer]. Arguments in the docstring but not in the function signature: [init_fn: , transform_fn: ].
+    DOC201: Method `MapOperator.create` does not have a return section in docstring
+    DOC101: Function `_map_task`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_map_task`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: Dict[str, Any], *blocks: Block, ctx: TaskContext, data_context: DataContext, map_transformer: MapTransformer]. Arguments in the docstring but not in the function signature: [blocks: , fn: ].
+    DOC402: Function `_map_task` has "yield" statements, but the docstring does not have a "Yields" section
+    DOC404: Function `_map_task` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
+--------------------
+python/ray/data/_internal/execution/operators/map_transformer.py
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `MapTransformFn.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `MapTransformFn.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [category: MapTransformFnCategory, input_type: MapTransformFnDataType, is_udf: bool, output_type: MapTransformFnDataType].
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `MapTransformer.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `MapTransformer.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [init_fn: Optional[Callable[[], None]], transform_fns: List[MapTransformFn]].
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `BuildOutputBlocksMapTransformFn.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `BuildOutputBlocksMapTransformFn.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [input_type: MapTransformFnDataType].
+    DOC402: Method `BuildOutputBlocksMapTransformFn.__call__` has "yield" statements, but the docstring does not have a "Yields" section
+    DOC404: Method `BuildOutputBlocksMapTransformFn.__call__` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `ApplyAdditionalSplitToOutputBlocks.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ApplyAdditionalSplitToOutputBlocks.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [additional_split_factor: int].
+--------------------
+python/ray/data/_internal/execution/operators/output_splitter.py
+    DOC101: Method `OutputSplitter._get_locations`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `OutputSplitter._get_locations`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [bundle: RefBundle].
+--------------------
+python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+    DOC101: Method `TaskPoolMapOperator.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TaskPoolMapOperator.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [data_context: DataContext, map_transformer: MapTransformer]. Arguments in the docstring but not in the function signature: [transform_fn: ].
+--------------------
+python/ray/data/_internal/execution/operators/union_operator.py
+    DOC101: Method `UnionOperator.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `UnionOperator.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [*input_ops: PhysicalOperator, data_context: DataContext]. Arguments in the docstring but not in the function signature: [input_ops: ].
+--------------------
+python/ray/data/_internal/execution/operators/zip_operator.py
+    DOC101: Method `ZipOperator.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ZipOperator.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [data_context: DataContext, left_input_op: PhysicalOperator]. Arguments in the docstring but not in the function signature: [left_input_ops: ].
+--------------------
+python/ray/data/_internal/execution/streaming_executor.py
+    DOC101: Method `StreamingExecutor._scheduling_loop_step`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `StreamingExecutor._scheduling_loop_step`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [topology: Topology].
+--------------------
+python/ray/data/_internal/execution/streaming_executor_state.py
+    DOC201: Method `OpBufferQueue.has_next` does not have a return section in docstring
+    DOC101: Method `OpState.get_output_blocking`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `OpState.get_output_blocking`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [output_split_idx: Optional[int]].
+    DOC103: Function `process_completed_tasks`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [resource_manager: ResourceManager]. Arguments in the docstring but not in the function signature: [backpressure_policies: ].
+--------------------
+python/ray/data/_internal/iterator/stream_split_iterator.py
+    DOC101: Method `SplitCoordinator.start_epoch`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `SplitCoordinator.start_epoch`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [split_idx: int].
+--------------------
+python/ray/data/_internal/logging.py
+    DOC201: Function `register_dataset_logger` does not have a return section in docstring
+    DOC201: Function `unregister_dataset_logger` does not have a return section in docstring
+--------------------
+python/ray/data/_internal/logical/operators/all_to_all_operator.py
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `AbstractAllToAll.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `AbstractAllToAll.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [input_op: LogicalOperator, name: str, num_outputs: Optional[int], ray_remote_args: Optional[Dict[str, Any]], sub_progress_bar_names: Optional[List[str]]].
+--------------------
+python/ray/data/_internal/logical/operators/join_operator.py
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `Join.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Join.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [aggregator_ray_remote_args: Optional[Dict[str, Any]], join_type: str, left_columns_suffix: Optional[str], left_input_op: LogicalOperator, left_key_columns: Tuple[str], num_partitions: int, partition_size_hint: Optional[int], right_columns_suffix: Optional[str], right_input_op: LogicalOperator, right_key_columns: Tuple[str]].
+--------------------
+python/ray/data/_internal/logical/operators/map_operator.py
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `AbstractMap.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `AbstractMap.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [compute: Optional[ComputeStrategy], input_op: Optional[LogicalOperator], min_rows_per_bundled_input: Optional[int], name: str, num_outputs: Optional[int], ray_remote_args: Optional[Dict[str, Any]], ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]]].
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `AbstractUDFMap.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `AbstractUDFMap.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [compute: Optional[ComputeStrategy], fn: UserDefinedFunction, fn_args: Optional[Iterable[Any]], fn_constructor_args: Optional[Iterable[Any]], fn_constructor_kwargs: Optional[Dict[str, Any]], fn_kwargs: Optional[Dict[str, Any]], input_op: LogicalOperator, min_rows_per_bundled_input: Optional[int], name: str, ray_remote_args: Optional[Dict[str, Any]], ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]]].
+    DOC101: Method `StreamingRepartition.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `StreamingRepartition.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [input_op: LogicalOperator].
+--------------------
+python/ray/data/_internal/logical/operators/n_ary_operator.py
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `NAry.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `NAry.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [*input_ops: LogicalOperator, num_outputs: Optional[int]].
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `Zip.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Zip.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [left_input_op: LogicalOperator, right_input_op: LogicalOperator].
+--------------------
+python/ray/data/_internal/logical/operators/one_to_one_operator.py
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `AbstractOneToOne.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `AbstractOneToOne.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [input_op: Optional[LogicalOperator], name: str, num_outputs: Optional[int]].
+--------------------
+python/ray/data/_internal/metadata_exporter.py
+    DOC101: Method `Topology.create_topology_metadata`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Topology.create_topology_metadata`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [op_to_id: Dict['PhysicalOperator', str]].
+--------------------
+python/ray/data/_internal/numpy_support.py
+    DOC111: Function `_convert_datetime_to_np_datetime`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC101: Function `convert_to_numpy`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `convert_to_numpy`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [column_values: Any].
+--------------------
+python/ray/data/_internal/output_buffer.py
+    DOC101: Method `BlockOutputBuffer.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `BlockOutputBuffer.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [output_block_size_option: OutputBlockSizeOption].
+--------------------
+python/ray/data/_internal/plan.py
+    DOC101: Method `ExecutionPlan.get_plan_as_string`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ExecutionPlan.get_plan_as_string`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [dataset_cls: Type['Dataset']].
+--------------------
+python/ray/data/_internal/planner/exchange/interfaces.py
+    DOC103: Method `ExchangeTaskSpec.reduce`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [*mapper_outputs: List[Block]]. Arguments in the docstring but not in the function signature: [mapper_outputs: ].
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `ExchangeTaskScheduler.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ExchangeTaskScheduler.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [exchange_spec: ExchangeTaskSpec].
+--------------------
+python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
+    DOC201: Method `_ConvertToArrowExpressionVisitor.visit_UnaryOp` does not have a return section in docstring
+--------------------
+python/ray/data/_internal/stats.py
+    DOC107: Method `DatasetStatsSummary.to_string`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC104: Method `OperatorStatsSummary.from_block_metadata`: Arguments are the same in the docstring and the function signature, but are in a different order.
+    DOC105: Method `OperatorStatsSummary.from_block_metadata`: Argument names match, but type hints in these args do not match: operator_name, block_stats, is_sub_operator
+    DOC101: Method `OperatorStatsSummary.__repr__`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `OperatorStatsSummary.__repr__`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `OperatorStatsSummary.__repr__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `OperatorStatsSummary.__repr__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [level: ].
+--------------------
+python/ray/data/_internal/util.py
+    DOC201: Function `_estimate_avail_cpus` does not have a return section in docstring
+    DOC107: Function `_check_import`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC402: Function `make_async_gen` has "yield" statements, but the docstring does not have a "Yields" section
+    DOC404: Function `make_async_gen` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
+    DOC103: Method `RetryingPyFileSystemHandler.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [retryable_errors: List[str]]. Arguments in the docstring but not in the function signature: [context: ].
+    DOC104: Function `call_with_retry`: Arguments are the same in the docstring and the function signature, but are in a different order.
+    DOC105: Function `call_with_retry`: Argument names match, but type hints in these args do not match: f, description, match, max_attempts, max_backoff_s
+    DOC201: Function `call_with_retry` does not have a return section in docstring
+    DOC104: Function `iterate_with_retry`: Arguments are the same in the docstring and the function signature, but are in a different order.
+    DOC105: Function `iterate_with_retry`: Argument names match, but type hints in these args do not match: iterable_factory, description, match, max_attempts, max_backoff_s
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `MemoryProfiler.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `MemoryProfiler.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [poll_interval_s: Optional[float]].
+--------------------
+python/ray/data/block.py
+    DOC201: Method `BlockAccessor.iter_rows` does not have a return section in docstring
+    DOC201: Method `BlockAccessor.to_numpy` does not have a return section in docstring
+    DOC102: Method `BlockAccessor._get_group_boundaries_sorted`: Docstring contains more arguments than in function signature.
+    DOC103: Method `BlockAccessor._get_group_boundaries_sorted`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the docstring but not in the function signature: [block: ].
+--------------------
+python/ray/data/context.py
+    DOC201: Method `DataContext.get_current` does not have a return section in docstring
+    DOC201: Method `DataContext.get_config` does not have a return section in docstring
+--------------------
+python/ray/data/dataset.py
+    DOC103: Method `Dataset.map`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**ray_remote_args: ]. Arguments in the docstring but not in the function signature: [ray_remote_args: ].
+    DOC201: Method `Dataset.map` does not have a return section in docstring
+    DOC103: Method `Dataset.map_batches`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**ray_remote_args: ]. Arguments in the docstring but not in the function signature: [ray_remote_args: ].
+    DOC201: Method `Dataset.map_batches` does not have a return section in docstring
+    DOC103: Method `Dataset.add_column`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**ray_remote_args: ]. Arguments in the docstring but not in the function signature: [ray_remote_args: ].
+    DOC201: Method `Dataset.add_column` does not have a return section in docstring
+    DOC103: Method `Dataset.drop_columns`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**ray_remote_args: ]. Arguments in the docstring but not in the function signature: [ray_remote_args: ].
+    DOC201: Method `Dataset.drop_columns` does not have a return section in docstring
+    DOC103: Method `Dataset.select_columns`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**ray_remote_args: ]. Arguments in the docstring but not in the function signature: [ray_remote_args: ].
+    DOC201: Method `Dataset.select_columns` does not have a return section in docstring
+    DOC103: Method `Dataset.rename_columns`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**ray_remote_args: ]. Arguments in the docstring but not in the function signature: [ray_remote_args: ].
+    DOC201: Method `Dataset.rename_columns` does not have a return section in docstring
+    DOC103: Method `Dataset.flat_map`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**ray_remote_args: ]. Arguments in the docstring but not in the function signature: [ray_remote_args: ].
+    DOC201: Method `Dataset.flat_map` does not have a return section in docstring
+    DOC103: Method `Dataset.filter`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**ray_remote_args: ]. Arguments in the docstring but not in the function signature: [ray_remote_args: ].
+    DOC201: Method `Dataset.filter` does not have a return section in docstring
+    DOC101: Method `Dataset.random_shuffle`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Dataset.random_shuffle`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**ray_remote_args: , num_blocks: Optional[int]].
+    DOC103: Method `Dataset.union`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [*other: List['Dataset']]. Arguments in the docstring but not in the function signature: [other: ].
+    DOC103: Method `Dataset.write_parquet`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**arrow_parquet_args: ]. Arguments in the docstring but not in the function signature: [arrow_parquet_args: ].
+    DOC103: Method `Dataset.write_json`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**pandas_json_args: ]. Arguments in the docstring but not in the function signature: [pandas_json_args: ].
+    DOC001: Function/method `write_iceberg`: Potential formatting errors in docstring. Error message: Expected a colon in 'to an iceberg table.'. (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `Dataset.write_iceberg`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Dataset.write_iceberg`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [catalog_kwargs: Optional[Dict[str, Any]], concurrency: Optional[int], ray_remote_args: Dict[str, Any], snapshot_properties: Optional[Dict[str, str]], table_identifier: str].
+    DOC103: Method `Dataset.write_csv`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**arrow_csv_args: ]. Arguments in the docstring but not in the function signature: [arrow_csv_args: ].
+    DOC101: Method `Dataset.write_tfrecords`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Dataset.write_tfrecords`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [tf_schema: Optional['schema_pb2.Schema']].
+    DOC101: Method `Dataset.write_webdataset`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Dataset.write_webdataset`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [encoder: Optional[Union[bool, str, callable, list]]].
+    DOC101: Method `Dataset.write_lance`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Dataset.write_lance`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [concurrency: Optional[int], ray_remote_args: Dict[str, Any]].
+    DOC101: Method `Dataset.iter_batches`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Dataset.iter_batches`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_collate_fn: Optional[Callable[[DataBatch], CollatedData]]].
+    DOC001: Function/method `to_numpy_refs`: Potential formatting errors in docstring. Error message: Expected a colon in 'future represents a dict of ndarrays. Defaults to None.'. (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `Dataset.to_numpy_refs`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Dataset.to_numpy_refs`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [column: Optional[str]].
+    DOC201: Method `Dataset.to_numpy_refs` does not have a return section in docstring
+    DOC201: Method `Dataset.to_random_access_dataset` does not have a return section in docstring
+    DOC201: Method `Dataset.stats` does not have a return section in docstring
+    DOC201: Method `Dataset.has_serializable_lineage` does not have a return section in docstring
+    DOC101: Method `Dataset._repr_mimebundle_`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `Dataset._repr_mimebundle_`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC103: Method `Dataset._repr_mimebundle_`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ].
+    DOC101: Method `Schema.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Schema.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [base_schema: Union['pyarrow.lib.Schema', 'PandasBlockSchema'], data_context: Optional[DataContext]].
+--------------------
+python/ray/data/datasource/datasource.py
+    DOC102: Method `Reader.get_read_tasks`: Docstring contains more arguments than in function signature.
+    DOC103: Method `Reader.get_read_tasks`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the docstring but not in the function signature: [read_args: ].
+    DOC101: Method `RandomIntRowDatasource.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `RandomIntRowDatasource.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [n: int, num_columns: int].
+--------------------
+python/ray/data/datasource/file_datasink.py
+    DOC101: Method `_FileDatasink.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `_FileDatasink.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [mode: SaveMode].
+    DOC101: Method `BlockBasedFileDatasink.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC107: Method `BlockBasedFileDatasink.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `BlockBasedFileDatasink.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**file_datasink_kwargs: , min_rows_per_file: Optional[int], path: ].
+--------------------
+python/ray/data/datasource/file_meta_provider.py
+    DOC101: Method `FileMetadataProvider._get_block_metadata`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `FileMetadataProvider._get_block_metadata`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ].
+    DOC101: Method `BaseFileMetadataProvider.expand_paths`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `BaseFileMetadataProvider.expand_paths`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [partitioning: Optional[Partitioning]].
+    DOC101: Function `_expand_directory`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_expand_directory`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [ignore_missing_path: bool].
+--------------------
+python/ray/data/datasource/filename_provider.py
+    DOC201: Method `FilenameProvider.get_filename_for_block` does not have a return section in docstring
+    DOC201: Method `FilenameProvider.get_filename_for_row` does not have a return section in docstring
+--------------------
+python/ray/data/datasource/parquet_meta_provider.py
+    DOC101: Method `ParquetMetadataProvider.prefetch_file_metadata`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ParquetMetadataProvider.prefetch_file_metadata`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**ray_remote_args: ].
+--------------------
+python/ray/data/datasource/path_util.py
+    DOC201: Function `_has_file_extension` does not have a return section in docstring
+    DOC201: Function `_resolve_paths_and_filesystem` does not have a return section in docstring
+--------------------
+python/ray/data/grouped_data.py
+    DOC103: Method `GroupedData.aggregate`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [*aggs: AggregateFn]. Arguments in the docstring but not in the function signature: [aggs: ].
+    DOC103: Method `GroupedData.map_groups`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**ray_remote_args: ]. Arguments in the docstring but not in the function signature: [ray_remote_args: ].
+--------------------
+python/ray/data/preprocessor.py
+    DOC101: Method `Preprocessor._derive_and_validate_output_columns`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Preprocessor._derive_and_validate_output_columns`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [columns: List[str], output_columns: Optional[List[str]]].
+    DOC201: Method `Preprocessor._derive_and_validate_output_columns` does not have a return section in docstring
+--------------------
+python/ray/data/preprocessors/chain.py
+    DOC103: Method `Chain.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [*preprocessors: Preprocessor]. Arguments in the docstring but not in the function signature: [preprocessors: ].
+--------------------
+python/ray/data/preprocessors/concatenator.py
+    DOC104: Method `Concatenator.__init__`: Arguments are the same in the docstring and the function signature, but are in a different order.
+    DOC105: Method `Concatenator.__init__`: Argument names match, but type hints in these args do not match: columns, output_column_name, dtype, raise_if_missing
+--------------------
+python/ray/data/preprocessors/normalizer.py
+    DOC107: Method `Normalizer.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/data/read_api.py
+    DOC103: Function `read_datasource`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**read_args: ]. Arguments in the docstring but not in the function signature: [read_args: ].
+    DOC101: Function `read_audio`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `read_audio`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [shuffle: Union[Literal['files'], None]].
+    DOC101: Function `read_videos`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `read_videos`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [include_timestamps: bool, override_num_blocks: Optional[int], shuffle: Union[Literal['files'], None]]. Arguments in the docstring but not in the function signature: [include_timestmaps: ].
+    DOC103: Function `read_mongo`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**mongo_args: ]. Arguments in the docstring but not in the function signature: [mongo_args: ].
+    DOC101: Function `read_bigquery`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `read_bigquery`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [query: Optional[str]].
+    DOC103: Function `read_parquet`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**arrow_parquet_args: ]. Arguments in the docstring but not in the function signature: [arrow_parquet_args: ].
+    DOC103: Function `read_parquet_bulk`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**arrow_parquet_args: ]. Arguments in the docstring but not in the function signature: [arrow_parquet_args: ].
+    DOC103: Function `read_json`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**arrow_json_args: ]. Arguments in the docstring but not in the function signature: [arrow_json_args: ].
+    DOC103: Function `read_csv`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**arrow_csv_args: ]. Arguments in the docstring but not in the function signature: [arrow_csv_args: ].
+    DOC101: Function `read_text`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `read_text`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [drop_empty_lines: bool].
+    DOC103: Function `read_numpy`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**numpy_load_args: ]. Arguments in the docstring but not in the function signature: [numpy_load_args: ].
+    DOC104: Function `read_binary_files`: Arguments are the same in the docstring and the function signature, but are in a different order.
+    DOC105: Function `read_binary_files`: Argument names match, but type hints in these args do not match: paths, include_paths, filesystem, parallelism, ray_remote_args, arrow_open_stream_args, meta_provider, partition_filter, partitioning, ignore_missing_paths, shuffle, file_extensions, concurrency, override_num_blocks
+--------------------
+python/ray/data/tests/test_split.py
+    DOC106: Function `assert_split_assignment`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `assert_split_assignment`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/exceptions.py
+    DOC101: Method `TaskCancelledError.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TaskCancelledError.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [error_message: Optional[str]].
+    DOC304: Class `ActorDiedError`: Class docstring has an argument/parameter section; please put it in the __init__() docstring
+    DOC101: Method `ObjectLostError.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `ObjectLostError.__init__`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `ObjectLostError.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `ObjectLostError.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [call_site: , owner_address: ].
+--------------------
+python/ray/experimental/array/distributed/linalg.py
+    DOC106: Function `tsqr`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `tsqr`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Function `modified_lu`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `modified_lu`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/experimental/channel/auto_transport_type.py
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `TypeHintResolver.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TypeHintResolver.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [actor_to_gpu_ids: Dict['ray.actor.ActorHandle', List[str]]].
+    DOC101: Method `TypeHintResolver._get_gpu_ids`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TypeHintResolver._get_gpu_ids`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [actor: 'ray.actor.ActorHandle'].
+--------------------
+python/ray/experimental/channel/common.py
+    DOC201: Method `ReaderInterface._read_list` does not have a return section in docstring
+    DOC201: Method `ReaderInterface.read` does not have a return section in docstring
+    DOC107: Method `WriterInterface.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC101: Method `WriterInterface.write`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `WriterInterface.write`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [val: Any].
+    DOC201: Function `_adapt` does not have a return section in docstring
+--------------------
+python/ray/experimental/channel/communicator.py
+    DOC201: Method `Communicator.get_rank` does not have a return section in docstring
+    DOC201: Method `Communicator.recv` does not have a return section in docstring
+--------------------
+python/ray/experimental/channel/cpu_communicator.py
+    DOC201: Method `CPUCommunicator.get_rank` does not have a return section in docstring
+--------------------
+python/ray/experimental/channel/intra_process_channel.py
+    DOC101: Method `IntraProcessChannel.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC107: Method `IntraProcessChannel.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `IntraProcessChannel.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_channel_id: Optional[str]].
+--------------------
+python/ray/experimental/channel/nccl_group.py
+    DOC201: Method `_NcclGroup.get_rank` does not have a return section in docstring
+    DOC101: Method `_NcclGroup.recv`: Docstring contains fewer arguments than in function signature.
+    DOC107: Method `_NcclGroup.recv`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `_NcclGroup.recv`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [allocator: , dtype: 'torch.dtype', shape: Tuple[int]]. Arguments in the docstring but not in the function signature: [buf: ].
+    DOC201: Method `_NcclGroup.recv` does not have a return section in docstring
+--------------------
+python/ray/experimental/channel/shared_memory_channel.py
+    DOC101: Function `_create_channel_ref`: Docstring contains fewer arguments than in function signature.
+    DOC107: Function `_create_channel_ref`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `_create_channel_ref`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [self: ].
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `_ResizeChannel.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `_ResizeChannel.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_node_id_to_reader_ref_info: Dict[str, ReaderRefInfo]].
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `SharedMemoryType.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `SharedMemoryType.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [buffer_size_bytes: Optional[int], num_shm_buffers: Optional[int]].
+    DOC303: Class `Channel`: The __init__() docstring does not need a "Returns" section, because it cannot return anything
+    DOC101: Method `Channel.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Channel.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_node_id_to_reader_ref_info: Optional[Dict[str, ReaderRefInfo]], _reader_registered: bool, _writer_node_id: Optional['ray.NodeID'], _writer_ref: Optional['ray.ObjectRef'], _writer_registered: bool].
+    DOC302: Class `Channel`: The class docstring does not need a "Returns" section, because __init__() cannot return anything
+    DOC101: Method `CompositeChannel.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `CompositeChannel.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_channel_dict: Optional[Dict[ray.ActorID, ChannelInterface]], _channels: Optional[Set[ChannelInterface]], _reader_registered: bool, _writer_registered: bool].
+--------------------
+python/ray/experimental/channel/torch_tensor_nccl_channel.py
+    DOC201: Method `TorchTensorNcclChannel._recv_cpu_and_gpu_data` does not have a return section in docstring
+    DOC201: Function `_get_ranks` does not have a return section in docstring
+    DOC201: Function `_init_communicator` does not have a return section in docstring
+--------------------
+python/ray/experimental/channel/utils.py
+    DOC103: Function `split_actors_by_node_locality`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [node: str]. Arguments in the docstring but not in the function signature: [writer_node: ].
+--------------------
+python/ray/experimental/compiled_dag_ref.py
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `CompiledDAGRef.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `CompiledDAGRef.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [channel_index: Optional[int], dag: 'ray.experimental.CompiledDAG', execution_index: int].
+--------------------
+python/ray/experimental/internal_kv.py
+    DOC101: Function `_internal_kv_put`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_internal_kv_put`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [key: Union[str, bytes], namespace: Optional[Union[str, bytes]], overwrite: bool, value: Union[str, bytes]].
+--------------------
+python/ray/experimental/locations.py
+    DOC111: Function `get_object_locations`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Function `get_object_locations`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [obj_refs: List[ObjectRef]]. Arguments in the docstring but not in the function signature: [object_refs: List[ObjectRef]].
+    DOC111: Function `get_local_object_locations`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Function `get_local_object_locations`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [obj_refs: List[ObjectRef]]. Arguments in the docstring but not in the function signature: [object_refs: List[ObjectRef]].
+--------------------
+python/ray/experimental/packaging/load_package.py
+    DOC201: Function `load_package` does not have a return section in docstring
+--------------------
+python/ray/experimental/shuffle.py
+    DOC404: Function `round_robin_partitioner` yield type(s) in docstring not consistent with the return annotation. The yield type (the 0th arg in Generator[...]/Iterator[...]): Tuple[PartitionID, InType]; docstring "yields" section types:
+--------------------
+python/ray/job_config.py
+    DOC101: Method `JobConfig.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `JobConfig.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_client_job: bool, _py_driver_sys_path: Optional[List[str]]].
+    DOC106: Method `JobConfig.from_json`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `JobConfig.from_json`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC201: Method `JobConfig.from_json` does not have a return section in docstring
+--------------------
+python/ray/llm/_internal/batch/observability/logging/__init__.py
+    DOC201: Function `_setup_logger` does not have a return section in docstring
+--------------------
+python/ray/llm/_internal/batch/processor/base.py
+    DOC101: Method `Processor.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Processor.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [stages: List[StatefulStage]].
+    DOC101: Method `ProcessorBuilder.build`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ProcessorBuilder.build`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ].
+--------------------
+python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
+    DOC101: Function `build_vllm_engine_processor`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `build_vllm_engine_processor`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [telemetry_agent: Optional[TelemetryAgent]].
+--------------------
+python/ray/llm/_internal/batch/stages/base.py
+    DOC405: Method `StatefulStageUDF.__call__` has both "return" and "yield" statements. Please use Generator[YieldType, SendType, ReturnType] as the return type annotation, and put your yield type in YieldType and return type in ReturnType. More details in https://jsh9.github.io/pydoclint/notes_generator_vs_iterator.html
+--------------------
+python/ray/llm/_internal/batch/stages/chat_template_stage.py
+    DOC404: Method `ChatTemplateUDF.udf` yield type(s) in docstring not consistent with the return annotation. The yield type (the 0th arg in Generator[...]/Iterator[...]): Dict[str, Any]; docstring "yields" section types:
+--------------------
+python/ray/llm/_internal/batch/stages/http_request_stage.py
+    DOC404: Method `HttpRequestUDF.udf` yield type(s) in docstring not consistent with the return annotation. The yield type (the 0th arg in Generator[...]/Iterator[...]): Dict[str, Any]; docstring "yields" section types:
+--------------------
+python/ray/llm/_internal/batch/stages/prepare_image_stage.py
+    DOC103: Method `ImageProcessor.process`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [images: List[_ImageType]]. Arguments in the docstring but not in the function signature: [image: ].
+--------------------
+python/ray/llm/_internal/batch/stages/sglang_engine_stage.py
+    DOC103: Method `SGLangEngineWrapper.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [idx_in_batch_column: str]. Arguments in the docstring but not in the function signature: [*args: ].
+    DOC103: Method `SGLangEngineWrapper.generate_async`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [row: Dict[str, Any]]. Arguments in the docstring but not in the function signature: [request: ].
+    DOC402: Method `SGLangEngineStageUDF.udf` has "yield" statements, but the docstring does not have a "Yields" section
+    DOC404: Method `SGLangEngineStageUDF.udf` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
+    DOC106: Method `SGLangEngineStage.post_init`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `SGLangEngineStage.post_init`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/llm/_internal/batch/stages/tokenize_stage.py
+    DOC404: Method `TokenizeUDF.udf` yield type(s) in docstring not consistent with the return annotation. The yield type (the 0th arg in Generator[...]/Iterator[...]): Dict[str, Any]; docstring "yields" section types:
+    DOC404: Method `DetokenizeUDF.udf` yield type(s) in docstring not consistent with the return annotation. The yield type (the 0th arg in Generator[...]/Iterator[...]): Dict[str, Any]; docstring "yields" section types:
+--------------------
+python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+    DOC103: Method `vLLMEngineWrapper.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [idx_in_batch_column: str]. Arguments in the docstring but not in the function signature: [*args: ].
+    DOC103: Method `vLLMEngineWrapper.generate_async`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [row: Dict[str, Any]]. Arguments in the docstring but not in the function signature: [request: ].
+    DOC101: Method `vLLMEngineStageUDF.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `vLLMEngineStageUDF.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [batch_size: int, max_concurrent_batches: int].
+    DOC402: Method `vLLMEngineStageUDF.udf` has "yield" statements, but the docstring does not have a "Yields" section
+    DOC404: Method `vLLMEngineStageUDF.udf` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
+    DOC106: Method `vLLMEngineStage.post_init`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `vLLMEngineStage.post_init`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/llm/_internal/common/observability/logging/__init__.py
+    DOC201: Function `_setup_logger` does not have a return section in docstring
+--------------------
+python/ray/llm/_internal/common/observability/telemetry_utils.py
+    DOC101: Method `Once.do_once`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Once.do_once`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [func: Callable[[], None]].
+--------------------
+python/ray/llm/_internal/common/utils/cloud_utils.py
+    DOC101: Method `CloudObjectCache.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `CloudObjectCache.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [missing_object_value: Any].
+    DOC101: Method `CloudObjectCache._check_cache`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `CloudObjectCache._check_cache`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [key: str].
+    DOC201: Function `remote_object_cache` does not have a return section in docstring
+--------------------
+python/ray/llm/_internal/common/utils/download_utils.py
+    DOC201: Function `get_model_location_on_disk` does not have a return section in docstring
+    DOC201: Method `CloudModelDownloader.get_model` does not have a return section in docstring
+--------------------
+python/ray/llm/_internal/serve/configs/json_mode_utils.py
+    DOC201: Method `JSONSchemaValidator.try_load_json_schema` does not have a return section in docstring
+--------------------
+python/ray/llm/_internal/serve/configs/openai_api_models.py
+    DOC201: Function `to_model_metadata` does not have a return section in docstring
+--------------------
+python/ray/llm/_internal/serve/configs/prompt_formats.py
+    DOC101: Method `Image.check_image_url`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `Image.check_image_url`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `Image.check_image_url`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `Image.check_image_url`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [value: ].
+    DOC201: Method `Image.check_image_url` does not have a return section in docstring
+--------------------
+python/ray/llm/_internal/serve/configs/server_models.py
+    DOC101: Method `LLMConfig.get_serve_options`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `LLMConfig.get_serve_options`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [name_prefix: str].
+--------------------
+python/ray/llm/_internal/serve/deployments/llm/llm_server.py
+    DOC101: Method `LLMServer.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `LLMServer.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [engine_cls: Optional[Type[LLMEngine]], image_retriever_cls: Optional[Type[ImageRetriever]], model_downloader: Optional[LoraModelLoader]].
+    DOC402: Method `LLMServer.embeddings` has "yield" statements, but the docstring does not have a "Yields" section
+    DOC404: Method `LLMServer.embeddings` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
+--------------------
+python/ray/llm/_internal/serve/deployments/llm/multiplex/utils.py
+    DOC201: Function `retry_with_exponential_backoff` does not have a return section in docstring
+    DOC101: Function `get_object_from_cloud`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `get_object_from_cloud`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [object_uri: str].
+--------------------
+python/ray/llm/_internal/serve/deployments/routers/router.py
+    DOC101: Method `LLMRouter.completions`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `LLMRouter.completions`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [body: CompletionRequest].
+    DOC101: Method `LLMRouter.chat`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `LLMRouter.chat`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [body: ChatCompletionRequest].
+    DOC101: Method `LLMRouter.embeddings`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `LLMRouter.embeddings`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [body: EmbeddingRequest].
+    DOC101: Method `LLMRouter.as_deployment`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `LLMRouter.as_deployment`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [llm_configs: Optional[List[LLMConfig]]].
+--------------------
+python/ray/llm/_internal/serve/observability/metrics/middleware.py
+    DOC106: Function `_get_route_details`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `_get_route_details`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/llm/tests/conftest.py
+    DOC404: Function `download_model_from_s3` yield type(s) in docstring not consistent with the return annotation. The yield type (the 0th arg in Generator[...]/Iterator[...]): str; docstring "yields" section types:
+--------------------
+python/ray/remote_function.py
+    DOC101: Method `RemoteFunction.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `RemoteFunction.__init__`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `RemoteFunction.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `RemoteFunction.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [function: , function_descriptor: , language: , task_options: ].
+    DOC102: Method `RemoteFunction.options`: Docstring contains more arguments than in function signature.
+    DOC106: Method `RemoteFunction.options`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC111: Method `RemoteFunction.options`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Method `RemoteFunction.options`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**task_options: ]. Arguments in the docstring but not in the function signature: [_labels: , _metadata: , accelerator_type: , enable_task_events: , label_selector: Dict[str, str], max_calls: , max_retries: , memory: , num_cpus: , num_gpus: , num_returns: , object_store_memory: , resources: Dict[str, float], retry_exceptions: , runtime_env: Dict[str, Any], scheduling_strategy: ].
+    DOC201: Method `RemoteFunction.options` does not have a return section in docstring
+--------------------
+python/ray/runtime_context.py
+    DOC201: Function `get_runtime_context` does not have a return section in docstring
+--------------------
+python/ray/runtime_env/runtime_env.py
+    DOC101: Method `RuntimeEnvConfig.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `RuntimeEnvConfig.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [log_files: Optional[List[str]]].
+    DOC101: Method `RuntimeEnv.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `RuntimeEnv.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , _validate: bool, mpi: Optional[Dict], py_executable: Optional[str]].
+--------------------
+python/ray/scripts/scripts.py
+    DOC101: Function `kill_procs`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `kill_procs`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [force: bool, grace_period: int, processes_to_kill: List[str]].
+    DOC101: Function `submit`: Docstring contains fewer arguments than in function signature.
+    DOC107: Function `submit`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `submit`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [args: , cluster_config_file: , cluster_name: , disable_usage_stats: , extra_screen_args: Optional[str], no_config_cache: , port_forward: , screen: , script: , script_args: , start: , stop: , tmux: ].
+--------------------
+python/ray/serve/_private/api.py
+    DOC101: Function `serve_start`: Docstring contains fewer arguments than in function signature.
+    DOC111: Function `serve_start`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Function `serve_start`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , global_logging_config: Union[None, dict, LoggingConfig]].
+    DOC201: Function `serve_start` does not have a return section in docstring
+--------------------
+python/ray/serve/_private/application_state.py
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `ApplicationState.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ApplicationState.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [deployment_state_manager: DeploymentStateManager, endpoint_state: EndpointState, logging_config: LoggingConfig, name: str].
+    DOC103: Method `ApplicationStateManager.deploy_app`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [deployment_args: List[Dict]]. Arguments in the docstring but not in the function signature: [deployment_args_list: ].
+    DOC102: Function `override_deployment_info`: Docstring contains more arguments than in function signature.
+    DOC103: Function `override_deployment_info`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the docstring but not in the function signature: [app_name: ].
+    DOC201: Function `override_deployment_info` does not have a return section in docstring
+--------------------
+python/ray/serve/_private/benchmarks/common.py
+    DOC201: Function `run_throughput_benchmark` does not have a return section in docstring
+--------------------
+python/ray/serve/_private/benchmarks/streaming/_grpc/test_server_pb2_grpc.py
+    DOC106: Method `GRPCTestServerStub.__init__`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `GRPCTestServerStub.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/serve/_private/client.py
+    DOC101: Method `ServeControllerClient._wait_for_application_running`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ServeControllerClient._wait_for_application_running`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [name: str, timeout_s: int].
+--------------------
+python/ray/serve/_private/config.py
+    DOC101: Method `DeploymentConfig.from_default`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `DeploymentConfig.from_default`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC103: Method `DeploymentConfig.from_default`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ].
+    DOC201: Method `DeploymentConfig.from_default` does not have a return section in docstring
+--------------------
+python/ray/serve/_private/controller.py
+    DOC111: Method `ServeController.listen_for_change`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Method `ServeController.listen_for_change` does not have a return section in docstring
+    DOC111: Method `ServeController.listen_for_change_java`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Method `ServeController.listen_for_change_java` does not have a return section in docstring
+    DOC102: Method `ServeController.deploy_applications`: Docstring contains more arguments than in function signature.
+    DOC103: Method `ServeController.deploy_applications`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [name_to_deployment_args_list: Dict[str, List[bytes]]]. Arguments in the docstring but not in the function signature: [deployment_args_list: , name: ].
+    DOC101: Method `ServeController.get_deployment_info`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ServeController.get_deployment_info`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [app_name: str].
+    DOC201: Method `ServeController.get_serve_status` does not have a return section in docstring
+    DOC201: Method `ServeController.get_deployment_status` does not have a return section in docstring
+    DOC101: Method `ServeController.get_ingress_deployment_name`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ServeController.get_ingress_deployment_name`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [app_name: str].
+    DOC101: Method `ServeController.graceful_shutdown`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ServeController.graceful_shutdown`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [wait: bool].
+    DOC201: Method `ServeController.graceful_shutdown` does not have a return section in docstring
+--------------------
+python/ray/serve/_private/deploy_utils.py
+    DOC201: Function `get_app_code_version` does not have a return section in docstring
+--------------------
+python/ray/serve/_private/deployment_scheduler.py
+    DOC201: Method `DeploymentScheduler._schedule_replica` does not have a return section in docstring
+--------------------
+python/ray/serve/_private/deployment_state.py
+    DOC201: Method `ReplicaStateContainer.get` does not have a return section in docstring
+    DOC201: Method `ReplicaStateContainer.pop` does not have a return section in docstring
+    DOC201: Method `ReplicaStateContainer.count` does not have a return section in docstring
+    DOC102: Method `DeploymentState._set_target_state`: Docstring contains more arguments than in function signature.
+    DOC103: Method `DeploymentState._set_target_state`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the docstring but not in the function signature: [status_trigger: ].
+    DOC101: Method `DeploymentState.deploy`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `DeploymentState.deploy`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [deployment_info: DeploymentInfo].
+    DOC106: Method `DeploymentState._stop_or_update_outdated_version_replicas`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `DeploymentState._stop_or_update_outdated_version_replicas`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC201: Method `DeploymentState._stop_or_update_outdated_version_replicas` does not have a return section in docstring
+    DOC101: Method `DeploymentState._check_startup_replicas`: Docstring contains fewer arguments than in function signature.
+    DOC107: Method `DeploymentState._check_startup_replicas`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `DeploymentState._check_startup_replicas`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [original_state: ReplicaState].
+    DOC201: Method `DeploymentState._check_startup_replicas` does not have a return section in docstring
+    DOC201: Method `DeploymentState._choose_pending_migration_replicas_to_stop` does not have a return section in docstring
+    DOC103: Method `DeploymentState.record_multiplexed_model_ids`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [replica_id: ReplicaID]. Arguments in the docstring but not in the function signature: [replica_name: ].
+    DOC101: Method `DeploymentStateManager._map_actor_names_to_deployment`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `DeploymentStateManager._map_actor_names_to_deployment`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [all_current_actor_names: List[str]].
+    DOC201: Method `DeploymentStateManager._map_actor_names_to_deployment` does not have a return section in docstring
+    DOC101: Method `DeploymentStateManager.get_deployment_details`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `DeploymentStateManager.get_deployment_details`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [id: DeploymentID].
+    DOC101: Method `DeploymentStateManager.deploy`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `DeploymentStateManager.deploy`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [deployment_id: DeploymentID, deployment_info: DeploymentInfo].
+    DOC201: Method `DeploymentStateManager.record_multiplexed_replica_info` does not have a return section in docstring
+--------------------
+python/ray/serve/_private/http_util.py
+    DOC106: Method `Response.__init__`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `Response.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC111: Method `Response.__init__`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Method `MessageQueue.get_one_message` does not have a return section in docstring
+    DOC101: Function `set_socket_reuse_port`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `set_socket_reuse_port`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [sock: socket.socket].
+--------------------
+python/ray/serve/_private/logging_utils.py
+    DOC102: Method `ServeFormatter.format`: Docstring contains more arguments than in function signature.
+    DOC103: Method `ServeFormatter.format`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the docstring but not in the function signature: [Returns: ].
+    DOC201: Method `ServeFormatter.format` does not have a return section in docstring
+    DOC101: Function `configure_component_cpu_profiler`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `configure_component_cpu_profiler`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [component_id: str, component_name: str, component_type: Optional[ServeComponentType]].
+--------------------
+python/ray/serve/_private/long_poll.py
+    DOC107: Method `LongPollClient.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC111: Method `LongPollHost.listen_for_change_java`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Method `LongPollHost.listen_for_change_java` does not have a return section in docstring
+--------------------
+python/ray/serve/_private/proxy_response_generator.py
+    DOC103: Method `_ProxyResponseGeneratorBase.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [disconnected_task: Optional[asyncio.Task], result_callback: Optional[Callable[[Any], Any]], timeout_s: Optional[float]]. Arguments in the docstring but not in the function signature: [- disconnected_task: , - result_callback: , - timeout_s: ].
+--------------------
+python/ray/serve/_private/proxy_state.py
+    DOC201: Method `ProxyStateManager.get_targets` does not have a return section in docstring
+--------------------
+python/ray/serve/_private/router.py
+    DOC101: Method `SingletonThreadRouter.assign_request`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `SingletonThreadRouter.assign_request`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**request_kwargs: , *request_args: , request_meta: RequestMetadata].
+--------------------
+python/ray/serve/_private/storage/kv_store.py
+    DOC201: Method `RayInternalKVStore.put` does not have a return section in docstring
+    DOC201: Method `RayInternalKVStore.delete` does not have a return section in docstring
+--------------------
+python/ray/serve/_private/storage/kv_store_base.py
+    DOC201: Method `KVStoreBase.put` does not have a return section in docstring
+--------------------
+python/ray/serve/_private/test_utils.py
+    DOC201: Function `check_replica_counts` does not have a return section in docstring
+--------------------
+python/ray/serve/_private/utils.py
+    DOC201: Function `override_runtime_envs_except_env_vars` does not have a return section in docstring
+    DOC101: Function `require_packages`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `require_packages`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [packages: List[str]].
+    DOC201: Function `require_packages` does not have a return section in docstring
+    DOC201: Function `extract_self_if_method_call` does not have a return section in docstring
+--------------------
+python/ray/serve/api.py
+    DOC101: Function `start`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `start`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ].
+    DOC201: Function `get_replica_context` does not have a return section in docstring
+    DOC201: Function `ingress` does not have a return section in docstring
+    DOC101: Function `deployment`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `deployment`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_func_or_class: Optional[Callable], logging_config: Default[Union[Dict, LoggingConfig, None]], route_prefix: Default[Union[str, None]], version: Default[str]].
+    DOC101: Function `run_many`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `run_many`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_local_testing_mode: bool].
+    DOC101: Function `run`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `run`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_local_testing_mode: bool].
+    DOC101: Function `multiplexed`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `multiplexed`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [func: Optional[Callable[..., Any]]].
+    DOC201: Function `multiplexed` does not have a return section in docstring
+    DOC201: Function `get_app_handle` does not have a return section in docstring
+    DOC101: Function `get_deployment_handle`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `get_deployment_handle`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_check_exists: bool, _record_telemetry: bool].
+    DOC201: Function `get_deployment_handle` does not have a return section in docstring
+--------------------
+python/ray/serve/autoscaling_policy.py
+    DOC101: Function `_calculate_desired_num_replicas`: Docstring contains fewer arguments than in function signature.
+    DOC111: Function `_calculate_desired_num_replicas`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Function `_calculate_desired_num_replicas`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [num_running_replicas: int, total_num_requests: int]. Arguments in the docstring but not in the function signature: [current_num_ongoing_requests: List[float]].
+--------------------
+python/ray/serve/batching.py
+    DOC111: Method `_BatchQueue.__init__`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Method `_BatchQueue.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [batch_wait_timeout_s: float]. Arguments in the docstring but not in the function signature: [timeout_s: ].
+    DOC101: Function `batch`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `batch`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_func: Optional[Callable]].
+    DOC201: Function `batch` does not have a return section in docstring
+--------------------
+python/ray/serve/context.py
+    DOC101: Function `_connect`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_connect`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [raise_if_no_controller_running: bool].
+--------------------
+python/ray/serve/deployment.py
+    DOC101: Method `Deployment.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC107: Method `Deployment.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `Deployment.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_internal: , deployment_config: DeploymentConfig, name: str, replica_config: ReplicaConfig, version: Optional[str]].
+    DOC201: Function `deployment_to_schema` does not have a return section in docstring
+--------------------
+python/ray/serve/handle.py
+    DOC101: Method `DeploymentHandle.options`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `DeploymentHandle.options`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_prefer_local_routing: Union[bool, DEFAULT], method_name: Union[str, DEFAULT], multiplexed_model_id: Union[str, DEFAULT], stream: Union[bool, DEFAULT], use_new_handle_api: Union[bool, DEFAULT]].
+    DOC201: Method `DeploymentHandle.options` does not have a return section in docstring
+    DOC106: Method `DeploymentHandle.remote`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC201: Method `DeploymentHandle.remote` does not have a return section in docstring
+--------------------
+python/ray/serve/tests/conftest.py
+    DOC106: Function `ray_instance`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `ray_instance`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC402: Function `ray_instance` has "yield" statements, but the docstring does not have a "Yields" section
+    DOC404: Function `ray_instance` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
+--------------------
+python/ray/serve/tests/test_callback.py
+    DOC106: Function `ray_instance`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `ray_instance`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC402: Function `ray_instance` has "yield" statements, but the docstring does not have a "Yields" section
+    DOC404: Function `ray_instance` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
+--------------------
+python/ray/serve/tests/test_config_files/syntax_error.py
+    DOC002: Syntax errors; cannot parse this Python file. Error message: '(' was never closed (<unknown>, line 1)
+--------------------
+python/ray/serve/tests/test_metrics.py
+    DOC106: Method `TestRequestContextMetrics._generate_metrics_summary`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `TestRequestContextMetrics._generate_metrics_summary`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/serve/tests/test_target_capacity.py
+    DOC107: Method `TestTargetCapacityUpdateAndServeStatus.check_num_replicas`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC201: Method `TestTargetCapacityUpdateAndServeStatus.check_num_replicas` does not have a return section in docstring
+--------------------
+python/ray/serve/tests/unit/test_deployment_class.py
+    DOC101: Function `get_random_dict_combos`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `get_random_dict_combos`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [d: Dict, n: int].
+--------------------
+python/ray/tests/autoscaler_test_utils.py
+    DOC201: Method `MockProcessRunner.assert_has_call` does not have a return section in docstring
+--------------------
+python/ray/tests/aws/utils/helpers.py
+    DOC106: Function `node_provider_tags`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `node_provider_tags`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Function `apply_node_provider_config_updates`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `apply_node_provider_config_updates`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/tests/conftest.py
+    DOC107: Function `wait_for_redis_to_start`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC104: Function `wait_for_redis_to_start`: Arguments are the same in the docstring and the function signature, but are in a different order.
+    DOC105: Function `wait_for_redis_to_start`: Argument names match, but type hints in these args do not match: redis_ip_address, redis_port
+--------------------
+python/ray/tests/kuberay/test_kuberay_node_provider.py
+    DOC106: Function `test_create_node_cap_at_max`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `test_create_node_cap_at_max`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/tests/kuberay/utils.py
+    DOC404: Function `_kubectl_port_forward` yield type(s) in docstring not consistent with the return annotation. The yield type (the 0th arg in Generator[...]/Iterator[...]): int; docstring "yields" section types: The local port. The service can then be accessed at 127.0.0.1
+    DOC101: Function `kubectl_delete`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `kubectl_delete`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [wait: bool].
+--------------------
+python/ray/tests/modin/modin_test_utils.py
+    DOC106: Function `df_equals`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `df_equals`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/tests/test_autoscaler_gcp.py
+    DOC106: Function `test_gcp_broken_pipe_retry`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `test_gcp_broken_pipe_retry`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/tests/test_batch_node_provider_unit.py
+    DOC106: Method `BatchingNodeProviderTester.update`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `BatchingNodeProviderTester.update`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC111: Method `BatchingNodeProviderTester.update`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Method `BatchingNodeProviderTester.update` does not have a return section in docstring
+--------------------
+python/ray/tests/test_client_reconnect.py
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `MiddlemanDataServicer.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `MiddlemanDataServicer.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [on_request: Optional[Hook], on_response: Optional[Hook]].
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `MiddlemanLogServicer.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `MiddlemanLogServicer.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [on_response: Optional[Hook]].
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `MiddlemanRayletServicer.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `MiddlemanRayletServicer.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [on_request: Optional[Hook], on_response: Optional[Hook]].
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `MiddlemanServer.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC107: Method `MiddlemanServer.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `MiddlemanServer.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [listen_addr: str, on_data_request: Optional[Hook], on_data_response: Optional[Hook], on_log_response: Optional[Hook], on_task_request: Optional[Hook], on_task_response: Optional[Hook], real_addr: ].
+--------------------
+python/ray/train/_checkpoint.py
+    DOC402: Method `Checkpoint.as_directory` has "yield" statements, but the docstring does not have a "Yields" section
+    DOC404: Method `Checkpoint.as_directory` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
+    DOC101: Function `_get_del_lock_path`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_get_del_lock_path`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [path: str, suffix: str].
+    DOC201: Function `_get_del_lock_path` does not have a return section in docstring
+--------------------
+python/ray/train/_internal/backend_executor.py
+    DOC101: Method `BackendExecutor.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC111: Method `BackendExecutor.__init__`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Method `BackendExecutor.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [trial_info: Optional[TrialInfo]].
+    DOC201: Method `BackendExecutor._is_share_resources_enabled` does not have a return section in docstring
+    DOC201: Method `BackendExecutor._create_rank_world_size_mappings` does not have a return section in docstring
+    DOC101: Method `BackendExecutor.start_training`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `BackendExecutor.start_training`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [metadata: Dict[str, Any], storage: StorageContext].
+    DOC106: Method `BackendExecutor.get_with_failure_handling`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `BackendExecutor.get_with_failure_handling`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/train/_internal/checkpoint_manager.py
+    DOC101: Function `_insert_into_sorted_list`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_insert_into_sorted_list`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [item: Any, key: Callable[[Any], Any], list: List[Any]].
+    DOC103: Method `_CheckpointManager.register_checkpoint`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [checkpoint_result: _TrainingResult]. Arguments in the docstring but not in the function signature: [checkpoint: ].
+    DOC101: Method `_CheckpointManager._get_checkpoint_score`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `_CheckpointManager._get_checkpoint_score`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [checkpoint: _TrainingResult].
+--------------------
+python/ray/train/_internal/data_config.py
+    DOC103: Method `DataConfig.configure`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ]. Arguments in the docstring but not in the function signature: [kwargs: ].
+--------------------
+python/ray/train/_internal/dl_predictor.py
+    DOC102: Method `DLPredictor._arrays_to_tensors`: Docstring contains more arguments than in function signature.
+    DOC103: Method `DLPredictor._arrays_to_tensors`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [numpy_arrays: Union[np.ndarray, Dict[str, np.ndarray]]]. Arguments in the docstring but not in the function signature: [ndarray: , numpy_array: ].
+--------------------
+python/ray/train/_internal/session.py
+    DOC101: Function `get_accelerator`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `get_accelerator`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [default_accelerator_cls: Type[Accelerator]].
+    DOC201: Function `get_accelerator` does not have a return section in docstring
+    DOC101: Function `report`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `report`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [checkpoint_dir_name: Optional[str]].
+    DOC201: Function `get_local_world_size` does not have a return section in docstring
+    DOC201: Function `get_node_rank` does not have a return section in docstring
+--------------------
+python/ray/train/_internal/storage.py
+    DOC101: Method `_ExcludingLocalFilesystem.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `_ExcludingLocalFilesystem.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ].
+    DOC101: Function `_is_directory`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_is_directory`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [fs: pyarrow.fs.FileSystem, fs_path: str].
+    DOC201: Function `_is_directory` does not have a return section in docstring
+    DOC201: Function `get_fs_and_path` does not have a return section in docstring
+--------------------
+python/ray/train/_internal/syncer.py
+    DOC201: Method `Syncer.sync_up_if_needed` does not have a return section in docstring
+    DOC201: Method `Syncer.sync_down_if_needed` does not have a return section in docstring
+--------------------
+python/ray/train/_internal/utils.py
+    DOC201: Function `construct_path` does not have a return section in docstring
+    DOC111: Function `construct_train_func`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+--------------------
+python/ray/train/_internal/worker_group.py
+    DOC101: Method `RayTrainWorker.__execute`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `RayTrainWorker.__execute`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ]. Arguments in the docstring but not in the function signature: [args, kwargs: ].
+    DOC201: Method `RayTrainWorker.__execute` does not have a return section in docstring
+    DOC101: Method `WorkerGroup.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC111: Method `WorkerGroup.__init__`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Method `WorkerGroup.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [actor_cls_args: Optional[Tuple], actor_cls_kwargs: Optional[Dict]]. Arguments in the docstring but not in the function signature: [remote_cls_args, remote_cls_kwargs: ].
+    DOC101: Method `WorkerGroup.execute_async`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `WorkerGroup.execute_async`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ]. Arguments in the docstring but not in the function signature: [args, kwargs: ].
+    DOC101: Method `WorkerGroup.execute`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `WorkerGroup.execute`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ]. Arguments in the docstring but not in the function signature: [args, kwargs: ].
+    DOC101: Method `WorkerGroup.execute_single_async`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `WorkerGroup.execute_single_async`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ]. Arguments in the docstring but not in the function signature: [args, kwargs: ].
+    DOC101: Method `WorkerGroup.execute_single`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `WorkerGroup.execute_single`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ]. Arguments in the docstring but not in the function signature: [args, kwargs: ].
+    DOC111: Method `WorkerGroup.remove_workers`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+--------------------
+python/ray/train/base_trainer.py
+    DOC101: Method `BaseTrainer.can_restore`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `BaseTrainer.can_restore`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [storage_filesystem: Optional[pyarrow.fs.FileSystem]].
+--------------------
+python/ray/train/data_parallel_trainer.py
+    DOC101: Method `DataParallelTrainer.restore`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `DataParallelTrainer.restore`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , path: str].
+    DOC201: Method `DataParallelTrainer.restore` does not have a return section in docstring
+    DOC101: Method `DataParallelTrainer._repr_mimebundle_`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `DataParallelTrainer._repr_mimebundle_`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC103: Method `DataParallelTrainer._repr_mimebundle_`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ].
+--------------------
+python/ray/train/horovod/horovod_trainer.py
+    DOC104: Method `HorovodTrainer.__init__`: Arguments are the same in the docstring and the function signature, but are in a different order.
+    DOC105: Method `HorovodTrainer.__init__`: Argument names match, but type hints in these args do not match: train_loop_per_worker, train_loop_config, horovod_config, scaling_config, dataset_config, run_config, datasets, metadata, resume_from_checkpoint
+--------------------
+python/ray/train/lightgbm/_lightgbm_utils.py
+    DOC201: Method `RayTrainReportCallback.get_model` does not have a return section in docstring
+--------------------
+python/ray/train/lightgbm/lightgbm_predictor.py
+    DOC201: Method `LightGBMPredictor.from_checkpoint` does not have a return section in docstring
+--------------------
+python/ray/train/lightgbm/lightgbm_trainer.py
+    DOC104: Method `LightGBMTrainer.__init__`: Arguments are the same in the docstring and the function signature, but are in a different order.
+    DOC105: Method `LightGBMTrainer.__init__`: Argument names match, but type hints in these args do not match: train_loop_per_worker, train_loop_config, lightgbm_config, scaling_config, run_config, datasets, dataset_config, resume_from_checkpoint, metadata, label_column, params, num_boost_round
+--------------------
+python/ray/train/lightgbm/v2.py
+    DOC104: Method `LightGBMTrainer.__init__`: Arguments are the same in the docstring and the function signature, but are in a different order.
+    DOC105: Method `LightGBMTrainer.__init__`: Argument names match, but type hints in these args do not match: train_loop_per_worker, train_loop_config, lightgbm_config, scaling_config, run_config, datasets, dataset_config, metadata, resume_from_checkpoint
+--------------------
+python/ray/train/predictor.py
+    DOC103: Method `Predictor.from_checkpoint`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ]. Arguments in the docstring but not in the function signature: [kwargs: ].
+    DOC201: Method `Predictor.from_pandas_udf` does not have a return section in docstring
+    DOC103: Method `Predictor.predict`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ]. Arguments in the docstring but not in the function signature: [kwargs: ].
+    DOC103: Method `Predictor._predict_pandas`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ]. Arguments in the docstring but not in the function signature: [kwargs: ].
+    DOC103: Method `Predictor._predict_numpy`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ]. Arguments in the docstring but not in the function signature: [kwargs: ].
+--------------------
+python/ray/train/tensorflow/tensorflow_predictor.py
+    DOC102: Method `TensorflowPredictor.__init__`: Docstring contains more arguments than in function signature.
+    DOC103: Method `TensorflowPredictor.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the docstring but not in the function signature: [model_weights: ].
+    DOC201: Method `TensorflowPredictor.from_checkpoint` does not have a return section in docstring
+--------------------
+python/ray/train/tensorflow/tensorflow_trainer.py
+    DOC104: Method `TensorflowTrainer.__init__`: Arguments are the same in the docstring and the function signature, but are in a different order.
+    DOC105: Method `TensorflowTrainer.__init__`: Argument names match, but type hints in these args do not match: train_loop_per_worker, train_loop_config, tensorflow_config, scaling_config, dataset_config, run_config, datasets, metadata, resume_from_checkpoint
+--------------------
+python/ray/train/tensorflow/train_loop_utils.py
+    DOC111: Function `prepare_dataset_shard`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+--------------------
+python/ray/train/tests/test_iter_torch_batches_gpu.py
+    DOC101: Method `BaseArrowBatchCollateFn.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `BaseArrowBatchCollateFn.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [device: Optional[Union[str, torch.device]]].
+    DOC101: Method `BaseNumpyBatchCollateFn.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `BaseNumpyBatchCollateFn.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [device: Optional[Union[str, torch.device]]].
+    DOC101: Method `BasePandasBatchCollateFn.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `BasePandasBatchCollateFn.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [device: Optional[Union[str, torch.device]]].
+--------------------
+python/ray/train/tests/test_new_persistence.py
+    DOC101: Function `_get_local_inspect_dir`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_get_local_inspect_dir`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [root_local_path: Path, storage_filesystem: Optional[pyarrow.fs.FileSystem], storage_local_path: Path, storage_path: str].
+--------------------
+python/ray/train/tests/test_worker_group.py
+    DOC106: Function `setup_and_check_worker_group`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `setup_and_check_worker_group`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/train/torch/torch_checkpoint.py
+    DOC201: Method `TorchCheckpoint.get_model` does not have a return section in docstring
+--------------------
+python/ray/train/torch/torch_predictor.py
+    DOC201: Method `TorchPredictor.from_checkpoint` does not have a return section in docstring
+--------------------
+python/ray/train/torch/torch_trainer.py
+    DOC104: Method `TorchTrainer.__init__`: Arguments are the same in the docstring and the function signature, but are in a different order.
+    DOC105: Method `TorchTrainer.__init__`: Argument names match, but type hints in these args do not match: train_loop_per_worker, train_loop_config, torch_config, scaling_config, run_config, datasets, dataset_config, metadata, resume_from_checkpoint
+--------------------
+python/ray/train/torch/train_loop_utils.py
+    DOC201: Function `get_device` does not have a return section in docstring
+    DOC201: Function `get_devices` does not have a return section in docstring
+    DOC111: Function `prepare_model`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Function `prepare_model` does not have a return section in docstring
+    DOC111: Function `prepare_data_loader`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Function `prepare_data_loader` does not have a return section in docstring
+    DOC111: Function `prepare_optimizer`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC111: Function `backward`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC111: Method `TorchWorkerProfiler.__init__`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC111: Method `_TorchAccelerator.prepare_model`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Method `_TorchAccelerator.prepare_model` does not have a return section in docstring
+    DOC111: Method `_TorchAccelerator.prepare_data_loader`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Method `_TorchAccelerator.prepare_data_loader` does not have a return section in docstring
+    DOC111: Method `_TorchAccelerator.prepare_optimizer`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC111: Method `_TorchAccelerator.backward`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+--------------------
+python/ray/train/v2/_internal/callbacks/accelerators.py
+    DOC101: Function `_share_cuda_visible_devices`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_share_cuda_visible_devices`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [worker_group: WorkerGroup].
+    DOC101: Function `_share_accelerator_ids`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_share_accelerator_ids`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [worker_group: WorkerGroup].
+    DOC101: Function `_get_visible_accelerator_ids_per_worker`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_get_visible_accelerator_ids_per_worker`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [accelerator_name: str, worker_metadatas: List[ActorMetadata]].
+--------------------
+python/ray/train/v2/_internal/execution/checkpoint/checkpoint_manager.py
+    DOC103: Method `CheckpointManager.register_checkpoint`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [checkpoint_result: _TrainingResult]. Arguments in the docstring but not in the function signature: [checkpoint: ].
+--------------------
+python/ray/train/v2/_internal/execution/context.py
+    DOC101: Method `TrainContext._save_checkpoint`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TrainContext._save_checkpoint`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [checkpoint: Optional[Checkpoint], checkpoint_dir_name: str, metrics: Dict[str, Any]].
+--------------------
+python/ray/train/v2/_internal/execution/controller/controller.py
+    DOC101: Method `TrainController._start_worker_group`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TrainController._start_worker_group`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [num_workers: int, resources_per_worker: dict].
+--------------------
+python/ray/train/v2/_internal/execution/storage.py
+    DOC101: Method `_ExcludingLocalFilesystem.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `_ExcludingLocalFilesystem.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ].
+    DOC101: Function `_is_directory`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_is_directory`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [fs: pyarrow.fs.FileSystem, fs_path: str].
+    DOC201: Function `_is_directory` does not have a return section in docstring
+    DOC201: Function `get_fs_and_path` does not have a return section in docstring
+    DOC101: Method `StorageContext.persist_current_checkpoint`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `StorageContext.persist_current_checkpoint`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [checkpoint_dir_name: str].
+--------------------
+python/ray/train/v2/_internal/execution/worker_group/worker.py
+    DOC101: Method `Worker.execute_async`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Worker.execute_async`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**fn_kwargs: , *fn_args: , fn: Callable[..., T]].
+--------------------
+python/ray/train/v2/_internal/execution/worker_group/worker_group.py
+    DOC201: Method `WorkerGroup.poll_status` does not have a return section in docstring
+    DOC101: Method `WorkerGroup._poll_workers_and_collect_errors`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `WorkerGroup._poll_workers_and_collect_errors`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [timeout: Optional[float]].
+    DOC101: Method `WorkerGroup.execute_async`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `WorkerGroup.execute_async`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**fn_kwargs: , *fn_args: , fn: Callable].
+    DOC101: Method `WorkerGroup.execute`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `WorkerGroup.execute`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**fn_kwargs: , *fn_args: , fn: Callable[..., T]].
+    DOC101: Method `WorkerGroup.execute_single_async`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `WorkerGroup.execute_single_async`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**fn_kwargs: , *fn_args: , fn: Callable[..., T], rank: int].
+    DOC101: Method `WorkerGroup.execute_single`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `WorkerGroup.execute_single`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**fn_kwargs: , *fn_args: , fn: Callable[..., T], rank: int].
+    DOC101: Method `WorkerGroup._assign_worker_ranks`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `WorkerGroup._assign_worker_ranks`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [workers: List[Worker]].
+    DOC101: Method `WorkerGroup._decorate_worker_log_file_paths`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `WorkerGroup._decorate_worker_log_file_paths`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [workers: List[Worker]].
+    DOC101: Method `WorkerGroup._sort_workers_by_node_id_and_gpu_id`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `WorkerGroup._sort_workers_by_node_id_and_gpu_id`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [workers: List[Worker]].
+    DOC201: Method `WorkerGroup._sort_workers_by_node_id_and_gpu_id` does not have a return section in docstring
+--------------------
+python/ray/train/v2/_internal/metrics/base.py
+    DOC201: Method `EnumMetric.record` does not have a return section in docstring
+--------------------
+python/ray/train/v2/_internal/util.py
+    DOC111: Function `construct_train_func`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC101: Function `get_callable_name`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `get_callable_name`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [fn: Callable].
+    DOC201: Function `get_callable_name` does not have a return section in docstring
+--------------------
+python/ray/train/v2/api/context.py
+    DOC201: Method `TrainContext.get_local_world_size` does not have a return section in docstring
+    DOC201: Method `TrainContext.get_node_rank` does not have a return section in docstring
+--------------------
+python/ray/train/v2/api/train_fn_utils.py
+    DOC101: Function `report`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `report`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [checkpoint_dir_name: Optional[str]].
+--------------------
+python/ray/train/v2/lightgbm/lightgbm_trainer.py
+    DOC101: Method `LightGBMTrainer.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `LightGBMTrainer.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [label_column: Optional[str], num_boost_round: Optional[int], params: Optional[Dict[str, Any]]].
+--------------------
+python/ray/train/v2/tensorflow/tensorflow_trainer.py
+    DOC101: Method `TensorflowTrainer.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TensorflowTrainer.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [dataset_config: Optional[DataConfig]].
+--------------------
+python/ray/train/v2/tests/test_persistence.py
+    DOC101: Function `_get_local_inspect_dir`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_get_local_inspect_dir`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [root_local_path: Path, storage_filesystem: Optional[pyarrow.fs.FileSystem], storage_local_path: Path, storage_path: str].
+--------------------
+python/ray/train/v2/tests/test_worker_group.py
+    DOC106: Function `setup_and_check_worker_group`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `setup_and_check_worker_group`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `setup_and_check_worker_group`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [node_ids: ]. Arguments in the docstring but not in the function signature: [ids: ].
+--------------------
+python/ray/train/v2/torch/torch_trainer.py
+    DOC104: Method `TorchTrainer.__init__`: Arguments are the same in the docstring and the function signature, but are in a different order.
+    DOC105: Method `TorchTrainer.__init__`: Argument names match, but type hints in these args do not match: train_loop_per_worker, train_loop_config, torch_config, scaling_config, run_config, datasets, dataset_config, metadata, resume_from_checkpoint
+--------------------
+python/ray/train/v2/torch/train_loop_utils.py
+    DOC111: Function `prepare_model`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Function `prepare_model` does not have a return section in docstring
+    DOC111: Function `prepare_data_loader`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Function `prepare_data_loader` does not have a return section in docstring
+--------------------
+python/ray/train/v2/xgboost/xgboost_trainer.py
+    DOC101: Method `XGBoostTrainer.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `XGBoostTrainer.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [label_column: Optional[str], num_boost_round: Optional[int], params: Optional[Dict[str, Any]]].
+--------------------
+python/ray/train/xgboost/_xgboost_utils.py
+    DOC201: Method `RayTrainReportCallback.get_model` does not have a return section in docstring
+--------------------
+python/ray/train/xgboost/v2.py
+    DOC104: Method `XGBoostTrainer.__init__`: Arguments are the same in the docstring and the function signature, but are in a different order.
+    DOC105: Method `XGBoostTrainer.__init__`: Argument names match, but type hints in these args do not match: train_loop_per_worker, train_loop_config, xgboost_config, scaling_config, run_config, datasets, dataset_config, metadata, resume_from_checkpoint
+--------------------
+python/ray/train/xgboost/xgboost_predictor.py
+    DOC201: Method `XGBoostPredictor.from_checkpoint` does not have a return section in docstring
+--------------------
+python/ray/train/xgboost/xgboost_trainer.py
+    DOC104: Method `XGBoostTrainer.__init__`: Arguments are the same in the docstring and the function signature, but are in a different order.
+    DOC105: Method `XGBoostTrainer.__init__`: Argument names match, but type hints in these args do not match: train_loop_per_worker, train_loop_config, xgboost_config, scaling_config, run_config, datasets, dataset_config, resume_from_checkpoint, metadata, label_column, params, num_boost_round
+--------------------
+python/ray/tune/analysis/experiment_analysis.py
+    DOC101: Method `ExperimentAnalysis.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ExperimentAnalysis.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [storage_filesystem: Optional[pyarrow.fs.FileSystem]].
+    DOC201: Method `ExperimentAnalysis.get_best_config` does not have a return section in docstring
+    DOC106: Method `ExperimentAnalysis.get_last_checkpoint`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `ExperimentAnalysis.get_last_checkpoint`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/tune/callback.py
+    DOC101: Method `CallbackList.can_restore`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `CallbackList.can_restore`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [checkpoint_dir: str].
+--------------------
+python/ray/tune/cli/commands.py
+    DOC101: Function `print_format_output`: Docstring contains fewer arguments than in function signature.
+    DOC106: Function `print_format_output`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `print_format_output`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `print_format_output`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [dataframe: ].
+--------------------
+python/ray/tune/examples/hyperopt_conditional_search_space_example.py
+    DOC106: Function `f_unpack_dict`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `f_unpack_dict`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/tune/examples/xgboost_dynamic_resources_example.py
+    DOC201: Function `example_resources_allocation_function` does not have a return section in docstring
+--------------------
+python/ray/tune/execution/experiment_state.py
+    DOC101: Function `_find_newest_experiment_checkpoint`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_find_newest_experiment_checkpoint`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [fs: Optional[pyarrow.fs.FileSystem]].
+    DOC201: Method `_ExperimentCheckpointManager.sync_up_experiment_state` does not have a return section in docstring
+--------------------
+python/ray/tune/execution/tune_controller.py
+    DOC101: Method `TuneController._execute_action`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TuneController._execute_action`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [after_save: bool].
+    DOC101: Method `TuneController._process_trial_save`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TuneController._process_trial_save`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [checkpoint_value: _TrainingResult].
+--------------------
+python/ray/tune/experiment/config_parser.py
+    DOC106: Function `_make_parser`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `_make_parser`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `_make_parser`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ]. Arguments in the docstring but not in the function signature: [kwargs: ].
+    DOC201: Function `_make_parser` does not have a return section in docstring
+    DOC103: Function `_create_trial_from_spec`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**trial_kwargs: ]. Arguments in the docstring but not in the function signature: [trial_kwargs: ].
+--------------------
+python/ray/tune/experiment/experiment.py
+    DOC201: Method `Experiment.from_json` does not have a return section in docstring
+--------------------
+python/ray/tune/experiment/trial.py
+    DOC101: Method `ExportFormat.validate`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `ExportFormat.validate`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `ExportFormat.validate`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `ExportFormat.validate`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [formats: ].
+    DOC101: Method `_TrialInfo.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `_TrialInfo.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [trial: 'Trial'].
+    DOC101: Method `Trial.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Trial.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [checkpoint_config: Optional[CheckpointConfig], config: Optional[Dict], evaluated_params: Optional[Dict], experiment_tag: str, export_formats: Optional[List[str]], log_to_file: Union[Optional[str], Tuple[Optional[str], Optional[str]]], max_failures: int, placement_group_factory: Optional[PlacementGroupFactory], restore_path: Optional[str], stopping_criterion: Optional[Dict[str, float]], storage: Optional[StorageContext], stub: bool, trainable_name: str, trial_dirname_creator: Optional[Callable[['Trial'], str]], trial_id: Optional[str], trial_name_creator: Optional[Callable[['Trial'], str]]].
+    DOC101: Method `Trial.update_resources`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Trial.update_resources`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [resources: Union[dict, PlacementGroupFactory]].
+    DOC103: Method `Trial.on_checkpoint`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [checkpoint_result: _TrainingResult]. Arguments in the docstring but not in the function signature: [checkpoint: ].
+--------------------
+python/ray/tune/experimental/output.py
+    DOC101: Function `_max_len`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_max_len`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [wrap: bool].
+    DOC201: Function `_max_len` does not have a return section in docstring
+    DOC201: Function `_get_trial_info` does not have a return section in docstring
+    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
+    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
+    DOC101: Method `ProgressReporter.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ProgressReporter.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [progress_metrics: Optional[Union[List[str], List[Dict[str, str]]]], verbosity: AirVerbosity].
+--------------------
+python/ray/tune/impl/tuner_internal.py
+    DOC101: Method `TunerInternal.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TunerInternal.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_entrypoint: AirEntrypoint, _tuner_kwargs: Optional[Dict], storage_filesystem: Optional[pyarrow.fs.FileSystem]].
+    DOC101: Method `TunerInternal._validate_trainable`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TunerInternal._validate_trainable`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [required_trainable_name: Optional[str], trainable: TrainableType].
+    DOC201: Method `TunerInternal._validate_trainable` does not have a return section in docstring
+    DOC101: Method `TunerInternal._validate_param_space_on_restore`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TunerInternal._validate_param_space_on_restore`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [flattened_param_space_keys: Optional[List[str]], new_param_space: Dict[str, Any]].
+    DOC201: Method `TunerInternal._validate_param_space_on_restore` does not have a return section in docstring
+    DOC103: Method `TunerInternal._load_tuner_state`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [tuner_state: Dict[str, Any]]. Arguments in the docstring but not in the function signature: [tuner_pkl_path: ].
+    DOC201: Method `TunerInternal._choose_run_config` does not have a return section in docstring
+--------------------
+python/ray/tune/logger/aim.py
+    DOC304: Class `AimLoggerCallback`: Class docstring has an argument/parameter section; please put it in the __init__() docstring
+--------------------
+python/ray/tune/logger/logger.py
+    DOC101: Method `LoggerCallback.log_trial_result`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `LoggerCallback.log_trial_result`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [iteration: int].
+--------------------
+python/ray/tune/logger/unified.py
+    DOC101: Method `UnifiedLogger.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `UnifiedLogger.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [trial: Optional['Trial']].
+--------------------
+python/ray/tune/progress_reporter.py
+    DOC103: Method `ProgressReporter.report`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [*sys_info: Dict]. Arguments in the docstring but not in the function signature: [sys_info: ].
+    DOC101: Method `TuneReporterBase.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TuneReporterBase.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [total_samples: Optional[int]].
+    DOC101: Method `TuneReporterBase._progress_str`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `TuneReporterBase._progress_str`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [*sys_info: Dict].
+    DOC201: Method `TuneReporterBase._progress_str` does not have a return section in docstring
+    DOC101: Method `JupyterNotebookReporter.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `JupyterNotebookReporter.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [total_samples: Optional[int]].
+    DOC101: Method `CLIReporter.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `CLIReporter.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [total_samples: Optional[int]].
+    DOC201: Function `_trial_progress_str` does not have a return section in docstring
+    DOC101: Function `_max_len`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_max_len`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [wrap: bool].
+    DOC201: Function `_max_len` does not have a return section in docstring
+    DOC101: Function `_generate_sys_info_str`: Docstring contains fewer arguments than in function signature.
+    DOC106: Function `_generate_sys_info_str`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC103: Function `_generate_sys_info_str`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [*sys_info: ].
+    DOC201: Function `_trial_errors_str` does not have a return section in docstring
+    DOC101: Function `_fair_filter_trials`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_fair_filter_trials`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [max_trials: int, sort_by_metric: bool].
+    DOC201: Function `_get_trial_info` does not have a return section in docstring
+    DOC201: Method `TrialProgressCallback.display_result` does not have a return section in docstring
+--------------------
+python/ray/tune/registry.py
+    DOC101: Function `register_trainable`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `register_trainable`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [warn: bool].
+    DOC106: Method `_Registry.register`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `_Registry.register`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/tune/result_grid.py
+    DOC101: Method `ResultGrid.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ResultGrid.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [experiment_analysis: ExperimentAnalysis].
+    DOC201: Method `ResultGrid.get_best_result` does not have a return section in docstring
+--------------------
+python/ray/tune/schedulers/__init__.py
+    DOC106: Function `create_scheduler`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `create_scheduler`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/tune/schedulers/async_hyperband.py
+    DOC101: Method `_Bracket.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `_Bracket.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [max_t: int, min_t: int, reduction_factor: float, s: int, stop_last_trials: bool].
+--------------------
+python/ray/tune/schedulers/pb2.py
+    DOC201: Function `_select_config` does not have a return section in docstring
+    DOC104: Method `PB2.__init__`: Arguments are the same in the docstring and the function signature, but are in a different order.
+    DOC105: Method `PB2.__init__`: Argument names match, but type hints in these args do not match: time_attr, metric, mode, perturbation_interval, hyperparam_bounds, quantile_fraction, log_config, require_attrs, synch, custom_explore_fn
+    DOC101: Method `PB2._validate_hyperparam_bounds`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `PB2._validate_hyperparam_bounds`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [hyperparam_bounds: dict].
+--------------------
+python/ray/tune/schedulers/pbt.py
+    DOC201: Method `PopulationBasedTraining._save_trial_state` does not have a return section in docstring
+--------------------
+python/ray/tune/schedulers/resource_changing_scheduler.py
+    DOC201: Method `DistributeResources.__call__` does not have a return section in docstring
+--------------------
+python/ray/tune/schedulers/trial_scheduler.py
+    DOC201: Method `TrialScheduler.set_search_properties` does not have a return section in docstring
+--------------------
+python/ray/tune/search/__init__.py
+    DOC102: Function `create_searcher`: Docstring contains more arguments than in function signature.
+    DOC106: Function `create_searcher`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `create_searcher`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `create_searcher`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the docstring but not in the function signature: [metric: , mode: ].
+--------------------
+python/ray/tune/search/basic_variant.py
+    DOC111: Method `_TrialIterator.__init__`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+--------------------
+python/ray/tune/search/bayesopt/bayesopt_search.py
+    DOC201: Method `BayesOptSearch.on_trial_complete` does not have a return section in docstring
+--------------------
+python/ray/tune/search/sample.py
+    DOC201: Function `sample_from` does not have a return section in docstring
+    DOC101: Function `loguniform`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `loguniform`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [base: object].
+    DOC201: Function `loguniform` does not have a return section in docstring
+    DOC101: Function `qloguniform`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `qloguniform`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [base: object].
+    DOC201: Function `qloguniform` does not have a return section in docstring
+    DOC201: Function `randn` does not have a return section in docstring
+    DOC201: Function `qrandn` does not have a return section in docstring
+--------------------
+python/ray/tune/search/search_algorithm.py
+    DOC201: Method `SearchAlgorithm.set_search_properties` does not have a return section in docstring
+    DOC202: Method `SearchAlgorithm.next_trial` has a return section in docstring, but there are no return statements or annotations
+--------------------
+python/ray/tune/search/searcher.py
+    DOC201: Method `Searcher.set_search_properties` does not have a return section in docstring
+    DOC201: Method `Searcher.set_max_concurrency` does not have a return section in docstring
+--------------------
+python/ray/tune/search/variant_generator.py
+    DOC201: Function `grid_search` does not have a return section in docstring
+--------------------
+python/ray/tune/search/zoopt/zoopt_search.py
+    DOC101: Method `ZOOptSearch.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ZOOptSearch.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ].
+--------------------
+python/ray/tune/stopper/trial_plateau.py
+    DOC111: Method `TrialPlateauStopper.__init__`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+--------------------
+python/ray/tune/trainable/trainable.py
+    DOC103: Method `Trainable.default_resource_request`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [config: Dict[str, Any]]. Arguments in the docstring but not in the function signature: [config[Dict[str, Any]]: ].
+    DOC201: Method `Trainable.resource_help` does not have a return section in docstring
+    DOC201: Method `Trainable.train_buffered` does not have a return section in docstring
+    DOC202: Method `Trainable.step` has a return section in docstring, but there are no return statements or annotations
+    DOC201: Method `Trainable._export_model` does not have a return section in docstring
+--------------------
+python/ray/tune/trainable/util.py
+    DOC201: Function `with_parameters` does not have a return section in docstring
+    DOC201: Function `with_resources` does not have a return section in docstring
+--------------------
+python/ray/tune/tune.py
+    DOC101: Function `run`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `run`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_entrypoint: AirEntrypoint, _remote_string_queue: Optional[Queue], checkpoint_config: Optional[CheckpointConfig], storage_filesystem: Optional['pyarrow.fs.FileSystem']]. Arguments in the docstring but not in the function signature: [checkpoint_keep_all_ranks: , checkpoint_upload_from_workers: ].
+    DOC101: Function `run_experiments`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `run_experiments`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_remote: Optional[bool], callbacks: Optional[Sequence[Callback]], concurrent: bool, experiments: Union[Experiment, Mapping, Sequence[Union[Experiment, Mapping]]], progress_reporter: Optional[ProgressReporter], raise_on_failed_trial: bool, resume: Optional[Union[bool, str]], resume_config: Optional[ResumeConfig], reuse_actors: bool, scheduler: Optional[TrialScheduler], verbose: Optional[Union[int, AirVerbosity, Verbosity]]].
+--------------------
+python/ray/tune/tuner.py
+    DOC304: Class `Tuner`: Class docstring has an argument/parameter section; please put it in the __init__() docstring
+    DOC104: Method `Tuner.restore`: Arguments are the same in the docstring and the function signature, but are in a different order.
+    DOC105: Method `Tuner.restore`: Argument names match, but type hints in these args do not match: path, trainable, resume_unfinished, resume_errored, restart_errored, param_space, storage_filesystem, _resume_config
+    DOC201: Method `Tuner.restore` does not have a return section in docstring
+    DOC101: Method `Tuner.can_restore`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Tuner.can_restore`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [storage_filesystem: Optional[pyarrow.fs.FileSystem]].
+    DOC201: Method `Tuner.fit` does not have a return section in docstring
+--------------------
+python/ray/tune/utils/object_cache.py
+    DOC404: Method `_ObjectCache.flush_cached_objects` yield type(s) in docstring not consistent with the return annotation. The yield type (the 0th arg in Generator[...]/Iterator[...]): U; docstring "yields" section types:
+--------------------
+python/ray/tune/utils/util.py
+    DOC101: Method `warn_if_slow.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `warn_if_slow.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [disable: bool, message: Optional[str], name: str, threshold: Optional[float]].
+    DOC101: Function `wait_for_gpu`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `wait_for_gpu`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [gpu_memory_limit: Optional[float]].
+    DOC202: Function `wait_for_gpu` has a return section in docstring, but there are no return statements or annotations
+    DOC102: Function `validate_save_restore`: Docstring contains more arguments than in function signature.
+    DOC103: Function `validate_save_restore`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the docstring but not in the function signature: [use_object_store: ].
+    DOC201: Function `validate_save_restore` does not have a return section in docstring
+--------------------
+python/ray/util/actor_group.py
+    DOC101: Method `ActorGroup.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC111: Method `ActorGroup.__init__`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Method `ActorGroup.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [init_args: Optional[Tuple], init_kwargs: Optional[Dict]]. Arguments in the docstring but not in the function signature: [init_args, init_kwargs: ].
+    DOC111: Method `ActorGroup.remove_actors`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+--------------------
+python/ray/util/actor_pool.py
+    DOC106: Method `ActorPool.submit`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `ActorPool.submit`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC101: Method `ActorPool.get_next`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `ActorPool.get_next`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `ActorPool.get_next`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `ActorPool.get_next`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [ignore_if_timedout: , timeout: ].
+    DOC101: Method `ActorPool.get_next_unordered`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `ActorPool.get_next_unordered`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `ActorPool.get_next_unordered`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `ActorPool.get_next_unordered`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [ignore_if_timedout: , timeout: ].
+    DOC101: Method `ActorPool.push`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `ActorPool.push`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `ActorPool.push`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `ActorPool.push`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [actor: ].
+--------------------
+python/ray/util/annotations.py
+    DOC106: Function `PublicAPI`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC103: Function `PublicAPI`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ]. Arguments in the docstring but not in the function signature: [api_group: , stability: ].
+    DOC201: Function `PublicAPI` does not have a return section in docstring
+    DOC101: Function `DeveloperAPI`: Docstring contains fewer arguments than in function signature.
+    DOC106: Function `DeveloperAPI`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC103: Function `DeveloperAPI`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ].
+    DOC201: Function `DeveloperAPI` does not have a return section in docstring
+    DOC101: Function `Deprecated`: Docstring contains fewer arguments than in function signature.
+    DOC106: Function `Deprecated`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC103: Function `Deprecated`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ]. Arguments in the docstring but not in the function signature: [message: ].
+    DOC201: Function `Deprecated` does not have a return section in docstring
+    DOC101: Function `_get_indent`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_get_indent`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [docstring: str].
+    DOC201: Function `_get_indent` does not have a return section in docstring
+--------------------
+python/ray/util/check_serialize.py
+    DOC101: Method `FailureTuple.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `FailureTuple.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [name: str, obj: Any, parent: Any].
+--------------------
+python/ray/util/client/__init__.py
+    DOC101: Method `_ClientContext.connect`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `_ClientContext.connect`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_credentials: Optional['grpc.ChannelCredentials'], namespace: str, ray_init_kwargs: Optional[Dict[str, Any]]].
+    DOC106: Method `_ClientContext.remote`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC103: Method `_ClientContext.remote`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ]. Arguments in the docstring but not in the function signature: [args: , kwargs: ].
+    DOC201: Method `_ClientContext.remote` does not have a return section in docstring
+--------------------
+python/ray/util/client/api.py
+    DOC106: Method `_ClientAPI.get`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `_ClientAPI.get`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC201: Method `_ClientAPI.get` does not have a return section in docstring
+    DOC102: Method `_ClientAPI.put`: Docstring contains more arguments than in function signature.
+    DOC106: Method `_ClientAPI.put`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC103: Method `_ClientAPI.put`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ]. Arguments in the docstring but not in the function signature: [args: , kwargs: , val: ].
+    DOC201: Method `_ClientAPI.put` does not have a return section in docstring
+    DOC106: Method `_ClientAPI.wait`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC103: Method `_ClientAPI.wait`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ]. Arguments in the docstring but not in the function signature: [args: , kwargs: ].
+    DOC201: Method `_ClientAPI.wait` does not have a return section in docstring
+    DOC106: Method `_ClientAPI.remote`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC103: Method `_ClientAPI.remote`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ]. Arguments in the docstring but not in the function signature: [args: , kwargs: ].
+    DOC201: Method `_ClientAPI.remote` does not have a return section in docstring
+    DOC103: Method `_ClientAPI.call_remote`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ]. Arguments in the docstring but not in the function signature: [args: , kwargs: ].
+    DOC201: Method `_ClientAPI.call_remote` does not have a return section in docstring
+    DOC101: Method `_ClientAPI.get_actor`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `_ClientAPI.get_actor`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [namespace: Optional[str]].
+    DOC201: Method `_ClientAPI.get_actor` does not have a return section in docstring
+    DOC101: Method `_ClientAPI.kill`: Docstring contains fewer arguments than in function signature.
+    DOC107: Method `_ClientAPI.kill`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `_ClientAPI.kill`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [actor: 'ClientActorHandle'].
+    DOC201: Method `_ClientAPI.kill` does not have a return section in docstring
+    DOC107: Method `_ClientAPI.cancel`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `_ClientAPI.cancel`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [obj: 'ClientObjectRef']. Arguments in the docstring but not in the function signature: [object_ref: ].
+    DOC201: Method `_ClientAPI.cancel` does not have a return section in docstring
+    DOC101: Method `_ClientAPI.method`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `_ClientAPI.method`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC103: Method `_ClientAPI.method`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ]. Arguments in the docstring but not in the function signature: [num_returns: ].
+    DOC201: Method `_ClientAPI.method` does not have a return section in docstring
+--------------------
+python/ray/util/client/common.py
+    DOC102: Method `ClientRemoteFunc.__init__`: Docstring contains more arguments than in function signature.
+    DOC106: Method `ClientRemoteFunc.__init__`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `ClientRemoteFunc.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `ClientRemoteFunc.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [f: , options: ]. Arguments in the docstring but not in the function signature: [_func: , _name: , _ref: ].
+    DOC102: Method `ClientActorClass.__init__`: Docstring contains more arguments than in function signature.
+    DOC106: Method `ClientActorClass.__init__`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `ClientActorClass.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `ClientActorClass.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [options: ]. Arguments in the docstring but not in the function signature: [_name: , _ref: ].
+    DOC101: Method `ClientActorHandle.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ClientActorHandle.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [actor_class: Optional[ClientActorClass]].
+    DOC101: Method `ClientRemoteMethod.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ClientRemoteMethod.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [num_returns: int, signature: inspect.Signature].
+--------------------
+python/ray/util/client/server/server.py
+    DOC107: Method `RayletServicer._put_object`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC201: Method `RayletServicer._put_object` does not have a return section in docstring
+--------------------
+python/ray/util/client/worker.py
+    DOC201: Method `Worker._add_ids_to_metadata` does not have a return section in docstring
+--------------------
+python/ray/util/collective/collective.py
+    DOC101: Function `init_collective_group`: Docstring contains fewer arguments than in function signature.
+    DOC107: Function `init_collective_group`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `init_collective_group`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [gloo_timeout: int].
+    DOC202: Function `init_collective_group` has a return section in docstring, but there are no return statements or annotations
+    DOC101: Function `create_collective_group`: Docstring contains fewer arguments than in function signature.
+    DOC107: Function `create_collective_group`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC111: Function `create_collective_group`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Function `create_collective_group`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [gloo_timeout: int].
+    DOC202: Function `create_collective_group` has a return section in docstring, but there are no return statements or annotations
+    DOC107: Function `allreduce`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Function `allreduce` has a return section in docstring, but there are no return statements or annotations
+    DOC101: Function `allreduce_multigpu`: Docstring contains fewer arguments than in function signature.
+    DOC107: Function `allreduce_multigpu`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC111: Function `allreduce_multigpu`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Function `allreduce_multigpu`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [op: ].
+    DOC202: Function `allreduce_multigpu` has a return section in docstring, but there are no return statements or annotations
+    DOC202: Function `barrier` has a return section in docstring, but there are no return statements or annotations
+    DOC107: Function `reduce`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Function `reduce` has a return section in docstring, but there are no return statements or annotations
+    DOC107: Function `reduce_multigpu`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Function `reduce_multigpu` has a return section in docstring, but there are no return statements or annotations
+    DOC107: Function `broadcast`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Function `broadcast` has a return section in docstring, but there are no return statements or annotations
+    DOC107: Function `broadcast_multigpu`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Function `broadcast_multigpu` has a return section in docstring, but there are no return statements or annotations
+    DOC107: Function `allgather`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Function `allgather` has a return section in docstring, but there are no return statements or annotations
+    DOC111: Function `allgather_multigpu`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC202: Function `allgather_multigpu` has a return section in docstring, but there are no return statements or annotations
+    DOC107: Function `reducescatter`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Function `reducescatter` has a return section in docstring, but there are no return statements or annotations
+    DOC107: Function `reducescatter_multigpu`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Function `reducescatter_multigpu` has a return section in docstring, but there are no return statements or annotations
+    DOC107: Function `send`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Function `send` has a return section in docstring, but there are no return statements or annotations
+    DOC107: Function `send_multigpu`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Function `send_multigpu` has a return section in docstring, but there are no return statements or annotations
+    DOC107: Function `recv`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Function `recv` has a return section in docstring, but there are no return statements or annotations
+    DOC101: Function `recv_multigpu`: Docstring contains fewer arguments than in function signature.
+    DOC107: Function `recv_multigpu`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `recv_multigpu`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [n_elements: int].
+    DOC202: Function `recv_multigpu` has a return section in docstring, but there are no return statements or annotations
+    DOC202: Function `synchronize` has a return section in docstring, but there are no return statements or annotations
+--------------------
+python/ray/util/collective/collective_group/base_collective_group.py
+    DOC106: Method `BaseGroup.__init__`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `BaseGroup.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/util/collective/collective_group/cuda_stream.py
+    DOC106: Method `StreamPool.__init__`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `StreamPool.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/util/collective/collective_group/gloo_collective_group.py
+    DOC101: Method `Rendezvous.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `Rendezvous.__init__`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `Rendezvous.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `Rendezvous.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [context: , device_type: , store_type: ].
+    DOC106: Method `Rendezvous.meet`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `Rendezvous.meet`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Method `GLOOGroup.__init__`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `GLOOGroup.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Method `GLOOGroup.allreduce`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `GLOOGroup.allreduce`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `GLOOGroup.allreduce`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [tensors: ]. Arguments in the docstring but not in the function signature: [tensor: ].
+    DOC202: Method `GLOOGroup.allreduce` has a return section in docstring, but there are no return statements or annotations
+    DOC106: Method `GLOOGroup.barrier`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `GLOOGroup.barrier`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Method `GLOOGroup.barrier` has a return section in docstring, but there are no return statements or annotations
+    DOC106: Method `GLOOGroup.reduce`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `GLOOGroup.reduce`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Method `GLOOGroup.reduce` has a return section in docstring, but there are no return statements or annotations
+    DOC106: Method `GLOOGroup.broadcast`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `GLOOGroup.broadcast`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Method `GLOOGroup.broadcast` has a return section in docstring, but there are no return statements or annotations
+    DOC106: Method `GLOOGroup.allgather`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `GLOOGroup.allgather`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC111: Method `GLOOGroup.allgather`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC202: Method `GLOOGroup.allgather` has a return section in docstring, but there are no return statements or annotations
+    DOC106: Method `GLOOGroup.reducescatter`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `GLOOGroup.reducescatter`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC111: Method `GLOOGroup.reducescatter`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC202: Method `GLOOGroup.reducescatter` has a return section in docstring, but there are no return statements or annotations
+    DOC106: Method `GLOOGroup.send`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `GLOOGroup.send`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Method `GLOOGroup.send` has a return section in docstring, but there are no return statements or annotations
+    DOC106: Method `GLOOGroup.recv`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `GLOOGroup.recv`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Method `GLOOGroup.recv` has a return section in docstring, but there are no return statements or annotations
+    DOC106: Method `GLOOGroup._collective`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `GLOOGroup._collective`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Method `GLOOGroup._collective` has a return section in docstring, but there are no return statements or annotations
+    DOC107: Method `GLOOGroup._point2point`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Method `GLOOGroup._point2point` has a return section in docstring, but there are no return statements or annotations
+    DOC106: Function `_flatten_for_scatter_gather`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `_flatten_for_scatter_gather`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/util/collective/collective_group/gloo_util.py
+    DOC106: Function `create_gloo_context`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `create_gloo_context`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Function `get_gloo_reduce_op`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `get_gloo_reduce_op`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Function `copy_tensor`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `copy_tensor`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Function `copy_tensor` has a return section in docstring, but there are no return statements or annotations
+--------------------
+python/ray/util/collective/collective_group/nccl_collective_group.py
+    DOC106: Method `Rendezvous.__init__`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `Rendezvous.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Method `Rendezvous.meet`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `Rendezvous.meet`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Method `Rendezvous.get_nccl_id`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `Rendezvous.get_nccl_id`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC201: Method `Rendezvous.get_nccl_id` does not have a return section in docstring
+    DOC106: Method `NCCLGroup.allreduce`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `NCCLGroup.allreduce`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Method `NCCLGroup.allreduce` has a return section in docstring, but there are no return statements or annotations
+    DOC106: Method `NCCLGroup.barrier`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `NCCLGroup.barrier`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Method `NCCLGroup.barrier` has a return section in docstring, but there are no return statements or annotations
+    DOC106: Method `NCCLGroup.reduce`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `NCCLGroup.reduce`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Method `NCCLGroup.reduce` has a return section in docstring, but there are no return statements or annotations
+    DOC106: Method `NCCLGroup.broadcast`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `NCCLGroup.broadcast`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Method `NCCLGroup.broadcast` has a return section in docstring, but there are no return statements or annotations
+    DOC106: Method `NCCLGroup.allgather`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `NCCLGroup.allgather`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC111: Method `NCCLGroup.allgather`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC202: Method `NCCLGroup.allgather` has a return section in docstring, but there are no return statements or annotations
+    DOC106: Method `NCCLGroup.reducescatter`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `NCCLGroup.reducescatter`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC111: Method `NCCLGroup.reducescatter`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC202: Method `NCCLGroup.reducescatter` has a return section in docstring, but there are no return statements or annotations
+    DOC106: Method `NCCLGroup.send`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `NCCLGroup.send`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Method `NCCLGroup.send` has a return section in docstring, but there are no return statements or annotations
+    DOC106: Method `NCCLGroup.recv`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `NCCLGroup.recv`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Method `NCCLGroup.recv` has a return section in docstring, but there are no return statements or annotations
+    DOC106: Method `NCCLGroup._get_nccl_collective_communicator`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `NCCLGroup._get_nccl_collective_communicator`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Method `NCCLGroup._get_nccl_p2p_communicator`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `NCCLGroup._get_nccl_p2p_communicator`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Method `NCCLGroup._destroy_store`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `NCCLGroup._destroy_store`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Method `NCCLGroup._destroy_store` has a return section in docstring, but there are no return statements or annotations
+    DOC106: Method `NCCLGroup._generate_nccl_uid`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `NCCLGroup._generate_nccl_uid`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Method `NCCLGroup._collective`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `NCCLGroup._collective`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Method `NCCLGroup._collective` has a return section in docstring, but there are no return statements or annotations
+    DOC107: Method `NCCLGroup._point2point`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Method `NCCLGroup._point2point` has a return section in docstring, but there are no return statements or annotations
+    DOC106: Function `_flatten_for_scatter_gather`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `_flatten_for_scatter_gather`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Function `_get_comm_key_from_devices`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `_get_comm_key_from_devices`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Function `_get_comm_key_send_recv`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `_get_comm_key_send_recv`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/util/collective/collective_group/nccl_util.py
+    DOC106: Function `create_nccl_communicator`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `create_nccl_communicator`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Function `get_nccl_reduce_op`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `get_nccl_reduce_op`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Function `copy_tensor`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `copy_tensor`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Function `copy_tensor` has a return section in docstring, but there are no return statements or annotations
+    DOC106: Function `get_tensor_device_list`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `get_tensor_device_list`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/util/collective/const.py
+    DOC106: Function `get_store_name`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `get_store_name`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC201: Function `get_store_name` does not have a return section in docstring
+--------------------
+python/ray/util/collective/util.py
+    DOC106: Method `NCCLUniqueIDStore.__init__`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `NCCLUniqueIDStore.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Method `NCCLUniqueIDStore.set_id`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `NCCLUniqueIDStore.set_id`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/util/dask/callbacks.py
+    DOC106: Method `RayDaskCallback._ray_presubmit`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `RayDaskCallback._ray_presubmit`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC107: Method `RayDaskCallback._ray_postsubmit`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC107: Method `RayDaskCallback._ray_pretask`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Method `RayDaskCallback._ray_pretask` has a return section in docstring, but there are no return statements or annotations
+    DOC106: Method `RayDaskCallback._ray_posttask`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `RayDaskCallback._ray_posttask`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC107: Method `RayDaskCallback._ray_postsubmit_all`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Method `RayDaskCallback._ray_finish`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `RayDaskCallback._ray_finish`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/util/dask/common.py
+    DOC106: Function `unpack_object_refs`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+--------------------
+python/ray/util/dask/scheduler.py
+    DOC102: Function `ray_dask_get`: Docstring contains more arguments than in function signature.
+    DOC106: Function `ray_dask_get`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `ray_dask_get`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC111: Function `ray_dask_get`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Function `ray_dask_get`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ]. Arguments in the docstring but not in the function signature: [num_workers: Optional[int], pool: Optional[ThreadPool], ray_callbacks: Optional[list[callable]]].
+    DOC106: Function `_apply_async_wrapper`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `_apply_async_wrapper`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Function `_rayify_task_wrapper`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `_rayify_task_wrapper`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Function `_rayify_task`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `_rayify_task`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC106: Function `dask_task_wrapper`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `dask_task_wrapper`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC111: Function `dask_task_wrapper`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC101: Function `ray_get_unpack`: Docstring contains fewer arguments than in function signature.
+    DOC106: Function `ray_get_unpack`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `ray_get_unpack`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `ray_get_unpack`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [progress_bar_actor: ].
+    DOC202: Function `ray_get_unpack` has a return section in docstring, but there are no return statements or annotations
+    DOC101: Function `ray_dask_get_sync`: Docstring contains fewer arguments than in function signature.
+    DOC106: Function `ray_dask_get_sync`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `ray_dask_get_sync`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC111: Function `ray_dask_get_sync`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC103: Function `ray_dask_get_sync`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ].
+--------------------
+python/ray/util/debug.py
+    DOC101: Function `log_once`: Docstring contains fewer arguments than in function signature.
+    DOC106: Function `log_once`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `log_once`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `log_once`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [key: ].
+    DOC201: Function `log_once` does not have a return section in docstring
+--------------------
+python/ray/util/iter.py
+    DOC201: Function `from_items` does not have a return section in docstring
+    DOC201: Function `from_range` does not have a return section in docstring
+    DOC107: Function `from_iterators`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC201: Function `from_iterators` does not have a return section in docstring
+    DOC107: Function `from_actors`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC201: Function `from_actors` does not have a return section in docstring
+    DOC107: Method `ParallelIterator.for_each`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC201: Method `ParallelIterator.filter` does not have a return section in docstring
+    DOC201: Method `ParallelIterator.batch` does not have a return section in docstring
+    DOC201: Method `ParallelIterator.flatten` does not have a return section in docstring
+    DOC201: Method `ParallelIterator.gather_sync` does not have a return section in docstring
+    DOC201: Method `ParallelIterator.batch_across_shards` does not have a return section in docstring
+    DOC106: Method `ParallelIterator.gather_async`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `ParallelIterator.gather_async`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC201: Method `ParallelIterator.gather_async` does not have a return section in docstring
+    DOC201: Method `ParallelIterator.get_shard` does not have a return section in docstring
+    DOC107: Method `LocalIterator.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC101: Method `LocalIterator.duplicate`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `LocalIterator.duplicate`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `LocalIterator.duplicate`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `LocalIterator.duplicate`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [n: ].
+    DOC101: Method `LocalIterator.union`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `LocalIterator.union`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [*others: 'LocalIterator[T]'].
+    DOC201: Method `LocalIterator.union` does not have a return section in docstring
+--------------------
+python/ray/util/metrics.py
+    DOC101: Method `Metric._record`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Metric._record`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [tags: Optional[Dict[str, str]]].
+    DOC111: Method `Counter.inc`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC111: Method `Histogram.observe`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC111: Method `Gauge.set`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Method `Gauge.set` does not have a return section in docstring
+--------------------
+python/ray/util/multiprocessing/pool.py
+    DOC111: Method `ResultThread.__init__`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC106: Method `AsyncResult.wait`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `AsyncResult.wait`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC101: Method `Pool.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Pool.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [context: Any].
+    DOC101: Method `Pool.imap`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Pool.imap`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [chunksize: Optional[int], func: Callable, iterable: Iterable].
+    DOC101: Method `Pool.imap_unordered`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Pool.imap_unordered`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [chunksize: Optional[int], func: Callable, iterable: Iterable].
+--------------------
+python/ray/util/placement_group.py
+    DOC201: Method `PlacementGroup.ready` does not have a return section in docstring
+    DOC111: Method `PlacementGroup.wait`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC201: Method `PlacementGroup.wait` does not have a return section in docstring
+    DOC201: Function `placement_group` does not have a return section in docstring
+    DOC101: Function `get_placement_group`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `get_placement_group`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [placement_group_name: str].
+    DOC201: Function `placement_group_table` does not have a return section in docstring
+    DOC201: Function `get_current_placement_group` does not have a return section in docstring
+--------------------
+python/ray/util/queue.py
+    DOC111: Method `Queue.__init__`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
+    DOC101: Method `Queue.put`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Queue.put`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [block: bool, item: Any, timeout: Optional[float]].
+    DOC101: Method `Queue.put_async`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Queue.put_async`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [block: bool, item: Any, timeout: Optional[float]].
+    DOC101: Method `Queue.get`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Queue.get`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [block: bool, timeout: Optional[float]].
+    DOC101: Method `Queue.get_async`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Queue.get_async`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [block: bool, timeout: Optional[float]].
+    DOC101: Method `Queue.put_nowait`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Queue.put_nowait`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [item: Any].
+    DOC101: Method `Queue.put_nowait_batch`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Queue.put_nowait_batch`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [items: Iterable].
+    DOC201: Method `Queue.get_nowait` does not have a return section in docstring
+    DOC101: Method `Queue.get_nowait_batch`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Queue.get_nowait_batch`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [num_items: int].
+    DOC201: Method `Queue.get_nowait_batch` does not have a return section in docstring
+--------------------
+python/ray/util/scheduling_strategies.py
+    DOC101: Method `PlacementGroupSchedulingStrategy.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `PlacementGroupSchedulingStrategy.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [placement_group: 'PlacementGroup', placement_group_bundle_index: int, placement_group_capture_child_tasks: Optional[bool]].
+    DOC101: Method `NodeAffinitySchedulingStrategy.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `NodeAffinitySchedulingStrategy.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_fail_on_unavailable: bool, _spill_on_unavailable: bool, node_id: str, soft: bool].
+    DOC101: Method `_LabelMatchExpression.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `_LabelMatchExpression.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [key: str, operator: Union[In, NotIn, Exists, DoesNotExist]].
+--------------------
+python/ray/util/spark/cluster_init.py
+    DOC101: Function `setup_ray_cluster`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `setup_ray_cluster`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ].
+    DOC101: Method `AutoscalingCluster.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `AutoscalingCluster.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [extra_provider_config: dict, idle_timeout_minutes: float, upscaling_speed: float].
+--------------------
+python/ray/util/state/api.py
+    DOC103: Method `StateApiClient.get`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [resource: StateResource]. Arguments in the docstring but not in the function signature: [resource_name: ].
+    DOC103: Method `StateApiClient.summary`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [resource: SummaryResource]. Arguments in the docstring but not in the function signature: [resource_name: ].
+    DOC402: Function `get_log` has "yield" statements, but the docstring does not have a "Yields" section
+    DOC404: Function `get_log` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
+    DOC102: Function `list_logs`: Docstring contains more arguments than in function signature.
+    DOC103: Function `list_logs`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the docstring but not in the function signature: [_interval: , actor_id: ].
+    DOC201: Function `list_logs` does not have a return section in docstring
+    DOC201: Function `summarize_tasks` does not have a return section in docstring
+    DOC201: Function `summarize_actors` does not have a return section in docstring
+    DOC201: Function `summarize_objects` does not have a return section in docstring
+--------------------
+python/ray/util/state/common.py
+    DOC101: Function `state_column`: Docstring contains fewer arguments than in function signature.
+    DOC107: Function `state_column`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `state_column`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , format_fn: ]. Arguments in the docstring but not in the function signature: [kwargs: ].
+    DOC201: Function `state_column` does not have a return section in docstring
+    DOC201: Function `filter_fields` does not have a return section in docstring
+    DOC201: Function `merge_sibings_for_task_group` does not have a return section in docstring
+    DOC101: Function `protobuf_message_to_dict`: Docstring contains fewer arguments than in function signature.
+    DOC107: Function `protobuf_message_to_dict`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `protobuf_message_to_dict`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [message: ].
+    DOC201: Function `protobuf_message_to_dict` does not have a return section in docstring
+--------------------
+python/ray/util/state/state_cli.py
+    DOC201: Function `_get_available_resources` does not have a return section in docstring
+    DOC101: Function `get_table_output`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `get_table_output`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [detail: bool].
+    DOC101: Function `ray_get`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `ray_get`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: Optional[str], timeout: float].
+    DOC101: Function `ray_list`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `ray_list`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: str, detail: bool, filter: List[str], format: str, limit: int, timeout: float].
+    DOC101: Function `task_summary`: Docstring contains fewer arguments than in function signature.
+    DOC107: Function `task_summary`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `task_summary`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: str, ctx: , timeout: float].
+    DOC101: Function `actor_summary`: Docstring contains fewer arguments than in function signature.
+    DOC107: Function `actor_summary`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `actor_summary`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: str, ctx: , timeout: float].
+    DOC101: Function `object_summary`: Docstring contains fewer arguments than in function signature.
+    DOC107: Function `object_summary`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `object_summary`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: str, ctx: , timeout: float].
+    DOC201: Function `_get_head_node_ip` does not have a return section in docstring
+    DOC101: Function `log_cluster`: Docstring contains fewer arguments than in function signature.
+    DOC107: Function `log_cluster`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `log_cluster`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: Optional[str], ctx: , encoding: str, encoding_errors: str, follow: bool, glob_filter: str, interval: float, node_id: Optional[str], node_ip: Optional[str], tail: int, timeout: int].
+    DOC201: Function `log_cluster` does not have a return section in docstring
+    DOC101: Function `log_actor`: Docstring contains fewer arguments than in function signature.
+    DOC107: Function `log_actor`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `log_actor`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: Optional[str], ctx: , err: bool, follow: bool, id: Optional[str], interval: float, node_id: Optional[str], node_ip: Optional[str], pid: Optional[str], tail: int, timeout: int].
+    DOC101: Function `log_worker`: Docstring contains fewer arguments than in function signature.
+    DOC107: Function `log_worker`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `log_worker`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: Optional[str], ctx: , err: bool, follow: bool, interval: float, node_id: Optional[str], node_ip: Optional[str], pid: Optional[str], tail: int, timeout: int].
+    DOC101: Function `log_job`: Docstring contains fewer arguments than in function signature.
+    DOC107: Function `log_job`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `log_job`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: Optional[str], ctx: , follow: bool, interval: float, submission_id: Optional[str], tail: int, timeout: int].
+    DOC101: Function `log_task`: Docstring contains fewer arguments than in function signature.
+    DOC107: Function `log_task`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `log_task`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: Optional[str], attempt_number: int, ctx: , err: bool, follow: bool, interval: float, tail: int, task_id: Optional[str], timeout: int].
+--------------------
+python/ray/util/state/state_manager.py
+    DOC101: Function `api_with_network_error_handler`: Docstring contains fewer arguments than in function signature.
+    DOC106: Function `api_with_network_error_handler`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC103: Function `api_with_network_error_handler`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ].
+--------------------
+python/ray/util/timer.py
+    DOC101: Method `_Timer.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `_Timer.__init__`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `_Timer.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `_Timer.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [window_size: ].
+--------------------
+python/ray/widgets/render.py
+    DOC101: Method `Template.render`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `Template.render`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC103: Method `Template.render`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ].
+--------------------
+python/ray/widgets/util.py
+    DOC103: Function `_has_missing`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [*deps: Iterable[Union[str, Optional[str]]]]. Arguments in the docstring but not in the function signature: [deps: ].
+    DOC103: Function `repr_with_fallback`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [*notebook_deps: Iterable[Union[str, Optional[str]]]]. Arguments in the docstring but not in the function signature: [notebook_deps: ].
+--------------------
+python/ray/workflow/api.py
+    DOC101: Function `run`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `run`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: , dag: DAGNode].
+    DOC101: Function `run_async`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `run_async`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: , dag: DAGNode].
+    DOC201: Function `continuation` does not have a return section in docstring
+    DOC101: Method `options.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `options.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**workflow_options: Dict[str, Any]].
+--------------------
+python/ray/workflow/serialization.py
+    DOC101: Method `Manager.save_objectref`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `Manager.save_objectref`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [workflow_id: 'str'].
+    DOC107: Function `dump_to_storage`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+--------------------
+python/ray/workflow/serialization_context.py
+    DOC402: Function `workflow_args_serialization_context` has "yield" statements, but the docstring does not have a "Yields" section
+    DOC404: Function `workflow_args_serialization_context` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
+    DOC402: Function `workflow_args_resolving_context` has "yield" statements, but the docstring does not have a "Yields" section
+    DOC404: Function `workflow_args_resolving_context` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
+--------------------
+python/ray/workflow/storage/filesystem.py
+    DOC107: Function `_open_atomic`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC202: Function `_open_atomic` has a return section in docstring, but there are no return statements or annotations
+    DOC402: Function `_open_atomic` has "yield" statements, but the docstring does not have a "Yields" section
+    DOC404: Function `_open_atomic` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
+--------------------
+python/ray/workflow/task_executor.py
+    DOC104: Function `_workflow_task_executor`: Arguments are the same in the docstring and the function signature, but are in a different order.
+    DOC105: Function `_workflow_task_executor`: Argument names match, but type hints in these args do not match: func, context, task_id, baked_inputs, runtime_options
+    DOC101: Method `_BakedWorkflowInputs.resolve`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `_BakedWorkflowInputs.resolve`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [store: workflow_storage.WorkflowStorage].
+--------------------
+python/ray/workflow/workflow_context.py
+    DOC106: Function `workflow_task_context`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `workflow_task_context`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC402: Function `workflow_task_context` has "yield" statements, but the docstring does not have a "Yields" section
+    DOC404: Function `workflow_task_context` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
+    DOC106: Function `workflow_logging_context`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `workflow_logging_context`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC402: Function `workflow_logging_context` has "yield" statements, but the docstring does not have a "Yields" section
+    DOC404: Function `workflow_logging_context` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
+--------------------
+python/ray/workflow/workflow_state_from_dag.py
+    DOC201: Function `workflow_state_from_dag` does not have a return section in docstring
+--------------------
+python/ray/workflow/workflow_storage.py
+    DOC201: Method `WorkflowIndexingStorage.list_workflow` does not have a return section in docstring
+    DOC201: Method `WorkflowStorage.load_actor_class_body` does not have a return section in docstring
+    DOC101: Method `WorkflowStorage.load_task_metadata`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `WorkflowStorage.load_task_metadata`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [task_id: TaskID].
+    DOC201: Method `WorkflowStorage.list_workflow` does not have a return section in docstring
+    DOC201: Method `WorkflowStorage._put` does not have a return section in docstring
+--------------------


### PR DESCRIPTION
## Why are these changes needed?

Right now the docstring's across Ray's code base are very inconsistent which leads to a number of problems when they are parsed by Sphynx to generate documentation, and are otherwise just harder for folks to read.

This adds https://github.com/jsh9/pydoclint to the pre-commit checks to validate that we're meeting a minimum standard that should keep things working (it currently excludes several settings that should probably not be excluded, but they significantly reduce the size of the ratchet file).

This PR also includes an allowlist of everything that is currently failing as of commit 25ea331a00. We'll circle back around over time and fix these, but it should currently operate as a ratchet and only allow the exact set of existing failures to persist.



This is likely to generate some logical merge conflicts over the next week or two as PRs are merged that were not based after this was merged, we'll fix them in follow up PRs instead of trying to coordinate a global rollout.

## Related issue number

We merged a number of fix PRs already to address basic structural problems in a lot of docstrings:
* https://github.com/ray-project/ray/pull/52872
* https://github.com/ray-project/ray/pull/52873
* https://github.com/ray-project/ray/pull/52875
* https://github.com/ray-project/ray/pull/52876
* https://github.com/ray-project/ray/pull/52877
* https://github.com/ray-project/ray/pull/52878
* https://github.com/ray-project/ray/pull/52879
* https://github.com/ray-project/ray/pull/52880
* https://github.com/ray-project/ray/pull/52881
* https://github.com/ray-project/ray/pull/52883

+ probably more xD
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
