### PR TITLE
Make uv run environment propagation the default

### DIFF
--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -446,7 +446,7 @@ your programs:
     print(ray.get(g.remote()))
 
 
-  While the above pattern can be useful for supporting legacy applications, it is recommended to
+  While the above pattern can be useful for supporting legacy applications, the Ray Team recommends
   also use uv for tracking nested environments. You can do this by creating a separate
   `pyproject.toml` containing the dependencies of the nested environment.
 

--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -408,7 +408,7 @@ your programs:
 
 .. note::
 
-  The uv environment will be inherited by all children tasks and actors. If you want to mix e.g. `pip`
+  The uv environment is inherited by all children tasks and actors. If you want to mix environments, for example,  `pip`
   runtime environments with `uv run` you will need to set the Python executable back to an executable
   that is not running in the isolated uv environment like so:
 

--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -409,7 +409,7 @@ your programs:
 .. note::
 
   The uv environment is inherited by all children tasks and actors. If you want to mix environments, for example,  `pip`
-  runtime environments with `uv run` you will need to set the Python executable back to an executable
+  runtime environments with `uv run`, you need to set the Python executable back to an executable
   that is not running in the isolated uv environment like so:
 
   .. code-block:: toml

--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -408,7 +408,7 @@ your programs:
 
 .. note::
 
-  The uv environment is inherited by all children tasks and actors. If you want to mix environments, for example,  `pip`
+  The uv environment is inherited by all children tasks and actors. If you want to mix environments, for example, `pip`
   runtime environments with `uv run`, you need to set the Python executable back to an executable
   that's not running in the isolated uv environment like the following:
 

--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -410,7 +410,7 @@ your programs:
 
   The uv environment is inherited by all children tasks and actors. If you want to mix environments, for example,  `pip`
   runtime environments with `uv run`, you need to set the Python executable back to an executable
-  that is not running in the isolated uv environment like so:
+  that's not running in the isolated uv environment like the following:
 
   .. code-block:: toml
 

--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -427,7 +427,8 @@ your programs:
       "virtualenv",
     ]
 
-  .. code-block:: python
+  .. testcode::
+    :skipif: True
 
     import ray
 

--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -447,7 +447,7 @@ your programs:
 
 
   While the above pattern can be useful for supporting legacy applications, the Ray Team recommends
