### PR TITLE
[Data] Fix ActorPool scaling to avoid scaling down when the input queue is empty

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1161,12 +1161,6 @@ python/ray/data/_internal/equalize.py
     DOC103: Function `_equalize`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [owned_by_consumer: bool].
     DOC103: Function `_shave_all_splits`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [per_split_num_rows: List[List[int]]].
 --------------------
-python/ray/data/_internal/execution/autoscaler/autoscaling_actor_pool.py
-    DOC101: Method `AutoscalingActorPool.scale_up`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `AutoscalingActorPool.scale_up`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [num_actors: int].
-    DOC101: Method `AutoscalingActorPool.scale_down`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `AutoscalingActorPool.scale_down`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [num_actors: int].
---------------------
 python/ray/data/_internal/execution/bundle_queue/bundle_queue.py
     DOC201: Method `BundleQueue.pop` does not have a return section in docstring
 --------------------

--- a/python/ray/data/_internal/execution/autoscaler/autoscaling_actor_pool.py
+++ b/python/ray/data/_internal/execution/autoscaler/autoscaling_actor_pool.py
@@ -72,6 +72,10 @@ class AutoscalingActorPool(ABC):
         The number of actually added actors may be less than the requested
         number.
 
+        Args:
+            num_actors: Number of additional actors to be added to the pool
+            reason: (Optional) Reason for action
+
         Returns:
             The number of actors actually added.
         """
@@ -83,6 +87,10 @@ class AutoscalingActorPool(ABC):
 
         The number of actually removed actors may be less than the requested
         number.
+
+        Args:
+            num_actors: Number of additional actors to be removed from the pool
+            reason: (Optional) Reason for action
 
         Returns:
             The number of actors actually removed.

--- a/python/ray/data/_internal/execution/autoscaler/autoscaling_actor_pool.py
+++ b/python/ray/data/_internal/execution/autoscaler/autoscaling_actor_pool.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import Optional
 
 from ray.data._internal.execution.interfaces.execution_options import ExecutionResources
 from ray.util.annotations import DeveloperAPI
@@ -65,7 +66,7 @@ class AutoscalingActorPool(ABC):
         )
 
     @abstractmethod
-    def scale_up(self, num_actors: int) -> int:
+    def scale_up(self, num_actors: int, *, reason: Optional[str] = None) -> int:
         """Request the actor pool to scale up by the given number of actors.
 
         The number of actually added actors may be less than the requested
@@ -77,7 +78,7 @@ class AutoscalingActorPool(ABC):
         ...
 
     @abstractmethod
-    def scale_down(self, num_actors: int) -> int:
+    def scale_down(self, num_actors: int, *, reason: Optional[str] = None) -> int:
         """Request actor pool to scale down by the given number of actors.
 
         The number of actually removed actors may be less than the requested

--- a/python/ray/data/_internal/execution/autoscaler/autoscaling_actor_pool.py
+++ b/python/ray/data/_internal/execution/autoscaler/autoscaling_actor_pool.py
@@ -66,6 +66,10 @@ class AutoscalingActorPool(ABC):
         )
 
     @abstractmethod
+    def can_scale_down(self):
+        ...
+
+    @abstractmethod
     def scale_up(self, num_actors: int, *, reason: Optional[str] = None) -> int:
         """Request the actor pool to scale up by the given number of actors.
 

--- a/python/ray/data/_internal/execution/autoscaler/default_autoscaler.py
+++ b/python/ray/data/_internal/execution/autoscaler/default_autoscaler.py
@@ -59,7 +59,7 @@ class DefaultAutoscaler(Autoscaler):
         op_state: "OpState",
     ):
         # Do not scale up, if the op is completed or no more inputs are coming.
-        if op.completed() or (op_state.total_enqueued_input_bundles() == 0):
+        if op.completed() or (op._inputs_complete and op_state.total_enqueued_input_bundles() == 0):
             return False
         if actor_pool.current_size() < actor_pool.min_size():
             # Scale up, if the actor pool is below min size.
@@ -84,7 +84,7 @@ class DefaultAutoscaler(Autoscaler):
         op_state: "OpState",
     ):
         # Scale down, if the op is completed or no more inputs are coming.
-        if op.completed() or (op_state.total_enqueued_input_bundles() == 0):
+        if op.completed() or (op._inputs_complete and op_state.total_enqueued_input_bundles() == 0):
             return True
         if actor_pool.current_size() > actor_pool.max_size():
             # Scale down, if the actor pool is above max size.

--- a/python/ray/data/_internal/execution/autoscaler/default_autoscaler.py
+++ b/python/ray/data/_internal/execution/autoscaler/default_autoscaler.py
@@ -90,19 +90,28 @@ class DefaultAutoscaler(Autoscaler):
                 return _AutoscalingAction.NO_OP, "reached max size"
             if not op_state._scheduling_status.under_resource_limits:
                 return _AutoscalingAction.NO_OP, "operator exceeding resource quota"
-            elif op_state.total_enqueued_input_bundles() <= actor_pool.num_free_task_slots():
+            elif (
+                op_state.total_enqueued_input_bundles()
+                <= actor_pool.num_free_task_slots()
+            ):
                 return _AutoscalingAction.NO_OP, (
                     f"pool has sufficient task slots remaining: "
                     f"enqueued inputs {op_state.total_enqueued_input_bundles()} <= "
                     f"free slots {actor_pool.num_free_task_slots()})"
                 )
 
-            return _AutoscalingAction.SCALE_UP, f"utilization of {util} >= {self._actor_pool_scaling_up_threshold}"
+            return (
+                _AutoscalingAction.SCALE_UP,
+                f"utilization of {util} >= {self._actor_pool_scaling_up_threshold}",
+            )
         elif util <= self._actor_pool_scaling_down_threshold:
             if actor_pool.current_size() <= actor_pool.min_size():
                 return _AutoscalingAction.NO_OP, "reached min size"
 
