### PR TITLE
[data] remove on_exit hook for ActorPoolMapOperator

### DIFF
--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -34,9 +34,6 @@ class PoolWorker:
     def get_location(self) -> str:
         return self.node_id
 
-    def on_exit(self):
-        pass
-
 
 class TestActorPool(unittest.TestCase):
     def setup_class(self):

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -1648,6 +1648,7 @@ def test_random_sample_fixed_seed_0002(
     assert set(ds.to_pandas()["item"].to_list()) == set(expected.tolist())
 
 
+@pytest.mark.skip(reason="Depends on https://github.com/ray-project/ray/issues/53246")
 def test_actor_udf_cleanup(ray_start_regular_shared, tmp_path):
     """Test that for the actor map operator, the UDF object is deleted properly."""
     test_file = tmp_path / "test.txt"


### PR DESCRIPTION
## Why are these changes needed?

* The on_exit hook was introduced to allow users to perform cleanup.
* However, it triggers a race condition bug in fault tolerance - after `on_exit` is called and the UDF is deleted, and before the actor actually exits, another retry task is submitted to the actor. 
* This PR removes the hook as the bug is inevitable unless we do the cleanup and actor exit in one single atomic step, which needs to be supported at the Ray Core level https://github.com/ray-project/ray/issues/53246
* Before https://github.com/ray-project/ray/issues/53246 is fixed, it's recommended to spawn a reaper process at the application level to perform the cleanup. 

