### PR TITLE
[ci] Make Ray client tests conditional

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -56,7 +56,7 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/_common/tests/... //python/ray/dag/... //python/ray/autoscaler/v2/... core
         --install-mask all-ray-libraries
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
-        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual,use_all_core,multi_gpu,spark_tests
+        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual,use_all_core,multi_gpu,spark_tests,client_tests
         --install-mask all-ray-libraries
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... //python/ray/autoscaler/v2/... core
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
@@ -73,7 +73,7 @@ steps:
         --install-mask all-ray-libraries
         --workers 4 --worker-id "{{matrix.worker_id}}" --parallelism-per-worker 3
         --python-version {{matrix.python}}
-        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual,use_all_core,multi_gpu,spark_tests
+        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual,use_all_core,multi_gpu,spark_tests,client_tests
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... //python/ray/autoscaler/v2/... core
         --install-mask all-ray-libraries
         --workers 4 --worker-id "{{matrix.worker_id}}" --parallelism-per-worker 3
@@ -84,6 +84,17 @@ steps:
       setup:
         python: ["3.12"]
         worker_id: ["0", "1", "2", "3"]
+
+  - label: ":ray: core: ray client tests"
+    tags:
+      - python
+        # - skip-on-premerge
+    instance_type: large
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/...   core
+        --install-mask all-ray-libraries
+        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
+        --only-tags client_tests
 
   - label: ":ray: core: redis tests"
     tags:
@@ -97,7 +108,7 @@ steps:
         --install-mask all-ray-libraries
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --test-env=TEST_EXTERNAL_REDIS=1
-        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual,use_all_core,multi_gpu,spark_tests
+        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual,use_all_core,multi_gpu,spark_tests,client_tests
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... //python/ray/autoscaler/v2/... core
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
         --only-tags use_all_core --skip-ray-installation

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -56,7 +56,7 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/_common/tests/... //python/ray/dag/... //python/ray/autoscaler/v2/... core
         --install-mask all-ray-libraries
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
-        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual,use_all_core,multi_gpu,spark_tests,client_tests
+        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual,use_all_core,multi_gpu,spark_tests,ray_client
         --install-mask all-ray-libraries
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... //python/ray/autoscaler/v2/... core
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
@@ -73,7 +73,7 @@ steps:
         --install-mask all-ray-libraries
         --workers 4 --worker-id "{{matrix.worker_id}}" --parallelism-per-worker 3
         --python-version {{matrix.python}}
-        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual,use_all_core,multi_gpu,spark_tests,client_tests
+        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual,use_all_core,multi_gpu,spark_tests,ray_client
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... //python/ray/autoscaler/v2/... core
         --install-mask all-ray-libraries
         --workers 4 --worker-id "{{matrix.worker_id}}" --parallelism-per-worker 3
@@ -88,13 +88,13 @@ steps:
   - label: ":ray: core: ray client tests"
     tags:
       - python
-        # - skip-on-premerge
+      - ray_client
     instance_type: large
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/...   core
         --install-mask all-ray-libraries
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
-        --only-tags client_tests
+        --only-tags ray_client
 
   - label: ":ray: core: redis tests"
     tags:
@@ -108,7 +108,7 @@ steps:
         --install-mask all-ray-libraries
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --test-env=TEST_EXTERNAL_REDIS=1
-        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual,use_all_core,multi_gpu,spark_tests,client_tests
+        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual,use_all_core,multi_gpu,spark_tests,ray_client
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... //python/ray/autoscaler/v2/... core
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
         --only-tags use_all_core --skip-ray-installation

--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -12,7 +12,7 @@ from pprint import pformat
 _ALL_TAGS = set(
     """
     always
-    lint python cpp core_cpp java workflow accelerated_dag dashboard
+    lint python cpp core_cpp java workflow accelerated_dag dashboard ray_client
     data serve ml tune train llm rllib rllib_gpu rllib_directly
     linux_wheels macos_wheels docker doc python_dependencies tools
     release_tests compiled_python k8s_doc

--- a/ci/pipeline/test_rules.txt
+++ b/ci/pipeline/test_rules.txt
@@ -87,6 +87,10 @@ python/ray/experimental/channel/
 @ python accelerated_dag
 ;
 
+python/ray/util/client/
+@ python ray_client
+;
+
 python/
 @ ml tune train data
 # Python changes might impact cross language stack in Java.

--- a/ci/ray_ci/macos/macos_ci.sh
+++ b/ci/ray_ci/macos/macos_ci.sh
@@ -37,7 +37,7 @@ run_tests() {
 run_flaky_tests() {
   # shellcheck disable=SC2046
   # 42 is the universal rayci exit code for test failures
-  (bazel query 'attr(tags, "client_tests|small_size_python_tests|large_size_python_tests_shard_0|large_size_python_tests_shard_1|large_size_python_tests_shard_2|medium_size_python_tests_a_to_j|medium_size_python_tests_k_to_z", tests(//python/ray/tests/...))' | select_flaky_tests |
+  (bazel query 'attr(tags, "ray_client|small_size_python_tests|large_size_python_tests_shard_0|large_size_python_tests_shard_1|large_size_python_tests_shard_2|medium_size_python_tests_a_to_j|medium_size_python_tests_k_to_z", tests(//python/ray/tests/...))' | select_flaky_tests |
     xargs bazel test --config=ci $(./ci/run/bazel_export_options) \
       --runs_per_test="$RUN_PER_FLAKY_TEST" \
       --test_env=CONDA_EXE --test_env=CONDA_PYTHON_EXE --test_env=CONDA_SHLVL --test_env=CONDA_PREFIX \
@@ -47,7 +47,7 @@ run_flaky_tests() {
 run_small_test() {
   # shellcheck disable=SC2046
   # 42 is the universal rayci exit code for test failures
-  (bazel query 'attr(tags, "client_tests|small_size_python_tests", tests(//python/ray/tests/...))' | filter_out_flaky_tests |
+  (bazel query 'attr(tags, "ray_client|small_size_python_tests", tests(//python/ray/tests/...))' | filter_out_flaky_tests |
     xargs bazel test --config=ci $(./ci/run/bazel_export_options) \
       --test_env=CONDA_EXE --test_env=CONDA_PYTHON_EXE --test_env=CONDA_SHLVL --test_env=CONDA_PREFIX \
       --test_env=CONDA_DEFAULT_ENV --test_env=CONDA_PROMPT_MODIFIER --test_env=CI) || exit 42

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -124,8 +124,8 @@ py_test_module_list(
         "test_client_reconnect.py",
     ],
     tags = [
-        "ray_client",
         "exclusive",
+        "ray_client",
         "team:core",
     ],
     deps = [
@@ -140,8 +140,8 @@ py_test_module_list(
         "test_client_builder.py",
     ],
     tags = [
-        "ray_client",
         "exclusive",
+        "ray_client",
         "team:core",
         "use_all_core",
     ],
@@ -160,8 +160,8 @@ py_test_module_list(
         "test_client_warnings.py",
     ],
     tags = [
-        "ray_client",
         "exclusive",
+        "ray_client",
         "team:core",
     ],
     deps = [
@@ -176,9 +176,9 @@ py_test_module_list(
         "test_client_init.py",
     ],
     tags = [
-        "ray_client",
         "exclusive",
         "no_windows",
+        "ray_client",
         "team:core",
     ],
     deps = [
@@ -219,8 +219,8 @@ py_test_module_list(
     ],
     name_suffix = "_client_mode",
     tags = [
-        "ray_client",
         "exclusive",
+        "ray_client",
         "team:core",
     ],
     deps = [

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -115,6 +115,8 @@ py_test(
     ],
 )
 
+##### Begin Ray Client tests #####
+
 py_test_module_list(
     size = "large",
     files = [
@@ -122,7 +124,7 @@ py_test_module_list(
         "test_client_reconnect.py",
     ],
     tags = [
-        "client_tests",
+        "ray_client",
         "exclusive",
         "team:core",
     ],
@@ -138,7 +140,7 @@ py_test_module_list(
         "test_client_builder.py",
     ],
     tags = [
-        "client_tests",
+        "ray_client",
         "exclusive",
         "team:core",
         "use_all_core",
@@ -158,7 +160,7 @@ py_test_module_list(
         "test_client_warnings.py",
     ],
     tags = [
-        "client_tests",
+        "ray_client",
         "exclusive",
         "team:core",
     ],
@@ -174,7 +176,7 @@ py_test_module_list(
         "test_client_init.py",
     ],
     tags = [
-        "client_tests",
+        "ray_client",
         "exclusive",
         "no_windows",
         "team:core",
@@ -184,6 +186,50 @@ py_test_module_list(
         "//:ray_lib",
     ],
 )
+
+py_test_module_list(
+    size = "large",
+    env = {
+        "RAY_CLIENT_MODE": "1",
+        "RAY_PROFILING": "1",
+    },
+    files = [
+        "test_actor.py",
+        "test_advanced.py",
+        "test_asyncio.py",
+        "test_basic.py",
+        "test_basic_2.py",
+        "test_basic_3.py",
+        "test_basic_4.py",
+        "test_basic_5.py",
+        "test_list_actors.py",
+        "test_list_actors_2.py",
+        "test_list_actors_3.py",
+        "test_list_actors_4.py",
+        "test_multiprocessing.py",
+        "test_object_assign_owner.py",
+        "test_placement_group.py",
+        "test_placement_group_2.py",
+        "test_placement_group_3.py",
+        "test_placement_group_4.py",
+        "test_placement_group_5.py",
+        "test_scheduling.py",
+        "test_scheduling_2.py",
+        "test_wait.py",
+    ],
+    name_suffix = "_client_mode",
+    tags = [
+        "ray_client",
+        "exclusive",
+        "team:core",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+##### End Ray Client tests #####
 
 # Issue #33491
 # Once test_memory_deadlock is fixed, remove this rule and move
@@ -1141,41 +1187,6 @@ py_test(
         "exclusive",
         "no_windows",
         "team:kuberay",
-    ],
-    deps = [
-        ":conftest",
-        "//:ray_lib",
-    ],
-)
-
-py_test_module_list(
-    size = "large",
-    env = {
-        "RAY_CLIENT_MODE": "1",
-        "RAY_PROFILING": "1",
-    },
-    files = [
-        "test_actor.py",
-        "test_advanced.py",
-        "test_asyncio.py",
-        "test_basic.py",
-        "test_basic_2.py",
-        "test_basic_3.py",
-        "test_basic_4.py",
-        "test_basic_5.py",
-        "test_list_actors.py",
-        "test_list_actors_2.py",
-        "test_list_actors_3.py",
-        "test_list_actors_4.py",
-        "test_multiprocessing.py",
-        "test_object_assign_owner.py",
-        "test_wait.py",
-    ],
-    name_suffix = "_client_mode",
-    tags = [
-        "client_tests",
-        "exclusive",
-        "team:core",
     ],
     deps = [
         ":conftest",

--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -14,6 +14,7 @@ import pytest
 from pydantic import BaseModel as BaseModelV2
 from pydantic.v1 import BaseModel as BaseModelV1
 
+import ray
 import ray.cloudpickle as cloudpickle
 import ray.util.client.server.server as ray_client_server
 from ray._private.client_mode_hook import (
@@ -63,8 +64,6 @@ def call_ray_start_shared(request):
 
 @pytest.mark.parametrize("connect_to_client", [False, True])
 def test_client_context_manager(call_ray_start_shared, connect_to_client):
-    import ray
-
     if connect_to_client:
         with ray_start_client_server_for_address(
             call_ray_start_shared

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -8,7 +8,6 @@ import ray
 from ray._private.utils import get_ray_doc_version
 from ray._private.test_utils import placement_group_assert_no_leak
 from ray._private.test_utils import skip_flaky_core_test_premerge
-from ray.util.client.ray_client_helpers import connect_to_client_or_not
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from ray.util.placement_group import (
     validate_placement_group,
@@ -26,8 +25,7 @@ def are_pairwise_unique(g):
     return True
 
 
-@pytest.mark.parametrize("connect_to_client", [True, False])
-def test_placement_ready(ray_start_regular, connect_to_client):
+def test_placement_ready(ray_start_regular):
     @ray.remote
     class Actor:
         def __init__(self):
@@ -43,28 +41,28 @@ def test_placement_ready(ray_start_regular, connect_to_client):
     # This test is to test the case that even there all resource in the
     # bundle got allocated, we are still able to return from ready[I
     # since ready use 0 CPU
-    with connect_to_client_or_not(connect_to_client):
-        pg = ray.util.placement_group(bundles=[{"CPU": 1}])
-        ray.get(pg.ready())
+    pg = ray.util.placement_group(bundles=[{"CPU": 1}])
+    ray.get(pg.ready())
+    a = Actor.options(
+        num_cpus=1,
+        scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg),
+    ).remote()
+    ray.get(a.v.remote())
+    ray.get(pg.ready())
+
+    with pytest.raises(ValueError):
         a = Actor.options(
-            num_cpus=1,
+            resources={"bundle": 1},
             scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg),
         ).remote()
         ray.get(a.v.remote())
-        ray.get(pg.ready())
 
-        with pytest.raises(ValueError):
-            a = Actor.options(
-                resources={"bundle": 1},
-                scheduling_strategy=PlacementGroupSchedulingStrategy(
-                    placement_group=pg
-                ),
-            ).remote()
-            ray.get(a.v.remote())
-
-        placement_group_assert_no_leak([pg])
+    placement_group_assert_no_leak([pg])
 
 
+@pytest.mark.skipif(
+    ray._private.client_mode_hook.is_client_mode_enabled, reason="Fails w/ Ray Client."
+)
 def test_placement_group_invalid_resource_request(shutdown_only):
     """
     Make sure exceptions are raised if
@@ -169,11 +167,8 @@ def test_placement_group_invalid_resource_request(shutdown_only):
     placement_group_assert_no_leak([pg])
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
 @pytest.mark.parametrize("gcs_actor_scheduling_enabled", [False, True])
-def test_placement_group_pack(
-    ray_start_cluster, connect_to_client, gcs_actor_scheduling_enabled
-):
+def test_placement_group_pack(ray_start_cluster, gcs_actor_scheduling_enabled):
     @ray.remote(num_cpus=2)
     class Actor(object):
         def __init__(self):
@@ -195,47 +190,45 @@ def test_placement_group_pack(
         )
     ray.init(address=cluster.address)
 
-    with connect_to_client_or_not(connect_to_client):
-        placement_group = ray.util.placement_group(
-            name="name",
-            strategy="PACK",
-            bundles=[
-                {"CPU": 2, "GPU": 0},  # Test 0 resource spec doesn't break tests.
-                {"CPU": 2},
-            ],
+    placement_group = ray.util.placement_group(
+        name="name",
+        strategy="PACK",
+        bundles=[
+            {"CPU": 2, "GPU": 0},  # Test 0 resource spec doesn't break tests.
+            {"CPU": 2},
+        ],
+    )
+    ray.get(placement_group.ready())
+    actor_1 = Actor.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=placement_group, placement_group_bundle_index=0
         )
-        ray.get(placement_group.ready())
-        actor_1 = Actor.options(
-            scheduling_strategy=PlacementGroupSchedulingStrategy(
-                placement_group=placement_group, placement_group_bundle_index=0
-            )
-        ).remote()
-        actor_2 = Actor.options(
-            scheduling_strategy=PlacementGroupSchedulingStrategy(
-                placement_group=placement_group, placement_group_bundle_index=1
-            )
-        ).remote()
+    ).remote()
+    actor_2 = Actor.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=placement_group, placement_group_bundle_index=1
+        )
+    ).remote()
 
-        ray.get(actor_1.value.remote())
-        ray.get(actor_2.value.remote())
+    ray.get(actor_1.value.remote())
+    ray.get(actor_2.value.remote())
 
