### PR TITLE
[release test] resolve Python testing warnings

### DIFF
--- a/release/ray_release/tests/test_buildkite.py
+++ b/release/ray_release/tests/test_buildkite.py
@@ -697,10 +697,10 @@ class BuildkiteSettingsTest(unittest.TestCase):
                 }
             )
             step = get_step(test, smoke_test=False)
-            self.assertEquals(step["concurrency_group"], "medium")
+            self.assertEqual(step["concurrency_group"], "medium")
 
             step = get_step(test, smoke_test=True)
-            self.assertEquals(step["concurrency_group"], "small")
+            self.assertEqual(step["concurrency_group"], "small")
 
     def testStepQueueClient(self):
         test_regular = MockTest(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
This small PR migrates from `unittest.assertEquals` to `unittest.assertEqual` which is deprecated from Python2.7:
```python
DeprecationWarning: Please use assertEqual instead.
```
## Related issue number

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
