### PR TITLE
[RLlib] Enhance Learner/LearnerGroup APIs: Add placement group and learner index.

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -892,8 +892,6 @@ class Algorithm(Checkpointable, Trainable):
             )
             agg_cls = ray.remote(
                 num_cpus=1,
-                # TODO (sven): Activate this when Ray has figured out GPU pre-loading.
-                # num_gpus=0.01 if self.config.num_gpus_per_learner > 0 else 0,
                 max_restarts=-1,
             )(AggregatorActor)
             self._aggregator_actor_manager = FaultTolerantActorManager(

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -81,8 +81,7 @@ from ray.tune.registry import get_trainable_cls
 from ray.tune.result import TRIAL_INFO
 from ray.tune.tune import _Config
 from ray.util import log_once
-
-Space = gym.Space
+from ray.util.placement_group import PlacementGroup
 
 
 if TYPE_CHECKING:
@@ -1272,6 +1271,7 @@ class AlgorithmConfig(_Config):
         env: Optional[EnvType] = None,
         spaces: Optional[Dict[ModuleID, Tuple[gym.Space, gym.Space]]] = None,
         rl_module_spec: Optional[RLModuleSpecType] = None,
+        placement_group: Optional["PlacementGroup"] = None,
     ) -> "LearnerGroup":
         """Builds and returns a new LearnerGroup object based on settings in `self`.
 
@@ -1303,7 +1303,11 @@ class AlgorithmConfig(_Config):
             rl_module_spec = self.get_multi_rl_module_spec(env=env, spaces=spaces)
 
         # Construct the actual LearnerGroup.
-        learner_group = LearnerGroup(config=self.copy(), module_spec=rl_module_spec)
+        learner_group = LearnerGroup(
+            config=self.copy(),
+            module_spec=rl_module_spec,
+            placement_group=placement_group,
+        )
 
         return learner_group
 
@@ -1699,8 +1703,8 @@ class AlgorithmConfig(_Config):
         env: Optional[Union[str, EnvType]] = NotProvided,
         *,
         env_config: Optional[EnvConfigDict] = NotProvided,
-        observation_space: Optional[gym.spaces.Space] = NotProvided,
-        action_space: Optional[gym.spaces.Space] = NotProvided,
+        observation_space: Optional[gym.Space] = NotProvided,
+        action_space: Optional[gym.Space] = NotProvided,
         render_env: Optional[bool] = NotProvided,
         clip_rewards: Optional[Union[bool, float]] = NotProvided,
         normalize_actions: Optional[bool] = NotProvided,
@@ -4386,7 +4390,7 @@ class AlgorithmConfig(_Config):
         self,
         *,
         env: Optional[EnvType] = None,
-        spaces: Optional[Dict[PolicyID, Tuple[Space, Space]]] = None,
+        spaces: Optional[Dict[PolicyID, Tuple[gym.Space, gym.Space]]] = None,
         inference_only: bool = False,
         # @HybridAPIStack
         policy_dict: Optional[Dict[str, PolicySpec]] = None,
@@ -5447,7 +5451,7 @@ class AlgorithmConfig(_Config):
         *,
         policies: Optional[MultiAgentPolicyConfigDict] = None,
         env: Optional[EnvType] = None,
-        spaces: Optional[Dict[PolicyID, Tuple[Space, Space]]] = None,
+        spaces: Optional[Dict[PolicyID, Tuple[gym.Space, gym.Space]]] = None,
         default_policy_class: Optional[Type[Policy]] = None,
     ) -> Tuple[MultiAgentPolicyConfigDict, Callable[[PolicyID, SampleBatchType], bool]]:
         r"""Compiles complete multi-agent config (dict) from the information in `self`.

--- a/rllib/algorithms/utils.py
+++ b/rllib/algorithms/utils.py
@@ -49,12 +49,6 @@ class AggregatorActor(FaultAwareApply):
         # Set device and node.
         self._node = platform.node()
         self._device = torch.device("cpu")
-        # TODO (sven): Activate this when Ray has figured out GPU pre-loading.
-        # self._device = torch.device(
-        #    f"cuda:{ray.get_gpu_ids()[0]}"
-        #    if self.config.num_gpus_per_learner > 0
-        #    else "cpu"
-        # )
         self.metrics = MetricsLogger()
 
         # Create the RLModule.

--- a/rllib/core/learner/learner.py
+++ b/rllib/core/learner/learner.py
@@ -240,6 +240,11 @@ class Learner(Checkpointable):
         # Whether self.build has already been called.
         self._is_built = False
 
+        # Attributes to be set separately (not by user's custom `build()` code)
+        # by a LearnerGroup.
+        self._learner_index = 0
+        self._placement_group = None
+
         # These are the attributes that are set during build.
 
         # The actual MultiRLModule used by this Learner.
@@ -1674,6 +1679,10 @@ class Learner(Checkpointable):
             reduce="sum",
             with_throughput=True,
         )
+
+    def _set_learner_index_and_placement_group(self, *, learner_index, placement_group):
+        self._learner_index = learner_index
+        self._placement_group = placement_group
 
     @Deprecated(new="Learner.update(batch=.., ..)", error=False)
     def update_from_batch(self, batch, **kwargs):

