### PR TITLE
[testdb] add test duration

### DIFF
--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -94,6 +94,7 @@ class TestResult:
     timestamp: int
     pull_request: str
     rayci_step_id: str
+    duration_ms: Optional[float] = None
 
     @classmethod
     def from_result(cls, result: Result):
@@ -105,6 +106,7 @@ class TestResult:
             timestamp=int(time.time() * 1000),
             pull_request=os.environ.get("BUILDKITE_PULL_REQUEST", ""),
             rayci_step_id=os.environ.get("RAYCI_STEP_ID", ""),
+            duration_ms=result.runtime,
         )
 
     @classmethod
@@ -117,6 +119,9 @@ class TestResult:
                 buildkite_url=(
                     f"{os.environ.get('BUILDKITE_BUILD_URL')}"
                     f"#{os.environ.get('BUILDKITE_JOB_ID')}"
+                ),
+                runtime=cls._to_float_or_none(
+                    event["testResult"].get("testAttemptDurationMillis")
                 ),
             )
         )
@@ -131,7 +136,15 @@ class TestResult:
             timestamp=result["timestamp"],
             pull_request=result.get("pull_request", ""),
             rayci_step_id=result.get("rayci_step_id", ""),
+            duration_ms=result.get("duration_ms"),
         )
+
+    @classmethod
+    def _to_float_or_none(cls, s: str) -> Optional[float]:
+        try:
+            return float(s)
+        except (ValueError, TypeError):
+            return None
 
     def is_failing(self) -> bool:
         return not self.is_passing()

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -71,6 +71,7 @@ def _stub_test_result(
         timestamp=0,
         pull_request="1",
         rayci_step_id=rayci_step_id,
+        duration_ms=5.0,
     )
 
 
@@ -227,19 +228,21 @@ def test_is_stable() -> None:
 def test_result_from_bazel_event() -> None:
     result = TestResult.from_bazel_event(
         {
-            "testResult": {"status": "PASSED"},
+            "testResult": {"status": "PASSED", "testAttemptDurationMillis": "5"},
         }
     )
     assert result.is_passing()
     assert result.branch == "food"
     assert result.pull_request == "1"
     assert result.rayci_step_id == "g4_s5"
+    assert result.duration_ms == 5
     result = TestResult.from_bazel_event(
         {
             "testResult": {"status": "FAILED"},
         }
     )
     assert result.is_failing()
+    assert result.duration_ms is None
 
 
 def test_from_bazel_event() -> None:


### PR DESCRIPTION
Add test duration to test db. The test duration data is already a part of bazel event; we just need to record it when creating the `TestResult` object.

Test:
- CI