### PR TITLE
[Data] Remove assertion that completed operators have empty input queues

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -294,14 +294,6 @@ class PhysicalOperator(Operator):
             self._output_block_size_option = None
 
     def mark_execution_finished(self):
-        from ..operators.base_physical_operator import InternalQueueOperatorMixin
-
-        if isinstance(self, InternalQueueOperatorMixin):
-            assert self.internal_queue_size() == 0, (
-                "Operator is marked as finished execution, but internal queue is "
-                f"non-empty (got {self.internal_queue_size()} bundles)!"
-            )
-
         """Manually mark that this operator has finished execution."""
         self._execution_finished = True
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

https://github.com/ray-project/ray/pull/52806 added an assertion that an operator's inqueue is empty when it's marked completed. But, this assumption isn't true for limit operator.

To avoid unexpected failures like in the PyTorch ResNet example, this PR removes the assertion.

## Related issue number

<!-- For example: "Closes #1234" -->

https://buildkite.com/ray-project/postmerge/builds/10131#0196d4cb-1dbc-4742-9df7-fcd84a17f991
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