-            return _AutoscalingAction.SCALE_DOWN, f"utilization of {util} <= {self._actor_pool_scaling_down_threshold}"
+            return (
+                _AutoscalingAction.SCALE_DOWN,
+                f"utilization of {util} <= {self._actor_pool_scaling_down_threshold}",
+            )
         else:
             return _AutoscalingAction.NO_OP, (
                 f"{self._actor_pool_scaling_down_threshold} < "

--- a/python/ray/data/_internal/execution/autoscaler/default_autoscaler.py
+++ b/python/ray/data/_internal/execution/autoscaler/default_autoscaler.py
@@ -66,7 +66,9 @@ class DefaultAutoscaler(Autoscaler):
         op_state: "OpState",
     ) -> _AutoscalingAction:
         # Do not scale up, if the op is completed or no more inputs are coming.
-        if op.completed() or (op._inputs_complete and op_state.total_enqueued_input_bundles() == 0):
+        if op.completed() or (
+            op._inputs_complete and op_state.total_enqueued_input_bundles() == 0
+        ):
             return _AutoscalingAction.SCALE_DOWN
 
         if actor_pool.current_size() < actor_pool.min_size():
@@ -93,14 +95,15 @@ class DefaultAutoscaler(Autoscaler):
         else:
             return _AutoscalingAction.NO_OP
 
-
     def _try_scale_up_or_down_actor_pool(self):
         for op, state in self._topology.items():
             actor_pools = op.get_autoscaling_actor_pools()
             for actor_pool in actor_pools:
                 while True:
                     # Try to scale up or down the actor pool.
-                    recommended_action = self._derive_scaling_action(actor_pool, op, state)
+                    recommended_action = self._derive_scaling_action(
+                        actor_pool, op, state
+                    )
 
                     if recommended_action is _AutoscalingAction.SCALE_UP:
                         if actor_pool.scale_up(1) == 0:

--- a/python/ray/data/_internal/execution/autoscaler/default_autoscaler.py
+++ b/python/ray/data/_internal/execution/autoscaler/default_autoscaler.py
@@ -59,7 +59,7 @@ class DefaultAutoscaler(Autoscaler):
         else:
             return actor_pool.num_active_actors() / actor_pool.current_size()
 
