### PR TITLE
Revert "[core] Correctly release dynamic generator refs (#52843)"

### DIFF
--- a/python/ray/_private/object_ref_generator.py
+++ b/python/ray/_private/object_ref_generator.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 from ray.util.annotations import DeveloperAPI
-from typing import Iterator, Deque, TYPE_CHECKING
-import collections
+from typing import Iterator, List, TYPE_CHECKING
 
 if TYPE_CHECKING:
     import ray
@@ -9,15 +8,15 @@ if TYPE_CHECKING:
 
 @DeveloperAPI
 class DynamicObjectRefGenerator:
-    def __init__(self, refs: Deque["ray.ObjectRef"]):
+    def __init__(self, refs: List["ray.ObjectRef"]):
         # TODO(swang): As an optimization, can also store the generator
         # ObjectID so that we don't need to keep individual ref counts for the
         # inner ObjectRefs.
-        self._refs: Deque["ray.ObjectRef"] = collections.deque(refs)
+        self._refs: List["ray.ObjectRef"] = refs
 
     def __iter__(self) -> Iterator("ray.ObjectRef"):
-        while self._refs:
-            yield self._refs.popleft()
+        for ref in self._refs:
+            yield ref
 
     def __len__(self) -> int:
         return len(self._refs)

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -37,7 +37,6 @@ from typing import (
 
 import contextvars
 import concurrent.futures
-import collections
 
 from libc.stdint cimport (
     int32_t,
@@ -2061,7 +2060,7 @@ cdef void execute_task(
                             should_retry_exceptions)
 
                     task_exception = False
-                    dynamic_refs = collections.deque()
+                    dynamic_refs = []
                     for idx in range(dynamic_returns.size()):
                         dynamic_refs.append(ObjectRef(
                             dynamic_returns[0][idx].first.Binary(),

--- a/python/ray/tests/test_generators.py
+++ b/python/ray/tests/test_generators.py
@@ -35,7 +35,7 @@ def assert_no_leak():
     sys.platform != "linux" and sys.platform != "linux2",
     reason="This test requires Linux.",
 )
-def test_generator_oom(ray_start_regular_shared):
+def test_generator_oom(ray_start_regular):
     num_returns = 100
 
     @ray.remote(max_retries=0)
@@ -68,7 +68,7 @@ def test_generator_oom(ray_start_regular_shared):
 
 @pytest.mark.parametrize("use_actors", [False, True])
 @pytest.mark.parametrize("store_in_plasma", [False, True])
-def test_generator_returns(ray_start_regular_shared, use_actors, store_in_plasma):
+def test_generator_returns(ray_start_regular, use_actors, store_in_plasma):
     remote_generator_fn = None
     if use_actors:
 
@@ -143,7 +143,7 @@ def test_generator_returns(ray_start_regular_shared, use_actors, store_in_plasma
 @pytest.mark.parametrize("store_in_plasma", [False, True])
 @pytest.mark.parametrize("num_returns_type", ["dynamic", None])
 def test_generator_errors(
-    ray_start_regular_shared, use_actors, store_in_plasma, num_returns_type
+    ray_start_regular, use_actors, store_in_plasma, num_returns_type
 ):
     remote_generator_fn = None
     if use_actors:
@@ -197,7 +197,7 @@ def test_generator_errors(
 @pytest.mark.parametrize("store_in_plasma", [False, True])
 @pytest.mark.parametrize("num_returns_type", ["dynamic", None])
 def test_dynamic_generator_retry_exception(
-    ray_start_regular_shared, store_in_plasma, num_returns_type
+    ray_start_regular, store_in_plasma, num_returns_type
 ):
     class CustomException(Exception):
         pass
@@ -250,7 +250,7 @@ def test_dynamic_generator_retry_exception(
 @pytest.mark.parametrize("store_in_plasma", [False, True])
 @pytest.mark.parametrize("num_returns_type", ["dynamic", None])
 def test_dynamic_generator(
-    ray_start_regular_shared, use_actors, store_in_plasma, num_returns_type
+    ray_start_regular, use_actors, store_in_plasma, num_returns_type
 ):
     if not use_actors:
 
@@ -334,32 +334,6 @@ def test_dynamic_generator(
             gen = ray.get(static.remote(3))
             for ref in gen:
                 ray.get(ref)
-
-
-def test_dynamic_generator_gc_each_yield(ray_start_cluster):
-    # Need to shutdown when going from ray_start_regular_shared to ray_start_cluster
-    ray.shutdown()
-
-    num_returns = 5
-
-    @ray.remote(num_returns="dynamic")
-    def generator():
-        for i in range(num_returns):
-            yield np.ones((1000, 1000), dtype=np.uint8)
-
-    def check_ref_counts(expected):
-        ref_counts = (
-            ray._private.worker.global_worker.core_worker.get_all_reference_counts()
-        )
-        return len(ref_counts) == expected
-
-    dynamic_ref = ray.get(generator.remote())
-
-    for i, ref in enumerate(dynamic_ref):
-        gc.collect()
-        # assert references are released after each yield
-        wait_for_condition(lambda: check_ref_counts(num_returns - i))
-        ray.get(ref)
 
 
 @pytest.mark.parametrize("num_returns_type", ["dynamic", None])


### PR DESCRIPTION
This reverts commit 9c69a7a14d070178be19b8959b45c2b152955edc.

After this PR we have seen resource leakage in batch llm data pipelines. #53124 .
I bisected and found this PR to be the issue. Testing if reverting will fix the issue?

Release tests: 
https://buildkite.com/ray-project/release/builds/42092