### PR TITLE
[Data] Remove `DataContext.eager_free`

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -722,5 +722,4 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
                 # Keep track of node ids to ensure we don't double count
                 node_ids.add(node_id)
 
-        inputs.destroy_if_owned()
         del self._running_tasks[task_index]

--- a/python/ray/data/_internal/execution/operators/zip_operator.py
+++ b/python/ray/data/_internal/execution/operators/zip_operator.py
@@ -229,12 +229,6 @@ class ZipOperator(InternalQueueOperatorMixin, PhysicalOperator):
             )
         stats = {self._name: to_stats(output_metadata)}
 
-        # Clean up inputs.
-        for ref in left_input:
-            ref.destroy_if_owned()
-        for ref in right_input:
-            ref.destroy_if_owned()
-
         return output_refs, stats
 
     def _calculate_blocks_rows_and_bytes(

--- a/python/ray/data/_internal/split.py
+++ b/python/ray/data/_internal/split.py
@@ -207,7 +207,7 @@ def _split_all_blocks(
             trace_deallocation(b, "split._split_all_blocks")
     else:
         for b in blocks_splitted:
-            trace_deallocation(b, "split._split_all_blocks", free=False)
+            trace_deallocation(b, "split._split_all_blocks")
 
     return itertools.chain.from_iterable(all_blocks_split_results)
 

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -93,8 +93,6 @@ DEFAULT_LARGE_ARGS_THRESHOLD = 50 * 1024 * 1024
 
 DEFAULT_USE_POLARS = False
 
-DEFAULT_EAGER_FREE = bool(int(os.environ.get("RAY_DATA_EAGER_FREE", "1")))
-
 DEFAULT_DECODING_SIZE_ESTIMATION_ENABLED = True
 
 DEFAULT_MIN_PARALLELISM = env_integer("RAY_DATA_DEFAULT_MIN_PARALLELISM", 200)
@@ -268,7 +266,6 @@ class DataContext:
             significant in comparison to task scheduling (i.e., low tens of ms).
         use_polars: Whether to use Polars for tabular dataset sorts, groupbys, and
             aggregations.
-        eager_free: Whether to eagerly free memory.
         decoding_size_estimation: Whether to estimate in-memory decoding data size for
             data source.
         min_parallelism: This setting is deprecated. Use ``read_op_min_num_blocks``
@@ -385,7 +382,6 @@ class DataContext:
     )
     large_args_threshold: int = DEFAULT_LARGE_ARGS_THRESHOLD
     use_polars: bool = DEFAULT_USE_POLARS
-    eager_free: bool = DEFAULT_EAGER_FREE
     decoding_size_estimation: bool = DEFAULT_DECODING_SIZE_ESTIMATION_ENABLED
     min_parallelism: int = DEFAULT_MIN_PARALLELISM
     read_op_min_num_blocks: int = DEFAULT_READ_OP_MIN_NUM_BLOCKS

--- a/python/ray/data/tests/test_util.py
+++ b/python/ray/data/tests/test_util.py
@@ -174,8 +174,7 @@ def test_memory_tracing(enabled):
     trace_allocation(ref1, "test1")
     trace_allocation(ref2, "test2")
     trace_allocation(ref3, "test5")
-    trace_deallocation(ref1, "test3", free=False)
-    trace_deallocation(ref2, "test4", free=True)
+    trace_deallocation(ref1, "test3")
     ray.get(ref1)
     with pytest.raises(ray.exceptions.ObjectFreedError):
         ray.get(ref2)
@@ -185,7 +184,6 @@ def test_memory_tracing(enabled):
     if enabled:
         assert "Leaked object, created at test1" in report, report
         assert "Leaked object, created at test5" in report, report
-        assert "Freed object from test2 at test4" in report, report
         assert "skipped dealloc at test3" in report, report
     else:
         assert "test1" not in report, report


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The code path for reconstructing eagerly freed objects is likely buggy, and the performance improvement from eagerly freeing objects is unclear. So, to avoid fault tolerance issues, this PR removes eager frees.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
