### PR TITLE
[ci] Resize more core tests

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -32,6 +32,7 @@ py_test_module_list(
     size = "medium",
     files = [
         "test_actor_cancel.py",
+        "test_actor_group.py",
         "test_actor_lifetime.py",
         "test_actor_pool.py",
         "test_advanced.py",
@@ -43,16 +44,14 @@ py_test_module_list(
         "test_advanced_7.py",
         "test_advanced_8.py",
         "test_advanced_9.py",
-        "test_array.py",
         "test_async.py",
-        "test_async_compat.py",
-        "test_asyncio.py",
-        "test_autoscaling_policy.py",
         "test_component_failures_2.py",
         "test_component_failures_3.py",
         "test_core_worker_io_thread_stack_size.py",
         "test_dashboard_profiler.py",
         "test_error_ray_not_initialized.py",
+        "test_exit_observability.py",
+        "test_failure_3.py",
         "test_gcs_pubsub.py",
         "test_gcs_utils.py",
         "test_get_locations.py",
@@ -65,7 +64,7 @@ py_test_module_list(
         "test_multiprocessing.py",
         "test_multiprocessing_standalone.py",
         "test_node_label_scheduling_strategy.py",
-        "test_protobuf_compatibility.py",
+        "test_runtime_env_agent.py",
     ],
     tags = [
         "exclusive",
@@ -265,6 +264,8 @@ py_test_module_list(
         "accelerators/test_nvidia_gpu.py",
         "accelerators/test_tpu.py",
         "test_actor_bounded_threads.py",
+        "test_actor_retry_1.py",
+        "test_actor_retry_2.py",
         "test_actor_state_metrics.py",
         "test_autoscaler_fake_scaledown.py",
         "test_bounded_unix_sockets.py",
@@ -275,6 +276,7 @@ py_test_module_list(
         "test_memory_scheduling.py",
         "test_metrics.py",
         "test_mpi.py",
+        "test_multi_node.py",
         "test_multi_node_2.py",
         "test_multi_tenancy.py",
         "test_multinode_failures.py",
@@ -288,8 +290,6 @@ py_test_module_list(
         "test_placement_group_2.py",
         "test_placement_group_4.py",
         "test_placement_group_failover.py",
-        "test_placement_group_metrics.py",
-        "test_queue.py",
         "test_ray_debugger.py",
         "test_ray_init.py",
         "test_ray_init_2.py",
@@ -336,6 +336,7 @@ py_test_module_list(
 py_test_module_list(
     size = "medium",
     files = [
+        "test_multi_node_3.py",
         "test_object_manager.py",
         "test_resource_demand_scheduler.py",
         "test_stress.py",
@@ -358,6 +359,7 @@ py_test_module_list(
 py_test_module_list(
     size = "small",
     files = [
+        "test_basic_3.py",
         "test_utils.py",
     ],
     tags = [
@@ -395,7 +397,6 @@ py_test_module_list(
     size = "large",
     files = [
         "test_basic.py",
-        "test_basic_3.py",
     ],
     tags = [
         "basic_test",
@@ -454,10 +455,15 @@ py_test_module_list(
     size = "small",
     files = [
         "accelerators/test_accelerators.py",
+        "test_actor_lineage_reconstruction.py",
         "test_actor_out_of_order.py",
         "test_annotations.py",
         "test_args.py",
+        "test_array.py",
+        "test_async_compat.py",
+        "test_asyncio.py",
         "test_asyncio_cluster.py",
+        "test_autoscaling_policy.py",
         "test_component_failures.py",
         "test_concurrency_group.py",
         "test_cross_language.py",
@@ -476,6 +482,10 @@ py_test_module_list(
         "test_mini.py",
         "test_node_death.py",
         "test_numba.py",
+        "test_object_spilling_no_asan.py",
+        "test_placement_group_metrics.py",
+        "test_protobuf_compatibility.py",
+        "test_queue.py",
         "test_raylet_output.py",
         "test_top_level_api.py",
         "test_unhandled_error.py",
@@ -743,17 +753,11 @@ py_test_module_list(
     files = [
         "test_actor.py",
         "test_actor_failures.py",
-        "test_actor_lineage_reconstruction.py",
-        "test_actor_retry_1.py",
-        "test_actor_retry_2.py",
         "test_cancel.py",
         "test_chaos.py",
-        "test_exit_observability.py",
         "test_failure.py",
         "test_failure_2.py",
-        "test_failure_3.py",
         "test_generators.py",
-        "test_multi_node.py",
         "test_placement_group_3.py",
         "test_placement_group_5.py",
         "test_reconstruction.py",
@@ -836,7 +840,6 @@ py_test_module_list(
         "test_object_spilling.py",
         "test_object_spilling_2.py",
         "test_object_spilling_3.py",
-        "test_object_spilling_no_asan.py",
         "test_placement_group_mini_integration.py",
         "test_reference_counting.py",
         "test_scheduling_2.py",
@@ -863,23 +866,6 @@ py_test_module_list(
     tags = [
         "exclusive",
         "large_size_python_tests_shard_1",
-        "team:core",
-    ],
-    deps = [
-        ":conftest",
-        "//:ray_lib",
-    ],
-)
-
-py_test_module_list(
-    size = "large",
-    files = [
-        "test_multi_node_3.py",
-    ],
-    tags = [
-        "exclusive",
-        "large_size_python_tests_shard_1",
-        "no_windows",
         "team:core",
     ],
     deps = [
@@ -942,36 +928,6 @@ py_test(
     tags = [
         "exclusive",
         "post_wheel_build",
-        "team:core",
-    ],
-    deps = [
-        ":conftest",
-        "//:ray_lib",
-    ],
-)
-
-py_test(
-    name = "test_actor_group",
-    size = "medium",
-    srcs = ["test_actor_group.py"],
-    tags = [
-        "exclusive",
-        "medium_size_python_tests_a_to_j",
-        "team:core",
-    ],
-    deps = [
-        ":conftest",
-        "//:ray_lib",
-    ],
-)
-
-py_test(
-    name = "test_runtime_env_agent",
-    size = "medium",
-    srcs = ["test_runtime_env_agent.py"],
-    tags = [
-        "exclusive",
-        "medium_size_python_tests_a_to_j",
         "team:core",
     ],
     deps = [

--- a/python/ray/tests/modin/BUILD
+++ b/python/ray/tests/modin/BUILD
@@ -2,7 +2,7 @@ load("@rules_python//python:defs.bzl", "py_test")
 
 py_test(
     name = "test_modin",
-    size = "large",
+    size = "small",
     srcs = ["test_modin.py"],
     tags = [
         "exclusive",


### PR DESCRIPTION
Modifying bazel sizes to be more accurate based on most recent postmerge run.

None of the chosen tests are near the border, so there shouldn't be issues on windows/mac builds (will monitor).