### PR TITLE
[core] Don't export task events for system `JobSupervisor` actor

### DIFF
--- a/python/ray/dashboard/modules/job/job_manager.py
+++ b/python/ray/dashboard/modules/job/job_manager.py
@@ -541,6 +541,9 @@ class JobManager:
                     runtime_env, submission_id, resources_specified
                 ),
                 namespace=SUPERVISOR_ACTOR_RAY_NAMESPACE,
+                # Don't pollute task events with system actor tasks that users don't
+                # know about.
+                enable_task_events=False,
             ).remote(
                 submission_id,
                 entrypoint,

--- a/python/ray/dashboard/modules/job/tests/test_job_manager.py
+++ b/python/ray/dashboard/modules/job/tests/test_job_manager.py
@@ -1403,7 +1403,10 @@ async def test_no_task_events_exported(shared_ray_instance, tmp_path):
     )
 
     assert "hello" in job_manager.get_job_logs(job_id)
-    assert len(list_tasks()) == 0
+
+    # Assert no task events for the JobSupervisor are exported.
+    for t in list_tasks():
+        assert "JobSupervisor" not in t.name
 
 
 if __name__ == "__main__":

--- a/python/ray/dashboard/modules/job/tests/test_job_manager.py
+++ b/python/ray/dashboard/modules/job/tests/test_job_manager.py
@@ -40,6 +40,7 @@ from ray.dashboard.modules.job.tests.conftest import (
 from ray.job_submission import JobStatus
 from ray.tests.conftest import call_ray_start  # noqa: F401
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy  # noqa: F401
+from ray.util.state import list_tasks
 
 import psutil
 
@@ -1390,6 +1391,20 @@ async def test_actor_creation_error_not_overwritten(shared_ray_instance, tmp_pat
             assert "path_not_exist is not a valid path" in data.message
             assert data.driver_exit_code is None
 
+
+@pytest.mark.asyncio
+async def test_no_task_events_exported(shared_ray_instance, tmp_path):
+    """Verify that no task events are exported by the JobSupervisor.
+    """
+    job_manager = create_job_manager(shared_ray_instance, tmp_path)
+    job_id = await job_manager.submit_job(entrypoint="echo hello")
+
+    await async_wait_for_condition(
+        check_job_succeeded, job_manager=job_manager, job_id=job_id
+    )
+
+    assert "hello" in job_manager.get_job_logs(job_id)
+    assert len(list_tasks()) == 0
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/dashboard/modules/job/tests/test_job_manager.py
+++ b/python/ray/dashboard/modules/job/tests/test_job_manager.py
@@ -1394,8 +1394,7 @@ async def test_actor_creation_error_not_overwritten(shared_ray_instance, tmp_pat
 
 @pytest.mark.asyncio
 async def test_no_task_events_exported(shared_ray_instance, tmp_path):
-    """Verify that no task events are exported by the JobSupervisor.
-    """
+    """Verify that no task events are exported by the JobSupervisor."""
     job_manager = create_job_manager(shared_ray_instance, tmp_path)
     job_id = await job_manager.submit_job(entrypoint="echo hello")
 
@@ -1405,6 +1404,7 @@ async def test_no_task_events_exported(shared_ray_instance, tmp_path):
 
     assert "hello" in job_manager.get_job_logs(job_id)
     assert len(list_tasks()) == 0
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
Users don't know this exists and it currently pollutes the task events.