### PR TITLE
LLM Serve Grafana dashboard changes for compatibility

### DIFF
--- a/python/ray/dashboard/modules/metrics/dashboards/serve_llm_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/serve_llm_dashboard_panels.py
@@ -17,11 +17,11 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="tokens/s",
         targets=[
             Target(
-                expr='rate(ray_vllm:request_prompt_tokens_sum{{model_name=~"$vllm_model_name"}}[$__rate_interval])',
+                expr='rate(ray_vllm:request_prompt_tokens_sum{{model_name=~"$vllm_model_name", {global_filters}}}[5m])',
                 legend="Prompt Tokens/Sec",
             ),
             Target(
-                expr='rate(ray_vllm:generation_tokens_total{{model_name=~"$vllm_model_name"}}[$__rate_interval])',
+                expr='rate(ray_vllm:generation_tokens_total{{model_name=~"$vllm_model_name", {global_filters}}}[5m])',
                 legend="Generation Tokens/Sec",
             ),
         ],
@@ -37,23 +37,23 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="tokens",
         targets=[
             Target(
-                expr='histogram_quantile(0.99, sum by(le) (rate(ray_vllm:time_per_output_token_seconds_bucket{{model_name=~"$vllm_model_name"}}[$__rate_interval])))',
+                expr='histogram_quantile(0.99, sum by(le) (rate(ray_vllm:time_per_output_token_seconds_bucket{{model_name=~"$vllm_model_name", {global_filters}}}[5m])))',
                 legend="P99",
             ),
             Target(
-                expr='histogram_quantile(0.95, sum by(le) (rate(ray_vllm:time_per_output_token_seconds_bucket{{model_name=~"$vllm_model_name"}}[$__rate_interval])))',
+                expr='histogram_quantile(0.95, sum by(le) (rate(ray_vllm:time_per_output_token_seconds_bucket{{model_name=~"$vllm_model_name", {global_filters}}}[5m])))',
                 legend="P95",
             ),
             Target(
-                expr='histogram_quantile(0.9, sum by(le) (rate(ray_vllm:time_per_output_token_seconds_bucket{{model_name=~"$vllm_model_name"}}[$__rate_interval])))',
+                expr='histogram_quantile(0.9, sum by(le) (rate(ray_vllm:time_per_output_token_seconds_bucket{{model_name=~"$vllm_model_name", {global_filters}}}[5m])))',
                 legend="P90",
             ),
             Target(
-                expr='histogram_quantile(0.5, sum by(le) (rate(ray_vllm:time_per_output_token_seconds_bucket{{model_name=~"$vllm_model_name"}}[$__rate_interval])))',
+                expr='histogram_quantile(0.5, sum by(le) (rate(ray_vllm:time_per_output_token_seconds_bucket{{model_name=~"$vllm_model_name", {global_filters}}}[5m])))',
                 legend="P50",
             ),
             Target(
-                expr='rate(ray_vllm:time_per_output_token_seconds_sum{{model_name=~"$vllm_model_name"}}[$__rate_interval])\n/\nrate(ray_vllm:time_per_output_token_seconds_count{{model_name=~"$vllm_model_name"}}[$__rate_interval])',
+                expr='rate(ray_vllm:time_per_output_token_seconds_sum{{model_name=~"$vllm_model_name", {global_filters}}}[5m])\n/\nrate(ray_vllm:time_per_output_token_seconds_count{{model_name=~"$vllm_model_name", {global_filters}}}[5m])',
                 legend="Mean",
             ),
         ],
@@ -69,11 +69,11 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="percentunit",
         targets=[
             Target(
-                expr='ray_vllm:gpu_cache_usage_perc{{model_name=~"$vllm_model_name"}}',
+                expr='ray_vllm:gpu_cache_usage_perc{{model_name=~"$vllm_model_name", {global_filters}}}',
                 legend="GPU Cache Usage",
             ),
             Target(
-                expr='ray_vllm:cpu_cache_usage_perc{{model_name=~"$vllm_model_name"}}',
+                expr='ray_vllm:cpu_cache_usage_perc{{model_name=~"$vllm_model_name", {global_filters}}}',
                 legend="CPU Cache Usage",
             ),
         ],
