### PR TITLE
[Data] Fixing null-safety when converting to `TensorArray`

### DIFF
--- a/python/ray/air/util/__init__.py
+++ b/python/ray/air/util/__init__.py
@@ -1,4 +1,3 @@
-
 # Lazy import to avoid ray init failures without pandas installed and allow
 # dataset to import modules in this file.
 _pandas = None

--- a/python/ray/air/util/__init__.py
+++ b/python/ray/air/util/__init__.py
@@ -1,0 +1,20 @@
+
+# Lazy import to avoid ray init failures without pandas installed and allow
+# dataset to import modules in this file.
+_pandas = None
+
+
+def _lazy_import_pandas():
+    global _pandas
+    if _pandas is None:
+        import pandas
+
+        _pandas = pandas
+    return _pandas
+
+
+def _lazy_import_pandas_no_raise():
+    try:
+        return _lazy_import_pandas()
+    except BaseException:
+        return None

--- a/python/ray/air/util/__init__.py
+++ b/python/ray/air/util/__init__.py
@@ -5,10 +5,11 @@ _pandas = None
 
 def _lazy_import_pandas():
     global _pandas
+
     if _pandas is None:
         import pandas
-
         _pandas = pandas
+
     return _pandas
 
 

--- a/python/ray/air/util/__init__.py
+++ b/python/ray/air/util/__init__.py
@@ -8,6 +8,7 @@ def _lazy_import_pandas():
 
     if _pandas is None:
         import pandas
+
         _pandas = pandas
 
     return _pandas

--- a/python/ray/air/util/data_batch_conversion.py
+++ b/python/ray/air/util/data_batch_conversion.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.air.data_batch_type import DataBatchType
+from ray.air.util.tensor_extensions.utils import _should_convert_to_tensor
 from ray.util.annotations import Deprecated, DeveloperAPI
 
 if TYPE_CHECKING:
@@ -294,7 +295,6 @@ def _cast_ndarray_columns_to_tensor_extension(df: "pd.DataFrame") -> "pd.DataFra
 
     from ray.air.util.tensor_extensions.pandas import (
         TensorArray,
-        column_needs_tensor_extension,
     )
 
     # Try to convert any ndarray columns to TensorArray columns.
@@ -305,7 +305,7 @@ def _cast_ndarray_columns_to_tensor_extension(df: "pd.DataFrame") -> "pd.DataFra
     # column names containing tensor columns, to make this an O(# of tensor columns)
     # check rather than the current O(# of columns) check.
     for col_name, col in df.items():
-        if column_needs_tensor_extension(col):
+        if _should_convert_to_tensor(col, col_name):
             try:
                 # Suppress Pandas warnings:
                 # https://github.com/ray-project/ray/issues/29270

--- a/python/ray/air/util/data_batch_conversion.py
+++ b/python/ray/air/util/data_batch_conversion.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from ray.air.constants import TENSOR_COLUMN_NAME
 from ray.air.data_batch_type import DataBatchType
+from ray.air.util import _lazy_import_pandas
 from ray.air.util.tensor_extensions.utils import _should_convert_to_tensor
 from ray.util.annotations import Deprecated, DeveloperAPI
 
@@ -17,19 +18,6 @@ try:
     import pyarrow
 except ImportError:
     pyarrow = None
-
-# Lazy import to avoid ray init failures without pandas installed and allow
-# dataset to import modules in this file.
-_pandas = None
-
-
-def _lazy_import_pandas():
-    global _pandas
-    if _pandas is None:
-        import pandas
-
-        _pandas = pandas
-    return _pandas
 
 
 @DeveloperAPI

--- a/python/ray/air/util/tensor_extensions/pandas.py
+++ b/python/ray/air/util/tensor_extensions/pandas.py
@@ -30,7 +30,6 @@
 # - Added support for heterogeneously-shaped tensors.
 # - Miscellaneous small bug fixes and optimizations.
 
-import logging
 import numbers
 import os
 from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
