### PR TITLE
[core] Speed up dask tests using a shared Ray instance fixture

### DIFF
--- a/python/ray/util/dask/callbacks.py
+++ b/python/ray/util/dask/callbacks.py
@@ -1,11 +1,12 @@
 import contextlib
 
-from ray import ObjectRef
 from collections import namedtuple, defaultdict
 from datetime import datetime
 from typing import Any, List, Optional
 
 from dask.callbacks import Callback
+
+import ray
 
 # The names of the Ray-specific callbacks. These are the kwarg names that
 # RayDaskCallback will accept on construction, and is considered the
@@ -102,7 +103,7 @@ class RayDaskCallback(Callback):
         """
         pass
 
-    def _ray_postsubmit(self, task, key, deps, object_ref: ObjectRef):
+    def _ray_postsubmit(self, task, key, deps, object_ref: ray.ObjectRef):
         """Run after submitting a Ray task.
 
         Args:
@@ -119,7 +120,7 @@ class RayDaskCallback(Callback):
         """
         pass
 
-    def _ray_pretask(self, key, object_refs: List[ObjectRef]):
+    def _ray_pretask(self, key, object_refs: List[ray.ObjectRef]):
         """Run before executing a Dask task within a Ray task.
 
         This method executes after Ray submits the task within a Ray
@@ -151,7 +152,7 @@ class RayDaskCallback(Callback):
         """
         pass
 
-    def _ray_postsubmit_all(self, object_refs: List[ObjectRef], dsk):
+    def _ray_postsubmit_all(self, object_refs: List[ray.ObjectRef], dsk):
         """Run after Ray submits all tasks.
 
         Args:
@@ -231,8 +232,6 @@ def local_ray_callbacks(callbacks=None):
 
 class ProgressBarCallback(RayDaskCallback):
     def __init__(self):
-        import ray
-
         @ray.remote
         class ProgressBarActor:
             def __init__(self):

--- a/python/ray/util/dask/scheduler.py
+++ b/python/ray/util/dask/scheduler.py
@@ -1,18 +1,19 @@
 import atexit
 import threading
+import time
 from collections import defaultdict
 from collections import OrderedDict
 from dataclasses import dataclass
 from multiprocessing.pool import ThreadPool
+from pprint import pprint
 from typing import Optional
-
-import ray
 
 import dask
 from dask.core import istask, ishashable, _execute_task
 from dask.system import CPU_COUNT
 from dask.threaded import pack_exception, _thread_get_id
 
+import ray
 from ray.util.dask.callbacks import local_ray_callbacks, unpack_ray_callbacks
 from ray.util.dask.common import unpack_object_refs
 from ray.util.dask.scheduler_utils import get_async, apply_sync
@@ -459,14 +460,11 @@ def render_progress_bar(tracker, object_refs):
         )
         if len(ready_refs) == len(object_refs):
             break
-        import time
-
         time.sleep(0.1)
     pb_bar.close()
     submitted, finished = ray.get(tracker.result.remote())
     if submitted != finished:
         print("Completed. There was state inconsistency.")
-    from pprint import pprint
 
     pprint(ray.get(tracker.report.remote()))
 

