### PR TITLE
[Serve] Refactor multiplex logics into `MultiplexScheduleMixin`

### DIFF
--- a/python/ray/serve/_private/replica_scheduler/common.py
+++ b/python/ray/serve/_private/replica_scheduler/common.py
@@ -13,6 +13,16 @@ from ray.serve._private.constants import (
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
 
+@dataclass()
+class RequestSchedulingContext:
+    multiplexed_start_matching_time: Optional[float] = None
+    tried_fewest_multiplexed_models: bool = False
+    tried_first_multiplexed_models: bool = False
+    tried_same_node: bool = False
+    tried_same_az: bool = False
+    should_backoff: bool = False
+
+
 @dataclass
 class PendingRequest:
     args: List[Any]
@@ -20,6 +30,9 @@ class PendingRequest:
     metadata: RequestMetadata
     created_at: float = field(default_factory=time.time)
     future: asyncio.Future = field(default_factory=lambda: asyncio.Future())
+    scheduling_context: RequestSchedulingContext = field(
+        default_factory=RequestSchedulingContext
+    )
 
     def reset_future(self):
         """Reset the `asyncio.Future`, must be called if this request is re-used."""

--- a/python/ray/serve/_private/replica_scheduler/pow_2_scheduler.py
+++ b/python/ray/serve/_private/replica_scheduler/pow_2_scheduler.py
@@ -1,30 +1,29 @@
-import asyncio
 import logging
 import random
-import time
 from typing import (
-    AsyncGenerator,
     List,
     Optional,
 )
 
-from ray.serve._private.common import (
-    RequestMetadata,
-    RunningReplicaInfo,
-)
 from ray.serve._private.constants import (
-    RAY_SERVE_MULTIPLEXED_MODEL_ID_MATCHING_TIMEOUT_S,
     SERVE_LOGGER_NAME,
+)
+from ray.serve._private.replica_scheduler.common import (
+    PendingRequest,
 )
 from ray.serve._private.replica_scheduler.replica_scheduler import (
     LocalityScope,
+    MultiplexScheduleMixin,
     ReplicaScheduler,
+)
+from ray.serve._private.replica_scheduler.replica_wrapper import (
+    RunningReplica,
 )
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
 
-class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
+class PowerOfTwoChoicesReplicaScheduler(MultiplexScheduleMixin, ReplicaScheduler):
     """Chooses a replica for each request using the "power of two choices" procedure.
 
     Requests are scheduled in FIFO order.
@@ -47,169 +46,65 @@ class PowerOfTwoChoicesReplicaScheduler(ReplicaScheduler):
     capped at (2 * num_replicas).
     """
 
-    async def choose_replicas_with_backoff(
+    async def choose_replicas(
         self,
-        request_metadata: Optional[RequestMetadata] = None,
-    ) -> AsyncGenerator[List[RunningReplicaInfo], None]:
-        """Generator that repeatedly chooses (at most) two random available replicas.
-
-        In the first iteration, only replicas colocated on the same node as this router
-        will be considered. If those are occupied, the full set of replicas will be
-        considered on subsequent iterations.
-
+        replicas_ranks: List[List[RunningReplica]],
+        pending_request: Optional[PendingRequest] = None,
+    ) -> List[List[RunningReplica]]:
+        """One iteration of the power of two choices procedure that chooses
+         (at most) two random available replicas.
         For multiplexing, this will first attempt to choose replicas that have the
         requested model ID for a configured timeout. If no replicas with the matching
         model ID are available after that timeout, it will fall back to the regular
         procedure.
-
-        After each iteration, there will be an increasing backoff sleep time (dictated
-        by `self.backoff_sequence_s`). The caller should exit the generator to reset the
-        backoff sleep time.
         """
-
-        try:
-            backoff_index = 0
-            entered_backoff = False
-
-            tried_same_az = False
-            tried_same_node = False
-
-            multiplexed_start_matching_time = None
-            multiplexed_matching_timeout = random.uniform(
-                RAY_SERVE_MULTIPLEXED_MODEL_ID_MATCHING_TIMEOUT_S,
-                RAY_SERVE_MULTIPLEXED_MODEL_ID_MATCHING_TIMEOUT_S * 2,
+        if (
+            pending_request is not None
+            and pending_request.metadata.multiplexed_model_id
+        ):
+            # Get candidates for multiplexed model ID.
+            candidate_replica_ids = self.apply_multiplex_scheduling(
+                pending_request=pending_request,
             )
-            tried_fewest_multiplexed_models = False
-            tried_first_multiplexed_models = False
+        elif (
+            pending_request is not None
+            and self._prefer_local_node_routing
+            and not pending_request.scheduling_context.tried_same_node
+            and len(self._colocated_replica_ids[LocalityScope.NODE]) > 0
+        ):
+            # Attempt to schedule requests to replicas on the
+            # same node at most once
+            candidate_replica_ids = self._colocated_replica_ids[LocalityScope.NODE]
+            pending_request.scheduling_context.tried_same_node = True
+            pending_request.scheduling_context.should_backoff = False
+        elif (
+            pending_request is not None
+            and self._prefer_local_az_routing
+            and not pending_request.scheduling_context.tried_same_az
+            and len(self._colocated_replica_ids[LocalityScope.AVAILABILITY_ZONE]) > 0
+        ):
+            # Attempt to schedule requests to replicas in the same
+            # AZ at most once
+            candidate_replica_ids = self._colocated_replica_ids[
+                LocalityScope.AVAILABILITY_ZONE
+            ]
+            pending_request.scheduling_context.tried_same_az = True
+            pending_request.scheduling_context.should_backoff = False
+        else:
+            # On subsequent iterations or when there are no replicas on the same
+            # node or AZ, consider all available replicas.
+            candidate_replica_ids = self._replica_id_set
+            if pending_request is not None:
+                pending_request.scheduling_context.should_backoff = True
 
-            while True:
-                # If no replicas are available, wait until `update_replicas` is called.
-                while len(self._replicas) == 0:
-                    logger.info(
-                        "No replicas are currently available for "
-                        f"{self._deployment_id}.",
-                        extra={"log_to_stderr": False},
-                    )
-                    self._replicas_updated_event.clear()
-                    await self._replicas_updated_event.wait()
-                    logger.info(
-                        f"New replicas are available for {self._deployment_id}, "
-                        "attempting to schedule queued requests.",
-                        extra={"log_to_stderr": False},
-                    )
+        if not candidate_replica_ids:
+            return []
 
-                if multiplexed_start_matching_time is None:
-                    multiplexed_start_matching_time = time.time()
-
-                candidate_replica_ids = None
-                if (
-                    request_metadata is not None
-                    and request_metadata.multiplexed_model_id
-                ):
-                    # Get candidates for multiplexed model ID.
-                    if (
-                        time.time() - multiplexed_start_matching_time
-                        < multiplexed_matching_timeout
-                    ):
-                        candidate_replica_ids = (
-                            self._multiplexed_model_id_to_replica_ids.get(
-                                request_metadata.multiplexed_model_id, None
-                            )
-                        )
-                        if (
-                            not candidate_replica_ids
-                            and request_metadata.multiplexed_model_id
-                            not in self._multiplexed_model_id_fallback_match
-                        ) or tried_first_multiplexed_models:
-                            # When there is no match for a multiplexed model id
-                            # or when the replica(s) with the matching model id is busy,
-                            # first try to fall back to replicas with the fewest models.
-                            candidate_replica_ids = (
-                                self._get_replica_ids_with_fewest_multiplexed_models()
-                            )
-                            self._multiplexed_model_id_fallback_match.add(
-                                request_metadata.multiplexed_model_id
-                            )
-                        elif candidate_replica_ids:
-                            self._multiplexed_model_id_fallback_match.discard(
-                                request_metadata.multiplexed_model_id
-                            )
-                        tried_first_multiplexed_models = True
-                    elif not tried_fewest_multiplexed_models:
-                        # After the `multiplexed_matching_timeout` is up, first try
-                        # routing to replicas that have the fewest models loaded.
-                        # We only try this once to avoid deterministically retrying on
-                        # the same replicas repeatedly.
-                        candidate_replica_ids = (
-                            self._get_replica_ids_with_fewest_multiplexed_models()
-                        )
-                        tried_fewest_multiplexed_models = True
-                    else:
-                        # If the timeout is up and we've already tried the candidates
-                        # with the fewest models loaded, fall back to all replicas.
-                        candidate_replica_ids = self._replica_id_set
-                    should_backoff = True
-                elif (
-                    self._prefer_local_node_routing
-                    and not tried_same_node
-                    and len(self._colocated_replica_ids[LocalityScope.NODE]) > 0
-                ):
-                    # Attempt to schedule requests to replicas on the
-                    # same node at most once
-                    candidate_replica_ids = self._colocated_replica_ids[
-                        LocalityScope.NODE
-                    ]
-                    tried_same_node = True
-                    should_backoff = False
-                elif (
-                    self._prefer_local_az_routing
-                    and not tried_same_az
-                    and len(
-                        self._colocated_replica_ids[LocalityScope.AVAILABILITY_ZONE]
-                    )
-                    > 0
-                ):
-                    # Attempt to schedule requests to replicas in the same
-                    # AZ at most once
-                    candidate_replica_ids = self._colocated_replica_ids[
-                        LocalityScope.AVAILABILITY_ZONE
-                    ]
-                    tried_same_az = True
-                    should_backoff = False
-                else:
-                    # On subsequent iterations or when there are no replicas on the same
-                    # node or AZ, consider all available replicas.
-                    candidate_replica_ids = self._replica_id_set
-                    should_backoff = True
-
-                if candidate_replica_ids:
-                    chosen_ids = random.sample(
-                        list(candidate_replica_ids),
-                        k=min(2, len(candidate_replica_ids)),
-                    )
-                    yield [self._replicas[chosen_id] for chosen_id in chosen_ids]
-
-                # We have a slight unintended behavior when enabled locality routing
-                # for both node and AZ. The intention is to try same node first,
-                # then try same AZ if node fails, then try everything else until a
-                # replica is found. These sequence should only help to reduce the
-                # latency of the request. No backoff and sleep should be applied, until
-                # we have fall into the case trying on all available replicas.
-                if not should_backoff:
-                    continue
-
-                if not entered_backoff:
-                    entered_backoff = True
-                    self.num_scheduling_tasks_in_backoff += 1
-                    self.num_scheduling_tasks_in_backoff_gauge.set(
-                        self.num_scheduling_tasks_in_backoff
-                    )
-
-                await asyncio.sleep(self.backoff_sequence_s[backoff_index])
-                backoff_index = min(backoff_index + 1, len(self.backoff_sequence_s) - 1)
-        finally:
-            if entered_backoff:
-                self.num_scheduling_tasks_in_backoff -= 1
-                self.num_scheduling_tasks_in_backoff_gauge.set(
-                    self.num_scheduling_tasks_in_backoff
-                )
+        chosen_ids = random.sample(
+            list(candidate_replica_ids),
+            k=min(2, len(candidate_replica_ids)),
+        )
+        replica_id_to_replica_map = {
+            replica.replica_id: replica for replica in replicas_ranks[0]
+        }
+        return [[replica_id_to_replica_map[chosen_id] for chosen_id in chosen_ids]]

--- a/python/ray/serve/_private/replica_scheduler/replica_scheduler.py
+++ b/python/ray/serve/_private/replica_scheduler/replica_scheduler.py
@@ -842,8 +842,10 @@ class ReplicaScheduler(ABC):
         replicas_ranks: List[List[RunningReplica]],
         pending_request: Optional[PendingRequest] = None,
     ) -> List[List[RunningReplica]]:
-        """One iteration of choosing available replicas.
-        This is the main function each custom scheduler should implement to
-        decide which replica to send the request.
+        """Chooses a subset of candidate replicas from available replicas.
+
+        This is the main function each replica scheduler should implement to
+        decide which replica to send the request to. This is one iteration of
+        replica selection.
         """
         pass

--- a/python/ray/serve/_private/replica_scheduler/replica_scheduler.py
+++ b/python/ray/serve/_private/replica_scheduler/replica_scheduler.py
@@ -51,6 +51,7 @@ class LocalityScope(str, enum.Enum):
 
 class MultiplexScheduleMixin:
     """Mixin for multiplex scheduling.
+
     This mixin is used to schedule requests to replicas that are multiplexed.
     It adds necessary attributes and methods to keep track of multiplexed
     model IDs and offer the helpers to apply multiplex scheduling and rank

--- a/python/ray/serve/_private/replica_scheduler/replica_scheduler.py
+++ b/python/ray/serve/_private/replica_scheduler/replica_scheduler.py
@@ -75,7 +75,8 @@ class MultiplexScheduleMixin:
         self, replicas: List[RunningReplica]
     ):
         """Update the multiplexed model IDs based on the replicas.
-        This is called when the replicas are updated.
+
+        This should be called when the replicas are updated.
         """
         new_multiplexed_model_id_to_replica_ids = defaultdict(set)
 

--- a/python/ray/serve/_private/replica_scheduler/replica_scheduler.py
+++ b/python/ray/serve/_private/replica_scheduler/replica_scheduler.py
@@ -2,8 +2,9 @@ import asyncio
 import enum
 import logging
 import math
+import random
 import time
-from abc import ABC
+from abc import ABC, abstractmethod
 from collections import defaultdict, deque
 from typing import (
     AsyncGenerator,
@@ -29,6 +30,7 @@ from ray.serve._private.common import (
 )
 from ray.serve._private.constants import (
     RAY_SERVE_MAX_QUEUE_LENGTH_RESPONSE_DEADLINE_S,
+    RAY_SERVE_MULTIPLEXED_MODEL_ID_MATCHING_TIMEOUT_S,
     RAY_SERVE_QUEUE_LENGTH_RESPONSE_DEADLINE_S,
     SERVE_LOGGER_NAME,
 )
@@ -45,6 +47,126 @@ logger = logging.getLogger(SERVE_LOGGER_NAME)
 class LocalityScope(str, enum.Enum):
     NODE = "NODE"
     AVAILABILITY_ZONE = "AVAILABILITY_ZONE"
+
+
+class MultiplexScheduleMixin:
+    """Mixin for multiplex scheduling.
+    This mixin is used to schedule requests to replicas that are multiplexed.
+    It adds necessary attributes and methods to keep track of multiplexed
+    model IDs and offer the helpers to apply multiplex scheduling and rank
+    replicas based on multiplexed model IDs.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._multiplexed_model_id_to_replica_ids: DefaultDict[
+            str, Set[ReplicaID]
+        ] = defaultdict(set)
+
+        # When there is no match for a multiplexed model id, we will try to fall back
+        # to all replicas immediately. This set is used to make sure we only fall back
+        # once for concurrent requests for the same model id.
+        # Whenever there is a match, we will remove the model id from this set.
+        self._multiplexed_model_id_fallback_match: Set[str] = set()
+        self._replica_id_set: Set[ReplicaID] = set()
+        self._replicas: Dict[ReplicaID, RunningReplica] = {}
+
+    def update_multiplexed_model_ids_with_replicas(
+        self, replicas: List[RunningReplica]
+    ):
+        """Update the multiplexed model IDs based on the replicas.
+        This is called when the replicas are updated.
+        """
+        new_multiplexed_model_id_to_replica_ids = defaultdict(set)
+
+        for r in replicas:
+            for model_id in r.multiplexed_model_ids:
+                new_multiplexed_model_id_to_replica_ids[model_id].add(r.replica_id)
+
+        self._multiplexed_model_id_to_replica_ids = (
+            new_multiplexed_model_id_to_replica_ids
+        )
+
+    def _get_replica_ids_with_fewest_multiplexed_models(self) -> Set[str]:
+        """Get the set of replicas that have the fewest multiplexed models loaded."""
+        candidates = set()
+        sorted_replicas = sorted(
+            self._replicas.values(), key=lambda x: len(x.multiplexed_model_ids)
+        )
+        least_num_multiplexed_model_ids = math.inf
+        for replica in sorted_replicas:
+            if len(replica.multiplexed_model_ids) <= least_num_multiplexed_model_ids:
+                candidates.add(replica.replica_id)
+                least_num_multiplexed_model_ids = len(replica.multiplexed_model_ids)
+            else:
+                break
+
+        return candidates
+
+    @property
+    def multiplexed_matching_timeout(self) -> float:
+        return random.uniform(
+            RAY_SERVE_MULTIPLEXED_MODEL_ID_MATCHING_TIMEOUT_S,
+            RAY_SERVE_MULTIPLEXED_MODEL_ID_MATCHING_TIMEOUT_S * 2,
+        )
+
+    def apply_multiplex_scheduling(
+        self,
+        pending_request: Optional[PendingRequest] = None,
+    ) -> Set[ReplicaID]:
+        """Apply multiplex scheduling to the pending request.
+        When the request is None, return all replicas.
+        """
+        if not pending_request:
+            return self._replica_id_set
+
+        if not pending_request.scheduling_context.multiplexed_start_matching_time:
+            pending_request.scheduling_context.multiplexed_start_matching_time = (
+                time.time()
+            )
+
+        multiplexed_start_matching_time = (
+            pending_request.scheduling_context.multiplexed_start_matching_time
+        )
+        multiplexed_model_id = pending_request.metadata.multiplexed_model_id
+        if (
+            time.time() - multiplexed_start_matching_time
+            < self.multiplexed_matching_timeout
+        ):
+            candidate_replica_ids = self._multiplexed_model_id_to_replica_ids.get(
+                multiplexed_model_id, None
+            )
+            if (
+                not candidate_replica_ids
+                and multiplexed_model_id
+                not in self._multiplexed_model_id_fallback_match
+            ) or pending_request.scheduling_context.tried_first_multiplexed_models:
+                # When there is no match for a multiplexed model id
+                # or when the replica(s) with the matching model id is busy,
+                # first try to fall back to replicas with the fewest models.
+                candidate_replica_ids = (
+                    self._get_replica_ids_with_fewest_multiplexed_models()
+                )
+                self._multiplexed_model_id_fallback_match.add(multiplexed_model_id)
+            elif candidate_replica_ids:
+                self._multiplexed_model_id_fallback_match.discard(multiplexed_model_id)
+            pending_request.scheduling_context.tried_first_multiplexed_models = True
+        elif not pending_request.scheduling_context.tried_fewest_multiplexed_models:
+            # After the `multiplexed_matching_timeout` is up, first try
+            # routing to replicas that have the fewest models loaded.
+            # We only try this once to avoid deterministically retrying on
+            # the same replicas repeatedly.
+            candidate_replica_ids = (
+                self._get_replica_ids_with_fewest_multiplexed_models()
+            )
+            pending_request.scheduling_context.tried_fewest_multiplexed_models = True
+        else:
+            # If the timeout is up, and we've already tried the candidates
+            # with the fewest models loaded, fall back to all replicas.
+            candidate_replica_ids = self._replica_id_set
+
+        pending_request.scheduling_context.should_backoff = True
+        return candidate_replica_ids
 
 
 class ReplicaScheduler(ABC):
@@ -112,15 +234,6 @@ class ReplicaScheduler(ABC):
         self._colocated_replica_ids: DefaultDict[
             LocalityScope, Set[ReplicaID]
         ] = defaultdict(set)
-        self._multiplexed_model_id_to_replica_ids: DefaultDict[
-            str, Set[ReplicaID]
-        ] = defaultdict(set)
-
-        # When there is no match for a multiplexed model id, we will try to fallback
-        # to all replicas immediately. This set is used to make sure we only fallback
-        # once for concurrent requests for the same model id.
-        # Whenever there is a match, we will remove the model id from this set.
-        self._multiplexed_model_id_fallback_match: Set[str] = set()
 
         # Tasks running the scheduling loop. The size of this set may vary over time
         # as new tasks will be scheduled when a request comes in or new replicas are
@@ -259,7 +372,8 @@ class ReplicaScheduler(ABC):
         new_replicas = {}
         new_replica_id_set = set()
         new_colocated_replica_ids = defaultdict(set)
-        new_multiplexed_model_id_to_replica_ids = defaultdict(set)
+        if hasattr(self, "update_multiplexed_model_ids_with_replicas"):
+            self.update_multiplexed_model_ids_with_replicas(replicas)
 
         for r in replicas:
             # If on the proxy, replica needs to call back into the proxy with
@@ -282,8 +396,6 @@ class ReplicaScheduler(ABC):
                 new_colocated_replica_ids[LocalityScope.AVAILABILITY_ZONE].add(
                     r.replica_id
                 )
-            for model_id in r.multiplexed_model_ids:
-                new_multiplexed_model_id_to_replica_ids[model_id].add(r.replica_id)
 
         if self._replica_id_set != new_replica_id_set:
             replica_id_set_strs = {r.unique_id for r in new_replica_id_set}
@@ -300,9 +412,6 @@ class ReplicaScheduler(ABC):
         self._replicas = new_replicas
         self._replica_id_set = new_replica_id_set
         self._colocated_replica_ids = new_colocated_replica_ids
-        self._multiplexed_model_id_to_replica_ids = (
-            new_multiplexed_model_id_to_replica_ids
-        )
         self._replica_queue_len_cache.remove_inactive_replicas(
             active_replica_ids=new_replica_id_set
         )
@@ -310,22 +419,6 @@ class ReplicaScheduler(ABC):
         self._event_loop.create_task(self._probe_queue_lens(replicas_to_ping, 0))
         self._replicas_updated_event.set()
         self.maybe_start_scheduling_tasks()
-
-    def _get_replica_ids_with_fewest_multiplexed_models(self) -> Set[str]:
-        """Get the set of replicas that have the fewest multiplexed models loaded."""
-        candidates = set()
-        sorted_replicas = sorted(
-            self._replicas.values(), key=lambda x: len(x.multiplexed_model_ids)
-        )
-        least_num_multiplexed_model_ids = math.inf
-        for replica in sorted_replicas:
-            if len(replica.multiplexed_model_ids) <= least_num_multiplexed_model_ids:
-                candidates.add(replica.replica_id)
-                least_num_multiplexed_model_ids = len(replica.multiplexed_model_ids)
-            else:
-                break
-
-        return candidates
 
     async def _probe_queue_lens(
         self,
@@ -345,7 +438,7 @@ class ReplicaScheduler(ABC):
         This method also updates the local cache of replica queue lengths according to
         the responses.
         """
-        result: List[Tuple[RunningReplica, int]] = []
+        result: List[Tuple[RunningReplica, Optional[int]]] = []
         if len(replicas) == 0:
             return result
 
@@ -533,15 +626,83 @@ class ReplicaScheduler(ABC):
                 pr.future.set_result(replica)
                 break
 
-    def _get_next_pending_request_metadata_to_schedule(
+    def _get_next_pending_request_to_schedule(
         self,
-    ) -> Optional[RequestMetadata]:
+    ) -> Optional[PendingRequest]:
         while len(self._pending_requests_to_schedule) > 0:
             pr = self._pending_requests_to_schedule.popleft()
             if not pr.future.done():
-                return pr.metadata
+                return pr
 
         return None
+
+    async def choose_replicas_with_backoff(
+        self,
+        pending_request: Optional[PendingRequest] = None,
+    ) -> AsyncGenerator[List[RunningReplica], None]:
+        """Generator that repeatedly chooses available replicas.
+        In the first iteration, only replicas colocated on the same node as this router
+        will be considered. If those are occupied, the full set of replicas will be
+        considered on subsequent iterations.
+        After each iteration, there will be an increasing backoff sleep time (dictated
+        by `self.backoff_sequence_s`). The caller should exit the generator to reset the
+        backoff sleep time.
+        """
+        entered_backoff = False
+        try:
+            backoff_index = 0
+
+            while True:
+                # If no replicas are available, wait until `update_replicas` is called.
+                while len(self._replicas) == 0:
+                    logger.info(
+                        "No replicas are currently available for "
+                        f"{self._deployment_id}.",
+                        extra={"log_to_stderr": False},
+                    )
+                    self._replicas_updated_event.clear()
+                    await self._replicas_updated_event.wait()
+                    logger.info(
+                        f"New replicas are available for {self._deployment_id}, "
+                        "attempting to schedule queued requests.",
+                        extra={"log_to_stderr": False},
+                    )
+
+                replica_ranks = [list(self._replicas.values())]
+                chosen_replicas: List[
+                    List[RunningReplica]
+                ] = await self.choose_replicas(
+                    replicas_ranks=replica_ranks,
+                    pending_request=pending_request,
+                )
+                for replicas in chosen_replicas:
+                    if replicas:
+                        yield replicas
+
+                # We have a slight unintended behavior when enabled locality routing
+                # for both node and AZ. The intention is to try same node first,
+                # then try same AZ if node fails, then try everything else until a
+                # replica is found. These sequence should only help to reduce the
+                # latency of the request. No backoff and sleep should be applied, until
+                # we have fall into the case trying on all available replicas.
+                if not pending_request.scheduling_context.should_backoff:
+                    continue
+
+                if not entered_backoff:
+                    entered_backoff = True
+                    self.num_scheduling_tasks_in_backoff += 1
+                    self.num_scheduling_tasks_in_backoff_gauge.set(
+                        self.num_scheduling_tasks_in_backoff
+                    )
+
+                await asyncio.sleep(self.backoff_sequence_s[backoff_index])
+                backoff_index = min(backoff_index + 1, len(self.backoff_sequence_s) - 1)
+        finally:
+            if entered_backoff:
+                self.num_scheduling_tasks_in_backoff -= 1
+                self.num_scheduling_tasks_in_backoff_gauge.set(
+                    self.num_scheduling_tasks_in_backoff
+                )
 
     async def fulfill_pending_requests(self):
         """Repeatedly tries to fulfill a pending request with an available replica.
@@ -556,9 +717,10 @@ class ReplicaScheduler(ABC):
             while len(self._scheduling_tasks) <= self.target_num_scheduling_tasks:
                 start_time = time.time()
                 backoff_index = 0
-                request_metadata = self._get_next_pending_request_metadata_to_schedule()
+                pending_request = self._get_next_pending_request_to_schedule()
+                request_metadata = pending_request.metadata if pending_request else None
                 async for candidates in self.choose_replicas_with_backoff(
-                    request_metadata
+                    pending_request
                 ):
                     # Clear out pending requests at the front of the
                     # queue that have been cancelled, then reevaluate
@@ -632,9 +794,6 @@ class ReplicaScheduler(ABC):
         By default, requests are scheduled in FIFO order, so this places a future on the
         back of an internal queue that will be popped when a replica is available.
 
-        If `emplace_front` is passed, the request will be placed at the front of the
-        queue.
-
         Upon cancellation (by the caller), the future is cancelled and will be passed
         over when a replica becomes available.
         """
@@ -677,8 +836,14 @@ class ReplicaScheduler(ABC):
             [self.create_replica_wrapper(r) for r in running_replicas]
         )
 
-    async def choose_replicas_with_backoff(
+    @abstractmethod
+    async def choose_replicas(
         self,
-        request_metadata: Optional[RequestMetadata] = None,
-    ) -> AsyncGenerator[List[RunningReplicaInfo], None]:
+        replicas_ranks: List[List[RunningReplica]],
+        pending_request: Optional[PendingRequest] = None,
+    ) -> List[List[RunningReplica]]:
+        """One iteration of choosing available replicas.
+        This is the main function each custom scheduler should implement to
+        decide which replica to send the request.
+        """
         pass

--- a/python/ray/serve/_private/replica_scheduler/replica_scheduler.py
+++ b/python/ray/serve/_private/replica_scheduler/replica_scheduler.py
@@ -864,5 +864,17 @@ class ReplicaScheduler(ABC):
         This is the main function each replica scheduler should implement to
         decide which replica to send the request to. This is one iteration of
         replica selection.
+
+        Args:
+            replicas_ranks: A list of lists of replicas, where each inner list
+                represents a rank of replicas. The first rank is the most
+                preferred and the last rank is the least preferred.
+            pending_request: The request to be scheduled. This is used to
+                determine which replicas are eligible for scheduling.
+
+        Returns:
+            A list of lists of replicas, where each inner list represents a
+            rank of replicas. The first rank is the most preferred and the last
+            rank is the least preferred.
         """
         pass

--- a/python/ray/serve/_private/replica_scheduler/replica_scheduler.py
+++ b/python/ray/serve/_private/replica_scheduler/replica_scheduler.py
@@ -117,7 +117,20 @@ class MultiplexScheduleMixin:
         pending_request: Optional[PendingRequest] = None,
     ) -> Set[ReplicaID]:
         """Apply multiplex scheduling to the pending request.
-        When the request is None, return all replicas.
+
+        When the request is None, return all replicas. Each call will try to
+        schedule the request to the replicas that have the multiplexed model ID
+        to the hierarchy of first the replicas with the multiplexed model ID,
+        then the replicas with the fewest multiplexed models, and finally all
+        replicas.
+
+        Args:
+            pending_request: The pending request to be scheduled based on
+                multiplexed model policy.
+
+        Returns:
+            A set of replica IDs that are candidates for the existing
+            scheduling call.
         """
         if not pending_request:
             return self._replica_id_set

--- a/python/ray/serve/_private/replica_scheduler/replica_scheduler.py
+++ b/python/ray/serve/_private/replica_scheduler/replica_scheduler.py
@@ -218,6 +218,8 @@ class ReplicaScheduler(ABC):
         create_replica_wrapper_func: Optional[
             Callable[[RunningReplicaInfo], RunningReplica]
         ] = None,
+        *args,
+        **kwargs,
     ):
         self._deployment_id = deployment_id
         self._handle_source = handle_source

--- a/python/ray/serve/tests/unit/test_pow_2_replica_scheduler.py
+++ b/python/ray/serve/tests/unit/test_pow_2_replica_scheduler.py
@@ -164,7 +164,7 @@ def pow_2_scheduler(request) -> PowerOfTwoChoicesReplicaScheduler:
     # to 0.01s to speed up the test.
     os.environ.update({"RAY_SERVE_MULTIPLEXED_MODEL_ID_MATCHING_TIMEOUT_S": "0.01"})
     importlib.reload(ray.serve._private.constants)
-    importlib.reload(ray.serve._private.replica_scheduler.pow_2_scheduler)
+    importlib.reload(ray.serve._private.replica_scheduler.replica_scheduler)
 
     # Reset mock timer to avoid state leakage.
     TIMER.reset()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Refactor multiplex logics into `MultiplexScheduleMixin` and apply to `PowerOfTwoChoicesReplicaScheduler`

## Related issue number

Closes https://anyscale1.atlassian.net/browse/LLM-1902?atlOrigin=eyJpIjoiMmY4YzUyYjNlNDZlNDA5ZTk3MmE5YzRjYWY0ZDJlNzIiLCJwIjoiaiJ9

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
