### PR TITLE
[core] Speed up reference counting tests

### DIFF
--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -62,6 +62,7 @@ py_test_module_list(
         "test_node_label_scheduling_strategy.py",
         "test_object_spilling_2.py",
         "test_reference_counting_2.py",
+        "test_reference_counting_standalone.py",
         "test_runtime_env_agent.py",
     ],
     tags = [

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -61,6 +61,7 @@ py_test_module_list(
         "test_multiprocessing_standalone.py",
         "test_node_label_scheduling_strategy.py",
         "test_object_spilling_2.py",
+        "test_reference_counting.py",
         "test_reference_counting_2.py",
         "test_reference_counting_standalone.py",
         "test_runtime_env_agent.py",
@@ -845,7 +846,6 @@ py_test_module_list(
         "test_object_spilling.py",
         "test_object_spilling_3.py",
         "test_placement_group_mini_integration.py",
-        "test_reference_counting.py",
         "test_scheduling_2.py",
     ],
     tags = [

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -1650,5 +1650,35 @@ def test_get_local_actor_state(ray_start_regular_shared):
     )
 
 
+def _all_actors_dead():
+    return len(list_actors(filters=[("state", "=", "ALIVE")])) == 0
+
+
+def test_kill_actor_immediately_after_creation(ray_start_regular_shared):
+    @ray.remote
+    class A:
+        pass
+
+    a = A.remote()
+    b = A.remote()
+
+    ray.kill(a)
+    ray.kill(b)
+    wait_for_condition(_all_actors_dead)
+
+
+def test_remove_actor_immediately_after_creation(ray_start_regular_shared):
+    @ray.remote
+    class A:
+        pass
+
+    a = A.remote()
+    b = A.remote()
+
+    del a
+    del b
+    wait_for_condition(_all_actors_dead)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_reference_counting.py
+++ b/python/ray/tests/test_reference_counting.py
@@ -14,7 +14,6 @@ import numpy as np
 import pytest
 
 import ray
-import ray._private.gcs_utils as gcs_utils
 import ray.cluster_utils
 from ray._private.test_utils import (
     SignalActor,
@@ -438,39 +437,6 @@ def test_basic_nested_ids(one_cpu_100MiB_shared):
     # Remove the outer reference and check that the inner object gets evicted.
     del outer_oid
     _fill_object_store_and_get(inner_oid_bytes, succeed=False)
-
-
-def _all_actors_dead():
-    return all(
-        actor["State"] == convert_actor_state(gcs_utils.ActorTableData.DEAD)
-        for actor in list(ray._private.state.actors().values())
-    )
-
-
-def test_kill_actor_immediately_after_creation(one_cpu_100MiB_shared):
-    @ray.remote
-    class A:
-        pass
-
-    a = A.remote()
-    b = A.remote()
-
-    ray.kill(a)
-    ray.kill(b)
-    wait_for_condition(_all_actors_dead, timeout=10)
-
-
-def test_remove_actor_immediately_after_creation(one_cpu_100MiB_shared):
-    @ray.remote
-    class A:
-        pass
-
-    a = A.remote()
-    b = A.remote()
-
-    del a
-    del b
-    wait_for_condition(_all_actors_dead, timeout=10)
 
 
 # Test that a reference borrowed by an actor constructor is freed if the actor is

--- a/python/ray/tests/test_reference_counting.py
+++ b/python/ray/tests/test_reference_counting.py
@@ -17,7 +17,6 @@ import ray
 import ray.cluster_utils
 from ray._private.test_utils import (
     SignalActor,
-    convert_actor_state,
     kill_actor_and_wait_for_failure,
     put_object,
     wait_for_condition,

--- a/python/ray/tests/test_reference_counting.py
+++ b/python/ray/tests/test_reference_counting.py
@@ -229,9 +229,7 @@ def test_pending_task_dependency_pinning(one_cpu_100MiB_shared):
     ray.get(obj_ref)
 
 
-def test_feature_flag(shutdown_only):
-    ray.init(object_store_memory=100 * 1024 * 1024)
-
+def test_feature_flag(one_cpu_100MiB_shared):
     @ray.remote
     def f(array):
         return np.sum(array)

--- a/python/ray/tests/test_reference_counting.py
+++ b/python/ray/tests/test_reference_counting.py
@@ -81,7 +81,7 @@ def check_refcounts(expected, timeout=10):
                 time.sleep(0.1)
 
 
-def test_local_refcounts(ray_start_regular):
+def test_local_refcounts(one_cpu_100MiB_shared):
     obj_ref1 = ray.put(None)
     check_refcounts({obj_ref1: (1, 0)})
     obj_ref1_copy = copy.copy(obj_ref1)
@@ -92,7 +92,7 @@ def test_local_refcounts(ray_start_regular):
     check_refcounts({})
 
 
-def test_dependency_refcounts(ray_start_regular):
+def test_dependency_refcounts(one_cpu_100MiB_shared):
     @ray.remote
     def one_dep(dep, signal=None, fail=False):
         if signal is not None:
@@ -542,7 +542,7 @@ def _all_actors_dead():
     )
 
 
-def test_kill_actor_immediately_after_creation(ray_start_regular):
+def test_kill_actor_immediately_after_creation(one_cpu_100MiB_shared):
     @ray.remote
     class A:
         pass
@@ -555,7 +555,7 @@ def test_kill_actor_immediately_after_creation(ray_start_regular):
     wait_for_condition(_all_actors_dead, timeout=10)
 
 
-def test_remove_actor_immediately_after_creation(ray_start_regular):
+def test_remove_actor_immediately_after_creation(one_cpu_100MiB_shared):
     @ray.remote
     class A:
         pass
@@ -570,7 +570,7 @@ def test_remove_actor_immediately_after_creation(ray_start_regular):
 
 # Test that a reference borrowed by an actor constructor is freed if the actor is
 # cancelled before being scheduled.
-def test_actor_constructor_borrow_cancellation(ray_start_regular):
+def test_actor_constructor_borrow_cancellation(one_cpu_100MiB_shared):
     # Schedule the actor with a non-existent resource so it's guaranteed to never be
     # scheduled.
     @ray.remote(resources={"nonexistent_resource": 1})

--- a/python/ray/tests/test_reference_counting.py
+++ b/python/ray/tests/test_reference_counting.py
@@ -537,8 +537,8 @@ def test_actor_constructor_borrow_cancellation(one_cpu_100MiB_shared):
         print(Actor.remote({"foo": ref}))
 
     test_implicit_cancel()
-    # Confirm that the ref object is not leaked.
 
+    # Confirm that the ref object is not leaked.
     check_refcounts({})
 
     # Test with explicit cancellation via ray.kill().

--- a/python/ray/tests/test_reference_counting_2.py
+++ b/python/ray/tests/test_reference_counting_2.py
@@ -1,7 +1,13 @@
+"""All tests in this file use a module-scoped fixture to reduce runtime.
+
+If you need a customized Ray instance (e.g., to change system config or env vars),
+put the test in `test_reference_counting_standalone.py`.
+"""
 # coding: utf-8
 import logging
 import os
 import copy
+import pickle
 import platform
 import random
 import signal
@@ -27,8 +33,8 @@ SIGKILL = signal.SIGKILL if sys.platform != "win32" else signal.SIGTERM
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture
-def one_worker_100MiB(request):
+@pytest.fixture(scope="module")
+def one_cpu_100MiB_shared():
     config = {
         "task_retry_delay_ms": 0,
         "object_timeout_milliseconds": 1000,
@@ -63,7 +69,7 @@ def _fill_object_store_and_get(obj, succeed=True, object_MiB=20, num_objects=5):
 @pytest.mark.parametrize(
     "use_ray_put,failure", [(False, False), (False, True), (True, False), (True, True)]
 )
-def test_recursively_nest_ids(one_worker_100MiB, use_ray_put, failure):
+def test_recursively_nest_ids(one_cpu_100MiB_shared, use_ray_put, failure):
     @ray.remote(max_retries=1)
     def recursive(ref, signal, max_depth, depth=0):
         unwrapped = ray.get(ref[0])
@@ -117,7 +123,7 @@ def test_recursively_nest_ids(one_worker_100MiB, use_ray_put, failure):
 @pytest.mark.parametrize(
     "use_ray_put,failure", [(False, False), (False, True), (True, False), (True, True)]
 )
-def test_return_object_ref(one_worker_100MiB, use_ray_put, failure):
+def test_return_object_ref(one_cpu_100MiB_shared, use_ray_put, failure):
     @ray.remote
     def return_an_id():
         return [put_object(np.zeros(20 * 1024 * 1024, dtype=np.uint8), use_ray_put)]
@@ -152,7 +158,7 @@ def test_return_object_ref(one_worker_100MiB, use_ray_put, failure):
 @pytest.mark.parametrize(
     "use_ray_put,failure", [(False, False), (False, True), (True, False), (True, True)]
 )
-def test_pass_returned_object_ref(one_worker_100MiB, use_ray_put, failure):
+def test_pass_returned_object_ref(one_cpu_100MiB_shared, use_ray_put, failure):
     @ray.remote
     def return_an_id():
         return [put_object(np.zeros(20 * 1024 * 1024, dtype=np.uint8), use_ray_put)]
@@ -198,7 +204,9 @@ def test_pass_returned_object_ref(one_worker_100MiB, use_ray_put, failure):
 @pytest.mark.parametrize(
     "use_ray_put,failure", [(False, False), (False, True), (True, False), (True, True)]
 )
-def test_recursively_pass_returned_object_ref(one_worker_100MiB, use_ray_put, failure):
+def test_recursively_pass_returned_object_ref(
+    one_cpu_100MiB_shared, use_ray_put, failure
+):
     @ray.remote
     def return_an_id():
         return put_object(np.zeros(20 * 1024 * 1024, dtype=np.uint8), use_ray_put)
@@ -262,7 +270,7 @@ def test_recursively_pass_returned_object_ref(one_worker_100MiB, use_ray_put, fa
     "use_ray_put,failure", [(False, False), (False, True), (True, False), (True, True)]
 )
 def test_recursively_return_borrowed_object_ref(
-    one_worker_100MiB, use_ray_put, failure
+    one_cpu_100MiB_shared, use_ray_put, failure
 ):
     @ray.remote
     def recursive(num_tasks_left):
@@ -301,7 +309,7 @@ def test_recursively_return_borrowed_object_ref(
 
 
 @pytest.mark.parametrize("failure", [False, True])
-def test_borrowed_id_failure(one_worker_100MiB, failure):
+def test_borrowed_id_failure(one_cpu_100MiB_shared, failure):
     @ray.remote
     class Parent:
         def __init__(self):
@@ -353,289 +361,8 @@ def test_borrowed_id_failure(one_worker_100MiB, failure):
     ray.get(borrower.resolve_ref.remote())
 
 
-@pytest.mark.skipif(platform.system() in ["Windows"], reason="Failing on Windows.")
-def test_object_unpin(ray_start_cluster):
-    nodes = []
-    cluster = ray_start_cluster
-    head_node = cluster.add_node(
-        num_cpus=0,
-        object_store_memory=100 * 1024 * 1024,
-        _system_config={
-            "subscriber_timeout_ms": 100,
-            "health_check_initial_delay_ms": 0,
-            "health_check_period_ms": 1000,
-            "health_check_failure_threshold": 5,
-        },
-    )
-    ray.init(address=cluster.address)
-
-    # Add worker nodes.
-    for i in range(2):
-        nodes.append(
-            cluster.add_node(
-                num_cpus=1,
-                resources={f"node_{i}": 1},
-                object_store_memory=100 * 1024 * 1024,
-            )
-        )
-    cluster.wait_for_nodes()
-
-    one_mb_array = np.ones(1 * 1024 * 1024, dtype=np.uint8)
-    ten_mb_array = np.ones(10 * 1024 * 1024, dtype=np.uint8)
-
-    @ray.remote
-    class ObjectsHolder:
-        def __init__(self):
-            self.ten_mb_objs = []
-            self.one_mb_objs = []
-
-        def put_10_mb(self):
-            self.ten_mb_objs.append(ray.put(ten_mb_array))
-
-        def put_1_mb(self):
-            self.one_mb_objs.append(ray.put(one_mb_array))
-
-        def pop_10_mb(self):
-            if len(self.ten_mb_objs) == 0:
-                return False
-            self.ten_mb_objs.pop()
-            return True
-
-        def pop_1_mb(self):
-            if len(self.one_mb_objs) == 0:
-                return False
-            self.one_mb_objs.pop()
-            return True
-
-    # Head node contains 11MB of data.
-    one_mb_arrays = []
-    ten_mb_arrays = []
-
-    one_mb_arrays.append(ray.put(one_mb_array))
-    ten_mb_arrays.append(ray.put(ten_mb_array))
-
-    def check_memory(mb):
-        return f"Plasma memory usage {mb} MiB" in memory_summary(
-            address=head_node.address, stats_only=True
-        )
-
-    def wait_until_node_dead(node):
-        for n in ray.nodes():
-            if n["ObjectStoreSocketName"] == node.address_info["object_store_address"]:
-                return not n["Alive"]
-        return False
-
-    wait_for_condition(lambda: check_memory(11))
-
-    # Pop one mb array and see if it works.
-    one_mb_arrays.pop()
-    wait_for_condition(lambda: check_memory(10))
-
-    # Pop 10 MB.
-    ten_mb_arrays.pop()
-    wait_for_condition(lambda: check_memory(0))
-
-    # Put 11 MB for each actor.
-    # actor 1: 1MB + 10MB
-    # actor 2: 1MB + 10MB
-    actor_on_node_1 = ObjectsHolder.options(resources={"node_0": 1}).remote()
-    actor_on_node_2 = ObjectsHolder.options(resources={"node_1": 1}).remote()
-    ray.get(actor_on_node_1.put_1_mb.remote())
-    ray.get(actor_on_node_1.put_10_mb.remote())
-    ray.get(actor_on_node_2.put_1_mb.remote())
-    ray.get(actor_on_node_2.put_10_mb.remote())
-    wait_for_condition(lambda: check_memory(22))
-
-    # actor 1: 10MB
-    # actor 2: 1MB
-    ray.get(actor_on_node_1.pop_1_mb.remote())
-    ray.get(actor_on_node_2.pop_10_mb.remote())
-    wait_for_condition(lambda: check_memory(11))
-
-    # The second node is dead, and actor 2 is dead.
-    cluster.remove_node(nodes[1], allow_graceful=False)
-    wait_for_condition(lambda: wait_until_node_dead(nodes[1]))
-    wait_for_condition(lambda: check_memory(10))
-
-    # The first actor is dead, so object should be GC'ed.
-    ray.kill(actor_on_node_1)
-    wait_for_condition(lambda: check_memory(0))
-
-
-@pytest.mark.skipif(platform.system() in ["Windows"], reason="Failing on Windows.")
-def test_object_unpin_stress(ray_start_cluster):
-    nodes = []
-    cluster = ray_start_cluster
-    cluster.add_node(
-        num_cpus=1, resources={"head": 1}, object_store_memory=1000 * 1024 * 1024
-    )
-    ray.init(address=cluster.address)
-
-    # Add worker nodes.
-    for i in range(2):
-        nodes.append(
-            cluster.add_node(
-                num_cpus=1,
-                resources={f"node_{i}": 1},
-                object_store_memory=1000 * 1024 * 1024,
-            )
-        )
-    cluster.wait_for_nodes()
-
-    one_mb_array = np.ones(1 * 1024 * 1024, dtype=np.uint8)
-    ten_mb_array = np.ones(10 * 1024 * 1024, dtype=np.uint8)
-
-    @ray.remote
-    class ObjectsHolder:
-        def __init__(self):
-            self.ten_mb_objs = []
-            self.one_mb_objs = []
-
-        def put_10_mb(self):
-            self.ten_mb_objs.append(ray.put(ten_mb_array))
-
-        def put_1_mb(self):
-            self.one_mb_objs.append(ray.put(one_mb_array))
-
-        def pop_10_mb(self):
-            if len(self.ten_mb_objs) == 0:
-                return False
-            self.ten_mb_objs.pop()
-            return True
-
-        def pop_1_mb(self):
-            if len(self.one_mb_objs) == 0:
-                return False
-            self.one_mb_objs.pop()
-            return True
-
-        def get_obj_size(self):
-            return len(self.ten_mb_objs) * 10 + len(self.one_mb_objs)
-
-    actor_on_node_1 = ObjectsHolder.options(resources={"node_0": 1}).remote()
-    actor_on_node_2 = ObjectsHolder.options(resources={"node_1": 1}).remote()
-    actor_on_head_node = ObjectsHolder.options(resources={"head": 1}).remote()
-
-    ray.get(actor_on_node_1.get_obj_size.remote())
-    ray.get(actor_on_node_2.get_obj_size.remote())
-    ray.get(actor_on_head_node.get_obj_size.remote())
-
-    def random_ops(actors):
-        r = random.random()
-        for actor in actors:
-            if r <= 0.25:
-                actor.put_10_mb.remote()
-            elif r <= 0.5:
-                actor.put_1_mb.remote()
-            elif r <= 0.75:
-                actor.pop_10_mb.remote()
-            else:
-                actor.pop_1_mb.remote()
-
-    total_iter = 15
-    for _ in range(total_iter):
-        random_ops([actor_on_node_1, actor_on_node_2, actor_on_head_node])
-
-    # Simulate node dead.
-    cluster.remove_node(nodes[1])
-    for _ in range(total_iter):
-        random_ops([actor_on_node_1, actor_on_head_node])
-
-    total_size = sum(
-        [
-            ray.get(actor_on_node_1.get_obj_size.remote()),
-            ray.get(actor_on_head_node.get_obj_size.remote()),
-        ]
-    )
-
-    wait_for_condition(
-        lambda: (
-            (f"Plasma memory usage {total_size} MiB") in memory_summary(stats_only=True)
-        )
-    )
-
-
-@pytest.mark.parametrize("inline_args", [True, False])
-def test_inlined_nested_refs(ray_start_cluster, inline_args):
-    cluster = ray_start_cluster
-    config = {}
-    if not inline_args:
-        config["max_direct_call_object_size"] = 0
-    cluster.add_node(
-        num_cpus=2, object_store_memory=100 * 1024 * 1024, _system_config=config
-    )
-    ray.init(address=cluster.address)
-
-    @ray.remote
-    class Actor:
-        def __init__(self):
-            return
-
-        def nested(self):
-            return ray.put("x")
-
-    @ray.remote
-    def nested_nested(a):
-        return a.nested.remote()
-
-    @ray.remote
-    def foo(ref):
-        time.sleep(1)
-        return ray.get(ref)
-
-    a = Actor.remote()
-    nested_nested_ref = nested_nested.remote(a)
-    # We get nested_ref's value directly from its owner.
-    nested_ref = ray.get(nested_nested_ref)
-
-    del nested_nested_ref
-    x = foo.remote(nested_ref)
-    del nested_ref
-    ray.get(x)
-
-
-# https://github.com/ray-project/ray/issues/17553
-@pytest.mark.parametrize("inline_args", [True, False])
-def test_return_nested_ids(shutdown_only, inline_args):
-    config = dict()
-    if inline_args:
-        config["max_direct_call_object_size"] = 100 * 1024 * 1024
-    else:
-        config["max_direct_call_object_size"] = 0
-    ray.init(object_store_memory=100 * 1024 * 1024, _system_config=config)
-
-    class Nested:
-        def __init__(self, blocks):
-            self._blocks = blocks
-
-    @ray.remote
-    def echo(fn):
-        return fn()
-
-    @ray.remote
-    def create_nested():
-        refs = [ray.put(np.random.random(1024 * 1024)) for _ in range(10)]
-        return Nested(refs)
-
-    @ray.remote
-    def test():
-        ref = create_nested.remote()
-        result1 = ray.get(ref)
-        del ref
-        result = echo.remote(lambda: result1)  # noqa
-        del result1
-
-        time.sleep(5)
-        block = ray.get(result)._blocks[0]
-        print(ray.get(block))
-
-    ray.get(test.remote())
-
-
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
-def test_actor_constructor_borrowed_refs(shutdown_only):
-    ray.init(object_store_memory=100 * 1024 * 1024)
-
+def test_actor_constructor_borrowed_refs(one_cpu_100MiB_shared):
     @ray.remote
     class Borrower:
         def __init__(self, borrowed_refs):
@@ -655,9 +382,7 @@ def test_actor_constructor_borrowed_refs(shutdown_only):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
-def test_deep_nested_refs(shutdown_only):
-    ray.init(object_store_memory=100 * 1024 * 1024)
-
+def test_deep_nested_refs(one_cpu_100MiB_shared):
     @ray.remote
     def f(x):
         print(f"=> step {x}")
@@ -674,9 +399,7 @@ def test_deep_nested_refs(shutdown_only):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
-def test_forward_nested_ref(shutdown_only):
-    ray.init(object_store_memory=100 * 1024 * 1024)
-
+def test_forward_nested_ref(one_cpu_100MiB_shared):
     @ray.remote
     def nested_ref():
         return ray.put(1)
@@ -711,9 +434,7 @@ def test_forward_nested_ref(shutdown_only):
         time.sleep(1)
 
 
-def test_out_of_band_actor_handle_deserialization(shutdown_only):
-    ray.init(object_store_memory=100 * 1024 * 1024)
-
+def test_out_of_band_actor_handle_deserialization(one_cpu_100MiB_shared):
     @ray.remote
     class Actor:
         def ping(self):
@@ -730,11 +451,7 @@ def test_out_of_band_actor_handle_deserialization(shutdown_only):
     assert ray.get(func.remote({"actor": actor})) == 1
 
 
-def test_out_of_band_actor_handle_bypass_reference_counting(shutdown_only):
-    import pickle
-
-    ray.init(object_store_memory=100 * 1024 * 1024)
-
+def test_out_of_band_actor_handle_bypass_reference_counting(one_cpu_100MiB_shared):
     @ray.remote
     class Actor:
         def ping(self):
@@ -751,7 +468,7 @@ def test_out_of_band_actor_handle_bypass_reference_counting(shutdown_only):
         ray.get(config["actor"].ping.remote())
 
 
-def test_generators(one_worker_100MiB):
+def test_generators(one_cpu_100MiB_shared):
     @ray.remote(num_returns="dynamic")
     def remote_generator():
         for _ in range(3):
@@ -777,7 +494,7 @@ def test_generators(one_worker_100MiB):
         _fill_object_store_and_get(r_oid, succeed=False)
 
 
-def test_lineage_leak(shutdown_only):
+def test_lineage_leak(one_cpu_100MiB_shared):
     ray.init()
 
     @ray.remote
@@ -791,8 +508,6 @@ def test_lineage_leak(shutdown_only):
     del ref
 
     def check_usage():
-        from ray._private.internal_api import memory_summary
-
         return "Plasma memory usage 0 MiB" in memory_summary(stats_only=True)
 
     wait_for_condition(check_usage)

--- a/python/ray/tests/test_reference_counting_2.py
+++ b/python/ray/tests/test_reference_counting_2.py
@@ -8,8 +8,6 @@ import logging
 import os
 import copy
 import pickle
-import platform
-import random
 import signal
 import sys
 import time

--- a/python/ray/tests/test_reference_counting_2.py
+++ b/python/ray/tests/test_reference_counting_2.py
@@ -384,7 +384,7 @@ def test_deep_nested_refs(one_cpu_100MiB_shared):
     @ray.remote
     def f(x):
         print(f"=> step {x}")
-        if x > 200:
+        if x > 25:
             return x
         return f.remote(x + 1)
 
@@ -493,8 +493,6 @@ def test_generators(one_cpu_100MiB_shared):
 
 
 def test_lineage_leak(one_cpu_100MiB_shared):
-    ray.init()
-
     @ray.remote
     def process(data):
         return b"\0" * 100_000_000

--- a/python/ray/tests/test_reference_counting_standalone.py
+++ b/python/ray/tests/test_reference_counting_standalone.py
@@ -1,0 +1,332 @@
+"""Reference counting tests that require their own custom fixture.
+
+The other reference counting tests use a shared Ray instance across the test module
+to reduce overheads & overall test runtime.
+"""
+# coding: utf-8
+import logging
+import os
+import copy
+import platform
+import random
+import signal
+import sys
+import time
+
+import numpy as np
+import pytest
+
+import ray
+import ray.cluster_utils
+from ray._private.internal_api import memory_summary
+from ray._private.test_utils import (
+    SignalActor,
+    put_object,
+    wait_for_condition,
+    wait_for_num_actors,
+)
+import ray._private.gcs_utils as gcs_utils
+
+SIGKILL = signal.SIGKILL if sys.platform != "win32" else signal.SIGTERM
+
+logger = logging.getLogger(__name__)
+
+
+def _fill_object_store_and_get(obj, succeed=True, object_MiB=20, num_objects=5):
+    for _ in range(num_objects):
+        ray.put(np.zeros(object_MiB * 1024 * 1024, dtype=np.uint8))
+
+    if type(obj) is bytes:
+        obj = ray.ObjectRef(obj)
+
+    if succeed:
+        wait_for_condition(
+            lambda: ray._private.worker.global_worker.core_worker.object_exists(obj)
+        )
+    else:
+        wait_for_condition(
+            lambda: not ray._private.worker.global_worker.core_worker.object_exists(obj)
+        )
+
+
+@pytest.mark.skipif(platform.system() in ["Windows"], reason="Failing on Windows.")
+def test_object_unpin(ray_start_cluster):
+    nodes = []
+    cluster = ray_start_cluster
+    head_node = cluster.add_node(
+        num_cpus=0,
+        object_store_memory=100 * 1024 * 1024,
+        _system_config={
+            "subscriber_timeout_ms": 100,
+            "health_check_initial_delay_ms": 0,
+            "health_check_period_ms": 1000,
+            "health_check_failure_threshold": 5,
+        },
+    )
+    ray.init(address=cluster.address)
+
+    # Add worker nodes.
+    for i in range(2):
+        nodes.append(
+            cluster.add_node(
+                num_cpus=1,
+                resources={f"node_{i}": 1},
+                object_store_memory=100 * 1024 * 1024,
+            )
+        )
+    cluster.wait_for_nodes()
+
+    one_mb_array = np.ones(1 * 1024 * 1024, dtype=np.uint8)
+    ten_mb_array = np.ones(10 * 1024 * 1024, dtype=np.uint8)
+
+    @ray.remote
+    class ObjectsHolder:
+        def __init__(self):
+            self.ten_mb_objs = []
+            self.one_mb_objs = []
+
+        def put_10_mb(self):
+            self.ten_mb_objs.append(ray.put(ten_mb_array))
+
+        def put_1_mb(self):
+            self.one_mb_objs.append(ray.put(one_mb_array))
+
+        def pop_10_mb(self):
+            if len(self.ten_mb_objs) == 0:
+                return False
+            self.ten_mb_objs.pop()
+            return True
+
+        def pop_1_mb(self):
+            if len(self.one_mb_objs) == 0:
+                return False
+            self.one_mb_objs.pop()
+            return True
+
+    # Head node contains 11MB of data.
+    one_mb_arrays = []
+    ten_mb_arrays = []
+
+    one_mb_arrays.append(ray.put(one_mb_array))
+    ten_mb_arrays.append(ray.put(ten_mb_array))
+
+    def check_memory(mb):
+        return f"Plasma memory usage {mb} MiB" in memory_summary(
+            address=head_node.address, stats_only=True
+        )
+
+    def wait_until_node_dead(node):
+        for n in ray.nodes():
+            if n["ObjectStoreSocketName"] == node.address_info["object_store_address"]:
+                return not n["Alive"]
+        return False
+
+    wait_for_condition(lambda: check_memory(11))
+
+    # Pop one mb array and see if it works.
+    one_mb_arrays.pop()
+    wait_for_condition(lambda: check_memory(10))
+
+    # Pop 10 MB.
+    ten_mb_arrays.pop()
+    wait_for_condition(lambda: check_memory(0))
+
+    # Put 11 MB for each actor.
+    # actor 1: 1MB + 10MB
+    # actor 2: 1MB + 10MB
+    actor_on_node_1 = ObjectsHolder.options(resources={"node_0": 1}).remote()
+    actor_on_node_2 = ObjectsHolder.options(resources={"node_1": 1}).remote()
+    ray.get(actor_on_node_1.put_1_mb.remote())
+    ray.get(actor_on_node_1.put_10_mb.remote())
+    ray.get(actor_on_node_2.put_1_mb.remote())
+    ray.get(actor_on_node_2.put_10_mb.remote())
+    wait_for_condition(lambda: check_memory(22))
+
+    # actor 1: 10MB
+    # actor 2: 1MB
+    ray.get(actor_on_node_1.pop_1_mb.remote())
+    ray.get(actor_on_node_2.pop_10_mb.remote())
+    wait_for_condition(lambda: check_memory(11))
+
+    # The second node is dead, and actor 2 is dead.
+    cluster.remove_node(nodes[1], allow_graceful=False)
+    wait_for_condition(lambda: wait_until_node_dead(nodes[1]))
+    wait_for_condition(lambda: check_memory(10))
+
+    # The first actor is dead, so object should be GC'ed.
+    ray.kill(actor_on_node_1)
+    wait_for_condition(lambda: check_memory(0))
+
+
+@pytest.mark.skipif(platform.system() in ["Windows"], reason="Failing on Windows.")
+def test_object_unpin_stress(ray_start_cluster):
+    nodes = []
+    cluster = ray_start_cluster
+    cluster.add_node(
+        num_cpus=1, resources={"head": 1}, object_store_memory=1000 * 1024 * 1024
+    )
+    ray.init(address=cluster.address)
+
+    # Add worker nodes.
+    for i in range(2):
+        nodes.append(
+            cluster.add_node(
+                num_cpus=1,
+                resources={f"node_{i}": 1},
+                object_store_memory=1000 * 1024 * 1024,
+            )
+        )
+    cluster.wait_for_nodes()
+
+    one_mb_array = np.ones(1 * 1024 * 1024, dtype=np.uint8)
+    ten_mb_array = np.ones(10 * 1024 * 1024, dtype=np.uint8)
+
+    @ray.remote
+    class ObjectsHolder:
+        def __init__(self):
+            self.ten_mb_objs = []
+            self.one_mb_objs = []
+
+        def put_10_mb(self):
+            self.ten_mb_objs.append(ray.put(ten_mb_array))
+
+        def put_1_mb(self):
+            self.one_mb_objs.append(ray.put(one_mb_array))
+
+        def pop_10_mb(self):
+            if len(self.ten_mb_objs) == 0:
+                return False
+            self.ten_mb_objs.pop()
+            return True
+
+        def pop_1_mb(self):
+            if len(self.one_mb_objs) == 0:
+                return False
+            self.one_mb_objs.pop()
+            return True
+
+        def get_obj_size(self):
+            return len(self.ten_mb_objs) * 10 + len(self.one_mb_objs)
+
+    actor_on_node_1 = ObjectsHolder.options(resources={"node_0": 1}).remote()
+    actor_on_node_2 = ObjectsHolder.options(resources={"node_1": 1}).remote()
+    actor_on_head_node = ObjectsHolder.options(resources={"head": 1}).remote()
+
+    ray.get(actor_on_node_1.get_obj_size.remote())
+    ray.get(actor_on_node_2.get_obj_size.remote())
+    ray.get(actor_on_head_node.get_obj_size.remote())
+
+    def random_ops(actors):
+        r = random.random()
+        for actor in actors:
+            if r <= 0.25:
+                actor.put_10_mb.remote()
+            elif r <= 0.5:
+                actor.put_1_mb.remote()
+            elif r <= 0.75:
+                actor.pop_10_mb.remote()
+            else:
+                actor.pop_1_mb.remote()
+
+    total_iter = 15
+    for _ in range(total_iter):
+        random_ops([actor_on_node_1, actor_on_node_2, actor_on_head_node])
+
+    # Simulate node dead.
+    cluster.remove_node(nodes[1])
+    for _ in range(total_iter):
+        random_ops([actor_on_node_1, actor_on_head_node])
+
+    total_size = sum(
+        [
+            ray.get(actor_on_node_1.get_obj_size.remote()),
+            ray.get(actor_on_head_node.get_obj_size.remote()),
+        ]
+    )
+
+    wait_for_condition(
+        lambda: (
+            (f"Plasma memory usage {total_size} MiB") in memory_summary(stats_only=True)
+        )
+    )
+
+
+@pytest.mark.parametrize("inline_args", [True, False])
+def test_inlined_nested_refs(ray_start_cluster, inline_args):
+    cluster = ray_start_cluster
+    config = {}
+    if not inline_args:
+        config["max_direct_call_object_size"] = 0
+    cluster.add_node(
+        num_cpus=2, object_store_memory=100 * 1024 * 1024, _system_config=config
+    )
+    ray.init(address=cluster.address)
+
+    @ray.remote
+    class Actor:
+        def __init__(self):
+            return
+
+        def nested(self):
+            return ray.put("x")
+
+    @ray.remote
+    def nested_nested(a):
+        return a.nested.remote()
+
+    @ray.remote
+    def foo(ref):
+        time.sleep(1)
+        return ray.get(ref)
+
+    a = Actor.remote()
+    nested_nested_ref = nested_nested.remote(a)
+    # We get nested_ref's value directly from its owner.
+    nested_ref = ray.get(nested_nested_ref)
+
+    del nested_nested_ref
+    x = foo.remote(nested_ref)
+    del nested_ref
+    ray.get(x)
+
+
+# https://github.com/ray-project/ray/issues/17553
+@pytest.mark.parametrize("inline_args", [True, False])
+def test_return_nested_ids(shutdown_only, inline_args):
+    config = dict()
+    if inline_args:
+        config["max_direct_call_object_size"] = 100 * 1024 * 1024
+    else:
+        config["max_direct_call_object_size"] = 0
+    ray.init(object_store_memory=100 * 1024 * 1024, _system_config=config)
+
+    class Nested:
+        def __init__(self, blocks):
+            self._blocks = blocks
+
+    @ray.remote
+    def echo(fn):
+        return fn()
+
+    @ray.remote
+    def create_nested():
+        refs = [ray.put(np.random.random(1024 * 1024)) for _ in range(10)]
+        return Nested(refs)
+
+    @ray.remote
+    def test():
+        ref = create_nested.remote()
+        result1 = ray.get(ref)
+        del ref
+        result = echo.remote(lambda: result1)  # noqa
+        del result1
+
+        time.sleep(5)
+        block = ray.get(result)._blocks[0]
+        print(ray.get(block))
+
+    ray.get(test.remote())
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_reference_counting_standalone.py
+++ b/python/ray/tests/test_reference_counting_standalone.py
@@ -7,7 +7,6 @@ to reduce overheads & overall test runtime.
 import logging
 import platform
 import random
-import signal
 import sys
 import time
 
@@ -21,8 +20,6 @@ from ray._private.test_utils import (
     SignalActor,
     wait_for_condition,
 )
-
-SIGKILL = signal.SIGKILL if sys.platform != "win32" else signal.SIGTERM
 
 logger = logging.getLogger(__name__)
 

--- a/python/ray/tests/test_reference_counting_standalone.py
+++ b/python/ray/tests/test_reference_counting_standalone.py
@@ -350,8 +350,8 @@ def test_out_of_band_serialized_object_ref(ray_start_regular):
     assert ray.get(ray.cloudpickle.loads(obj_ref_str)) == "hello"
 
 
-def test_captured_object_ref(one_cpu_100MiB_shared):
-    captured_id = ray.put(np.zeros(10 * 1024 * 1024, dtype=np.uint8))
+def test_captured_object_ref(ray_start_regular):
+    captured_id = ray.put(np.zeros(1024, dtype=np.uint8))
 
     @ray.remote
     def f(signal):
@@ -370,7 +370,7 @@ def test_captured_object_ref(one_cpu_100MiB_shared):
     ray.get(signal.send.remote())
     _fill_object_store_and_get(obj_ref)
 
-    captured_id = ray.put(np.zeros(10 * 1024 * 1024, dtype=np.uint8))
+    captured_id = ray.put(np.zeros(1024, dtype=np.uint8))
 
     @ray.remote
     class Actor:

--- a/python/ray/tests/test_reference_counting_standalone.py
+++ b/python/ray/tests/test_reference_counting_standalone.py
@@ -5,8 +5,6 @@ to reduce overheads & overall test runtime.
 """
 # coding: utf-8
 import logging
-import os
-import copy
 import platform
 import random
 import signal
@@ -20,12 +18,8 @@ import ray
 import ray.cluster_utils
 from ray._private.internal_api import memory_summary
 from ray._private.test_utils import (
-    SignalActor,
-    put_object,
     wait_for_condition,
-    wait_for_num_actors,
 )
-import ray._private.gcs_utils as gcs_utils
 
 SIGKILL = signal.SIGKILL if sys.platform != "win32" else signal.SIGTERM
 


### PR DESCRIPTION
Converts `test_reference_counting_*.py` to use shared Ray instance fixtures where possible.

Those tests that require their own Ray instance are moved to `test_reference_counting_standalone.py`.