### PR TITLE
[core] Refactor actor method binding with `ActorMethodShell` and remove weakrefs

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -492,7 +492,7 @@ class ActorMethod:
                 )
 
             gpu_object_manager = ray._private.worker.global_worker.gpu_object_manager
-            gpu_object_manager.add_gpu_object_ref(obj_ref, self._actor_ref())
+            gpu_object_manager.add_gpu_object_ref(obj_ref, self._actor)
 
         return obj_ref
 

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -1688,5 +1688,17 @@ def test_exit_immediately_after_creation(ray_start_regular_shared, exit_type: st
     wait_for_condition(lambda: _num_actors_alive() == 0)
 
 
+def test_one_liner_actor_method_invocation(shutdown_only):
+    @ray.remote
+    class Foo:
+        def method(self):
+            return "ok"
+
+    # This one‐liner used to fail with “Lost reference to actor”.
+    # Now it should succeed and return our value.
+    result = ray.get(Foo.remote().method.remote())
+    assert result == "ok"
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -1696,6 +1696,7 @@ def test_one_liner_actor_method_invocation(shutdown_only):
 
     # This one‐liner used to fail with “Lost reference to actor”.
     # Now it should succeed and return our value.
+    # See https://github.com/ray-project/ray/pull/53178
     result = ray.get(Foo.remote().method.remote())
     assert result == "ok"
 

--- a/python/ray/tests/test_actor_failures.py
+++ b/python/ray/tests/test_actor_failures.py
@@ -751,12 +751,6 @@ def test_actor_failure_per_type(ray_start_cluster):
             self.a = Actor.remote()
             return self.a
 
-    # Test actor is dead because its reference is gone.
-    # Q(sang): Should we raise RayACtorError in this case?
-    with pytest.raises(RuntimeError, match="Lost reference to actor") as exc_info:
-        ray.get(Actor.remote().check_alive.remote())
-    print(exc_info._excinfo[1])
-
     # Test actor killed by ray.kill
     a = Actor.remote()
     ray.kill(a)

--- a/python/ray/util/tracing/tracing_helper.py
+++ b/python/ray/util/tracing/tracing_helper.py
@@ -416,14 +416,12 @@ def _tracing_actor_method_invocation(method):
         **_kwargs: Any,
     ) -> Any:
         # If tracing feature flag is not on, perform a no-op
-        if not _is_tracing_enabled() or self._actor_ref()._ray_is_cross_language:
+        if not _is_tracing_enabled() or self._actor._ray_is_cross_language:
             if kwargs is not None:
                 assert "_ray_trace_ctx" not in kwargs
             return method(self, args, kwargs, *_args, **_kwargs)
 
-        class_name = (
-            self._actor_ref()._ray_actor_creation_function_descriptor.class_name
-        )
+        class_name = self._actor._ray_actor_creation_function_descriptor.class_name
         method_name = self._method_name
         assert "_ray_trace_ctx" not in _kwargs
 
@@ -436,7 +434,7 @@ def _tracing_actor_method_invocation(method):
             # Inject a _ray_trace_ctx as a dictionary
             kwargs["_ray_trace_ctx"] = _DictPropagator.inject_current_context()
 
-            span.set_attribute("ray.actor_id", self._actor_ref()._ray_actor_id.hex())
+            span.set_attribute("ray.actor_id", self._actor._ray_actor_id.hex())
 
             return method(self, args, kwargs, *_args, **_kwargs)
 


### PR DESCRIPTION
## Why are these changes needed?

Ray actors previously kept only weak references inside `ActorMethod` to avoid circular refs and delay GC. This led to confusing `RuntimeError: Lost reference to actor` errors when users wrote one-liner invocations like:
```
ray.get(Foo.remote().method.remote())
```
This behavior had changed in https://github.com/ray-project/ray/pull/6044

In order to fix this, we introduce following changes:

1. New lightweight shell class `ActorMethodMetadata` that caches per-method metadata (name, return count, retry settings, decorator, signature) without referencing back to the `ActorHandle`, eliminating cycles.
2. `ActorHandle` updates:
  - In `ActorHandle.__init__`, build a `_method_shells` dict of `ActorMethodMetadata` for each remote method.
  - In `ActorHandle.__getattr__`, if the attribute matches a shell, call `shell.bind(self)` to produce a fresh `ActorMethod` holding a strong reference to the handle.
3. Simplify `ActorMethod` by removing `weakref` in favor of `self._actor`.
4. Add a simple unit test to verify the one liner invocation.

## Related issue number

Closes #6265 