### PR TITLE
[serve.llm] fix: update check_health return type

### DIFF
--- a/python/ray/llm/_internal/serve/deployments/llm/llm_engine.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/llm_engine.py
@@ -42,9 +42,11 @@ class LLMEngine(abc.ABC):
         """Generate an LLMRawResponse stream based on the GenerationRequest"""
         pass
 
-    async def check_health(self) -> bool:
-        """Check the health of the engine"""
-        return True
+    async def check_health(self) -> None:
+        """Check the health of the replica. Does not return anything. Raise error when
+        the engine is dead and needs to be restarted.
+        """
+        return
 
     ##############################################################
     # Optional methods

--- a/python/ray/llm/_internal/serve/deployments/llm/llm_server.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/llm_server.py
@@ -613,11 +613,11 @@ class LLMServer(_LLMServerBase):
         return self._process_llm_request(request, is_chat=False)
 
     async def check_health(self) -> None:
-        """Check the health of the replica. Does not return anything. Raise error when
-        the engine is dead and needs to be restarted."""
-        healthy = await self.engine.check_health()
-        if not healthy:
-            raise RuntimeError("Engine is not healthy. Please restart the engine.")
+        """
+        Check the health of the replica. Does not return anything. Raise error when
+        the engine is dead and needs to be restarted.
+        """
+        return await self.engine.check_health()
 
     async def embeddings(self, request: EmbeddingRequest) -> LLMEmbeddingsResponse:
         """Runs an embeddings request to the vllm engine, and return the response.

--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
@@ -794,9 +794,11 @@ class VLLMEngine(LLMEngine):
 
         return embedding_data, total_prompt_tokens
 
-    async def check_health(self) -> bool:
+    async def check_health(self) -> None:
         if not hasattr(self.engine, "check_health"):
-            return False
+            raise RuntimeError(
+                f"{type(self.engine)} does not support health check."
+            )
 
         try:
             return await asyncio.wait_for(self.engine.check_health(), timeout=15)

--- a/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py
@@ -796,9 +796,7 @@ class VLLMEngine(LLMEngine):
 
     async def check_health(self) -> None:
         if not hasattr(self.engine, "check_health"):
-            raise RuntimeError(
-                f"{type(self.engine)} does not support health check."
-            )
+            raise RuntimeError(f"{type(self.engine)} does not support health check.")
 
         try:
             return await asyncio.wait_for(self.engine.check_health(), timeout=15)

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
@@ -387,7 +387,7 @@ class TestLLMServer:
         server = await create_server(llm_config, engine_cls=MockVLLMEngine)
 
         # Mock the engine's check_health method
-        server.engine.check_health = AsyncMock(return_value=True)
+        server.engine.check_health = AsyncMock(return_value=None)
 
         # Perform the health check, no exceptions should be raised
         await server.check_health()

--- a/python/ray/llm/tests/serve/mocks/mock_vllm_engine.py
+++ b/python/ray/llm/tests/serve/mocks/mock_vllm_engine.py
@@ -124,8 +124,8 @@ class MockVLLMEngine(LLMEngine):
             yield llm_response
             await asyncio.sleep(generation_time)
 
-    async def check_health(self) -> bool:
-        return True
+    async def check_health(self) -> None:
+        return
 
     def stats(self) -> VLLMEngineStats:
         return self._stats.to_stats()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`_LLMServerBase`'s `check_health` returns None (#51064)
`vLLM`'s `check_health` returns None [code](https://github.com/vllm-project/vllm/blame/3e0d435027f7585afbbc8b44ca1e386c0a88ae47/vllm/v1/engine/async_llm.py#L470)

But some intermediate-level code returns boolean, this is inconsistent. #53099 has a bug: `is_healthy = ...check_heath()` where `is_healthy` is assigned `None`, and next line it checks `not is_healthy` and accidentally raise exception.

This PR changes all return type to None.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
