### PR TITLE
Revert "[core] Only check first task in scheduling class queue for fa…

### DIFF
--- a/src/ray/raylet/local_task_manager.cc
+++ b/src/ray/raylet/local_task_manager.cc
@@ -183,17 +183,17 @@ void LocalTaskManager::DispatchScheduledTasksToWorkers() {
     // Count the number of scheduling classes that require CPU and sum their total CPU
     // requests.
     size_t num_classes_with_cpu = 0;
-    for (const auto &[_, cur_dispatch_queue] : tasks_to_dispatch_) {
-      // Only need to check the first because all tasks with the same scheduling class
-      // have the same CPU resource requirements.
-      RAY_CHECK(!cur_dispatch_queue.empty());
-      const auto &work = cur_dispatch_queue.front();
-      const auto &task_spec = work->task.GetTaskSpecification();
-      auto cpu_request_ =
-          task_spec.GetRequiredResources().Get(scheduling::ResourceID::CPU()).Double();
-      if (cpu_request_ > 0) {
-        num_classes_with_cpu++;
-        total_cpu_requests_ += cur_dispatch_queue.size() * cpu_request_;
+    for (const auto &entry : tasks_to_dispatch_) {
+      const auto &cur_dispatch_queue = entry.second;
+      for (const auto &work : cur_dispatch_queue) {
+        const auto &task_spec = work->task.GetTaskSpecification();
+        auto cpu_request_ =
+            task_spec.GetRequiredResources().Get(scheduling::ResourceID::CPU()).Double();
+        if (cpu_request_ > 0) {
+          num_classes_with_cpu++;
+          total_cpu_requests_ += cur_dispatch_queue.size() * cpu_request_;
+          break;
+        }
       }
     }
     const auto &sched_cls_desc =

--- a/src/ray/raylet/local_task_manager.h
+++ b/src/ray/raylet/local_task_manager.h
@@ -321,7 +321,6 @@ class LocalTaskManager : public ILocalTaskManager {
   /// All tasks in this map that have dependencies should be registered with
   /// the dependency manager, in case a dependency gets evicted while the task
   /// is still queued.
-  /// Note that if a queue exists, it should be guaranteed to be non-empty.
   absl::flat_hash_map<SchedulingClass, std::deque<std::shared_ptr<internal::Work>>>
       tasks_to_dispatch_;
 
@@ -341,7 +340,6 @@ class LocalTaskManager : public ILocalTaskManager {
   /// in this queue may not match the order in which we initially received the
   /// tasks. This also means that the PullManager may request dependencies for
   /// these tasks in a different order than the waiting task queue.
-  /// Note that if a queue exists, it should be guaranteed to be non-empty.
   std::list<std::shared_ptr<internal::Work>> waiting_task_queue_;
 
   /// An index for the above queue.


### PR DESCRIPTION
…ir scheduling (#52478)"

This reverts commit 251a1315ed44b2aefd4ad85ca7314f85b234dea0.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