@@ -89,23 +89,23 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="s",
         targets=[
             Target(
-                expr='rate(ray_vllm:time_to_first_token_seconds_sum{{model_name=~"$vllm_model_name"}}[$__rate_interval])\n/\nrate(ray_vllm:time_to_first_token_seconds_count{{model_name=~"$vllm_model_name"}}[$__rate_interval])',
+                expr='rate(ray_vllm:time_to_first_token_seconds_sum{{model_name=~"$vllm_model_name", {global_filters}}}[5m])\n/\nrate(ray_vllm:time_to_first_token_seconds_count{{model_name=~"$vllm_model_name", {global_filters}}}[5m])',
                 legend="Average",
             ),
             Target(
-                expr='histogram_quantile(0.5, sum by(le)(rate(ray_vllm:time_to_first_token_seconds_bucket{{model_name=~"$vllm_model_name"}}[$__rate_interval])))',
+                expr='histogram_quantile(0.5, sum by(le)(rate(ray_vllm:time_to_first_token_seconds_bucket{{model_name=~"$vllm_model_name", {global_filters}}}[5m])))',
                 legend="P50",
             ),
             Target(
-                expr='histogram_quantile(0.9, sum by(le)(rate(ray_vllm:time_to_first_token_seconds_bucket{{model_name=~"$vllm_model_name"}}[$__rate_interval])))',
+                expr='histogram_quantile(0.9, sum by(le)(rate(ray_vllm:time_to_first_token_seconds_bucket{{model_name=~"$vllm_model_name", {global_filters}}}[5m])))',
                 legend="P90",
             ),
             Target(
-                expr='histogram_quantile(0.95, sum by(le) (rate(ray_vllm:time_to_first_token_seconds_bucket{{model_name=~"$vllm_model_name"}}[$__rate_interval])))',
+                expr='histogram_quantile(0.95, sum by(le) (rate(ray_vllm:time_to_first_token_seconds_bucket{{model_name=~"$vllm_model_name", {global_filters}}}[5m])))',
                 legend="P95",
             ),
             Target(
-                expr='histogram_quantile(0.99, sum by(le)(rate(ray_vllm:time_to_first_token_seconds_bucket{{model_name=~"$vllm_model_name"}}[$__rate_interval])))',
+                expr='histogram_quantile(0.99, sum by(le)(rate(ray_vllm:time_to_first_token_seconds_bucket{{model_name=~"$vllm_model_name", {global_filters}}}[5m])))',
                 legend="P99",
             ),
         ],
@@ -121,23 +121,23 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="s",
         targets=[
             Target(
-                expr='rate(ray_vllm:e2e_request_latency_seconds_sum{{model_name=~"$vllm_model_name"}}[$__rate_interval])\n/\nrate(ray_vllm:e2e_request_latency_seconds_count{{model_name=~"$vllm_model_name"}}[$__rate_interval])',
+                expr='rate(ray_vllm:e2e_request_latency_seconds_sum{{model_name=~"$vllm_model_name", {global_filters}}}[5m])\n/\nrate(ray_vllm:e2e_request_latency_seconds_count{{model_name=~"$vllm_model_name", {global_filters}}}[5m])',
                 legend="Average",
             ),
             Target(
-                expr='histogram_quantile(0.5, sum by(le) (rate(ray_vllm:e2e_request_latency_seconds_bucket{{model_name=~"$vllm_model_name"}}[$__rate_interval])))',
+                expr='histogram_quantile(0.5, sum by(le) (rate(ray_vllm:e2e_request_latency_seconds_bucket{{model_name=~"$vllm_model_name", {global_filters}}}[5m])))',
                 legend="P50",
             ),
             Target(
-                expr='histogram_quantile(0.9, sum by(le) (rate(ray_vllm:e2e_request_latency_seconds_bucket{{model_name=~"$vllm_model_name"}}[$__rate_interval])))',
+                expr='histogram_quantile(0.9, sum by(le) (rate(ray_vllm:e2e_request_latency_seconds_bucket{{model_name=~"$vllm_model_name", {global_filters}}}[5m])))',
                 legend="P90",
             ),
             Target(
-                expr='histogram_quantile(0.95, sum by(le) (rate(ray_vllm:e2e_request_latency_seconds_bucket{{model_name=~"$vllm_model_name"}}[$__rate_interval])))',
+                expr='histogram_quantile(0.95, sum by(le) (rate(ray_vllm:e2e_request_latency_seconds_bucket{{model_name=~"$vllm_model_name", {global_filters}}}[5m])))',
                 legend="P95",
             ),
             Target(
-                expr='histogram_quantile(0.99, sum by(le) (rate(ray_vllm:e2e_request_latency_seconds_bucket{{model_name=~"$vllm_model_name"}}[$__rate_interval])))',
+                expr='histogram_quantile(0.99, sum by(le) (rate(ray_vllm:e2e_request_latency_seconds_bucket{{model_name=~"$vllm_model_name", {global_filters}}}[5m])))',
                 legend="P99",
             ),
         ],
