### PR TITLE
[RLlib] Unwrap alpha value in cql torch learner

### DIFF
--- a/rllib/algorithms/cql/torch/cql_torch_learner.py
+++ b/rllib/algorithms/cql/torch/cql_torch_learner.py
@@ -213,8 +213,8 @@ class CQLTorchLearner(SACTorchLearner):
                 # TODO (simon): Add these keys to SAC Learner.
                 "cql_loss": cql_loss,
                 "alpha_loss": alpha_loss,
-                "alpha_value": alpha,
-                "log_alpha_value": torch.log(alpha),
+                "alpha_value": alpha[0],
+                "log_alpha_value": torch.log(alpha[0]),
                 "target_entropy": self.target_entropy[module_id],
                 LOGPS_KEY: torch.mean(
                     fwd_out["logp_resampled"]


### PR DESCRIPTION
## Why are these changes needed?

Same issue as fixed [here](https://github.com/ray-project/ray/pull/51639/files#diff-3af13cb99c2a03e94759d49ec40f80231b82dbdc761ac7ef14b49f898e425992R214-R215)
We tolerated bad inputs into the MetricsLogger before. alpha is a vector with length 1 and should ne unnested before logging it.

This fixes the failing CQL test
<img width="1627" alt="Screenshot 2025-05-15 at 21 40 15" src="https://github.com/user-attachments/assets/9ce535af-99dc-4e6e-be64-4f9e297be751" />

Sample:
https://buildkite.com/ray-project/postmerge/builds/10127#0196d256-69d3-4312-85d7-e09896a5c0eb

<img width="923" alt="Screenshot 2025-05-15 at 21 41 02" src="https://github.com/user-attachments/assets/b7209b30-57e7-4bdf-aeeb-ebc729cb3b47" />