-  also use uv for tracking nested environments. You can do this by creating a separate
+  also using uv for tracking nested environments. You can use this approach by creating a separate
   `pyproject.toml` containing the dependencies of the nested environment.
 
 

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -572,7 +572,7 @@ RAY_EXPORT_EVENT_MAX_BACKUP_COUNT = env_bool("RAY_EXPORT_EVENT_MAX_BACKUP_COUNT"
 # pyproject.toml is found. If RAY_ENABLE_UV_RUN_RUNTIME_ENV is enabled AND the driver
 # is run with `uv run`, the regular RAY_RUNTIME_ENV_HOOK will be deactivated
 # because in most cases it doesn't work unless the user specifically makes the code
-# for the runtime env hook available in their UV environment and makes sure their hook
+# for the runtime env hook available in their uv environment and makes sure their hook
 # is compatible with the UV runtime environment. If a user wants to combine a custom
 # RAY_RUNTIME_ENV_HOOK with `uv run`, they should flag off RAY_ENABLE_UV_RUN_RUNTIME_ENV
 # and call ray._private.runtime_env.uv_runtime_env_hook.hook manually in their hook or

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -568,13 +568,13 @@ RAY_EXPORT_EVENT_MAX_BACKUP_COUNT = env_bool("RAY_EXPORT_EVENT_MAX_BACKUP_COUNT"
 
 # If set, updates the runtime environment to use `uv run` if the driver was run with `uv run`.
 # This runtime environment propagates the arguments of `uv run` to all the worker
-# processes via the py_executable plugin and also set the working_dir so the
-# pyproject.toml is found. If RAY_ENABLE_UV_RUN_RUNTIME_ENV is enabled AND the driver
-# is run with `uv run`, the regular RAY_RUNTIME_ENV_HOOK will be deactivated
-# because in most cases it doesn't work unless the user specifically makes the code
-# for the runtime env hook available in their uv environment and makes sure their hook
-# is compatible with the uv runtime environment. If a user wants to combine a custom
-# RAY_RUNTIME_ENV_HOOK with `uv run`, they should flag off RAY_ENABLE_UV_RUN_RUNTIME_ENV
-# and call ray._private.runtime_env.uv_runtime_env_hook.hook manually in their hook or
-# manually set the py_executable in their runtime environment hook.
+# processes via the py_executable plugin and also sets the working_dir so uv finds the
+# pyproject.toml. If you enable RAY_ENABLE_UV_RUN_RUNTIME_ENV AND the driver
+# is run with `uv run`, Ray deactivates the regular RAY_RUNTIME_ENV_HOOK
+# because in most cases the hooks wouldn't work unless you specifically make the code
+# for the runtime env hook available in your uv environment and makes sure your hook
+# is compatible with your uv runtime environment. If you want to combine a custom
+# RAY_RUNTIME_ENV_HOOK with `uv run`, you should flag off RAY_ENABLE_UV_RUN_RUNTIME_ENV
+# and call ray._private.runtime_env.uv_runtime_env_hook.hook manually in your hook or
+# manually set the py_executable in your runtime environment hook.
 RAY_ENABLE_UV_RUN_RUNTIME_ENV = env_bool("RAY_ENABLE_UV_RUN_RUNTIME_ENV", True)

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -567,7 +567,7 @@ RAY_EXPORT_EVENT_MAX_FILE_SIZE_BYTES = env_bool(
 RAY_EXPORT_EVENT_MAX_BACKUP_COUNT = env_bool("RAY_EXPORT_EVENT_MAX_BACKUP_COUNT", 20)
 
 # If set, use the `uv run` runtime environment in case the driver is run with `uv run`.
-# This runtime environment will propagate the arguments of `uv run` to all the worker
+# This runtime environment propagates the arguments of `uv run` to all the worker
 # processes via the py_executable plugin and also set the working_dir so the
 # pyproject.toml is found. If RAY_ENABLE_UV_RUN_RUNTIME_ENV is enabled AND the driver
 # is run with `uv run`, the regular RAY_RUNTIME_ENV_HOOK will be deactivated

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -566,13 +566,14 @@ RAY_EXPORT_EVENT_MAX_FILE_SIZE_BYTES = env_bool(
 
 RAY_EXPORT_EVENT_MAX_BACKUP_COUNT = env_bool("RAY_EXPORT_EVENT_MAX_BACKUP_COUNT", 20)
 
-# If set, updates the runtime environment to use `uv run` if the driver was run with `uv run`.
-# This runtime environment propagates the arguments of `uv run` to all the worker
-# processes via the py_executable plugin and also sets the working_dir so uv finds the
-# pyproject.toml. If you enable RAY_ENABLE_UV_RUN_RUNTIME_ENV AND the driver
-# is run with `uv run`, Ray deactivates the regular RAY_RUNTIME_ENV_HOOK
+# If this flag is set and you run the driver with `uv run`, propagate the `uv run`
+# environment to all workers. Under the hood the uv run command line is propagated
+# using the py_executable runtime environment plugin and the working directory is
+# propagated via the `working_dir` plugin so uv finds the pyproject.toml.
+# If you enable RAY_ENABLE_UV_RUN_RUNTIME_ENV AND you run the driver
+# with `uv run`, Ray deactivates the regular RAY_RUNTIME_ENV_HOOK
 # because in most cases the hooks wouldn't work unless you specifically make the code
-# for the runtime env hook available in your uv environment and makes sure your hook
+# for the runtime env hook available in your uv environment and make sure your hook
 # is compatible with your uv runtime environment. If you want to combine a custom
 # RAY_RUNTIME_ENV_HOOK with `uv run`, you should flag off RAY_ENABLE_UV_RUN_RUNTIME_ENV
 # and call ray._private.runtime_env.uv_runtime_env_hook.hook manually in your hook or

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -571,7 +571,7 @@ RAY_EXPORT_EVENT_MAX_BACKUP_COUNT = env_bool("RAY_EXPORT_EVENT_MAX_BACKUP_COUNT"
 # processes via the py_executable plugin and also set the working_dir so the
 # pyproject.toml is found. If RAY_ENABLE_UV_RUN_RUNTIME_ENV is enabled AND the driver
 # is run with `uv run`, the regular RAY_RUNTIME_ENV_HOOK will be deactivated
-# since in most cases it will not work unless the user specifically makes the code
+# because in most cases it doesn't work unless the user specifically makes the code
 # for the runtime env hook available in their UV environment and makes sure their hook
 # is compatible with the UV runtime environment. If a user wants to combine a custom
 # RAY_RUNTIME_ENV_HOOK with `uv run`, they should flag off RAY_ENABLE_UV_RUN_RUNTIME_ENV

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -565,3 +565,16 @@ RAY_EXPORT_EVENT_MAX_FILE_SIZE_BYTES = env_bool(
 )
 
 RAY_EXPORT_EVENT_MAX_BACKUP_COUNT = env_bool("RAY_EXPORT_EVENT_MAX_BACKUP_COUNT", 20)
+
+# If set, use the `uv run` runtime environment in case the driver is run with `uv run`.
+# This runtime environment will propagate the arguments of `uv run` to all the worker
+# processes via the py_executable plugin and also set the working_dir so the
+# pyproject.toml is found. If RAY_ENABLE_UV_RUN_RUNTIME_ENV is enabled AND the driver
+# is run with `uv run`, the regular RAY_RUNTIME_ENV_HOOK will be deactivated
+# since in most cases it will not work unless the user specifically makes the code
+# for the runtime env hook available in their UV environment and makes sure their hook
+# is compatible with the UV runtime environment. If a user wants to combine a custom
+# RAY_RUNTIME_ENV_HOOK with `uv run`, they should flag off RAY_ENABLE_UV_RUN_RUNTIME_ENV
+# and call ray._private.runtime_env.uv_runtime_env_hook.hook manually in their hook or
+# manually set the py_executable in their runtime environment hook.
+RAY_ENABLE_UV_RUN_RUNTIME_ENV = env_bool("RAY_ENABLE_UV_RUN_RUNTIME_ENV", True)

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -566,10 +566,10 @@ RAY_EXPORT_EVENT_MAX_FILE_SIZE_BYTES = env_bool(
 
 RAY_EXPORT_EVENT_MAX_BACKUP_COUNT = env_bool("RAY_EXPORT_EVENT_MAX_BACKUP_COUNT", 20)
 
-# If this flag is set and you run the driver with `uv run`, propagate the `uv run`
-# environment to all workers. Under the hood the uv run command line is propagated
-# using the py_executable runtime environment plugin and the working directory is
-# propagated via the `working_dir` plugin so uv finds the pyproject.toml.
+# If this flag is set and you run the driver with `uv run`, Ray propagates the `uv run`
+# environment to all workers. Ray does this by setting the `py_executable` to the
+# `uv run`` command line and by propagating the working directory
+# via the `working_dir` plugin so uv finds the pyproject.toml.
 # If you enable RAY_ENABLE_UV_RUN_RUNTIME_ENV AND you run the driver
 # with `uv run`, Ray deactivates the regular RAY_RUNTIME_ENV_HOOK
 # because in most cases the hooks wouldn't work unless you specifically make the code

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -566,7 +566,7 @@ RAY_EXPORT_EVENT_MAX_FILE_SIZE_BYTES = env_bool(
 
 RAY_EXPORT_EVENT_MAX_BACKUP_COUNT = env_bool("RAY_EXPORT_EVENT_MAX_BACKUP_COUNT", 20)
 
-# If set, use the `uv run` runtime environment in case the driver is run with `uv run`.
+# If set, updates the runtime environment to use `uv run` if the driver was run with `uv run`.
 # This runtime environment propagates the arguments of `uv run` to all the worker
 # processes via the py_executable plugin and also set the working_dir so the
 # pyproject.toml is found. If RAY_ENABLE_UV_RUN_RUNTIME_ENV is enabled AND the driver

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -573,7 +573,7 @@ RAY_EXPORT_EVENT_MAX_BACKUP_COUNT = env_bool("RAY_EXPORT_EVENT_MAX_BACKUP_COUNT"
 # is run with `uv run`, the regular RAY_RUNTIME_ENV_HOOK will be deactivated
 # because in most cases it doesn't work unless the user specifically makes the code
 # for the runtime env hook available in their uv environment and makes sure their hook
-# is compatible with the UV runtime environment. If a user wants to combine a custom
+# is compatible with the uv runtime environment. If a user wants to combine a custom
 # RAY_RUNTIME_ENV_HOOK with `uv run`, they should flag off RAY_ENABLE_UV_RUN_RUNTIME_ENV
 # and call ray._private.runtime_env.uv_runtime_env_hook.hook manually in their hook or
 # manually set the py_executable in their runtime environment hook.

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1285,9 +1285,9 @@ def _maybe_modify_runtime_env(
     runtime_env: Optional[Dict[str, Any]], _skip_env_hook: bool
 ) -> Dict[str, Any]:
     """
-    If RAY_ENABLE_UV_RUN_RUNTIME_ENV is set (which is the default) and the driver was run with `uv run`,
+    If you set RAY_ENABLE_UV_RUN_RUNTIME_ENV, which is the default, and run the driver with `uv run`,
     this function sets up a runtime environment that replicates the driver's environment to the
-    workers. Otherwise, the runtime environment is modified by the user's runtime environment hook.
+    workers. Otherwise, if a runtime environment hook is present it will modify the runtime environment.
     """
 
     if ray_constants.RAY_ENABLE_UV_RUN_RUNTIME_ENV:

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1286,7 +1286,7 @@ def _maybe_modify_runtime_env(
 ) -> Dict[str, Any]:
     """
     If RAY_ENABLE_UV_RUN_RUNTIME_ENV is set (which is the default) and the driver was run with `uv run`,
-    this function will set up a runtime environment that will replicate the driver's environment to the
+    this function sets up a runtime environment that replicates the driver's environment to the
     workers. Otherwise, the runtime environment is modified by the user's runtime environment hook.
     """
 

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1293,7 +1293,7 @@ def _maybe_modify_runtime_env(
     if ray_constants.RAY_ENABLE_UV_RUN_RUNTIME_ENV:
         from ray._private.runtime_env.uv_runtime_env_hook import (
             hook,
-            _get_uv_run_cmdline
+            _get_uv_run_cmdline,
         )
 
         cmdline = _get_uv_run_cmdline()
@@ -1303,7 +1303,7 @@ def _maybe_modify_runtime_env(
             return hook(runtime_env)
 
     if ray_constants.RAY_RUNTIME_ENV_HOOK in os.environ and not _skip_env_hook:
-            return load_class(os.environ[ray_constants.RAY_RUNTIME_ENV_HOOK])(runtime_env)
+        return load_class(os.environ[ray_constants.RAY_RUNTIME_ENV_HOOK])(runtime_env)
 
 
 @PublicAPI

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1281,7 +1281,9 @@ _global_node = None
 """ray._private.node.Node: The global node object that is created by ray.init()."""
 
 
-def _maybe_modify_runtime_env(runtime_env: Optional[Dict[str, Any]], _skip_env_hook: bool) -> Dict[str, Any]:
+def _maybe_modify_runtime_env(
+    runtime_env: Optional[Dict[str, Any]], _skip_env_hook: bool
+) -> Dict[str, Any]:
     """
     If RAY_ENABLE_UV_RUN_RUNTIME_ENV is set (which is the default) and the driver was run with `uv run`,
     this function will set up a runtime environment that will replicate the driver's environment to the
@@ -1289,7 +1291,10 @@ def _maybe_modify_runtime_env(runtime_env: Optional[Dict[str, Any]], _skip_env_h
     """
 
     if ray_constants.RAY_ENABLE_UV_RUN_RUNTIME_ENV:
-        from ray._private.runtime_env.uv_runtime_env_hook import hook, _get_uv_run_cmdline
+        from ray._private.runtime_env.uv_runtime_env_hook import (
+            hook,
+            _get_uv_run_cmdline
+        )
 
         cmdline = _get_uv_run_cmdline()
         if cmdline:
@@ -1298,9 +1303,7 @@ def _maybe_modify_runtime_env(runtime_env: Optional[Dict[str, Any]], _skip_env_h
             return hook(runtime_env)
 
     if ray_constants.RAY_RUNTIME_ENV_HOOK in os.environ and not _skip_env_hook:
-            return load_class(os.environ[ray_constants.RAY_RUNTIME_ENV_HOOK])(
-                runtime_env
-            )
+            return load_class(os.environ[ray_constants.RAY_RUNTIME_ENV_HOOK])(runtime_env)
 
 
 @PublicAPI

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1305,6 +1305,8 @@ def _maybe_modify_runtime_env(
     if ray_constants.RAY_RUNTIME_ENV_HOOK in os.environ and not _skip_env_hook:
         return load_class(os.environ[ray_constants.RAY_RUNTIME_ENV_HOOK])(runtime_env)
 
+    return runtime_env
+
 
 @PublicAPI
 @client_mode_hook


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This makes it so `RAY_RUNTIME_ENV_HOOK=ray._private.runtime_env.uv_runtime_env_hook.hook` does not need to be set any more to use the uv run runtime environment propagation.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