-    def _derive_action(
+    def _derive_scaling_action(
         self,
         actor_pool: AutoscalingActorPool,
         op: "PhysicalOperator",
@@ -100,7 +100,7 @@ class DefaultAutoscaler(Autoscaler):
             for actor_pool in actor_pools:
                 while True:
                     # Try to scale up or down the actor pool.
-                    recommended_action = self._derive_action(actor_pool, op, state)
+                    recommended_action = self._derive_scaling_action(actor_pool, op, state)
 
                     if recommended_action is _AutoscalingAction.SCALE_UP:
                         if actor_pool.scale_up(1) == 0:

--- a/python/ray/data/_internal/execution/autoscaler/default_autoscaler.py
+++ b/python/ray/data/_internal/execution/autoscaler/default_autoscaler.py
@@ -108,7 +108,9 @@ class DefaultAutoscaler(Autoscaler):
                 f"utilization of {util} >= {self._actor_pool_scaling_up_threshold}",
             )
         elif util <= self._actor_pool_scaling_down_threshold:
-            if actor_pool.current_size() <= actor_pool.min_size():
+            if not actor_pool.can_scale_down():
+                return _AutoscalingAction.NO_OP, "debounced"
+            elif actor_pool.current_size() <= actor_pool.min_size():
                 return _AutoscalingAction.NO_OP, "reached min size"
 
             return (
@@ -132,7 +134,7 @@ class DefaultAutoscaler(Autoscaler):
 
                 if recommended_action is _AutoscalingAction.SCALE_UP:
                     actor_pool.scale_up(1, reason=reason)
-                elif recommended_action is _AutoscalingAction.SCALE_DOWN and actor_pool.can_scale_down():
+                elif recommended_action is _AutoscalingAction.SCALE_DOWN:
                     actor_pool.scale_down(1, reason=reason)
 
     def _try_scale_up_cluster(self):

--- a/python/ray/data/_internal/execution/autoscaler/default_autoscaler.py
+++ b/python/ray/data/_internal/execution/autoscaler/default_autoscaler.py
@@ -109,7 +109,7 @@ class DefaultAutoscaler(Autoscaler):
             )
         elif util <= self._actor_pool_scaling_down_threshold:
             if not actor_pool.can_scale_down():
-                return _AutoscalingAction.NO_OP, "debounced"
+                return _AutoscalingAction.NO_OP, "not allowed"
             elif actor_pool.current_size() <= actor_pool.min_size():
                 return _AutoscalingAction.NO_OP, "reached min size"
 

--- a/python/ray/data/_internal/execution/autoscaler/default_autoscaler.py
+++ b/python/ray/data/_internal/execution/autoscaler/default_autoscaler.py
@@ -86,8 +86,9 @@ class DefaultAutoscaler(Autoscaler):
             #   - Actor Pool has sufficient amount of slots available to handle
             #   pending tasks
             if (
-                not op_state._scheduling_status.under_resource_limits or
-                op_state.total_enqueued_input_bundles() <= actor_pool.num_free_task_slots()
+                not op_state._scheduling_status.under_resource_limits
+                or op_state.total_enqueued_input_bundles()
+                <= actor_pool.num_free_task_slots()
             ):
                 return _AutoscalingAction.NO_OP
 

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -178,6 +178,12 @@ class _ActorPoolInfo:
     pending: int
     restarting: int
 
+    def __str__(self):
+        return (
+            f"running={self.running}, restarting={self.restarting}, "
+            f"pending={self.pending}"
+        )
+
 
 class PhysicalOperator(Operator):
     """Abstract class for physical operators.

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -1,6 +1,7 @@
 import logging
 import uuid
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 import ray
@@ -167,6 +168,15 @@ class MetadataOpTask(OpTask):
     def on_task_finished(self):
         """Callback when the task is finished."""
         self._task_done_callback()
+
+
+@dataclass
+class _ActorInfo:
+    """Breakdown of the state of the actors used by the ``PhysicalOperator``"""
+
+    running: int
+    pending: int
+    restarting: int
 
 
 class PhysicalOperator(Operator):
@@ -632,14 +642,9 @@ class PhysicalOperator(Operator):
         """
         return ""
 
-    def actor_info_counts(self) -> Tuple[int, int, int]:
-        """Returns Actor counts for Alive, Restarting and Pending Actors.
-
-        This method will be called in add_output API in OpState. Subclasses can
-        override it to return counts for Alive, Restarting and Pending
-        Actors.
-        """
-        return 0, 0, 0
+    def get_actor_info(self) -> _ActorInfo:
+        """Returns the current status of actors being used by the operator"""
+        return _ActorInfo(running=0, pending=0, restarting=0)
 
     def _cancel_active_tasks(self, force: bool):
         tasks: List[OpTask] = self.get_active_tasks()

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -633,15 +633,6 @@ class PhysicalOperator(Operator):
         """
         pass
 
-    def actor_info_progress_str(self) -> str:
-        """Returns Actor progress strings for Alive, Restarting and Pending Actors.
-
-        This method will be called in summary_str API in OpState. Subclasses can
-        override it to return Actor progress strings for Alive, Restarting and Pending
-        Actors.
-        """
-        return ""
-
     def get_actor_info(self) -> _ActorInfo:
         """Returns the current status of actors being used by the operator"""
         return _ActorInfo(running=0, pending=0, restarting=0)

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -171,7 +171,7 @@ class MetadataOpTask(OpTask):
 
 
 @dataclass
-class _ActorInfo:
+class _ActorPoolInfo:
     """Breakdown of the state of the actors used by the ``PhysicalOperator``"""
 
     running: int
@@ -633,9 +633,9 @@ class PhysicalOperator(Operator):
         """
         pass
 
-    def get_actor_info(self) -> _ActorInfo:
+    def get_actor_info(self) -> _ActorPoolInfo:
         """Returns the current status of actors being used by the operator"""
-        return _ActorInfo(running=0, pending=0, restarting=0)
+        return _ActorPoolInfo(running=0, pending=0, restarting=0)
 
     def _cancel_active_tasks(self, force: bool):
         tasks: List[OpTask] = self.get_active_tasks()

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -17,7 +17,7 @@ from ray.data._internal.execution.interfaces import (
     RefBundle,
     TaskContext,
 )
-from ray.data._internal.execution.interfaces.physical_operator import _ActorInfo
+from ray.data._internal.execution.interfaces.physical_operator import _ActorPoolInfo
 from ray.data._internal.execution.operators.map_operator import MapOperator, _map_task
 from ray.data._internal.execution.operators.map_transformer import MapTransformer
 from ray.data._internal.execution.util import locality_string
@@ -423,7 +423,7 @@ class ActorPoolMapOperator(MapOperator):
             else:
                 self._actor_pool.update_running_actor_state(actor, False)
 
-    def get_actor_info(self) -> _ActorInfo:
+    def get_actor_info(self) -> _ActorPoolInfo:
         """Returns Actor counts for Alive, Restarting and Pending Actors."""
         return self._actor_pool.get_actor_info()
 
@@ -893,9 +893,9 @@ class _ActorPool(AutoscalingActorPool):
 
         return ref
 
-    def get_actor_info(self) -> _ActorInfo:
+    def get_actor_info(self) -> _ActorPoolInfo:
         """Returns current snapshot of actors' being used in the pool"""
-        return _ActorInfo(
+        return _ActorPoolInfo(
             running=self.num_alive_actors(),
             pending=self.num_pending_actors(),
             restarting=self.num_restarting_actors(),

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -598,10 +598,8 @@ class _ActorPool(AutoscalingActorPool):
 
     def scale_up(self, num_actors: int, *, reason: Optional[str] = None) -> int:
         logger.info(
-            f"Scaling up actor pool by {num_actors} ("
-            f"running={self.num_running_actors()}, "
-            f"pending={self.num_pending_actors()}, "
-            f"restarting={self.num_restarting_actors()}; reason={reason})"
+            f"Scaling up actor pool by {num_actors} "
+            f"(reason={reason}, {self.get_actor_info()})"
         )
 
         for _ in range(num_actors):
@@ -621,10 +619,8 @@ class _ActorPool(AutoscalingActorPool):
 
         if num_released > 0:
             logger.info(
-                f"Scaled down actor pool by {num_released} ("
-                f"running={self.num_running_actors()}, "
-                f"pending={self.num_pending_actors()}, "
-                f"restarting={self.num_restarting_actors()}; reason={reason})"
+                f"Scaled down actor pool by {num_released} "
+                f"(reason={reason}; {self.get_actor_info()})"
             )
 
         return num_released

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -16,8 +16,7 @@ from ray.data._internal.execution.interfaces import (
     RefBundle,
     TaskContext,
 )
-from ray.data._internal.execution.interfaces.physical_operator import \
-    _ActorInfo
+from ray.data._internal.execution.interfaces.physical_operator import _ActorInfo
 from ray.data._internal.execution.operators.map_operator import MapOperator, _map_task
 from ray.data._internal.execution.operators.map_transformer import MapTransformer
 from ray.data._internal.execution.util import locality_string
@@ -573,7 +572,9 @@ class _ActorPool(AutoscalingActorPool):
         )
 
     def scale_up(self, num_actors: int) -> int:
-        logger.info(f"Scaling up actor pool by {num_actors} (current is {self._running_actors})")
+        logger.info(
+            f"Scaling up actor pool by {num_actors} (current is {self._running_actors})"
+        )
 
         for _ in range(num_actors):
             actor, ready_ref = self._create_actor_fn()

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -155,7 +155,9 @@ class ActorPoolMapOperator(MapOperator):
 
         # Create the actor workers and add them to the pool.
         self._cls = ray.remote(**self._ray_remote_args)(_MapWorker)
-        self._actor_pool.scale_up(self._actor_pool.min_size(), reason="scaling to min size")
+        self._actor_pool.scale_up(
+            self._actor_pool.min_size(), reason="scaling to min size"
+        )
 
         # If `wait_for_min_actors_s` is specified and is positive, then
         # Actor Pool will block until min number of actors is provisioned.

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -421,10 +421,6 @@ class ActorPoolMapOperator(MapOperator):
             else:
                 self._actor_pool.update_running_actor_state(actor, False)
 
-    def actor_info_progress_str(self) -> str:
-        """Returns Actor progress strings for Alive, Restarting and Pending Actors."""
-        return self._actor_pool._get_summary_str()
-
     def get_actor_info(self) -> _ActorInfo:
         """Returns Actor counts for Alive, Restarting and Pending Actors."""
         return self._actor_pool.get_actor_info()
@@ -862,18 +858,6 @@ class _ActorPool(AutoscalingActorPool):
             pending=self.num_pending_actors(),
             restarting=self.num_restarting_actors(),
         )
-
-    def _get_summary_str(self) -> str:
-        """Returns Actor progress strings for Alive, Restarting and Pending Actors."""
-        alive, pending, restarting = self.get_actor_info()
-        total = alive + pending + restarting
-        if total == alive:
-            return f"; Actors: {total}"
-        else:
-            return (
-                f"; Actors: {total} (alive {alive}, restarting {restarting}, "
-                f"pending {pending})"
-            )
 
     def per_actor_resource_usage(self) -> ExecutionResources:
         """Per actor resource usage."""

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -587,8 +587,9 @@ class _ActorPool(AutoscalingActorPool):
         #       scaling up, ie if actor pool just scaled down, it'd still be able
         #       to scale back up immediately.
         return (
-            self._last_scale_up_ts is None or
-            time.time() >= self._last_scale_up_ts + self._ACTOR_POOL_SCALE_DOWN_DEBOUNCE_PERIOD_S
+            self._last_scale_up_ts is None
+            or time.time()
+            >= self._last_scale_up_ts + self._ACTOR_POOL_SCALE_DOWN_DEBOUNCE_PERIOD_S
         )
 
     def scale_up(self, num_actors: int, *, reason: Optional[str] = None) -> int:

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -22,7 +22,8 @@ from ray.data._internal.execution.interfaces.physical_operator import (
     DataOpTask,
     MetadataOpTask,
     OpTask,
-    Waitable, _ActorInfo,
+    Waitable,
+    _ActorInfo,
 )
 from ray.data._internal.execution.operators.base_physical_operator import (
     AllToAllOperator,
@@ -703,6 +704,7 @@ def _rank_operators(
 
     return [_ranker(op) for op in ops]
 
+
 def _actor_info_summary_str(info: _ActorInfo) -> str:
     total = info.running + info.pending + info.restarting
     base = f"Actors: {total}"
@@ -714,4 +716,3 @@ def _actor_info_summary_str(info: _ActorInfo) -> str:
             f"{base} (running={info.running}, restarting={info.restarting}, "
             f"pending={info.pending})"
         )
-

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -715,6 +715,4 @@ def _actor_info_summary_str(info: _ActorPoolInfo) -> str:
     if total == info.running:
         return base
     else:
-        return (
-            f"{base} ({info})"
-        )
+        return f"{base} ({info})"

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -23,7 +23,7 @@ from ray.data._internal.execution.interfaces.physical_operator import (
     MetadataOpTask,
     OpTask,
     Waitable,
-    _ActorInfo,
+    _ActorPoolInfo,
 )
 from ray.data._internal.execution.operators.base_physical_operator import (
     AllToAllOperator,
@@ -708,7 +708,7 @@ def _rank_operators(
     return [_ranker(op) for op in ops]
 
 
-def _actor_info_summary_str(info: _ActorInfo) -> str:
+def _actor_info_summary_str(info: _ActorPoolInfo) -> str:
     total = info.running + info.pending + info.restarting
     base = f"Actors: {total}"
 

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -259,7 +259,7 @@ class OpState:
                 ref.num_rows() is not None
             ), "RefBundle must have a valid number of rows"
             self.progress_bar.update(ref.num_rows(), self.op.num_output_rows_total())
-        active, restarting, pending = self.op.actor_info_counts()
+        active, restarting, pending = self.op.get_actor_info()
         self.op.metrics.num_alive_actors = active
         self.op.metrics.num_restarting_actors = restarting
         self.op.metrics.num_pending_actors = pending

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -255,15 +255,18 @@ class OpState:
         """Move a bundle produced by the operator to its outqueue."""
         self.output_queue.append(ref)
         self.num_completed_tasks += 1
+
         if self.progress_bar:
             assert (
                 ref.num_rows() is not None
             ), "RefBundle must have a valid number of rows"
             self.progress_bar.update(ref.num_rows(), self.op.num_output_rows_total())
-        active, restarting, pending = self.op.get_actor_info()
-        self.op.metrics.num_alive_actors = active
-        self.op.metrics.num_restarting_actors = restarting
-        self.op.metrics.num_pending_actors = pending
+
+        actor_info = self.op.get_actor_info()
+
+        self.op.metrics.num_alive_actors = actor_info.running
+        self.op.metrics.num_restarting_actors = actor_info.restarting
+        self.op.metrics.num_pending_actors = actor_info.pending
 
     def refresh_progress_bar(self, resource_manager: ResourceManager) -> None:
         """Update the console with the latest operator progress."""

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -22,7 +22,7 @@ from ray.data._internal.execution.interfaces.physical_operator import (
     DataOpTask,
     MetadataOpTask,
     OpTask,
-    Waitable,
+    Waitable, _ActorInfo,
 )
 from ray.data._internal.execution.operators.base_physical_operator import (
     AllToAllOperator,
@@ -288,7 +288,7 @@ class OpState:
             desc += f" [backpressured:{','.join(backpressure_types)}]"
 
         # Actors info
-        desc += self.op.actor_info_progress_str()
+        desc += f"; {_actor_info_summary_str(self.op.get_actor_info())}"
 
         # Queued blocks
         desc += f"; Queued blocks: {self.total_enqueued_input_bundles()}"
@@ -702,3 +702,16 @@ def _rank_operators(
         )
 
     return [_ranker(op) for op in ops]
+
+def _actor_info_summary_str(info: _ActorInfo) -> str:
+    total = info.running + info.pending + info.restarting
+    base = f"Actors: {total}"
+
+    if total == info.running:
+        return base
+    else:
+        return (
+            f"{base} (running={info.running}, restarting={info.restarting}, "
+            f"pending={info.pending})"
+        )
+

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -716,6 +716,5 @@ def _actor_info_summary_str(info: _ActorPoolInfo) -> str:
         return base
     else:
         return (
-            f"{base} (running={info.running}, restarting={info.restarting}, "
-            f"pending={info.pending})"
+            f"{base} ({info})"
         )

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -15,7 +15,7 @@ from ray._private.test_utils import wait_for_condition
 from ray.actor import ActorHandle
 from ray.data._internal.compute import ActorPoolStrategy
 from ray.data._internal.execution.interfaces import ExecutionResources
-from ray.data._internal.execution.interfaces.physical_operator import _ActorInfo
+from ray.data._internal.execution.interfaces.physical_operator import _ActorPoolInfo
 from ray.data._internal.execution.operators.actor_pool_map_operator import (
     ActorPoolMapOperator,
     _ActorPool,
@@ -182,7 +182,7 @@ class TestActorPool(unittest.TestCase):
         assert pool.num_active_actors() == 0
         assert pool.num_idle_actors() == 1
         assert pool.num_free_slots() == 1
-        assert pool.get_actor_info() == _ActorInfo(running=0, pending=0, restarting=1)
+        assert pool.get_actor_info() == _ActorPoolInfo(running=0, pending=0, restarting=1)
 
         # Mark the actor as alive and test pick_actor succeeds
         pool.update_running_actor_state(actor, False)
@@ -196,7 +196,7 @@ class TestActorPool(unittest.TestCase):
         assert pool.num_active_actors() == 1
         assert pool.num_idle_actors() == 0
         assert pool.num_free_slots() == 0
-        assert pool.get_actor_info() == _ActorInfo(running=1, pending=0, restarting=0)
+        assert pool.get_actor_info() == _ActorPoolInfo(running=1, pending=0, restarting=0)
 
         # Return the actor
         pool.return_actor(picked_actor)
@@ -208,7 +208,7 @@ class TestActorPool(unittest.TestCase):
         assert pool.num_active_actors() == 0
         assert pool.num_idle_actors() == 1
         assert pool.num_free_slots() == 1
-        assert pool.get_actor_info() == _ActorInfo(running=1, pending=0, restarting=0)
+        assert pool.get_actor_info() == _ActorPoolInfo(running=1, pending=0, restarting=0)
 
     def test_repeated_picking(self):
         # Test that we can repeatedly pick the same actor.

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -12,6 +12,8 @@ from ray._private.test_utils import wait_for_condition
 from ray.actor import ActorHandle
 from ray.data._internal.compute import ActorPoolStrategy
 from ray.data._internal.execution.interfaces import ExecutionResources
+from ray.data._internal.execution.interfaces.physical_operator import \
+    _ActorInfo
 from ray.data._internal.execution.operators.actor_pool_map_operator import (
     ActorPoolMapOperator,
     _ActorPool,
@@ -155,7 +157,7 @@ class TestActorPool(unittest.TestCase):
         assert pool.num_idle_actors() == 1
         assert pool.num_free_slots() == 1
         assert (
-            pool._get_summary_str() == "; Actors: 1 (alive 0, restarting 1, pending 0)"
+            pool.get_actor_info() == _ActorInfo(running=0, pending=0, restarting=1)
         )
 
         # Mark the actor as alive and test pick_actor succeeds
@@ -170,7 +172,7 @@ class TestActorPool(unittest.TestCase):
         assert pool.num_active_actors() == 1
         assert pool.num_idle_actors() == 0
         assert pool.num_free_slots() == 0
-        assert pool._get_summary_str() == "; Actors: 1"
+        assert pool.get_actor_info() == _ActorInfo(running=1, pending=0, restarting=0)
 
         # Return the actor
         pool.return_actor(picked_actor)
@@ -182,7 +184,7 @@ class TestActorPool(unittest.TestCase):
         assert pool.num_active_actors() == 0
         assert pool.num_idle_actors() == 1
         assert pool.num_free_slots() == 1
-        assert pool._get_summary_str() == "; Actors: 1"
+        assert pool.get_actor_info() == _ActorInfo(running=1, pending=0, restarting=0)
 
     def test_repeated_picking(self):
         # Test that we can repeatedly pick the same actor.

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -12,8 +12,7 @@ from ray._private.test_utils import wait_for_condition
 from ray.actor import ActorHandle
 from ray.data._internal.compute import ActorPoolStrategy
 from ray.data._internal.execution.interfaces import ExecutionResources
-from ray.data._internal.execution.interfaces.physical_operator import \
-    _ActorInfo
+from ray.data._internal.execution.interfaces.physical_operator import _ActorInfo
 from ray.data._internal.execution.operators.actor_pool_map_operator import (
     ActorPoolMapOperator,
     _ActorPool,
@@ -156,9 +155,7 @@ class TestActorPool(unittest.TestCase):
         assert pool.num_active_actors() == 0
         assert pool.num_idle_actors() == 1
         assert pool.num_free_slots() == 1
-        assert (
-            pool.get_actor_info() == _ActorInfo(running=0, pending=0, restarting=1)
-        )
+        assert pool.get_actor_info() == _ActorInfo(running=0, pending=0, restarting=1)
 
         # Mark the actor as alive and test pick_actor succeeds
         pool.update_running_actor_state(actor, False)

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -122,7 +122,7 @@ class TestActorPool(unittest.TestCase):
             pool.scale_up(1)
             # Assert we can't scale down immediately after scale up
             assert not pool.can_scale_down()
-            assert pool._last_scale_up_ts == time.time()
+            assert pool._last_scaling_up_ts == time.time()
 
             # Advance clock
             f.tick(

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -287,7 +287,7 @@ class TestActorPool(unittest.TestCase):
         pool = self._create_actor_pool()
         actor, _ = self._add_pending_actor(pool)
         # Kill inactive actor.
-        killed = pool._kill_inactive_actor()
+        killed = pool._release_inactive_actor()
         # Check that an actor was killed.
         assert killed
         # Check that actor is not in pool.
@@ -309,7 +309,7 @@ class TestActorPool(unittest.TestCase):
         pool = self._create_actor_pool()
         actor = self._add_ready_actor(pool)
         # Kill inactive actor.
-        killed = pool._kill_inactive_actor()
+        killed = pool._release_inactive_actor()
         # Check that an actor was killed.
         assert killed
         # Check that actor is not in pool.
@@ -333,7 +333,7 @@ class TestActorPool(unittest.TestCase):
         # Pick actor (and double-check that the actor was picked).
         assert pool.pick_actor() == actor
         # Kill inactive actor.
-        killed = pool._kill_inactive_actor()
+        killed = pool._release_inactive_actor()
         # Check that an actor was NOT killed.
         assert not killed
         # Check that the active actor is still in the pool.
@@ -348,7 +348,7 @@ class TestActorPool(unittest.TestCase):
         # Add idle worker.
         idle_actor = self._add_ready_actor(pool)
         # Kill inactive actor.
-        killed = pool._kill_inactive_actor()
+        killed = pool._release_inactive_actor()
         # Check that an actor was killed.
         assert killed
         # Check that the idle actor is still in the pool.

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -2,6 +2,7 @@ import asyncio
 import collections
 import datetime
 import threading
+import time
 import unittest
 from typing import Any, Optional, Tuple
 from unittest.mock import MagicMock, patch
@@ -124,11 +125,14 @@ class TestActorPool(unittest.TestCase):
             assert pool._last_scale_up_ts == time.time()
 
             # Advance clock
-            f.tick(datetime.timedelta(seconds=_ActorPool._ACTOR_POOL_SCALE_DOWN_DEBOUNCE_PERIOD_S + 1))
+            f.tick(
+                datetime.timedelta(
+                    seconds=_ActorPool._ACTOR_POOL_SCALE_DOWN_DEBOUNCE_PERIOD_S + 1
+                )
+            )
 
             # Assert can scale down after debounce period
             assert pool.can_scale_down()
-
 
     def test_add_pending(self):
         # Test that pending actor is added in the correct state.

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -182,7 +182,9 @@ class TestActorPool(unittest.TestCase):
         assert pool.num_active_actors() == 0
         assert pool.num_idle_actors() == 1
         assert pool.num_free_slots() == 1
-        assert pool.get_actor_info() == _ActorPoolInfo(running=0, pending=0, restarting=1)
+        assert pool.get_actor_info() == _ActorPoolInfo(
+            running=0, pending=0, restarting=1
+        )
 
         # Mark the actor as alive and test pick_actor succeeds
         pool.update_running_actor_state(actor, False)
@@ -196,7 +198,9 @@ class TestActorPool(unittest.TestCase):
         assert pool.num_active_actors() == 1
         assert pool.num_idle_actors() == 0
         assert pool.num_free_slots() == 0
-        assert pool.get_actor_info() == _ActorPoolInfo(running=1, pending=0, restarting=0)
+        assert pool.get_actor_info() == _ActorPoolInfo(
+            running=1, pending=0, restarting=0
+        )
 
         # Return the actor
         pool.return_actor(picked_actor)
@@ -208,7 +212,9 @@ class TestActorPool(unittest.TestCase):
         assert pool.num_active_actors() == 0
         assert pool.num_idle_actors() == 1
         assert pool.num_free_slots() == 1
-        assert pool.get_actor_info() == _ActorPoolInfo(running=1, pending=0, restarting=0)
+        assert pool.get_actor_info() == _ActorPoolInfo(
+            running=1, pending=0, restarting=0
+        )
 
     def test_repeated_picking(self):
         # Test that we can repeatedly pick the same actor.

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -319,7 +319,7 @@ class TestActorPool(unittest.TestCase):
         pool = self._create_actor_pool()
         actor, _ = self._add_pending_actor(pool)
         # Kill inactive actor.
-        killed = pool._release_inactive_actor()
+        killed = pool._remove_inactive_actor()
         # Check that an actor was killed.
         assert killed
         # Check that actor is not in pool.
@@ -341,7 +341,7 @@ class TestActorPool(unittest.TestCase):
         pool = self._create_actor_pool()
         actor = self._add_ready_actor(pool)
         # Kill inactive actor.
-        killed = pool._release_inactive_actor()
+        killed = pool._remove_inactive_actor()
         # Check that an actor was killed.
         assert killed
         # Check that actor is not in pool.
@@ -365,7 +365,7 @@ class TestActorPool(unittest.TestCase):
         # Pick actor (and double-check that the actor was picked).
         assert pool.pick_actor() == actor
         # Kill inactive actor.
-        killed = pool._release_inactive_actor()
+        killed = pool._remove_inactive_actor()
         # Check that an actor was NOT killed.
         assert not killed
         # Check that the active actor is still in the pool.
@@ -380,7 +380,7 @@ class TestActorPool(unittest.TestCase):
         # Add idle worker.
         idle_actor = self._add_ready_actor(pool)
         # Kill inactive actor.
-        killed = pool._release_inactive_actor()
+        killed = pool._remove_inactive_actor()
         # Check that an actor was killed.
         assert killed
         # Check that the idle actor is still in the pool.

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -155,8 +155,7 @@ class TestActorPool(unittest.TestCase):
         assert pool.num_idle_actors() == 1
         assert pool.num_free_slots() == 1
         assert (
-            pool.actor_info_progress_str()
-            == "; Actors: 1 (alive 0, restarting 1, pending 0)"
+            pool._get_summary_str() == "; Actors: 1 (alive 0, restarting 1, pending 0)"
         )
 
         # Mark the actor as alive and test pick_actor succeeds
@@ -171,7 +170,7 @@ class TestActorPool(unittest.TestCase):
         assert pool.num_active_actors() == 1
         assert pool.num_idle_actors() == 0
         assert pool.num_free_slots() == 0
-        assert pool.actor_info_progress_str() == "; Actors: 1"
+        assert pool._get_summary_str() == "; Actors: 1"
 
         # Return the actor
         pool.return_actor(picked_actor)
@@ -183,7 +182,7 @@ class TestActorPool(unittest.TestCase):
         assert pool.num_active_actors() == 0
         assert pool.num_idle_actors() == 1
         assert pool.num_free_slots() == 1
-        assert pool.actor_info_progress_str() == "; Actors: 1"
+        assert pool._get_summary_str() == "; Actors: 1"
 
     def test_repeated_picking(self):
         # Test that we can repeatedly pick the same actor.

--- a/python/ray/data/tests/test_autoscaler.py
+++ b/python/ray/data/tests/test_autoscaler.py
@@ -139,7 +139,7 @@ def test_actor_pool_scaling():
         )
 
         with patch(actor_pool, "can_scale_down", False):
-            assert_autoscaling_action(_AutoscalingAction.NO_OP, "debounced")
+            assert_autoscaling_action(_AutoscalingAction.NO_OP, "not allowed")
 
     # Should scale down since the pool is above the max size.
     with patch(actor_pool, "current_size", 16):

--- a/python/ray/data/tests/test_autoscaler.py
+++ b/python/ray/data/tests/test_autoscaler.py
@@ -88,11 +88,15 @@ def test_actor_pool_scaling():
     with patch(op, "completed", True):
         assert_autoscaling_action(_AutoscalingAction.SCALE_DOWN)
 
-    # Should scale down since all inputs have been already dispatched
-    with patch(op, "_inputs_complete", True, is_method=False):
-        with patch(op_state.input_queues[0], "__len__", 0):
-            with patch(op, "internal_queue_size", 0):
+    # Should scale down only once all inputs have been already dispatched
+    with patch(op_state.input_queues[0], "__len__", 0):
+        with patch(op, "internal_queue_size", 0):
+            with patch(op, "_inputs_complete", True, is_method=False):
                 assert_autoscaling_action(_AutoscalingAction.SCALE_DOWN)
+
+            with patch(op, "_inputs_complete", False, is_method=False):
+                assert_autoscaling_action(_AutoscalingAction.NO_OP)
+
 
     # Should be no-op since the op doesn't have enough resources.
     with patch(

--- a/python/ray/data/tests/test_autoscaler.py
+++ b/python/ray/data/tests/test_autoscaler.py
@@ -54,50 +54,54 @@ def test_actor_pool_scaling():
         yield
         setattr(mock, attr, original)
 
-    def assert_autoscaling_action(expected_action):
+    def assert_autoscaling_action(expected_action, expected_reason):
         nonlocal actor_pool, op, op_state
 
-        assert (
-            autoscaler._derive_scaling_action(
-                actor_pool=actor_pool,
-                op=op,
-                op_state=op_state,
-            )
-            == expected_action
-        )
+        assert autoscaler._derive_scaling_action(
+            actor_pool=actor_pool,
+            op=op,
+            op_state=op_state,
+        ) == (expected_action, expected_reason)
 
     # Should scale up since the util above the threshold.
     assert autoscaler._calculate_actor_pool_util(actor_pool) == 0.9
-    assert_autoscaling_action(_AutoscalingAction.SCALE_UP)
+    assert_autoscaling_action(_AutoscalingAction.SCALE_UP, 'utilization of 0.9 >= 0.8')
 
     # Should be no-op since the util is below the threshold.
     with patch(actor_pool, "num_active_actors", 7):
         assert autoscaler._calculate_actor_pool_util(actor_pool) == 0.7
-        assert_autoscaling_action(_AutoscalingAction.NO_OP)
+        assert_autoscaling_action(_AutoscalingAction.NO_OP, '0.5 < 0.7 < 0.8')
 
     # Should be no-op since we have reached the max size.
     with patch(actor_pool, "current_size", 15):
-        assert_autoscaling_action(_AutoscalingAction.NO_OP)
+        with patch(actor_pool, "num_active_actors", 15):
+            assert_autoscaling_action(_AutoscalingAction.NO_OP, 'reached max size')
+
+    # Should be no-op since we have reached the min size.
+    with patch(actor_pool, "current_size", 5):
+        with patch(actor_pool, "num_active_actors", 2):
+            assert_autoscaling_action(_AutoscalingAction.NO_OP, 'reached min size')
+
 
     # Should scale up since the pool is below the min size.
     with patch(actor_pool, "current_size", 4):
-        assert_autoscaling_action(_AutoscalingAction.SCALE_UP)
+        assert_autoscaling_action(_AutoscalingAction.SCALE_UP, 'pool below min size')
 
     # Should scale down since if the op is completed, or
     # the op has no more inputs.
     with patch(op, "completed", True):
-        assert_autoscaling_action(_AutoscalingAction.SCALE_DOWN)
+        assert_autoscaling_action(_AutoscalingAction.SCALE_DOWN, 'consumed all inputs')
 
     # Should scale down only once all inputs have been already dispatched
     with patch(op_state.input_queues[0], "__len__", 0):
         with patch(op, "internal_queue_size", 0):
             with patch(op, "_inputs_complete", True, is_method=False):
-                assert_autoscaling_action(_AutoscalingAction.SCALE_DOWN)
+                assert_autoscaling_action(_AutoscalingAction.SCALE_DOWN, 'consumed all inputs')
 
             # If inputs are not completed, should be no-op as there's nothing
             # to schedule and Actor Pool still has free slots
             with patch(op, "_inputs_complete", False, is_method=False):
-                assert_autoscaling_action(_AutoscalingAction.NO_OP)
+                assert_autoscaling_action(_AutoscalingAction.NO_OP, "pool has sufficient task slots remaining: enqueued inputs 0 <= free slots 5)")
 
     # Should be no-op since the op doesn't have enough resources.
     with patch(
@@ -106,21 +110,22 @@ def test_actor_pool_scaling():
         False,
         is_method=False,
     ):
-        assert_autoscaling_action(_AutoscalingAction.NO_OP)
+        assert_autoscaling_action(_AutoscalingAction.NO_OP, "operator exceeding resource quota")
 
     # Should be a no-op since the op has enough free slots for
     # the existing inputs.
     with patch(op_state, "total_enqueued_input_bundles", 5):
-        assert_autoscaling_action(_AutoscalingAction.NO_OP)
+        # TODO fix, should follow the same utilization ratio
+        assert_autoscaling_action(_AutoscalingAction.NO_OP, "pool has sufficient task slots remaining: enqueued inputs 5 <= free slots 5)")
 
     # Should scale down since the util is below the threshold.
     with patch(actor_pool, "num_active_actors", 4):
         assert autoscaler._calculate_actor_pool_util(actor_pool) == 0.4
-        assert_autoscaling_action(_AutoscalingAction.SCALE_DOWN)
+        assert_autoscaling_action(_AutoscalingAction.SCALE_DOWN, "utilization of 0.4 <= 0.5")
 
     # Should scale down since the pool is above the max size.
     with patch(actor_pool, "current_size", 16):
-        assert_autoscaling_action(_AutoscalingAction.SCALE_DOWN)
+        assert_autoscaling_action(_AutoscalingAction.SCALE_DOWN, "pool exceeding max size")
 
 
 def test_cluster_scaling():

--- a/python/ray/data/tests/test_autoscaler.py
+++ b/python/ray/data/tests/test_autoscaler.py
@@ -139,9 +139,7 @@ def test_actor_pool_scaling():
         )
 
         with patch(actor_pool, "can_scale_down", False):
-            assert_autoscaling_action(
-                _AutoscalingAction.NO_OP, "debounced"
-            )
+            assert_autoscaling_action(_AutoscalingAction.NO_OP, "debounced")
 
     # Should scale down since the pool is above the max size.
     with patch(actor_pool, "current_size", 16):

--- a/python/ray/data/tests/test_autoscaler.py
+++ b/python/ray/data/tests/test_autoscaler.py
@@ -94,6 +94,8 @@ def test_actor_pool_scaling():
             with patch(op, "_inputs_complete", True, is_method=False):
                 assert_autoscaling_action(_AutoscalingAction.SCALE_DOWN)
 
+            # If inputs are not completed, should be no-op as there's nothing
+            # to schedule and Actor Pool still has free slots
             with patch(op, "_inputs_complete", False, is_method=False):
                 assert_autoscaling_action(_AutoscalingAction.NO_OP)
 

--- a/python/ray/data/tests/test_autoscaler.py
+++ b/python/ray/data/tests/test_autoscaler.py
@@ -97,7 +97,6 @@ def test_actor_pool_scaling():
             with patch(op, "_inputs_complete", False, is_method=False):
                 assert_autoscaling_action(_AutoscalingAction.NO_OP)
 
-
     # Should be no-op since the op doesn't have enough resources.
     with patch(
         op_state._scheduling_status,

--- a/python/ray/data/tests/test_autoscaler.py
+++ b/python/ray/data/tests/test_autoscaler.py
@@ -4,8 +4,10 @@ from unittest.mock import MagicMock
 import pytest
 
 from ray.data import ExecutionResources
-from ray.data._internal.execution.autoscaler.default_autoscaler import \
-    DefaultAutoscaler, _AutoscalingAction
+from ray.data._internal.execution.autoscaler.default_autoscaler import (
+    DefaultAutoscaler,
+    _AutoscalingAction,
+)
 from ray.data._internal.execution.operators.base_physical_operator import (
     InternalQueueOperatorMixin,
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This is a follow-up for a https://github.com/ray-project/ray/pull/52806 that inadvertently modified autoscaling condition allowing downscaling to happen before all inputs have completed.

Changes

1. Fixed ActorPool to avoid downscaling if the enqueued blocks are 0 until all inputs are done.
1. Unified and streamlined ActorPool scaling handler to be just 1 method
2. Updated tests
3. Tidying up

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