-        # Get all actors.
-        actor_infos = ray._private.state.actors()
+    # Get all actors.
+    actor_infos = ray._private.state.actors()
 
-        # Make sure all actors in counter_list are collocated in one node.
-        actor_info_1 = actor_infos.get(actor_1._actor_id.hex())
-        actor_info_2 = actor_infos.get(actor_2._actor_id.hex())
+    # Make sure all actors in counter_list are collocated in one node.
+    actor_info_1 = actor_infos.get(actor_1._actor_id.hex())
+    actor_info_2 = actor_infos.get(actor_2._actor_id.hex())
 
-        assert actor_info_1 and actor_info_2
+    assert actor_info_1 and actor_info_2
 
-        node_of_actor_1 = actor_info_1["Address"]["NodeID"]
-        node_of_actor_2 = actor_info_2["Address"]["NodeID"]
-        assert node_of_actor_1 == node_of_actor_2
-        placement_group_assert_no_leak([placement_group])
+    node_of_actor_1 = actor_info_1["Address"]["NodeID"]
+    node_of_actor_2 = actor_info_2["Address"]["NodeID"]
+    assert node_of_actor_1 == node_of_actor_2
+    placement_group_assert_no_leak([placement_group])
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
-def test_placement_group_strict_pack(ray_start_cluster, connect_to_client):
+def test_placement_group_strict_pack(ray_start_cluster):
     @ray.remote(num_cpus=2)
     class Actor(object):
         def __init__(self):
@@ -250,56 +243,52 @@ def test_placement_group_strict_pack(ray_start_cluster, connect_to_client):
         cluster.add_node(num_cpus=4)
     ray.init(address=cluster.address)
 
-    with connect_to_client_or_not(connect_to_client):
-        placement_group = ray.util.placement_group(
-            name="name",
-            strategy="STRICT_PACK",
-            bundles=[
-                {
-                    "memory": 50
-                    * 1024
-                    * 1024,  # Test memory resource spec doesn't break tests.
-                    "CPU": 2,
-                },
-                {"CPU": 2},
-            ],
+    placement_group = ray.util.placement_group(
+        name="name",
+        strategy="STRICT_PACK",
+        bundles=[
+            {
+                "memory": 50
+                * 1024
+                * 1024,  # Test memory resource spec doesn't break tests.
+                "CPU": 2,
+            },
+            {"CPU": 2},
+        ],
+    )
+    ray.get(placement_group.ready())
+    actor_1 = Actor.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=placement_group, placement_group_bundle_index=0
         )
-        ray.get(placement_group.ready())
-        actor_1 = Actor.options(
-            scheduling_strategy=PlacementGroupSchedulingStrategy(
-                placement_group=placement_group, placement_group_bundle_index=0
-            )
-        ).remote()
-        actor_2 = Actor.options(
-            scheduling_strategy=PlacementGroupSchedulingStrategy(
-                placement_group=placement_group, placement_group_bundle_index=1
-            )
-        ).remote()
+    ).remote()
+    actor_2 = Actor.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=placement_group, placement_group_bundle_index=1
+        )
+    ).remote()
 
-        ray.get(actor_1.value.remote())
-        ray.get(actor_2.value.remote())
+    ray.get(actor_1.value.remote())
+    ray.get(actor_2.value.remote())
 
-        # Get all actors.
-        actor_infos = ray._private.state.actors()
+    # Get all actors.
+    actor_infos = ray._private.state.actors()
 
-        # Make sure all actors in counter_list are collocated in one node.
-        actor_info_1 = actor_infos.get(actor_1._actor_id.hex())
-        actor_info_2 = actor_infos.get(actor_2._actor_id.hex())
+    # Make sure all actors in counter_list are collocated in one node.
+    actor_info_1 = actor_infos.get(actor_1._actor_id.hex())
+    actor_info_2 = actor_infos.get(actor_2._actor_id.hex())
 
-        assert actor_info_1 and actor_info_2
+    assert actor_info_1 and actor_info_2
 
-        node_of_actor_1 = actor_info_1["Address"]["NodeID"]
-        node_of_actor_2 = actor_info_2["Address"]["NodeID"]
-        assert node_of_actor_1 == node_of_actor_2
+    node_of_actor_1 = actor_info_1["Address"]["NodeID"]
+    node_of_actor_2 = actor_info_2["Address"]["NodeID"]
+    assert node_of_actor_1 == node_of_actor_2
 
-        placement_group_assert_no_leak([placement_group])
+    placement_group_assert_no_leak([placement_group])
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
 @pytest.mark.parametrize("gcs_actor_scheduling_enabled", [False, True])
-def test_placement_group_spread(
-    ray_start_cluster, connect_to_client, gcs_actor_scheduling_enabled
-):
+def test_placement_group_spread(ray_start_cluster, gcs_actor_scheduling_enabled):
     @ray.remote
     class Actor(object):
         def __init__(self):
@@ -321,43 +310,39 @@ def test_placement_group_spread(
         )
     ray.init(address=cluster.address)
 
-    with connect_to_client_or_not(connect_to_client):
-        placement_group = ray.util.placement_group(
-            name="name",
-            strategy="STRICT_SPREAD",
-            bundles=[{"CPU": 2}, {"CPU": 2}],
-        )
-        ray.get(placement_group.ready())
-        actors = [
-            Actor.options(
-                scheduling_strategy=PlacementGroupSchedulingStrategy(
-                    placement_group=placement_group, placement_group_bundle_index=i
-                ),
-                num_cpus=2,
-            ).remote()
-            for i in range(num_nodes)
-        ]
+    placement_group = ray.util.placement_group(
+        name="name",
+        strategy="STRICT_SPREAD",
+        bundles=[{"CPU": 2}, {"CPU": 2}],
+    )
+    ray.get(placement_group.ready())
+    actors = [
+        Actor.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=placement_group, placement_group_bundle_index=i
+            ),
+            num_cpus=2,
+        ).remote()
+        for i in range(num_nodes)
+    ]
 
-        [ray.get(actor.value.remote()) for actor in actors]
+    [ray.get(actor.value.remote()) for actor in actors]
 
-        # Get all actors.
-        actor_infos = ray._private.state.actors()
+    # Get all actors.
+    actor_infos = ray._private.state.actors()
 
-        # Make sure all actors in counter_list are located in separate nodes.
-        actor_info_objs = [actor_infos.get(actor._actor_id.hex()) for actor in actors]
-        assert are_pairwise_unique(
-            [info_obj["Address"]["NodeID"] for info_obj in actor_info_objs]
-        )
+    # Make sure all actors in counter_list are located in separate nodes.
+    actor_info_objs = [actor_infos.get(actor._actor_id.hex()) for actor in actors]
+    assert are_pairwise_unique(
+        [info_obj["Address"]["NodeID"] for info_obj in actor_info_objs]
+    )
 
-        placement_group_assert_no_leak([placement_group])
+    placement_group_assert_no_leak([placement_group])
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
 @pytest.mark.parametrize("gcs_actor_scheduling_enabled", [False, True])
 @skip_flaky_core_test_premerge("https://github.com/ray-project/ray/issues/38726")
-def test_placement_group_strict_spread(
-    ray_start_cluster, connect_to_client, gcs_actor_scheduling_enabled
-):
+def test_placement_group_strict_spread(ray_start_cluster, gcs_actor_scheduling_enabled):
     @ray.remote
     class Actor(object):
         def __init__(self):
@@ -379,59 +364,57 @@ def test_placement_group_strict_spread(
         )
     ray.init(address=cluster.address)
 
-    with connect_to_client_or_not(connect_to_client):
-        placement_group = ray.util.placement_group(
-            name="name",
-            strategy="STRICT_SPREAD",
-            bundles=[{"CPU": 2}, {"CPU": 2}, {"CPU": 2}],
-        )
-        ray.get(placement_group.ready())
-        actors = [
-            Actor.options(
-                scheduling_strategy=PlacementGroupSchedulingStrategy(
-                    placement_group=placement_group, placement_group_bundle_index=i
-                ),
-                num_cpus=1,
-            ).remote()
-            for i in range(num_nodes)
-        ]
+    placement_group = ray.util.placement_group(
+        name="name",
+        strategy="STRICT_SPREAD",
+        bundles=[{"CPU": 2}, {"CPU": 2}, {"CPU": 2}],
+    )
+    ray.get(placement_group.ready())
+    actors = [
+        Actor.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=placement_group, placement_group_bundle_index=i
+            ),
+            num_cpus=1,
+        ).remote()
+        for i in range(num_nodes)
+    ]
 
-        [ray.get(actor.value.remote()) for actor in actors]
+    [ray.get(actor.value.remote()) for actor in actors]
 
-        # Get all actors.
-        actor_infos = ray._private.state.actors()
+    # Get all actors.
+    actor_infos = ray._private.state.actors()
 
-        # Make sure all actors in counter_list are located in separate nodes.
-        actor_info_objs = [actor_infos.get(actor._actor_id.hex()) for actor in actors]
-        assert are_pairwise_unique(
-            [info_obj["Address"]["NodeID"] for info_obj in actor_info_objs]
-        )
+    # Make sure all actors in counter_list are located in separate nodes.
+    actor_info_objs = [actor_infos.get(actor._actor_id.hex()) for actor in actors]
+    assert are_pairwise_unique(
+        [info_obj["Address"]["NodeID"] for info_obj in actor_info_objs]
+    )
 
-        actors_no_special_bundle = [
-            Actor.options(
-                scheduling_strategy=PlacementGroupSchedulingStrategy(
-                    placement_group=placement_group
-                ),
-                num_cpus=1,
-            ).remote()
-            for _ in range(num_nodes)
-        ]
-        [ray.get(actor.value.remote()) for actor in actors_no_special_bundle]
-
-        actor_no_resource = Actor.options(
+    actors_no_special_bundle = [
+        Actor.options(
             scheduling_strategy=PlacementGroupSchedulingStrategy(
                 placement_group=placement_group
             ),
-            num_cpus=2,
+            num_cpus=1,
         ).remote()
-        with pytest.raises(ray.exceptions.GetTimeoutError):
-            ray.get(actor_no_resource.value.remote(), timeout=1)
+        for _ in range(num_nodes)
+    ]
+    [ray.get(actor.value.remote()) for actor in actors_no_special_bundle]
 
-        placement_group_assert_no_leak([placement_group])
+    actor_no_resource = Actor.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=placement_group
+        ),
+        num_cpus=2,
+    ).remote()
+    with pytest.raises(ray.exceptions.GetTimeoutError):
+        ray.get(actor_no_resource.value.remote(), timeout=1)
+
+    placement_group_assert_no_leak([placement_group])
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
-def test_placement_group_actor_resource_ids(ray_start_cluster, connect_to_client):
+def test_placement_group_actor_resource_ids(ray_start_cluster):
     @ray.remote(num_cpus=1)
     class F:
         def f(self):
@@ -443,18 +426,16 @@ def test_placement_group_actor_resource_ids(ray_start_cluster, connect_to_client
         cluster.add_node(num_cpus=4)
     ray.init(address=cluster.address)
 
-    with connect_to_client_or_not(connect_to_client):
-        g1 = ray.util.placement_group([{"CPU": 2}])
-        a1 = F.options(
-            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=g1)
-        ).remote()
-        resources = ray.get(a1.f.remote())
-        assert resources == {"CPU": 1}
-        placement_group_assert_no_leak([g1])
+    g1 = ray.util.placement_group([{"CPU": 2}])
+    a1 = F.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=g1)
+    ).remote()
+    resources = ray.get(a1.f.remote())
+    assert resources == {"CPU": 1}
+    placement_group_assert_no_leak([g1])
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
-def test_placement_group_task_resource_ids(ray_start_cluster, connect_to_client):
+def test_placement_group_task_resource_ids(ray_start_cluster):
     @ray.remote(num_cpus=1)
     def f():
         return ray.get_runtime_context().get_assigned_resources()
@@ -465,28 +446,26 @@ def test_placement_group_task_resource_ids(ray_start_cluster, connect_to_client)
         cluster.add_node(num_cpus=4)
     ray.init(address=cluster.address)
 
-    with connect_to_client_or_not(connect_to_client):
-        g1 = ray.util.placement_group([{"CPU": 2}])
-        o1 = f.options(
-            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=g1)
-        ).remote()
-        resources = ray.get(o1)
-        assert resources == {"CPU": 1}
+    g1 = ray.util.placement_group([{"CPU": 2}])
+    o1 = f.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=g1)
+    ).remote()
+    resources = ray.get(o1)
+    assert resources == {"CPU": 1}
 
-        # Now retry with a bundle index constraint.
-        o1 = f.options(
-            scheduling_strategy=PlacementGroupSchedulingStrategy(
-                placement_group=g1, placement_group_bundle_index=0
-            )
-        ).remote()
-        resources = ray.get(o1)
-        assert resources == {"CPU": 1}
+    # Now retry with a bundle index constraint.
+    o1 = f.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=g1, placement_group_bundle_index=0
+        )
+    ).remote()
+    resources = ray.get(o1)
+    assert resources == {"CPU": 1}
 
-        placement_group_assert_no_leak([g1])
+    placement_group_assert_no_leak([g1])
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
-def test_placement_group_hang(ray_start_cluster, connect_to_client):
+def test_placement_group_hang(ray_start_cluster):
     @ray.remote(num_cpus=1)
     def f():
         return ray.get_runtime_context().get_assigned_resources()
@@ -497,28 +476,25 @@ def test_placement_group_hang(ray_start_cluster, connect_to_client):
         cluster.add_node(num_cpus=4)
     ray.init(address=cluster.address)
 
-    with connect_to_client_or_not(connect_to_client):
-        # Warm workers up, so that this triggers the hang rice.
-        ray.get(f.remote())
+    # Warm workers up, so that this triggers the hang rice.
+    ray.get(f.remote())
 
-        g1 = ray.util.placement_group([{"CPU": 2}])
-        # This will start out infeasible. The placement group will then be
-        # created and it transitions to feasible.
-        o1 = f.options(
-            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=g1)
-        ).remote()
+    g1 = ray.util.placement_group([{"CPU": 2}])
+    # This will start out infeasible. The placement group will then be
+    # created and it transitions to feasible.
+    o1 = f.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=g1)
+    ).remote()
 
-        resources = ray.get(o1)
-        assert resources == {"CPU": 1}
+    resources = ray.get(o1)
+    assert resources == {"CPU": 1}
 
-        placement_group_assert_no_leak([g1])
+    placement_group_assert_no_leak([g1])
 
 
-@pytest.mark.parametrize("connect_to_client", [True, False])
-def test_placement_group_empty_bundle_error(ray_start_regular, connect_to_client):
-    with connect_to_client_or_not(connect_to_client):
-        with pytest.raises(ValueError):
-            ray.util.placement_group([])
+def test_placement_group_empty_bundle_error(ray_start_regular):
+    with pytest.raises(ValueError):
+        ray.util.placement_group([])
 
 
 def test_placement_group_equal_hash(ray_start_regular):
@@ -592,6 +568,9 @@ def test_placement_group_scheduling_warning(ray_start_regular):
     assert not w
 
 
+@pytest.mark.skipif(
+    ray._private.client_mode_hook.is_client_mode_enabled, reason="Fails w/ Ray Client."
+)
 @pytest.mark.filterwarnings(
     "default:Setting 'object_store_memory' for actors is deprecated"
 )

--- a/python/ray/tests/test_placement_group_2.py
+++ b/python/ray/tests/test_placement_group_2.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import time
 
@@ -15,7 +16,6 @@ from ray._private.test_utils import (
     run_string_as_driver,
     wait_for_condition,
 )
-from ray.util.client.ray_client_helpers import connect_to_client_or_not
 from ray.util.placement_group import get_current_placement_group
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
@@ -26,8 +26,7 @@ class Increase:
         return x + 2
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
-def test_check_bundle_index(ray_start_cluster, connect_to_client):
+def test_check_bundle_index(ray_start_cluster):
     @ray.remote(num_cpus=2)
     class Actor(object):
         def __init__(self):
