### PR TITLE
[core] Deflake `test_memory_pressure.py`

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -117,8 +117,7 @@ steps:
     tags:
       - python
       - oss
-      # XXX: fix!
-      # - skip-on-premerge
+      - skip-on-premerge
     instance_type: medium
     commands:
       - cleanup() { ./ci/build/upload_build_info.sh; }; trap cleanup EXIT

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -117,7 +117,8 @@ steps:
     tags:
       - python
       - oss
-      - skip-on-premerge
+      # XXX: fix!
+      # - skip-on-premerge
     instance_type: medium
     commands:
       - cleanup() { ./ci/build/upload_build_info.sh; }; trap cleanup EXIT

--- a/python/ray/tests/test_memory_pressure.py
+++ b/python/ray/tests/test_memory_pressure.py
@@ -171,9 +171,7 @@ def test_non_restartable_actor_throws_oom_error(ray_with_memory_monitor):
     reason="memory monitor only on linux currently",
 )
 @pytest.mark.parametrize("restartable", [False, True])
-def test_restartable_actor_throws_oom_error(
-    ray_with_memory_monitor, restartable: bool
-):
+def test_restartable_actor_throws_oom_error(ray_with_memory_monitor, restartable: bool):
     addr = ray_with_memory_monitor
     if restartable:
         leaker = Leaker.options(max_restarts=1, max_task_retries=1).remote()

--- a/python/ray/tests/test_memory_pressure.py
+++ b/python/ray/tests/test_memory_pressure.py
@@ -97,12 +97,12 @@ class Leaker:
     def __init__(self):
         self.leaks = []
 
-    def allocate(self, allocate_bytes: int, sleep_time_s: int = 0):
+    def allocate(self, allocate_bytes: int, sleep_time_ms: int = 0):
         # divide by 8 as each element in the array occupies 8 bytes
         new_list = [0] * ceil(allocate_bytes / 8)
         self.leaks.append(new_list)
 
-        time.sleep(sleep_time_s / 1000)
+        time.sleep(sleep_time_ms / 1000)
 
     def get_worker_id(self):
         return ray._private.worker.global_worker.core_worker.get_worker_id().hex()
@@ -170,16 +170,20 @@ def test_non_restartable_actor_throws_oom_error(ray_with_memory_monitor):
     sys.platform != "linux" and sys.platform != "linux2",
     reason="memory monitor only on linux currently",
 )
+@pytest.mark.parametrize("restartable", [False, True])
 def test_restartable_actor_throws_oom_error(
-    ray_with_memory_monitor,
+    ray_with_memory_monitor, restartable: bool
 ):
     addr = ray_with_memory_monitor
-    leaker = Leaker.options(max_restarts=1, max_task_retries=1).remote()
+    if restartable:
+        leaker = Leaker.options(max_restarts=1, max_task_retries=1).remote()
+    else:
+        leaker = Leaker.options(max_restarts=0, max_task_retries=0).remote()
 
     bytes_to_alloc = get_additional_bytes_to_reach_memory_usage_pct(
         memory_usage_threshold + 0.1
     )
-    with pytest.raises(ray.exceptions.OutOfMemoryError) as _:
+    with pytest.raises(ray.exceptions.OutOfMemoryError):
         ray.get(leaker.allocate.remote(bytes_to_alloc, memory_monitor_refresh_ms * 3))
 
     wait_for_condition(
@@ -188,7 +192,7 @@ def test_restartable_actor_throws_oom_error(
         retry_interval_ms=100,
         addr=addr,
         tag="MemoryManager.ActorEviction.Total",
-        value=2.0,
+        value=2.0 if restartable else 1.0,
     )
 
     wait_for_condition(
@@ -197,7 +201,7 @@ def test_restartable_actor_throws_oom_error(
         retry_interval_ms=100,
         addr=addr,
         tag="Leaker.__init__",
-        value=2.0,
+        value=2.0 if restartable else 1.0,
     )
 
 


### PR DESCRIPTION
The test is failing periodically in CI due to memory usage being above the memory monitor threshold prior to running an actor: https://buildkite.com/ray-project/postmerge/builds/10292#0196f473-d8f0-41fa-8041-addf42660c57/179-477

I'm attempting to deflake it by converting it to follow the same pattern as its sister test and combining them using a fixture. This only requires that we're below the memory monitor threshold to start, not that we are below `0.3 * threshold`.