### PR TITLE
[core] add missing depends_on for spark-on-ray build

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -463,6 +463,8 @@ steps:
         --parallelism-per-worker 3
         --only-tags spark_on_ray
         --except-tags kubernetes
+    depends_on:
+      - corebuild
 
   # block on premerge and microcheck
   - block: "run multi gpu tests"


### PR DESCRIPTION
needs to explicitly wait for corebuild since it is behind a block step now.