--- a/rllib/core/learner/learner_group.py
+++ b/rllib/core/learner/learner_group.py
@@ -48,13 +48,27 @@ from ray.util.annotations import PublicAPI
 
 if TYPE_CHECKING:
     from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
+    from ray.util.placement_group import PlacementGroup
 
 
 def _get_backend_config(learner_class: Type[Learner]) -> str:
     if learner_class.framework == "torch":
-        from ray.train.torch import TorchConfig
+        from ray.train.torch.config import TorchConfig, _TorchBackend
 
-        backend_config = TorchConfig()
+        # Override `_TorchBackend` share_cuda_visible_devices=True setting.
+        # We need this to be False to make sure Learner actors only see their
+        # own GPU. There is no need in RLlib's LearnerGroups for 2 different Learner
+        # actors to communicate with each other through their GPUs.
+        class _RLlibTorchBackend(_TorchBackend):
+            share_cuda_visible_devices = False
+
+        class RLlibTorchConfig(TorchConfig):
+            @property
+            def backend_cls(self):
+                return _RLlibTorchBackend
+
+        backend_config = RLlibTorchConfig()
+
     elif learner_class.framework == "tf2":
         from ray.train.tensorflow import TensorflowConfig
 
@@ -66,6 +80,20 @@ def _get_backend_config(learner_class: Type[Learner]) -> str:
         )
 
     return backend_config
+
+
+class RLlibBackendExecutor(BackendExecutor):
+    # Override `BackendExecutor` placement group creation logic. We need to pass our own
+    # to make sure the one of the Algorithm (Trainable) is used for all the
+    # Algorithm's actors.
+    def _create_placement_group(self):
+        pass
+
+    # TODO (sven): Change this once there is a better (public) API for this in the
+    #  superclass.
+    def set_placement_group(self, placement_group):
+        if placement_group is not None:
+            self._placement_group = placement_group
 
 
 @PublicAPI(stability="alpha")
@@ -82,6 +110,7 @@ class LearnerGroup(Checkpointable):
         config: "AlgorithmConfig",
         # TODO (sven): Rename into `rl_module_spec`.
         module_spec: Optional[RLModuleSpecType] = None,
+        placement_group: Optional["PlacementGroup"] = None,
     ):
         """Initializes a LearnerGroup instance.
 
@@ -98,6 +127,10 @@ class LearnerGroup(Checkpointable):
                 the specifics for your RLModule to be used in each Learner.
             module_spec: If not already specified in `config`, a separate overriding
                 RLModuleSpec may be provided via this argument.
+            placement_group: An optional `PlacementGroup` instance to set the
+                `RLlibBackendExecutor`'s `self._placement_group` attribute to.
+                If run within an Algorithm (tune.Trainable), the placement group of tune
+                trial actor is passed through here.
         """
         self.config = config.copy(copy_frozen=False)
         self._module_spec = module_spec
@@ -132,23 +165,20 @@ class LearnerGroup(Checkpointable):
                 if self.config.num_gpus_per_learner == 0
                 else 0
             )
-            num_gpus_per_learner = max(
-                0,
-                self.config.num_gpus_per_learner
-                # TODO (sven): Activate this when Ray has figured out GPU pre-loading.
-                # - (0.01 * self.config.num_aggregator_actors_per_learner),
-            )
+            num_gpus_per_learner = max(0, self.config.num_gpus_per_learner)
             resources_per_learner = {
                 "CPU": num_cpus_per_learner,
                 "GPU": num_gpus_per_learner,
             }
 
-            backend_executor = BackendExecutor(
+            backend_executor = RLlibBackendExecutor(
                 backend_config=backend_config,
                 num_workers=self.config.num_learners,
                 resources_per_worker=resources_per_learner,
                 max_retries=0,
             )
+            # Set the placement group - if any - of the BackendExecutor.
+            backend_executor.set_placement_group(placement_group)
             backend_executor.start(
                 train_cls=learner_class,
                 train_cls_kwargs={
@@ -159,6 +189,16 @@ class LearnerGroup(Checkpointable):
             self._backend_executor = backend_executor
 
             self._workers = [w.actor for w in backend_executor.worker_group.workers]
+
+            ray.get(
+                [
+                    worker._set_learner_index_and_placement_group.remote(
+                        learner_index=idx,
+                        placement_group=placement_group,
+                    )
+                    for idx, worker in enumerate(self._workers)
+                ]
+            )
 
             # Run the neural network building code on remote workers.
             ray.get([w.build.remote() for w in self._workers])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Enhance Learner/LearnerGroup APIs:
* Add placement group and learner index to all Learner objects under attributes: self._learner_index and self._placement_group (may be None).
* Set `share_cuda_visible_devices = False` for the Train `BackendExecutor` instance used by RLlib. This may be a temporary measure until a completed bug fix in Ray Train, where different actors on the same node do NOT receive the same values under `CUDA_VISIBLE_DEVICES` (even though this would be the expected behavior).

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
