### PR TITLE
[train] handle Noop ScalingDecision

### DIFF
--- a/python/ray/train/v2/_internal/execution/callback.py
+++ b/python/ray/train/v2/_internal/execution/callback.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
         TrainControllerState,
     )
     from ray.train.v2._internal.execution.failure_handling import FailureDecision
-    from ray.train.v2._internal.execution.scaling_policy import ScalingDecision
+    from ray.train.v2._internal.execution.scaling_policy import ResizeDecision
     from ray.train.v2._internal.execution.worker_group import (
         Worker,
         WorkerGroup,
@@ -92,11 +92,11 @@ class ControllerCallback(RayTrainCallback):
         """Called before the controller executes a failure decision."""
         pass
 
-    def before_controller_execute_scaling_decision(
+    def before_controller_execute_resize_decision(
         self,
-        scaling_decision: "ScalingDecision",
+        resize_decision: "ResizeDecision",
     ):
-        """Called before the controller executes a scaling decision."""
+        """Called before the controller executes a resize decision."""
         pass
 
 

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -380,17 +380,15 @@ class TrainController:
         """
         controller_state = self.get_state()
 
-        if isinstance(controller_state, InitializingState):
+        if isinstance(
+            controller_state, (InitializingState, ReschedulingState, RestartingState)
+        ):
             return self._make_and_handle_scaling_decision_for_non_running_worker_group(
                 controller_state
             )
         elif isinstance(controller_state, SchedulingState):
             assert isinstance(controller_state.scaling_decision, ResizeDecision)
             return self._execute_resize_decision(controller_state.scaling_decision)
-        elif isinstance(controller_state, ReschedulingState):
-            return self._make_and_handle_scaling_decision_for_non_running_worker_group(
-                controller_state
-            )
         elif isinstance(controller_state, RunningState):
             worker_group_status = self._poll_workers()
 
@@ -427,10 +425,6 @@ class TrainController:
                     previous_state=controller_state,
                     next_state=next_state,
                 )
-        elif isinstance(controller_state, RestartingState):
-            return self._make_and_handle_scaling_decision_for_non_running_worker_group(
-                controller_state
-            )
         elif isinstance(controller_state, ResizingState):
             return TrainControllerLoopIterationResult(
                 run_attempt_id=self._get_run_attempt_id(),


### PR DESCRIPTION
This PR makes two changes to simplify controller state management and appropriately handle Noops.

[1] Change `SchedulingState` to always take a `ResizeDecision`.

[2] Consolidates the behavior of the following states:
     1.  `InitializingState`
     2. `RestartingState`
     3. `ReschedulingState`
 
For all of these, they will now follow this pattern:
     1. Call `self._scaling_policy.make_decision_for_non_running_worker_group()`
     2. If `NoopDecision`, remain in current state.
     3. If `ResizeDecision`, transition to `SchedulingState`.