### PR TITLE
[ci] Remove `use_all_core` for core CI tests

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -56,11 +56,8 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/_common/tests/... //python/ray/dag/... //python/ray/autoscaler/v2/... core
         --install-mask all-ray-libraries
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
-        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual,use_all_core,multi_gpu,spark_on_ray,ray_client,compiled_graphs
+        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual,multi_gpu,spark_on_ray,ray_client,compiled_graphs
         --install-mask all-ray-libraries
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... //python/ray/autoscaler/v2/... core
-        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
-        --only-tags use_all_core --skip-ray-installation
 
   - label: ":ray: core: cgraph python tests"
     tags:
@@ -85,12 +82,7 @@ steps:
         --install-mask all-ray-libraries
         --workers 4 --worker-id "{{matrix.worker_id}}" --parallelism-per-worker 3
         --python-version {{matrix.python}}
-        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual,use_all_core,multi_gpu,spark_on_ray,ray_client
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... //python/ray/autoscaler/v2/... core
-        --install-mask all-ray-libraries
-        --workers 4 --worker-id "{{matrix.worker_id}}" --parallelism-per-worker 3
-        --python-version {{matrix.python}}
-        --only-tags use_all_core --skip-ray-installation
+        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual,multi_gpu,spark_on_ray,ray_client
     depends_on: corebuild-multipy
     matrix:
       setup:
@@ -119,10 +111,7 @@ steps:
         --install-mask all-ray-libraries
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --test-env=TEST_EXTERNAL_REDIS=1
-        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual,use_all_core,multi_gpu,spark_on_ray,ray_client
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... //python/ray/autoscaler/v2/... core
-        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
-        --only-tags use_all_core --skip-ray-installation
+        --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual,multi_gpu,spark_on_ray,ray_client
 
   - label: ":ray: core: memory pressure tests"
     tags:

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -138,22 +138,6 @@ py_test_module_list(
     size = "medium",
     files = [
         "test_client_builder.py",
-    ],
-    tags = [
-        "exclusive",
-        "ray_client",
-        "team:core",
-        "use_all_core",
-    ],
-    deps = [
-        ":conftest",
-        "//:ray_lib",
-    ],
-)
-
-py_test_module_list(
-    size = "medium",
-    files = [
         "test_client_multi.py",
         "test_client_proxy.py",
         "test_client_references.py",

--- a/python/ray/util/client/__init__.py
+++ b/python/ray/util/client/__init__.py
@@ -14,7 +14,6 @@ from ray.util.annotations import DeveloperAPI
 from ray._private.utils import check_version_info
 
 
-# FOOBAR.
 logger = logging.getLogger(__name__)
 
 

--- a/python/ray/util/client/__init__.py
+++ b/python/ray/util/client/__init__.py
@@ -14,6 +14,7 @@ from ray.util.annotations import DeveloperAPI
 from ray._private.utils import check_version_info
 
 
+# FOOBAR.
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
There was only a single test that had this tag, `test_client_builder.py`. Moved it to be grouped with the other Ray Client tests and removed the usage of this tag entirely.