### PR TITLE
[dashboard] Set `allow_redirects=False` in the proxy request to the subprocess module

### DIFF
--- a/python/ray/dashboard/subprocesses/handle.py
+++ b/python/ray/dashboard/subprocesses/handle.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 
 def filter_hop_by_hop_headers(
-    headers: Union[dict[str, str], multidict.CIMultiDictProxy[str]]
+    headers: Union[dict[str, str], multidict.CIMultiDictProxy[str]],
 ) -> dict[str, str]:
     """
     Filter out hop-by-hop headers from the headers dict.
@@ -266,6 +266,7 @@ class SubprocessModuleHandle:
             url,
             data=body,
             headers=filter_hop_by_hop_headers(request.headers),
+            allow_redirects=False,
         ) as backend_resp:
             resp_body = await backend_resp.read()
             return aiohttp.web.Response(

--- a/python/ray/dashboard/subprocesses/tests/test_e2e.py
+++ b/python/ray/dashboard/subprocesses/tests/test_e2e.py
@@ -117,6 +117,26 @@ async def test_load_multiple_modules(aiohttp_client, default_module_config):
     assert await response.text() == "Hello from TestModule1"
 
 
+async def test_redirect_between_modules(aiohttp_client, default_module_config):
+    """Tests that a redirect can be handled between modules."""
+    app = await start_http_server_app(default_module_config, [TestModule, TestModule1])
+    client = await aiohttp_client(app)
+
+    # Allow redirects to be handled between modules.
+    # NOTE: If redirects were followed at the module level,
+    # the test would error, since following /test in TestModule1 would
+    # result in a 404.
+    # Instead, the redirect should be handled at the subprocess proxy level,
+    # where the redirect request is forwarded to the correct module.
+    response = await client.get("/redirect_between_modules", allow_redirects=True)
+    assert response.status == 200
+    assert await response.text() == "Hello, World from GET /test, run_finished: True"
+
+    response = await client.get("/redirect_within_module", allow_redirects=True)
+    assert response.status == 200
+    assert await response.text() == "Hello from TestModule1"
+
+
 async def test_cached_endpoint(aiohttp_client, default_module_config):
     """
     Test whether the ray.dashboard.optional_utils.aiohttp_cache decorator works.

--- a/python/ray/dashboard/subprocesses/tests/utils.py
+++ b/python/ray/dashboard/subprocesses/tests/utils.py
@@ -165,3 +165,16 @@ class TestModule1(BaseTestModule):
     @routes.get("/test1")
     async def test(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
         return aiohttp.web.Response(text="Hello from TestModule1")
+
+    @routes.get("/redirect_between_modules")
+    async def redirect_between_modules(
+        self, req: aiohttp.web.Request
+    ) -> aiohttp.web.Response:
+        # Redirect to the /test route in TestModule
+        raise aiohttp.web.HTTPFound(location="/test")
+
+    @routes.get("/redirect_within_module")
+    async def redirect_within_module(
+        self, req: aiohttp.web.Request
+    ) -> aiohttp.web.Response:
+        raise aiohttp.web.HTTPFound(location="/test1")


### PR DESCRIPTION
## Summary

Redirects are currently handled all the way when the request gets routed to the subprocess module head (`HttpServerDashboardHead` -> `ReportHead`). This doesn't allow redirect responses across subprocess modules (ex: `ReportHead` redirecting to a `StateHead` endpoint).

Disabling the default `allow_redirects=True` allows the redirect request to be handled at the client level, which enables routing the redirect request to the right subprocess module.

| **Before PR** | **After PR** |
|---------------|--------------|
| ![Screenshot 2025-05-13 at 3 25 58 PM](https://github.com/user-attachments/assets/8e91aa04-8267-4ab8-852b-27c95112eb42) | ![Screenshot 2025-05-13 at 3 26 10 PM](https://github.com/user-attachments/assets/42db5bb5-76e0-452c-8db4-7f4721328bb2) |






