### PR TITLE
Add progress bars to hash operators

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -230,6 +230,11 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         description="Number of input blocks received by operator.",
         metrics_group=MetricsGroup.INPUTS,
     )
+    num_row_inputs_received: int = metric_field(
+        default=0,
+        description="Number of input rows received by operator.",
+        metrics_group=MetricsGroup.INPUTS,
+    )
     bytes_inputs_received: int = metric_field(
         default=0,
         description="Byte size of input blocks received by operator.",
@@ -629,6 +634,7 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
     def on_input_received(self, input: RefBundle):
         """Callback when the operator receives a new input."""
         self.num_inputs_received += 1
+        self.num_row_inputs_received += input.num_rows() or 0
         self.bytes_inputs_received += input.size_bytes()
 
     def on_input_queued(self, input: RefBundle):

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -28,6 +28,7 @@ from ray.data._internal.execution.interfaces.execution_options import (
 from ray.data._internal.execution.interfaces.op_runtime_metrics import OpRuntimeMetrics
 from ray.data._internal.logical.interfaces import LogicalOperator, Operator
 from ray.data._internal.output_buffer import OutputBlockSizeOption
+from ray.data._internal.progress_bar import ProgressBar
 from ray.data._internal.stats import StatsDict, Timer
 from ray.data.context import DataContext
 
@@ -701,9 +702,74 @@ class PhysicalOperator(Operator):
                     # In all cases, we swallow the exception.
                     pass
 
+    def upstream_op_num_outputs(self):
+        upstream_op_num_outputs = sum(
+            op.num_outputs_total() or 0 for op in self.input_dependencies
+        )
+        return upstream_op_num_outputs
+
 
 class ReportsExtraResourceUsage(abc.ABC):
     @abc.abstractmethod
     def extra_resource_usage(self: PhysicalOperator) -> ExecutionResources:
         """Returns resources used by this operator beyond standard accounting."""
         ...
+
+
+def estimate_total_num_of_blocks(
+    num_tasks_submitted: int,
+    upstream_op_num_outputs: int,
+    metrics: OpRuntimeMetrics,
+    total_num_tasks: Optional[int] = None,
+) -> Tuple[int, int, int]:
+    """This method is trying to estimate total number of blocks/rows based on
+    - How many outputs produced by the input deps
+    - How many blocks/rows produced by tasks of this operator
+    """
+
+    if (
+        upstream_op_num_outputs > 0
+        and metrics.num_inputs_received > 0
+        and metrics.num_tasks_finished > 0
+    ):
+        estimated_num_tasks = total_num_tasks
+        if estimated_num_tasks is None:
+            estimated_num_tasks = (
+                upstream_op_num_outputs
+                / metrics.num_inputs_received
+                * num_tasks_submitted
+            )
+
+        estimated_num_output_bundles = round(
+            estimated_num_tasks
+            * metrics.num_outputs_of_finished_tasks
+            / metrics.num_tasks_finished
+        )
+        estimated_output_num_rows = round(
+            estimated_num_tasks
+            * metrics.rows_task_outputs_generated
+            / metrics.num_tasks_finished
+        )
+        return (
+            estimated_num_tasks,
+            estimated_num_output_bundles,
+            estimated_output_num_rows,
+        )
+
+    return (0, 0, 0)
+
+
+def _create_sub_pb(
+    name: str, total_output_rows: Optional[int], position: int
+) -> Tuple[ProgressBar, int]:
+    progress_bar = ProgressBar(
+        name,
+        total_output_rows or 1,
+        unit="row",
+        position=position,
+    )
+    # NOTE: call `set_description` to trigger the initial print of progress
+    # bar on console.
+    progress_bar.set_description(f"  *- {name}")
+    position += 1
+    return progress_bar, position

--- a/python/ray/data/_internal/execution/operators/base_physical_operator.py
+++ b/python/ray/data/_internal/execution/operators/base_physical_operator.py
@@ -7,8 +7,8 @@ from ray.data._internal.execution.interfaces import (
     RefBundle,
     TaskContext,
 )
+from ray.data._internal.execution.interfaces.physical_operator import _create_sub_pb
 from ray.data._internal.logical.interfaces import LogicalOperator
-from ray.data._internal.progress_bar import ProgressBar
 from ray.data._internal.stats import StatsDict
 from ray.data.context import DataContext
 
@@ -152,17 +152,10 @@ class AllToAllOperator(InternalQueueOperatorMixin, PhysicalOperator):
         if self._sub_progress_bar_names is not None:
             self._sub_progress_bar_dict = {}
             for name in self._sub_progress_bar_names:
-                bar = ProgressBar(
-                    name,
-                    self.num_output_rows_total() or 1,
-                    unit="row",
-                    position=position,
+                bar, position = _create_sub_pb(
+                    name, self.num_output_rows_total(), position
                 )
-                # NOTE: call `set_description` to trigger the initial print of progress
-                # bar on console.
-                bar.set_description(f"  *- {name}")
                 self._sub_progress_bar_dict[name] = bar
-                position += 1
             return len(self._sub_progress_bar_dict)
         else:
             return 0

--- a/python/ray/data/_internal/execution/operators/hash_aggregate.py
+++ b/python/ray/data/_internal/execution/operators/hash_aggregate.py
@@ -143,6 +143,8 @@ class HashAggregateOperator(HashShufflingOperatorBase):
                 key_columns, aggregation_fns
             ),
             aggregator_ray_remote_args_override=aggregator_ray_remote_args_override,
+            shuffle_progress_bar_name="Shuffle",
+            finalize_progress_bar_name="Aggregation",
         )
 
     def _get_default_num_cpus_per_partition(self) -> int:

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -32,17 +32,24 @@ from ray.data._internal.arrow_ops.transform_pyarrow import (
     _create_empty_table,
     hash_partition,
 )
-from ray.data._internal.execution.interfaces import PhysicalOperator, RefBundle
+from ray.data._internal.execution.interfaces import (
+    PhysicalOperator,
+    RefBundle,
+)
 from ray.data._internal.execution.interfaces.physical_operator import (
     DataOpTask,
     MetadataOpTask,
     OpTask,
+    _create_sub_pb,
+    estimate_total_num_of_blocks,
 )
+from ray.data._internal.stats import OpRuntimeMetrics
 from ray.data._internal.table_block import TableBlockAccessor
 from ray.data._internal.util import GiB, MiB
 from ray.data.block import (
     Block,
     BlockAccessor,
+    BlockExecStats,
     BlockMetadata,
     BlockMetadataWithSchema,
     BlockStats,
@@ -198,7 +205,7 @@ def _shuffle_block(
             - Map of partition ids to partition shard stats produced from the
             shuffled block
     """
-
+    stats = BlockExecStats.builder()
     assert (len(key_columns) > 0) ^ (override_partition_id is not None), (
         f"Either list of key columns to hash-partition by (got {key_columns} or "
         f"target partition id override (got {override_partition_id}) must be provided!"
@@ -214,7 +221,8 @@ def _shuffle_block(
     )
 
     if block.num_rows == 0:
-        return BlockAccessor.for_block(block).get_metadata(), {}
+        empty = BlockAccessor.for_block(block).get_metadata(exec_stats=stats.build())
+        return (empty, {})
 
     num_partitions = pool.num_partitions
 
@@ -285,7 +293,9 @@ def _shuffle_block(
         pending_submissions = unready
         i += 1
 
-    original_block_metadata = BlockAccessor.for_block(block).get_metadata()
+    original_block_metadata = BlockAccessor.for_block(block).get_metadata(
+        exec_stats=stats.build()
+    )
 
     if logger.isEnabledFor(logging.DEBUG):
         num_rows_series, byte_sizes_series = zip(
@@ -336,7 +346,48 @@ class _PartitionStats:
         )
 
 
-class HashShufflingOperatorBase(PhysicalOperator):
+class HashShuffleProgressBarMixin(abc.ABC):
+    @property
+    @abc.abstractmethod
+    def shuffle_name(self) -> str:
+        ...
+
+    @property
+    @abc.abstractmethod
+    def reduce_name(self) -> str:
+        ...
+
+    def initialize_sub_progress_bars(self, position: int) -> int:
+        """Display all sub progres bars in the termainl, and return the number of bars."""
+
+        # shuffle
+        progress_bars_created = 0
+        self.shuffle_bar = None
+        if self.shuffle_name is not None:
+            self.shuffle_bar, position = _create_sub_pb(
+                self.shuffle_name, self.num_output_rows_total(), position
+            )
+            progress_bars_created += 1
+        self.shuffle_metrics = OpRuntimeMetrics(self)
+
+        # reduce
+        self.reduce_bar = None
+        if self.reduce_name is not None:
+            self.reduce_bar, position = _create_sub_pb(
+                self.reduce_name, self.num_output_rows_total(), position
+            )
+            progress_bars_created += 1
+        self.reduce_metrics = OpRuntimeMetrics(self)
+
+        return progress_bars_created
+
+    def close_sub_progress_bars(self):
+        """Close all internal sub progress bars."""
+        self.shuffle_bar.close()
+        self.reduce_bar.close()
+
+
+class HashShufflingOperatorBase(PhysicalOperator, HashShuffleProgressBarMixin):
     """Physical operator base-class for any operators requiring hash-based
     shuffling.
 
@@ -368,6 +419,8 @@ class HashShufflingOperatorBase(PhysicalOperator):
         partition_size_hint: Optional[int] = None,
         input_block_transformer: Optional[BlockTransformer] = None,
         aggregator_ray_remote_args_override: Optional[Dict[str, Any]] = None,
+        shuffle_progress_bar_name: Optional[str] = None,
+        finalize_progress_bar_name: Optional[str] = None,
     ):
         super().__init__(
             name=name,
@@ -375,6 +428,14 @@ class HashShufflingOperatorBase(PhysicalOperator):
             data_context=data_context,
             target_max_block_size=None,
         )
+
+        if shuffle_progress_bar_name is None:
+            shuffle_progress_bar_name = "Shuffle"
+        if finalize_progress_bar_name is None:
+            finalize_progress_bar_name = "Reduce"
+
+        self._shuffle_name = shuffle_progress_bar_name
+        self._reduce_name = finalize_progress_bar_name
 
         assert len(key_columns) == len(input_ops), (
             "Each input operation has to specify matching tuple of columns used as "
@@ -453,14 +514,19 @@ class HashShufflingOperatorBase(PhysicalOperator):
 
         self._aggregator_pool.start()
 
+    @property
+    def shuffle_name(self) -> str:
+        return self._shuffle_name
+
+    @property
+    def reduce_name(self) -> str:
+        return self._reduce_name
+
     def _add_input_inner(self, input_bundle: RefBundle, input_index: int) -> None:
 
         # TODO move to base class
-        self._metrics.on_input_queued(input_bundle)
-        try:
-            self._do_add_input_inner(input_bundle, input_index)
-        finally:
-            self._metrics.on_input_dequeued(input_bundle)
+        self.shuffle_metrics.on_input_received(input_bundle)
+        self._do_add_input_inner(input_bundle, input_index)
 
     def _do_add_input_inner(self, input_bundle: RefBundle, input_index: int):
         input_blocks_refs: List[ObjectRef[Block]] = input_bundle.block_refs
@@ -513,7 +579,7 @@ class HashShufflingOperatorBase(PhysicalOperator):
             if should_broadcast_schemas:
                 self._has_schemas_broadcasted[input_index] = True
 
-            def _on_partitioning_done():
+            def _on_partitioning_done(cur_shuffle_task_idx: int):
                 task = self._shuffling_tasks[input_index].pop(cur_shuffle_task_idx)
                 # Fetch input block and resulting partition shards block metadata and
                 # handle obtained metadata
@@ -529,15 +595,42 @@ class HashShufflingOperatorBase(PhysicalOperator):
                     input_index, input_block_metadata, partition_shards_stats
                 )
 
+                # Update Shuffle metrics on task output generated
+                blocks = [(task.get_waitable(), input_block_metadata)]
+                # NOTE: schema doesn't matter because we are creating a ref bundle
+                # for metrics recording purposes
+                out_bundle = RefBundle(blocks, schema=None, owns_blocks=False)
+                self.shuffle_metrics.on_output_taken(input_bundle)
+                self.shuffle_metrics.on_task_output_generated(
+                    cur_shuffle_task_idx, out_bundle
+                )
+                self.shuffle_metrics.on_task_finished(cur_shuffle_task_idx, None)
+
+                # Update Shuffle progress bar
+                self.shuffle_bar.update(i=input_block_metadata.num_rows)
+
             # TODO update metrics
             self._shuffling_tasks[input_index][cur_shuffle_task_idx] = MetadataOpTask(
                 task_index=cur_shuffle_task_idx,
                 object_ref=input_block_partition_shards_metadata_tuple_ref,
-                task_done_callback=_on_partitioning_done,
+                task_done_callback=functools.partial(
+                    _on_partitioning_done, cur_shuffle_task_idx
+                ),
                 task_resource_bundle=(
                     ExecutionResources.from_resource_dict(shuffle_task_resource_bundle)
                 ),
             )
+
+            #  Update Shuffle Metrics on task submission
+            self.shuffle_metrics.on_task_submitted(
+                cur_shuffle_task_idx,
+                RefBundle(
+                    [(block_ref, block_metadata)], schema=None, owns_blocks=False
+                ),
+            )
+
+            # Update Shuffle progress bar
+            self.shuffle_bar.update(total=self.shuffle_metrics.num_row_inputs_received)
 
     def has_next(self) -> bool:
         self._try_finalize()
@@ -547,7 +640,8 @@ class HashShufflingOperatorBase(PhysicalOperator):
         bundle: RefBundle = self._output_queue.popleft()
 
         # TODO move to base class
-        self._metrics.on_output_dequeued(bundle)
+        self.reduce_metrics.on_output_dequeued(bundle)
+        self.reduce_metrics.on_output_taken(bundle)
 
         self._output_blocks_stats.extend(to_stats(bundle.metadata))
 
@@ -596,10 +690,31 @@ class HashShufflingOperatorBase(PhysicalOperator):
             f"partition id is {self._last_finalized_partition_id})"
         )
 
-        def _on_bundle_ready(bundle: RefBundle):
+        def _on_bundle_ready(partition_id: int, bundle: RefBundle):
             # Add finalized block to the output queue
             self._output_queue.append(bundle)
-            self._metrics.on_output_queued(bundle)
+
+            # Update Finalize Metrics on task output generated
+            self.reduce_metrics.on_output_queued(bundle)
+            self.reduce_metrics.on_task_output_generated(
+                task_index=partition_id, output=bundle
+            )
+            self.reduce_metrics.on_task_finished(
+                task_index=partition_id, exception=None
+            )
+            _, num_outputs, num_rows = estimate_total_num_of_blocks(
+                partition_id + 1,
+                self.upstream_op_num_outputs(),
+                self.reduce_metrics,
+                total_num_tasks=self._num_partitions,
+            )
+            self._estimated_num_output_bundles = num_outputs
+            self._estimated_output_num_rows = num_rows
+
+            # Update Finalize progress bar
+            self.reduce_bar.update(
+                i=bundle.num_rows(), total=self.num_output_rows_total()
+            )
 
         def _on_aggregation_done(partition_id: int, exc: Optional[Exception]):
             if partition_id in self._finalizing_tasks:
@@ -679,8 +794,7 @@ class HashShufflingOperatorBase(PhysicalOperator):
             self._finalizing_tasks[partition_id] = DataOpTask(
                 task_index=partition_id,
                 streaming_gen=block_gen,
-                output_ready_callback=_on_bundle_ready,
-                # TODO fix to pass in task_id into the callback
+                output_ready_callback=functools.partial(_on_bundle_ready, partition_id),
                 task_done_callback=functools.partial(
                     _on_aggregation_done, partition_id
                 ),
@@ -688,6 +802,12 @@ class HashShufflingOperatorBase(PhysicalOperator):
                     ExecutionResources.from_resource_dict(finalize_task_resource_bundle)
                 ),
             )
