### PR TITLE
[Docs] Standardize on all-caps NVIDIA

### DIFF
--- a/.vale/styles/config/vocabularies/General/accept.txt
+++ b/.vale/styles/config/vocabularies/General/accept.txt
@@ -58,7 +58,7 @@ namespace
 NER
 Nsight
 NumPy
-Nvidia
+NVIDIA
 pretraining
 Pythonic
 QPS

--- a/doc/source/cluster/kubernetes/examples/rayjob-batch-inference-example.md
+++ b/doc/source/cluster/kubernetes/examples/rayjob-batch-inference-example.md
@@ -14,7 +14,7 @@ You must have a Kubernetes cluster running,`kubectl` configured to use it, and G
 If you already have a Kubernetes cluster with GPUs, you can skip this step.
 
 
-Otherwise, follow [this tutorial](kuberay-gke-gpu-cluster-setup), but substitute the following GPU node pool creation command to create a Kubernetes cluster on GKE with four Nvidia T4 GPUs:
+Otherwise, follow [this tutorial](kuberay-gke-gpu-cluster-setup), but substitute the following GPU node pool creation command to create a Kubernetes cluster on GKE with four NVIDIA T4 GPUs:
 
 ```sh
 gcloud container node-pools create gpu-node-pool \
@@ -28,7 +28,7 @@ gcloud container node-pools create gpu-node-pool \
   --machine-type n1-standard-64
 ```
 
