### PR TITLE
[train][ci] Dedup ML doctest runners

### DIFF
--- a/.buildkite/ml.rayci.yml
+++ b/.buildkite/ml.rayci.yml
@@ -148,7 +148,7 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tune/... ml
         --parallelism-per-worker 3
-        --except-tags soft_imports,gpu_only,rllib
+        --except-tags doctest,soft_imports,gpu_only,rllib
     depends_on: [ "mlbuild", "forge" ]
 
   - label: ":train: ml: tune soft import tests"
@@ -166,7 +166,7 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/air/... ml
         --parallelism-per-worker 3
-        --except-tags gpu
+        --except-tags gpu,doctest
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/data/... ml
         --parallelism-per-worker 3
         --only-tags ray_air

--- a/python/ray/train/BUILD
+++ b/python/ray/train/BUILD
@@ -2,6 +2,7 @@ load("@rules_python//python:defs.bzl", "py_library", "py_test")
 load("//bazel:python.bzl", "doctest")
 
 doctest(
+    name = "py_doctest[train]",
     size = "large",
     files = glob(
         ["**/*.py"],
@@ -20,6 +21,7 @@ doctest(
 )
 
 doctest(
+    name = "py_doctest[train-gpu]",
     size = "large",
     files = [
         "_internal/session.py",


### PR DESCRIPTION
## Summary

Doctests only need to run in the `:train: ml: doc tests` pipeline rather than being duplicated in each library's individual test suite. Exclude doctests from being run in `tune tests` and `air tests`.