@@ -40,127 +39,119 @@ def test_check_bundle_index(ray_start_cluster, connect_to_client):
     cluster.add_node(num_cpus=4)
     ray.init(address=cluster.address)
 
-    with connect_to_client_or_not(connect_to_client):
-        placement_group = ray.util.placement_group(
-            name="name", strategy="SPREAD", bundles=[{"CPU": 2}, {"CPU": 2}]
-        )
+    placement_group = ray.util.placement_group(
+        name="name", strategy="SPREAD", bundles=[{"CPU": 2}, {"CPU": 2}]
+    )
 
-        with pytest.raises(ValueError, match="bundle index 3 is invalid"):
-            Actor.options(
-                scheduling_strategy=PlacementGroupSchedulingStrategy(
-                    placement_group=placement_group, placement_group_bundle_index=3
-                )
-            ).remote()
+    with pytest.raises(ValueError, match="bundle index 3 is invalid"):
+        Actor.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=placement_group, placement_group_bundle_index=3
+            )
+        ).remote()
 
-        with pytest.raises(ValueError, match="bundle index -2 is invalid"):
-            Actor.options(
-                scheduling_strategy=PlacementGroupSchedulingStrategy(
-                    placement_group=placement_group, placement_group_bundle_index=-2
-                )
-            ).remote()
+    with pytest.raises(ValueError, match="bundle index -2 is invalid"):
+        Actor.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=placement_group, placement_group_bundle_index=-2
+            )
+        ).remote()
 
-        with pytest.raises(ValueError, match="bundle index must be -1"):
-            Actor.options(placement_group_bundle_index=0).remote()
+    with pytest.raises(ValueError, match="bundle index must be -1"):
+        Actor.options(placement_group_bundle_index=0).remote()
 
-        placement_group_assert_no_leak([placement_group])
+    placement_group_assert_no_leak([placement_group])
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
-def test_pending_placement_group_wait(ray_start_cluster, connect_to_client):
+def test_pending_placement_group_wait(ray_start_cluster):
     cluster = ray_start_cluster
     [cluster.add_node(num_cpus=2) for _ in range(1)]
     ray.init(address=cluster.address)
     cluster.wait_for_nodes()
 
-    with connect_to_client_or_not(connect_to_client):
-        # Wait on placement group that cannot be created.
-        placement_group = ray.util.placement_group(
-            name="name",
-            strategy="SPREAD",
-            bundles=[
-                {"CPU": 2},
-                {"CPU": 2},
-                {"GPU": 2},
-            ],
-        )
-        ready, unready = ray.wait([placement_group.ready()], timeout=0.1)
-        assert len(unready) == 1
-        assert len(ready) == 0
-        table = ray.util.placement_group_table(placement_group)
-        assert table["state"] == "PENDING"
-        for i in range(3):
-            assert len(table["bundles_to_node_id"][i]) == 0
+    # Wait on placement group that cannot be created.
+    placement_group = ray.util.placement_group(
+        name="name",
+        strategy="SPREAD",
+        bundles=[
+            {"CPU": 2},
+            {"CPU": 2},
+            {"GPU": 2},
+        ],
+    )
+    ready, unready = ray.wait([placement_group.ready()], timeout=0.1)
+    assert len(unready) == 1
+    assert len(ready) == 0
+    table = ray.util.placement_group_table(placement_group)
+    assert table["state"] == "PENDING"
+    for i in range(3):
+        assert len(table["bundles_to_node_id"][i]) == 0
 
-        with pytest.raises(ray.exceptions.GetTimeoutError):
-            ray.get(placement_group.ready(), timeout=0.1)
+    with pytest.raises(ray.exceptions.GetTimeoutError):
+        ray.get(placement_group.ready(), timeout=0.1)
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
-def test_placement_group_wait(ray_start_cluster, connect_to_client):
+def test_placement_group_wait(ray_start_cluster):
     cluster = ray_start_cluster
     [cluster.add_node(num_cpus=2) for _ in range(2)]
     ray.init(address=cluster.address)
     cluster.wait_for_nodes()
 
-    with connect_to_client_or_not(connect_to_client):
-        # Wait on placement group that cannot be created.
-        placement_group = ray.util.placement_group(
-            name="name",
-            strategy="SPREAD",
-            bundles=[
-                {"CPU": 2},
-                {"CPU": 2},
-            ],
+    # Wait on placement group that cannot be created.
+    placement_group = ray.util.placement_group(
+        name="name",
+        strategy="SPREAD",
+        bundles=[
+            {"CPU": 2},
+            {"CPU": 2},
+        ],
+    )
+    ready, unready = ray.wait([placement_group.ready()])
+    assert len(unready) == 0
+    assert len(ready) == 1
+    table = ray.util.placement_group_table(placement_group)
+    assert table["state"] == "CREATED"
+    pg = ray.get(placement_group.ready())
+    assert pg.bundle_specs == placement_group.bundle_specs
+    assert pg.id.binary() == placement_group.id.binary()
+
+    @ray.remote
+    def get_node_id():
+        return ray.get_runtime_context().get_node_id()
+
+    for i in range(2):
+        scheduling_strategy = PlacementGroupSchedulingStrategy(
+            placement_group=placement_group,
+            placement_group_bundle_index=i,
         )
-        ready, unready = ray.wait([placement_group.ready()])
-        assert len(unready) == 0
-        assert len(ready) == 1
-        table = ray.util.placement_group_table(placement_group)
-        assert table["state"] == "CREATED"
-        pg = ray.get(placement_group.ready())
-        assert pg.bundle_specs == placement_group.bundle_specs
-        assert pg.id.binary() == placement_group.id.binary()
-
-        @ray.remote
-        def get_node_id():
-            return ray.get_runtime_context().get_node_id()
-
-        for i in range(2):
-            scheduling_strategy = PlacementGroupSchedulingStrategy(
-                placement_group=placement_group,
-                placement_group_bundle_index=i,
-            )
-            node_id = ray.get(
-                get_node_id.options(scheduling_strategy=scheduling_strategy).remote()
-            )
-            assert node_id == table["bundles_to_node_id"][i]
+        node_id = ray.get(
+            get_node_id.options(scheduling_strategy=scheduling_strategy).remote()
+        )
+        assert node_id == table["bundles_to_node_id"][i]
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
-def test_schedule_placement_group_when_node_add(ray_start_cluster, connect_to_client):
+def test_schedule_placement_group_when_node_add(ray_start_cluster):
     cluster = ray_start_cluster
     cluster.add_node(num_cpus=4)
     ray.init(address=cluster.address)
 
-    with connect_to_client_or_not(connect_to_client):
-        # Creating a placement group that cannot be satisfied yet.
-        placement_group = ray.util.placement_group([{"GPU": 2}, {"CPU": 2}])
+    # Creating a placement group that cannot be satisfied yet.
+    placement_group = ray.util.placement_group([{"GPU": 2}, {"CPU": 2}])
 
-        def is_placement_group_created():
-            table = ray.util.placement_group_table(placement_group)
-            if "state" not in table:
-                return False
-            return table["state"] == "CREATED"
+    def is_placement_group_created():
+        table = ray.util.placement_group_table(placement_group)
+        if "state" not in table:
+            return False
+        return table["state"] == "CREATED"
 
-        # Add a node that has GPU.
-        cluster.add_node(num_cpus=4, num_gpus=4)
+    # Add a node that has GPU.
+    cluster.add_node(num_cpus=4, num_gpus=4)
 
-        # Make sure the placement group is created.
-        wait_for_condition(is_placement_group_created)
+    # Make sure the placement group is created.
+    wait_for_condition(is_placement_group_created)
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
-def test_atomic_creation(ray_start_cluster, connect_to_client):
+def test_atomic_creation(ray_start_cluster):
     # Setup cluster.
     cluster = ray_start_cluster
     bundle_cpu_size = 2
@@ -183,100 +174,96 @@ def test_atomic_creation(ray_start_cluster, connect_to_client):
         time.sleep(6)
         return True
 
-    with connect_to_client_or_not(connect_to_client):
-        # Schedule tasks to fail initial placement group creation.
-        tasks = [bothering_task.remote() for _ in range(2)]
+    # Schedule tasks to fail initial placement group creation.
+    tasks = [bothering_task.remote() for _ in range(2)]
 
-        # Make sure the two common task has scheduled.
-        def tasks_scheduled():
-            return ray.available_resources()["CPU"] == 2.0
+    # Make sure the two common task has scheduled.
+    def tasks_scheduled():
+        return ray.available_resources()["CPU"] == 2.0
 
-        wait_for_condition(tasks_scheduled)
+    wait_for_condition(tasks_scheduled)
 
-        # Create an actor that will fail bundle scheduling.
-        # It is important to use pack strategy to make test less flaky.
-        pg = ray.util.placement_group(
-            name="name",
-            strategy="SPREAD",
-            bundles=[
-                {"CPU": bundle_cpu_size} for _ in range(num_nodes * bundle_per_node)
-            ],
-        )
+    # Create an actor that will fail bundle scheduling.
+    # It is important to use pack strategy to make test less flaky.
+    pg = ray.util.placement_group(
+        name="name",
+        strategy="SPREAD",
+        bundles=[{"CPU": bundle_cpu_size} for _ in range(num_nodes * bundle_per_node)],
+    )
 
-        # Create a placement group actor.
-        # This shouldn't be scheduled because atomic
-        # placement group creation should've failed.
-        pg_actor = NormalActor.options(
+    # Create a placement group actor.
+    # This shouldn't be scheduled because atomic
+    # placement group creation should've failed.
+    pg_actor = NormalActor.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=pg,
+            placement_group_bundle_index=num_nodes * bundle_per_node - 1,
+        ),
+    ).remote()
+
+    # Wait on the placement group now. It should be unready
+    # because normal actor takes resources that are required
+    # for one of bundle creation.
+    ready, unready = ray.wait([pg.ready()], timeout=0.5)
+    assert len(ready) == 0
+    assert len(unready) == 1
+    # Wait until all tasks are done.
+    assert all(ray.get(tasks))
+
+    # Wait on the placement group creation. Since resources are now
+    # available, it should be ready soon.
+    ready, unready = ray.wait([pg.ready()])
+    assert len(ready) == 1
+    assert len(unready) == 0
+
+    # Confirm that the placement group actor is created. It will
+    # raise an exception if actor was scheduled before placement
+    # group was created thus it checks atomicity.
+    ray.get(pg_actor.ping.remote(), timeout=3.0)
+    ray.kill(pg_actor)
+
+    # Make sure atomic creation failure didn't impact resources.
+    @ray.remote(num_cpus=bundle_cpu_size)
+    def resource_check():
+        return True
+
+    # This should hang because every resources
+    # are claimed by placement group.
+    check_without_pg = [
+        resource_check.remote() for _ in range(bundle_per_node * num_nodes)
+    ]
+
+    # This all should scheduled on each bundle.
+    check_with_pg = [
+        resource_check.options(
             scheduling_strategy=PlacementGroupSchedulingStrategy(
-                placement_group=pg,
-                placement_group_bundle_index=num_nodes * bundle_per_node - 1,
-            ),
+                placement_group=pg, placement_group_bundle_index=i
+            )
         ).remote()
+        for i in range(bundle_per_node * num_nodes)
+    ]
 
-        # Wait on the placement group now. It should be unready
-        # because normal actor takes resources that are required
-        # for one of bundle creation.
-        ready, unready = ray.wait([pg.ready()], timeout=0.5)
-        assert len(ready) == 0
-        assert len(unready) == 1
-        # Wait until all tasks are done.
-        assert all(ray.get(tasks))
+    # Make sure these are hanging.
+    ready, unready = ray.wait(check_without_pg, timeout=0)
+    assert len(ready) == 0
+    assert len(unready) == bundle_per_node * num_nodes
 
-        # Wait on the placement group creation. Since resources are now
-        # available, it should be ready soon.
-        ready, unready = ray.wait([pg.ready()])
-        assert len(ready) == 1
-        assert len(unready) == 0
+    # Make sure these are all scheduled.
+    assert all(ray.get(check_with_pg))
 
-        # Confirm that the placement group actor is created. It will
-        # raise an exception if actor was scheduled before placement
-        # group was created thus it checks atomicity.
-        ray.get(pg_actor.ping.remote(), timeout=3.0)
-        ray.kill(pg_actor)
+    ray.util.remove_placement_group(pg)
 
-        # Make sure atomic creation failure didn't impact resources.
-        @ray.remote(num_cpus=bundle_cpu_size)
-        def resource_check():
-            return True
+    def pg_removed():
+        return ray.util.placement_group_table(pg)["state"] == "REMOVED"
 
-        # This should hang because every resources
-        # are claimed by placement group.
-        check_without_pg = [
-            resource_check.remote() for _ in range(bundle_per_node * num_nodes)
-        ]
+    wait_for_condition(pg_removed)
 
-        # This all should scheduled on each bundle.
-        check_with_pg = [
-            resource_check.options(
-                scheduling_strategy=PlacementGroupSchedulingStrategy(
-                    placement_group=pg, placement_group_bundle_index=i
-                )
-            ).remote()
-            for i in range(bundle_per_node * num_nodes)
-        ]
-
-        # Make sure these are hanging.
-        ready, unready = ray.wait(check_without_pg, timeout=0)
-        assert len(ready) == 0
-        assert len(unready) == bundle_per_node * num_nodes
-
-        # Make sure these are all scheduled.
-        assert all(ray.get(check_with_pg))
-
-        ray.util.remove_placement_group(pg)
-
-        def pg_removed():
-            return ray.util.placement_group_table(pg)["state"] == "REMOVED"
-
-        wait_for_condition(pg_removed)
-
-        # Make sure check without pgs are all
-        # scheduled properly because resources are cleaned up.
-        assert all(ray.get(check_without_pg))
+    # Make sure check without pgs are all
+    # scheduled properly because resources are cleaned up.
+    assert all(ray.get(check_without_pg))
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
-def test_mini_integration(ray_start_cluster, connect_to_client):
+def test_mini_integration(ray_start_cluster):
     # Create bundles as many as number of gpus in the cluster.
     # Do some random work and make sure all resources are properly recovered.
 
@@ -298,268 +285,256 @@ def test_mini_integration(ray_start_cluster, connect_to_client):
     cluster.wait_for_nodes()
     ray.init(address=cluster.address)
 
-    with connect_to_client_or_not(connect_to_client):
+    @ray.remote(num_cpus=0, num_gpus=1)
+    def random_tasks():
+        import random
+        import time
 
-        @ray.remote(num_cpus=0, num_gpus=1)
-        def random_tasks():
-            import random
-            import time
+        sleep_time = random.uniform(0.1, 0.2)
+        time.sleep(sleep_time)
+        return True
 
-            sleep_time = random.uniform(0.1, 0.2)
-            time.sleep(sleep_time)
+    pgs = []
+    pg_tasks = []
+    # total bundle gpu usage = bundles_per_pg*total_num_pg*per_bundle_gpus
+    # Note this is half of total
+    for index in range(total_num_pg):
+        pgs.append(
+            ray.util.placement_group(
+                name=f"name{index}",
+                strategy="PACK",
+                bundles=[{"GPU": per_bundle_gpus} for _ in range(bundles_per_pg)],
+            )
+        )
+
+    # Schedule tasks.
+    for i in range(total_num_pg):
+        pg = pgs[i]
+        pg_tasks.append(
+            [
+                random_tasks.options(
+                    scheduling_strategy=PlacementGroupSchedulingStrategy(
+                        placement_group=pg,
+                        placement_group_bundle_index=bundle_index,
+                    )
+                ).remote()
+                for bundle_index in range(bundles_per_pg)
+            ]
+        )
+
+    # Make sure tasks are done and we remove placement groups.
+    num_removed_pg = 0
+    pg_indexes = [2, 3, 1, 7, 8, 9, 0, 6, 4, 5]
+    while num_removed_pg < total_num_pg:
+        index = pg_indexes[num_removed_pg]
+        pg = pgs[index]
+        assert all(ray.get(pg_tasks[index]))
+        ray.util.remove_placement_group(pg)
+        num_removed_pg += 1
+
+    @ray.remote(num_cpus=2, num_gpus=per_node_gpus)
+    class A:
+        def ping(self):
             return True
 
