### PR TITLE
[dashboard] Propagate response headers for proxy stream requests

### DIFF
--- a/python/ray/dashboard/subprocesses/handle.py
+++ b/python/ray/dashboard/subprocesses/handle.py
@@ -290,7 +290,10 @@ class SubprocessModuleHandle:
             data=body,
             headers=filter_hop_by_hop_headers(request.headers),
         ) as backend_resp:
-            proxy_resp = aiohttp.web.StreamResponse(status=backend_resp.status)
+            proxy_resp = aiohttp.web.StreamResponse(
+                status=backend_resp.status,
+                headers=filter_hop_by_hop_headers(backend_resp.headers),
+            )
             await proxy_resp.prepare(request)
 
             async for chunk, _ in backend_resp.content.iter_chunks():


### PR DESCRIPTION
## Summary

Response headers are being set on the streamed response, but they are not being propagated through the 2nd layer which is the proxy stream handler. This PR sets the headers of the response from the proxy to be the same as the headers of the module API call.

## Related Issues

Closes https://github.com/ray-project/ray/issues/53113
https://github.com/ray-project/ray/pull/53008