### PR TITLE
[serve] Fix runtime_env validation for py_modules

### DIFF
--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -260,9 +260,9 @@ class RayActorOptionsSchema(BaseModel):
         if v is None:
             return
 
-        uris = v.get("py_modules", []).copy()
+        uris = v.get("py_modules", [])
         if "working_dir" in v:
-            uris.append(v["working_dir"])
+            uris = [*uris, v["working_dir"]]
 
         for uri in uris:
             if uri is not None:
@@ -574,9 +574,9 @@ class ServeApplicationSchema(BaseModel):
         if v is None:
             return
 
-        uris = v.get("py_modules", []).copy()
+        uris = v.get("py_modules", [])
         if "working_dir" in v:
-            uris.append(v["working_dir"])
+            uris = [*uris, v["working_dir"]]
 
         for uri in uris:
             if uri is not None:

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -260,8 +260,8 @@ class RayActorOptionsSchema(BaseModel):
         if v is None:
             return
 
-        uris = v.get("py_modules", [])
-        if "working_dir" in v and v["working_dir"] not in uris:
+        uris = v.get("py_modules", []).copy()
+        if "working_dir" in v:
             uris.append(v["working_dir"])
 
         for uri in uris:
@@ -574,8 +574,8 @@ class ServeApplicationSchema(BaseModel):
         if v is None:
             return
 
-        uris = v.get("py_modules", [])
-        if "working_dir" in v and v["working_dir"] not in uris:
+        uris = v.get("py_modules", []).copy()
+        if "working_dir" in v:
             uris.append(v["working_dir"])
 
         for uri in uris:

--- a/python/ray/serve/tests/unit/test_schema.py
+++ b/python/ray/serve/tests/unit/test_schema.py
@@ -761,7 +761,6 @@ def test_deployment_to_schema_to_deployment():
     )
     assert deployment.ray_actor_options["runtime_env"]["py_modules"] == [
         TEST_DEPLOY_GROUP_PINNED_URI,
-        TEST_MODULE_PINNED_URI,
     ]
 
 

--- a/python/ray/serve/tests/unit/test_schema.py
+++ b/python/ray/serve/tests/unit/test_schema.py
@@ -135,13 +135,10 @@ class TestRayActorOptionsSchema:
 
         ray_actor_options_schema = self.get_valid_ray_actor_options_schema()
         ray_actor_options_schema["runtime_env"] = env
+        original_runtime_env = copy.deepcopy(env)
         schema = RayActorOptionsSchema.parse_obj(ray_actor_options_schema)
-
-        original_runtime_env = copy.deepcopy(schema.runtime_env)
-        # Make sure "working_dir" is only added once.
-        for _ in range(5):
-            schema = RayActorOptionsSchema.parse_obj(schema)
-            assert schema.runtime_env == original_runtime_env
+        # Make sure runtime environment is unchanged by the validation
+        assert schema.runtime_env == original_runtime_env
 
     @pytest.mark.parametrize("env", get_invalid_runtime_envs())
     def test_ray_actor_options_invalid_runtime_env(self, env):
@@ -445,13 +442,10 @@ class TestServeApplicationSchema:
 
         serve_application_schema = self.get_valid_serve_application_schema()
         serve_application_schema["runtime_env"] = env
+        original_runtime_env = copy.deepcopy(env)
         schema = ServeApplicationSchema.parse_obj(serve_application_schema)
-
-        original_runtime_env = copy.deepcopy(schema.runtime_env)
-        # Make sure "working_dir" is only added once.
-        for _ in range(5):
-            schema = ServeApplicationSchema.parse_obj(schema)
-            assert schema.runtime_env == original_runtime_env
+        # Make sure runtime environment is unchanged by the validation
+        assert schema.runtime_env == original_runtime_env
 
     @pytest.mark.parametrize("env", get_invalid_runtime_envs())
     def test_serve_application_invalid_runtime_env(self, env):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This fixes the fix https://github.com/ray-project/ray/pull/41688 -- that fix was the wrong fix since the validation should never change the runtime_env.

It introduced the problem in https://discuss.ray.io/t/query-application-status-api-triggers-re-deployment/22517

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