-        pgs = []
-        pg_tasks = []
-        # total bundle gpu usage = bundles_per_pg*total_num_pg*per_bundle_gpus
-        # Note this is half of total
-        for index in range(total_num_pg):
-            pgs.append(
-                ray.util.placement_group(
-                    name=f"name{index}",
-                    strategy="PACK",
-                    bundles=[{"GPU": per_bundle_gpus} for _ in range(bundles_per_pg)],
-                )
-            )
-
-        # Schedule tasks.
-        for i in range(total_num_pg):
-            pg = pgs[i]
-            pg_tasks.append(
-                [
-                    random_tasks.options(
-                        scheduling_strategy=PlacementGroupSchedulingStrategy(
-                            placement_group=pg,
-                            placement_group_bundle_index=bundle_index,
-                        )
-                    ).remote()
-                    for bundle_index in range(bundles_per_pg)
-                ]
-            )
-
-        # Make sure tasks are done and we remove placement groups.
-        num_removed_pg = 0
-        pg_indexes = [2, 3, 1, 7, 8, 9, 0, 6, 4, 5]
-        while num_removed_pg < total_num_pg:
-            index = pg_indexes[num_removed_pg]
-            pg = pgs[index]
-            assert all(ray.get(pg_tasks[index]))
-            ray.util.remove_placement_group(pg)
-            num_removed_pg += 1
-
-        @ray.remote(num_cpus=2, num_gpus=per_node_gpus)
-        class A:
-            def ping(self):
-                return True
-
-        # Make sure all resources are properly returned by scheduling
-        # actors that take up all existing resources.
-        actors = [A.remote() for _ in range(num_nodes)]
-        assert all(ray.get([a.ping.remote() for a in actors]))
+    # Make sure all resources are properly returned by scheduling
+    # actors that take up all existing resources.
+    actors = [A.remote() for _ in range(num_nodes)]
+    assert all(ray.get([a.ping.remote() for a in actors]))
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
-def test_capture_child_actors(ray_start_cluster, connect_to_client):
+def test_capture_child_actors(ray_start_cluster):
     cluster = ray_start_cluster
     total_num_actors = 4
     for _ in range(2):
         cluster.add_node(num_cpus=total_num_actors)
     ray.init(address=cluster.address)
 
-    with connect_to_client_or_not(connect_to_client):
-        pg = ray.util.placement_group([{"CPU": 2}, {"CPU": 2}], strategy="STRICT_PACK")
-        ray.get(pg.ready())
+    pg = ray.util.placement_group([{"CPU": 2}, {"CPU": 2}], strategy="STRICT_PACK")
+    ray.get(pg.ready())
 
-        # If get_current_placement_group is used when the current worker/driver
-        # doesn't belong to any of placement group, it should return None.
-        assert get_current_placement_group() is None
+    # If get_current_placement_group is used when the current worker/driver
+    # doesn't belong to any of placement group, it should return None.
+    assert get_current_placement_group() is None
 
-        # Test actors first.
-        @ray.remote(num_cpus=1)
-        class NestedActor:
-            def ready(self):
-                return True
+    # Test actors first.
+    @ray.remote(num_cpus=1)
+    class NestedActor:
+        def ready(self):
+            return True
 
-        @ray.remote(num_cpus=1)
-        class Actor:
-            def __init__(self):
-                self.actors = []
+    @ray.remote(num_cpus=1)
+    class Actor:
+        def __init__(self):
+            self.actors = []
 
-            def ready(self):
-                return True
+        def ready(self):
+            return True
 
-            def schedule_nested_actor(self):
-                # Make sure we can capture the current placement group.
-                assert get_current_placement_group() is not None
-                # Actors should be implicitly captured.
-                actor = NestedActor.remote()
-                ray.get(actor.ready.remote())
-                self.actors.append(actor)
+        def schedule_nested_actor(self):
+            # Make sure we can capture the current placement group.
+            assert get_current_placement_group() is not None
+            # Actors should be implicitly captured.
+            actor = NestedActor.remote()
+            ray.get(actor.ready.remote())
+            self.actors.append(actor)
 
-            def schedule_nested_actor_outside_pg(self):
-                # Don't use placement group.
-                actor = NestedActor.options(
-                    scheduling_strategy=PlacementGroupSchedulingStrategy(
-                        placement_group=None
-                    )
-                ).remote()
-                ray.get(actor.ready.remote())
-                self.actors.append(actor)
+        def schedule_nested_actor_outside_pg(self):
+            # Don't use placement group.
+            actor = NestedActor.options(
+                scheduling_strategy=PlacementGroupSchedulingStrategy(
+                    placement_group=None
+                )
+            ).remote()
+            ray.get(actor.ready.remote())
+            self.actors.append(actor)
 
-        a = Actor.options(
-            scheduling_strategy=PlacementGroupSchedulingStrategy(
-                placement_group=pg, placement_group_capture_child_tasks=True
-            )
-        ).remote()
+    a = Actor.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=pg, placement_group_capture_child_tasks=True
+        )
+    ).remote()
+    ray.get(a.ready.remote())
+    # 1 top level actor + 3 children.
+    for _ in range(total_num_actors - 1):
+        ray.get(a.schedule_nested_actor.remote())
+    # Make sure all the actors are scheduled on the same node.
+    # (why? The placement group has STRICT_PACK strategy).
+    node_id_set = set()
+    for actor_info in ray._private.state.actors().values():
+        if actor_info["State"] == convert_actor_state(gcs_utils.ActorTableData.ALIVE):
+            node_id = actor_info["Address"]["NodeID"]
+            node_id_set.add(node_id)
+
+    # Since all node id should be identical, set should be equal to 1.
+    assert len(node_id_set) == 1
+
+    # Kill an actor and wait until it is killed.
+    kill_actor_and_wait_for_failure(a)
+    with pytest.raises(ray.exceptions.RayActorError):
         ray.get(a.ready.remote())
-        # 1 top level actor + 3 children.
-        for _ in range(total_num_actors - 1):
-            ray.get(a.schedule_nested_actor.remote())
-        # Make sure all the actors are scheduled on the same node.
-        # (why? The placement group has STRICT_PACK strategy).
-        node_id_set = set()
-        for actor_info in ray._private.state.actors().values():
-            if actor_info["State"] == convert_actor_state(
-                gcs_utils.ActorTableData.ALIVE
-            ):
-                node_id = actor_info["Address"]["NodeID"]
-                node_id_set.add(node_id)
 
-        # Since all node id should be identical, set should be equal to 1.
-        assert len(node_id_set) == 1
+    # Now create an actor, but do not capture the current tasks
+    a = Actor.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+    ).remote()
+    ray.get(a.ready.remote())
+    # 1 top level actor + 3 children.
+    for _ in range(total_num_actors - 1):
+        ray.get(a.schedule_nested_actor.remote())
+    # Make sure all the actors are not scheduled on the same node.
+    # It is because the child tasks are not scheduled on the same
+    # placement group.
+    node_id_set = set()
+    for actor_info in ray._private.state.actors().values():
+        if actor_info["State"] == convert_actor_state(gcs_utils.ActorTableData.ALIVE):
+            node_id = actor_info["Address"]["NodeID"]
+            node_id_set.add(node_id)
 
-        # Kill an actor and wait until it is killed.
-        kill_actor_and_wait_for_failure(a)
-        with pytest.raises(ray.exceptions.RayActorError):
-            ray.get(a.ready.remote())
+    assert len(node_id_set) == 2
 
-        # Now create an actor, but do not capture the current tasks
-        a = Actor.options(
-            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
-        ).remote()
+    # Kill an actor and wait until it is killed.
+    kill_actor_and_wait_for_failure(a)
+    with pytest.raises(ray.exceptions.RayActorError):
         ray.get(a.ready.remote())
-        # 1 top level actor + 3 children.
-        for _ in range(total_num_actors - 1):
-            ray.get(a.schedule_nested_actor.remote())
-        # Make sure all the actors are not scheduled on the same node.
-        # It is because the child tasks are not scheduled on the same
-        # placement group.
-        node_id_set = set()
-        for actor_info in ray._private.state.actors().values():
-            if actor_info["State"] == convert_actor_state(
-                gcs_utils.ActorTableData.ALIVE
-            ):
-                node_id = actor_info["Address"]["NodeID"]
-                node_id_set.add(node_id)
 
-        assert len(node_id_set) == 2
+    # Lastly, make sure when None is specified, actors are not scheduled
+    # on the same placement group.
+    a = Actor.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+    ).remote()
+    ray.get(a.ready.remote())
+    # 1 top level actor + 3 children.
+    for _ in range(total_num_actors - 1):
+        ray.get(a.schedule_nested_actor_outside_pg.remote())
+    # Make sure all the actors are not scheduled on the same node.
+    # It is because the child tasks are not scheduled on the same
+    # placement group.
+    node_id_set = set()
+    for actor_info in ray._private.state.actors().values():
+        if actor_info["State"] == convert_actor_state(gcs_utils.ActorTableData.ALIVE):
+            node_id = actor_info["Address"]["NodeID"]
+            node_id_set.add(node_id)
 
-        # Kill an actor and wait until it is killed.
-        kill_actor_and_wait_for_failure(a)
-        with pytest.raises(ray.exceptions.RayActorError):
-            ray.get(a.ready.remote())
-
-        # Lastly, make sure when None is specified, actors are not scheduled
-        # on the same placement group.
-        a = Actor.options(
-            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
-        ).remote()
-        ray.get(a.ready.remote())
-        # 1 top level actor + 3 children.
-        for _ in range(total_num_actors - 1):
-            ray.get(a.schedule_nested_actor_outside_pg.remote())
-        # Make sure all the actors are not scheduled on the same node.
-        # It is because the child tasks are not scheduled on the same
-        # placement group.
-        node_id_set = set()
-        for actor_info in ray._private.state.actors().values():
-            if actor_info["State"] == convert_actor_state(
-                gcs_utils.ActorTableData.ALIVE
-            ):
-                node_id = actor_info["Address"]["NodeID"]
-                node_id_set.add(node_id)
-
-        assert len(node_id_set) == 2
+    assert len(node_id_set) == 2
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
-def test_capture_child_tasks(ray_start_cluster, connect_to_client):
+def test_capture_child_tasks(ray_start_cluster):
     cluster = ray_start_cluster
     total_num_tasks = 4
     for _ in range(2):
         cluster.add_node(num_cpus=total_num_tasks, num_gpus=total_num_tasks)
     ray.init(address=cluster.address)
 
-    with connect_to_client_or_not(connect_to_client):
-        pg = ray.util.placement_group(
-            [
-                {
-                    "CPU": 2,
-                    "GPU": 2,
-                },
-                {
-                    "CPU": 2,
-                    "GPU": 2,
-                },
-            ],
-            strategy="STRICT_PACK",
-        )
-        ray.get(pg.ready())
+    pg = ray.util.placement_group(
+        [
+            {
+                "CPU": 2,
+                "GPU": 2,
+            },
+            {
+                "CPU": 2,
+                "GPU": 2,
+            },
+        ],
+        strategy="STRICT_PACK",
+    )
+    ray.get(pg.ready())
 
-        # If get_current_placement_group is used when the current worker/driver
-        # doesn't belong to any of placement group, it should return None.
-        assert get_current_placement_group() is None
+    # If get_current_placement_group is used when the current worker/driver
+    # doesn't belong to any of placement group, it should return None.
+    assert get_current_placement_group() is None
 
-        # Test if tasks capture child tasks.
-        @ray.remote
-        def task():
-            return get_current_placement_group()
+    # Test if tasks capture child tasks.
+    @ray.remote
+    def task():
+        return get_current_placement_group()
 
-        @ray.remote
-        def create_nested_task(child_cpu, child_gpu, set_none=False):
-            assert get_current_placement_group() is not None
-            kwargs = {
-                "num_cpus": child_cpu,
-                "num_gpus": child_gpu,
-            }
-            if set_none:
-                kwargs["placement_group"] = None
-            return ray.get([task.options(**kwargs).remote() for _ in range(3)])
+    @ray.remote
+    def create_nested_task(child_cpu, child_gpu, set_none=False):
+        assert get_current_placement_group() is not None
+        kwargs = {
+            "num_cpus": child_cpu,
+            "num_gpus": child_gpu,
+        }
+        if set_none:
+            kwargs["placement_group"] = None
+        return ray.get([task.options(**kwargs).remote() for _ in range(3)])
 
-        t = create_nested_task.options(
-            num_cpus=1,
-            num_gpus=0,
-            scheduling_strategy=PlacementGroupSchedulingStrategy(
-                placement_group=pg, placement_group_capture_child_tasks=True
-            ),
-        ).remote(1, 0)
-        pgs = ray.get(t)
-        # Every task should have current placement group because they
-        # should be implicitly captured by default.
-        assert None not in pgs
+    t = create_nested_task.options(
+        num_cpus=1,
+        num_gpus=0,
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=pg, placement_group_capture_child_tasks=True
+        ),
+    ).remote(1, 0)
+    pgs = ray.get(t)
+    # Every task should have current placement group because they
+    # should be implicitly captured by default.
+    assert None not in pgs
 
-        t1 = create_nested_task.options(
-            num_cpus=1,
-            num_gpus=0,
-            scheduling_strategy=PlacementGroupSchedulingStrategy(
-                placement_group=pg, placement_group_capture_child_tasks=True
-            ),
-        ).remote(1, 0, True)
-        pgs = ray.get(t1)
-        # Every task should have no placement group since it's set to None.
-        # should be implicitly captured by default.
-        assert set(pgs) == {None}
+    t1 = create_nested_task.options(
+        num_cpus=1,
+        num_gpus=0,
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=pg, placement_group_capture_child_tasks=True
+        ),
+    ).remote(1, 0, True)
+    pgs = ray.get(t1)
+    # Every task should have no placement group since it's set to None.
+    # should be implicitly captured by default.
+    assert set(pgs) == {None}
 
-        # Test if tasks don't capture child tasks when the option is off.
-        t2 = create_nested_task.options(
-            num_cpus=0,
-            num_gpus=1,
-            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg),
-        ).remote(0, 1)
-        pgs = ray.get(t2)
-        # All placement groups should be None since we don't capture child
-        # tasks.
-        assert not all(pgs)
+    # Test if tasks don't capture child tasks when the option is off.
+    t2 = create_nested_task.options(
+        num_cpus=0,
+        num_gpus=1,
+        scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg),
+    ).remote(0, 1)
+    pgs = ray.get(t2)
+    # All placement groups should be None since we don't capture child
+    # tasks.
+    assert not all(pgs)
 
 
 def test_automatic_cleanup_job(ray_start_cluster):
