### PR TITLE
[core] Speed up `test_basic.py::test_release_resources_race`

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -263,10 +263,6 @@ RAY_CONFIG(int64_t, fetch_fail_timeout_milliseconds, 600000)
 /// Temporary workaround for https://github.com/ray-project/ray/pull/16402.
 RAY_CONFIG(bool, yield_plasma_lock_workaround, true)
 
-// Whether to inline object status in serialized references.
-// See https://github.com/ray-project/ray/issues/16025 for more details.
-RAY_CONFIG(bool, inline_object_status_in_refs, true)
-
 /// Number of times raylet client tries connecting to a raylet.
 RAY_CONFIG(int64_t, raylet_client_num_connect_attempts, 10)
 RAY_CONFIG(int64_t, raylet_client_connect_timeout_milliseconds, 1000)

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1487,11 +1487,9 @@ Status CoreWorker::GetOwnershipInfo(const ObjectID &object_id,
   rpc::GetObjectStatusReply object_status;
   // Optimization: if the object exists, serialize and inline its status. This also
   // resolves some race conditions in resource release (#16025).
-  if (RayConfig::instance().inline_object_status_in_refs()) {
-    auto existing_object = memory_store_->GetIfExists(object_id);
-    if (existing_object != nullptr) {
-      PopulateObjectStatus(object_id, existing_object, &object_status);
-    }
+  auto existing_object = memory_store_->GetIfExists(object_id);
+  if (existing_object != nullptr) {
+    PopulateObjectStatus(object_id, existing_object, &object_status);
   }
   *serialized_object_status = object_status.SerializeAsString();
   return Status::OK();


### PR DESCRIPTION
- Reduce the size of the `ray.put` objects.
- Reduce the number of function calls.
- Remove feature flag that has been on by default for ~5 years.