### PR TITLE
[core] Deflake `test_output.py::test_dedup_logs`

### DIFF
--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -21,7 +21,7 @@ def test_dedup_logs():
 import time
 
 import ray
-from ray._private.test_utils import SignalActor
+from ray._private.test_utils import SignalActor, wait_for_condition
 
 signal = SignalActor.remote()
 
@@ -31,6 +31,9 @@ def verbose():
     print(f"hello world, id={time.time()}")
 
 refs = [verbose.remote() for _ in range(4)]
+wait_for_condition(
+    lambda: ray.get(signal.cur_num_waiters.remote()) == 4
+)
 ray.get(signal.send.remote())
 ray.get(refs)
 """

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -18,16 +18,21 @@ from ray.autoscaler.v2.utils import is_autoscaler_v2
 
 def test_dedup_logs():
     script = """
-import ray
 import time
 
-@ray.remote
-def verbose():
-    print(f"hello world, id={time.time()}")
-    time.sleep(1)
+import ray
+from ray._private.test_utils import SignalActor
 
-ray.init(num_cpus=4)
-ray.get([verbose.remote() for _ in range(10)])
+signal = SignalActor.remote()
+
+@ray.remote(num_cpus=0)
+def verbose():
+    ray.get(signal.wait.remote())
+    print(f"hello world, id={time.time()}")
+
+refs = [verbose.remote() for _ in range(4)]
+ray.get(signal.send.remote())
+ray.get(refs)
 """
 
     proc = run_string_as_driver_nonblocking(script)
@@ -35,7 +40,7 @@ ray.get([verbose.remote() for _ in range(10)])
 
     assert out_str.count("hello") == 2, out_str
     assert out_str.count("RAY_DEDUP_LOGS") == 1, out_str
-    assert out_str.count("[repeated 9x across cluster]") == 1, out_str
+    assert out_str.count("[repeated 3x across cluster]") == 1, out_str
 
 
 def test_dedup_error_warning_logs(ray_start_cluster, monkeypatch):


### PR DESCRIPTION
Test was flaky, even locally, because the timing in CI might cause the tasks to run spaced out and therefore the logs not to be deduped. Example flake: https://buildkite.com/ray-project/postmerge/builds/10232#0196e94c-c1f5-494e-9ffd-232334fa8926/179-1408.

I've updated it to control the timing conditions more closely using a `SignalActor`.

Before the change, it failed about 50% of the time on my laptop. After the change, it passed 10/10 consecutive runs.