### PR TITLE
[ci] Remove unused `PARALLEL_CI` blocks

### DIFF
--- a/python/ray/serve/tests/test_minimal_installation.py
+++ b/python/ray/serve/tests/test_minimal_installation.py
@@ -16,7 +16,4 @@ def test_error_msg():
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/serve/tests/test_serve_ha.py
+++ b/python/ray/serve/tests/test_serve_ha.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import threading
 from time import sleep

--- a/python/ray/serve/tests/test_serve_ha.py
+++ b/python/ray/serve/tests/test_serve_ha.py
@@ -122,7 +122,4 @@ assert serve_details.controller_info.node_id == head_node_id
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/accelerators/test_accelerators.py
+++ b/python/ray/tests/accelerators/test_accelerators.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import pytest
 

--- a/python/ray/tests/accelerators/test_accelerators.py
+++ b/python/ray/tests/accelerators/test_accelerators.py
@@ -19,7 +19,4 @@ def test_accelerators():
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/accelerators/test_amd_gpu.py
+++ b/python/ray/tests/accelerators/test_amd_gpu.py
@@ -85,7 +85,4 @@ def test_set_current_process_visible_accelerator_ids():
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/accelerators/test_hpu.py
+++ b/python/ray/tests/accelerators/test_hpu.py
@@ -291,7 +291,4 @@ def test_hpu_with_placement_group(shutdown_only):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/accelerators/test_intel_gpu.py
+++ b/python/ray/tests/accelerators/test_intel_gpu.py
@@ -111,7 +111,4 @@ def test_set_current_process_visible_accelerator_ids():
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/accelerators/test_neuron.py
+++ b/python/ray/tests/accelerators/test_neuron.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import subprocess
 import pytest

