### PR TITLE
Revert "[dashboard] Add a `/api/v0/logs/file` API param to customize the downloaded filename (#53008)"

### DIFF
--- a/python/ray/dashboard/modules/state/state_head.py
+++ b/python/ray/dashboard/modules/state/state_head.py
@@ -30,12 +30,7 @@ from ray.dashboard.utils import RateLimitedModule
 from ray.dashboard.subprocesses.routes import SubprocessRouteTable as routes
 from ray.dashboard.subprocesses.module import SubprocessModule
 from ray.dashboard.subprocesses.utils import ResponseType
-from ray.util.state.common import (
-    DEFAULT_DOWNLOAD_FILENAME,
-    DEFAULT_LOG_LIMIT,
-    DEFAULT_RPC_TIMEOUT,
-    GetLogOptions,
-)
+from ray.util.state.common import DEFAULT_LOG_LIMIT, DEFAULT_RPC_TIMEOUT, GetLogOptions
 from ray.util.state.exception import DataSourceUnavailable
 from ray.util.state.state_manager import StateDataSourceClient
 
@@ -200,7 +195,7 @@ class StateHead(SubprocessModule, RateLimitedModule):
 
     @routes.get("/api/v0/logs/{media_type}", resp_type=ResponseType.STREAM)
     @RateLimitedModule.enforce_max_concurrent_calls
-    async def get_logs(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
+    async def get_logs(self, req: aiohttp.web.Request):
         """
         Fetches logs from the given criteria.
         """
@@ -210,12 +205,7 @@ class StateHead(SubprocessModule, RateLimitedModule):
             node_id=req.query.get("node_id", None),
             node_ip=req.query.get("node_ip", None),
             media_type=req.match_info.get("media_type", "file"),
-            # The filename to match on the server side.
             filename=req.query.get("filename", None),
-            # The filename to download the log as on the client side.
-            download_filename=req.query.get(
-                "download_filename", DEFAULT_DOWNLOAD_FILENAME
-            ),
             actor_id=req.query.get("actor_id", None),
             task_id=req.query.get("task_id", None),
             submission_id=req.query.get("submission_id", None),
@@ -236,13 +226,7 @@ class StateHead(SubprocessModule, RateLimitedModule):
                 return None
             return actor_info_dict[actor_id]
 
-        response = aiohttp.web.StreamResponse(
-            headers={
-                "Content-Disposition": (
-                    f'attachment; filename="{options.download_filename}"'
-                )
-            },
-        )
+        response = aiohttp.web.StreamResponse()
         response.content_type = "text/plain"
 
         logs_gen = self._log_api.stream_logs(options, get_actor_fn)

--- a/python/ray/tests/test_state_api_log.py
+++ b/python/ray/tests/test_state_api_log.py
@@ -968,34 +968,6 @@ def test_logs_stream_and_tail(ray_start_with_dashboard):
         assert line in file_response
 
 
-def test_log_download_filename(ray_start_with_dashboard):
-    """Test that the download filename can be specified when downloading a log."""
-
-    assert (
-        wait_until_server_available(ray_start_with_dashboard.address_info["webui_url"])
-        is True
-    )
-    webui_url = ray_start_with_dashboard.address_info["webui_url"]
-    webui_url = format_web_url(webui_url)
-    node_id = list_nodes()[0]["node_id"]
-
-    download_filename = "dummy.out"
-
-    stream_response = requests.get(
-        webui_url
-        + (
-            f"/api/v0/logs/file?node_id={node_id}&filename=gcs_server.out"
-            f"&lines=5&download_filename={download_filename}"
-        ),
-    )
-    if stream_response.status_code != 200:
-        raise ValueError(stream_response.content.decode("utf-8"))
-    assert (
-        stream_response.headers["Content-Disposition"]
-        == f'attachment; filename="{download_filename}"'
-    )
-
-
 def test_log_list(ray_start_cluster):
     cluster = ray_start_cluster
     num_nodes = 5

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -47,7 +47,6 @@ logger = logging.getLogger(__name__)
 DEFAULT_RPC_TIMEOUT = 30
 DEFAULT_LIMIT = 100
 DEFAULT_LOG_LIMIT = 1000
-DEFAULT_DOWNLOAD_FILENAME = "file.txt"
 
 # Max number of entries from API server to the client
 RAY_MAX_LIMIT_FROM_API_SERVER = env_integer(
@@ -378,12 +377,8 @@ class GetLogOptions:
     # One of {file, stream}. File means it will return the whole log.
     # stream means it will keep the connection and streaming the log.
     media_type: str = "file"
-    # The filename to match when finding the log to download from the Ray log directory.
-    # NOTE: This can be a nested path relative to the Ray log directory.
+    # The file name of the log.
     filename: Optional[str] = None
-    # The filename to download the log as on the client side.
-    # If not provided, the filename will be "file.txt".
-    download_filename: str = DEFAULT_DOWNLOAD_FILENAME
     # The actor id of the log. It is used only for worker logs.
     actor_id: Optional[str] = None
     # The task id of the log.
@@ -1706,6 +1701,7 @@ def remove_ansi_escape_codes(text: str) -> str:
 
 
 def dict_to_state(d: Dict, state_resource: StateResource) -> StateSchema:
+
     """Convert a dict to a state schema.
 
     Args:


### PR DESCRIPTION
This reverts commit 1a40faccb6670670096beef8c85b6f35a0958b6d.

Broke `test_api_state_log`: https://buildkite.com/ray-project/postmerge/builds/10232#0196e94c-c1e7-4258-b4c0-db97f24aeda7/177-1941