### PR TITLE
[cgraph] Speed up `test_dag_error_handling.py`

### DIFF
--- a/python/ray/dag/tests/experimental/test_dag_error_handling.py
+++ b/python/ray/dag/tests/experimental/test_dag_error_handling.py
@@ -150,7 +150,14 @@ def test_dag_exception_multi_output(ray_start_regular, capsys):
     compiled_dag = dag.experimental_compile()
 
     # Verify that fetching each output individually raises the error.
-    # 3) Fetching each of the above subsequently raises the error again.
+    refs = compiled_dag.execute("hello")
+    for ref in refs:
+        with pytest.raises(TypeError) as exc_info:
+            ray.get(ref)
+        # Traceback should match the original actor class definition.
+        assert "self.i += x" in str(exc_info.value)
+
+    # Verify that another bad input exhibits the same behavior.
     refs = compiled_dag.execute("hello")
     for ref in refs:
         with pytest.raises(TypeError) as exc_info:

--- a/python/ray/dag/tests/experimental/test_dag_error_handling.py
+++ b/python/ray/dag/tests/experimental/test_dag_error_handling.py
@@ -306,6 +306,7 @@ def test_buffered_get_timeout(ray_start_regular, zero_teardown_timeout):
 
     compiled_dag.teardown(kill_actors=True)
 
+
 def test_get_with_zero_timeout(ray_start_regular):
     @ray.remote
     class Actor:

--- a/python/ray/dag/tests/experimental/test_dag_error_handling.py
+++ b/python/ray/dag/tests/experimental/test_dag_error_handling.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 import copy
 import logging
-import os
 import pickle
 import re
 import sys

--- a/python/ray/dag/tests/experimental/test_dag_error_handling.py
+++ b/python/ray/dag/tests/experimental/test_dag_error_handling.py
@@ -286,7 +286,7 @@ def test_get_timeout(ray_start_regular, zero_teardown_timeout):
     compiled_dag.teardown(kill_actors=True)
 
 
-def test_buffered_get_timeout(ray_start_regular):
+def test_buffered_get_timeout(ray_start_regular, zero_teardown_timeout):
     a = Actor.remote(0)
     with InputNode() as inp:
         dag = a.sleep.bind(inp)
@@ -304,6 +304,7 @@ def test_buffered_get_timeout(ray_start_regular):
         # other two that take 1s each, this should time out.
         ray.get(refs[-1], timeout=1)
 
+    compiled_dag.teardown(kill_actors=True)
 
 def test_get_with_zero_timeout(ray_start_regular):
     @ray.remote


### PR DESCRIPTION
- Remove parametrization for `single_fetch` (no significant implementation difference in the logic).
- Reduce timeouts for tests with `sleep` and set a teardown timeout of `0s` to avoid hanging after test.
- Reduce number of executions from `100` -> `10` for a few tests.
- Combine two of the double-compile tests into one.

Before:
```bash
===================== 31 passed in 130.73s (0:02:10) ======================
```

After:
```bash
====================== 25 passed in 91.79s (0:01:31) ======================
```

I also tried to use a shared cluster fixture but it didn't work because worker processes were leaked between tests. Should probably be looked into.