@@ -828,7 +803,7 @@ def test_bundle_recreated_when_raylet_fo_after_gcs_server_restart(
     cluster.add_node(num_cpus=2)
     cluster.wait_for_nodes()
 
-    # Schedule an actor and make sure its creaton successfully.
+    # Schedule an actor and make sure it is created successfully.
     actor = Increase.options(
         scheduling_strategy=PlacementGroupSchedulingStrategy(
             placement_group=placement_group, placement_group_bundle_index=0
@@ -839,8 +814,6 @@ def test_bundle_recreated_when_raylet_fo_after_gcs_server_restart(
 
 
 if __name__ == "__main__":
-    import os
-
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
     else:

--- a/python/ray/tests/test_placement_group_3.py
+++ b/python/ray/tests/test_placement_group_3.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import time
 
@@ -23,7 +24,6 @@ from ray._private.test_utils import (
 )
 from ray.autoscaler._private.commands import debug_status
 from ray.exceptions import RaySystemError
-from ray.util.client.ray_client_helpers import connect_to_client_or_not
 from ray.util.placement_group import placement_group, remove_placement_group
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
@@ -127,29 +127,25 @@ def test_placement_group_wait_api_timeout(shutdown_only):
     assert 5 <= time.time() - start
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
-def test_schedule_placement_groups_at_the_same_time(connect_to_client):
+def test_schedule_placement_groups_at_the_same_time(shutdown_only):
     ray.init(num_cpus=4)
 
-    with connect_to_client_or_not(connect_to_client):
-        pgs = [placement_group([{"CPU": 2}]) for _ in range(6)]
+    pgs = [placement_group([{"CPU": 2}]) for _ in range(6)]
 
-        wait_pgs = {pg.ready(): pg for pg in pgs}
+    wait_pgs = {pg.ready(): pg for pg in pgs}
 
-        def is_all_placement_group_removed():
-            ready, _ = ray.wait(list(wait_pgs.keys()), timeout=0.5)
-            if ready:
-                ready_pg = wait_pgs[ready[0]]
-                remove_placement_group(ready_pg)
-                del wait_pgs[ready[0]]
+    def is_all_placement_group_removed():
+        ready, _ = ray.wait(list(wait_pgs.keys()), timeout=0.5)
+        if ready:
+            ready_pg = wait_pgs[ready[0]]
+            remove_placement_group(ready_pg)
+            del wait_pgs[ready[0]]
 
-            if len(wait_pgs) == 0:
-                return True
-            return False
+        if len(wait_pgs) == 0:
+            return True
+        return False
 
-        wait_for_condition(is_all_placement_group_removed)
-
-    ray.shutdown()
+    wait_for_condition(is_all_placement_group_removed)
 
 
 def test_detached_placement_group(ray_start_cluster):
@@ -352,36 +348,33 @@ ray.shutdown()
     assert error_count == 1
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
-def test_placement_group_synchronous_registration(ray_start_cluster, connect_to_client):
+def test_placement_group_synchronous_registration(ray_start_cluster):
     cluster = ray_start_cluster
     # One node which only has one CPU.
     cluster.add_node(num_cpus=1)
     cluster.wait_for_nodes()
     ray.init(address=cluster.address)
 
-    with connect_to_client_or_not(connect_to_client):
-        # Create a placement group that has two bundles and `STRICT_PACK`
-        # strategy so its registration will successful but scheduling failed.
-        placement_group = ray.util.placement_group(
-            name="name",
-            strategy="STRICT_PACK",
-            bundles=[
-                {
-                    "CPU": 1,
-                },
-                {"CPU": 1},
-            ],
-        )
-        # Make sure we can properly remove it immediately
-        # as its registration is synchronous.
-        ray.util.remove_placement_group(placement_group)
+    # Create a placement group that has two bundles and `STRICT_PACK`
+    # strategy so its registration will successful but scheduling failed.
+    placement_group = ray.util.placement_group(
+        name="name",
+        strategy="STRICT_PACK",
+        bundles=[
+            {
+                "CPU": 1,
+            },
+            {"CPU": 1},
+        ],
+    )
+    # Make sure we can properly remove it immediately
+    # as its registration is synchronous.
+    ray.util.remove_placement_group(placement_group)
 
-        wait_for_condition(lambda: is_placement_group_removed(placement_group))
+    wait_for_condition(lambda: is_placement_group_removed(placement_group))
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
-def test_placement_group_gpu_set(ray_start_cluster, connect_to_client):
+def test_placement_group_gpu_set(ray_start_cluster):
     cluster = ray_start_cluster
     # One node which only has one CPU.
     cluster.add_node(num_cpus=1, num_gpus=1)
@@ -389,36 +382,34 @@ def test_placement_group_gpu_set(ray_start_cluster, connect_to_client):
     cluster.wait_for_nodes()
     ray.init(address=cluster.address)
 
-    with connect_to_client_or_not(connect_to_client):
-        placement_group = ray.util.placement_group(
-            name="name",
-            strategy="PACK",
-            bundles=[{"CPU": 1, "GPU": 1}, {"CPU": 1, "GPU": 1}],
+    placement_group = ray.util.placement_group(
+        name="name",
+        strategy="PACK",
+        bundles=[{"CPU": 1, "GPU": 1}, {"CPU": 1, "GPU": 1}],
+    )
+
+    @ray.remote(num_gpus=1)
+    def get_gpus():
+        return ray.get_gpu_ids()
+
+    result = get_gpus.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=placement_group, placement_group_bundle_index=0
         )
+    ).remote()
+    result = ray.get(result)
+    assert result == [0]
 
-        @ray.remote(num_gpus=1)
-        def get_gpus():
-            return ray.get_gpu_ids()
-
-        result = get_gpus.options(
-            scheduling_strategy=PlacementGroupSchedulingStrategy(
-                placement_group=placement_group, placement_group_bundle_index=0
-            )
-        ).remote()
-        result = ray.get(result)
-        assert result == [0]
-
-        result = get_gpus.options(
-            scheduling_strategy=PlacementGroupSchedulingStrategy(
-                placement_group=placement_group, placement_group_bundle_index=1
-            )
-        ).remote()
-        result = ray.get(result)
-        assert result == [0]
+    result = get_gpus.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=placement_group, placement_group_bundle_index=1
+        )
+    ).remote()
+    result = ray.get(result)
+    assert result == [0]
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
-def test_placement_group_gpu_assigned(ray_start_cluster, connect_to_client):
+def test_placement_group_gpu_assigned(ray_start_cluster):
     cluster = ray_start_cluster
     cluster.add_node(num_gpus=2)
     ray.init(address=cluster.address)
@@ -426,37 +417,34 @@ def test_placement_group_gpu_assigned(ray_start_cluster, connect_to_client):
 
     @ray.remote(num_gpus=1, num_cpus=0)
     def f():
-        import os
-
         return os.environ["CUDA_VISIBLE_DEVICES"]
 
-    with connect_to_client_or_not(connect_to_client):
-        pg1 = ray.util.placement_group([{"GPU": 1}])
-        pg2 = ray.util.placement_group([{"GPU": 1}])
+    pg1 = ray.util.placement_group([{"GPU": 1}])
+    pg2 = ray.util.placement_group([{"GPU": 1}])
 
-        assert pg1.wait(10)
-        assert pg2.wait(10)
+    assert pg1.wait(10)
+    assert pg2.wait(10)
 
-        gpu_ids_res.add(
-            ray.get(
-                f.options(
-                    scheduling_strategy=PlacementGroupSchedulingStrategy(
-                        placement_group=pg1
-                    )
-                ).remote()
-            )
+    gpu_ids_res.add(
+        ray.get(
+            f.options(
+                scheduling_strategy=PlacementGroupSchedulingStrategy(
+                    placement_group=pg1
+                )
+            ).remote()
         )
-        gpu_ids_res.add(
-            ray.get(
-                f.options(
-                    scheduling_strategy=PlacementGroupSchedulingStrategy(
-                        placement_group=pg2
-                    )
-                ).remote()
-            )
+    )
+    gpu_ids_res.add(
+        ray.get(
+            f.options(
+                scheduling_strategy=PlacementGroupSchedulingStrategy(
+                    placement_group=pg2
+                )
+            ).remote()
         )
+    )
 
-        assert len(gpu_ids_res) == 2
+    assert len(gpu_ids_res) == 2
 
 
 @pytest.mark.repeat(3)
@@ -517,8 +505,7 @@ def test_actor_scheduling_not_block_with_placement_group(ray_start_cluster):
         )
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
-def test_placement_group_gpu_unique_assigned(ray_start_cluster, connect_to_client):
+def test_placement_group_gpu_unique_assigned(ray_start_cluster):
     cluster = ray_start_cluster
     cluster.add_node(num_gpus=4, num_cpus=4)
     ray.init(address=cluster.address)

--- a/python/ray/tests/test_placement_group_4.py
+++ b/python/ray/tests/test_placement_group_4.py
@@ -14,7 +14,6 @@ from ray._private.test_utils import (
 from ray._raylet import PlacementGroupID
 from ray.util.placement_group import PlacementGroup
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
-from ray.util.client.ray_client_helpers import connect_to_client_or_not
 from ray._private.runtime_env.context import RuntimeEnvContext
 from ray._private.runtime_env.plugin import RuntimeEnvPlugin
 
@@ -37,8 +36,7 @@ class MockWorkerStartupSlowlyPlugin(RuntimeEnvPlugin):
         return 0
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
-def test_remove_placement_group(ray_start_cluster, connect_to_client):
+def test_remove_placement_group(ray_start_cluster):
     cluster = ray_start_cluster
     cluster.add_node(num_cpus=4)
     ray.init(address=cluster.address)
@@ -50,76 +48,73 @@ def test_remove_placement_group(ray_start_cluster, connect_to_client):
     # warm up the cluster.
     ray.get([warmup.remote() for _ in range(4)])
 
-    with connect_to_client_or_not(connect_to_client):
-        # First try to remove a placement group that doesn't
-        # exist. This should not do anything.
-        random_group_id = PlacementGroupID.from_random()
-        random_placement_group = PlacementGroup(random_group_id)
-        for _ in range(3):
-            ray.util.remove_placement_group(random_placement_group)
+    # First try to remove a placement group that doesn't
+    # exist. This should not do anything.
+    random_group_id = PlacementGroupID.from_random()
+    random_placement_group = PlacementGroup(random_group_id)
+    for _ in range(3):
+        ray.util.remove_placement_group(random_placement_group)
 
-        # Creating a placement group as soon as it is
-        # created should work.
-        placement_group = ray.util.placement_group([{"CPU": 2}, {"CPU": 2}])
-        assert placement_group.wait(10)
+    # Creating a placement group as soon as it is
+    # created should work.
+    placement_group = ray.util.placement_group([{"CPU": 2}, {"CPU": 2}])
+    assert placement_group.wait(10)
 
-        ray.util.remove_placement_group(placement_group)
+    ray.util.remove_placement_group(placement_group)
 
-        wait_for_condition(lambda: is_placement_group_removed(placement_group))
+    wait_for_condition(lambda: is_placement_group_removed(placement_group))
 
-        # # Now let's create a placement group.
-        placement_group = ray.util.placement_group([{"CPU": 2}, {"CPU": 2}])
-        assert placement_group.wait(10)
+    # # Now let's create a placement group.
+    placement_group = ray.util.placement_group([{"CPU": 2}, {"CPU": 2}])
+    assert placement_group.wait(10)
 
-        # Create an actor that occupies resources.
-        @ray.remote(num_cpus=2)
-        class A:
-            def f(self):
-                return 3
-
-        # Currently, there's no way to prevent
-        # tasks to be retried for removed placement group.
-        # Set max_retrie=0 for testing.
-        # TODO(sang): Handle this edge case.
-        @ray.remote(num_cpus=2, max_retries=0)
-        def long_running_task():
-            print(os.getpid())
-            import time
-
-            time.sleep(50)
-
-        # Schedule a long running task and actor.
-        task_ref = long_running_task.options(
-            scheduling_strategy=PlacementGroupSchedulingStrategy(
-                placement_group=placement_group
-            )
-        ).remote()
-        a = A.options(
-            scheduling_strategy=PlacementGroupSchedulingStrategy(
-                placement_group=placement_group
-            )
-        ).remote()
-        assert ray.get(a.f.remote()) == 3
-
-        ray.util.remove_placement_group(placement_group)
-        # Subsequent remove request shouldn't do anything.
-        for _ in range(3):
-            ray.util.remove_placement_group(placement_group)
-
-        # Make sure placement group resources are
-        # released and we can schedule this task.
-        @ray.remote(num_cpus=4)
-        def f():
+    # Create an actor that occupies resources.
+    @ray.remote(num_cpus=2)
+    class A:
+        def f(self):
             return 3
 
-        assert ray.get(f.remote()) == 3
-        # Since the placement group is removed,
-        # the actor should've been killed.
-        # That means this request should fail.
-        with pytest.raises(ray.exceptions.RayActorError, match="actor died"):
-            ray.get(a.f.remote(), timeout=3.0)
-        with pytest.raises(ray.exceptions.WorkerCrashedError):
-            ray.get(task_ref)
+    # Currently, there's no way to prevent
+    # tasks to be retried for removed placement group.
+    # Set max_retries=0 for testing.
+    # TODO(sang): Handle this edge case.
+    @ray.remote(num_cpus=2, max_retries=0)
+    def long_running_task():
+        print(os.getpid())
+        time.sleep(50)
+
+    # Schedule a long running task and actor.
+    task_ref = long_running_task.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=placement_group
+        )
+    ).remote()
+    a = A.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=placement_group
+        )
+    ).remote()
+    assert ray.get(a.f.remote()) == 3
+
+    ray.util.remove_placement_group(placement_group)
+    # Subsequent remove request shouldn't do anything.
+    for _ in range(3):
+        ray.util.remove_placement_group(placement_group)
+
+    # Make sure placement group resources are
+    # released and we can schedule this task.
+    @ray.remote(num_cpus=4)
+    def f():
+        return 3
+
+    assert ray.get(f.remote()) == 3
+    # Since the placement group is removed,
+    # the actor should've been killed.
+    # That means this request should fail.
+    with pytest.raises(ray.exceptions.RayActorError, match="actor died"):
+        ray.get(a.f.remote(), timeout=3.0)
+    with pytest.raises(ray.exceptions.WorkerCrashedError):
+        ray.get(task_ref)
 
 
 @pytest.mark.parametrize(
@@ -178,30 +173,27 @@ def test_remove_placement_group_worker_startup_slowly(
         ray.get(task_ref)
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
-def test_remove_pending_placement_group(ray_start_cluster, connect_to_client):
+def test_remove_pending_placement_group(ray_start_cluster):
     cluster = ray_start_cluster
     cluster.add_node(num_cpus=4)
     ray.init(address=cluster.address)
 
-    with connect_to_client_or_not(connect_to_client):
-        # Create a placement group that cannot be scheduled now.
-        placement_group = ray.util.placement_group([{"GPU": 2}, {"CPU": 2}])
-        ray.util.remove_placement_group(placement_group)
+    # Create a placement group that cannot be scheduled now.
+    placement_group = ray.util.placement_group([{"GPU": 2}, {"CPU": 2}])
+    ray.util.remove_placement_group(placement_group)
 
-        # TODO(sang): Add state check here.
-        @ray.remote(num_cpus=4)
-        def f():
-            return 3
+    # TODO(sang): Add state check here.
+    @ray.remote(num_cpus=4)
+    def f():
+        return 3
 
-        # Make sure this task is still schedulable.
-        assert ray.get(f.remote()) == 3
+    # Make sure this task is still schedulable.
+    assert ray.get(f.remote()) == 3
 
-        placement_group_assert_no_leak([placement_group])
+    placement_group_assert_no_leak([placement_group])
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
-def test_placement_group_table(ray_start_cluster, connect_to_client):
+def test_placement_group_table(ray_start_cluster):
     @ray.remote(num_cpus=2)
     class Actor(object):
         def __init__(self):
@@ -217,62 +209,61 @@ def test_placement_group_table(ray_start_cluster, connect_to_client):
     ray.init(address=cluster.address)
     pgs_created = []
 
-    with connect_to_client_or_not(connect_to_client):
-        # Originally placement group creation should be pending because
-        # there are no resources.
-        name = "name"
-        strategy = "PACK"
-        bundles = [{"CPU": 2, "GPU": 1}, {"CPU": 2}]
-        placement_group = ray.util.placement_group(
-            name=name, strategy=strategy, bundles=bundles
+    # Originally placement group creation should be pending because
+    # there are no resources.
+    name = "name"
+    strategy = "PACK"
+    bundles = [{"CPU": 2, "GPU": 1}, {"CPU": 2}]
+    placement_group = ray.util.placement_group(
+        name=name, strategy=strategy, bundles=bundles
+    )
+    pgs_created.append(placement_group)
+    result = ray.util.placement_group_table(placement_group)
+    assert result["name"] == name
+    assert result["strategy"] == strategy
+    for i in range(len(bundles)):
+        assert bundles[i] == result["bundles"][i]
+    assert result["state"] == "PENDING"
+
+    # Now the placement group should be scheduled.
+    cluster.add_node(num_cpus=5, num_gpus=1)
+    cluster.wait_for_nodes()
+
+    actor_1 = Actor.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=placement_group, placement_group_bundle_index=0
         )
-        pgs_created.append(placement_group)
-        result = ray.util.placement_group_table(placement_group)
-        assert result["name"] == name
-        assert result["strategy"] == strategy
-        for i in range(len(bundles)):
-            assert bundles[i] == result["bundles"][i]
-        assert result["state"] == "PENDING"
+    ).remote()
+    ray.get(actor_1.value.remote())
 
-        # Now the placement group should be scheduled.
-        cluster.add_node(num_cpus=5, num_gpus=1)
-        cluster.wait_for_nodes()
+    result = ray.util.placement_group_table(placement_group)
+    assert result["state"] == "CREATED"
 
-        actor_1 = Actor.options(
-            scheduling_strategy=PlacementGroupSchedulingStrategy(
-                placement_group=placement_group, placement_group_bundle_index=0
-            )
-        ).remote()
-        ray.get(actor_1.value.remote())
-
-        result = ray.util.placement_group_table(placement_group)
-        assert result["state"] == "CREATED"
-
-        # Add tow more placement group for placement group table test.
-        second_strategy = "SPREAD"
-        pgs_created.append(
-            ray.util.placement_group(
-                name="second_placement_group", strategy=second_strategy, bundles=bundles
-            )
+    # Add tow more placement group for placement group table test.
+    second_strategy = "SPREAD"
+    pgs_created.append(
+        ray.util.placement_group(
+            name="second_placement_group", strategy=second_strategy, bundles=bundles
         )
-        pgs_created.append(
-            ray.util.placement_group(
-                name="third_placement_group", strategy=second_strategy, bundles=bundles
-            )
+    )
+    pgs_created.append(
+        ray.util.placement_group(
+            name="third_placement_group", strategy=second_strategy, bundles=bundles
         )
+    )
 
-        placement_group_table = ray.util.placement_group_table()
-        assert len(placement_group_table) == 3
+    placement_group_table = ray.util.placement_group_table()
+    assert len(placement_group_table) == 3
 
-        true_name_set = {"name", "second_placement_group", "third_placement_group"}
-        get_name_set = set()
+    true_name_set = {"name", "second_placement_group", "third_placement_group"}
+    get_name_set = set()
 
-        for _, placement_group_data in placement_group_table.items():
-            get_name_set.add(placement_group_data["name"])
+    for _, placement_group_data in placement_group_table.items():
+        get_name_set.add(placement_group_data["name"])
 
-        assert true_name_set == get_name_set
+    assert true_name_set == get_name_set
 
-        placement_group_assert_no_leak(pgs_created)
+    placement_group_assert_no_leak(pgs_created)
 
 
 def test_placement_group_stats(ray_start_cluster):
@@ -344,8 +335,7 @@ def test_placement_group_stats(ray_start_cluster):
     placement_group_assert_no_leak([pg2])
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
-def test_cuda_visible_devices(ray_start_cluster, connect_to_client):
+def test_cuda_visible_devices(ray_start_cluster):
     @ray.remote(num_gpus=1)
     def f():
         return os.environ["CUDA_VISIBLE_DEVICES"]
@@ -356,21 +346,17 @@ def test_cuda_visible_devices(ray_start_cluster, connect_to_client):
         cluster.add_node(num_gpus=1)
     ray.init(address=cluster.address)
 
-    with connect_to_client_or_not(connect_to_client):
-        g1 = ray.util.placement_group([{"CPU": 1, "GPU": 1}])
-        o1 = f.options(
-            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=g1)
-        ).remote()
+    g1 = ray.util.placement_group([{"CPU": 1, "GPU": 1}])
+    o1 = f.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=g1)
+    ).remote()
 