+
+            # Update Finalize Metrics on task submission
+            # NOTE: This is empty because the input is directly forwarded from the
+            # output of the shuffling stage, which we don't return.
+            empty_bundle = RefBundle([], schema=None, owns_blocks=False)
+            self.reduce_metrics.on_task_submitted(partition_id, empty_bundle)
 
         # Update last finalized partition id
         self._last_finalized_partition_id = max(target_partition_ids)
@@ -701,10 +821,23 @@ class HashShufflingOperatorBase(PhysicalOperator):
         self._shuffling_tasks.clear()
         self._finalizing_tasks.clear()
 
-    def get_stats(self):
+    def _extra_metrics(self):
+        shuffle_name = f"{self._name}_shuffle"
+        finalize_name = f"{self._name}_finalize"
+
+        self.shuffle_metrics.as_dict()
+
         return {
-            # TODO factor in output blocks metadata
-            self._name: self._shuffled_blocks_stats,
+            shuffle_name: self.shuffle_metrics.as_dict(),
+            finalize_name: self.reduce_metrics.as_dict(),
+        }
+
+    def get_stats(self):
+        shuffle_name = f"{self._name}_shuffle"
+        reduce_name = f"{self._name}_finalize"
+        return {
+            shuffle_name: self._shuffled_blocks_stats,
+            reduce_name: self._output_blocks_stats,
         }
 
     def current_processor_usage(self) -> ExecutionResources:
@@ -898,6 +1031,7 @@ class HashShuffleOperator(HashShufflingOperatorBase):
                     key_columns=key_columns,
                 )
             ),
+            shuffle_progress_bar_name="Shufle",
         )
 
     def _get_default_num_cpus_per_partition(self) -> int:
@@ -1263,12 +1397,12 @@ class HashShuffleAggregator:
     ) -> AsyncGenerator[Union[Block, "BlockMetadataWithSchema"], None]:
         with self._lock:
             # Finalize given partition id
-            result = self._agg.finalize(partition_id)
+            exec_stats_builder = BlockExecStats.builder()
+            block = self._agg.finalize(partition_id)
+            exec_stats = exec_stats_builder.build()
             # Clear any remaining state (to release resources)
             self._agg.clear(partition_id)
 
         # TODO break down blocks to target size
-        from ray.data.block import BlockMetadataWithSchema
-
-        yield result
-        yield BlockMetadataWithSchema.from_block(result)
+        yield block
+        yield BlockMetadataWithSchema.from_block(block, stats=exec_stats)

--- a/python/ray/data/_internal/execution/operators/join.py
+++ b/python/ray/data/_internal/execution/operators/join.py
@@ -185,6 +185,8 @@ class JoinOperator(HashShufflingOperatorBase):
                 )
             ),
             aggregator_ray_remote_args_override=aggregator_ray_remote_args_override,
