### PR TITLE
[ci] use the pinned pytest version when performing install-min test

### DIFF
--- a/ci/env/install-minimal.sh
+++ b/ci/env/install-minimal.sh
@@ -31,8 +31,7 @@ rm -rf "${WORKSPACE_DIR}/python/ray/thirdparty_files"
 eval "${WORKSPACE_DIR}/ci/ci.sh build"
 
 # Install test requirements
-python -m pip install -U \
-  pytest==7.0.1
+python -m pip install pytest -c "${WORKSPACE_DIR}/python/requirements_compiled.txt"
 
 # Train requirements.
 # TODO: make this dynamic


### PR DESCRIPTION
so that the pytest version is upgraded and synced with the lock file