-        devices = ray.get(o1)
-        assert devices == "0", devices
-        placement_group_assert_no_leak([g1])
+    devices = ray.get(o1)
+    assert devices == "0", devices
+    placement_group_assert_no_leak([g1])
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
-def test_placement_group_reschedule_when_node_dead(
-    ray_start_cluster, connect_to_client
-):
+def test_placement_group_reschedule_when_node_dead(ray_start_cluster):
     @ray.remote(num_cpus=1)
     class Actor(object):
         def __init__(self):
@@ -391,58 +377,56 @@ def test_placement_group_reschedule_when_node_dead(
     assert len(nodes) == 3
     assert nodes[0]["alive"] and nodes[1]["alive"] and nodes[2]["alive"]
 
-    with connect_to_client_or_not(connect_to_client):
-        placement_group = ray.util.placement_group(
-            name="name", strategy="SPREAD", bundles=[{"CPU": 2}, {"CPU": 2}, {"CPU": 2}]
-        )
-        actor_1 = Actor.options(
-            scheduling_strategy=PlacementGroupSchedulingStrategy(
-                placement_group=placement_group, placement_group_bundle_index=0
-            ),
-            lifetime="detached",
-        ).remote()
-        actor_2 = Actor.options(
-            scheduling_strategy=PlacementGroupSchedulingStrategy(
-                placement_group=placement_group, placement_group_bundle_index=1
-            ),
-            lifetime="detached",
-        ).remote()
-        actor_3 = Actor.options(
-            scheduling_strategy=PlacementGroupSchedulingStrategy(
-                placement_group=placement_group, placement_group_bundle_index=2
-            ),
-            lifetime="detached",
-        ).remote()
-        ray.get(actor_1.value.remote())
-        ray.get(actor_2.value.remote())
-        ray.get(actor_3.value.remote())
+    placement_group = ray.util.placement_group(
+        name="name", strategy="SPREAD", bundles=[{"CPU": 2}, {"CPU": 2}, {"CPU": 2}]
+    )
+    actor_1 = Actor.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=placement_group, placement_group_bundle_index=0
+        ),
+        lifetime="detached",
+    ).remote()
+    actor_2 = Actor.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=placement_group, placement_group_bundle_index=1
+        ),
+        lifetime="detached",
+    ).remote()
+    actor_3 = Actor.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=placement_group, placement_group_bundle_index=2
+        ),
+        lifetime="detached",
+    ).remote()
+    ray.get(actor_1.value.remote())
+    ray.get(actor_2.value.remote())
+    ray.get(actor_3.value.remote())
 
-        cluster.remove_node(get_other_nodes(cluster, exclude_head=True)[-1])
-        cluster.wait_for_nodes()
+    cluster.remove_node(get_other_nodes(cluster, exclude_head=True)[-1])
+    cluster.wait_for_nodes()
 
-        actor_4 = Actor.options(
-            scheduling_strategy=PlacementGroupSchedulingStrategy(
-                placement_group=placement_group, placement_group_bundle_index=0
-            ),
-            lifetime="detached",
-        ).remote()
-        actor_5 = Actor.options(
-            scheduling_strategy=PlacementGroupSchedulingStrategy(
-                placement_group=placement_group, placement_group_bundle_index=1
-            ),
-            lifetime="detached",
-        ).remote()
-        actor_6 = Actor.options(
-            scheduling_strategy=PlacementGroupSchedulingStrategy(
-                placement_group=placement_group, placement_group_bundle_index=2
-            ),
-            lifetime="detached",
-        ).remote()
-        ray.get(actor_4.value.remote())
-        ray.get(actor_5.value.remote())
-        ray.get(actor_6.value.remote())
-        placement_group_assert_no_leak([placement_group])
-        ray.shutdown()
+    actor_4 = Actor.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=placement_group, placement_group_bundle_index=0
+        ),
+        lifetime="detached",
+    ).remote()
+    actor_5 = Actor.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=placement_group, placement_group_bundle_index=1
+        ),
+        lifetime="detached",
+    ).remote()
+    actor_6 = Actor.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=placement_group, placement_group_bundle_index=2
+        ),
+        lifetime="detached",
+    ).remote()
+    ray.get(actor_4.value.remote())
+    ray.get(actor_5.value.remote())
+    ray.get(actor_6.value.remote())
+    placement_group_assert_no_leak([placement_group])
 
 
 def test_infeasible_pg(ray_start_cluster):

--- a/python/ray/tests/test_placement_group_5.py
+++ b/python/ray/tests/test_placement_group_5.py
@@ -10,7 +10,6 @@ import ray
 from ray._private.test_utils import placement_group_assert_no_leak
 from ray.tests.test_placement_group import are_pairwise_unique
 from ray.util.state import list_actors, list_placement_groups
-from ray.util.client.ray_client_helpers import connect_to_client_or_not
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from ray._private.runtime_env.plugin import RuntimeEnvPlugin
 from ray._private.test_utils import wait_for_condition
@@ -18,8 +17,7 @@ from click.testing import CliRunner
 import ray.scripts.scripts as scripts
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
-def test_placement_group_no_resource(ray_start_cluster, connect_to_client):
+def test_placement_group_no_resource(ray_start_cluster):
     @ray.remote(num_cpus=1)
     class Actor(object):
         def __init__(self):
@@ -42,82 +40,80 @@ def test_placement_group_no_resource(ray_start_cluster, connect_to_client):
         cluster.add_node(num_cpus=2)
     ray.init(address=cluster.address)
 
-    with connect_to_client_or_not(connect_to_client):
-        for _ in range(10):
-            pg1 = ray.util.placement_group(
-                name="pg1",
-                bundles=[
-                    {"CPU": 2},
-                ],
+    for _ in range(10):
+        pg1 = ray.util.placement_group(
+            name="pg1",
+            bundles=[
+                {"CPU": 2},
+            ],
+        )
+        pg2 = ray.util.placement_group(
+            name="pg2",
+            bundles=[
+                {"CPU": 2},
+            ],
+        )
+        ray.get(pg1.ready())
+        ray.get(pg2.ready())
+        actor_11 = Actor.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=pg1, placement_group_bundle_index=0
             )
-            pg2 = ray.util.placement_group(
-                name="pg2",
-                bundles=[
-                    {"CPU": 2},
-                ],
+        ).remote()
+        actor_12 = Actor.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=pg1, placement_group_bundle_index=0
             )
-            ray.get(pg1.ready())
-            ray.get(pg2.ready())
-            actor_11 = Actor.options(
-                scheduling_strategy=PlacementGroupSchedulingStrategy(
-                    placement_group=pg1, placement_group_bundle_index=0
-                )
-            ).remote()
-            actor_12 = Actor.options(
-                scheduling_strategy=PlacementGroupSchedulingStrategy(
-                    placement_group=pg1, placement_group_bundle_index=0
-                )
-            ).remote()
-            actor_13 = PhantomActor.options(
-                scheduling_strategy=PlacementGroupSchedulingStrategy(
-                    placement_group=pg1, placement_group_bundle_index=0
-                )
-            ).remote()
-            actor_21 = Actor.options(
-                scheduling_strategy=PlacementGroupSchedulingStrategy(
-                    placement_group=pg2, placement_group_bundle_index=0
-                )
-            ).remote()
-            actor_22 = Actor.options(
-                scheduling_strategy=PlacementGroupSchedulingStrategy(
-                    placement_group=pg2, placement_group_bundle_index=0
-                )
-            ).remote()
-            actor_23 = PhantomActor.options(
-                scheduling_strategy=PlacementGroupSchedulingStrategy(
-                    placement_group=pg2, placement_group_bundle_index=0
-                )
-            ).remote()
+        ).remote()
+        actor_13 = PhantomActor.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=pg1, placement_group_bundle_index=0
+            )
+        ).remote()
+        actor_21 = Actor.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=pg2, placement_group_bundle_index=0
+            )
+        ).remote()
+        actor_22 = Actor.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=pg2, placement_group_bundle_index=0
+            )
+        ).remote()
+        actor_23 = PhantomActor.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=pg2, placement_group_bundle_index=0
+            )
+        ).remote()
 
-            first_node = [actor_11, actor_12, actor_13]
-            second_node = [actor_21, actor_22, actor_23]
+        first_node = [actor_11, actor_12, actor_13]
+        second_node = [actor_21, actor_22, actor_23]
 
-            for actor in chain(first_node, second_node):
-                ray.get(actor.value.remote())
+        for actor in chain(first_node, second_node):
+            ray.get(actor.value.remote())
 
-            # Get all actors.
-            actor_infos = ray._private.state.actors()
+        # Get all actors.
+        actor_infos = ray._private.state.actors()
 
-            first_node_ids = [
-                actor_infos.get(actor._actor_id.hex())["Address"]["NodeID"]
-                for actor in first_node
-            ]
-            second_node_ids = [
-                actor_infos.get(actor._actor_id.hex())["Address"]["NodeID"]
-                for actor in second_node
-            ]
+        first_node_ids = [
+            actor_infos.get(actor._actor_id.hex())["Address"]["NodeID"]
+            for actor in first_node
+        ]
+        second_node_ids = [
+            actor_infos.get(actor._actor_id.hex())["Address"]["NodeID"]
+            for actor in second_node
+        ]
 
-            def check_eq(ip1, ip2):
-                assert ip1 == ip2
-                return ip1
+        def check_eq(ip1, ip2):
+            assert ip1 == ip2
+            return ip1
 
-            assert reduce(check_eq, first_node_ids) != reduce(check_eq, second_node_ids)
+        assert reduce(check_eq, first_node_ids) != reduce(check_eq, second_node_ids)
 
-            placement_group_assert_no_leak([pg1, pg2])
+        placement_group_assert_no_leak([pg1, pg2])
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
-def test_pg_no_resource_bundle_index(ray_start_cluster, connect_to_client):
+def test_pg_no_resource_bundle_index(ray_start_cluster):
     @ray.remote(num_cpus=0)
     class Actor:
         def node_id(self):
@@ -129,26 +125,23 @@ def test_pg_no_resource_bundle_index(ray_start_cluster, connect_to_client):
         cluster.add_node(num_cpus=1)
     ray.init(address=cluster.address)
 
-    with connect_to_client_or_not(connect_to_client):
-        pg = ray.util.placement_group(
-            bundles=[{"CPU": 1} for _ in range(num_nodes)],
-        )
-        ray.get(pg.ready())
-        first_bundle_node_id = ray.util.placement_group_table(pg)["bundles_to_node_id"][
-            0
-        ]
+    pg = ray.util.placement_group(
+        bundles=[{"CPU": 1} for _ in range(num_nodes)],
+    )
+    ray.get(pg.ready())
+    first_bundle_node_id = ray.util.placement_group_table(pg)["bundles_to_node_id"][0]
 
-        # Iterate 10 times to make sure it is not flaky.
-        for _ in range(10):
-            actor = Actor.options(
-                scheduling_strategy=PlacementGroupSchedulingStrategy(
-                    placement_group=pg, placement_group_bundle_index=0
-                )
-            ).remote()
+    # Iterate 10 times to make sure it is not flaky.
+    for _ in range(10):
+        actor = Actor.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=pg, placement_group_bundle_index=0
+            )
+        ).remote()
 
-            assert first_bundle_node_id == ray.get(actor.node_id.remote())
+        assert first_bundle_node_id == ray.get(actor.node_id.remote())
 
-        placement_group_assert_no_leak([pg])
+    placement_group_assert_no_leak([pg])
 
 
 # Make sure the task observability API outputs don't contain
