### PR TITLE
[data.llm] Fix test_batch_vllm leaking resources by using larger wait_for_min_actors_s

### DIFF
--- a/python/ray/llm/_internal/batch/processor/base.py
+++ b/python/ray/llm/_internal/batch/processor/base.py
@@ -4,6 +4,7 @@ from typing import Optional, List, Type, Callable, Dict, Union, Tuple, Any
 
 from pydantic import Field
 
+import ray
 from ray.data.block import UserDefinedFunction
 from ray.data import Dataset
 from ray.util.annotations import PublicAPI, DeveloperAPI
@@ -132,6 +133,10 @@ class Processor:
         self.preprocess = None
         self.postprocess = None
         self.stages: OrderedDict[str, StatefulStage] = OrderedDict()
+
+        # FIXES: https://github.com/ray-project/ray/issues/53124
+        # TODO (Kourosh): Remove this once the issue is fixed.
+        ray.data.DataContext.get_current().wait_for_min_actors_s = 600
 
         # NOTE (Kourosh): If pre/postprocess is not provided, use the identity function.
         # Wrapping is required even if they are identity functions, b/c data_column

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -213,8 +213,6 @@ class vLLMEngineWrapper:
 
         lora_request = None
         if "model" in row and row["model"] != self.model:
-            if self.vllm_use_v1:
-                raise ValueError("LoRA is only supported with vLLM v0")
 
             lora_name = row["model"]
             if lora_name not in self.lora_name_to_request:

--- a/release/llm_tests/batch/test_batch_vllm.py
+++ b/release/llm_tests/batch/test_batch_vllm.py
@@ -1,7 +1,5 @@
 import sys
 
-import ray.data.context
-
 import pytest
 
 import ray

--- a/release/llm_tests/batch/test_batch_vllm.py
+++ b/release/llm_tests/batch/test_batch_vllm.py
@@ -8,17 +8,6 @@ import ray
 from ray.data.llm import build_llm_processor, vLLMEngineProcessorConfig
 
 
-@pytest.fixture(autouse=True, scope="module")
-def setup_data_context():
-    """Fixture to set DataContext wait_for_min_actors_s for all tests in this module.
-
-    FIXES: https://github.com/ray-project/ray/issues/53124
-    TODO (Kourosh): Remove this once the issue is fixed.
-    """
-    ray.data.DataContext.get_current().wait_for_min_actors_s = 600
-    yield
-
-
 def test_chat_template_with_vllm():
     """Test vLLM with explicit chat template."""
 

--- a/release/llm_tests/batch/test_batch_vllm.py
+++ b/release/llm_tests/batch/test_batch_vllm.py
@@ -50,34 +50,20 @@ def test_chat_template_with_vllm():
 
 
 @pytest.mark.parametrize(
-    "tp_size,pp_size,concurrency,vllm_use_v1",
+    "tp_size,pp_size,concurrency",
     [
-        (2, 1, 2, True),  # TP=2, concurrency=2, vLLM v1
-        (1, 2, 2, False),  # PP=2, concurrency=2, vLLM v0
+        (2, 1, 2),  # TP=2, concurrency=2
+        (1, 2, 2),  # PP=2, concurrency=2
     ],
 )
-def test_vllm_llama_parallel(tp_size, pp_size, concurrency, vllm_use_v1):
+def test_vllm_llama_parallel(tp_size, pp_size, concurrency):
     """Test vLLM with Llama model using different parallelism configurations."""
 
-    if vllm_use_v1:
-        runtime_env = dict(
-            env_vars=dict(
-                VLLM_USE_V1="1",
-            ),
-        )
-        # vLLM v1 does not support decoupled tokenizer,
-        # but since the tokenizer is in a separate process,
-        # the overhead should be moderated.
-        tokenize = False
-        detokenize = False
-    else:
-        runtime_env = dict(
-            env_vars=dict(
-                VLLM_USE_V1="0",
-            ),
-        )
-        tokenize = True
-        detokenize = True
+    # vLLM v1 does not support decoupled tokenizer,
+    # but since the tokenizer is in a separate process,
+    # the overhead should be moderated.
+    tokenize = False
+    detokenize = False
 
     processor_config = vLLMEngineProcessorConfig(
         model_source="unsloth/Llama-3.2-1B-Instruct",
@@ -88,7 +74,6 @@ def test_vllm_llama_parallel(tp_size, pp_size, concurrency, vllm_use_v1):
             enable_chunked_prefill=True,
             max_num_batched_tokens=2048,
         ),
-        runtime_env=runtime_env,
         tokenize=tokenize,
         detokenize=detokenize,
         batch_size=16,
@@ -146,11 +131,6 @@ def test_vllm_llama_lora():
         detokenize=True,
         batch_size=16,
         concurrency=1,
-        runtime_env={
-            "env_vars": {
-                "VLLM_USE_V1": "0",
-            }
-        },
     )
 
     processor = build_llm_processor(
@@ -191,31 +171,16 @@ def test_vllm_llama_lora():
         ("Qwen/Qwen2.5-VL-3B-Instruct", 2, 1, 2, 60),
     ],
 )
-@pytest.mark.parametrize("vllm_use_v1", [True, False])
 def test_vllm_vision_language_models(
-    model_source, tp_size, pp_size, concurrency, sample_size, vllm_use_v1
+    model_source, tp_size, pp_size, concurrency, sample_size
 ):
     """Test vLLM with vision language models using different configurations."""
 
-    if vllm_use_v1:
-        runtime_env = dict(
-            env_vars=dict(
-                VLLM_USE_V1="1",
-            ),
-        )
-        # vLLM v1 does not support decoupled tokenizer,
-        # but since the tokenizer is in a separate process,
-        # the overhead should be moderated.
-        tokenize = False
-        detokenize = False
-    else:
-        runtime_env = dict(
-            env_vars=dict(
-                VLLM_USE_V1="0",
-            ),
-        )
-        tokenize = True
-        detokenize = True
+    # vLLM v1 does not support decoupled tokenizer,
+    # but since the tokenizer is in a separate process,
+    # the overhead should be moderated.
+    tokenize = False
+    detokenize = False
 
     processor_config = vLLMEngineProcessorConfig(
         model_source=model_source,
@@ -227,7 +192,6 @@ def test_vllm_vision_language_models(
             enable_chunked_prefill=True,
         ),
         apply_chat_template=True,
-        runtime_env=runtime_env,
         tokenize=tokenize,
         detokenize=detokenize,
         batch_size=16,


### PR DESCRIPTION
Evaluating option 1 as a fix to https://github.com/ray-project/ray/issues/53124.

NOTE: We should revert the wait_for_min_actors_s change when the data leak issue is fixed. 

release test: https://buildkite.com/ray-project/release/builds/42269