@@ -153,15 +153,15 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="Requests",
         targets=[
             Target(
-                expr='ray_vllm:num_requests_running{{model_name=~"$vllm_model_name"}}',
+                expr='ray_vllm:num_requests_running{{model_name=~"$vllm_model_name", {global_filters}}}',
                 legend="Num Running",
             ),
             Target(
-                expr='ray_vllm:num_requests_swapped{{model_name=~"$vllm_model_name"}}',
+                expr='ray_vllm:num_requests_swapped{{model_name=~"$vllm_model_name", {global_filters}}}',
                 legend="Num Swapped",
             ),
             Target(
-                expr='ray_vllm:num_requests_waiting{{model_name=~"$vllm_model_name"}}',
+                expr='ray_vllm:num_requests_waiting{{model_name=~"$vllm_model_name", {global_filters}}}',
                 legend="Num Waiting",
             ),
         ],
@@ -177,7 +177,7 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="Requests",
         targets=[
             Target(
-                expr='sum by(le) (increase(ray_vllm:request_prompt_tokens_bucket{{model_name=~"$vllm_model_name"}}[$__rate_interval]))',
+                expr='sum by(le) (increase(ray_vllm:request_prompt_tokens_bucket{{model_name=~"$vllm_model_name", {global_filters}}}[5m]))',
                 legend="{{le}}",
                 template=TargetTemplate.HEATMAP,
             ),
@@ -195,7 +195,7 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="Requests",
         targets=[
             Target(
-                expr='sum by(le) (increase(ray_vllm:request_generation_tokens_bucket{{model_name=~"$vllm_model_name"}}[$__rate_interval]))',
+                expr='sum by(le) (increase(ray_vllm:request_generation_tokens_bucket{{model_name=~"$vllm_model_name", {global_filters}}}[5m]))',
                 legend="{{le}}",
                 template=TargetTemplate.HEATMAP,
             ),
@@ -213,8 +213,8 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="Requests",
         targets=[
             Target(
-                expr='sum by(finished_reason) (increase(ray_vllm:request_success_total{{model_name=~"$vllm_model_name"}}[$__rate_interval]))',
-                legend="__auto",
+                expr='sum by(finished_reason) (increase(ray_vllm:request_success_total{{model_name=~"$vllm_model_name", {global_filters}}}[5m]))',
+                legend="{{finished_reason}}",
             ),
         ],
         fill=1,
@@ -229,7 +229,7 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="s",
         targets=[
             Target(
-                expr='rate(ray_vllm:request_queue_time_seconds_sum{{model_name=~"$vllm_model_name"}}[$__rate_interval])',
+                expr='rate(ray_vllm:request_queue_time_seconds_sum{{model_name=~"$vllm_model_name", {global_filters}}}[5m])',
                 legend="{{model_name}}",
             ),
         ],
@@ -245,11 +245,11 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="s",
         targets=[
             Target(
-                expr='rate(ray_vllm:request_decode_time_seconds_sum{{model_name=~"$vllm_model_name"}}[$__rate_interval])',
+                expr='rate(ray_vllm:request_decode_time_seconds_sum{{model_name=~"$vllm_model_name", {global_filters}}}[5m])',
                 legend="Decode",
             ),
             Target(
-                expr='rate(ray_vllm:request_prefill_time_seconds_sum{{model_name=~"$vllm_model_name"}}[$__rate_interval])',
+                expr='rate(ray_vllm:request_prefill_time_seconds_sum{{model_name=~"$vllm_model_name", {global_filters}}}[5m])',
                 legend="Prefill",
             ),
         ],
@@ -265,7 +265,7 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="none",
         targets=[
             Target(
-                expr='rate(ray_vllm:request_max_num_generation_tokens_sum{{model_name=~"$vllm_model_name"}}[$__rate_interval])',
+                expr='rate(ray_vllm:request_max_num_generation_tokens_sum{{model_name=~"$vllm_model_name", {global_filters}}}[5m])',
                 legend="{{model_name}}",
             ),
         ],
@@ -281,11 +281,11 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="Tokens",
         targets=[
             Target(
-                expr='(sum by (model_id) (delta(ray_serve_llm_tokens_input{{WorkerId=~"$workerid", model_id !~ ".+--.+"}}[1d])))',
+                expr='(sum by (model_id) (delta(ray_serve_llm_tokens_input{{WorkerId=~"$workerid", model_id !~ ".+--.+", {global_filters}}}[1d])))',
                 legend="Input: {{model_id}}",
             ),
             Target(
-                expr='(sum by (model_id) (delta(ray_serve_llm_tokens_generated{{WorkerId=~"$workerid", model_id !~ ".+--.+"}}[1d])))',
+                expr='(sum by (model_id) (delta(ray_serve_llm_tokens_generated{{WorkerId=~"$workerid", model_id !~ ".+--.+", {global_filters}}}[1d])))',
                 legend="Generated: {{model_id}}",
             ),
         ],
@@ -302,11 +302,11 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="Tokens",
         targets=[
             Target(
-                expr='delta(ray_serve_llm_tokens_input{{WorkerId=~"$workerid"}}[1h])',
+                expr='delta(ray_serve_llm_tokens_input{{WorkerId=~"$workerid", {global_filters}}}[1h])',
                 legend="Input: {{model_id}}",
             ),
             Target(
-                expr='delta(ray_serve_llm_tokens_generated{{WorkerId=~"$workerid"}}[1h])',
+                expr='delta(ray_serve_llm_tokens_generated{{WorkerId=~"$workerid", {global_filters}}}[1h])',
                 legend="Generated: {{model_id}}",
             ),
         ],
@@ -323,15 +323,15 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="Requests",
         targets=[
             Target(
-                expr='(sum by (WorkerId) (delta(ray_serve_llm_requests_errored{{WorkerId=~"$workerid"}}[1h])))',
+                expr='(sum by (WorkerId) (delta(ray_serve_llm_requests_errored{{WorkerId=~"$workerid", {global_filters}}}[1h])))',
                 legend="Errored",
             ),
             Target(
-                expr='(sum by (WorkerId) (delta(ray_serve_llm_requests_finished{{WorkerId=~"$workerid"}}[1h])))',
+                expr='(sum by (WorkerId) (delta(ray_serve_llm_requests_finished{{WorkerId=~"$workerid", {global_filters}}}[1h])))',
                 legend="Finished",
             ),
             Target(
-                expr='(sum by (WorkerId) (delta(ray_serve_llm_requests_started{{WorkerId=~"$workerid"}}[1h])))',
+                expr='(sum by (WorkerId) (delta(ray_serve_llm_requests_started{{WorkerId=~"$workerid", {global_filters}}}[1h])))',
                 legend="Started",
             ),
         ],
@@ -347,7 +347,7 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="Requests",
         targets=[
             Target(
-                expr='sum by (model_id) (delta(ray_serve_llm_requests_started{{WorkerId=~"$workerid", model_id !~ ".+--.+"}}[1d]))',
+                expr='sum by (model_id) (delta(ray_serve_llm_requests_started{{WorkerId=~"$workerid", model_id !~ ".+--.+", {global_filters}}}[1d]))',
                 legend="{{model_id}}",
             ),
         ],
@@ -364,7 +364,7 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="none",
         targets=[
             Target(
-                expr='sum by (model_id) (delta(ray_serve_llm_tokens_input{{WorkerId=~"$workerid"}}[1d])) / sum by (model_id) (delta(ray_serve_llm_tokens_generated{{WorkerId=~"$workerid"}}[1d]))',
+                expr='sum by (model_id) (delta(ray_serve_llm_tokens_input{{WorkerId=~"$workerid", {global_filters}}}[1d])) / sum by (model_id) (delta(ray_serve_llm_tokens_generated{{WorkerId=~"$workerid", {global_filters}}}[1d]))',
                 legend="{{model_id}}",
             ),
         ],
@@ -381,7 +381,7 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="Tokens",
         targets=[
             Target(
-                expr='sum by (model_id) (delta(ray_serve_llm_tokens_input{{WorkerId=~"$workerid"}}[1d])) + sum by (model_id) (delta(ray_serve_llm_tokens_generated{{WorkerId=~"$workerid"}}[1d]))',
+                expr='sum by (model_id) (delta(ray_serve_llm_tokens_input{{WorkerId=~"$workerid", {global_filters}}}[1d])) + sum by (model_id) (delta(ray_serve_llm_tokens_generated{{WorkerId=~"$workerid", {global_filters}}}[1d]))',
                 legend="{{model_id}}",
             ),
         ],
@@ -398,8 +398,8 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="Tokens/s",
         targets=[
             Target(
-                expr='max_over_time(sum by (model_id) (rate(ray_serve_llm_tokens_generated{{WorkerId=~"$workerid"}}[2m]))[24h:])',
-                legend="{{ model_id }}",
+                expr='max_over_time(sum by (model_id) (rate(ray_serve_llm_tokens_generated{{WorkerId=~"$workerid", {global_filters}}}[2m]))[24h:])',
+                legend="{{model_id}}",
             ),
         ],
         fill=1,
@@ -415,8 +415,8 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="Requests",
         targets=[
             Target(
-                expr='sum by (model_id) (delta(ray_serve_llm_requests_started{{WorkerId=~"$workerid",model_id !~ ".+--.+"}}[1w]))',
-                legend="{{ model_id }}",
+                expr='sum by (model_id) (delta(ray_serve_llm_requests_started{{WorkerId=~"$workerid",model_id !~ ".+--.+", {global_filters}}}[1w]))',
+                legend="{{ model_id}}",
             ),
         ],
         fill=1,
@@ -432,8 +432,8 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="Requests",
         targets=[
             Target(
-                expr='(sum by (model_id) (delta(ray_serve_llm_tokens_input{{WorkerId=~"$workerid",model_id !~ ".+--.+", model_id=~"$ray_llm_model_id"}}[1w])) +\nsum by (model_id) (delta(ray_serve_llm_tokens_generated{{WorkerId=~"$workerid",model_id !~ ".+--.+", model_id=~"$ray_llm_model_id"}}[1w]))) / sum by (model_id) (delta(ray_serve_llm_requests_started{{WorkerId=~"$workerid",model_id !~ ".+--.+", model_id=~"$ray_llm_model_id"}}[1w]))',
-                legend="{{ model_id }}",
+                expr='(sum by (model_id) (delta(ray_serve_llm_tokens_input{{WorkerId=~"$workerid",model_id !~ ".+--.+", model_id=~"$ray_llm_model_id", {global_filters}}}[1w])) +\nsum by (model_id) (delta(ray_serve_llm_tokens_generated{{WorkerId=~"$workerid",model_id !~ ".+--.+", model_id=~"$ray_llm_model_id", {global_filters}}}[1w]))) / sum by (model_id) (delta(ray_serve_llm_requests_started{{WorkerId=~"$workerid",model_id !~ ".+--.+", model_id=~"$ray_llm_model_id", {global_filters}}}[1w]))',
+                legend="{{ model_id}}",
             ),
         ],
         fill=1,
@@ -449,8 +449,8 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="Requests",
         targets=[
             Target(
-                expr='(sum by (model_id) (delta(ray_serve_llm_tokens_input{{WorkerId=~"$workerid",model_id !~ ".+--.+"}}[1w])) + sum by (model_id) (delta(ray_serve_llm_tokens_generated{{WorkerId=~"$workerid",model_id !~ ".+--.+"}}[1w])))/ sum by (model_id) (delta(ray_serve_llm_requests_started{{WorkerId=~"$workerid",model_id !~ ".+--.+"}}[1w]))',
-                legend="{{ model_id }}",
+                expr='(sum by (model_id) (delta(ray_serve_llm_tokens_input{{WorkerId=~"$workerid",model_id !~ ".+--.+", {global_filters}}}[1w])) + sum by (model_id) (delta(ray_serve_llm_tokens_generated{{WorkerId=~"$workerid",model_id !~ ".+--.+", {global_filters}}}[1w])))/ sum by (model_id) (delta(ray_serve_llm_requests_started{{WorkerId=~"$workerid",model_id !~ ".+--.+", {global_filters}}}[1w]))',
+                legend="{{ model_id}}",
             ),
         ],
         fill=1,
@@ -466,11 +466,11 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="Tokens",
         targets=[
             Target(
-                expr='sum by (model_id) (delta(ray_serve_llm_tokens_input{{WorkerId=~"$workerid",model_id !~ ".+--.+"}}[1w]))',
-                legend="In: {{ model_id }}",
+                expr='sum by (model_id) (delta(ray_serve_llm_tokens_input{{WorkerId=~"$workerid",model_id !~ ".+--.+", {global_filters}}}[1w]))',
+                legend="In: {{ model_id}}",
             ),
             Target(
-                expr='sum by (model_id) (delta(ray_serve_llm_tokens_generated{{WorkerId=~"$workerid",model_id !~ ".+--.+"}}[1w]))',
+                expr='sum by (model_id) (delta(ray_serve_llm_tokens_generated{{WorkerId=~"$workerid",model_id !~ ".+--.+", {global_filters}}}[1w]))',
                 legend="Out: {{ model_id }}",
             ),
         ],
@@ -487,12 +487,12 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="Tokens",
         targets=[
             Target(
-                expr='sum by (model_id) (delta(ray_serve_llm_tokens_input{{WorkerId=~"$workerid",model_id !~ ".+--.+"}}[1w])) / sum by (model_id) (delta(ray_serve_llm_requests_started{{WorkerId=~"$workerid",model_id !~ ".+--.+"}}[1w]))',
-                legend="In: {{ model_id }}",
+                expr='sum by (model_id) (delta(ray_serve_llm_tokens_input{{WorkerId=~"$workerid",model_id !~ ".+--.+", {global_filters}}}[1w])) / sum by (model_id) (delta(ray_serve_llm_requests_started{{WorkerId=~"$workerid",model_id !~ ".+--.+", {global_filters}}}[1w]))',
+                legend="In: {{ model_id}}",
             ),
             Target(
-                expr='sum by (model_id) (delta(ray_serve_llm_tokens_generated{{WorkerId=~"$workerid",model_id !~ ".+--.+"}}[1w])) / sum by (model_id) (delta(ray_serve_llm_requests_started{{WorkerId=~"$workerid",model_id !~ ".+--.+"}}[1w]))',
-                legend="Out: {{ model_id }}",
+                expr='sum by (model_id) (delta(ray_serve_llm_tokens_generated{{WorkerId=~"$workerid",model_id !~ ".+--.+", {global_filters}}}[1w])) / sum by (model_id) (delta(ray_serve_llm_requests_started{{WorkerId=~"$workerid",model_id !~ ".+--.+", {global_filters}}}[1w]))',
+                legend="Out: {{ model_id}}",
             ),
         ],
         fill=1,

--- a/python/ray/dashboard/modules/metrics/dashboards/serve_llm_grafana_dashboard_base.json
+++ b/python/ray/dashboard/modules/metrics/dashboards/serve_llm_grafana_dashboard_base.json
@@ -46,9 +46,9 @@
         "type": "query",
         "hide": 0,
         "datasource": "${datasource}",
-        "definition": "label_values(ray_vllm:request_prompt_tokens_sum, model_name)",
+        "definition": "label_values(ray_vllm:request_prompt_tokens_sum{{{global_filters}}}, model_name)",
         "query": {
-          "query": "label_values(ray_vllm:request_prompt_tokens_sum, model_name)",
+          "query": "label_values(ray_vllm:request_prompt_tokens_sum{{{global_filters}}}, model_name)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -71,9 +71,9 @@
         "type": "query",
         "hide": 0,
         "datasource": "${datasource}",
-        "definition": "label_values(ray_serve_llm_tokens_input_total, model_id)",
+        "definition": "label_values(ray_serve_llm_tokens_input_total{{{global_filters}}}, model_id)",
         "query": {
-          "query": "label_values(ray_serve_llm_tokens_input_total, model_id)",
+          "query": "label_values(ray_serve_llm_tokens_input_total{{{global_filters}}}, model_id)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -96,9 +96,9 @@
         "type": "query",
         "hide": 0,
         "datasource": "${datasource}",
-        "definition": "label_values(ray_serve_llm_tokens_input_total, WorkerId)",
+        "definition": "label_values(ray_serve_llm_tokens_input_total{{{global_filters}}}, WorkerId)",
         "query": {
-          "query": "label_values(ray_serve_llm_tokens_input_total, WorkerId)",
+          "query": "label_values(ray_serve_llm_tokens_input_total{{{global_filters}}}, WorkerId)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

- Older Grafana versions (v7.5.17) do not support `$__rate_interval`.
- `{global_filters}` template is needed to inject user specified global filters at dashboard creation.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
[LLM-1911](https://anyscale1.atlassian.net/browse/LLM-1911)
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
   - [x] Tested on OSS Ray and Workspaces