@@ -204,11 +197,8 @@ def test_task_using_pg_observability(ray_start_cluster):
     wait_for_condition(check_demands)
 
 
-@pytest.mark.parametrize("connect_to_client", [False, True])
 @pytest.mark.parametrize("scheduling_strategy", ["SPREAD", "STRICT_SPREAD", "PACK"])
-def test_placement_group_bin_packing_priority(
-    ray_start_cluster, connect_to_client, scheduling_strategy
-):
+def test_placement_group_bin_packing_priority(ray_start_cluster, scheduling_strategy):
     @ray.remote
     class Actor(object):
         def __init__(self):
@@ -249,26 +239,25 @@ def test_placement_group_bin_packing_priority(
     add_nodes_to_cluster(cluster)
     ray.init(address=cluster.address)
 
-    with connect_to_client_or_not(connect_to_client):
-        placement_group = ray.util.placement_group(
-            name="name",
-            strategy=scheduling_strategy,
-            bundles=default_bundles,
-        )
-        ray.get(placement_group.ready())
+    placement_group = ray.util.placement_group(
+        name="name",
+        strategy=scheduling_strategy,
+        bundles=default_bundles,
+    )
+    ray.get(placement_group.ready())
 
-        actors = [index_to_actor(placement_group, i) for i in range(default_num_nodes)]
+    actors = [index_to_actor(placement_group, i) for i in range(default_num_nodes)]
 
-        [ray.get(actor.value.remote()) for actor in actors]
+    [ray.get(actor.value.remote()) for actor in actors]
 
-        # Get all actors.
-        actor_infos = ray._private.state.actors()
+    # Get all actors.
+    actor_infos = ray._private.state.actors()
 
-        # Make sure all actors in counter_list are located in separate nodes.
-        actor_info_objs = [actor_infos.get(actor._actor_id.hex()) for actor in actors]
-        assert are_pairwise_unique(
-            [info_obj["Address"]["NodeID"] for info_obj in actor_info_objs]
-        )
+    # Make sure all actors in counter_list are located in separate nodes.
+    actor_info_objs = [actor_infos.get(actor._actor_id.hex()) for actor in actors]
+    assert are_pairwise_unique(
+        [info_obj["Address"]["NodeID"] for info_obj in actor_info_objs]
+    )
 
 
 @pytest.mark.parametrize("multi_bundle", [True, False])

--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -1,11 +1,9 @@
 # coding: utf-8
 import collections
 import logging
-import platform
 import subprocess
 import sys
 import time
-import unittest
 
 import numpy as np
 import pytest

--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -225,9 +225,7 @@ def test_load_balancing_with_dependencies(ray_start_cluster):
     attempt_to_load_balance(f, [x], 100, num_nodes, 20)
 
 
-@pytest.mark.skipif(
-    platform.system() == "Windows", reason="Failing on Windows. Multi node."
-)
+@pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows (multi node).")
 def test_spillback_waiting_task_on_oom(ray_start_cluster):
     # This test ensures that tasks are spilled if they are not schedulable due
     # to lack of object store memory.
@@ -435,7 +433,10 @@ def test_locality_aware_leasing_borrowed_objects(ray_start_cluster):
     )
 
 
-@unittest.skipIf(sys.platform == "win32", "Failing on Windows.")
+@pytest.mark.skipif(
+    ray._private.client_mode_hook.is_client_mode_enabled, reason="Fails w/ Ray Client."
+)
+@pytest.mark.skipif(sys.platform == "win32", "Fails on Windows.")
 def test_lease_request_leak(shutdown_only):
     ray.init(num_cpus=1, _system_config={"object_timeout_milliseconds": 200})
 

--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -434,7 +434,7 @@ def test_locality_aware_leasing_borrowed_objects(ray_start_cluster):
 @pytest.mark.skipif(
     ray._private.client_mode_hook.is_client_mode_enabled, reason="Fails w/ Ray Client."
 )
-@pytest.mark.skipif(sys.platform == "win32", "Fails on Windows.")
+@pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows.")
 def test_lease_request_leak(shutdown_only):
     ray.init(num_cpus=1, _system_config={"object_timeout_milliseconds": 200})
 

--- a/python/ray/tests/test_scheduling_2.py
+++ b/python/ray/tests/test_scheduling_2.py
@@ -162,6 +162,9 @@ def test_default_scheduling_strategy(ray_start_cluster):
     ]
 
 
+@pytest.mark.skipif(
+    ray._private.client_mode_hook.is_client_mode_enabled, reason="Fails w/ Ray Client."
+)
 def test_placement_group_scheduling_strategy(ray_start_cluster):
     cluster = ray_start_cluster
     cluster.add_node(num_cpus=8, resources={"head": 1})

--- a/python/ray/tests/test_scheduling_2.py
+++ b/python/ray/tests/test_scheduling_2.py
@@ -15,7 +15,6 @@ from ray._private.test_utils import (
     get_metric_check_condition,
     MetricSamplePattern,
 )
-from ray.util.client.ray_client_helpers import connect_to_client_or_not
 from ray.util.placement_group import placement_group
 from ray.util.scheduling_strategies import (
     NodeAffinitySchedulingStrategy,
@@ -100,8 +99,7 @@ def test_critical_object_store_mem_resource_utilization(ray_start_cluster):
     assert ray.get(f.remote()) == non_local_node.unique_id
 
 
-@pytest.mark.parametrize("connect_to_client", [True, False])
-def test_default_scheduling_strategy(ray_start_cluster, connect_to_client):
+def test_default_scheduling_strategy(ray_start_cluster):
     cluster = ray_start_cluster
     cluster.add_node(
         num_cpus=16,
@@ -116,62 +114,55 @@ def test_default_scheduling_strategy(ray_start_cluster, connect_to_client):
     ray.get(pg.ready())
     ray.get(pg.ready())
 
-    with connect_to_client_or_not(connect_to_client):
+    @ray.remote(scheduling_strategy="DEFAULT")
+    def get_node_id_1():
+        return ray._private.worker.global_worker.current_node_id
 
-        @ray.remote(scheduling_strategy="DEFAULT")
-        def get_node_id_1():
-            return ray._private.worker.global_worker.current_node_id
+    head_node_id = ray.get(get_node_id_1.options(resources={"head": 1}).remote())
+    worker_node_id = ray.get(get_node_id_1.options(resources={"worker": 1}).remote())
 
-        head_node_id = ray.get(get_node_id_1.options(resources={"head": 1}).remote())
-        worker_node_id = ray.get(
-            get_node_id_1.options(resources={"worker": 1}).remote()
-        )
+    assert ray.get(get_node_id_1.remote()) == head_node_id
 
-        assert ray.get(get_node_id_1.remote()) == head_node_id
+    @ray.remote(
+        num_cpus=1,
+        scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg),
+    )
+    def get_node_id_2():
+        return ray._private.worker.global_worker.current_node_id
 
-        @ray.remote(
-            num_cpus=1,
-            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg),
-        )
-        def get_node_id_2():
-            return ray._private.worker.global_worker.current_node_id
+    assert (
+        ray.get(get_node_id_2.options(scheduling_strategy="DEFAULT").remote())
+        == head_node_id
+    )
 
-        assert (
-            ray.get(get_node_id_2.options(scheduling_strategy="DEFAULT").remote())
-            == head_node_id
-        )
+    @ray.remote
+    def get_node_id_3():
+        return ray._private.worker.global_worker.current_node_id
 
-        @ray.remote
-        def get_node_id_3():
-            return ray._private.worker.global_worker.current_node_id
+    @ray.remote(
+        num_cpus=1,
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=pg, placement_group_capture_child_tasks=True
+        ),
+    )
+    class Actor1:
+        def get_node_ids(self):
+            return [
+                ray._private.worker.global_worker.current_node_id,
+                # Use parent's placement group
+                ray.get(get_node_id_3.remote()),
+                ray.get(get_node_id_3.options(scheduling_strategy="DEFAULT").remote()),
+            ]
 
-        @ray.remote(
-            num_cpus=1,
-            scheduling_strategy=PlacementGroupSchedulingStrategy(
-                placement_group=pg, placement_group_capture_child_tasks=True
-            ),
-        )
-        class Actor1:
-            def get_node_ids(self):
-                return [
-                    ray._private.worker.global_worker.current_node_id,
-                    # Use parent's placement group
-                    ray.get(get_node_id_3.remote()),
-                    ray.get(
-                        get_node_id_3.options(scheduling_strategy="DEFAULT").remote()
-                    ),
-                ]
-
-        actor1 = Actor1.remote()
-        assert ray.get(actor1.get_node_ids.remote()) == [
-            worker_node_id,
-            worker_node_id,
-            head_node_id,
-        ]
+    actor1 = Actor1.remote()
+    assert ray.get(actor1.get_node_ids.remote()) == [
+        worker_node_id,
+        worker_node_id,
+        head_node_id,
+    ]
 
 
-@pytest.mark.parametrize("connect_to_client", [True, False])
-def test_placement_group_scheduling_strategy(ray_start_cluster, connect_to_client):
+def test_placement_group_scheduling_strategy(ray_start_cluster):
     cluster = ray_start_cluster
     cluster.add_node(num_cpus=8, resources={"head": 1})
     cluster.add_node(num_cpus=8, num_gpus=8, resources={"worker": 1})
@@ -181,57 +172,53 @@ def test_placement_group_scheduling_strategy(ray_start_cluster, connect_to_clien
     pg = ray.util.placement_group(bundles=[{"CPU": 1, "GPU": 1}, {"CPU": 1, "GPU": 1}])
     ray.get(pg.ready())
 
-    with connect_to_client_or_not(connect_to_client):
+    @ray.remote(scheduling_strategy="DEFAULT")
+    def get_node_id_1():
+        return ray._private.worker.global_worker.current_node_id
 
-        @ray.remote(scheduling_strategy="DEFAULT")
-        def get_node_id_1():
+    worker_node_id = ray.get(get_node_id_1.options(resources={"worker": 1}).remote())
+
+    assert (
+        ray.get(
+            get_node_id_1.options(
+                num_cpus=1,
+                scheduling_strategy=PlacementGroupSchedulingStrategy(
+                    placement_group=pg
+                ),
+            ).remote()
+        )
+        == worker_node_id
+    )
+
+    @ray.remote(
+        num_cpus=1,
+        scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg),
+    )
+    def get_node_id_2():
+        return ray._private.worker.global_worker.current_node_id
+
+    assert ray.get(get_node_id_2.remote()) == worker_node_id
+
+    @ray.remote(
+        num_cpus=1,
+        scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg),
+    )
+    class Actor1:
+        def get_node_id(self):
             return ray._private.worker.global_worker.current_node_id
 
-        worker_node_id = ray.get(
-            get_node_id_1.options(resources={"worker": 1}).remote()
-        )
+    actor1 = Actor1.remote()
+    assert ray.get(actor1.get_node_id.remote()) == worker_node_id
 
-        assert (
-            ray.get(
-                get_node_id_1.options(
-                    num_cpus=1,
-                    scheduling_strategy=PlacementGroupSchedulingStrategy(
-                        placement_group=pg
-                    ),
-                ).remote()
-            )
-            == worker_node_id
-        )
-
-        @ray.remote(
-            num_cpus=1,
-            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg),
-        )
-        def get_node_id_2():
+    @ray.remote
+    class Actor2:
+        def get_node_id(self):
             return ray._private.worker.global_worker.current_node_id
 
-        assert ray.get(get_node_id_2.remote()) == worker_node_id
-
-        @ray.remote(
-            num_cpus=1,
-            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg),
-        )
-        class Actor1:
-            def get_node_id(self):
-                return ray._private.worker.global_worker.current_node_id
-
-        actor1 = Actor1.remote()
-        assert ray.get(actor1.get_node_id.remote()) == worker_node_id
-
-        @ray.remote
-        class Actor2:
-            def get_node_id(self):
-                return ray._private.worker.global_worker.current_node_id
-
-        actor2 = Actor2.options(
-            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
-        ).remote()
-        assert ray.get(actor2.get_node_id.remote()) == worker_node_id
+    actor2 = Actor2.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+    ).remote()
+    assert ray.get(actor2.get_node_id.remote()) == worker_node_id
 
     with pytest.raises(ValueError):
 
