### PR TITLE
[core] [doc test] added missing tests for examples

### DIFF
--- a/doc/BUILD
+++ b/doc/BUILD
@@ -108,6 +108,38 @@ py_test(
     ],
 )
 
+py_test(
+    name = "gentle_walkthrough",
+    size = "small",
+    srcs = ["test_myst_doc.py"],
+    args = [
+        "--path",
+        "doc/source/ray-core/examples/gentle_walkthrough.ipynb",
+    ],
+    data = ["//doc/source/ray-core/examples:core_examples"],
+    main = "test_myst_doc.py",
+    tags = [
+        "exclusive",
+        "team:core",
+    ],
+)
+
+py_test(
+    name = "web_crawler",
+    size = "small",
+    srcs = ["test_myst_doc.py"],
+    args = [
+        "--path",
+        "doc/source/ray-core/examples/web-crawler.ipynb",
+    ],
+    data = ["//doc/source/ray-core/examples:core_examples"],
+    main = "test_myst_doc.py",
+    tags = [
+        "exclusive",
+        "team:core",
+    ],
+)
+
 # --------------------------------------------------------------------
 # Test all doc/source/ray-observability/doc_code code included in rst/md files.
 # --------------------------------------------------------------------
@@ -187,6 +219,17 @@ py_test(
     ],
 )
 
+py_test(
+    name = "doc_code_monte_carlo_pi",
+    size = "small",
+    srcs = ["source/ray-core/doc_code/monte_carlo_pi.py"],
+    main = "source/ray-core/doc_code/monte_carlo_pi.py",
+    tags = [
+        "exclusive",
+        "team:core",
+    ],
+)
+
 py_test_run_all_subdirectory(
     size = "medium",
     include = ["source/ray-core/doc_code/*.py"],
@@ -197,6 +240,7 @@ py_test_run_all_subdirectory(
         "source/ray-core/doc_code/cgraph_profiling.py",
         "source/ray-core/doc_code/cgraph_nccl.py",
         "source/ray-core/doc_code/cgraph_overlap.py",
+        "source/ray-core/doc_code/monte_carlo_pi.py",
         # not testing this as it purposefully segfaults
         "source/ray-core/doc_code/cgraph_troubleshooting.py",
     ],

--- a/doc/BUILD
+++ b/doc/BUILD
@@ -110,7 +110,7 @@ py_test(
 
 py_test(
     name = "gentle_walkthrough",
-    size = "small",
+    size = "medium",
     srcs = ["test_myst_doc.py"],
     args = [
         "--path",
@@ -126,7 +126,7 @@ py_test(
 
 py_test(
     name = "web_crawler",
-    size = "small",
+    size = "medium",
     srcs = ["test_myst_doc.py"],
     args = [
         "--path",
@@ -219,17 +219,6 @@ py_test(
     ],
 )
 
-py_test(
-    name = "doc_code_monte_carlo_pi",
-    size = "small",
-    srcs = ["source/ray-core/doc_code/monte_carlo_pi.py"],
-    main = "source/ray-core/doc_code/monte_carlo_pi.py",
-    tags = [
-        "exclusive",
-        "team:core",
-    ],
-)
-
 py_test_run_all_subdirectory(
     size = "medium",
     include = ["source/ray-core/doc_code/*.py"],
@@ -240,7 +229,6 @@ py_test_run_all_subdirectory(
         "source/ray-core/doc_code/cgraph_profiling.py",
         "source/ray-core/doc_code/cgraph_nccl.py",
         "source/ray-core/doc_code/cgraph_overlap.py",
-        "source/ray-core/doc_code/monte_carlo_pi.py",
         # not testing this as it purposefully segfaults
         "source/ray-core/doc_code/cgraph_troubleshooting.py",
     ],


### PR DESCRIPTION
During a test audit, found that these three notebooks were not covered by Bazel tests.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