@@ -758,8 +757,9 @@ class TensorArray(
                     pass
                 elif all(
                     (
-                        v is None or
-                        isinstance(v, (np.ndarray, TensorArrayElement)) or
+                        v is None
+                        or isinstance(v, (np.ndarray, TensorArrayElement))
+                        or
                         # NOTE: String is also a sequence
                         (isinstance(v, Sequence) and not isinstance(v, str))
                     )

--- a/python/ray/air/util/tensor_extensions/utils.py
+++ b/python/ray/air/util/tensor_extensions/utils.py
@@ -68,9 +68,10 @@ def _should_convert_to_tensor(
         #   existing behavior where all column values were blindly converted to Numpy
         #   leading to list of ndarrays being converted a tensor):
         or (
-            isinstance(column_values, (List, np.ndarray)) and (
-                isinstance(column_values[0], np.ndarray) or
-                _is_ndarray_like_not_pa_array_not_pd_series(column_values[0])
+            isinstance(column_values, (List, np.ndarray))
+            and (
+                isinstance(column_values[0], np.ndarray)
+                or _is_ndarray_like_not_pa_array_not_pd_series(column_values[0])
             )
         )
     )

--- a/python/ray/air/util/tensor_extensions/utils.py
+++ b/python/ray/air/util/tensor_extensions/utils.py
@@ -62,17 +62,17 @@ def _should_convert_to_tensor(
         # - Provided collection is already implementing Ndarray protocol like
         #   `torch.Tensor`, `pd.Series`, etc (but *excluding* `pyarrow.Array`,
         #   `pyarrow.ChunkedArray`)
-        or _is_ndarray_like_not_pyarrow_array(column_values)
+        or _is_ndarray_like_not_pa_array_not_pd_series(column_values)
         # - Provided column values is a list of a) ndarrays or b) ndarray-like objects
         #   (excluding Pyarrow arrays). This is done for compatibility with previous
         #   existing behavior where all column values were blindly converted to Numpy
         #   leading to list of ndarrays being converted a tensor):
         or isinstance(column_values[0], np.ndarray)
-        or _is_ndarray_like_not_pyarrow_array(column_values[0])
+        or _is_ndarray_like_not_pa_array_not_pd_series(column_values[0])
     )
 
 
-def _is_ndarray_like_not_pyarrow_array(column_values):
+def _is_ndarray_like_not_pa_array_not_pd_series(column_values):
     return (
         is_ndarray_like(column_values)
         and not _is_arrow_array(column_values)

--- a/python/ray/air/util/tensor_extensions/utils.py
+++ b/python/ray/air/util/tensor_extensions/utils.py
@@ -74,9 +74,9 @@ def _should_convert_to_tensor(
 
 def _is_ndarray_like_not_pyarrow_array(column_values):
     return (
-        is_ndarray_like(column_values) and
-        not _is_arrow_array(column_values) and
-        not _is_pandas_series(column_values)
+        is_ndarray_like(column_values)
+        and not _is_arrow_array(column_values)
+        and not _is_pandas_series(column_values)
     )
 
 

--- a/python/ray/air/util/tensor_extensions/utils.py
+++ b/python/ray/air/util/tensor_extensions/utils.py
@@ -67,8 +67,12 @@ def _should_convert_to_tensor(
         #   (excluding Pyarrow arrays). This is done for compatibility with previous
         #   existing behavior where all column values were blindly converted to Numpy
         #   leading to list of ndarrays being converted a tensor):
-        or isinstance(column_values[0], np.ndarray)
-        or _is_ndarray_like_not_pa_array_not_pd_series(column_values[0])
+        or (
+            isinstance(column_values, (List, np.ndarray)) and (
+                isinstance(column_values[0], np.ndarray) or
+                _is_ndarray_like_not_pa_array_not_pd_series(column_values[0])
+            )
+        )
     )
 
 

--- a/python/ray/air/util/tensor_extensions/utils.py
+++ b/python/ray/air/util/tensor_extensions/utils.py
@@ -68,12 +68,21 @@ def _should_convert_to_tensor(
         #   existing behavior where all column values were blindly converted to Numpy
         #   leading to list of ndarrays being converted a tensor):
         or (
-            isinstance(column_values, (List, np.ndarray))
+            _is_list_or_ndarray_or_pd_series(column_values)
             and (
                 isinstance(column_values[0], np.ndarray)
                 or _is_ndarray_like_not_pa_array_not_pd_series(column_values[0])
             )
         )
+    )
+
+
+def _is_list_or_ndarray_or_pd_series(values):
+    pd = _lazy_import_pandas_no_raise()
+
+    return isinstance(values, (List, np.ndarray)) or (
+        pd is not None and
+        isinstance(values, pd.Series)
     )
 
 

--- a/python/ray/air/util/tensor_extensions/utils.py
+++ b/python/ray/air/util/tensor_extensions/utils.py
@@ -81,8 +81,7 @@ def _is_list_or_ndarray_or_pd_series(values):
     pd = _lazy_import_pandas_no_raise()
 
     return isinstance(values, (List, np.ndarray)) or (
-        pd is not None and
-        isinstance(values, pd.Series)
+        pd is not None and isinstance(values, pd.Series)
     )
 
 

--- a/python/ray/data/extensions/__init__.py
+++ b/python/ray/data/extensions/__init__.py
@@ -19,7 +19,6 @@ from ray.data.extensions.tensor_extension import (
     TensorArray,
     TensorArrayElement,
     TensorDtype,
-    column_needs_tensor_extension,
 )
 
 __all__ = [
@@ -32,7 +31,6 @@ __all__ = [
     "ArrowTensorArray",
     "ArrowVariableShapedTensorType",
     "ArrowVariableShapedTensorArray",
-    "column_needs_tensor_extension",
     "ArrowConversionError",
     # Object array extension
     "ArrowPythonObjectArray",

--- a/python/ray/data/extensions/tensor_extension.py
+++ b/python/ray/data/extensions/tensor_extension.py
@@ -10,6 +10,5 @@ from ray.air.util.tensor_extensions.pandas import (  # noqa: F401
     TensorArray,
     TensorArrayElement,
     TensorDtype,
-    column_needs_tensor_extension,
 )
 from ray.air.util.tensor_extensions.utils import create_ragged_ndarray  # noqa: F401


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, when creating `TensorArray` we're not properly handling nulls. This PR addresses that.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