@@ -252,192 +239,173 @@ def test_placement_group_scheduling_strategy(ray_start_cluster, connect_to_clien
         func.options(scheduling_strategy="XXX").remote()
 
 
-@pytest.mark.parametrize("connect_to_client", [True, False])
-def test_node_affinity_scheduling_strategy(
-    monkeypatch, ray_start_cluster, connect_to_client
-):
+def test_node_affinity_scheduling_strategy(monkeypatch, ray_start_cluster):
     cluster = ray_start_cluster
     cluster.add_node(num_cpus=8, resources={"head": 1})
     ray.init(address=cluster.address)
     cluster.add_node(num_cpus=8, resources={"worker": 1})
     cluster.wait_for_nodes()
 
-    with connect_to_client_or_not(connect_to_client):
+    @ray.remote
+    def get_node_id():
+        return ray.get_runtime_context().get_node_id()
 
-        @ray.remote
-        def get_node_id():
-            return ray.get_runtime_context().get_node_id()
+    head_node_id = ray.get(
+        get_node_id.options(num_cpus=0, resources={"head": 1}).remote()
+    )
+    worker_node_id = ray.get(
+        get_node_id.options(num_cpus=0, resources={"worker": 1}).remote()
+    )
 
-        head_node_id = ray.get(
-            get_node_id.options(num_cpus=0, resources={"head": 1}).remote()
-        )
-        worker_node_id = ray.get(
-            get_node_id.options(num_cpus=0, resources={"worker": 1}).remote()
-        )
-
-        assert worker_node_id == ray.get(
-            get_node_id.options(
-                scheduling_strategy=NodeAffinitySchedulingStrategy(
-                    worker_node_id, soft=False
-                )
-            ).remote()
-        )
-        assert head_node_id == ray.get(
-            get_node_id.options(
-                scheduling_strategy=NodeAffinitySchedulingStrategy(
-                    head_node_id, soft=False
-                )
-            ).remote()
-        )
-
-        # Doesn't fail when the node doesn't exist since soft is true.
-        ray.get(
-            get_node_id.options(
-                scheduling_strategy=NodeAffinitySchedulingStrategy(
-                    ray.NodeID.from_random().hex(), soft=True
-                )
-            ).remote()
-        )
-
-        # Doesn't fail when the node is infeasible since soft is true.
-        assert worker_node_id == ray.get(
-            get_node_id.options(
-                scheduling_strategy=NodeAffinitySchedulingStrategy(
-                    head_node_id, soft=True
-                ),
-                resources={"worker": 1},
-            ).remote()
-        )
-
-        # Fail when the node doesn't exist.
-        with pytest.raises(ray.exceptions.TaskUnschedulableError):
-            ray.get(
-                get_node_id.options(
-                    scheduling_strategy=NodeAffinitySchedulingStrategy(
-                        ray.NodeID.from_random().hex(), soft=False
-                    )
-                ).remote()
-            )
-
-        # Fail when the node is infeasible.
-        with pytest.raises(ray.exceptions.TaskUnschedulableError):
-            ray.get(
-                get_node_id.options(
-                    scheduling_strategy=NodeAffinitySchedulingStrategy(
-                        head_node_id, soft=False
-                    ),
-                    resources={"not_exist": 1},
-                ).remote()
-            )
-
-        crashed_worker_node = cluster.add_node(
-            num_cpus=8, resources={"crashed_worker": 1}
-        )
-        cluster.wait_for_nodes()
-        crashed_worker_node_id = ray.get(
-            get_node_id.options(num_cpus=0, resources={"crashed_worker": 1}).remote()
-        )
-
-        @ray.remote(
-            max_retries=-1,
-            scheduling_strategy=NodeAffinitySchedulingStrategy(
-                crashed_worker_node_id, soft=True
-            ),
-        )
-        def crashed_get_node_id():
-            if ray.get_runtime_context().get_node_id() == crashed_worker_node_id:
-                internal_kv._internal_kv_put(
-                    "crashed_get_node_id", "crashed_worker_node_id"
-                )
-                while True:
-                    time.sleep(1)
-            else:
-                return ray.get_runtime_context().get_node_id()
-
-        r = crashed_get_node_id.remote()
-        while not internal_kv._internal_kv_exists("crashed_get_node_id"):
-            time.sleep(0.1)
-        cluster.remove_node(crashed_worker_node, allow_graceful=False)
-        assert ray.get(r) in {head_node_id, worker_node_id}
-
-        @ray.remote(num_cpus=1)
-        class Actor:
-            def get_node_id(self):
-                return ray.get_runtime_context().get_node_id()
-
-        actor = Actor.options(
+    assert worker_node_id == ray.get(
+        get_node_id.options(
             scheduling_strategy=NodeAffinitySchedulingStrategy(
                 worker_node_id, soft=False
             )
         ).remote()
-        assert worker_node_id == ray.get(actor.get_node_id.remote())
-
-        actor = Actor.options(
+    )
+    assert head_node_id == ray.get(
+        get_node_id.options(
             scheduling_strategy=NodeAffinitySchedulingStrategy(head_node_id, soft=False)
         ).remote()
-        assert head_node_id == ray.get(actor.get_node_id.remote())
+    )
 
-        actor = Actor.options(
-            scheduling_strategy=NodeAffinitySchedulingStrategy(
-                worker_node_id, soft=False
-            ),
-            num_cpus=0,
-        ).remote()
-        assert worker_node_id == ray.get(actor.get_node_id.remote())
-
-        actor = Actor.options(
-            scheduling_strategy=NodeAffinitySchedulingStrategy(
-                head_node_id, soft=False
-            ),
-            num_cpus=0,
-        ).remote()
-        assert head_node_id == ray.get(actor.get_node_id.remote())
-
-        # Wait until the target node becomes available.
-        worker_actor = Actor.options(resources={"worker": 1}).remote()
-        assert worker_node_id == ray.get(worker_actor.get_node_id.remote())
-        actor = Actor.options(
-            scheduling_strategy=NodeAffinitySchedulingStrategy(
-                worker_node_id, soft=True
-            ),
-            resources={"worker": 1},
-        ).remote()
-        del worker_actor
-        assert worker_node_id == ray.get(actor.get_node_id.remote())
-
-        # Doesn't fail when the node doesn't exist since soft is true.
-        actor = Actor.options(
+    # Doesn't fail when the node doesn't exist since soft is true.
+    ray.get(
+        get_node_id.options(
             scheduling_strategy=NodeAffinitySchedulingStrategy(
                 ray.NodeID.from_random().hex(), soft=True
             )
         ).remote()
-        assert ray.get(actor.get_node_id.remote())
+    )
 
-        # Doesn't fail when the node is infeasible since soft is true.
-        actor = Actor.options(
+    # Doesn't fail when the node is infeasible since soft is true.
+    assert worker_node_id == ray.get(
+        get_node_id.options(
             scheduling_strategy=NodeAffinitySchedulingStrategy(head_node_id, soft=True),
             resources={"worker": 1},
         ).remote()
-        assert worker_node_id == ray.get(actor.get_node_id.remote())
+    )
 
-        # Fail when the node doesn't exist.
-        with pytest.raises(ray.exceptions.ActorUnschedulableError):
-            actor = Actor.options(
+    # Fail when the node doesn't exist.
+    with pytest.raises(ray.exceptions.TaskUnschedulableError):
+        ray.get(
+            get_node_id.options(
                 scheduling_strategy=NodeAffinitySchedulingStrategy(
                     ray.NodeID.from_random().hex(), soft=False
                 )
             ).remote()
-            ray.get(actor.get_node_id.remote())
+        )
 
-        # Fail when the node is infeasible.
-        with pytest.raises(ray.exceptions.ActorUnschedulableError):
-            actor = Actor.options(
+    # Fail when the node is infeasible.
+    with pytest.raises(ray.exceptions.TaskUnschedulableError):
+        ray.get(
+            get_node_id.options(
                 scheduling_strategy=NodeAffinitySchedulingStrategy(
-                    worker_node_id, soft=False
+                    head_node_id, soft=False
                 ),
                 resources={"not_exist": 1},
             ).remote()
-            ray.get(actor.get_node_id.remote())
+        )
+
+    crashed_worker_node = cluster.add_node(num_cpus=8, resources={"crashed_worker": 1})
+    cluster.wait_for_nodes()
+    crashed_worker_node_id = ray.get(
+        get_node_id.options(num_cpus=0, resources={"crashed_worker": 1}).remote()
+    )
+
+    @ray.remote(
+        max_retries=-1,
+        scheduling_strategy=NodeAffinitySchedulingStrategy(
+            crashed_worker_node_id, soft=True
+        ),
+    )
+    def crashed_get_node_id():
+        if ray.get_runtime_context().get_node_id() == crashed_worker_node_id:
+            internal_kv._internal_kv_put(
+                "crashed_get_node_id", "crashed_worker_node_id"
+            )
+            while True:
+                time.sleep(1)
+        else:
+            return ray.get_runtime_context().get_node_id()
+
+    r = crashed_get_node_id.remote()
+    while not internal_kv._internal_kv_exists("crashed_get_node_id"):
+        time.sleep(0.1)
+    cluster.remove_node(crashed_worker_node, allow_graceful=False)
+    assert ray.get(r) in {head_node_id, worker_node_id}
+
+    @ray.remote(num_cpus=1)
+    class Actor:
+        def get_node_id(self):
+            return ray.get_runtime_context().get_node_id()
+
+    actor = Actor.options(
+        scheduling_strategy=NodeAffinitySchedulingStrategy(worker_node_id, soft=False)
+    ).remote()
+    assert worker_node_id == ray.get(actor.get_node_id.remote())
+
+    actor = Actor.options(
+        scheduling_strategy=NodeAffinitySchedulingStrategy(head_node_id, soft=False)
+    ).remote()
+    assert head_node_id == ray.get(actor.get_node_id.remote())
+
+    actor = Actor.options(
+        scheduling_strategy=NodeAffinitySchedulingStrategy(worker_node_id, soft=False),
+        num_cpus=0,
+    ).remote()
+    assert worker_node_id == ray.get(actor.get_node_id.remote())
+
+    actor = Actor.options(
+        scheduling_strategy=NodeAffinitySchedulingStrategy(head_node_id, soft=False),
+        num_cpus=0,
+    ).remote()
+    assert head_node_id == ray.get(actor.get_node_id.remote())
+
+    # Wait until the target node becomes available.
+    worker_actor = Actor.options(resources={"worker": 1}).remote()
+    assert worker_node_id == ray.get(worker_actor.get_node_id.remote())
+    actor = Actor.options(
+        scheduling_strategy=NodeAffinitySchedulingStrategy(worker_node_id, soft=True),
+        resources={"worker": 1},
+    ).remote()
+    del worker_actor
+    assert worker_node_id == ray.get(actor.get_node_id.remote())
+
+    # Doesn't fail when the node doesn't exist since soft is true.
+    actor = Actor.options(
+        scheduling_strategy=NodeAffinitySchedulingStrategy(
+            ray.NodeID.from_random().hex(), soft=True
+        )
+    ).remote()
+    assert ray.get(actor.get_node_id.remote())
+
+    # Doesn't fail when the node is infeasible since soft is true.
+    actor = Actor.options(
+        scheduling_strategy=NodeAffinitySchedulingStrategy(head_node_id, soft=True),
+        resources={"worker": 1},
+    ).remote()
+    assert worker_node_id == ray.get(actor.get_node_id.remote())
+
+    # Fail when the node doesn't exist.
+    with pytest.raises(ray.exceptions.ActorUnschedulableError):
+        actor = Actor.options(
+            scheduling_strategy=NodeAffinitySchedulingStrategy(
+                ray.NodeID.from_random().hex(), soft=False
+            )
+        ).remote()
+        ray.get(actor.get_node_id.remote())
+
+    # Fail when the node is infeasible.
+    with pytest.raises(ray.exceptions.ActorUnschedulableError):
+        actor = Actor.options(
+            scheduling_strategy=NodeAffinitySchedulingStrategy(
+                worker_node_id, soft=False
+            ),
+            resources={"not_exist": 1},
+        ).remote()
+        ray.get(actor.get_node_id.remote())
 
 
 def test_node_affinity_scheduling_strategy_spill_on_unavailable(ray_start_cluster):
@@ -496,8 +464,7 @@ def test_node_affinity_scheduling_strategy_fail_on_unavailable(ray_start_cluster
         ray.get(a2.get_node_id.remote())
 
 
-@pytest.mark.parametrize("connect_to_client", [True, False])
-def test_spread_scheduling_strategy(ray_start_cluster, connect_to_client):
+def test_spread_scheduling_strategy(ray_start_cluster):
     cluster = ray_start_cluster
     # Create a head node
     cluster.add_node(
@@ -511,62 +478,60 @@ def test_spread_scheduling_strategy(ray_start_cluster, connect_to_client):
         cluster.add_node(num_cpus=8, resources={f"foo:{i}": 1})
     cluster.wait_for_nodes()
 
-    with connect_to_client_or_not(connect_to_client):
+    @ray.remote
+    def get_node_id():
+        return ray.get_runtime_context().get_node_id()
 
-        @ray.remote
-        def get_node_id():
-            return ray.get_runtime_context().get_node_id()
+    worker_node_ids = {
+        ray.get(get_node_id.options(resources={f"foo:{i}": 1}).remote())
+        for i in range(2)
+    }
+    # Wait for updating driver raylet's resource view.
+    time.sleep(5)
 
-        worker_node_ids = {
-            ray.get(get_node_id.options(resources={f"foo:{i}": 1}).remote())
-            for i in range(2)
-        }
-        # Wait for updating driver raylet's resource view.
-        time.sleep(5)
-
-        @ray.remote(scheduling_strategy="SPREAD")
-        def task1():
-            internal_kv._internal_kv_put("test_task1", "task1")
-            while internal_kv._internal_kv_exists("test_task1"):
-                time.sleep(0.1)
-            return ray.get_runtime_context().get_node_id()
-
-        @ray.remote
-        def task2():
-            internal_kv._internal_kv_put("test_task2", "task2")
-            return ray.get_runtime_context().get_node_id()
-
-        locations = []
-        locations.append(task1.remote())
-        while not internal_kv._internal_kv_exists("test_task1"):
+    @ray.remote(scheduling_strategy="SPREAD")
+    def task1():
+        internal_kv._internal_kv_put("test_task1", "task1")
+        while internal_kv._internal_kv_exists("test_task1"):
             time.sleep(0.1)
-        # Wait for updating driver raylet's resource view.
-        time.sleep(5)
-        locations.append(task2.options(scheduling_strategy="SPREAD").remote())
-        while not internal_kv._internal_kv_exists("test_task2"):
-            time.sleep(0.1)
-        internal_kv._internal_kv_del("test_task1")
-        internal_kv._internal_kv_del("test_task2")
-        assert set(ray.get(locations)) == worker_node_ids
+        return ray.get_runtime_context().get_node_id()
 
-        # Wait for updating driver raylet's resource view.
-        time.sleep(5)
+    @ray.remote
+    def task2():
+        internal_kv._internal_kv_put("test_task2", "task2")
+        return ray.get_runtime_context().get_node_id()
 
-        # Make sure actors can be spreaded as well.
-        @ray.remote(num_cpus=1)
-        class Actor:
-            def ping(self):
-                return ray.get_runtime_context().get_node_id()
+    locations = []
+    locations.append(task1.remote())
+    while not internal_kv._internal_kv_exists("test_task1"):
+        time.sleep(0.1)
+    # Wait for updating driver raylet's resource view.
+    time.sleep(5)
+    locations.append(task2.options(scheduling_strategy="SPREAD").remote())
+    while not internal_kv._internal_kv_exists("test_task2"):
+        time.sleep(0.1)
+    internal_kv._internal_kv_del("test_task1")
+    internal_kv._internal_kv_del("test_task2")
+    assert set(ray.get(locations)) == worker_node_ids
 
-        actors = []
-        locations = []
-        for i in range(8):
-            actors.append(Actor.options(scheduling_strategy="SPREAD").remote())
-            locations.append(ray.get(actors[-1].ping.remote()))
-        locations.sort()
-        expected_locations = list(worker_node_ids) * 4
-        expected_locations.sort()
-        assert locations == expected_locations
+    # Wait for updating driver raylet's resource view.
+    time.sleep(5)
+
+    # Make sure actors can be spreaded as well.
+    @ray.remote(num_cpus=1)
+    class Actor:
+        def ping(self):
+            return ray.get_runtime_context().get_node_id()
+
+    actors = []
+    locations = []
+    for i in range(8):
+        actors.append(Actor.options(scheduling_strategy="SPREAD").remote())
+        locations.append(ray.get(actors[-1].ping.remote()))
+    locations.sort()
+    expected_locations = list(worker_node_ids) * 4
+    expected_locations.sort()
+    assert locations == expected_locations
 
 
 @pytest.mark.skipif(

--- a/python/ray/tests/test_scheduling_2.py
+++ b/python/ray/tests/test_scheduling_2.py
@@ -696,6 +696,9 @@ def test_demand_report_when_scale_up(autoscaler_v2, shutdown_only):
     ray.shutdown()
 
 
+@pytest.mark.skipif(
+    ray._private.client_mode_hook.is_client_mode_enabled, reason="Fails w/ Ray Client."
+)
 def test_data_locality_spilled_objects(
     ray_start_cluster_enabled, fs_only_object_spilling_config
 ):

--- a/python/ray/util/client/ray_client_helpers.py
+++ b/python/ray/util/client/ray_client_helpers.py
@@ -6,7 +6,7 @@ import ray as real_ray
 from ray.job_config import JobConfig
 import ray.util.client.server.server as ray_client_server
 from ray.util.client import ray
-from ray._private.client_mode_hook import enable_client_mode, disable_client_hook
+from ray._private.client_mode_hook import disable_client_hook
 
 
 @contextmanager

--- a/python/ray/util/client/ray_client_helpers.py
+++ b/python/ray/util/client/ray_client_helpers.py
@@ -80,36 +80,3 @@ def ray_start_cluster_client_server_pair(address):
         ray._inside_client_test = False
         ray.disconnect()
         server.stop(0)
-
-
-@contextmanager
-def connect_to_client_or_not(connect_to_client: bool):
-    """Utility for running test logic with and without a Ray client connection.
-
-    If client_connect is True, will connect to Ray client in context.
-    If client_connect is False, does nothing.
-
-    How to use:
-    Given a test of the following form:
-
-    def test_<name>(args):
-        <initialize a ray cluster>
-        <use the ray cluster>
-
-    Modify the test to
-
-    @pytest.mark.parametrize("connect_to_client", [False, True])
-    def test_<name>(args, connect_to_client)
-    <initialize a ray cluster>
-    with connect_to_client_or_not(connect_to_client):
-        <use the ray cluster>
-
-    Parameterize the argument connect over True, False to run the test with and
-    without a Ray client connection.
-    """
-
-    if connect_to_client:
-        with ray_start_client_server(namespace=""), enable_client_mode():
-            yield
-    else:
-        yield


### PR DESCRIPTION
- Makes Ray Client tests conditional on the `ray/util/client/` directory
- Pulls out the parametrized logic inside of the `test_placement_group*` and `test_scheduling*` tests and instead uses the `RAY_CLIENT_MODE` environment variable. There are no changes to these tests, the diff is so large because they were all un-indented after removing the context manager.

This should speed up premerge significantly (the placement group tests are slow and this was ~doubling their runtime).