### PR TITLE
[core] Add `RAY_actor_scheduling_queue_max_reorder_wait_seconds` and make related tests 30× faster

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -958,3 +958,8 @@ RAY_CONFIG(bool, enable_infeasible_task_early_exit, false);
 // Frequency at which to check all local worker & driver sockets for unexpected
 // disconnects.
 RAY_CONFIG(int64_t, raylet_check_for_unexpected_worker_disconnect_interval_ms, 1000)
+
+/// The maximum time in seconds that an actor task can wait in the scheduling queue
+/// for tasks with smaller sequence numbers to show up. If timed out, the task will
+/// be cancelled.
+RAY_CONFIG(int64_t, actor_scheduling_queue_max_reorder_wait_seconds, 30)

--- a/src/ray/core_worker/test/task_receiver_test.cc
+++ b/src/ray/core_worker/test/task_receiver_test.cc
@@ -145,6 +145,8 @@ class TaskReceiverTest : public ::testing::Test {
                                   std::placeholders::_4,
                                   std::placeholders::_5,
                                   std::placeholders::_6);
+    RayConfig::instance().initialize(
+        R"({"actor_scheduling_queue_max_reorder_wait_seconds": 1})");
     receiver_ = std::make_unique<MockTaskReceiver>(
         task_execution_service_,
         task_event_buffer_,

--- a/src/ray/core_worker/transport/actor_scheduling_queue.cc
+++ b/src/ray/core_worker/transport/actor_scheduling_queue.cc
@@ -30,10 +30,8 @@ ActorSchedulingQueue::ActorSchedulingQueue(
     std::shared_ptr<ConcurrencyGroupManager<FiberState>> fiber_state_manager,
     bool is_asyncio,
     int fiber_max_concurrency,
-    const std::vector<ConcurrencyGroup> &concurrency_groups,
-    int64_t reorder_wait_seconds)
-    : reorder_wait_seconds_(reorder_wait_seconds),
-      wait_timer_(task_execution_service),
+    const std::vector<ConcurrencyGroup> &concurrency_groups)
+    : wait_timer_(task_execution_service),
       main_thread_id_(std::this_thread::get_id()),
       waiter_(waiter),
       task_event_buffer_(task_event_buffer),

--- a/src/ray/core_worker/transport/actor_scheduling_queue.h
+++ b/src/ray/core_worker/transport/actor_scheduling_queue.h
@@ -38,9 +38,6 @@
 namespace ray {
 namespace core {
 
-/// The max time to wait for out-of-order tasks.
-const int kMaxReorderWaitSeconds = 30;
-
 /// Used to ensure serial order of task execution per actor handle.
 /// See direct_actor.proto for a description of the ordering protocol.
 class ActorSchedulingQueue : public SchedulingQueue {
@@ -53,8 +50,7 @@ class ActorSchedulingQueue : public SchedulingQueue {
       std::shared_ptr<ConcurrencyGroupManager<FiberState>> fiber_state_manager,
       bool is_asyncio,
       int fiber_max_concurrency,
-      const std::vector<ConcurrencyGroup> &concurrency_groups,
-      int64_t reorder_wait_seconds = kMaxReorderWaitSeconds);
+      const std::vector<ConcurrencyGroup> &concurrency_groups);
 
   void Stop() override;
 
@@ -90,7 +86,8 @@ class ActorSchedulingQueue : public SchedulingQueue {
   /// Called when we time out waiting for an earlier task to show up.
   void OnSequencingWaitTimeout();
   /// Max time in seconds to wait for dependencies to show up.
-  const int64_t reorder_wait_seconds_ = 0;
+  const int64_t reorder_wait_seconds_ =
+      RayConfig::instance().actor_scheduling_queue_max_reorder_wait_seconds();
   /// Sorted map of (accept, rej) task callbacks keyed by their sequence number.
   std::map<int64_t, InboundRequest> pending_actor_tasks_;
   /// The next sequence number we are waiting for to arrive.

--- a/src/ray/core_worker/transport/actor_scheduling_queue.h
+++ b/src/ray/core_worker/transport/actor_scheduling_queue.h
@@ -87,7 +87,7 @@ class ActorSchedulingQueue : public SchedulingQueue {
   void OnSequencingWaitTimeout();
   /// Max time in seconds to wait for dependencies to show up.
   const int64_t reorder_wait_seconds_ =
-      RayConfig::instance().actor_scheduling_queue_max_reorder_wait_seconds();
+      ::RayConfig::instance().actor_scheduling_queue_max_reorder_wait_seconds();
   /// Sorted map of (accept, rej) task callbacks keyed by their sequence number.
   std::map<int64_t, InboundRequest> pending_actor_tasks_;
   /// The next sequence number we are waiting for to arrive.

--- a/src/ray/core_worker/transport/task_receiver.cc
+++ b/src/ray/core_worker/transport/task_receiver.cc
@@ -35,6 +35,7 @@ void TaskReceiver::Init(std::shared_ptr<rpc::CoreWorkerClientPool> client_pool,
 void TaskReceiver::HandleTask(rpc::PushTaskRequest request,
                               rpc::PushTaskReply *reply,
                               rpc::SendReplyCallback send_reply_callback) {
+  RAY_LOG(INFO) << "HandleTask";
   RAY_CHECK(waiter_ != nullptr) << "Must call init() prior to use";
   TaskSpecification task_spec(std::move(*request.mutable_task_spec()));
 

--- a/src/ray/core_worker/transport/task_receiver.cc
+++ b/src/ray/core_worker/transport/task_receiver.cc
@@ -35,7 +35,6 @@ void TaskReceiver::Init(std::shared_ptr<rpc::CoreWorkerClientPool> client_pool,
 void TaskReceiver::HandleTask(rpc::PushTaskRequest request,
                               rpc::PushTaskReply *reply,
                               rpc::SendReplyCallback send_reply_callback) {
-  RAY_LOG(INFO) << "HandleTask";
   RAY_CHECK(waiter_ != nullptr) << "Must call init() prior to use";
   TaskSpecification task_spec(std::move(*request.mutable_task_spec()));
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The main bottleneck in `task_receiver_test.cc` is an out-of-order task waiting for previous tasks to complete and eventually timing out. The default timeout is 30 seconds. This PR makes it configurable and sets it to 1 second instead, significantly speeding up the test.

Before: 30001 ms
<img width="944" alt="Screenshot 2025-05-16 at 1 50 42 PM" src="https://github.com/user-attachments/assets/c58ee07b-b54f-45cf-8e02-ae2f1d9eb468" />

After: 1006 ms
<img width="950" alt="image" src="https://github.com/user-attachments/assets/4d5071c0-eef3-4b7c-93f1-31958f4382af" />


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
