### PR TITLE
[Dashboard] Add configurability of 'orgId' param for requesting Grafana dashboards

### DIFF
--- a/doc/source/cluster/configure-manage-dashboard.md
+++ b/doc/source/cluster/configure-manage-dashboard.md
@@ -204,6 +204,7 @@ To view embedded time-series visualizations in Ray Dashboard, the following must
 Configure these settings using the `RAY_GRAFANA_HOST`, `RAY_PROMETHEUS_HOST`, `RAY_PROMETHEUS_NAME`, and `RAY_GRAFANA_IFRAME_HOST` environment variables when you start the Ray Clusters.
 
 * Set `RAY_GRAFANA_HOST` to an address that the head node can use to access Grafana. Head node does health checks on Grafana on the backend.
+* Set `RAY_GRAFANA_ORG_ID` to the organization id which you will used in Grafana. Default is "1".
 * Set `RAY_PROMETHEUS_HOST` to an address the head node can use to access Prometheus.
 * Set `RAY_PROMETHEUS_NAME` to select a different data source to use for the Grafana dashboard panels to use. Default is "Prometheus".
 * Set `RAY_GRAFANA_IFRAME_HOST` to an address that the user's browsers can use to access Grafana and embed visualizations. If `RAY_GRAFANA_IFRAME_HOST` is not set, Ray Dashboard uses the value of `RAY_GRAFANA_HOST`.

--- a/doc/source/cluster/configure-manage-dashboard.md
+++ b/doc/source/cluster/configure-manage-dashboard.md
@@ -204,7 +204,7 @@ To view embedded time-series visualizations in Ray Dashboard, the following must
 Configure these settings using the `RAY_GRAFANA_HOST`, `RAY_PROMETHEUS_HOST`, `RAY_PROMETHEUS_NAME`, and `RAY_GRAFANA_IFRAME_HOST` environment variables when you start the Ray Clusters.
 
 * Set `RAY_GRAFANA_HOST` to an address that the head node can use to access Grafana. Head node does health checks on Grafana on the backend.
-* Set `RAY_GRAFANA_ORG_ID` to the organization id which you will used in Grafana. Default is "1".
+* Set `RAY_GRAFANA_ORG_ID` to the organization ID you use in Grafana. Default is "1".
 * Set `RAY_PROMETHEUS_HOST` to an address the head node can use to access Prometheus.
 * Set `RAY_PROMETHEUS_NAME` to select a different data source to use for the Grafana dashboard panels to use. Default is "Prometheus".
 * Set `RAY_GRAFANA_IFRAME_HOST` to an address that the user's browsers can use to access Grafana and embed visualizations. If `RAY_GRAFANA_IFRAME_HOST` is not set, Ray Dashboard uses the value of `RAY_GRAFANA_HOST`.