--- a/python/ray/util/dask/tests/BUILD
+++ b/python/ray/util/dask/tests/BUILD
@@ -41,6 +41,18 @@ py_test(
 )
 
 py_test(
+    name = "test_dask_multi_node",
+    size = "medium",
+    srcs = ["test_dask_multi_node.py"],
+    main = "test_dask_multi_node.py",
+    tags = [
+        "exclusive",
+        "team:core",
+    ],
+    deps = ["//python/ray/util/dask:dask_lib"],
+)
+
+py_test(
     name = "test_dask_optimization_client_mode",
     size = "small",
     srcs = ["test_dask_optimization.py"],

--- a/python/ray/util/dask/tests/test_dask_callback.py
+++ b/python/ray/util/dask/tests/test_dask_callback.py
@@ -1,6 +1,5 @@
 import sys
 
-import sys
 
 import dask
 import pytest

--- a/python/ray/util/dask/tests/test_dask_callback.py
+++ b/python/ray/util/dask/tests/test_dask_callback.py
@@ -1,22 +1,17 @@
 import sys
 
+import sys
+
 import dask
 import pytest
 
 import ray
+from ray.tests.conftest import *  # noqa: F403, F401
 from ray.util.dask import ray_dask_get, RayDaskCallback
 
 pytestmark = pytest.mark.skipif(
     sys.version_info >= (3, 12), reason="Skip dask tests for Python version 3.12+"
 )
-
-
-@pytest.fixture
-def ray_start_1_cpu():
-    address_info = ray.init(num_cpus=2)
-    yield address_info
-    # The code after the yield will run as teardown code.
-    ray.shutdown()
 
 
 @dask.delayed
@@ -34,7 +29,7 @@ def test_callback_active():
     assert not RayDaskCallback.ray_active
 
 
-def test_presubmit_shortcircuit(ray_start_1_cpu):
+def test_presubmit_shortcircuit(ray_start_regular_shared):
     """
     Test that presubmit return short-circuits task submission, and that task's
     result is set to the presubmit return value.
@@ -57,7 +52,7 @@ def test_presubmit_shortcircuit(ray_start_1_cpu):
     assert result == 0
 
 
-def test_pretask_posttask_shared_state(ray_start_1_cpu):
+def test_pretask_posttask_shared_state(ray_start_regular_shared):
     """
     Test that pretask return value is passed to corresponding posttask
     callback.
@@ -77,7 +72,7 @@ def test_pretask_posttask_shared_state(ray_start_1_cpu):
     assert result == 5
 
 
-def test_postsubmit(ray_start_1_cpu):
+def test_postsubmit(ray_start_regular_shared):
     """
     Test that postsubmit is called after each task.
     """
@@ -109,7 +104,7 @@ def test_postsubmit(ray_start_1_cpu):
     assert result == 5
 
 
-def test_postsubmit_all(ray_start_1_cpu):
+def test_postsubmit_all(ray_start_regular_shared):
     """
     Test that postsubmit_all is called once.
     """
@@ -141,7 +136,7 @@ def test_postsubmit_all(ray_start_1_cpu):
     assert result == 5
 
 
-def test_finish(ray_start_1_cpu):
+def test_finish(ray_start_regular_shared):
     """
     Test that finish callback is called once.
     """
@@ -173,7 +168,7 @@ def test_finish(ray_start_1_cpu):
     assert result == 5
 
 
-def test_multiple_callbacks(ray_start_1_cpu):
+def test_multiple_callbacks(ray_start_regular_shared):
     """
     Test that multiple callbacks are supported.
     """
@@ -208,7 +203,7 @@ def test_multiple_callbacks(ray_start_1_cpu):
     assert result == 5
 
 
-def test_pretask_posttask_shared_state_multi(ray_start_1_cpu):
+def test_pretask_posttask_shared_state_multi(ray_start_regular_shared):
     """
     Test that pretask return values are passed to the correct corresponding
     posttask callbacks when multiple callbacks are given.
@@ -244,6 +239,4 @@ def test_pretask_posttask_shared_state_multi(ray_start_1_cpu):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/util/dask/tests/test_dask_multi_node.py
+++ b/python/ray/util/dask/tests/test_dask_multi_node.py
@@ -1,0 +1,74 @@
+import sys
+
+import dask
+import dask.array as da
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+import pytest
+
+import ray
+from ray.tests.conftest import *  # noqa: F403, F401
+from ray.util.client.common import ClientObjectRef
+from ray.util.dask import disable_dask_on_ray, enable_dask_on_ray, ray_dask_get
+from ray.util.dask.callbacks import ProgressBarCallback
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info >= (3, 12), reason="Skip dask tests for Python version 3.12+"
+)
+
+
+def test_ray_dask_resources(ray_start_cluster, ray_enable_dask_on_ray):
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=1)
+    cluster.add_node(num_cpus=1, resources={"other_pin": 1})
+    pinned_node = cluster.add_node(num_cpus=1, num_gpus=1, resources={"pin": 1})
+
+    ray.init(address=cluster.address)
+
+    def get_node_id():
+        return ray._private.worker.global_worker.node.unique_id
+
+    # Test annotations on collection.
+    with dask.annotate(ray_remote_args=dict(num_cpus=1, resources={"pin": 0.01})):
+        c = dask.delayed(get_node_id)()
+    result = c.compute(optimize_graph=False)
+
+    assert result == pinned_node.unique_id
+
+    # Test annotations on compute.
+    c = dask.delayed(get_node_id)()
+    with dask.annotate(ray_remote_args=dict(num_gpus=1, resources={"pin": 0.01})):
+        result = c.compute(optimize_graph=False)
+
+    assert result == pinned_node.unique_id
+
+    # Test compute global Ray remote args.
+    c = dask.delayed(get_node_id)
+    result = c().compute(ray_remote_args={"resources": {"pin": 0.01}})
+
+    assert result == pinned_node.unique_id
+
+    # Test annotations on collection override global resource.
+    with dask.annotate(ray_remote_args=dict(resources={"pin": 0.01})):
+        c = dask.delayed(get_node_id)()
+    result = c.compute(
+        ray_remote_args=dict(resources={"other_pin": 0.01}), optimize_graph=False
+    )
+
+    assert result == pinned_node.unique_id
+
+    # Test top-level resources raises an error.
+    with pytest.raises(ValueError):
+        with dask.annotate(resources={"pin": 0.01}):
+            c = dask.delayed(get_node_id)()
+        result = c.compute(optimize_graph=False)
+    with pytest.raises(ValueError):
+        c = dask.delayed(get_node_id)
+        result = c().compute(resources={"pin": 0.01})
+
+
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/util/dask/tests/test_dask_multi_node.py
+++ b/python/ray/util/dask/tests/test_dask_multi_node.py
@@ -1,17 +1,10 @@
 import sys
 
 import dask
-import dask.array as da
-import dask.dataframe as dd
-import numpy as np
-import pandas as pd
 import pytest
 
 import ray
 from ray.tests.conftest import *  # noqa: F403, F401
-from ray.util.client.common import ClientObjectRef
-from ray.util.dask import disable_dask_on_ray, enable_dask_on_ray, ray_dask_get
-from ray.util.dask.callbacks import ProgressBarCallback
 
 pytestmark = pytest.mark.skipif(
     sys.version_info >= (3, 12), reason="Skip dask tests for Python version 3.12+"

--- a/python/ray/util/dask/tests/test_dask_multi_node.py
+++ b/python/ray/util/dask/tests/test_dask_multi_node.py
@@ -68,7 +68,5 @@ def test_ray_dask_resources(ray_start_cluster, ray_enable_dask_on_ray):
         result = c().compute(resources={"pin": 0.01})
 
 
-
-
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/util/dask/tests/test_dask_multi_node.py
+++ b/python/ray/util/dask/tests/test_dask_multi_node.py
@@ -5,10 +5,17 @@ import pytest
 
 import ray
 from ray.tests.conftest import *  # noqa: F403, F401
+from ray.util.dask import enable_dask_on_ray
 
 pytestmark = pytest.mark.skipif(
     sys.version_info >= (3, 12), reason="Skip dask tests for Python version 3.12+"
 )
+
+
+@pytest.fixture
+def ray_enable_dask_on_ray():
+    with enable_dask_on_ray():
+        yield
 
 
 def test_ray_dask_resources(ray_start_cluster, ray_enable_dask_on_ray):

--- a/python/ray/util/dask/tests/test_dask_optimization.py
+++ b/python/ray/util/dask/tests/test_dask_optimization.py
@@ -67,6 +67,4 @@ def test_dataframe_optimize(mock_rewrite, ray_start_regular_shared):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/util/dask/tests/test_dask_scheduler.py
+++ b/python/ray/util/dask/tests/test_dask_scheduler.py
@@ -1,5 +1,4 @@
 import sys
-import unittest
 
 import dask
 import dask.array as da
@@ -20,21 +19,13 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.fixture
-def ray_start_1_cpu():
-    address_info = ray.init(num_cpus=2)
-    yield address_info
-    # The code after the yield will run as teardown code.
-    ray.shutdown()
-
-
-@pytest.fixture
 def ray_enable_dask_on_ray():
     with enable_dask_on_ray():
         yield
 
 
-@unittest.skipIf(sys.platform == "win32", "Failing on Windows.")
-def test_ray_dask_basic(ray_start_1_cpu):
+@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
+def test_ray_dask_basic(ray_start_regular_shared):
     @ray.remote
     def stringify(x):
         return "The answer is {}".format(x)
@@ -75,58 +66,8 @@ def test_ray_dask_basic(ray_start_1_cpu):
     assert ans == "The answer is 6", ans
 
 
-def test_ray_dask_resources(ray_start_cluster, ray_enable_dask_on_ray):
-    cluster = ray_start_cluster
-    cluster.add_node(num_cpus=1)
-    cluster.add_node(num_cpus=1, resources={"other_pin": 1})
-    pinned_node = cluster.add_node(num_cpus=1, num_gpus=1, resources={"pin": 1})
-
-    ray.init(address=cluster.address)
-
-    def get_node_id():
-        return ray._private.worker.global_worker.node.unique_id
-
-    # Test annotations on collection.
-    with dask.annotate(ray_remote_args=dict(num_cpus=1, resources={"pin": 0.01})):
-        c = dask.delayed(get_node_id)()
-    result = c.compute(optimize_graph=False)
-
-    assert result == pinned_node.unique_id
-
-    # Test annotations on compute.
-    c = dask.delayed(get_node_id)()
-    with dask.annotate(ray_remote_args=dict(num_gpus=1, resources={"pin": 0.01})):
-        result = c.compute(optimize_graph=False)
-
-    assert result == pinned_node.unique_id
-
-    # Test compute global Ray remote args.
-    c = dask.delayed(get_node_id)
-    result = c().compute(ray_remote_args={"resources": {"pin": 0.01}})
-
-    assert result == pinned_node.unique_id
-
-    # Test annotations on collection override global resource.
-    with dask.annotate(ray_remote_args=dict(resources={"pin": 0.01})):
-        c = dask.delayed(get_node_id)()
-    result = c.compute(
-        ray_remote_args=dict(resources={"other_pin": 0.01}), optimize_graph=False
-    )
-
-    assert result == pinned_node.unique_id
-
-    # Test top-level resources raises an error.
-    with pytest.raises(ValueError):
-        with dask.annotate(resources={"pin": 0.01}):
-            c = dask.delayed(get_node_id)()
-        result = c.compute(optimize_graph=False)
-    with pytest.raises(ValueError):
-        c = dask.delayed(get_node_id)
-        result = c().compute(resources={"pin": 0.01})
-
-
-@unittest.skipIf(sys.platform == "win32", "Failing on Windows.")
-def test_ray_dask_persist(ray_start_1_cpu):
+@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
+def test_ray_dask_persist(ray_start_regular_shared):
     arr = da.ones(5) + 2
     result = arr.persist(scheduler=ray_dask_get)
     assert isinstance(
@@ -134,7 +75,7 @@ def test_ray_dask_persist(ray_start_1_cpu):
     )
 
 
-def test_sort_with_progress_bar(ray_start_1_cpu):
+def test_sort_with_progress_bar(ray_start_regular_shared):
     npartitions = 10
     df = dd.from_pandas(
         pd.DataFrame(
@@ -158,6 +99,4 @@ def test_sort_with_progress_bar(ray_start_1_cpu):
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
Update dask tests to use a shared Ray instance fixture. One test requires a multi-cluster setup, so moved it to its own file.

Latest postmerge results:
```
[2025-05-21T05:31:19Z] //python/ray/util/dask/tests:test_dask_optimization                      PASSED in 7.9s
[2025-05-21T05:31:19Z] //python/ray/util/dask/tests:test_dask_optimization_client_mode          PASSED in 7.9s
[2025-05-21T05:31:19Z] //python/ray/util/dask/tests:test_dask_scheduler                         PASSED in 31.9s
[2025-05-21T05:31:19Z] //python/ray/util/dask/tests:test_dask_scheduler_client_mode             PASSED in 31.6s
[2025-05-21T05:31:19Z] //python/ray/util/dask/tests:test_dask_callback                           FLAKY, failed in 1 out of 2 in 60.7s
```

This premerge results:
```
[2025-05-21T14:38:33Z] //python/ray/util/dask/tests:test_dask_optimization                      PASSED in 11.7s
[2025-05-21T14:38:33Z] //python/ray/util/dask/tests:test_dask_optimization_client_mode          PASSED in 10.2s
[2025-05-21T14:38:42Z] //python/ray/util/dask/tests:test_dask_callback                          PASSED in 17.6s
[2025-05-21T14:38:42Z] //python/ray/util/dask/tests:test_dask_multi_node                        PASSED in 14.2s
[2025-05-21T14:38:42Z] //python/ray/util/dask/tests:test_dask_scheduler                         PASSED in 17.2s
[2025-05-21T14:38:42Z] //python/ray/util/dask/tests:test_dask_scheduler_client_mode             PASSED in 13.1s
```