### PR TITLE
setup-dev.py: fix invalid '-r' option in mv command

### DIFF
--- a/python/ray/setup-dev.py
+++ b/python/ray/setup-dev.py
@@ -84,7 +84,7 @@ def do_link(package, force=False, skip_list=None, allow_list=None, local_path=No
             generated_folder = os.path.join(package_home, "generated")
             if not os.path.exists(serve_temp_dir):
                 os.makedirs(serve_temp_dir)
-            subprocess.check_call(["mv", "-r", generated_folder, serve_temp_dir])
+            subprocess.check_call(["mv", generated_folder, serve_temp_dir])
 
         # Create backup of the old directory if it exists
         if os.path.exists(package_home):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
after https://github.com/ray-project/ray/pull/53063, exec `python python/ray/setup-dev.py -y` failed:

```
mv: invalid option -- 'r'
Try 'mv --help' for more information.
subprocess.CalledProcessError: Command '['mv', '-r', '.../lib/python3.9/site-packages/ray/serve/generated', '/tmp/ray/_serve/']' returned non-zero exit status 1.
```

## Related issue number

<!-- For example: "Closes #1234" -->
Fix https://github.com/ray-project/ray/pull/53063

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