-This example uses four [Nvidia T4](https://cloud.google.com/compute/docs/gpus#nvidia_t4_gpus) GPUs. The machine type is `n1-standard-64`, which has [64 vCPUs and 240 GB RAM](https://cloud.google.com/compute/docs/general-purpose-machines#n1_machine_types).
+This example uses four [NVIDIA T4](https://cloud.google.com/compute/docs/gpus#nvidia_t4_gpus) GPUs. The machine type is `n1-standard-64`, which has [64 vCPUs and 240 GB RAM](https://cloud.google.com/compute/docs/general-purpose-machines#n1_machine_types).
 
 ## Step 1: Install the KubeRay Operator
 

--- a/doc/source/cluster/kubernetes/user-guides/azure-aks-gpu-cluster.md
+++ b/doc/source/cluster/kubernetes/user-guides/azure-aks-gpu-cluster.md
@@ -43,7 +43,7 @@ az aks nodepool add \
    --max-count 3 \
    --enable-cluster-autoscaler
 ```
-To use Nvidia GPU operator alternatively, follow instructions [here](https://learn.microsoft.com/en-us/azure/aks/gpu-cluster?tabs=add-ubuntu-gpu-node-pool#skip-gpu-driver-installation-preview)
+To use NVIDIA GPU operator alternatively, follow instructions [here](https://learn.microsoft.com/en-us/azure/aks/gpu-cluster?tabs=add-ubuntu-gpu-node-pool#skip-gpu-driver-installation-preview)
 
 ## Step 4: Get kubeconfig
 

--- a/doc/source/cluster/kubernetes/user-guides/config.md
+++ b/doc/source/cluster/kubernetes/user-guides/config.md
@@ -135,7 +135,7 @@ workloads a minimum amount of CPU but [allow them to take advantage of unused CP
 throttled][1] if they use more than their requested CPU.
 
 For GPU workloads, you may also wish to specify GPU
-limits. For example, set `nvidia.com/gpu: 2` if using an Nvidia GPU device plugin
+limits. For example, set `nvidia.com/gpu: 2` if using an NVIDIA GPU device plugin
 and you wish to specify a pod with access to 2 GPUs.
 See {ref}`this guide <kuberay-gpu>` for more details on GPU support.
 

--- a/doc/source/cluster/kubernetes/user-guides/gpu.rst
+++ b/doc/source/cluster/kubernetes/user-guides/gpu.rst
@@ -30,7 +30,7 @@ To add custom dependencies, use one, or both, of the following methods:
 Configuring Ray pods for GPU usage
 __________________________________
 
-Using Nvidia GPUs requires specifying `nvidia.com/gpu` resource `limits` and `requests` in the container fields of your `RayCluster`'s
+Using NVIDIA GPUs requires specifying `nvidia.com/gpu` resource `limits` and `requests` in the container fields of your `RayCluster`'s
 `headGroupSpec` and/or `workerGroupSpecs`.
 
 Here is a config snippet for a RayCluster workerGroup of up
@@ -187,7 +187,7 @@ GPU taints and tolerations
   for you. If you are using a managed Kubernetes service, you might not need to worry
   about this section.
 
-The `Nvidia gpu plugin`_ for Kubernetes applies `taints`_ to GPU nodes; these taints prevent non-GPU pods from being scheduled on GPU nodes.
+The `NVIDIA gpu plugin`_ for Kubernetes applies `taints`_ to GPU nodes; these taints prevent non-GPU pods from being scheduled on GPU nodes.
 Managed Kubernetes services like GKE, EKS, and AKS automatically apply matching `tolerations`_
 to pods requesting GPU resources. Tolerations are applied by means of Kubernetes's `ExtendedResourceToleration`_ `admission controller`_.
 If this admission controller is not enabled for your Kubernetes cluster, you may need to manually add a GPU toleration to each of your GPU pod configurations. For example,
@@ -222,7 +222,7 @@ Further reference and discussion
 --------------------------------
 Read about Kubernetes device plugins `here <https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/>`__,
 about Kubernetes GPU plugins `here <https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus>`__,
-and about Nvidia's GPU plugin for Kubernetes `here <https://github.com/NVIDIA/k8s-device-plugin>`__.
+and about NVIDIA's GPU plugin for Kubernetes `here <https://github.com/NVIDIA/k8s-device-plugin>`__.
 
 .. _`GKE`: https://cloud.google.com/kubernetes-engine/docs/how-to/gpus
 .. _`EKS`: https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html
@@ -235,7 +235,7 @@ and about Nvidia's GPU plugin for Kubernetes `here <https://github.com/NVIDIA/k8
 
 .. _`tolerations`: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
 .. _`taints`: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-.. _`Nvidia gpu plugin`: https://github.com/NVIDIA/k8s-device-plugin
+.. _`NVIDIA gpu plugin`: https://github.com/NVIDIA/k8s-device-plugin
 .. _`admission controller`: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/
 .. _`ExtendedResourceToleration`: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#extendedresourcetoleration
 .. _`Kubernetes docs`: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/

--- a/doc/source/ray-core/scheduling/accelerators.rst
+++ b/doc/source/ray-core/scheduling/accelerators.rst
@@ -15,7 +15,7 @@ The accelerators natively supported by Ray Core are:
    * - Accelerator
      - Ray Resource Name
      - Support Level
-   * - Nvidia GPU
+   * - NVIDIA GPU
      - GPU
      - Fully tested, supported by the Ray team
    * - AMD GPU
@@ -45,13 +45,13 @@ If you need to, you can :ref:`override <specify-node-resources>` this.
 
 .. tab-set::
 
-    .. tab-item:: Nvidia GPU
-        :sync: Nvidia GPU
+    .. tab-item:: NVIDIA GPU
+        :sync: NVIDIA GPU
 
         .. tip::
 
             You can set the ``CUDA_VISIBLE_DEVICES`` environment variable before starting a Ray node
-            to limit the Nvidia GPUs that are visible to Ray.
+            to limit the NVIDIA GPUs that are visible to Ray.
             For example, ``CUDA_VISIBLE_DEVICES=1,3 ray start --head --num-gpus=2``
             lets Ray only see devices 1 and 3.
 
@@ -135,8 +135,8 @@ and assign accelerators to the task or actor by setting the corresponding enviro
 
 .. tab-set::
 
-    .. tab-item:: Nvidia GPU
-        :sync: Nvidia GPU
+    .. tab-item:: NVIDIA GPU
+        :sync: NVIDIA GPU
 
         .. testcode::
 
@@ -446,8 +446,8 @@ so multiple tasks and actors can share the same accelerator.
 
 .. tab-set::
 
-    .. tab-item:: Nvidia GPU
-        :sync: Nvidia GPU
+    .. tab-item:: NVIDIA GPU
+        :sync: NVIDIA GPU
 
         .. testcode::
             :hide:

--- a/doc/source/ray-observability/reference/system-metrics.rst
+++ b/doc/source/ray-observability/reference/system-metrics.rst
@@ -40,7 +40,7 @@ Ray exports a number of system metrics, which provide introspection into the sta
      - The number of CPU cores per node.
    * - `ray_node_gpus_utilization`
      - `InstanceId`, `GpuDeviceName`, `GpuIndex`
-     - The GPU utilization per GPU as a percentage quantity (0..NGPU*100). `GpuDeviceName` is a name of a GPU device (e.g., Nvidia A10G) and `GpuIndex` is the index of the GPU.
+     - The GPU utilization per GPU as a percentage quantity (0..NGPU*100). `GpuDeviceName` is a name of a GPU device (e.g., NVIDIA A10G) and `GpuIndex` is the index of the GPU.
    * - `ray_node_disk_usage`
      - `InstanceId`
      - The amount of disk space used per node, in bytes.

--- a/doc/source/ray-overview/installation.rst
+++ b/doc/source/ray-overview/installation.rst
@@ -350,7 +350,7 @@ The optional ``Platform`` tag specifies the platform where the image is intended
    * - -cpu
      - These are based off of an Ubuntu image.
    * - -cuXX
-     - These are based off of an NVIDIA CUDA image with the specified CUDA version. They require the Nvidia Docker Runtime.
+     - These are based off of an NVIDIA CUDA image with the specified CUDA version. They require the NVIDIA Docker Runtime.
    * - -gpu
      - Aliases to a specific ``-cuXX`` tagged image.
    * - <no tag>

--- a/doc/source/templates/04_finetuning_llms_with_deepspeed/finetune_hf_llm.py
+++ b/doc/source/templates/04_finetuning_llms_with_deepspeed/finetune_hf_llm.py
@@ -573,7 +573,7 @@ def parse_args():
         choices=["no", "fp16", "bf16", "fp8"],
         help="Whether to use mixed precision. Choose"
         "between fp16 and bf16 (bfloat16). Bf16 requires PyTorch >= 1.10."
-        "and an Nvidia Ampere GPU.",
+        "and an NVIDIA Ampere GPU.",
     )
 
     parser.add_argument(

--- a/docker/base-deps/README.md
+++ b/docker/base-deps/README.md
@@ -21,7 +21,7 @@ The optional `Platform` tag specifies the platform where the image is intended f
 | Platform tag | Description |
 | --------------- | ----------- |
 | `-cpu`  | These are based off of an Ubuntu image. |
-| `-cuXX` | These are based off of an NVIDIA CUDA image with the specified CUDA version `xx`. They require the Nvidia Docker Runtime. |
+| `-cuXX` | These are based off of an NVIDIA CUDA image with the specified CUDA version `xx`. They require the NVIDIA Docker Runtime. |
 | `-gpu`  | Aliases to a specific `-cuXX` tagged image. |
 | no tag  | Aliases to `-cpu` tagged images for `ray`, and aliases to ``-gpu`` tagged images for `ray-ml`. |
 

--- a/docker/ray-ml/README.md
+++ b/docker/ray-ml/README.md
@@ -18,7 +18,7 @@ The optional `Platform` tag specifies the platform where the image is intended f
 | Platform tag | Description |
 | --------------- | ----------- |
 | `-cpu`  | These are based off of an Ubuntu image. |
-| `-cuXX` | These are based off of an NVIDIA CUDA image with the specified CUDA version `xx`. They require the Nvidia Docker Runtime. |
+| `-cuXX` | These are based off of an NVIDIA CUDA image with the specified CUDA version `xx`. They require the NVIDIA Docker Runtime. |
 | `-gpu`  | Aliases to a specific `-cuXX` tagged image. |
 | no tag  | Aliases to `-cpu` tagged images for `ray`, and aliases to ``-gpu`` tagged images for `ray-ml`. |
 

--- a/docker/ray/README.md
+++ b/docker/ray/README.md
@@ -19,7 +19,7 @@ The optional `Platform` tag specifies the platform where the image is intended f
 | Platform tag | Description |
 | --------------- | ----------- |
 | `-cpu`  | These are based off of an Ubuntu image. |
-| `-cuXX` | These are based off of an NVIDIA CUDA image with the specified CUDA version `xx`. They require the Nvidia Docker Runtime. |
+| `-cuXX` | These are based off of an NVIDIA CUDA image with the specified CUDA version `xx`. They require the NVIDIA Docker Runtime. |
 | `-gpu`  | Aliases to a specific `-cuXX` tagged image. |
 | no tag  | Aliases to `-cpu` tagged images for `ray`, and aliases to ``-gpu`` tagged images for `ray-ml`. |
 

--- a/python/ray/_private/accelerators/accelerator.py
+++ b/python/ray/_private/accelerators/accelerator.py
@@ -12,7 +12,7 @@ class AcceleratorManager(ABC):
         """Get the name of the resource representing this accelerator family.
 
         Returns:
-            The resource name: e.g., the resource name for Nvidia GPUs is "GPU"
+            The resource name: e.g., the resource name for NVIDIA GPUs is "GPU"
         """
 
     @staticmethod
@@ -22,7 +22,7 @@ class AcceleratorManager(ABC):
 
         Returns:
             The env var for setting visible accelerator ids: e.g.,
-                CUDA_VISIBLE_DEVICES for Nvidia GPUs.
+                CUDA_VISIBLE_DEVICES for NVIDIA GPUs.
         """
 
     @staticmethod
@@ -46,7 +46,7 @@ class AcceleratorManager(ABC):
         The result should only be used when get_current_node_num_accelerators() > 0.
 
         Returns:
-            The detected accelerator type of this family: e.g., H100 for Nvidia GPU.
+            The detected accelerator type of this family: e.g., H100 for NVIDIA GPU.
             Return None if it's unknown or the node doesn't have
             accelerators of this family.
         """

--- a/python/ray/_private/accelerators/nvidia_gpu.py
+++ b/python/ray/_private/accelerators/nvidia_gpu.py
@@ -16,7 +16,7 @@ NVIDIA_GPU_NAME_PATTERN = re.compile(r"\w+\s+([A-Z0-9]+)")
 
 
 class NvidiaGPUAcceleratorManager(AcceleratorManager):
-    """Nvidia GPU accelerators."""
+    """NVIDIA GPU accelerators."""
 
     @staticmethod
     def get_resource_name() -> str:

--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -877,7 +877,7 @@ class DockerCommandRunner(CommandRunnerInterface):
                 return run_options + ["--runtime=nvidia"]
             except Exception as e:
                 logger.warning(
-                    "Nvidia Container Runtime is present, but no GPUs found."
+                    "NVIDIA Container Runtime is present, but no GPUs found."
                 )
                 logger.debug(f"nvidia-smi error: {e}")
                 return run_options

--- a/python/ray/autoscaler/vsphere/defaults.yaml
+++ b/python/ray/autoscaler/vsphere/defaults.yaml
@@ -52,10 +52,10 @@ available_node_types:
         # This number should be >= 0.
         min_workers: 1
         max_workers: 3
-        # You can override the resources here. For GPU, currently only Nvidia GPU is supported. If no ESXi host can
+        # You can override the resources here. For GPU, currently only NVIDIA GPU is supported. If no ESXi host can
         # fulfill the requirement, the Ray node creation will fail. The number of created nodes may not meet the desired
         # minimum number. The vSphere node provider will not distinguish the GPU type. It will just count the quantity:
-        # mount the first k random available Nvidia GPU to the VM, if the user set {"GPU": k}.
+        # mount the first k random available NVIDIA GPU to the VM, if the user set {"GPU": k}.
         # resources: {"CPU": 2, "Memory": 4096, "GPU": 1}
         resources: {}
     worker_2:
@@ -63,10 +63,10 @@ available_node_types:
          # This number should be >= 0.
          min_workers: 1
          max_workers: 2
-         # You can override the resources here. For GPU, currently only Nvidia GPU is supported. If no ESXi host can
+         # You can override the resources here. For GPU, currently only NVIDIA GPU is supported. If no ESXi host can
          # fulfill the requirement, the Ray node creation will fail. The number of created nodes may not meet the desired
          # minimum number. The vSphere node provider will not distinguish the GPU type. It will just count the quantity:
-         # mount the first k random available Nvidia GPU to the VM, if the user set {"GPU": k}.
+         # mount the first k random available NVIDIA GPU to the VM, if the user set {"GPU": k}.
          # resources: {"CPU": 2, "Memory": 4096, "GPU": 1}
          resources: {}
 

--- a/python/ray/autoscaler/vsphere/example-full.yaml
+++ b/python/ray/autoscaler/vsphere/example-full.yaml
@@ -53,10 +53,10 @@ available_node_types:
         # This number should be >= 0.
         min_workers: 1
         max_workers: 3
-        # You can override the resources here. For GPU, currently only Nvidia GPU is supported. If no ESXi host can
+        # You can override the resources here. For GPU, currently only NVIDIA GPU is supported. If no ESXi host can
         # fulfill the requirement, the Ray node creation will fail. The number of created nodes may not meet the desired
         # minimum number. The vSphere node provider will not distinguish the GPU type. It will just count the quantity:
-        # mount the first k random available Nvidia GPU to the VM, if the user set {"GPU": k}.
+        # mount the first k random available NVIDIA GPU to the VM, if the user set {"GPU": k}.
         # resources: {"CPU": 2, "Memory": 4096, "GPU": 1}
         resources: {}
         node_config: {"vm_class": "best-effort-xlarge"}
@@ -65,10 +65,10 @@ available_node_types:
          # This number should be >= 0.
          min_workers: 1
          max_workers: 2
-         # You can override the resources here. For GPU, currently only Nvidia GPU is supported. If no ESXi host can
+         # You can override the resources here. For GPU, currently only NVIDIA GPU is supported. If no ESXi host can
          # fulfill the requirement, the Ray node creation will fail. The number of created nodes may not meet the desired
          # minimum number. The vSphere node provider will not distinguish the GPU type. It will just count the quantity:
-         # mount the first k random available Nvidia GPU to the VM, if the user set {"GPU": k}.
+         # mount the first k random available NVIDIA GPU to the VM, if the user set {"GPU": k}.
          # resources: {"CPU": 2, "Memory": 4096, "GPU": 1}
          resources: {}
          node_config: {"vm_class": "best-effort-xlarge"}

--- a/python/ray/autoscaler/vsphere/example-minimal.yaml
+++ b/python/ray/autoscaler/vsphere/example-minimal.yaml
@@ -30,10 +30,10 @@ available_node_types:
         # This number should be >= 0.
         min_workers: 1
         max_workers: 3
-        # You can override the resources here. For GPU, currently only Nvidia GPU is supported. If no ESXi host can
+        # You can override the resources here. For GPU, currently only NVIDIA GPU is supported. If no ESXi host can
         # fulfill the requirement, the Ray node creation will fail. The number of created nodes may not meet the desired
         # minimum number. The vSphere node provider will not distinguish the GPU type. It will just count the quantity:
-        # mount the first k random available Nvidia GPU to the VM, if the user set {"GPU": k}.
+        # mount the first k random available NVIDIA GPU to the VM, if the user set {"GPU": k}.
         # resources: {"CPU": 2, "Memory": 4096, "GPU": 1}
         resources: {}
 

--- a/python/ray/dashboard/client/src/components/ActorTable.tsx
+++ b/python/ray/dashboard/client/src/components/ActorTable.tsx
@@ -269,7 +269,7 @@ const ActorTable = ({
           <br />
           1. non-GPU Ray image is used on this node. Switch to a GPU Ray image
           and try again. <br />
-          2. Non Nvidia GPUs are being used. Non Nvidia GPUs' utilizations are
+          2. Non NVIDIA GPUs are being used. Non NVIDIA GPUs' utilizations are
           not currently supported.
           <br />
           3. pynvml module raises an exception.

--- a/python/ray/dashboard/client/src/pages/node/index.tsx
+++ b/python/ray/dashboard/client/src/pages/node/index.tsx
@@ -80,7 +80,7 @@ const columns = [
         <br />
         1. non-GPU Ray image is used on this node. Switch to a GPU Ray image and
         try again. <br />
-        2. Non Nvidia GPUs are being used. Non Nvidia GPUs' utilizations are not
+        2. Non NVIDIA GPUs are being used. Non NVIDIA GPUs' utilizations are not
         currently supported.
         <br />
         3. pynvml module raises an exception.

--- a/python/ray/experimental/channel/communicator.py
+++ b/python/ray/experimental/channel/communicator.py
@@ -18,7 +18,7 @@ TorchTensorAllocator = Callable[[Tuple[int], "torch.dtype"], "torch.Tensor"]
 @DeveloperAPI
 class Communicator(ABC):
     """
-    Communicator for a group of Compiled Graph actors on Nvidia GPU.
+    Communicator for a group of Compiled Graph actors on NVIDIA GPU.
 
     The Compiled Graph execution leverages this internally to support communication
     between actors in the group.


### PR DESCRIPTION
## Why are these changes needed?

Vale currently throws an error if you use "NVIDIA" instead of "Nvidia" but actually we should be using all-caps NVIDIA:

<img width="1106" alt="image" src="https://github.com/user-attachments/assets/1c53eb09-d370-4620-a2d0-5f10ff335de6" />

This PR updates the Vale vocab and fixes the spelling across the repo.

## Related issue number

N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