--- a/python/ray/tests/accelerators/test_neuron.py
+++ b/python/ray/tests/accelerators/test_neuron.py
@@ -101,7 +101,4 @@ def test_get_neuron_core_count_failure_with_empty_results(mock_isdir, mock_subpr
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/accelerators/test_npu.py
+++ b/python/ray/tests/accelerators/test_npu.py
@@ -127,7 +127,4 @@ def test_auto_detected_more_than_visible(monkeypatch, shutdown_only):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/accelerators/test_nvidia_gpu.py
+++ b/python/ray/tests/accelerators/test_nvidia_gpu.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import pytest
 

--- a/python/ray/tests/accelerators/test_nvidia_gpu.py
+++ b/python/ray/tests/accelerators/test_nvidia_gpu.py
@@ -64,7 +64,4 @@ def test_gpu_info_parsing(patch_mock_pynvml):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/accelerators/test_tpu.py
+++ b/python/ray/tests/accelerators/test_tpu.py
@@ -329,7 +329,4 @@ def test_num_tpu_chips(mock_glob):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/aws/test_autoscaler_aws.py
+++ b/python/ray/tests/aws/test_autoscaler_aws.py
@@ -1,4 +1,5 @@
 import copy
+import sys
 from unittest.mock import Mock, patch
 
 import pytest
@@ -1185,6 +1186,4 @@ def test_cloudwatch_alarm_update_worker_node(
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/aws/test_aws_batch_tag_update.py
+++ b/python/ray/tests/aws/test_aws_batch_tag_update.py
@@ -1,3 +1,4 @@
+import sys
 import threading
 import time
 import unittest
@@ -65,6 +66,4 @@ class TagBatchTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/gcp/test_gcp_node_provider.py
+++ b/python/ray/tests/gcp/test_gcp_node_provider.py
@@ -1,8 +1,10 @@
+import logging
+import sys
 from typing import Dict
 from threading import RLock
-import pytest
 from unittest.mock import MagicMock, patch, call
-import logging
+
+import pytest
 
 from ray.autoscaler._private.gcp.node import (
     GCPCompute,
@@ -440,6 +442,4 @@ def test_tpu_accelerator_config_to_type(test_case):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/gcp/test_gcp_tpu_command_runner.py
+++ b/python/ray/tests/gcp/test_gcp_tpu_command_runner.py
@@ -287,7 +287,4 @@ def test_tpu_pod_resources():
 if __name__ == "__main__":
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/gcp/test_gcp_tpu_command_runner.py
+++ b/python/ray/tests/gcp/test_gcp_tpu_command_runner.py
@@ -1,13 +1,15 @@
+import hashlib
+import os
+import sys
+from getpass import getuser
+from unittest.mock import patch
+
 import pytest
 
-import os
 from ray.tests.test_autoscaler import MockProvider, MockProcessRunner
 from ray.autoscaler._private.gcp.tpu_command_runner import TPUCommandRunner
 from ray.autoscaler._private.command_runner import SSHCommandRunner
 from ray._private import ray_constants
-from getpass import getuser
-import hashlib
-from unittest.mock import patch
 
 _MOCK_TPU_NAME = "my-tpu"
 _MOCK_ACCELERATOR_TYPE = "v4-16"
@@ -285,6 +287,4 @@ def test_tpu_pod_resources():
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/horovod/test_horovod.py
+++ b/python/ray/tests/horovod/test_horovod.py
@@ -1,5 +1,8 @@
+import sys
+
 import pytest
 import torch
+
 import ray
 from ray.util.client.ray_client_helpers import ray_start_client_server
 
@@ -91,7 +94,4 @@ def test_horovod_example(ray_start_4_cpus):
 
 
 if __name__ == "__main__":
-    import pytest
-    import sys
-
     sys.exit(pytest.main(["-v", __file__] + sys.argv[1:]))

--- a/python/ray/tests/kuberay/test_autoscaling_config.py
+++ b/python/ray/tests/kuberay/test_autoscaling_config.py
@@ -1,12 +1,13 @@
 import copy
 from pathlib import Path
+import platform
 import requests
+import sys
 from typing import Any, Dict, Optional
 from unittest import mock
-
-import platform
-import pytest
 import yaml
+
+import pytest
 
 from ray.autoscaler._private.kuberay.autoscaling_config import (
     _derive_autoscaling_config_from_ray_cr,
@@ -15,7 +16,6 @@ from ray.autoscaler._private.kuberay.autoscaling_config import (
     _get_num_tpus,
     _get_custom_resources,
 )
-
 from ray.autoscaler._private.kuberay.utils import tpu_node_selectors_to_type
 
 AUTOSCALING_CONFIG_MODULE_PATH = "ray.autoscaler._private.kuberay.autoscaling_config"
@@ -553,6 +553,4 @@ def test_get_num_tpus(ray_cr_in: Dict[str, Any], expected_num_tpus: int):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/kuberay/test_autoscaling_e2e.py
+++ b/python/ray/tests/kuberay/test_autoscaling_e2e.py
@@ -2,15 +2,14 @@ import base64
 import copy
 import logging
 import os
-import pytest
 import subprocess
 import sys
 import tempfile
 import unittest
-
 from typing import Any, Dict
-
 import yaml
+
+import pytest
 
 from ray.tests.kuberay.utils import (
     get_pod,
@@ -373,8 +372,6 @@ class KubeRayAutoscalingTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    import pytest
-
     kubeconfig_base64 = os.environ.get("KUBECONFIG_BASE64")
     if kubeconfig_base64:
         kubeconfig_file = os.environ.get("KUBECONFIG")

--- a/python/ray/tests/ludwig/test_ludwig.py
+++ b/python/ray/tests/ludwig/test_ludwig.py
@@ -20,8 +20,10 @@
 import contextlib
 import os
 import tempfile
+import sys
 
 import pytest
+
 import ray
 
 ludwig_installed = True
@@ -160,7 +162,4 @@ def test_ray_tabular_client():
 
 
 if __name__ == "__main__":
-    import pytest
-    import sys
-
     sys.exit(pytest.main(["-v", "-x", __file__]))

--- a/python/ray/tests/spark/test_GPU.py
+++ b/python/ray/tests/spark/test_GPU.py
@@ -224,7 +224,4 @@ class TestBasicSparkGPUCluster(RayOnSparkGPUClusterTestBase):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/spark/test_basic.py
+++ b/python/ray/tests/spark/test_basic.py
@@ -495,7 +495,4 @@ class TestSparkLocalCluster:
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/spark/test_databricks_hook.py
+++ b/python/ray/tests/spark/test_databricks_hook.py
@@ -84,7 +84,4 @@ class TestDatabricksHook:
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/spark/test_multicores_per_task.py
+++ b/python/ray/tests/spark/test_multicores_per_task.py
@@ -48,7 +48,4 @@ class TestMultiCoresPerTaskCluster(RayOnSparkGPUClusterTestBase):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/spark/test_utils.py
+++ b/python/ray/tests/spark/test_utils.py
@@ -190,7 +190,4 @@ def test_append_default_spilling_dir_config():
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -1651,7 +1651,4 @@ def test_get_local_actor_state(ray_start_regular_shared):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -1371,7 +1371,4 @@ assert alive_actors == 10
 
 
 if __name__ == "__main__":
-    import pytest
-
-    # Test suite is timing out. Disable on windows for now.
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -1374,7 +1374,4 @@ if __name__ == "__main__":
     import pytest
 
     # Test suite is timing out. Disable on windows for now.
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_actor_bounded_threads.py
+++ b/python/ray/tests/test_actor_bounded_threads.py
@@ -168,7 +168,4 @@ def test_async_actor_cg_have_bounded_num_of_threads(shutdown_only):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_actor_cancel.py
+++ b/python/ray/tests/test_actor_cancel.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 import sys
 import time
 import concurrent.futures

--- a/python/ray/tests/test_actor_cancel.py
+++ b/python/ray/tests/test_actor_cancel.py
@@ -473,7 +473,4 @@ def test_concurrent_submission_and_cancellation(shutdown_only):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_actor_failures.py
+++ b/python/ray/tests/test_actor_failures.py
@@ -1246,7 +1246,4 @@ def test_actor_restart_and_partial_task_not_completed(shutdown_only):
 if __name__ == "__main__":
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_actor_failures.py
+++ b/python/ray/tests/test_actor_failures.py
@@ -1,12 +1,13 @@
 import atexit
 import asyncio
 import collections
-import numpy as np
 import os
-import pytest
 import signal
 import sys
 import time
+
+import pytest
+import numpy as np
 
 import ray
 from ray.actor import exit_actor
@@ -1244,6 +1245,4 @@ def test_actor_restart_and_partial_task_not_completed(shutdown_only):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_actor_group.py
+++ b/python/ray/tests/test_actor_group.py
@@ -98,7 +98,6 @@ def test_bad_resources(ray_start_2_cpus):
 
 
 if __name__ == "__main__":
-    import os
     import sys
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_actor_group.py
+++ b/python/ray/tests/test_actor_group.py
@@ -101,7 +101,4 @@ if __name__ == "__main__":
     import os
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_actor_group.py
+++ b/python/ray/tests/test_actor_group.py
@@ -1,3 +1,4 @@
+import sys
 import time
 import warnings
 
@@ -98,6 +99,4 @@ def test_bad_resources(ray_start_2_cpus):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_actor_lifetime.py
+++ b/python/ray/tests/test_actor_lifetime.py
@@ -84,7 +84,4 @@ if __name__ == "__main__":
     import pytest
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_actor_lifetime.py
+++ b/python/ray/tests/test_actor_lifetime.py
@@ -1,18 +1,17 @@
-import ray
 import os
 import time
 import signal
 import sys
+
 import pytest
 
+import ray
+from ray.exceptions import RayActorError
 from ray.job_config import JobConfig
-
 from ray._private.test_utils import (
     wait_for_condition,
     wait_for_pid_to_exit,
 )
-
-from ray.exceptions import RayActorError
 
 SIGKILL = signal.SIGKILL if sys.platform != "win32" else signal.SIGTERM
 
@@ -81,7 +80,4 @@ def test_default_actor_lifetime(default_actor_lifetime, child_actor_lifetime):
 
 
 if __name__ == "__main__":
-    import pytest
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_actor_lineage_reconstruction.py
+++ b/python/ray/tests/test_actor_lineage_reconstruction.py
@@ -1,4 +1,3 @@
-import os
 import gc
 import sys
 

--- a/python/ray/tests/test_actor_lineage_reconstruction.py
+++ b/python/ray/tests/test_actor_lineage_reconstruction.py
@@ -103,7 +103,4 @@ def test_actor_reconstruction_triggered_by_lineage_reconstruction(ray_start_clus
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_actor_out_of_order.py
+++ b/python/ray/tests/test_actor_out_of_order.py
@@ -50,7 +50,6 @@ def test_async_actor_execute_out_of_order(shutdown_only):
 
 
 if __name__ == "__main__":
-    import os
     import pytest
 
     # Test suite is timing out. Disable on windows for now.

--- a/python/ray/tests/test_actor_out_of_order.py
+++ b/python/ray/tests/test_actor_out_of_order.py
@@ -1,5 +1,7 @@
 import sys
 
+import pytest
+
 import ray
 import ray.cluster_utils
 from ray._private.test_utils import SignalActor
@@ -50,7 +52,5 @@ def test_async_actor_execute_out_of_order(shutdown_only):
 
 
 if __name__ == "__main__":
-    import pytest
-
     # Test suite is timing out. Disable on windows for now.
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_actor_out_of_order.py
+++ b/python/ray/tests/test_actor_out_of_order.py
@@ -54,7 +54,4 @@ if __name__ == "__main__":
     import pytest
 
     # Test suite is timing out. Disable on windows for now.
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_actor_pool.py
+++ b/python/ray/tests/test_actor_pool.py
@@ -273,6 +273,5 @@ def test_push(init):
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_actor_pool.py
+++ b/python/ray/tests/test_actor_pool.py
@@ -275,7 +275,4 @@ def test_push(init):
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_actor_resources.py
+++ b/python/ray/tests/test_actor_resources.py
@@ -679,6 +679,4 @@ def test_actor_cuda_visible_devices(shutdown_only):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_actor_resources.py
+++ b/python/ray/tests/test_actor_resources.py
@@ -681,7 +681,4 @@ def test_actor_cuda_visible_devices(shutdown_only):
 if __name__ == "__main__":
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_actor_retry_1.py
+++ b/python/ray/tests/test_actor_retry_1.py
@@ -149,7 +149,4 @@ def test_exit_only_no_over_retry(shutdown_only):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_actor_retry_1.py
+++ b/python/ray/tests/test_actor_retry_1.py
@@ -1,4 +1,3 @@
-import os
 import sys
 
 import pytest

--- a/python/ray/tests/test_actor_retry_2.py
+++ b/python/ray/tests/test_actor_retry_2.py
@@ -339,7 +339,4 @@ def test_task_retries_on_exit(ray_start_regular_shared):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_actor_state_metrics.py
+++ b/python/ray/tests/test_actor_state_metrics.py
@@ -1,8 +1,10 @@
 import asyncio
-from collections import defaultdict
-import pytest
 import time
+import sys
+from collections import defaultdict
 from typing import Dict
+
+import pytest
 
 import ray
 from ray._private.utils import hex_to_binary
@@ -317,6 +319,4 @@ def test_get_all_actors_info(shutdown_only):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_actor_state_metrics.py
+++ b/python/ray/tests/test_actor_state_metrics.py
@@ -318,6 +318,5 @@ def test_get_all_actors_info(shutdown_only):
 
 if __name__ == "__main__":
     import sys
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_actor_state_metrics.py
+++ b/python/ray/tests/test_actor_state_metrics.py
@@ -320,7 +320,4 @@ if __name__ == "__main__":
     import sys
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_advanced.py
+++ b/python/ray/tests/test_advanced.py
@@ -479,7 +479,4 @@ def test_illegal_api_calls(ray_start_regular):
 if __name__ == "__main__":
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_advanced.py
+++ b/python/ray/tests/test_advanced.py
@@ -477,6 +477,4 @@ def test_illegal_api_calls(ray_start_regular):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_advanced_2.py
+++ b/python/ray/tests/test_advanced_2.py
@@ -743,7 +743,4 @@ def test_zero_capacity_deletion_semantics(shutdown_only):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_advanced_3.py
+++ b/python/ray/tests/test_advanced_3.py
@@ -356,6 +356,4 @@ def test_decorated_function(ray_start_regular):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_advanced_3.py
+++ b/python/ray/tests/test_advanced_3.py
@@ -358,7 +358,4 @@ def test_decorated_function(ray_start_regular):
 if __name__ == "__main__":
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_advanced_4.py
+++ b/python/ray/tests/test_advanced_4.py
@@ -267,6 +267,4 @@ def test_function_table_gc_actor(call_ray_start):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_advanced_4.py
+++ b/python/ray/tests/test_advanced_4.py
@@ -267,7 +267,6 @@ def test_function_table_gc_actor(call_ray_start):
 
 
 if __name__ == "__main__":
-    import os
     import pytest
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_advanced_4.py
+++ b/python/ray/tests/test_advanced_4.py
@@ -270,7 +270,4 @@ if __name__ == "__main__":
     import os
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_advanced_5.py
+++ b/python/ray/tests/test_advanced_5.py
@@ -230,7 +230,4 @@ if __name__ == "__main__":
     import os
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_advanced_5.py
+++ b/python/ray/tests/test_advanced_5.py
@@ -227,6 +227,4 @@ def test_worker_lease_reply_with_resources(ray_start_cluster_enabled):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_advanced_5.py
+++ b/python/ray/tests/test_advanced_5.py
@@ -227,7 +227,6 @@ def test_worker_lease_reply_with_resources(ray_start_cluster_enabled):
 
 
 if __name__ == "__main__":
-    import os
     import pytest
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_advanced_6.py
+++ b/python/ray/tests/test_advanced_6.py
@@ -246,7 +246,4 @@ def test_worker_niceness(ray_start_regular):
 if __name__ == "__main__":
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_advanced_6.py
+++ b/python/ray/tests/test_advanced_6.py
@@ -244,6 +244,4 @@ def test_worker_niceness(ray_start_regular):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_advanced_7.py
+++ b/python/ray/tests/test_advanced_7.py
@@ -266,7 +266,4 @@ if __name__ == "__main__":
     import os
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_advanced_7.py
+++ b/python/ray/tests/test_advanced_7.py
@@ -263,7 +263,6 @@ def test_task_output_inline_bytes_limit(ray_start_cluster_enabled):
 
 
 if __name__ == "__main__":
-    import os
     import pytest
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_advanced_7.py
+++ b/python/ray/tests/test_advanced_7.py
@@ -6,8 +6,8 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 
-import numpy as np
 import pytest
+import numpy as np
 
 import ray.cluster_utils
 from ray._private.test_utils import client_test_enabled
@@ -263,6 +263,4 @@ def test_task_output_inline_bytes_limit(ray_start_cluster_enabled):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_advanced_8.py
+++ b/python/ray/tests/test_advanced_8.py
@@ -669,6 +669,4 @@ def test_duplicated_arg(ray_start_cluster):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_advanced_8.py
+++ b/python/ray/tests/test_advanced_8.py
@@ -671,7 +671,4 @@ def test_duplicated_arg(ray_start_cluster):
 if __name__ == "__main__":
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_advanced_9.py
+++ b/python/ray/tests/test_advanced_9.py
@@ -1,4 +1,6 @@
 import os
+import psutil
+import subprocess
 import sys
 import time
 
@@ -17,8 +19,6 @@ from ray._private.test_utils import (
 )
 from ray.experimental.internal_kv import _internal_kv_list
 from ray.tests.conftest import call_ray_start
-import subprocess
-import psutil
 
 
 @pytest.fixture
@@ -510,6 +510,4 @@ def test_jemalloc_ray_start(monkeypatch, ray_start_cluster):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_advanced_9.py
+++ b/python/ray/tests/test_advanced_9.py
@@ -512,7 +512,4 @@ def test_jemalloc_ray_start(monkeypatch, ray_start_cluster):
 if __name__ == "__main__":
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_annotations.py
+++ b/python/ray/tests/test_annotations.py
@@ -106,7 +106,4 @@ for _ in range(3):
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_annotations.py
+++ b/python/ray/tests/test_annotations.py
@@ -104,6 +104,5 @@ for _ in range(3):
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_args.py
+++ b/python/ray/tests/test_args.py
@@ -1,4 +1,6 @@
 # coding: utf-8
+import sys
+
 import pytest
 
 import ray
@@ -80,7 +82,4 @@ def test_args_intertwined(ray_start_regular):
 
 
 if __name__ == "__main__":
-    import pytest
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_args.py
+++ b/python/ray/tests/test_args.py
@@ -84,7 +84,4 @@ if __name__ == "__main__":
     import os
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_args.py
+++ b/python/ray/tests/test_args.py
@@ -81,7 +81,6 @@ def test_args_intertwined(ray_start_regular):
 
 if __name__ == "__main__":
     import pytest
-    import os
     import sys
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_array.py
+++ b/python/ray/tests/test_array.py
@@ -246,7 +246,4 @@ if __name__ == "__main__":
     import os
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_array.py
+++ b/python/ray/tests/test_array.py
@@ -1,8 +1,9 @@
+import sys
 from importlib import reload
+
+import pytest
 import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal
-import pytest
-import sys
 
 import ray
 import ray.experimental.array.remote as ra
@@ -243,6 +244,4 @@ def test_distributed_array_methods(ray_start_cluster_2_nodes, reload_modules):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_array.py
+++ b/python/ray/tests/test_array.py
@@ -243,7 +243,6 @@ def test_distributed_array_methods(ray_start_cluster_2_nodes, reload_modules):
 
 
 if __name__ == "__main__":
-    import os
     import pytest
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_async.py
+++ b/python/ray/tests/test_async.py
@@ -163,6 +163,5 @@ def test_concurrent_future_many(ray_start_regular_shared):
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_async.py
+++ b/python/ray/tests/test_async.py
@@ -165,7 +165,4 @@ def test_concurrent_future_many(ray_start_regular_shared):
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_async_compat.py
+++ b/python/ray/tests/test_async_compat.py
@@ -66,6 +66,5 @@ def test_sync_to_async_is_cached() -> None:
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_async_compat.py
+++ b/python/ray/tests/test_async_compat.py
@@ -68,7 +68,4 @@ def test_sync_to_async_is_cached() -> None:
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_asyncio.py
+++ b/python/ray/tests/test_asyncio.py
@@ -431,7 +431,4 @@ def test_asyncio_actor_argument_collision(ray_start_regular_shared):
 if __name__ == "__main__":
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_asyncio.py
+++ b/python/ray/tests/test_asyncio.py
@@ -429,6 +429,4 @@ def test_asyncio_actor_argument_collision(ray_start_regular_shared):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_asyncio_cluster.py
+++ b/python/ray/tests/test_asyncio_cluster.py
@@ -31,7 +31,6 @@ async def test_asyncio_cluster_wait():
 
 
 if __name__ == "__main__":
-    import os
     import pytest
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_asyncio_cluster.py
+++ b/python/ray/tests/test_asyncio_cluster.py
@@ -31,6 +31,4 @@ async def test_asyncio_cluster_wait():
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_asyncio_cluster.py
+++ b/python/ray/tests/test_asyncio_cluster.py
@@ -34,7 +34,4 @@ if __name__ == "__main__":
     import os
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -3735,7 +3735,4 @@ def test_prom_null_metric_inc_fix():
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_autoscaler_drain_node_api.py
+++ b/python/ray/tests/test_autoscaler_drain_node_api.py
@@ -117,7 +117,4 @@ if __name__ == "__main__":
     import os
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_autoscaler_drain_node_api.py
+++ b/python/ray/tests/test_autoscaler_drain_node_api.py
@@ -1,6 +1,7 @@
 import logging
 import platform
 import time
+import sys
 
 import pytest
 
@@ -114,6 +115,4 @@ def test_drain_api(autoscaler_v2, shutdown_only):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_autoscaler_drain_node_api.py
+++ b/python/ray/tests/test_autoscaler_drain_node_api.py
@@ -114,7 +114,6 @@ def test_drain_api(autoscaler_v2, shutdown_only):
 
 
 if __name__ == "__main__":
-    import os
     import sys
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_autoscaler_e2e.py
+++ b/python/ray/tests/test_autoscaler_e2e.py
@@ -1,9 +1,10 @@
 import subprocess
-from ray.autoscaler._private.constants import AUTOSCALER_METRIC_PORT
+import sys
 
 import pytest
+
 import ray
-import sys
+from ray.autoscaler._private.constants import AUTOSCALER_METRIC_PORT
 from ray._private.test_utils import (
     wait_for_condition,
     get_metric_check_condition,
@@ -368,6 +369,4 @@ def test_infeasible_task_early_cancellation_actor_creation(
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_autoscaler_e2e.py
+++ b/python/ray/tests/test_autoscaler_e2e.py
@@ -371,7 +371,4 @@ if __name__ == "__main__":
     import os
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_autoscaler_e2e.py
+++ b/python/ray/tests/test_autoscaler_e2e.py
@@ -368,7 +368,6 @@ def test_infeasible_task_early_cancellation_actor_creation(
 
 
 if __name__ == "__main__":
-    import os
     import pytest
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_autoscaler_fake_multinode.py
+++ b/python/ray/tests/test_autoscaler_fake_multinode.py
@@ -220,7 +220,6 @@ def test_autoscaler_not_kill_blocking_node(setup_cluster):
 
 
 if __name__ == "__main__":
-    import os
     import sys
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_autoscaler_fake_multinode.py
+++ b/python/ray/tests/test_autoscaler_fake_multinode.py
@@ -223,7 +223,4 @@ if __name__ == "__main__":
     import os
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_autoscaler_fake_multinode.py
+++ b/python/ray/tests/test_autoscaler_fake_multinode.py
@@ -1,9 +1,10 @@
+import time
 import pytest
 import platform
+import sys
 
 import ray
 from ray.cluster_utils import AutoscalingCluster
-import time
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="Failing on Windows.")
@@ -220,6 +221,4 @@ def test_autoscaler_not_kill_blocking_node(setup_cluster):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_autoscaler_fake_scaledown.py
+++ b/python/ray/tests/test_autoscaler_fake_scaledown.py
@@ -188,7 +188,6 @@ def test_no_scaledown_with_spilled_objects(autoscaler_v2, shutdown_only):
 
 
 if __name__ == "__main__":
-    import os
     import sys
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_autoscaler_fake_scaledown.py
+++ b/python/ray/tests/test_autoscaler_fake_scaledown.py
@@ -191,7 +191,4 @@ if __name__ == "__main__":
     import os
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_autoscaler_fake_scaledown.py
+++ b/python/ray/tests/test_autoscaler_fake_scaledown.py
@@ -1,5 +1,6 @@
 import platform
 import re
+import sys
 
 import numpy as np
 import pytest
@@ -188,6 +189,4 @@ def test_no_scaledown_with_spilled_objects(autoscaler_v2, shutdown_only):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_autoscaler_gcp.py
+++ b/python/ray/tests/test_autoscaler_gcp.py
@@ -66,7 +66,4 @@ if __name__ == "__main__":
     import os
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_autoscaler_gcp.py
+++ b/python/ray/tests/test_autoscaler_gcp.py
@@ -1,3 +1,4 @@
+import sys
 from typing import List
 
 import pytest
@@ -63,6 +64,4 @@ def test_gcp_broken_pipe_retry(error_input, expected_error_raised):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_autoscaler_gcp.py
+++ b/python/ray/tests/test_autoscaler_gcp.py
@@ -63,7 +63,6 @@ def test_gcp_broken_pipe_retry(error_input, expected_error_raised):
 
 
 if __name__ == "__main__":
-    import os
     import sys
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_autoscaler_util.py
+++ b/python/ray/tests/test_autoscaler_util.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import pytest
 

--- a/python/ray/tests/test_autoscaler_util.py
+++ b/python/ray/tests/test_autoscaler_util.py
@@ -33,7 +33,4 @@ def test_with_envs():
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_autoscaler_yaml.py
+++ b/python/ray/tests/test_autoscaler_yaml.py
@@ -652,7 +652,4 @@ class AutoscalingConfigTest(unittest.TestCase):
 if __name__ == "__main__":
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_autoscaler_yaml.py
+++ b/python/ray/tests/test_autoscaler_yaml.py
@@ -3,9 +3,10 @@ import logging
 import os
 import sys
 import tempfile
-from typing import Dict, Any
 import unittest
 import urllib
+from typing import Dict, Any
+from unittest import mock
 from unittest.mock import MagicMock, Mock, patch
 
 import jsonschema
@@ -13,7 +14,6 @@ import pytest
 import yaml
 from click.exceptions import ClickException
 
-from unittest import mock
 from ray._private.test_utils import load_test_config, recursive_fnmatch
 from ray.autoscaler._private._azure.config import (
     _configure_key_pair as _azure_configure_key_pair,
@@ -650,6 +650,4 @@ class AutoscalingConfigTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_autoscaling_policy.py
+++ b/python/ray/tests/test_autoscaling_policy.py
@@ -622,7 +622,4 @@ if __name__ == "__main__":
     import os
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_autoscaling_policy.py
+++ b/python/ray/tests/test_autoscaling_policy.py
@@ -3,6 +3,7 @@ import copy
 import logging
 import yaml
 import tempfile
+import sys
 from typing import Dict, Callable, List
 import shutil
 from queue import PriorityQueue
@@ -619,6 +620,4 @@ class AutoscalingPolicyTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_autoscaling_policy.py
+++ b/python/ray/tests/test_autoscaling_policy.py
@@ -619,7 +619,6 @@ class AutoscalingPolicyTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    import os
     import sys
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -1186,7 +1186,4 @@ def test_import_ray_does_not_import_grpc():
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_basic_2.py
+++ b/python/ray/tests/test_basic_2.py
@@ -784,7 +784,4 @@ if __name__ == "__main__":
     import pytest
 
     # Skip test_basic_2_client_mode for now- the test suite is breaking.
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_basic_3.py
+++ b/python/ray/tests/test_basic_3.py
@@ -151,7 +151,4 @@ def test_many_fractional_resources(shutdown_only):
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_basic_3.py
+++ b/python/ray/tests/test_basic_3.py
@@ -149,6 +149,5 @@ def test_many_fractional_resources(shutdown_only):
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_basic_4.py
+++ b/python/ray/tests/test_basic_4.py
@@ -1,13 +1,13 @@
 # coding: utf-8
 import logging
+import os
 import subprocess
 import sys
 import time
 from pathlib import Path
-import os
+from unittest import mock
 
 import pytest
-from unittest import mock
 
 import ray
 import ray.cluster_utils
@@ -263,6 +263,4 @@ def test_fair_queueing(shutdown_only):
 
 
 if __name__ == "__main__":
-    import os
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_basic_4.py
+++ b/python/ray/tests/test_basic_4.py
@@ -265,7 +265,4 @@ def test_fair_queueing(shutdown_only):
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_basic_5.py
+++ b/python/ray/tests/test_basic_5.py
@@ -367,7 +367,4 @@ def test_head_node_resource_ray_start(call_ray_start):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_batch_node_provider_integration.py
+++ b/python/ray/tests/test_batch_node_provider_integration.py
@@ -178,7 +178,6 @@ def test_fake_batching_autoscaler_e2e(shutdown_only):
 
 
 if __name__ == "__main__":
-    import os
     import sys
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_batch_node_provider_integration.py
+++ b/python/ray/tests/test_batch_node_provider_integration.py
@@ -178,6 +178,4 @@ def test_fake_batching_autoscaler_e2e(shutdown_only):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_batch_node_provider_integration.py
+++ b/python/ray/tests/test_batch_node_provider_integration.py
@@ -181,7 +181,4 @@ if __name__ == "__main__":
     import os
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_batch_node_provider_unit.py
+++ b/python/ray/tests/test_batch_node_provider_unit.py
@@ -3,7 +3,6 @@ Validates BatchingNodeProvider's book-keeping logic.
 """
 from copy import copy
 from uuid import uuid4
-import os
 import random
 import sys
 from typing import Any, Dict

--- a/python/ray/tests/test_batch_node_provider_unit.py
+++ b/python/ray/tests/test_batch_node_provider_unit.py
@@ -481,7 +481,4 @@ def test_terminate_node_in_multihost_replica():
 
 if __name__ == "__main__":
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_bounded_unix_sockets.py
+++ b/python/ray/tests/test_bounded_unix_sockets.py
@@ -99,7 +99,4 @@ def test_actors_have_bounded_num_of_sockets(shutdown_only):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_bounded_unix_sockets.py
+++ b/python/ray/tests/test_bounded_unix_sockets.py
@@ -1,5 +1,4 @@
 import sys
-import os
 
 import ray
 import logging

--- a/python/ray/tests/test_cancel.py
+++ b/python/ray/tests/test_cancel.py
@@ -733,7 +733,4 @@ def test_recursive_cancel_error_messages(shutdown_only, capsys):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_cancel.py
+++ b/python/ray/tests/test_cancel.py
@@ -1,4 +1,3 @@
-import os
 import random
 import signal
 import sys

--- a/python/ray/tests/test_channel.py
+++ b/python/ray/tests/test_channel.py
@@ -1424,7 +1424,4 @@ def test_torch_dtype():
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_channel.py
+++ b/python/ray/tests/test_channel.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 import pickle
 import logging
-import os
 import sys
 import time
 import traceback

--- a/python/ray/tests/test_chaos.py
+++ b/python/ray/tests/test_chaos.py
@@ -317,7 +317,6 @@ def test_node_killer_filter(autoscaler_v2):
 
 
 if __name__ == "__main__":
-    import os
     import pytest
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_chaos.py
+++ b/python/ray/tests/test_chaos.py
@@ -320,7 +320,4 @@ if __name__ == "__main__":
     import os
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_chaos.py
+++ b/python/ray/tests/test_chaos.py
@@ -1,11 +1,10 @@
 import sys
+import time
 import random
 
-import ray
-
 import pytest
-import time
 
+import ray
 from ray.experimental import shuffle
 from ray.tests.conftest import _ray_start_chaos_cluster
 from ray.util.placement_group import placement_group
@@ -317,6 +316,4 @@ def test_node_killer_filter(autoscaler_v2):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -1307,7 +1307,4 @@ def test_ray_cluster_dump(configure_lang, configure_aws, _unlink_test_ssh_key):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_cli_logger.py
+++ b/python/ray/tests/test_cli_logger.py
@@ -25,7 +25,6 @@ def test_pathname():
 
 
 if __name__ == "__main__":
-    import os
     import sys
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_cli_logger.py
+++ b/python/ray/tests/test_cli_logger.py
@@ -28,7 +28,4 @@ if __name__ == "__main__":
     import os
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_cli_logger.py
+++ b/python/ray/tests/test_cli_logger.py
@@ -1,7 +1,10 @@
-from ray.autoscaler._private import cli_logger
 import io
+import sys
 from unittest.mock import patch
+
 import pytest
+
+from ray.autoscaler._private import cli_logger
 
 
 def test_colorful_mock_with_style():
@@ -25,6 +28,4 @@ def test_pathname():
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -964,7 +964,4 @@ def test_internal_kv_in_proxy_mode(call_ray_start_shared):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_client_builder.py
+++ b/python/ray/tests/test_client_builder.py
@@ -448,7 +448,4 @@ def test_task_use_prestarted_worker(call_ray_start):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_client_init.py
+++ b/python/ray/tests/test_client_init.py
@@ -1,11 +1,12 @@
 """Client tests that run their own init (as with init_and_serve) live here"""
-import pytest
 
 import time
 import random
 import sys
 import subprocess
 from unittest.mock import patch
+
+import pytest
 
 import ray.util.client.server.server as ray_client_server
 import ray.core.generated.ray_client_pb2 as ray_client_pb2
@@ -196,6 +197,4 @@ def test_max_clients(init_and_serve):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_client_init.py
+++ b/python/ray/tests/test_client_init.py
@@ -199,7 +199,4 @@ if __name__ == "__main__":
     import os
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_client_init.py
+++ b/python/ray/tests/test_client_init.py
@@ -196,7 +196,6 @@ def test_max_clients(init_and_serve):
 
 
 if __name__ == "__main__":
-    import os
     import pytest
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_client_metadata.py
+++ b/python/ray/tests/test_client_metadata.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from ray.util.client.ray_client_helpers import ray_start_client_server
@@ -45,6 +47,4 @@ def test_get_runtime_context(ray_start_regular_shared):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_client_metadata.py
+++ b/python/ray/tests/test_client_metadata.py
@@ -48,7 +48,4 @@ if __name__ == "__main__":
     import os
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_client_metadata.py
+++ b/python/ray/tests/test_client_metadata.py
@@ -45,7 +45,6 @@ def test_get_runtime_context(ray_start_regular_shared):
 
 
 if __name__ == "__main__":
-    import os
     import sys
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_client_multi.py
+++ b/python/ray/tests/test_client_multi.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import pytest
 import ray

--- a/python/ray/tests/test_client_multi.py
+++ b/python/ray/tests/test_client_multi.py
@@ -207,7 +207,4 @@ if __name__ == "__main__":
     from ray._private import auto_init_hook
 
     auto_init_hook.enable_auto_connect = False
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -485,7 +485,4 @@ def test_proxy_cancelled_grpc_request_stream():
 if __name__ == "__main__":
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_client_proxy.py
+++ b/python/ray/tests/test_client_proxy.py
@@ -483,6 +483,4 @@ def test_proxy_cancelled_grpc_request_stream():
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_client_reconnect.py
+++ b/python/ray/tests/test_client_reconnect.py
@@ -584,7 +584,4 @@ def test_client_reconnect_grace_period(call_ray_start_shared):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_client_references.py
+++ b/python/ray/tests/test_client_references.py
@@ -323,7 +323,6 @@ def test_named_actor_refcount(ray_start_regular):
 
 
 if __name__ == "__main__":
-    import os
     import sys
 
     import pytest

--- a/python/ray/tests/test_client_references.py
+++ b/python/ray/tests/test_client_references.py
@@ -1,3 +1,4 @@
+import sys
 from concurrent.futures import Future
 
 import pytest
@@ -323,8 +324,4 @@ def test_named_actor_refcount(ray_start_regular):
 
 
 if __name__ == "__main__":
-    import sys
-
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_client_references.py
+++ b/python/ray/tests/test_client_references.py
@@ -328,7 +328,4 @@ if __name__ == "__main__":
 
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_client_terminate.py
+++ b/python/ray/tests/test_client_terminate.py
@@ -142,7 +142,4 @@ if __name__ == "__main__":
     import os
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_client_terminate.py
+++ b/python/ray/tests/test_client_terminate.py
@@ -138,7 +138,4 @@ def test_kill_cancel_metadata(ray_start_regular):
 
 
 if __name__ == "__main__":
-    import pytest
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_client_terminate.py
+++ b/python/ray/tests/test_client_terminate.py
@@ -139,7 +139,6 @@ def test_kill_cancel_metadata(ray_start_regular):
 
 if __name__ == "__main__":
     import pytest
-    import os
     import sys
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_client_warnings.py
+++ b/python/ray/tests/test_client_warnings.py
@@ -34,7 +34,6 @@ class LoggerSuite(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    import os
     import sys
     import pytest
 

--- a/python/ray/tests/test_client_warnings.py
+++ b/python/ray/tests/test_client_warnings.py
@@ -1,10 +1,11 @@
+import sys
+import unittest
+
+import pytest
+import numpy as np
+
 from ray.util.client.ray_client_helpers import ray_start_client_server
 from ray.util.debug import _logged
-
-import numpy as np
-import pytest
-
-import unittest
 
 
 @pytest.fixture(autouse=True)
@@ -34,7 +35,4 @@ class LoggerSuite(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    import sys
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_client_warnings.py
+++ b/python/ray/tests/test_client_warnings.py
@@ -38,7 +38,4 @@ if __name__ == "__main__":
     import sys
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_command_runner.py
+++ b/python/ray/tests/test_command_runner.py
@@ -392,7 +392,4 @@ if __name__ == "__main__":
     import os
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_command_runner.py
+++ b/python/ray/tests/test_command_runner.py
@@ -1,3 +1,7 @@
+import hashlib
+import sys
+from getpass import getuser
+
 import pytest
 
 from ray.tests.test_autoscaler import MockProvider, MockProcessRunner
@@ -8,8 +12,6 @@ from ray.autoscaler._private.command_runner import (
     _with_environment_variables,
 )
 from ray.autoscaler.sdk import get_docker_host_mount_location
-from getpass import getuser
-import hashlib
 
 auth_config = {
     "ssh_user": "ray",
@@ -389,6 +391,4 @@ def test_docker_shm_override(run_option_type):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_command_runner.py
+++ b/python/ray/tests/test_command_runner.py
@@ -389,7 +389,6 @@ def test_docker_shm_override(run_option_type):
 
 
 if __name__ == "__main__":
-    import os
     import sys
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_component_failures.py
+++ b/python/ray/tests/test_component_failures.py
@@ -185,7 +185,4 @@ ray.wait([ray.ObjectRef(ray._private.utils.hex_to_binary("{}"))])
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_component_failures_2.py
+++ b/python/ray/tests/test_component_failures_2.py
@@ -141,7 +141,6 @@ def test_get_node_info_after_raylet_died(ray_start_cluster_head):
 
 
 if __name__ == "__main__":
-    import os
     import pytest
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_component_failures_2.py
+++ b/python/ray/tests/test_component_failures_2.py
@@ -141,6 +141,4 @@ def test_get_node_info_after_raylet_died(ray_start_cluster_head):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_component_failures_2.py
+++ b/python/ray/tests/test_component_failures_2.py
@@ -144,7 +144,4 @@ if __name__ == "__main__":
     import os
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_component_failures_3.py
+++ b/python/ray/tests/test_component_failures_3.py
@@ -1,8 +1,8 @@
 import sys
 import time
 
-import numpy as np
 import pytest
+import numpy as np
 
 import ray
 import ray._private.ray_constants as ray_constants
@@ -116,6 +116,4 @@ def test_dying_worker(ray_start_2_cpus):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_component_failures_3.py
+++ b/python/ray/tests/test_component_failures_3.py
@@ -119,7 +119,4 @@ if __name__ == "__main__":
     import os
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_component_failures_3.py
+++ b/python/ray/tests/test_component_failures_3.py
@@ -116,7 +116,6 @@ def test_dying_worker(ray_start_2_cpus):
 
 
 if __name__ == "__main__":
-    import os
     import pytest
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_concurrency_group.py
+++ b/python/ray/tests/test_concurrency_group.py
@@ -319,6 +319,5 @@ actor = A.remote()
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_concurrency_group.py
+++ b/python/ray/tests/test_concurrency_group.py
@@ -321,7 +321,4 @@ actor = A.remote()
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_coordinator_server.py
+++ b/python/ray/tests/test_coordinator_server.py
@@ -1,8 +1,11 @@
+import json
 import os
 import random
-import unittest
 import socket
-import json
+import sys
+import unittest
+
+import pytest
 
 from ray.autoscaler.local.coordinator_server import OnPremCoordinatorServer
 from ray.autoscaler._private.providers import _NODE_PROVIDERS, _get_node_provider
@@ -25,7 +28,6 @@ from ray.autoscaler.tags import (
     STATUS_UP_TO_DATE,
 )
 from ray._private.utils import get_ray_temp_dir
-import pytest
 
 
 class OnPremCoordinatorServerTest(unittest.TestCase):
@@ -291,6 +293,4 @@ class OnPremCoordinatorServerTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_coordinator_server.py
+++ b/python/ray/tests/test_coordinator_server.py
@@ -293,7 +293,4 @@ class OnPremCoordinatorServerTest(unittest.TestCase):
 if __name__ == "__main__":
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_core_worker_io_thread_stack_size.py
+++ b/python/ray/tests/test_core_worker_io_thread_stack_size.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import pytest
 import ray

--- a/python/ray/tests/test_core_worker_io_thread_stack_size.py
+++ b/python/ray/tests/test_core_worker_io_thread_stack_size.py
@@ -1,5 +1,7 @@
 import sys
+
 import pytest
+
 import ray
 
 
@@ -20,6 +22,4 @@ async def test_core_worker_io_thread_stack_size(shutdown_only):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_core_worker_io_thread_stack_size.py
+++ b/python/ray/tests/test_core_worker_io_thread_stack_size.py
@@ -23,7 +23,4 @@ async def test_core_worker_io_thread_stack_size(shutdown_only):
 if __name__ == "__main__":
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_cross_language.py
+++ b/python/ray/tests/test_cross_language.py
@@ -28,7 +28,4 @@ def test_cross_language_raise_exception(shutdown_only):
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_cross_language.py
+++ b/python/ray/tests/test_cross_language.py
@@ -26,6 +26,5 @@ def test_cross_language_raise_exception(shutdown_only):
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_dashboard.py
+++ b/python/ray/tests/test_dashboard.py
@@ -206,7 +206,4 @@ def test_dashboard_agent_metrics_or_http_port_conflict(listen_port, call_ray_sta
 if __name__ == "__main__":
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_dashboard.py
+++ b/python/ray/tests/test_dashboard.py
@@ -204,6 +204,4 @@ def test_dashboard_agent_metrics_or_http_port_conflict(listen_port, call_ray_sta
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_dataclient_disconnect.py
+++ b/python/ray/tests/test_dataclient_disconnect.py
@@ -88,7 +88,4 @@ def test_dataclient_disconnect_before_request():
 if __name__ == "__main__":
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_dataclient_disconnect.py
+++ b/python/ray/tests/test_dataclient_disconnect.py
@@ -86,6 +86,4 @@ def test_dataclient_disconnect_before_request():
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_debug_tools.py
+++ b/python/ray/tests/test_debug_tools.py
@@ -1,15 +1,13 @@
 import os
 import subprocess
 import sys
-
-import pytest
 from pathlib import Path
 
-import ray
+import pytest
 
+import ray
 import ray._private.services as services
 import ray._private.ray_constants as ray_constants
-
 from ray._private.test_utils import wait_for_condition
 
 
@@ -133,8 +131,6 @@ def test_memory_profile_dashboard_and_agent(monkeypatch, shutdown_only):
 
 
 if __name__ == "__main__":
-    import pytest
-
     # Make subprocess happy in bazel.
     os.environ["LC_ALL"] = "en_US.UTF-8"
     os.environ["LANG"] = "en_US.UTF-8"

--- a/python/ray/tests/test_debug_tools.py
+++ b/python/ray/tests/test_debug_tools.py
@@ -138,7 +138,4 @@ if __name__ == "__main__":
     # Make subprocess happy in bazel.
     os.environ["LC_ALL"] = "en_US.UTF-8"
     os.environ["LANG"] = "en_US.UTF-8"
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_distributed_sort.py
+++ b/python/ray/tests/test_distributed_sort.py
@@ -21,6 +21,5 @@ def test_distributed_sort():
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_distributed_sort.py
+++ b/python/ray/tests/test_distributed_sort.py
@@ -23,7 +23,4 @@ def test_distributed_sort():
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_draining.py
+++ b/python/ray/tests/test_draining.py
@@ -435,6 +435,5 @@ def test_draining_reason(ray_start_cluster, graceful):
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_draining.py
+++ b/python/ray/tests/test_draining.py
@@ -437,7 +437,4 @@ def test_draining_reason(ray_start_cluster, graceful):
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_environ.py
+++ b/python/ray/tests/test_environ.py
@@ -67,7 +67,4 @@ if __name__ == "__main__":
 
     os.environ["LC_ALL"] = "en_US.UTF-8"
     os.environ["LANG"] = "en_US.UTF-8"
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_environ.py
+++ b/python/ray/tests/test_environ.py
@@ -1,6 +1,9 @@
 import os
-import pytest
+import sys
 import unittest
+
+import pytest
+
 import ray
 from ray._private.utils import update_envs
 
@@ -62,9 +65,6 @@ def test_update_envs():
 
 
 if __name__ == "__main__":
-    import pytest
-    import sys
-
     os.environ["LC_ALL"] = "en_US.UTF-8"
     os.environ["LANG"] = "en_US.UTF-8"
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_error_ray_not_initialized.py
+++ b/python/ray/tests/test_error_ray_not_initialized.py
@@ -48,7 +48,4 @@ def test_errors_before_initializing_ray(set_enable_auto_connect):
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_error_ray_not_initialized.py
+++ b/python/ray/tests/test_error_ray_not_initialized.py
@@ -46,6 +46,5 @@ def test_errors_before_initializing_ray(set_enable_auto_connect):
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_exceptiongroup.py
+++ b/python/ray/tests/test_exceptiongroup.py
@@ -190,7 +190,4 @@ def test_except_star_exceptiongroup(ray_start_regular):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_exceptiongroup.py
+++ b/python/ray/tests/test_exceptiongroup.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from textwrap import dedent
 

--- a/python/ray/tests/test_exit_observability.py
+++ b/python/ray/tests/test_exit_observability.py
@@ -450,7 +450,4 @@ def test_node_start_end_time(ray_start_cluster):
 if __name__ == "__main__":
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_exit_observability.py
+++ b/python/ray/tests/test_exit_observability.py
@@ -4,9 +4,9 @@ import signal
 import sys
 
 import pytest
-from ray._private.state_api_test_utils import verify_failed_task
 
 import ray
+from ray._private.state_api_test_utils import verify_failed_task
 from ray._private.test_utils import run_string_as_driver, wait_for_condition
 from ray.util.state import list_workers, list_nodes, list_tasks
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
@@ -448,6 +448,4 @@ def test_node_start_end_time(ray_start_cluster):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -800,6 +800,4 @@ def test_update_object_location_batch_failure(
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -802,7 +802,4 @@ def test_update_object_location_batch_failure(
 if __name__ == "__main__":
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_failure_2.py
+++ b/python/ray/tests/test_failure_2.py
@@ -420,7 +420,4 @@ time.sleep(60)
 if __name__ == "__main__":
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_failure_2.py
+++ b/python/ray/tests/test_failure_2.py
@@ -418,6 +418,4 @@ time.sleep(60)
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_failure_3.py
+++ b/python/ray/tests/test_failure_3.py
@@ -566,7 +566,4 @@ while True:
 if __name__ == "__main__":
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_failure_3.py
+++ b/python/ray/tests/test_failure_3.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import signal
+import time
 import threading
 import json
 from pathlib import Path
@@ -9,7 +10,6 @@ import ray
 import numpy as np
 import pytest
 import psutil
-import time
 
 from ray._private.test_utils import (
     SignalActor,
@@ -564,6 +564,4 @@ while True:
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_failure_4.py
+++ b/python/ray/tests/test_failure_4.py
@@ -803,6 +803,5 @@ def test_shows_both_user_exception_system_error_same_time(ray_start_cluster):
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_failure_4.py
+++ b/python/ray/tests/test_failure_4.py
@@ -805,7 +805,4 @@ def test_shows_both_user_exception_system_error_same_time(ray_start_cluster):
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -1313,7 +1313,4 @@ def test_pg_removal_after_gcs_restarts(
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_gcs_ha_e2e.py
+++ b/python/ray/tests/test_gcs_ha_e2e.py
@@ -44,6 +44,5 @@ print("Num Alive Nodes: ", sum([1 if n["Alive"] else 0 for n in ray.nodes()]))
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_gcs_ha_e2e.py
+++ b/python/ray/tests/test_gcs_ha_e2e.py
@@ -46,7 +46,4 @@ print("Num Alive Nodes: ", sum([1 if n["Alive"] else 0 for n in ray.nodes()]))
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_gcs_ha_e2e_2.py
+++ b/python/ray/tests/test_gcs_ha_e2e_2.py
@@ -48,6 +48,5 @@ print(ray._private.worker._global_node.session_name)
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_gcs_ha_e2e_2.py
+++ b/python/ray/tests/test_gcs_ha_e2e_2.py
@@ -50,7 +50,4 @@ print(ray._private.worker._global_node.session_name)
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_gcs_pubsub.py
+++ b/python/ray/tests/test_gcs_pubsub.py
@@ -158,6 +158,5 @@ def test_two_subscribers(ray_start_regular):
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_gcs_pubsub.py
+++ b/python/ray/tests/test_gcs_pubsub.py
@@ -160,7 +160,4 @@ def test_two_subscribers(ray_start_regular):
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_gcs_utils.py
+++ b/python/ray/tests/test_gcs_utils.py
@@ -321,7 +321,4 @@ def test_redis_cleanup(redis_replicas, shutdown_only):
 if __name__ == "__main__":
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_gcs_utils.py
+++ b/python/ray/tests/test_gcs_utils.py
@@ -1,13 +1,14 @@
+import asyncio
 import contextlib
 import os
-import time
 import signal
 import sys
-import asyncio
+import time
 
 import pytest
-import ray
 import redis
+
+import ray
 from ray._raylet import GcsClient
 import ray._private.gcs_utils as gcs_utils
 from ray._private.test_utils import (
@@ -319,6 +320,4 @@ def test_redis_cleanup(redis_replicas, shutdown_only):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_generators.py
+++ b/python/ray/tests/test_generators.py
@@ -805,7 +805,4 @@ def test_ray_client(call_ray_start_shared, store_in_plasma):
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_generators.py
+++ b/python/ray/tests/test_generators.py
@@ -803,6 +803,5 @@ def test_ray_client(call_ray_start_shared, store_in_plasma):
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_get_locations.py
+++ b/python/ray/tests/test_get_locations.py
@@ -1,3 +1,4 @@
+import sys
 import time
 
 import numpy as np
@@ -267,6 +268,4 @@ def test_get_local_locations_generator_multi_nodes(ray_start_cluster):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_get_locations.py
+++ b/python/ray/tests/test_get_locations.py
@@ -270,7 +270,4 @@ if __name__ == "__main__":
     import sys
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_get_locations.py
+++ b/python/ray/tests/test_get_locations.py
@@ -268,6 +268,5 @@ def test_get_local_locations_generator_multi_nodes(ray_start_cluster):
 
 if __name__ == "__main__":
     import sys
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_get_or_create_actor.py
+++ b/python/ray/tests/test_get_or_create_actor.py
@@ -119,7 +119,4 @@ def test_get_or_create_named_actor(shutdown_only):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_global_gc.py
+++ b/python/ray/tests/test_global_gc.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 import gc
 import logging
+import sys
 import weakref
 
 import numpy as np
@@ -216,6 +217,4 @@ def test_global_gc_actors(shutdown_only):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_global_gc.py
+++ b/python/ray/tests/test_global_gc.py
@@ -219,7 +219,4 @@ if __name__ == "__main__":
     import os
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_global_gc.py
+++ b/python/ray/tests/test_global_gc.py
@@ -216,7 +216,6 @@ def test_global_gc_actors(shutdown_only):
 
 
 if __name__ == "__main__":
-    import os
     import sys
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_global_state.py
+++ b/python/ray/tests/test_global_state.py
@@ -1,6 +1,8 @@
 import os
 import sys
 import time
+from typing import Optional
+
 import pytest
 
 import ray
@@ -13,7 +15,6 @@ from ray._private.test_utils import (
     make_global_state_accessor,
     wait_for_condition,
 )
-from typing import Optional
 
 
 def test_replenish_resources(ray_start_regular):
@@ -714,6 +715,4 @@ def test_get_draining_nodes(ray_start_cluster):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_global_state.py
+++ b/python/ray/tests/test_global_state.py
@@ -716,7 +716,4 @@ def test_get_draining_nodes(ray_start_cluster):
 if __name__ == "__main__":
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_grpc_client_credentials.py
+++ b/python/ray/tests/test_grpc_client_credentials.py
@@ -55,7 +55,6 @@ def test_grpc_client_credentials_are_generated(monkeypatch):
 
 
 if __name__ == "__main__":
-    import os
     import sys
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_grpc_client_credentials.py
+++ b/python/ray/tests/test_grpc_client_credentials.py
@@ -58,7 +58,4 @@ if __name__ == "__main__":
     import os
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_grpc_client_credentials.py
+++ b/python/ray/tests/test_grpc_client_credentials.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 import grpc
 
@@ -55,6 +57,4 @@ def test_grpc_client_credentials_are_generated(monkeypatch):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_healthcheck.py
+++ b/python/ray/tests/test_healthcheck.py
@@ -68,6 +68,5 @@ def test_healthcheck_ray_client_server():
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_healthcheck.py
+++ b/python/ray/tests/test_healthcheck.py
@@ -70,7 +70,4 @@ def test_healthcheck_ray_client_server():
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_ids.py
+++ b/python/ray/tests/test_ids.py
@@ -85,7 +85,4 @@ def test_id_methods(id_cls, size):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_implicit_resource.py
+++ b/python/ray/tests/test_implicit_resource.py
@@ -77,7 +77,4 @@ def test_implicit_resource_autoscaling(autoscaler_v2, shutdown_only):
 if __name__ == "__main__":
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_implicit_resource.py
+++ b/python/ray/tests/test_implicit_resource.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import time
 import pytest

--- a/python/ray/tests/test_implicit_resource.py
+++ b/python/ray/tests/test_implicit_resource.py
@@ -1,5 +1,6 @@
 import sys
 import time
+
 import pytest
 
 import ray
@@ -74,6 +75,4 @@ def test_implicit_resource_autoscaling(autoscaler_v2, shutdown_only):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_iter.py
+++ b/python/ray/tests/test_iter.py
@@ -562,7 +562,4 @@ def test_serialization(ray_start_regular_shared):
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_iter.py
+++ b/python/ray/tests/test_iter.py
@@ -560,6 +560,5 @@ def test_serialization(ray_start_regular_shared):
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_job.py
+++ b/python/ray/tests/test_job.py
@@ -453,7 +453,4 @@ if __name__ == "__main__":
     # Make subprocess happy in bazel.
     os.environ["LC_ALL"] = "en_US.UTF-8"
     os.environ["LANG"] = "en_US.UTF-8"
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_joblib.py
+++ b/python/ray/tests/test_joblib.py
@@ -242,7 +242,4 @@ def test_task_to_actor_assignment(shutdown_only):
 if __name__ == "__main__":
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_joblib.py
+++ b/python/ray/tests/test_joblib.py
@@ -1,11 +1,11 @@
 import sys
 import time
 import os
-import pytest
 from unittest import mock
 
 import joblib
 import pickle
+import pytest
 import numpy as np
 
 from sklearn.datasets import load_digits, load_iris
@@ -240,6 +240,4 @@ def test_task_to_actor_assignment(shutdown_only):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_kill_raylet_signal_log.py
+++ b/python/ray/tests/test_kill_raylet_signal_log.py
@@ -50,7 +50,4 @@ def test_kill_raylet_signal_log_win(shutdown_only):
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_kill_raylet_signal_log.py
+++ b/python/ray/tests/test_kill_raylet_signal_log.py
@@ -48,6 +48,5 @@ def test_kill_raylet_signal_log_win(shutdown_only):
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_label_scheduling.py
+++ b/python/ray/tests/test_label_scheduling.py
@@ -1,6 +1,8 @@
-import pytest
-import ray
 import sys
+
+import pytest
+
+import ray
 
 
 @ray.remote
@@ -95,6 +97,4 @@ def test_label_selector_multiple(cluster_with_labeled_nodes):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_label_scheduling.py
+++ b/python/ray/tests/test_label_scheduling.py
@@ -98,7 +98,4 @@ if __name__ == "__main__":
     import os
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_label_scheduling.py
+++ b/python/ray/tests/test_label_scheduling.py
@@ -95,7 +95,6 @@ def test_label_selector_multiple(cluster_with_labeled_nodes):
 
 
 if __name__ == "__main__":
-    import os
     import pytest
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_label_utils.py
+++ b/python/ray/tests/test_label_utils.py
@@ -243,7 +243,4 @@ if __name__ == "__main__":
     import os
 
     # Skip test_basic_2_client_mode for now- the test suite is breaking.
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_label_utils.py
+++ b/python/ray/tests/test_label_utils.py
@@ -240,7 +240,6 @@ def test_validate_node_labels():
 
 
 if __name__ == "__main__":
-    import os
 
     # Skip test_basic_2_client_mode for now- the test suite is breaking.
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_list_actors.py
+++ b/python/ray/tests/test_list_actors.py
@@ -56,7 +56,4 @@ if __name__ == "__main__":
     import os
 
     # Test suite is timing out. Disable on windows for now.
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_list_actors.py
+++ b/python/ray/tests/test_list_actors.py
@@ -53,7 +53,6 @@ def test_list_named_actors_basic_local_mode(ray_start_regular):
 
 
 if __name__ == "__main__":
-    import os
 
     # Test suite is timing out. Disable on windows for now.
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_list_actors_2.py
+++ b/python/ray/tests/test_list_actors_2.py
@@ -22,7 +22,4 @@ def test_list_named_actors_restarting_actor(ray_start_regular):
 
 if __name__ == "__main__":
     # Test suite is timing out. Disable on windows for now.
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_list_actors_3.py
+++ b/python/ray/tests/test_list_actors_3.py
@@ -49,7 +49,6 @@ assert "sad" in ray.util.list_named_actors()
 
 
 if __name__ == "__main__":
-    import os
 
     # Test suite is timing out. Disable on windows for now.
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_list_actors_3.py
+++ b/python/ray/tests/test_list_actors_3.py
@@ -52,7 +52,4 @@ if __name__ == "__main__":
     import os
 
     # Test suite is timing out. Disable on windows for now.
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_list_actors_4.py
+++ b/python/ray/tests/test_list_actors_4.py
@@ -87,7 +87,4 @@ if __name__ == "__main__":
     import os
 
     # Test suite is timing out. Disable on windows for now.
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_list_actors_4.py
+++ b/python/ray/tests/test_list_actors_4.py
@@ -84,7 +84,6 @@ async def test_list_named_actors_with_normal_task(shutdown_only):
 
 
 if __name__ == "__main__":
-    import os
 
     # Test suite is timing out. Disable on windows for now.
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_log_dedup.py
+++ b/python/ray/tests/test_log_dedup.py
@@ -1,4 +1,7 @@
+import sys
+
 import pytest
+
 from ray._private.ray_logging import LogDeduplicator
 
 
@@ -184,6 +187,4 @@ def test_dedup_logs_allow_and_skip_regexes():
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_logging.py
+++ b/python/ray/tests/test_logging.py
@@ -1255,8 +1255,6 @@ class TestSetupLogRecordFactory:
 
 
 if __name__ == "__main__":
-    import sys
-
     # Make subprocess happy in bazel.
     os.environ["LC_ALL"] = "en_US.UTF-8"
     os.environ["LANG"] = "en_US.UTF-8"

--- a/python/ray/tests/test_logging.py
+++ b/python/ray/tests/test_logging.py
@@ -1260,7 +1260,4 @@ if __name__ == "__main__":
     # Make subprocess happy in bazel.
     os.environ["LC_ALL"] = "en_US.UTF-8"
     os.environ["LANG"] = "en_US.UTF-8"
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_logging_2.py
+++ b/python/ray/tests/test_logging_2.py
@@ -1,7 +1,6 @@
 import logging.config
 import pytest
 import ray
-import os
 import logging
 import sys
 import json

--- a/python/ray/tests/test_logging_2.py
+++ b/python/ray/tests/test_logging_2.py
@@ -495,7 +495,4 @@ assert old_test_logger.getEffectiveLevel() == logging.DEBUG
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_memory_scheduling.py
+++ b/python/ray/tests/test_memory_scheduling.py
@@ -78,7 +78,4 @@ if __name__ == "__main__":
     import os
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_memory_scheduling.py
+++ b/python/ray/tests/test_memory_scheduling.py
@@ -1,5 +1,8 @@
-import numpy as np
+import sys
 import time
+
+import pytest
+import numpy as np
 
 import ray
 from ray._private.test_utils import wait_for_condition
@@ -74,7 +77,4 @@ def test_object_store_memory_reporting_task():
 
 
 if __name__ == "__main__":
-    import pytest
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_memory_scheduling.py
+++ b/python/ray/tests/test_memory_scheduling.py
@@ -75,7 +75,6 @@ def test_object_store_memory_reporting_task():
 
 if __name__ == "__main__":
     import pytest
-    import os
     import sys
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_memstat.py
+++ b/python/ray/tests/test_memstat.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 
 import numpy as np
@@ -377,6 +378,4 @@ def test_task_status(ray_start_regular):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_memstat.py
+++ b/python/ray/tests/test_memstat.py
@@ -379,7 +379,4 @@ def test_task_status(ray_start_regular):
 if __name__ == "__main__":
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -360,7 +360,4 @@ def test_opentelemetry_conflict(shutdown_only):
 if __name__ == "__main__":
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_metrics.py
+++ b/python/ray/tests/test_metrics.py
@@ -1,7 +1,8 @@
 import os
 import platform
+import sys
 
-import psutil  # We must import psutil after ray because we bundle it with ray.
+import psutil
 import pytest
 import requests
 
@@ -358,6 +359,4 @@ def test_opentelemetry_conflict(shutdown_only):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -1075,7 +1075,4 @@ if __name__ == "__main__":
     import sys
 
     # Test suite is timing out. Disable on windows for now.
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -7,7 +7,6 @@ import re
 import requests
 import warnings
 from collections import defaultdict
-
 from pprint import pformat
 from unittest.mock import MagicMock
 
@@ -1072,7 +1071,4 @@ def test_invalid_system_metric_names(caplog):
 
 
 if __name__ == "__main__":
-    import sys
-
-    # Test suite is timing out. Disable on windows for now.
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_metrics_agent_2.py
+++ b/python/ray/tests/test_metrics_agent_2.py
@@ -1,17 +1,16 @@
-import time
 import sys
-
-import pytest
-
-import ray._private.prometheus_exporter as prometheus_exporter
-
+import time
 from typing import List
 
+from opencensus.metrics.export.metric_descriptor import MetricDescriptorType
 from opencensus.stats.view_manager import ViewManager
 from opencensus.stats.stats_recorder import StatsRecorder
 from opencensus.stats import execution_context
 from prometheus_client.core import REGISTRY
-from opencensus.metrics.export.metric_descriptor import MetricDescriptorType
+import pytest
+
+import ray._private.prometheus_exporter as prometheus_exporter
+
 from ray._private.metrics_agent import Gauge, MetricsAgent, Record, RAY_WORKER_TIMEOUT_S
 from ray._private.services import new_port
 from ray.core.generated.metrics_pb2 import (
@@ -23,7 +22,6 @@ from ray.core.generated.metrics_pb2 import (
     LabelValue,
 )
 from ray._raylet import WorkerID
-
 from ray._private.test_utils import (
     fetch_prometheus_metrics,
     fetch_raw_prometheus,
@@ -491,7 +489,4 @@ def test_metrics_agent_export_format_correct(get_agent):
 
 
 if __name__ == "__main__":
-    import sys
-
-    # Test suite is timing out. Disable on windows for now.
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_metrics_agent_2.py
+++ b/python/ray/tests/test_metrics_agent_2.py
@@ -495,7 +495,4 @@ if __name__ == "__main__":
     import sys
 
     # Test suite is timing out. Disable on windows for now.
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_metrics_agent_2.py
+++ b/python/ray/tests/test_metrics_agent_2.py
@@ -1,4 +1,3 @@
-import os
 import time
 import sys
 

--- a/python/ray/tests/test_metrics_head.py
+++ b/python/ray/tests/test_metrics_head.py
@@ -200,7 +200,4 @@ def test_serve_dashboard_utilizes_global_filters():
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_microbenchmarks.py
+++ b/python/ray/tests/test_microbenchmarks.py
@@ -1,6 +1,8 @@
-import pytest
+import sys
 import time
+
 import numpy as np
+import pytest
 
 import ray
 
@@ -102,7 +104,4 @@ def test_cache(ray_start_regular):
 
 
 if __name__ == "__main__":
-    import pytest
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_microbenchmarks.py
+++ b/python/ray/tests/test_microbenchmarks.py
@@ -103,7 +103,6 @@ def test_cache(ray_start_regular):
 
 if __name__ == "__main__":
     import pytest
-    import os
     import sys
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_microbenchmarks.py
+++ b/python/ray/tests/test_microbenchmarks.py
@@ -106,7 +106,4 @@ if __name__ == "__main__":
     import os
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_mini.py
+++ b/python/ray/tests/test_mini.py
@@ -66,7 +66,4 @@ if __name__ == "__main__":
     import os
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_mini.py
+++ b/python/ray/tests/test_mini.py
@@ -1,3 +1,7 @@
+import sys
+
+import pytest
+
 import ray
 
 test_values = [1, 1.0, "test", b"test", (0, 1), [0, 1], {0: 1}]
@@ -62,7 +66,4 @@ def test_actor_api(ray_start_regular):
 
 
 if __name__ == "__main__":
-    import pytest
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_mini.py
+++ b/python/ray/tests/test_mini.py
@@ -63,7 +63,6 @@ def test_actor_api(ray_start_regular):
 
 if __name__ == "__main__":
     import pytest
-    import os
     import sys
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_minimal_install.py
+++ b/python/ray/tests/test_minimal_install.py
@@ -101,7 +101,4 @@ def test_module_import_with_various_non_minimal_deps(pydantic_version: str):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_monitor.py
+++ b/python/ray/tests/test_monitor.py
@@ -1,6 +1,10 @@
-from ray.autoscaler._private.monitor import parse_resource_demands
-import ray._private.gcs_utils as gcs_utils
+import sys
+
+import pytest
+
 import ray
+import ray._private.gcs_utils as gcs_utils
+from ray.autoscaler._private.monitor import parse_resource_demands
 
 ray.experimental.internal_kv.redis = False
 
@@ -48,7 +52,4 @@ def test_parse_resource_demands():
 
 
 if __name__ == "__main__":
-    import sys
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_monitor.py
+++ b/python/ray/tests/test_monitor.py
@@ -52,7 +52,4 @@ if __name__ == "__main__":
     import sys
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_monitor.py
+++ b/python/ray/tests/test_monitor.py
@@ -48,7 +48,6 @@ def test_parse_resource_demands():
 
 
 if __name__ == "__main__":
-    import os
     import sys
     import pytest
 

--- a/python/ray/tests/test_multi_node.py
+++ b/python/ray/tests/test_multi_node.py
@@ -417,8 +417,6 @@ print("success")
 
 
 if __name__ == "__main__":
-    import pytest
-
     # Make subprocess happy in bazel.
     os.environ["LC_ALL"] = "en_US.UTF-8"
     os.environ["LANG"] = "en_US.UTF-8"

--- a/python/ray/tests/test_multi_node.py
+++ b/python/ray/tests/test_multi_node.py
@@ -422,7 +422,4 @@ if __name__ == "__main__":
     # Make subprocess happy in bazel.
     os.environ["LC_ALL"] = "en_US.UTF-8"
     os.environ["LANG"] = "en_US.UTF-8"
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_multi_node_2.py
+++ b/python/ray/tests/test_multi_node_2.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 import time
 
 import pytest
@@ -365,7 +366,4 @@ def test_multi_node_pgs(ray_start_cluster):
 
 
 if __name__ == "__main__":
-    import pytest
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_multi_node_2.py
+++ b/python/ray/tests/test_multi_node_2.py
@@ -369,7 +369,4 @@ if __name__ == "__main__":
     import os
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_multi_node_2.py
+++ b/python/ray/tests/test_multi_node_2.py
@@ -366,7 +366,6 @@ def test_multi_node_pgs(ray_start_cluster):
 
 if __name__ == "__main__":
     import pytest
-    import os
     import sys
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_multi_node_3.py
+++ b/python/ray/tests/test_multi_node_3.py
@@ -455,7 +455,4 @@ if __name__ == "__main__":
     # Make subprocess happy in bazel.
     os.environ["LC_ALL"] = "en_US.UTF-8"
     os.environ["LANG"] = "en_US.UTF-8"
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_multi_node_3.py
+++ b/python/ray/tests/test_multi_node_3.py
@@ -450,8 +450,6 @@ def test_ray_stop_kill_workers():
 
 
 if __name__ == "__main__":
-    import pytest
-
     # Make subprocess happy in bazel.
     os.environ["LC_ALL"] = "en_US.UTF-8"
     os.environ["LANG"] = "en_US.UTF-8"

--- a/python/ray/tests/test_multi_tenancy.py
+++ b/python/ray/tests/test_multi_tenancy.py
@@ -326,7 +326,4 @@ def test_kill_idle_workers_that_are_behind_owned_workers(shutdown_only):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_multinode_failures.py
+++ b/python/ray/tests/test_multinode_failures.py
@@ -181,7 +181,4 @@ def test_raylet_failed(ray_start_cluster):
 if __name__ == "__main__":
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_multinode_failures.py
+++ b/python/ray/tests/test_multinode_failures.py
@@ -179,6 +179,4 @@ def test_raylet_failed(ray_start_cluster):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_multinode_failures_2.py
+++ b/python/ray/tests/test_multinode_failures_2.py
@@ -123,7 +123,6 @@ def test_actor_creation_node_failure(ray_start_cluster):
 
 
 if __name__ == "__main__":
-    import os
     import pytest
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_multinode_failures_2.py
+++ b/python/ray/tests/test_multinode_failures_2.py
@@ -123,6 +123,4 @@ def test_actor_creation_node_failure(ray_start_cluster):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_multinode_failures_2.py
+++ b/python/ray/tests/test_multinode_failures_2.py
@@ -126,7 +126,4 @@ if __name__ == "__main__":
     import os
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_multiprocessing.py
+++ b/python/ray/tests/test_multiprocessing.py
@@ -471,7 +471,4 @@ def test_imap_timeout(pool_4_processes, use_iter):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_multiprocessing_standalone.py
+++ b/python/ray/tests/test_multiprocessing_standalone.py
@@ -180,7 +180,4 @@ def test_deadlock_avoidance_in_recursive_tasks(shutdown_only):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_namespace.py
+++ b/python/ray/tests/test_namespace.py
@@ -267,6 +267,5 @@ def test_namespace_validation(shutdown_only):
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_namespace.py
+++ b/python/ray/tests/test_namespace.py
@@ -269,7 +269,4 @@ def test_namespace_validation(shutdown_only):
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_nccl_channel.py
+++ b/python/ray/tests/test_nccl_channel.py
@@ -518,7 +518,4 @@ def test_direct_return_with_cpu_data_channel(ray_start_cluster):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_nccl_channel.py
+++ b/python/ray/tests/test_nccl_channel.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 import logging
-import os
 import sys
 import torch
 from typing import List, Dict, Tuple

--- a/python/ray/tests/test_network_failure_e2e.py
+++ b/python/ray/tests/test_network_failure_e2e.py
@@ -317,7 +317,4 @@ wait_for_condition(lambda: ray.get(counter.get.remote()) == 1)
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_network_failure_e2e.py
+++ b/python/ray/tests/test_network_failure_e2e.py
@@ -315,6 +315,5 @@ wait_for_condition(lambda: ray.get(counter.get.remote()) == 1)
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_node_label_scheduling_strategy.py
+++ b/python/ray/tests/test_node_label_scheduling_strategy.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import pytest
 

--- a/python/ray/tests/test_node_label_scheduling_strategy.py
+++ b/python/ray/tests/test_node_label_scheduling_strategy.py
@@ -338,7 +338,4 @@ def test_node_label_scheduling_invalid_paramter(call_ray_start):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_node_labels.py
+++ b/python/ray/tests/test_node_labels.py
@@ -161,7 +161,4 @@ def test_ray_start_set_node_labels_from_file():
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_node_manager.py
+++ b/python/ray/tests/test_node_manager.py
@@ -528,7 +528,4 @@ def test_can_reuse_released_workers(
 if __name__ == "__main__":
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_node_manager.py
+++ b/python/ray/tests/test_node_manager.py
@@ -1,3 +1,15 @@
+import collections
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from typing import List, Optional
+
+import pytest
+
 import ray
 from ray.util.state import list_workers
 from ray._private.test_utils import (
@@ -7,20 +19,10 @@ from ray._private.test_utils import (
     wait_for_condition,
     get_resource_usage,
 )
-import pytest
-import os
 from ray.util.state import list_objects
-import subprocess
 from ray._private.utils import get_num_cpus
-import time
-import sys
 from ray._private.runtime_env.context import RuntimeEnvContext
 from ray._private.runtime_env.plugin import RuntimeEnvPlugin
-from typing import List, Optional
-import logging
-import tempfile
-import collections
-import shutil
 
 
 # This tests the queue transitions for infeasible tasks. This has been an issue
@@ -526,6 +528,4 @@ def test_can_reuse_released_workers(
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_node_provider_availability_tracker.py
+++ b/python/ray/tests/test_node_provider_availability_tracker.py
@@ -1,6 +1,5 @@
 import datetime
 import dataclasses
-import os
 import sys
 import pytest
 

--- a/python/ray/tests/test_node_provider_availability_tracker.py
+++ b/python/ray/tests/test_node_provider_availability_tracker.py
@@ -211,7 +211,4 @@ def test_summary_from_dict():
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_numba.py
+++ b/python/ray/tests/test_numba.py
@@ -36,7 +36,4 @@ if __name__ == "__main__":
     import os
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_numba.py
+++ b/python/ray/tests/test_numba.py
@@ -1,4 +1,7 @@
+import pytest
+import sys
 import unittest
+
 
 from numba import njit
 import numpy as np
@@ -32,7 +35,4 @@ class NumbaTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    import pytest
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_numba.py
+++ b/python/ray/tests/test_numba.py
@@ -33,7 +33,6 @@ class NumbaTest(unittest.TestCase):
 
 if __name__ == "__main__":
     import pytest
-    import os
     import sys
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_object_assign_owner.py
+++ b/python/ray/tests/test_object_assign_owner.py
@@ -197,7 +197,4 @@ if __name__ == "__main__":
     import pytest
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_object_assign_owner.py
+++ b/python/ray/tests/test_object_assign_owner.py
@@ -2,7 +2,6 @@ import pytest
 import ray
 import time
 import numpy as np
-import os
 from ray._private.test_utils import skip_flaky_core_test_premerge
 from ray.exceptions import OwnerDiedError
 

--- a/python/ray/tests/test_object_assign_owner.py
+++ b/python/ray/tests/test_object_assign_owner.py
@@ -1,7 +1,10 @@
-import pytest
-import ray
+import sys
 import time
+
+import pytest
 import numpy as np
+
+import ray
 from ray._private.test_utils import skip_flaky_core_test_premerge
 from ray.exceptions import OwnerDiedError
 
@@ -193,7 +196,4 @@ def test_owner_assign_inner_object(shutdown_only):
 
 
 if __name__ == "__main__":
-    import pytest
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_object_manager.py
+++ b/python/ray/tests/test_object_manager.py
@@ -731,7 +731,4 @@ if __name__ == "__main__":
     import sys
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_object_manager.py
+++ b/python/ray/tests/test_object_manager.py
@@ -1,4 +1,5 @@
 import multiprocessing
+import sys
 import time
 import warnings
 from collections import defaultdict
@@ -728,6 +729,4 @@ def test_maximize_concurrent_pull_race_condition(ray_start_cluster_head):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_object_manager.py
+++ b/python/ray/tests/test_object_manager.py
@@ -729,6 +729,5 @@ def test_maximize_concurrent_pull_race_condition(ray_start_cluster_head):
 
 if __name__ == "__main__":
     import sys
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_object_spilling.py
+++ b/python/ray/tests/test_object_spilling.py
@@ -795,7 +795,4 @@ def test_spill_worker_failure(ray_start_regular):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_object_spilling_2.py
+++ b/python/ray/tests/test_object_spilling_2.py
@@ -480,7 +480,4 @@ os.kill(os.getpid(), sig)
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_object_spilling_3.py
+++ b/python/ray/tests/test_object_spilling_3.py
@@ -395,6 +395,5 @@ def test_evict_secondary_copies_before_spill(ray_start_cluster, object_spilling_
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_object_spilling_3.py
+++ b/python/ray/tests/test_object_spilling_3.py
@@ -397,7 +397,4 @@ def test_evict_secondary_copies_before_spill(ray_start_cluster, object_spilling_
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_object_spilling_no_asan.py
+++ b/python/ray/tests/test_object_spilling_no_asan.py
@@ -51,7 +51,4 @@ def test_spill_fusion(fs_only_object_spilling_config, shutdown_only):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_object_store_metrics.py
+++ b/python/ray/tests/test_object_store_metrics.py
@@ -1,10 +1,11 @@
-from collections import defaultdict
-import pytest
-from typing import Dict
-import numpy as np
 import sys
+from collections import defaultdict
+from typing import Dict
 
+import pytest
 import requests
+import numpy as np
+
 import ray
 from ray._private.test_utils import (
     raw_metrics,
@@ -386,6 +387,4 @@ def test_object_store_memory_matches_dashboard_obj_memory(shutdown_only):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_object_store_metrics.py
+++ b/python/ray/tests/test_object_store_metrics.py
@@ -387,6 +387,5 @@ def test_object_store_memory_matches_dashboard_obj_memory(shutdown_only):
 
 if __name__ == "__main__":
     import sys
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_object_store_metrics.py
+++ b/python/ray/tests/test_object_store_metrics.py
@@ -389,7 +389,4 @@ if __name__ == "__main__":
     import sys
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -888,7 +888,4 @@ if __name__ == "__main__":
         ray.init(num_cpus=1, object_store_memory=(100 * MB))
         ray.shutdown()
     else:
-        if os.environ.get("PARALLEL_CI"):
-            sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-        else:
-            sys.exit(pytest.main(["-sv", __file__]))
+        sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_path_utils.py
+++ b/python/ray/tests/test_path_utils.py
@@ -1,4 +1,3 @@
-import os
 import sys
 
 

--- a/python/ray/tests/test_path_utils.py
+++ b/python/ray/tests/test_path_utils.py
@@ -37,7 +37,4 @@ def test_is_path_raises_error_for_non_string_input():
 if __name__ == "__main__":
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_path_utils.py
+++ b/python/ray/tests/test_path_utils.py
@@ -1,6 +1,5 @@
 import sys
 
-
 import pytest
 
 import ray._private.path_utils as PathUtils
@@ -34,6 +33,4 @@ def test_is_path_raises_error_for_non_string_input():
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_placement_group.py
+++ b/python/ray/tests/test_placement_group.py
@@ -705,7 +705,4 @@ class TestPlacementGroupValidation:
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_placement_group_2.py
+++ b/python/ray/tests/test_placement_group_2.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import time
 

--- a/python/ray/tests/test_placement_group_2.py
+++ b/python/ray/tests/test_placement_group_2.py
@@ -814,7 +814,4 @@ def test_bundle_recreated_when_raylet_fo_after_gcs_server_restart(
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_placement_group_3.py
+++ b/python/ray/tests/test_placement_group_3.py
@@ -752,6 +752,4 @@ def test_fractional_resources_handle_correct(ray_start_cluster):
 
 
 if __name__ == "__main__":
-    import os
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_placement_group_3.py
+++ b/python/ray/tests/test_placement_group_3.py
@@ -754,7 +754,4 @@ def test_fractional_resources_handle_correct(ray_start_cluster):
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_placement_group_4.py
+++ b/python/ray/tests/test_placement_group_4.py
@@ -451,7 +451,4 @@ def test_infeasible_pg(ray_start_cluster):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_placement_group_5.py
+++ b/python/ray/tests/test_placement_group_5.py
@@ -643,7 +643,4 @@ def test_placement_group_strict_pack_soft_target_node_id(ray_start_cluster):
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_placement_group_5.py
+++ b/python/ray/tests/test_placement_group_5.py
@@ -641,6 +641,5 @@ def test_placement_group_strict_pack_soft_target_node_id(ray_start_cluster):
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_placement_group_metrics.py
+++ b/python/ray/tests/test_placement_group_metrics.py
@@ -62,6 +62,5 @@ def test_basic_states(shutdown_only):
 
 if __name__ == "__main__":
     import sys
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_placement_group_metrics.py
+++ b/python/ray/tests/test_placement_group_metrics.py
@@ -64,7 +64,4 @@ if __name__ == "__main__":
     import sys
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_placement_group_metrics.py
+++ b/python/ray/tests/test_placement_group_metrics.py
@@ -1,6 +1,8 @@
+import sys
 from collections import defaultdict
-import pytest
 from typing import Dict
+
+import pytest
 
 import ray
 from ray._private.test_utils import (
@@ -61,6 +63,4 @@ def test_basic_states(shutdown_only):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_placement_group_mini_integration.py
+++ b/python/ray/tests/test_placement_group_mini_integration.py
@@ -127,6 +127,5 @@ def test_placement_group_remove_stress(ray_start_cluster, execution_number):
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_placement_group_mini_integration.py
+++ b/python/ray/tests/test_placement_group_mini_integration.py
@@ -129,7 +129,4 @@ def test_placement_group_remove_stress(ray_start_cluster, execution_number):
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_plasma_unlimited.py
+++ b/python/ray/tests/test_plasma_unlimited.py
@@ -3,9 +3,11 @@ import json
 import random
 import os
 import shutil
+import sys
 import platform
-import pytest
 import psutil
+
+import pytest
 
 import ray
 from ray._private.test_utils import (
@@ -371,6 +373,4 @@ def test_object_store_memory_metrics_reported_correctly(shutdown_only):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_plasma_unlimited.py
+++ b/python/ray/tests/test_plasma_unlimited.py
@@ -373,7 +373,4 @@ def test_object_store_memory_metrics_reported_correctly(shutdown_only):
 if __name__ == "__main__":
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_protobuf_compatibility.py
+++ b/python/ray/tests/test_protobuf_compatibility.py
@@ -30,6 +30,4 @@ def test_protobuf_compatibility(shutdown_only):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_pydantic_serialization.py
+++ b/python/ray/tests/test_pydantic_serialization.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 import logging
 from typing import Any, Dict, List, Optional, Type, Tuple
-import os
 import sys
 from packaging import version
 

--- a/python/ray/tests/test_pydantic_serialization.py
+++ b/python/ray/tests/test_pydantic_serialization.py
@@ -266,7 +266,4 @@ def test_validation_error(
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_queue.py
+++ b/python/ray/tests/test_queue.py
@@ -276,7 +276,4 @@ if __name__ == "__main__":
     import os
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_queue.py
+++ b/python/ray/tests/test_queue.py
@@ -1,5 +1,7 @@
-import pytest
 import time
+import sys
+
+import pytest
 
 import ray
 from ray.exceptions import GetTimeoutError, RayActorError
@@ -273,6 +275,4 @@ def test_pull_from_streaming_batch_queue(ray_start_regular_shared):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_queue.py
+++ b/python/ray/tests/test_queue.py
@@ -273,7 +273,6 @@ def test_pull_from_streaming_batch_queue(ray_start_regular_shared):
 
 
 if __name__ == "__main__":
-    import os
     import sys
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_ray_debugger.py
+++ b/python/ray/tests/test_ray_debugger.py
@@ -394,7 +394,4 @@ if __name__ == "__main__":
     # Make subprocess happy in bazel.
     os.environ["LC_ALL"] = "en_US.UTF-8"
     os.environ["LANG"] = "en_US.UTF-8"
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_ray_debugger.py
+++ b/python/ray/tests/test_ray_debugger.py
@@ -3,12 +3,12 @@ import os
 import subprocess
 import sys
 import unittest
+import pexpect
+from pexpect.popen_spawn import PopenSpawn
 from telnetlib import Telnet
 from typing import Union
 
 import pytest
-import pexpect
-from pexpect.popen_spawn import PopenSpawn
 
 import ray
 from ray._private import ray_constants, services
@@ -389,8 +389,6 @@ def test_env_var_enables_ray_debugger():
 
 
 if __name__ == "__main__":
-    import pytest
-
     # Make subprocess happy in bazel.
     os.environ["LC_ALL"] = "en_US.UTF-8"
     os.environ["LANG"] = "en_US.UTF-8"

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -400,7 +400,4 @@ if __name__ == "__main__":
 
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -1,15 +1,14 @@
+import json
 import os
 import sys
 import unittest.mock
 import signal
 import subprocess
+import tempfile
+from pathlib import Path
 
 import grpc
 import pytest
-import tempfile
-import json
-
-from pathlib import Path
 
 import ray
 import ray._private.services
@@ -396,8 +395,4 @@ def test_ray_init_with_runtime_env_as_object(
 
 
 if __name__ == "__main__":
-    import sys
-
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_ray_init_2.py
+++ b/python/ray/tests/test_ray_init_2.py
@@ -451,7 +451,4 @@ if __name__ == "__main__":
 
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_ray_init_2.py
+++ b/python/ray/tests/test_ray_init_2.py
@@ -447,8 +447,4 @@ def test_can_create_task_in_multiple_sessions(shutdown_only):
 
 
 if __name__ == "__main__":
-    import sys
-
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_ray_shutdown.py
+++ b/python/ray/tests/test_ray_shutdown.py
@@ -484,7 +484,4 @@ def test_sigterm_while_ray_get_and_wait(shutdown_only, is_get):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_raylet_output.py
+++ b/python/ray/tests/test_raylet_output.py
@@ -57,7 +57,4 @@ if __name__ == "__main__":
     # Make subprocess happy in bazel.
     os.environ["LC_ALL"] = "en_US.UTF-8"
     os.environ["LANG"] = "en_US.UTF-8"
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_reconstruction.py
+++ b/python/ray/tests/test_reconstruction.py
@@ -573,6 +573,4 @@ def test_reconstruction_chain(config, ray_start_cluster, reconstruction_enabled)
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_reconstruction.py
+++ b/python/ray/tests/test_reconstruction.py
@@ -575,7 +575,4 @@ def test_reconstruction_chain(config, ray_start_cluster, reconstruction_enabled)
 if __name__ == "__main__":
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_reconstruction_2.py
+++ b/python/ray/tests/test_reconstruction_2.py
@@ -2,8 +2,8 @@ import os
 import sys
 import time
 
-import numpy as np
 import pytest
+import numpy as np
 
 import ray
 import ray._private.ray_constants as ray_constants
@@ -605,6 +605,4 @@ def test_object_reconstruction_pending_creation(config, ray_start_cluster):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_reconstruction_2.py
+++ b/python/ray/tests/test_reconstruction_2.py
@@ -607,7 +607,4 @@ def test_object_reconstruction_pending_creation(config, ray_start_cluster):
 if __name__ == "__main__":
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_reconstruction_stress.py
+++ b/python/ray/tests/test_reconstruction_stress.py
@@ -1,4 +1,3 @@
-import os
 import signal
 import sys
 

--- a/python/ray/tests/test_reconstruction_stress.py
+++ b/python/ray/tests/test_reconstruction_stress.py
@@ -73,7 +73,4 @@ def test_reconstruction_stress(config, ray_start_cluster):
 if __name__ == "__main__":
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_reconstruction_stress.py
+++ b/python/ray/tests/test_reconstruction_stress.py
@@ -70,6 +70,4 @@ def test_reconstruction_stress(config, ray_start_cluster):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_reconstruction_stress_spill.py
+++ b/python/ray/tests/test_reconstruction_stress_spill.py
@@ -74,7 +74,4 @@ def test_reconstruction_stress_spill(config, ray_start_cluster):
 if __name__ == "__main__":
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_reconstruction_stress_spill.py
+++ b/python/ray/tests/test_reconstruction_stress_spill.py
@@ -1,8 +1,8 @@
 import signal
 import sys
 
-import numpy as np
 import pytest
+import numpy as np
 
 import ray
 
@@ -71,6 +71,4 @@ def test_reconstruction_stress_spill(config, ray_start_cluster):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_reconstruction_stress_spill.py
+++ b/python/ray/tests/test_reconstruction_stress_spill.py
@@ -1,4 +1,3 @@
-import os
 import signal
 import sys
 

--- a/python/ray/tests/test_reference_counting.py
+++ b/python/ray/tests/test_reference_counting.py
@@ -605,7 +605,4 @@ def test_actor_constructor_borrow_cancellation(ray_start_regular):
 if __name__ == "__main__":
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_reference_counting.py
+++ b/python/ray/tests/test_reference_counting.py
@@ -603,6 +603,4 @@ def test_actor_constructor_borrow_cancellation(ray_start_regular):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_reference_counting_2.py
+++ b/python/ray/tests/test_reference_counting_2.py
@@ -801,7 +801,4 @@ def test_lineage_leak(shutdown_only):
 if __name__ == "__main__":
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_reference_counting_2.py
+++ b/python/ray/tests/test_reference_counting_2.py
@@ -799,6 +799,4 @@ def test_lineage_leak(shutdown_only):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -2,6 +2,7 @@ import copy
 import os
 import json
 import shutil
+import sys
 import tempfile
 import time
 import unittest
@@ -9,9 +10,9 @@ from dataclasses import asdict
 from datetime import datetime
 from time import sleep
 from unittest import mock
+import yaml
 
 import pytest
-import yaml
 
 import ray
 import ray._private.ray_constants
@@ -4080,6 +4081,4 @@ def test_utilization_score_plugin_2(lexical_score_plugin):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -4082,7 +4082,4 @@ def test_utilization_score_plugin_2(lexical_score_plugin):
 if __name__ == "__main__":
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_resource_isolation_config.py
+++ b/python/ray/tests/test_resource_isolation_config.py
@@ -225,7 +225,4 @@ def test_enabled_reserved_memory_less_than_minimum_raises_exception(monkeypatch)
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_resource_isolation_config.py
+++ b/python/ray/tests/test_resource_isolation_config.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 import sys
 

--- a/python/ray/tests/test_resource_metrics.py
+++ b/python/ray/tests/test_resource_metrics.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-import os
 
 import pytest
 

--- a/python/ray/tests/test_resource_metrics.py
+++ b/python/ray/tests/test_resource_metrics.py
@@ -103,7 +103,4 @@ ray.get([f.remote() for _ in range(2)])"""
 if __name__ == "__main__":
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_resource_metrics.py
+++ b/python/ray/tests/test_resource_metrics.py
@@ -1,3 +1,4 @@
+import sys
 from collections import defaultdict
 
 import pytest
@@ -100,6 +101,4 @@ ray.get([f.remote() for _ in range(2)])"""
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_response_cache.py
+++ b/python/ray/tests/test_response_cache.py
@@ -1,13 +1,15 @@
+import sys
+import threading
+import time
+
+import pytest
+
 from ray.util.client.common import (
     _id_is_newer,
     ResponseCache,
     OrderedResponseCache,
     INT32_MAX,
 )
-import threading
-import time
-
-import pytest
 
 
 def test_id_is_newer():
@@ -218,6 +220,4 @@ def test_response_cache_invalidate():
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_response_cache.py
+++ b/python/ray/tests/test_response_cache.py
@@ -221,7 +221,4 @@ if __name__ == "__main__":
     import os
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_response_cache.py
+++ b/python/ray/tests/test_response_cache.py
@@ -218,7 +218,6 @@ def test_response_cache_invalidate():
 
 
 if __name__ == "__main__":
-    import os
     import sys
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_context.py
+++ b/python/ray/tests/test_runtime_context.py
@@ -418,7 +418,4 @@ def test_async_actor_task_id(shutdown_only):
 if __name__ == "__main__":
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_context.py
+++ b/python/ray/tests/test_runtime_context.py
@@ -1,11 +1,12 @@
-import ray
 import os
 import signal
 import time
 import sys
-import pytest
 import warnings
 
+import pytest
+
+import ray
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from ray.util.state import list_tasks
 from ray._private.test_utils import wait_for_condition
@@ -416,6 +417,4 @@ def test_async_actor_task_id(shutdown_only):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -988,7 +988,4 @@ def test_runtime_env_interface():
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_2.py
+++ b/python/ray/tests/test_runtime_env_2.py
@@ -249,7 +249,4 @@ if __name__ == "__main__":
     import os
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_2.py
+++ b/python/ray/tests/test_runtime_env_2.py
@@ -1,10 +1,11 @@
-import conda
-import pytest
-import time
-import sys
 import fnmatch
 import os
+import time
+import sys
 from typing import List
+
+import conda
+import pytest
 
 import ray
 from ray.dashboard.modules.job.common import JobStatus
@@ -246,7 +247,4 @@ class TestNoUserInfoInLogs:
 
 
 if __name__ == "__main__":
-    import os
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -1,14 +1,15 @@
 import os
 import platform
-from pathlib import Path
-import pytest
 import subprocess
 import sys
 import tempfile
 import time
+import yaml
+from pathlib import Path
 from typing import List
 from unittest import mock
-import yaml
+
+import pytest
 
 import ray
 from ray.runtime_env import RuntimeEnv

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -1186,6 +1186,4 @@ setup(
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_complicated.py
+++ b/python/ray/tests/test_runtime_env_complicated.py
@@ -1187,7 +1187,4 @@ setup(
 if __name__ == "__main__":
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_conda_and_pip.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip.py
@@ -370,7 +370,4 @@ def test_working_dir_applies_for_conda_creation(start_cluster, tmp_working_dir):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_conda_and_pip_2.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_2.py
@@ -92,7 +92,4 @@ def test_install_failure_logging(
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_conda_and_pip_3.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_3.py
@@ -140,7 +140,4 @@ class TestGC:
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_conda_and_pip_4.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_4.py
@@ -125,7 +125,4 @@ def test_runtime_env_with_pip_config(ray_start_regular_shared):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_conda_and_pip_5.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_5.py
@@ -97,6 +97,5 @@ def test_runtime_env_cache_with_pip_check(start_cluster):
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_conda_and_pip_5.py
+++ b/python/ray/tests/test_runtime_env_conda_and_pip_5.py
@@ -99,7 +99,4 @@ def test_runtime_env_cache_with_pip_check(start_cluster):
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_env_vars.py
+++ b/python/ray/tests/test_runtime_env_env_vars.py
@@ -320,6 +320,4 @@ def test_appendable_environ(ray_start_regular):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_env_vars.py
+++ b/python/ray/tests/test_runtime_env_env_vars.py
@@ -322,7 +322,4 @@ def test_appendable_environ(ray_start_regular):
 if __name__ == "__main__":
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_failure.py
+++ b/python/ray/tests/test_runtime_env_failure.py
@@ -153,7 +153,4 @@ class TestRuntimeEnvFailure:
 if __name__ == "__main__":
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_failure.py
+++ b/python/ray/tests/test_runtime_env_failure.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from unittest import mock
 
 import pytest
@@ -151,6 +152,4 @@ class TestRuntimeEnvFailure:
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_fork_process.py
+++ b/python/ray/tests/test_runtime_env_fork_process.py
@@ -94,7 +94,4 @@ def test_fork_process_job_config_from_env_var(ray_start_cluster):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -850,7 +850,4 @@ def test_get_local_dir_from_uri():
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_plugin.py
+++ b/python/ray/tests/test_runtime_env_plugin.py
@@ -1,13 +1,13 @@
 import asyncio
+import json
 import logging
 import os
-from pathlib import Path
-import time
-from unittest import mock
-
+import sys
 import tempfile
-import json
+import time
+from pathlib import Path
 from typing import List
+from unittest import mock
 
 import pytest
 
@@ -770,6 +770,4 @@ class TestGC:
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_plugin.py
+++ b/python/ray/tests/test_runtime_env_plugin.py
@@ -772,7 +772,4 @@ class TestGC:
 if __name__ == "__main__":
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_profiler.py
+++ b/python/ray/tests/test_runtime_env_profiler.py
@@ -262,7 +262,4 @@ def test_nsight_not_installed():
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_py_executable.py
+++ b/python/ray/tests/test_runtime_env_py_executable.py
@@ -49,7 +49,4 @@ def test_py_executable_with_working_dir(shutdown_only, tmp_working_dir):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_ray_minimal.py
+++ b/python/ray/tests/test_runtime_env_ray_minimal.py
@@ -67,7 +67,4 @@ def test_ray_init(shutdown_only):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_setup_func.py
+++ b/python/ray/tests/test_runtime_env_setup_func.py
@@ -256,7 +256,4 @@ ray.get(f.remote())
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_strong_type.py
+++ b/python/ray/tests/test_runtime_env_strong_type.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import pytest
 import ray

--- a/python/ray/tests/test_runtime_env_strong_type.py
+++ b/python/ray/tests/test_runtime_env_strong_type.py
@@ -64,7 +64,4 @@ def test_pip(start_cluster):
 
 if __name__ == "__main__":
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_uv.py
+++ b/python/ray/tests/test_runtime_env_uv.py
@@ -186,7 +186,4 @@ def test_package_install_with_multiple_options(shutdown_only):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_uv_run.py
+++ b/python/ray/tests/test_runtime_env_uv_run.py
@@ -418,7 +418,4 @@ with open("{tmp_out_dir / "output.txt"}", "w") as out:
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_validation.py
+++ b/python/ray/tests/test_runtime_env_validation.py
@@ -366,7 +366,4 @@ class TestRuntimeEnvPluginSchemaManager:
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_working_dir.py
+++ b/python/ray/tests/test_runtime_env_working_dir.py
@@ -602,7 +602,4 @@ def test_override_failure(shutdown_only):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_working_dir_2.py
+++ b/python/ray/tests/test_runtime_env_working_dir_2.py
@@ -209,7 +209,4 @@ def test_file_created_before_1980(shutdown_only, tmp_working_dir):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_working_dir_3.py
+++ b/python/ray/tests/test_runtime_env_working_dir_3.py
@@ -379,7 +379,4 @@ def test_pin_runtime_env_uri(start_cluster, tmp_working_dir, expiration_s, monke
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_working_dir_4.py
+++ b/python/ray/tests/test_runtime_env_working_dir_4.py
@@ -226,7 +226,4 @@ ray.init(runtime_env={{"working_dir": "{tmp_working_dir}"}})
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_runtime_env_working_dir_remote_uri.py
+++ b/python/ray/tests/test_runtime_env_working_dir_remote_uri.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from typing import Dict, Optional, Tuple
 

--- a/python/ray/tests/test_runtime_env_working_dir_remote_uri.py
+++ b/python/ray/tests/test_runtime_env_working_dir_remote_uri.py
@@ -127,7 +127,4 @@ def test_remote_package_uri_multi_node(
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -750,6 +750,4 @@ def test_scheduling_class_depth(ray_start_regular):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -753,7 +753,4 @@ if __name__ == "__main__":
     import os
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -750,7 +750,6 @@ def test_scheduling_class_depth(ray_start_regular):
 
 
 if __name__ == "__main__":
-    import os
     import pytest
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_scheduling_2.py
+++ b/python/ray/tests/test_scheduling_2.py
@@ -824,6 +824,4 @@ def test_negative_resource_availability(shutdown_only):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_scheduling_2.py
+++ b/python/ray/tests/test_scheduling_2.py
@@ -826,7 +826,4 @@ def test_negative_resource_availability(shutdown_only):
 if __name__ == "__main__":
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_scheduling_performance.py
+++ b/python/ray/tests/test_scheduling_performance.py
@@ -102,6 +102,4 @@ def test_actor_scheduling_latency(ray_start_cluster, args):
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_scheduling_performance.py
+++ b/python/ray/tests/test_scheduling_performance.py
@@ -102,7 +102,6 @@ def test_actor_scheduling_latency(ray_start_cluster, args):
 
 
 if __name__ == "__main__":
-    import os
     import pytest
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_scheduling_performance.py
+++ b/python/ray/tests/test_scheduling_performance.py
@@ -105,7 +105,4 @@ if __name__ == "__main__":
     import os
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_serialization.py
+++ b/python/ray/tests/test_serialization.py
@@ -790,7 +790,6 @@ def test_can_out_of_band_serialize_object_ref_with_env_var(shutdown_only, monkey
 
 
 if __name__ == "__main__":
-    import os
     import pytest
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_serialization.py
+++ b/python/ray/tests/test_serialization.py
@@ -793,7 +793,4 @@ if __name__ == "__main__":
     import os
     import pytest
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_serialization.py
+++ b/python/ray/tests/test_serialization.py
@@ -790,6 +790,4 @@ def test_can_out_of_band_serialize_object_ref_with_env_var(shutdown_only, monkey
 
 
 if __name__ == "__main__":
-    import pytest
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_shuffle.py
+++ b/python/ray/tests/test_shuffle.py
@@ -51,7 +51,4 @@ def test_shuffle_multi_node_no_streaming(ray_start_cluster):
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_shuffle.py
+++ b/python/ray/tests/test_shuffle.py
@@ -49,6 +49,5 @@ def test_shuffle_multi_node_no_streaming(ray_start_cluster):
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -3732,7 +3732,4 @@ def test_hang_driver_has_no_is_running_task(monkeypatch, ray_start_cluster):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_state_api_2.py
+++ b/python/ray/tests/test_state_api_2.py
@@ -379,7 +379,4 @@ def test_ray_timeline(shutdown_only):
 if __name__ == "__main__":
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_state_api_2.py
+++ b/python/ray/tests/test_state_api_2.py
@@ -377,6 +377,4 @@ def test_ray_timeline(shutdown_only):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_state_api_log.py
+++ b/python/ray/tests/test_state_api_log.py
@@ -1,19 +1,16 @@
+import asyncio
 import json
 import os
 import sys
-import asyncio
+from pathlib import Path
 from typing import List
-import urllib
 from unittest.mock import MagicMock, AsyncMock
 
-import pytest
-from ray.util.state.state_cli import logs_state_cli_group
-from ray.util.state import list_jobs
-import requests
-from click.testing import CliRunner
 import grpc
-
-from pathlib import Path
+import requests
+import pytest
+import urllib
+from click.testing import CliRunner
 
 import ray
 from ray._private.test_utils import (
@@ -21,6 +18,8 @@ from ray._private.test_utils import (
     wait_for_condition,
     wait_until_server_available,
 )
+from ray.util.state.state_cli import logs_state_cli_group
+from ray.util.state import list_jobs
 
 from ray._raylet import ActorID, NodeID, TaskID, WorkerID
 from ray.core.generated.common_pb2 import Address
@@ -1560,6 +1559,4 @@ def test_log_cli(shutdown_only):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_state_api_log.py
+++ b/python/ray/tests/test_state_api_log.py
@@ -1562,7 +1562,4 @@ def test_log_cli(shutdown_only):
 if __name__ == "__main__":
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_storage.py
+++ b/python/ray/tests/test_storage.py
@@ -293,7 +293,4 @@ def test_add_creatable_buckets_param_if_s3_uri():
 if __name__ == "__main__":
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_storage.py
+++ b/python/ray/tests/test_storage.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
-
 import os
 import sys
 import subprocess
 import urllib
+from packaging.version import parse as parse_version
 from pathlib import Path
 
-from packaging.version import parse as parse_version
 import pyarrow.fs
 import pytest
 
@@ -291,6 +290,4 @@ def test_add_creatable_buckets_param_if_s3_uri():
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_streaming_generator.py
+++ b/python/ray/tests/test_streaming_generator.py
@@ -577,6 +577,5 @@ def test_streaming_generator_exception(shutdown_only):
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_streaming_generator.py
+++ b/python/ray/tests/test_streaming_generator.py
@@ -579,7 +579,4 @@ def test_streaming_generator_exception(shutdown_only):
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_streaming_generator_2.py
+++ b/python/ray/tests/test_streaming_generator_2.py
@@ -537,6 +537,5 @@ def test_reconstruction_generator_out_of_scope(
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_streaming_generator_2.py
+++ b/python/ray/tests/test_streaming_generator_2.py
@@ -539,7 +539,4 @@ def test_reconstruction_generator_out_of_scope(
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_streaming_generator_3.py
+++ b/python/ray/tests/test_streaming_generator_3.py
@@ -301,7 +301,4 @@ def test_completed_next_ready_is_finished(shutdown_only):
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_streaming_generator_3.py
+++ b/python/ray/tests/test_streaming_generator_3.py
@@ -299,6 +299,5 @@ def test_completed_next_ready_is_finished(shutdown_only):
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_streaming_generator_4.py
+++ b/python/ray/tests/test_streaming_generator_4.py
@@ -299,7 +299,4 @@ def test_cancel(shutdown_only, use_asyncio):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_streaming_generator_backpressure.py
+++ b/python/ray/tests/test_streaming_generator_backpressure.py
@@ -311,7 +311,4 @@ def test_backpressure_pause_signal(shutdown_only):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_streaming_generator_regression.py
+++ b/python/ray/tests/test_streaming_generator_regression.py
@@ -135,6 +135,5 @@ def test_segfault_report_streaming_generator_output(
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_streaming_generator_regression.py
+++ b/python/ray/tests/test_streaming_generator_regression.py
@@ -137,7 +137,4 @@ def test_segfault_report_streaming_generator_output(
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_stress.py
+++ b/python/ray/tests/test_stress.py
@@ -100,7 +100,6 @@ def test_wait(ray_start_combination):
 
 if __name__ == "__main__":
     import pytest
-    import os
     import sys
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_stress.py
+++ b/python/ray/tests/test_stress.py
@@ -103,7 +103,4 @@ if __name__ == "__main__":
     import os
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_stress.py
+++ b/python/ray/tests/test_stress.py
@@ -1,6 +1,8 @@
-import numpy as np
-import pytest
 import time
+import sys
+
+import pytest
+import numpy as np
 
 import ray
 from ray.cluster_utils import Cluster, cluster_not_supported
@@ -99,7 +101,4 @@ def test_wait(ray_start_combination):
 
 
 if __name__ == "__main__":
-    import pytest
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_stress_sharded.py
+++ b/python/ray/tests/test_stress_sharded.py
@@ -88,7 +88,4 @@ if __name__ == "__main__":
     import os
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_stress_sharded.py
+++ b/python/ray/tests/test_stress_sharded.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 import pytest
 
@@ -84,7 +86,4 @@ def test_getting_many_objects(ray_start_sharded):
 
 
 if __name__ == "__main__":
-    import pytest
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_stress_sharded.py
+++ b/python/ray/tests/test_stress_sharded.py
@@ -85,7 +85,6 @@ def test_getting_many_objects(ray_start_sharded):
 
 if __name__ == "__main__":
     import pytest
-    import os
     import sys
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_system_metrics.py
+++ b/python/ray/tests/test_system_metrics.py
@@ -45,7 +45,4 @@ def test_unintentional_worker_failures_metric(shutdown_only):
 if __name__ == "__main__":
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_system_metrics.py
+++ b/python/ray/tests/test_system_metrics.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 
 import pytest
@@ -43,6 +44,4 @@ def test_unintentional_worker_failures_metric(shutdown_only):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_task_events.py
+++ b/python/ray/tests/test_task_events.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 from typing import Dict
 
-import os
 import pytest
 import sys
 import threading

--- a/python/ray/tests/test_task_events.py
+++ b/python/ray/tests/test_task_events.py
@@ -558,7 +558,4 @@ def test_is_debugger_paused_async_actor(shutdown_only, actor_concurrency):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_task_events_2.py
+++ b/python/ray/tests/test_task_events_2.py
@@ -1303,7 +1303,4 @@ class TestIsActorTaskRunning:
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_task_events_3.py
+++ b/python/ray/tests/test_task_events_3.py
@@ -307,7 +307,4 @@ def test_enable_task_events_nested_actor(
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_task_events_3.py
+++ b/python/ray/tests/test_task_events_3.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 import sys
 

--- a/python/ray/tests/test_task_metrics.py
+++ b/python/ray/tests/test_task_metrics.py
@@ -1,12 +1,11 @@
-from collections import defaultdict
-import sys
 import copy
 import multiprocessing
+import sys
+from collections import defaultdict
 
 import pytest
 
 import ray
-
 from ray._private.metrics_agent import RAY_WORKER_TIMEOUT_S
 from ray._private.test_utils import (
     raw_metrics,
@@ -704,6 +703,4 @@ time.sleep(999)
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_task_metrics.py
+++ b/python/ray/tests/test_task_metrics.py
@@ -707,7 +707,4 @@ time.sleep(999)
 if __name__ == "__main__":
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_task_metrics.py
+++ b/python/ray/tests/test_task_metrics.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 import sys
-import os
 import copy
 import multiprocessing
 

--- a/python/ray/tests/test_task_metrics_reconstruction.py
+++ b/python/ray/tests/test_task_metrics_reconstruction.py
@@ -73,7 +73,4 @@ def test_task_reconstruction(ray_start_cluster):
 if __name__ == "__main__":
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_task_metrics_reconstruction.py
+++ b/python/ray/tests/test_task_metrics_reconstruction.py
@@ -1,6 +1,5 @@
 import numpy as np
 import sys
-import os
 
 import pytest
 

--- a/python/ray/tests/test_task_metrics_reconstruction.py
+++ b/python/ray/tests/test_task_metrics_reconstruction.py
@@ -1,6 +1,6 @@
-import numpy as np
 import sys
 
+import numpy as np
 import pytest
 
 import ray
@@ -70,6 +70,4 @@ def test_task_reconstruction(ray_start_cluster):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_tempfile.py
+++ b/python/ray/tests/test_tempfile.py
@@ -159,7 +159,4 @@ if __name__ == "__main__":
     # Make subprocess happy in bazel.
     os.environ["LC_ALL"] = "en_US.UTF-8"
     os.environ["LANG"] = "en_US.UTF-8"
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_threaded_actor.py
+++ b/python/ray/tests/test_threaded_actor.py
@@ -291,7 +291,6 @@ def test_threaded_actor_integration_test_stress(
 
 
 if __name__ == "__main__":
-    import os
 
     # Test suite is timing out. Disable on windows for now.
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_threaded_actor.py
+++ b/python/ray/tests/test_threaded_actor.py
@@ -294,7 +294,4 @@ if __name__ == "__main__":
     import os
 
     # Test suite is timing out. Disable on windows for now.
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_tls_auth.py
+++ b/python/ray/tests/test_tls_auth.py
@@ -154,7 +154,4 @@ if __name__ == "__main__":
     import pytest
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_tls_auth.py
+++ b/python/ray/tests/test_tls_auth.py
@@ -151,7 +151,4 @@ assert ray.is_initialized()
 
 
 if __name__ == "__main__":
-    import pytest
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_top_level_api.py
+++ b/python/ray/tests/test_top_level_api.py
@@ -117,6 +117,5 @@ def test_for_strings():
 
 
 if __name__ == "__main__":
-    import os
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_top_level_api.py
+++ b/python/ray/tests/test_top_level_api.py
@@ -119,7 +119,4 @@ def test_for_strings():
 if __name__ == "__main__":
     import os
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_tqdm.py
+++ b/python/ray/tests/test_tqdm.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import time
 

--- a/python/ray/tests/test_tqdm.py
+++ b/python/ray/tests/test_tqdm.py
@@ -111,7 +111,4 @@ def test_flush_interval():
 
 if __name__ == "__main__":
     # Test suite is timing out. Disable on windows for now.
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_traceback.py
+++ b/python/ray/tests/test_traceback.py
@@ -408,7 +408,4 @@ if __name__ == "__main__":
     import os
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_traceback.py
+++ b/python/ray/tests/test_traceback.py
@@ -3,8 +3,8 @@ import sys
 import threading
 
 import pytest
-import ray
 
+import ray
 from ray.exceptions import RayTaskError, RayActorError
 
 """This module tests stacktrace of Ray.
@@ -404,7 +404,4 @@ def test_serialization_error_message(shutdown_only):
 
 
 if __name__ == "__main__":
-    import pytest
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_traceback.py
+++ b/python/ray/tests/test_traceback.py
@@ -405,7 +405,6 @@ def test_serialization_error_message(shutdown_only):
 
 if __name__ == "__main__":
     import pytest
-    import os
     import sys
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_tracing.py
+++ b/python/ray/tests/test_tracing.py
@@ -2,9 +2,11 @@ import asyncio
 import glob
 import json
 import os
-import pytest
 import shutil
+import sys
 from unittest.mock import patch
+
+import pytest
 
 import ray
 from ray._private.test_utils import check_call_ray
@@ -222,6 +224,4 @@ def test_deserialization_works_without_opentelemetry(ray_start_regular):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_tracing.py
+++ b/python/ray/tests/test_tracing.py
@@ -224,7 +224,4 @@ def test_deserialization_works_without_opentelemetry(ray_start_regular):
 if __name__ == "__main__":
     import sys
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_typing.py
+++ b/python/ray/tests/test_typing.py
@@ -42,7 +42,4 @@ if __name__ == "__main__":
     os.environ["LC_ALL"] = "en_US.UTF-8"
     os.environ["LANG"] = "en_US.UTF-8"
 
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_usage_stats.py
+++ b/python/ray/tests/test_usage_stats.py
@@ -1535,7 +1535,4 @@ def test_usages_stats_dashboard(monkeypatch, ray_start_cluster, reset_usage_stat
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_utils.py
+++ b/python/ray/tests/test_utils.py
@@ -4,16 +4,17 @@ Unit/Integration Testing for python/_private/utils.py
 
 This currently expects to work for minimal installs.
 """
-
-import pytest
 import logging
+import os
+import pytest
+import sys
+from unittest.mock import patch, mock_open
+
 from ray._private.utils import (
     parse_pg_formatted_resources_to_original,
     try_import_each_module,
     get_current_node_cpu_model_name,
 )
-from unittest.mock import patch, mock_open
-import sys
 
 logger = logging.getLogger(__name__)
 
@@ -82,10 +83,4 @@ def test_get_current_node_cpu_model_name():
 
 
 if __name__ == "__main__":
-    import os
-
-    # Skip test_basic_2_client_mode for now- the test suite is breaking.
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_utils.py
+++ b/python/ray/tests/test_utils.py
@@ -5,7 +5,6 @@ Unit/Integration Testing for python/_private/utils.py
 This currently expects to work for minimal installs.
 """
 import logging
-import os
 import pytest
 import sys
 from unittest.mock import patch, mock_open

--- a/python/ray/tests/test_wait.py
+++ b/python/ray/tests/test_wait.py
@@ -5,7 +5,6 @@ import numpy as np
 import time
 import logging
 import sys
-import os
 
 from ray._private.test_utils import client_test_enabled
 

--- a/python/ray/tests/test_wait.py
+++ b/python/ray/tests/test_wait.py
@@ -135,7 +135,4 @@ def test_wait_always_fetch_local(monkeypatch, ray_start_cluster):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_widgets.py
+++ b/python/ray/tests/test_widgets.py
@@ -1,8 +1,10 @@
-import logging
 import importlib
+import logging
+import sys
 from unittest import mock
 
 import pytest
+
 import ray
 from ray.widgets.util import repr_with_fallback, _can_display_ipywidgets
 
@@ -181,6 +183,4 @@ def test_can_display_ipywidgets(
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/test_worker_capping.py
+++ b/python/ray/tests/test_worker_capping.py
@@ -293,7 +293,4 @@ def test_idle_workers(shutdown_only):
 
 if __name__ == "__main__":
     os.environ["RAY_worker_cap_enabled"] = "true"
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_worker_state.py
+++ b/python/ray/tests/test_worker_state.py
@@ -159,7 +159,4 @@ def test_worker_paused_async_actor(shutdown_only, actor_concurrency):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_worker_state.py
+++ b/python/ray/tests/test_worker_state.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 import sys
 import threading

--- a/python/ray/tests/vsphere/test_cluster_operator.py
+++ b/python/ray/tests/vsphere/test_cluster_operator.py
@@ -1,11 +1,12 @@
 import copy
 import os
 import re
+import sys
 import tempfile
-
-import pytest
 from threading import RLock
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from ray.autoscaler.tags import (
     NODE_KIND_HEAD,
@@ -662,6 +663,4 @@ def test_get_vm_service_ingress():
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/vsphere/test_vmray_node_provider.py
+++ b/python/ray/tests/vsphere/test_vmray_node_provider.py
@@ -1,7 +1,9 @@
 import copy
-import pytest
+import sys
 import threading
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from ray.autoscaler.tags import (
     TAG_RAY_CLUSTER_NAME,
@@ -183,6 +185,4 @@ def test_terminate_nodes():
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/train/tests/test_train_head.py
+++ b/python/ray/train/tests/test_train_head.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import time
 

--- a/python/ray/train/tests/test_train_head.py
+++ b/python/ray/train/tests/test_train_head.py
@@ -72,7 +72,4 @@ def test_add_actor_status(ray_start_8_cpus):
 
 
 if __name__ == "__main__":
-    if os.environ.get("PARALLEL_CI"):
-        sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))
-    else:
-        sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", __file__]))


### PR DESCRIPTION
According to @can-anyscale this is an abandoned feature.

Also fixed a bunch of delayed imports and isort helped sort them.