+            shuffle_progress_bar_name="Shuffle",
+            finalize_progress_bar_name="Join",
         )
 
     def _get_default_num_cpus_per_partition(self) -> int:

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -36,6 +36,7 @@ from ray.data._internal.execution.interfaces.physical_operator import (
     DataOpTask,
     MetadataOpTask,
     OpTask,
+    estimate_total_num_of_blocks,
 )
 from ray.data._internal.execution.operators.base_physical_operator import (
     InternalQueueOperatorMixin,
@@ -407,23 +408,13 @@ class MapOperator(OneToOneOperator, InternalQueueOperatorMixin, ABC):
 
             # Estimate number of tasks and rows from inputs received and tasks
             # submitted so far
-            upstream_op_num_outputs = self.input_dependencies[0].num_outputs_total()
-            if upstream_op_num_outputs:
-                estimated_num_tasks = (
-                    upstream_op_num_outputs
-                    / self._metrics.num_inputs_received
-                    * self._next_data_task_idx
-                )
-                self._estimated_num_output_bundles = round(
-                    estimated_num_tasks
-                    * self._metrics.num_outputs_of_finished_tasks
-                    / self._metrics.num_tasks_finished
-                )
-                self._estimated_output_num_rows = round(
-                    estimated_num_tasks
-                    * self._metrics.rows_task_outputs_generated
-                    / self._metrics.num_tasks_finished
-                )
+            (
+                _,
+                self._estimated_num_output_bundles,
+                self._estimated_output_num_rows,
+            ) = estimate_total_num_of_blocks(
+                self._next_data_task_idx, self.upstream_op_num_outputs(), self._metrics
+            )
 
             self._data_tasks.pop(task_index)
             # Notify output queue that this task is complete.

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -81,6 +81,7 @@ def gen_expected_metrics(
             "'average_bytes_outputs_per_task': N",
             "'average_max_uss_per_task': H",
             "'num_inputs_received': N",
+            "'num_row_inputs_received': N",
             "'bytes_inputs_received': N",
             "'num_task_inputs_processed': N",
             "'bytes_task_inputs_processed': N",
@@ -125,6 +126,7 @@ def gen_expected_metrics(
             "'obj_store_mem_internal_inqueue': Z",
             "'obj_store_mem_internal_outqueue': Z",
             "'num_inputs_received': N",
+            "'num_row_inputs_received': N",
             "'bytes_inputs_received': N",
             "'row_outputs_taken': N",
             "'block_outputs_taken': N",
@@ -613,6 +615,7 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "      average_bytes_outputs_per_task: N,\n"
         "      average_max_uss_per_task: H,\n"
         "      num_inputs_received: N,\n"
+        "      num_row_inputs_received: N,\n"
         "      bytes_inputs_received: N,\n"
         "      num_task_inputs_processed: N,\n"
         "      bytes_task_inputs_processed: N,\n"
@@ -704,7 +707,7 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
 
     def check_stats():
         stats = canonicalize(repr(ds._plan.stats().to_summary()))
-        assert stats == expected_stats
+        assert stats == expected_stats, stats
         return True
 
     # TODO(hchen): The reason why `wait_for_condition` is needed here is because
@@ -735,6 +738,7 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "      average_bytes_outputs_per_task: N,\n"
         "      average_max_uss_per_task: H,\n"
         "      num_inputs_received: N,\n"
+        "      num_row_inputs_received: N,\n"
         "      bytes_inputs_received: N,\n"
         "      num_task_inputs_processed: N,\n"
         "      bytes_task_inputs_processed: N,\n"
@@ -812,6 +816,7 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "            average_bytes_outputs_per_task: N,\n"
         "            average_max_uss_per_task: H,\n"
         "            num_inputs_received: N,\n"
+        "            num_row_inputs_received: N,\n"
         "            bytes_inputs_received: N,\n"
         "            num_task_inputs_processed: N,\n"
         "            bytes_task_inputs_processed: N,\n"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
We want to make transparent progress bars for all operators. Currently, `join` operators (or any operator that uses `HashShufflingBaseOperator`) will not show a progress bar, so it looks a lil funky. 
<!-- Please give a short summary of the change and the problem this solves. -->
## After these changes

Example Script
```python
import ray
ds = ray.data.range(100000000)
ds.repartition(num_blocks=4, shuffle=True, keys=['id']).materialize()
```


https://github.com/user-attachments/assets/e9e0eb2f-c8e8-4193-b84f-68936e75b765



## Other changes
- In `OpruntimeMetrics`, added `num_row_inputs_received` (a counterpart to `num_inputs_received`)
- Uplifted some estimated row output computation logic from the `MapOperator` to `PhysicalOperator` so it can also be used by `HashShufflingBaseOperator`
<!-- I noticed that `sub_progress_bar_names` implicity assumes that progress bar units are rows, which I don't think is strict requirement.  -->

## Related issue number
https://anyscale1.atlassian.net/browse/DATA-574 and https://anyscale1.atlassian.net/browse/DATA-925
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
