### PR TITLE
[Core] Fix a check failure where removing PG fails to return the PG resources

### DIFF
--- a/python/ray/tests/test_placement_group_5.py
+++ b/python/ray/tests/test_placement_group_5.py
@@ -12,7 +12,7 @@ from ray.tests.test_placement_group import are_pairwise_unique
 from ray.util.state import list_actors, list_placement_groups
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from ray._private.runtime_env.plugin import RuntimeEnvPlugin
-from ray._private.test_utils import wait_for_condition
+from ray._private.test_utils import wait_for_condition, fetch_prometheus_metrics
 from click.testing import CliRunner
 import ray.scripts.scripts as scripts
 
@@ -638,6 +638,88 @@ def test_placement_group_strict_pack_soft_target_node_id(ray_start_cluster):
         )
         == head_node_id
     )
+
+
+def test_remove_placement_group_with_pending_worker_lease_waiting_for_pg_resource(
+    shutdown_only,
+):
+    """
+    Test removing a pg with a pending worker lease request acquiring the pg resources.
+    details: https://github.com/ray-project/ray/issues/51124
+    Specific test steps:
+      1. Create a placement group with only 1 bundle.
+      2. Create two actors using the aforementioned pg. At this point,
+         the latter actor lease request will definitely be pending in local task manager dispatch queue due to
+         unavailable pg bundle resources.
+      3. Remove the pg while the latter actor lease request is pending.
+      4. Verify that the pending actor lease request is cancelled and the pg
+         is removed successfully.
+    """
+    context = ray.init(num_cpus=1)
+    prom_address = f"{context.address_info['node_ip_address']}:{context.address_info['metrics_export_port']}"
+
+    pg = ray.util.placement_group(
+        [{"CPU": 1}],
+    )
+
+    @ray.remote(
+        num_cpus=1,
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=pg, placement_group_bundle_index=0
+        ),
+    )
+    class Actor:
+        def ping(self):
+            pass
+
+    actor1 = Actor.remote()
+    # Actor1 is scheduled and used all the PG resources.
+    ray.get(actor1.ping.remote())
+
+    actor2 = Actor.remote()
+
+    def wait_for_actor2_added_to_dispatch_queue():
+        metrics = fetch_prometheus_metrics([prom_address])
+        samples = metrics.get("ray_scheduler_tasks", None)
+        if samples is None:
+            return False
+        for sample in samples:
+            if sample.labels["State"] == "Dispatched" and sample.value == 1:
+                # actor2 is in the local task manager dispatch queue
+                return True
+        return False
+
+    wait_for_condition(wait_for_actor2_added_to_dispatch_queue, timeout=30)
+
+    ray.util.remove_placement_group(pg)
+
+    def check_pg_removed():
+        pgs = list_placement_groups()
+        assert len(pgs) == 1
+        assert "REMOVED" == pgs[0].state
+        return True
+
+    wait_for_condition(check_pg_removed)
+
+    # Actors should be dead due to the pg removal.
+    def check_actor_dead():
+        actors = list_actors()
+        assert len(actors) == 2
+        assert [actors[0].state, actors[1].state] == ["DEAD", "DEAD"]
+        return True
+
+    wait_for_condition(check_actor_dead)
+
+    # Actor2 should be cancelled due to the pg removal.
+    with pytest.raises(ray.exceptions.ActorUnschedulableError):
+        ray.get(actor2.ping.remote())
+
+    # Check that the raylet is still running.
+    @ray.remote
+    def task():
+        return 1
+
+    assert ray.get(task.remote()) == 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Example of sequence of events that causes this check failure is:
- A single 1 CPU bundle PG is created -> (PG_CPU_RESOURCE: [1/1])
- A 1 CPU actor is created and used that 1 CPU from the PG -> (PG_CPU_RESOURCE: [0/1])
- Another 1 CPU actor is created and its worker lease request is added to the local task manager dispatch queue since there is no available PG resources (already used by the first actor).
- The PG is manually removed by the user.
- `CancelResourceReserve` RPC is sent to the raylet.
- The `CancelResourceReserve` handler first tries to cancel any lease requests in the local task manager that need the PG resource AND is WAITING_FOR_WORKER. In this case there is none of them.
- The worker that runs the first actor is forcibly killed by `DestroyWorker` which calls `DisconnectClient`. `DisconnectClient` first releases the PG resource used by the first actor since it's killed (PG_CPU_RESOURCE: [1/1]) and it calls `ScheduleAndDispatchTasks` which unblocks the second actor and the just released PG resource is claimed by the second actor immediately https://github.com/ray-project/ray/blob/9b1917a8659dd73b67777a4d745e2a52e85d5594/src/ray/raylet/local_task_manager.cc#L335 (PG_CPU_RESOURCE: [0/1])
- Then we try to return the PG resource https://github.com/ray-project/ray/blob/9b1917a8659dd73b67777a4d745e2a52e85d5594/src/ray/raylet/node_manager.cc#L2169 which expects the PG resource is completely free (i.e. available == total) but it's not the case since it's now used by the second actor (i.e. available is 0) and causes the check failure.

The fix is that when the PG is removed, we should cancel the actor 2 lease request as well. So by the time we `DestroyWorker` of actor 1, actor 2 lease request is already cancelled and removed from the local task manager dispatch queue so that it won't have chance to acquire the PG resource released by the first actor.

This is the minimal fix for #51124 and I have a follow-up #52751 to make the relevant code cleaner and add c++ unit tests after #53120 is merged.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->
Closes #51124
## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