--- a/python/ray/dashboard/client/src/App.tsx
+++ b/python/ray/dashboard/client/src/App.tsx
@@ -83,7 +83,7 @@ export type GlobalContextType = {
   /**
    * The param 'orgId' used in grafana. Default is 1.
    */
-  grafanaOrgId: string | undefined;
+  grafanaOrgId: string;
   /**
    * The uids of the dashboards that ray exports that powers the various metrics UIs.
    */
@@ -115,7 +115,7 @@ export const GlobalContext = React.createContext<GlobalContextType>({
   namespaceMap: {},
   metricsContextLoaded: false,
   grafanaHost: undefined,
-  grafanaOrgId: undefined,
+  grafanaOrgId: "1",
   dashboardUids: undefined,
   prometheusHealth: undefined,
   sessionName: undefined,
@@ -134,7 +134,7 @@ const App = () => {
     namespaceMap: {},
     metricsContextLoaded: false,
     grafanaHost: undefined,
-    grafanaOrgId: undefined,
+    grafanaOrgId: "1",
     dashboardUids: undefined,
     prometheusHealth: undefined,
     sessionName: undefined,

--- a/python/ray/dashboard/client/src/App.tsx
+++ b/python/ray/dashboard/client/src/App.tsx
@@ -81,6 +81,10 @@ export type GlobalContextType = {
    */
   grafanaHost: string | undefined;
   /**
+   * The param 'orgId' used in grafana. Default is 1.
+   */
+  grafanaOrgId: string | undefined;
+  /**
    * The uids of the dashboards that ray exports that powers the various metrics UIs.
    */
   dashboardUids: DashboardUids | undefined;
@@ -111,6 +115,7 @@ export const GlobalContext = React.createContext<GlobalContextType>({
   namespaceMap: {},
   metricsContextLoaded: false,
   grafanaHost: undefined,
+  grafanaOrgId: undefined,
   dashboardUids: undefined,
   prometheusHealth: undefined,
   sessionName: undefined,
@@ -129,6 +134,7 @@ const App = () => {
     namespaceMap: {},
     metricsContextLoaded: false,
     grafanaHost: undefined,
+    grafanaOrgId: undefined,
     dashboardUids: undefined,
     prometheusHealth: undefined,
     sessionName: undefined,
@@ -159,6 +165,7 @@ const App = () => {
     const doEffect = async () => {
       const {
         grafanaHost,
+        grafanaOrgId,
         sessionName,
         prometheusHealth,
         dashboardUids,
@@ -168,6 +175,7 @@ const App = () => {
         ...existingContext,
         metricsContextLoaded: true,
         grafanaHost,
+        grafanaOrgId,
         dashboardUids,
         sessionName,
         prometheusHealth,

--- a/python/ray/dashboard/client/src/pages/metrics/Metrics.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/metrics/Metrics.component.test.tsx
@@ -10,6 +10,7 @@ const Wrapper = ({ children }: PropsWithChildren<{}>) => {
       value={{
         metricsContextLoaded: true,
         grafanaHost: "localhost:3000",
+        grafanaOrgId: "1",
         dashboardUids: {
           default: "rayDefaultDashboard",
           serve: "rayServeDashboard",
@@ -37,6 +38,7 @@ const MetricsDisabledWrapper = ({ children }: PropsWithChildren<{}>) => {
       value={{
         metricsContextLoaded: true,
         grafanaHost: undefined,
+        grafanaOrgId: undefined,
         dashboardUids: {
           default: "rayDefaultDashboard",
           serve: "rayServeDashboard",

--- a/python/ray/dashboard/client/src/pages/metrics/Metrics.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/metrics/Metrics.component.test.tsx
@@ -38,7 +38,7 @@ const MetricsDisabledWrapper = ({ children }: PropsWithChildren<{}>) => {
       value={{
         metricsContextLoaded: true,
         grafanaHost: undefined,
-        grafanaOrgId: undefined,
+        grafanaOrgId: "1",
         dashboardUids: {
           default: "rayDefaultDashboard",
           serve: "rayServeDashboard",

--- a/python/ray/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/python/ray/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -380,8 +380,13 @@ const DATA_METRICS_CONFIG: MetricsSectionConfig[] = [
 ];
 
 export const Metrics = () => {
-  const { grafanaHost, grafanaOrgId, prometheusHealth, dashboardUids, dashboardDatasource } =
-    useContext(GlobalContext);
+  const {
+    grafanaHost,
+    grafanaOrgId,
+    prometheusHealth,
+    dashboardUids,
+    dashboardDatasource,
+  } = useContext(GlobalContext);
 
   const grafanaDefaultDashboardUid =
     dashboardUids?.default ?? "rayDefaultDashboard";

--- a/python/ray/dashboard/client/src/pages/metrics/Metrics.tsx
+++ b/python/ray/dashboard/client/src/pages/metrics/Metrics.tsx
@@ -93,27 +93,27 @@ const METRICS_CONFIG: MetricsSectionConfig[] = [
     contents: [
       {
         title: "Scheduler Task State",
-        pathParams: "orgId=1&theme=light&panelId=26",
+        pathParams: "theme=light&panelId=26",
       },
       {
         title: "Requested Live Tasks by Name",
-        pathParams: "orgId=1&theme=light&panelId=35",
+        pathParams: "theme=light&panelId=35",
       },
       {
         title: "Running Tasks by Name",
-        pathParams: "orgId=1&theme=light&panelId=38",
+        pathParams: "theme=light&panelId=38",
       },
       {
         title: "Scheduler Actor State",
-        pathParams: "orgId=1&theme=light&panelId=33",
+        pathParams: "theme=light&panelId=33",
       },
       {
         title: "Requested Live Actors by Name",
-        pathParams: "orgId=1&theme=light&panelId=36",
+        pathParams: "theme=light&panelId=36",
       },
       {
         title: "Out of Memory Failures by Name",
-        pathParams: "orgId=1&theme=light&panelId=44",
+        pathParams: "theme=light&panelId=44",
       },
     ],
   },
@@ -122,19 +122,19 @@ const METRICS_CONFIG: MetricsSectionConfig[] = [
     contents: [
       {
         title: "Scheduler CPUs (logical slots)",
-        pathParams: "orgId=1&theme=light&panelId=27",
+        pathParams: "theme=light&panelId=27",
       },
       {
         title: "Scheduler GPUs (logical slots)",
-        pathParams: "orgId=1&theme=light&panelId=28",
+        pathParams: "theme=light&panelId=28",
       },
       {
         title: "Object Store Memory",
-        pathParams: "orgId=1&theme=light&panelId=29",
+        pathParams: "theme=light&panelId=29",
       },
       {
         title: "Placement Groups",
-        pathParams: "orgId=1&theme=light&panelId=40",
+        pathParams: "theme=light&panelId=40",
       },
     ],
   },
@@ -143,47 +143,47 @@ const METRICS_CONFIG: MetricsSectionConfig[] = [
     contents: [
       {
         title: "Node Count",
-        pathParams: "orgId=1&theme=light&panelId=24",
+        pathParams: "theme=light&panelId=24",
       },
       {
         title: "Node CPU (hardware utilization)",
-        pathParams: "orgId=1&theme=light&panelId=2",
+        pathParams: "theme=light&panelId=2",
       },
       {
         title: "Node Memory (heap + object store)",
-        pathParams: "orgId=1&theme=light&panelId=4",
+        pathParams: "theme=light&panelId=4",
       },
       {
         title: "Node Memory Percentage (heap + object store)",
-        pathParams: "orgId=1&theme=light&panelId=48",
+        pathParams: "theme=light&panelId=48",
       },
       {
         title: "Node GPU (hardware utilization)",
-        pathParams: "orgId=1&theme=light&panelId=8",
+        pathParams: "theme=light&panelId=8",
       },
       {
         title: "Node GPU Memory (GRAM)",
-        pathParams: "orgId=1&theme=light&panelId=18",
+        pathParams: "theme=light&panelId=18",
       },
       {
         title: "Node Disk",
-        pathParams: "orgId=1&theme=light&panelId=6",
+        pathParams: "theme=light&panelId=6",
       },
       {
         title: "Node Disk IO Speed",
-        pathParams: "orgId=1&theme=light&panelId=32",
+        pathParams: "theme=light&panelId=32",
       },
       {
         title: "Node Network",
-        pathParams: "orgId=1&theme=light&panelId=20",
+        pathParams: "theme=light&panelId=20",
       },
       {
         title: "Node CPU by Component",
-        pathParams: "orgId=1&theme=light&panelId=37",
+        pathParams: "theme=light&panelId=37",
       },
       {
         title: "Node Memory by Component",
-        pathParams: "orgId=1&theme=light&panelId=34",
+        pathParams: "theme=light&panelId=34",
       },
     ],
   },
@@ -195,35 +195,35 @@ const DATA_METRICS_CONFIG: MetricsSectionConfig[] = [
     contents: [
       {
         title: "Bytes Spilled",
-        pathParams: "orgId=1&theme=light&panelId=1",
+        pathParams: "theme=light&panelId=1",
       },
       {
         title: "Bytes Allocated",
-        pathParams: "orgId=1&theme=light&panelId=2",
+        pathParams: "theme=light&panelId=2",
       },
       {
         title: "Bytes Freed",
-        pathParams: "orgId=1&theme=light&panelId=3",
+        pathParams: "theme=light&panelId=3",
       },
       {
         title: "Object Store Memory",
-        pathParams: "orgId=1&theme=light&panelId=4",
+        pathParams: "theme=light&panelId=4",
       },
       {
         title: "CPUs (logical slots)",
-        pathParams: "orgId=1&theme=light&panelId=5",
+        pathParams: "theme=light&panelId=5",
       },
       {
         title: "GPUs (logical slots)",
-        pathParams: "orgId=1&theme=light&panelId=6",
+        pathParams: "theme=light&panelId=6",
       },
       {
         title: "Bytes Outputted",
-        pathParams: "orgId=1&theme=light&panelId=7",
+        pathParams: "theme=light&panelId=7",
       },
       {
         title: "Rows Outputted",
-        pathParams: "orgId=1&theme=light&panelId=11",
+        pathParams: "theme=light&panelId=11",
       },
     ],
   },
@@ -232,19 +232,19 @@ const DATA_METRICS_CONFIG: MetricsSectionConfig[] = [
     contents: [
       {
         title: "Input Blocks Received by Operator",
-        pathParams: "orgId=1&theme=light&panelId=17",
+        pathParams: "theme=light&panelId=17",
       },
       {
         title: "Input Blocks Processed by Tasks",
-        pathParams: "orgId=1&theme=light&panelId=19",
+        pathParams: "theme=light&panelId=19",
       },
       {
         title: "Input Bytes Processed by Tasks",
-        pathParams: "orgId=1&theme=light&panelId=20",
+        pathParams: "theme=light&panelId=20",
       },
       {
         title: "Input Bytes Submitted to Tasks",
-        pathParams: "orgId=1&theme=light&panelId=21",
+        pathParams: "theme=light&panelId=21",
       },
     ],
   },
@@ -253,23 +253,23 @@ const DATA_METRICS_CONFIG: MetricsSectionConfig[] = [
     contents: [
       {
         title: "Blocks Generated by Tasks",
-        pathParams: "orgId=1&theme=light&panelId=22",
+        pathParams: "theme=light&panelId=22",
       },
       {
         title: "Bytes Generated by Tasks",
-        pathParams: "orgId=1&theme=light&panelId=23",
+        pathParams: "theme=light&panelId=23",
       },
       {
         title: "Rows Generated by Tasks",
-        pathParams: "orgId=1&theme=light&panelId=24",
+        pathParams: "theme=light&panelId=24",
       },
       {
         title: "Output Blocks Taken by Downstream Operators",
-        pathParams: "orgId=1&theme=light&panelId=25",
+        pathParams: "theme=light&panelId=25",
       },
       {
         title: "Output Bytes Taken by Downstream Operators",
-        pathParams: "orgId=1&theme=light&panelId=26",
+        pathParams: "theme=light&panelId=26",
       },
     ],
   },
@@ -278,47 +278,47 @@ const DATA_METRICS_CONFIG: MetricsSectionConfig[] = [
     contents: [
       {
         title: "Submitted Tasks",
-        pathParams: "orgId=1&theme=light&panelId=29",
+        pathParams: "theme=light&panelId=29",
       },
       {
         title: "Running Tasks",
-        pathParams: "orgId=1&theme=light&panelId=30",
+        pathParams: "theme=light&panelId=30",
       },
       {
         title: "Tasks with output blocks",
-        pathParams: "orgId=1&theme=light&panelId=31",
+        pathParams: "theme=light&panelId=31",
       },
       {
         title: "Finished Tasks",
-        pathParams: "orgId=1&theme=light&panelId=32",
+        pathParams: "theme=light&panelId=32",
       },
       {
         title: "Failed Tasks",
-        pathParams: "orgId=1&theme=light&panelId=33",
+        pathParams: "theme=light&panelId=33",
       },
       {
         title: "Block Generation Time",
-        pathParams: "orgId=1&theme=light&panelId=8",
+        pathParams: "theme=light&panelId=8",
       },
       {
         title: "Task Submission Backpressure Time",
-        pathParams: "orgId=1&theme=light&panelId=37",
+        pathParams: "theme=light&panelId=37",
       },
       {
         title: "(p50) Task Completion Time",
-        pathParams: "orgId=1&theme=light&panelId=40",
+        pathParams: "theme=light&panelId=40",
       },
       {
         title: "(p75) Task Completion Time",
-        pathParams: "orgId=1&theme=light&panelId=41",
+        pathParams: "theme=light&panelId=41",
       },
       {
         title: "(p99) Task Completion Time",
-        pathParams: "orgId=1&theme=light&panelId=44",
+        pathParams: "theme=light&panelId=44",
       },
       {
         title: "(p100) Task Completion Time",
-        pathParams: "orgId=1&theme=light&panelId=45",
+        pathParams: "theme=light&panelId=45",
       },
     ],
   },
@@ -327,31 +327,31 @@ const DATA_METRICS_CONFIG: MetricsSectionConfig[] = [
     contents: [
       {
         title: "Operator Internal Inqueue Size (Blocks)",
-        pathParams: "orgId=1&theme=light&panelId=13",
+        pathParams: "theme=light&panelId=13",
       },
       {
         title: "Operator Internal Inqueue Size (Bytes)",
-        pathParams: "orgId=1&theme=light&panelId=14",
+        pathParams: "theme=light&panelId=14",
       },
       {
         title: "Operator Internal Outqueue Size (Blocks)",
-        pathParams: "orgId=1&theme=light&panelId=15",
+        pathParams: "theme=light&panelId=15",
       },
       {
         title: "Operator Internal Outqueue Size (Bytes)",
-        pathParams: "orgId=1&theme=light&panelId=16",
+        pathParams: "theme=light&panelId=16",
       },
       {
         title: "Size of Blocks used in Pending Tasks (Bytes)",
-        pathParams: "orgId=1&theme=light&panelId=34",
+        pathParams: "theme=light&panelId=34",
       },
       {
         title: "Freed Memory in Object Store (Bytes)",
-        pathParams: "orgId=1&theme=light&panelId=35",
+        pathParams: "theme=light&panelId=35",
       },
       {
         title: "Spilled Memory in Object Store (Bytes)",
-        pathParams: "orgId=1&theme=light&panelId=36",
+        pathParams: "theme=light&panelId=36",
       },
     ],
   },
@@ -360,15 +360,15 @@ const DATA_METRICS_CONFIG: MetricsSectionConfig[] = [
     contents: [
       {
         title: "Iteration Initialization Time",
-        pathParams: "orgId=1&theme=light&panelId=12",
+        pathParams: "theme=light&panelId=12",
       },
       {
         title: "Iteration Blocked Time",
-        pathParams: "orgId=1&theme=light&panelId=9",
+        pathParams: "theme=light&panelId=9",
       },
       {
         title: "Iteration User Time",
-        pathParams: "orgId=1&theme=light&panelId=10",
+        pathParams: "theme=light&panelId=10",
       },
     ],
   },
@@ -380,12 +380,13 @@ const DATA_METRICS_CONFIG: MetricsSectionConfig[] = [
 ];
 
 export const Metrics = () => {
-  const { grafanaHost, prometheusHealth, dashboardUids, dashboardDatasource } =
+  const { grafanaHost, grafanaOrgId, prometheusHealth, dashboardUids, dashboardDatasource } =
     useContext(GlobalContext);
 
   const grafanaDefaultDashboardUid =
     dashboardUids?.default ?? "rayDefaultDashboard";
 
+  const grafanaOrgIdParam = grafanaOrgId ?? "1";
   const grafanaDefaultDatasource = dashboardDatasource ?? "Prometheus";
 
   const [refreshOption, setRefreshOption] = useState<RefreshOptions>(
@@ -469,7 +470,7 @@ export const Metrics = () => {
               >
                 <MenuItem
                   component="a"
-                  href={`${grafanaHost}/d/${grafanaDefaultDashboardUid}/?var-datasource=${grafanaDefaultDatasource}`}
+                  href={`${grafanaHost}/d/${grafanaDefaultDashboardUid}/?orgId=${grafanaOrgId}&var-datasource=${grafanaDefaultDatasource}`}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
@@ -479,7 +480,7 @@ export const Metrics = () => {
                   <Tooltip title="The Ray Data dashboard has a dropdown to filter the data metrics by Dataset ID">
                     <MenuItem
                       component="a"
-                      href={`${grafanaHost}/d/${dashboardUids["data"]}/?var-datasource=${grafanaDefaultDatasource}`}
+                      href={`${grafanaHost}/d/${dashboardUids["data"]}/?orgId=${grafanaOrgId}&var-datasource=${grafanaDefaultDatasource}`}
                       target="_blank"
                       rel="noopener noreferrer"
                     >
@@ -550,6 +551,7 @@ export const Metrics = () => {
                 metricConfig={config}
                 refreshParams={refreshParams}
                 timeRangeParams={timeRangeParams}
+                grafanaOrgId={grafanaOrgIdParam}
                 dashboardUid={grafanaDefaultDashboardUid}
                 dashboardDatasource={grafanaDefaultDatasource}
               />
@@ -561,6 +563,7 @@ export const Metrics = () => {
                   metricConfig={config}
                   refreshParams={refreshParams}
                   timeRangeParams={timeRangeParams}
+                  grafanaOrgId={grafanaOrgIdParam}
                   dashboardUid={dashboardUids["data"]}
                   dashboardDatasource={grafanaDefaultDatasource}
                 />
@@ -576,6 +579,7 @@ type MetricsSectionProps = {
   metricConfig: MetricsSectionConfig;
   refreshParams: string;
   timeRangeParams: string;
+  grafanaOrgId: string;
   dashboardUid: string;
   dashboardDatasource: string;
 };
@@ -584,6 +588,7 @@ const MetricsSection = ({
   metricConfig: { title, contents },
   refreshParams,
   timeRangeParams,
+  grafanaOrgId,
   dashboardUid,
   dashboardDatasource,
 }: MetricsSectionProps) => {
@@ -608,7 +613,7 @@ const MetricsSection = ({
       >
         {contents.map(({ title, pathParams }) => {
           const path =
-            `/d-solo/${dashboardUid}?${pathParams}` +
+            `/d-solo/${dashboardUid}?${pathParams}&orgId=${grafanaOrgId}` +
             `&${refreshParams}&timezone=${currentTimeZone}${timeRangeParams}&var-SessionName=${sessionName}&var-datasource=${dashboardDatasource}`;
           return (
             <Paper

--- a/python/ray/dashboard/client/src/pages/metrics/utils.ts
+++ b/python/ray/dashboard/client/src/pages/metrics/utils.ts
@@ -68,13 +68,13 @@ export const getMetricsInfo = async () => {
       info.dashboardUids = resp.data.data.dashboardUids;
       info.dashboardDatasource = resp.data.data.dashboardDatasource;
     }
-  } catch (e) { }
+  } catch (e) {}
   try {
     const resp = await fetchPrometheusHealthcheck();
     if (resp.data.result) {
       info.prometheusHealth = resp.data.result;
     }
-  } catch (e) { }
+  } catch (e) {}
 
   return info;
 };
@@ -93,6 +93,6 @@ export const getTimeZoneInfo = async () => {
         value: resp.data.value,
       };
     }
-  } catch (e) { }
+  } catch (e) {}
   return null;
 };

--- a/python/ray/dashboard/client/src/pages/metrics/utils.ts
+++ b/python/ray/dashboard/client/src/pages/metrics/utils.ts
@@ -16,6 +16,7 @@ type GrafanaHealthcheckRsp = {
   msg: string;
   data: {
     grafanaHost: string;
+    grafanaOrgId: string;
     sessionName: string;
     dashboardUids: DashboardUids;
     dashboardDatasource: string;
@@ -42,6 +43,7 @@ const fetchPrometheusHealthcheck = async () => {
 
 type MetricsInfo = {
   grafanaHost?: string;
+  grafanaOrgId?: string;
   sessionName?: string;
   prometheusHealth?: boolean;
   dashboardUids?: DashboardUids;
@@ -51,6 +53,7 @@ type MetricsInfo = {
 export const getMetricsInfo = async () => {
   const info: MetricsInfo = {
     grafanaHost: undefined,
+    grafanaOrgId: undefined,
     sessionName: undefined,
     prometheusHealth: undefined,
     dashboardUids: undefined,
@@ -60,17 +63,18 @@ export const getMetricsInfo = async () => {
     const resp = await fetchGrafanaHealthcheck();
     if (resp.data.result) {
       info.grafanaHost = resp.data.data.grafanaHost;
+      info.grafanaOrgId = resp.data.data.grafanaOrgId;
       info.sessionName = resp.data.data.sessionName;
       info.dashboardUids = resp.data.data.dashboardUids;
       info.dashboardDatasource = resp.data.data.dashboardDatasource;
     }
-  } catch (e) {}
+  } catch (e) { }
   try {
     const resp = await fetchPrometheusHealthcheck();
     if (resp.data.result) {
       info.prometheusHealth = resp.data.result;
     }
-  } catch (e) {}
+  } catch (e) { }
 
   return info;
 };
@@ -89,6 +93,6 @@ export const getTimeZoneInfo = async () => {
         value: resp.data.value,
       };
     }
-  } catch (e) {}
+  } catch (e) { }
   return null;
 };

--- a/python/ray/dashboard/client/src/pages/metrics/utils.ts
+++ b/python/ray/dashboard/client/src/pages/metrics/utils.ts
@@ -43,7 +43,7 @@ const fetchPrometheusHealthcheck = async () => {
 
 type MetricsInfo = {
   grafanaHost?: string;
-  grafanaOrgId?: string;
+  grafanaOrgId: string;
   sessionName?: string;
   prometheusHealth?: boolean;
   dashboardUids?: DashboardUids;
@@ -53,7 +53,7 @@ type MetricsInfo = {
 export const getMetricsInfo = async () => {
   const info: MetricsInfo = {
     grafanaHost: undefined,
-    grafanaOrgId: undefined,
+    grafanaOrgId: "1",
     sessionName: undefined,
     prometheusHealth: undefined,
     dashboardUids: undefined,

--- a/python/ray/dashboard/client/src/pages/overview/OverviewPage.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/overview/OverviewPage.component.test.tsx
@@ -72,35 +72,36 @@ describe("OverviewPage", () => {
 
 const Wrapper =
   (grafanaHostDisabled: boolean) =>
-  ({ children }: PropsWithChildren<{}>) => {
-    return (
-      <STYLE_WRAPPER>
-        <MemoryRouter>
-          <GlobalContext.Provider
-            value={{
-              metricsContextLoaded: true,
-              grafanaHost: grafanaHostDisabled
-                ? "DISABLED"
-                : "http://localhost:3000",
-              dashboardUids: {
-                default: "rayDefaultDashboard",
-                serve: "rayServeDashboard",
-                serveDeployment: "rayServeDeploymentDashboard",
-                data: "rayDataDashboard",
-              },
-              prometheusHealth: true,
-              sessionName: "session-name",
-              nodeMap: {},
-              nodeMapByIp: {},
-              namespaceMap: {},
-              dashboardDatasource: "Prometheus",
-              serverTimeZone: undefined,
-              currentTimeZone: undefined,
-            }}
-          >
-            {children}
-          </GlobalContext.Provider>
-        </MemoryRouter>
-      </STYLE_WRAPPER>
-    );
-  };
+    ({ children }: PropsWithChildren<{}>) => {
+      return (
+        <STYLE_WRAPPER>
+          <MemoryRouter>
+            <GlobalContext.Provider
+              value={{
+                metricsContextLoaded: true,
+                grafanaHost: grafanaHostDisabled
+                  ? "DISABLED"
+                  : "http://localhost:3000",
+                grafanaOrgId: "1",
+                dashboardUids: {
+                  default: "rayDefaultDashboard",
+                  serve: "rayServeDashboard",
+                  serveDeployment: "rayServeDeploymentDashboard",
+                  data: "rayDataDashboard",
+                },
+                prometheusHealth: true,
+                sessionName: "session-name",
+                nodeMap: {},
+                nodeMapByIp: {},
+                namespaceMap: {},
+                dashboardDatasource: "Prometheus",
+                serverTimeZone: undefined,
+                currentTimeZone: undefined,
+              }}
+            >
+              {children}
+            </GlobalContext.Provider>
+          </MemoryRouter>
+        </STYLE_WRAPPER>
+      );
+    };

--- a/python/ray/dashboard/client/src/pages/overview/OverviewPage.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/overview/OverviewPage.component.test.tsx
@@ -72,36 +72,36 @@ describe("OverviewPage", () => {
 
 const Wrapper =
   (grafanaHostDisabled: boolean) =>
-    ({ children }: PropsWithChildren<{}>) => {
-      return (
-        <STYLE_WRAPPER>
-          <MemoryRouter>
-            <GlobalContext.Provider
-              value={{
-                metricsContextLoaded: true,
-                grafanaHost: grafanaHostDisabled
-                  ? "DISABLED"
-                  : "http://localhost:3000",
-                grafanaOrgId: "1",
-                dashboardUids: {
-                  default: "rayDefaultDashboard",
-                  serve: "rayServeDashboard",
-                  serveDeployment: "rayServeDeploymentDashboard",
-                  data: "rayDataDashboard",
-                },
-                prometheusHealth: true,
-                sessionName: "session-name",
-                nodeMap: {},
-                nodeMapByIp: {},
-                namespaceMap: {},
-                dashboardDatasource: "Prometheus",
-                serverTimeZone: undefined,
-                currentTimeZone: undefined,
-              }}
-            >
-              {children}
-            </GlobalContext.Provider>
-          </MemoryRouter>
-        </STYLE_WRAPPER>
-      );
-    };
+  ({ children }: PropsWithChildren<{}>) => {
+    return (
+      <STYLE_WRAPPER>
+        <MemoryRouter>
+          <GlobalContext.Provider
+            value={{
+              metricsContextLoaded: true,
+              grafanaHost: grafanaHostDisabled
+                ? "DISABLED"
+                : "http://localhost:3000",
+              grafanaOrgId: "1",
+              dashboardUids: {
+                default: "rayDefaultDashboard",
+                serve: "rayServeDashboard",
+                serveDeployment: "rayServeDeploymentDashboard",
+                data: "rayDataDashboard",
+              },
+              prometheusHealth: true,
+              sessionName: "session-name",
+              nodeMap: {},
+              nodeMapByIp: {},
+              namespaceMap: {},
+              dashboardDatasource: "Prometheus",
+              serverTimeZone: undefined,
+              currentTimeZone: undefined,
+            }}
+          >
+            {children}
+          </GlobalContext.Provider>
+        </MemoryRouter>
+      </STYLE_WRAPPER>
+    );
+  };

--- a/python/ray/dashboard/client/src/pages/overview/cards/ClusterUtilizationCard.tsx
+++ b/python/ray/dashboard/client/src/pages/overview/cards/ClusterUtilizationCard.tsx
@@ -16,6 +16,7 @@ export const ClusterUtilizationCard = ({
   const {
     metricsContextLoaded,
     grafanaHost,
+    grafanaOrgId,
     prometheusHealth,
     sessionName,
     dashboardUids,
@@ -24,7 +25,7 @@ export const ClusterUtilizationCard = ({
   } = useContext(GlobalContext);
   const grafanaDefaultDashboardUid =
     dashboardUids?.default ?? "rayDefaultDashboard";
-  const path = `/d-solo/${grafanaDefaultDashboardUid}/default-dashboard?orgId=1&theme=light&panelId=41&var-datasource=${dashboardDatasource}`;
+  const path = `/d-solo/${grafanaDefaultDashboardUid}/default-dashboard?orgId=${grafanaOrgId}&theme=light&panelId=41&var-datasource=${dashboardDatasource}`;
   const timeRangeParams = "&from=now-1h&to=now";
 
   if (!metricsContextLoaded || grafanaHost === "DISABLED") {

--- a/python/ray/dashboard/client/src/pages/overview/cards/NodeCountCard.tsx
+++ b/python/ray/dashboard/client/src/pages/overview/cards/NodeCountCard.tsx
@@ -13,6 +13,7 @@ export const NodeCountCard = ({ className, sx }: NodeCountCardProps) => {
   const {
     metricsContextLoaded,
     grafanaHost,
+    grafanaOrgId,
     prometheusHealth,
     sessionName,
     dashboardUids,
@@ -21,7 +22,7 @@ export const NodeCountCard = ({ className, sx }: NodeCountCardProps) => {
   } = useContext(GlobalContext);
   const grafanaDefaultDashboardUid =
     dashboardUids?.default ?? "rayDefaultDashboard";
-  const path = `/d-solo/${grafanaDefaultDashboardUid}/default-dashboard?orgId=1&theme=light&panelId=24&var-datasource=${dashboardDatasource}`;
+  const path = `/d-solo/${grafanaDefaultDashboardUid}/default-dashboard?orgId=${grafanaOrgId}&theme=light&panelId=24&var-datasource=${dashboardDatasource}`;
   const timeRangeParams = "&from=now-1h&to=now";
 
   if (!metricsContextLoaded || grafanaHost === "DISABLED") {

--- a/python/ray/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.component.test.tsx
@@ -10,6 +10,7 @@ const Wrapper = ({ children }: PropsWithChildren<{}>) => {
       value={{
         metricsContextLoaded: true,
         grafanaHost: "localhost:3000",
+        grafanaOrgId: "1",
         dashboardUids: {
           default: "rayDefaultDashboard",
           serve: "rayServeDashboard",
@@ -37,6 +38,7 @@ const MetricsDisabledWrapper = ({ children }: PropsWithChildren<{}>) => {
       value={{
         metricsContextLoaded: true,
         grafanaHost: undefined,
+        grafanaOrgId: undefined,
         dashboardUids: {
           default: "rayDefaultDashboard",
           serve: "rayServeDashboard",

--- a/python/ray/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.component.test.tsx
@@ -38,7 +38,7 @@ const MetricsDisabledWrapper = ({ children }: PropsWithChildren<{}>) => {
       value={{
         metricsContextLoaded: true,
         grafanaHost: undefined,
-        grafanaOrgId: undefined,
+        grafanaOrgId: "1",
         dashboardUids: {
           default: "rayDefaultDashboard",
           serve: "rayServeDashboard",

--- a/python/ray/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.tsx
+++ b/python/ray/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.tsx
@@ -225,8 +225,13 @@ export const useViewServeDeploymentMetricsButtonUrl = (
   deploymentName: string,
   replicaId?: string,
 ) => {
-  const { grafanaHost, grafanaOrgId, prometheusHealth, dashboardUids, dashboardDatasource } =
-    useContext(GlobalContext);
+  const {
+    grafanaHost,
+    grafanaOrgId,
+    prometheusHealth,
+    dashboardUids,
+    dashboardDatasource,
+  } = useContext(GlobalContext);
   const grafanaServeDashboardUid =
     dashboardUids?.serveDeployment ?? "rayServeDashboard";
 
@@ -237,6 +242,6 @@ export const useViewServeDeploymentMetricsButtonUrl = (
   return grafanaHost === undefined || !prometheusHealth
     ? null
     : `${grafanaHost}/d/${grafanaServeDashboardUid}?orgId=${grafanaOrgId}&var-Deployment=${encodeURIComponent(
-      deploymentName,
-    )}${replicaStr}&var-datasource=${dashboardDatasource}`;
+        deploymentName,
+      )}${replicaStr}&var-datasource=${dashboardDatasource}`;
 };

--- a/python/ray/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.tsx
+++ b/python/ray/dashboard/client/src/pages/serve/ServeDeploymentMetricsSection.tsx
@@ -27,15 +27,15 @@ import {
 const METRICS_CONFIG: MetricConfig[] = [
   {
     title: "QPS per replica",
-    pathParams: "orgId=1&theme=light&panelId=2",
+    pathParams: "theme=light&panelId=2",
   },
   {
     title: "Error QPS per replica",
-    pathParams: "orgId=1&theme=light&panelId=3",
+    pathParams: "&theme=light&panelId=3",
   },
   {
     title: "P90 latency per replica",
-    pathParams: "orgId=1&theme=light&panelId=5",
+    pathParams: "&theme=light&panelId=5",
   },
 ];
 
@@ -53,6 +53,7 @@ export const ServeReplicaMetricsSection = ({
 }: ServeDeploymentMetricsSectionProps) => {
   const {
     grafanaHost,
+    grafanaOrgId,
     prometheusHealth,
     dashboardUids,
     dashboardDatasource,
@@ -183,7 +184,7 @@ export const ServeReplicaMetricsSection = ({
         >
           {METRICS_CONFIG.map(({ title, pathParams }) => {
             const path =
-              `/d-solo/${grafanaServeDashboardUid}?${pathParams}` +
+              `/d-solo/${grafanaServeDashboardUid}?orgId=${grafanaOrgId}&${pathParams}` +
               `${refreshParams}&timezone=${currentTimeZone}${timeRangeParams}&var-Deployment=${encodeURIComponent(
                 deploymentName,
               )}&var-Replica=${encodeURIComponent(
@@ -224,7 +225,7 @@ export const useViewServeDeploymentMetricsButtonUrl = (
   deploymentName: string,
   replicaId?: string,
 ) => {
-  const { grafanaHost, prometheusHealth, dashboardUids, dashboardDatasource } =
+  const { grafanaHost, grafanaOrgId, prometheusHealth, dashboardUids, dashboardDatasource } =
     useContext(GlobalContext);
   const grafanaServeDashboardUid =
     dashboardUids?.serveDeployment ?? "rayServeDashboard";
@@ -235,7 +236,7 @@ export const useViewServeDeploymentMetricsButtonUrl = (
 
   return grafanaHost === undefined || !prometheusHealth
     ? null
-    : `${grafanaHost}/d/${grafanaServeDashboardUid}?var-Deployment=${encodeURIComponent(
-        deploymentName,
-      )}${replicaStr}&var-datasource=${dashboardDatasource}`;
+    : `${grafanaHost}/d/${grafanaServeDashboardUid}?orgId=${grafanaOrgId}&var-Deployment=${encodeURIComponent(
+      deploymentName,
+    )}${replicaStr}&var-datasource=${dashboardDatasource}`;
 };

--- a/python/ray/dashboard/client/src/pages/serve/ServeMetricsSection.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/serve/ServeMetricsSection.component.test.tsx
@@ -14,6 +14,7 @@ const Wrapper = ({ children }: PropsWithChildren<{}>) => {
       value={{
         metricsContextLoaded: true,
         grafanaHost: "localhost:3000",
+        grafanaOrgId: "1",
         dashboardUids: {
           default: "rayDefaultDashboard",
           serve: "rayServeDashboard",
@@ -41,6 +42,7 @@ const MetricsDisabledWrapper = ({ children }: PropsWithChildren<{}>) => {
       value={{
         metricsContextLoaded: true,
         grafanaHost: undefined,
+        grafanaOrgId: undefined,
         dashboardUids: {
           default: "rayDefaultDashboard",
           serve: "rayServeDashboard",

--- a/python/ray/dashboard/client/src/pages/serve/ServeMetricsSection.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/serve/ServeMetricsSection.component.test.tsx
@@ -42,7 +42,7 @@ const MetricsDisabledWrapper = ({ children }: PropsWithChildren<{}>) => {
       value={{
         metricsContextLoaded: true,
         grafanaHost: undefined,
-        grafanaOrgId: undefined,
+        grafanaOrgId: "1",
         dashboardUids: {
           default: "rayDefaultDashboard",
           serve: "rayServeDashboard",

--- a/python/ray/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
+++ b/python/ray/dashboard/client/src/pages/serve/ServeMetricsSection.tsx
@@ -27,15 +27,15 @@ import {
 export const APPS_METRICS_CONFIG: MetricConfig[] = [
   {
     title: "QPS per application",
-    pathParams: "orgId=1&theme=light&panelId=7",
+    pathParams: "theme=light&panelId=7",
   },
   {
     title: "Error QPS per application",
-    pathParams: "orgId=1&theme=light&panelId=8",
+    pathParams: "theme=light&panelId=8",
   },
   {
     title: "P90 latency per application",
-    pathParams: "orgId=1&theme=light&panelId=15",
+    pathParams: "theme=light&panelId=15",
   },
 ];
 
@@ -43,27 +43,27 @@ export const APPS_METRICS_CONFIG: MetricConfig[] = [
 export const SERVE_SYSTEM_METRICS_CONFIG: MetricConfig[] = [
   {
     title: "Ongoing HTTP Requests",
-    pathParams: "orgId=1&theme=light&panelId=20",
+    pathParams: "theme=light&panelId=20",
   },
   {
     title: "Ongoing gRPC Requests",
-    pathParams: "orgId=1&theme=light&panelId=21",
+    pathParams: "theme=light&panelId=21",
   },
   {
     title: "Scheduling Tasks",
-    pathParams: "orgId=1&theme=light&panelId=22",
+    pathParams: "theme=light&panelId=22",
   },
   {
     title: "Scheduling Tasks in Backoff",
-    pathParams: "orgId=1&theme=light&panelId=23",
+    pathParams: "theme=light&panelId=23",
   },
   {
     title: "Controller Control Loop Duration",
-    pathParams: "orgId=1&theme=light&panelId=24",
+    pathParams: "theme=light&panelId=24",
   },
   {
     title: "Number of Control Loops",
-    pathParams: "orgId=1&theme=light&panelId=25",
+    pathParams: "theme=light&panelId=25",
   },
 ];
 
@@ -79,6 +79,7 @@ export const ServeMetricsSection = ({
 }: ServeMetricsSectionProps) => {
   const {
     grafanaHost,
+    grafanaOrgId,
     prometheusHealth,
     dashboardUids,
     dashboardDatasource,
@@ -130,7 +131,7 @@ export const ServeMetricsSection = ({
           }}
         >
           <Button
-            href={`${grafanaHost}/d/${grafanaServeDashboardUid}?var-datasource=${dashboardDatasource}`}
+            href={`${grafanaHost}/d/${grafanaServeDashboardUid}?orgId=${grafanaOrgId}&var-datasource=${dashboardDatasource}`}
             target="_blank"
             rel="noopener noreferrer"
             endIcon={<RiExternalLinkLine />}
@@ -200,7 +201,7 @@ export const ServeMetricsSection = ({
         >
           {metricsConfig.map(({ title, pathParams }) => {
             const path =
-              `/d-solo/${grafanaServeDashboardUid}?${pathParams}` +
+              `/d-solo/${grafanaServeDashboardUid}?orgId=${grafanaOrgId}&${pathParams}` +
               `${refreshParams}&timezone=${currentTimeZone}${timeRangeParams}&var-datasource=${dashboardDatasource}`;
             return (
               <Paper

--- a/python/ray/dashboard/client/src/util/test-utils.tsx
+++ b/python/ray/dashboard/client/src/util/test-utils.tsx
@@ -12,6 +12,7 @@ export const TEST_APP_WRAPPER = ({ children }: PropsWithChildren<{}>) => {
     namespaceMap: {},
     metricsContextLoaded: true,
     grafanaHost: "localhost:3000",
+    grafanaOrgId: "1",
     dashboardUids: {
       default: "rayDefaultDashboard",
       serve: "rayServeDashboard",

--- a/python/ray/dashboard/modules/metrics/metrics_head.py
+++ b/python/ray/dashboard/modules/metrics/metrics_head.py
@@ -44,6 +44,8 @@ PROMETHEUS_HEALTHCHECK_PATH = "-/healthy"
 
 DEFAULT_GRAFANA_HOST = "http://localhost:3000"
 GRAFANA_HOST_ENV_VAR = "RAY_GRAFANA_HOST"
+GRAFANA_ORG_ID_ENV_VAR = "RAY_GRAFANA_ORG_ID"
+DEFAULT_GRAFANA_ORG_ID = "1"
 GRAFANA_HOST_DISABLED_VALUE = "DISABLED"
 GRAFANA_IFRAME_HOST_ENV_VAR = "RAY_GRAFANA_IFRAME_HOST"
 GRAFANA_DASHBOARD_OUTPUT_DIR_ENV_VAR = "RAY_METRICS_GRAFANA_DASHBOARD_OUTPUT_DIR"
@@ -114,6 +116,9 @@ class MetricsHead(SubprocessModule):
         self._prometheus_name = os.environ.get(
             PROMETHEUS_NAME_ENV_VAR, DEFAULT_PROMETHEUS_NAME
         )
+        self._grafana_org_id = os.environ.get(
+            GRAFANA_ORG_ID_ENV_VAR, DEFAULT_GRAFANA_ORG_ID
+        )
 
         # To be set later when dashboards gets generated
         self._dashboard_uids = {}
@@ -157,6 +162,7 @@ class MetricsHead(SubprocessModule):
                     status_code=dashboard_utils.HTTPStatusCode.OK,
                     message="Grafana running",
                     grafana_host=grafana_iframe_host,
+                    grafana_org_id=self._grafana_org_id,
                     session_name=self.session_name,
                     dashboard_uids=self._dashboard_uids,
                     dashboard_datasource=self._prometheus_name,

--- a/python/ray/dashboard/modules/usage_stats/usage_stats_head.py
+++ b/python/ray/dashboard/modules/usage_stats/usage_stats_head.py
@@ -67,7 +67,7 @@ class UsageStatsHead(dashboard_utils.DashboardHeadModule):
 
         grafana_running = False
         try:
-            resp = requests.get(f"{self._dashboard_url_base}")
+            resp = requests.get(f"{self._dashboard_url_base}/api/grafana_health")
             if resp.status_code == 200:
                 json = resp.json()
                 grafana_running = (

--- a/python/ray/dashboard/modules/usage_stats/usage_stats_head.py
+++ b/python/ray/dashboard/modules/usage_stats/usage_stats_head.py
@@ -67,7 +67,7 @@ class UsageStatsHead(dashboard_utils.DashboardHeadModule):
 
         grafana_running = False
         try:
-            resp = requests.get(f"{self._dashboard_url_base}/api/grafana_health")
+            resp = requests.get(f"{self._dashboard_url_base}")
             if resp.status_code == 200:
                 json = resp.json()
                 grafana_running = (


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The Grafana can add multi orgs, so we can't sure the orgId is always be set 1.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
