### PR TITLE
[core] add missing depends_on

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -342,6 +342,7 @@ steps:
         --build-type asan-clang --cache-test-results --parallelism-per-worker 2
     depends_on:
       - block-core-cpp-sanitizer-tests
+      - corebuild
 
   - label: ":ray: core: cpp ubsan tests"
     tags: core_cpp
@@ -352,6 +353,7 @@ steps:
         --cache-test-results --parallelism-per-worker 2
     depends_on:
       - block-core-cpp-sanitizer-tests
+      - corebuild
 
   - label: ":ray: core: cpp tsan tests"
     tags: core_cpp
@@ -362,11 +364,13 @@ steps:
         --cache-test-results --parallelism-per-worker 2
     depends_on:
       - block-core-cpp-sanitizer-tests
+      - corebuild
 
   - label: ":ray: core: flaky cpp tests"
     key: core_flaky_cpp_tests
     tags:
       - python
+      - flaky
       - skip-on-premerge
     instance_type: large
     soft_fail: true


### PR DESCRIPTION
step that does not have explicit `depends_on` will be blocked by the last `wait` block. when a step has explicit `depends_on`, it has to specify all `depends_on`. Otherwise, the missing `corebuild` dependency can lead to test failure that is caused by out of order execution.

