### PR TITLE
[core] Improve actor GC error message to suggest storing the actor handle before use

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -352,7 +352,10 @@ class ActorMethod:
             actor = self._actor_hard_ref or self._actor_ref()
 
             if actor is None:
-                raise RuntimeError("Lost reference to actor")
+                # See https://github.com/ray-project/ray/issues/6265 for more details.
+                raise RuntimeError(
+                    "Lost reference to actor. Actor handles must be stored as variables, e.g. `actor = MyActor.remote()` before calling methods."
+                )
 
             return actor._actor_method_call(
                 self._method_name,


### PR DESCRIPTION
## Why are these changes needed?

This PR improves the runtime error message raised when an actor handle is garbage-collected during a remote method invocation, making it clearer what went wrong and how to work around it.

Previously, invoking an actor method in a single expression like:
```
ray.get(MyActor.remote().do_work.remote())
```
would raise a generic error
```
RuntimeError: Lost reference to actor
```
because Ray only held a weak reference to the actor stub. Users were left guessing how to avoid this error.

Note: this PR does not fix the actual issue. See https://github.com/ray-project/ray/issues/6265 for more details. A way to fix the issue is by keeping a strong reference to the actor but for the brief window when we build and execute the invocation closure. Until a more permanent fix is implemented, let's improve the error message with the workaround to unblock users.

## Related issue number

Closes https://github.com/ray-project/ray/issues/6265
