### PR TITLE
[core] GRPCServer takes ownership of GRPCService

### DIFF
--- a/src/ray/common/ray_syncer/ray_syncer.cc
+++ b/src/ray/common/ray_syncer/ray_syncer.cc
@@ -251,6 +251,4 @@ ServerBidiReactor *RaySyncerService::StartSync(grpc::CallbackServerContext *cont
   return reactor;
 }
 
-RaySyncerService::~RaySyncerService() = default;
-
 }  // namespace ray::syncer

--- a/src/ray/common/ray_syncer/ray_syncer.h
+++ b/src/ray/common/ray_syncer/ray_syncer.h
@@ -193,9 +193,7 @@ class RaySyncer {
 /// like tree-based one.
 class RaySyncerService : public ray::rpc::syncer::RaySyncer::CallbackService {
  public:
-  RaySyncerService(RaySyncer &syncer) : syncer_(syncer) {}
-
-  ~RaySyncerService();
+  explicit RaySyncerService(RaySyncer &syncer) : syncer_(syncer) {}
 
   grpc::ServerBidiReactor<RaySyncMessage, RaySyncMessage> *StartSync(
       grpc::CallbackServerContext *context) override;

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -375,7 +375,6 @@ CoreWorker::CoreWorker(CoreWorkerOptions options, const WorkerID &worker_id)
       periodical_runner_(PeriodicalRunner::Create(io_service_)),
       task_queue_length_(0),
       num_executed_tasks_(0),
-      grpc_service_(io_service_, *this),
       task_execution_service_work_(task_execution_service_.get_executor()),
       exiting_detail_(std::nullopt),
       pid_(getpid()),
@@ -528,7 +527,10 @@ CoreWorker::CoreWorker(CoreWorkerOptions options, const WorkerID &worker_id)
       std::make_unique<rpc::GrpcServer>(WorkerTypeString(options_.worker_type),
                                         assigned_port,
                                         options_.node_ip_address == "127.0.0.1");
-  core_worker_server_->RegisterService(grpc_service_, false /* token_auth */);
+
+  core_worker_server_->RegisterService(
+      std::make_unique<rpc::CoreWorkerGrpcService>(io_service_, *this),
+      false /* token_auth */);
   core_worker_server_->Run();
 
   // Set our own address.

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1872,9 +1872,6 @@ class CoreWorker : public rpc::CoreWorkerServiceHandler {
   /// of that resource allocated for this worker. This is set on task assignment.
   ResourceMappingType resource_ids_ ABSL_GUARDED_BY(mutex_);
 
-  /// Common rpc service for all worker modules.
-  rpc::CoreWorkerGrpcService grpc_service_;
-
   /// Used to notify the task receiver when the arguments of a queued
   /// actor task are ready.
   std::unique_ptr<DependencyWaiterImpl> task_argument_waiter_;

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -299,10 +299,8 @@ void GcsServer::InitGcsNodeManager(const GcsInitData &gcs_init_data) {
                                        rpc_server_.GetClusterId());
   // Initialize by gcs tables data.
   gcs_node_manager_->Initialize(gcs_init_data);
-  // Register service.
-  node_info_service_ = std::make_unique<rpc::NodeInfoGrpcService>(
-      io_context_provider_.GetDefaultIOContext(), *gcs_node_manager_);
-  rpc_server_.RegisterService(*node_info_service_);
+  rpc_server_.RegisterService(std::make_unique<rpc::NodeInfoGrpcService>(
+      io_context_provider_.GetDefaultIOContext(), *gcs_node_manager_));
 }
 
 void GcsServer::InitGcsHealthCheckManager(const GcsInitData &gcs_init_data) {
@@ -338,10 +336,8 @@ void GcsServer::InitGcsResourceManager(const GcsInitData &gcs_init_data) {
 
   // Initialize by gcs tables data.
   gcs_resource_manager_->Initialize(gcs_init_data);
-  // Register service.
-  node_resource_info_service_.reset(new rpc::NodeResourceInfoGrpcService(
+  rpc_server_.RegisterService(std::make_unique<rpc::NodeResourceInfoGrpcService>(
       io_context_provider_.GetDefaultIOContext(), *gcs_resource_manager_));
-  rpc_server_.RegisterService(*node_resource_info_service_);
 
   periodical_runner_->RunFnPeriodically(
       [this] {
@@ -430,10 +426,8 @@ void GcsServer::InitGcsJobManager(const GcsInitData &gcs_init_data) {
                                       client_factory);
   gcs_job_manager_->Initialize(gcs_init_data);
 
-  // Register service.
-  job_info_service_ = std::make_unique<rpc::JobInfoGrpcService>(
-      io_context_provider_.GetDefaultIOContext(), *gcs_job_manager_);
-  rpc_server_.RegisterService(*job_info_service_);
+  rpc_server_.RegisterService(std::make_unique<rpc::JobInfoGrpcService>(
+      io_context_provider_.GetDefaultIOContext(), *gcs_job_manager_));
 }
 
 void GcsServer::InitGcsActorManager(const GcsInitData &gcs_init_data) {
@@ -499,10 +493,8 @@ void GcsServer::InitGcsActorManager(const GcsInitData &gcs_init_data) {
 
   // Initialize by gcs tables data.
   gcs_actor_manager_->Initialize(gcs_init_data);
-  // Register service.
-  actor_info_service_ = std::make_unique<rpc::ActorInfoGrpcService>(
-      io_context_provider_.GetDefaultIOContext(), *gcs_actor_manager_);
-  rpc_server_.RegisterService(*actor_info_service_);
+  rpc_server_.RegisterService(std::make_unique<rpc::ActorInfoGrpcService>(
+      io_context_provider_.GetDefaultIOContext(), *gcs_actor_manager_));
 }
 
 void GcsServer::InitGcsPlacementGroupManager(const GcsInitData &gcs_init_data) {
@@ -524,10 +516,8 @@ void GcsServer::InitGcsPlacementGroupManager(const GcsInitData &gcs_init_data) {
       });
   // Initialize by gcs tables data.
   gcs_placement_group_manager_->Initialize(gcs_init_data);
-  // Register service.
-  placement_group_info_service_.reset(new rpc::PlacementGroupInfoGrpcService(
+  rpc_server_.RegisterService(std::make_unique<rpc::PlacementGroupInfoGrpcService>(
       io_context_provider_.GetDefaultIOContext(), *gcs_placement_group_manager_));
-  rpc_server_.RegisterService(*placement_group_info_service_);
 }
 
 GcsServer::StorageType GcsServer::GetStorageType() const {
@@ -559,8 +549,7 @@ void GcsServer::InitRaySyncer(const GcsInitData &gcs_init_data) {
       syncer::MessageType::RESOURCE_VIEW, nullptr, gcs_resource_manager_.get());
   ray_syncer_->Register(
       syncer::MessageType::COMMANDS, nullptr, gcs_resource_manager_.get());
-  ray_syncer_service_ = std::make_unique<syncer::RaySyncerService>(*ray_syncer_);
-  rpc_server_.RegisterService(*ray_syncer_service_);
+  rpc_server_.RegisterService(std::make_unique<syncer::RaySyncerService>(*ray_syncer_));
 }
 
 void GcsServer::InitFunctionManager() {
@@ -615,19 +604,17 @@ void GcsServer::InitKVManager() {
 
 void GcsServer::InitKVService() {
   RAY_CHECK(kv_manager_);
-  kv_service_ = std::make_unique<rpc::InternalKVGrpcService>(
-      io_context_provider_.GetIOContext<GcsInternalKVManager>(), *kv_manager_);
-  // Register service.
-  rpc_server_.RegisterService(*kv_service_, false /* token_auth */);
+  rpc_server_.RegisterService(
+      std::make_unique<rpc::InternalKVGrpcService>(
+          io_context_provider_.GetIOContext<GcsInternalKVManager>(), *kv_manager_),
+      false /* token_auth */);
 }
 
 void GcsServer::InitPubSubHandler() {
   auto &io_context = io_context_provider_.GetIOContext<GcsPublisher>();
   pubsub_handler_ = std::make_unique<InternalPubSubHandler>(io_context, *gcs_publisher_);
-  pubsub_service_ =
-      std::make_unique<rpc::InternalPubSubGrpcService>(io_context, *pubsub_handler_);
-  // Register service.
-  rpc_server_.RegisterService(*pubsub_service_);
+  rpc_server_.RegisterService(
+      std::make_unique<rpc::InternalPubSubGrpcService>(io_context, *pubsub_handler_));
 }
 
 void GcsServer::InitRuntimeEnvManager() {
@@ -668,19 +655,15 @@ void GcsServer::InitRuntimeEnvManager() {
                              std::move(task),
                              std::chrono::milliseconds(delay_ms));
       });
-  runtime_env_service_ = std::make_unique<rpc::RuntimeEnvGrpcService>(
-      io_context_provider_.GetDefaultIOContext(), *runtime_env_handler_);
-  // Register service.
-  rpc_server_.RegisterService(*runtime_env_service_);
+  rpc_server_.RegisterService(std::make_unique<rpc::RuntimeEnvGrpcService>(
+      io_context_provider_.GetDefaultIOContext(), *runtime_env_handler_));
 }
 
 void GcsServer::InitGcsWorkerManager() {
   gcs_worker_manager_ = std::make_unique<GcsWorkerManager>(
       *gcs_table_storage_, io_context_provider_.GetDefaultIOContext(), *gcs_publisher_);
-  // Register service.
-  worker_info_service_.reset(new rpc::WorkerInfoGrpcService(
+  rpc_server_.RegisterService(std::make_unique<rpc::WorkerInfoGrpcService>(
       io_context_provider_.GetDefaultIOContext(), *gcs_worker_manager_));
-  rpc_server_.RegisterService(*worker_info_service_);
 }
 
 void GcsServer::InitGcsAutoscalerStateManager(const GcsInitData &gcs_init_data) {
@@ -726,19 +709,17 @@ void GcsServer::InitGcsAutoscalerStateManager(const GcsInitData &gcs_init_data) 
       io_context_provider_.GetDefaultIOContext(),
       gcs_publisher_.get());
   gcs_autoscaler_state_manager_->Initialize(gcs_init_data);
-
-  autoscaler_state_service_.reset(new rpc::autoscaler::AutoscalerStateGrpcService(
-      io_context_provider_.GetDefaultIOContext(), *gcs_autoscaler_state_manager_));
-
-  rpc_server_.RegisterService(*autoscaler_state_service_);
+  rpc_server_.RegisterService(
+      std::make_unique<rpc::autoscaler::AutoscalerStateGrpcService>(
+          io_context_provider_.GetDefaultIOContext(), *gcs_autoscaler_state_manager_));
 }
 
 void GcsServer::InitGcsTaskManager() {
   auto &io_context = io_context_provider_.GetIOContext<GcsTaskManager>();
   gcs_task_manager_ = std::make_unique<GcsTaskManager>(io_context);
   // Register service.
-  task_info_service_.reset(new rpc::TaskInfoGrpcService(io_context, *gcs_task_manager_));
-  rpc_server_.RegisterService(*task_info_service_);
+  rpc_server_.RegisterService(
+      std::make_unique<rpc::TaskInfoGrpcService>(io_context, *gcs_task_manager_));
 }
 
 void GcsServer::InstallEventListeners() {

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -263,18 +263,10 @@ class GcsServer {
   std::unique_ptr<GcsFunctionManager> function_manager_;
   /// Stores references to URIs stored by the GCS for runtime envs.
   std::unique_ptr<ray::RuntimeEnvManager> runtime_env_manager_;
-  /// Global KV storage handler and service.
+  /// Global KV storage handler.
   std::unique_ptr<GcsInternalKVManager> kv_manager_;
-  std::unique_ptr<rpc::InternalKVGrpcService> kv_service_;
-  /// Job info handler and service.
+  /// Job info handler.
   std::unique_ptr<GcsJobManager> gcs_job_manager_;
-  std::unique_ptr<rpc::JobInfoGrpcService> job_info_service_;
-  /// Actor info service.
-  std::unique_ptr<rpc::ActorInfoGrpcService> actor_info_service_;
-  /// Node info handler and service.
-  std::unique_ptr<rpc::NodeInfoGrpcService> node_info_service_;
-  /// Node resource info handler and service.
-  std::unique_ptr<rpc::NodeResourceInfoGrpcService> node_resource_info_service_;
 
   /// Ray Syncer related fields.
   std::unique_ptr<syncer::RaySyncer> ray_syncer_;
@@ -287,22 +279,12 @@ class GcsServer {
   std::unique_ptr<UsageStatsClient> usage_stats_client_;
   /// The gcs worker manager.
   std::unique_ptr<GcsWorkerManager> gcs_worker_manager_;
-  /// Worker info service.
-  std::unique_ptr<rpc::WorkerInfoGrpcService> worker_info_service_;
-  /// Placement Group info handler and service.
-  std::unique_ptr<rpc::PlacementGroupInfoGrpcService> placement_group_info_service_;
-  /// Runtime env handler and service.
+  /// Runtime env handler.
   std::unique_ptr<RuntimeEnvHandler> runtime_env_handler_;
-  std::unique_ptr<rpc::RuntimeEnvGrpcService> runtime_env_service_;
-  /// GCS PubSub handler and service.
+  /// GCS PubSub handler.
   std::unique_ptr<InternalPubSubHandler> pubsub_handler_;
-  std::unique_ptr<rpc::InternalPubSubGrpcService> pubsub_service_;
   /// GCS Task info manager for managing task states change events.
   std::unique_ptr<GcsTaskManager> gcs_task_manager_;
-  /// Independent task info service from the main grpc service.
-  std::unique_ptr<rpc::TaskInfoGrpcService> task_info_service_;
-  /// Gcs Autoscaler state manager.
-  std::unique_ptr<rpc::autoscaler::AutoscalerStateGrpcService> autoscaler_state_service_;
   /// Grpc based pubsub's periodical runner.
   std::shared_ptr<PeriodicalRunner> pubsub_periodical_runner_;
   /// The runner to run function periodically.

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -108,7 +108,6 @@ ObjectManager::ObjectManager(
                              config_.object_manager_address == "127.0.0.1",
                              ClusterID::Nil(),
                              config_.rpc_service_threads_number),
-      object_manager_service_(rpc_service_, *this),
       client_call_manager_(main_service,
                            /*record_stats=*/true,
                            ClusterID::Nil(),
@@ -184,7 +183,9 @@ void ObjectManager::StartRpcService() {
   for (int i = 0; i < config_.rpc_service_threads_number; i++) {
     rpc_threads_[i] = std::thread(&ObjectManager::RunRpcService, this, i);
   }
-  object_manager_server_.RegisterService(object_manager_service_, false /* token_auth */);
+  object_manager_server_.RegisterService(
+      std::make_unique<rpc::ObjectManagerGrpcService>(rpc_service_, *this),
+      false /* token_auth */);
   object_manager_server_.Run();
 }
 

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -443,9 +443,6 @@ class ObjectManager : public ObjectManagerInterface,
   /// The gPRC server.
   rpc::GrpcServer object_manager_server_;
 
-  /// The gRPC service.
-  rpc::ObjectManagerGrpcService object_manager_service_;
-
   /// The client call manager used to deal with reply.
   rpc::ClientCallManager client_call_manager_;
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -182,7 +182,6 @@ NodeManager::NodeManager(
       node_manager_server_("NodeManager",
                            config.node_manager_port,
                            config.node_manager_address == "127.0.0.1"),
-      node_manager_service_(io_service, *this),
       local_object_manager_(
           self_node_id_,
           config.node_manager_address,
@@ -215,7 +214,6 @@ NodeManager::NodeManager(
       record_metrics_period_ms_(config.record_metrics_period_ms),
       next_resource_seq_no_(0),
       ray_syncer_(io_service_, self_node_id_.Binary()),
-      ray_syncer_service_(ray_syncer_),
       worker_killing_policy_(
           CreateWorkerKillingPolicy(RayConfig::instance().worker_killing_policy())),
       memory_monitor_(std::make_unique<MemoryMonitor>(
@@ -307,8 +305,10 @@ NodeManager::NodeManager(
 
   RAY_CHECK_OK(store_client_->Connect(config.store_socket_name));
   // Run the node manager rpc server.
-  node_manager_server_.RegisterService(node_manager_service_, false);
-  node_manager_server_.RegisterService(ray_syncer_service_);
+  node_manager_server_.RegisterService(
+      std::make_unique<rpc::NodeManagerGrpcService>(io_service, *this), false);
+  node_manager_server_.RegisterService(
+      std::make_unique<syncer::RaySyncerService>(ray_syncer_));
   node_manager_server_.Run();
   // GCS will check the health of the service named with the node id.
   // Fail to setup this will lead to the health check failure.

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -835,9 +835,6 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   /// The RPC server.
   rpc::GrpcServer node_manager_server_;
 
-  /// The node manager RPC service.
-  rpc::NodeManagerGrpcService node_manager_service_;
-
   /// Manages all local objects that are pinned (primary
   /// copies), freed, and/or spilled.
   LocalObjectManager local_object_manager_;
@@ -936,9 +933,6 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
 
   /// Ray syncer for synchronization
   syncer::RaySyncer ray_syncer_;
-
-  /// RaySyncerService for gRPC
-  syncer::RaySyncerService ray_syncer_service_;
 
   /// The Policy for selecting the worker to kill when the node runs out of memory.
   std::shared_ptr<WorkerKillingPolicy> worker_killing_policy_;

--- a/src/ray/rpc/grpc_server.h
+++ b/src/ray/rpc/grpc_server.h
@@ -123,13 +123,12 @@ class GrpcServer {
   int GetPort() const { return port_; }
 
   /// Register a grpc service. Multiple services can be registered to the same server.
-  /// Note that the `service` registered must remain valid for the lifetime of the
-  /// `GrpcServer`, as it holds the underlying `grpc::Service`.
   ///
   /// \param[in] service A `GrpcService` to register to this server.
   /// NOTE: if token_auth is not set to false, cluster_id_ must not be Nil.
-  void RegisterService(GrpcService &service, bool token_auth = true);
-  void RegisterService(grpc::Service &service);
+  void RegisterService(std::unique_ptr<GrpcService> &&service, bool token_auth = true);
+
+  void RegisterService(std::unique_ptr<grpc::Service> &&grpc_service);
 
   grpc::Server &GetServer() { return *server_; }
 
@@ -168,7 +167,10 @@ class GrpcServer {
   /// Indicates whether this server has been closed.
   bool is_closed_;
   /// The `grpc::Service` objects which should be registered to `ServerBuilder`.
-  std::vector<std::reference_wrapper<grpc::Service>> services_;
+  std::vector<std::unique_ptr<grpc::Service>> grpc_services_;
+  /// The `GrpcService`(defined below) objects which contain grpc::Service objects not in
+  /// the above vector.
+  std::vector<std::unique_ptr<GrpcService>> services_;
   /// The `ServerCallFactory` objects.
   std::vector<std::unique_ptr<ServerCallFactory>> server_call_factories_;
   /// The number of completion queues the server is polling from.

--- a/src/ray/rpc/test/grpc_bench/grpc_bench.cc
+++ b/src/ray/rpc/test/grpc_bench/grpc_bench.cc
@@ -79,8 +79,7 @@ int main() {
     main_service.run();
   });
   GreeterServiceHandler handler;
-  GreeterGrpcService grpc_service(main_service, handler);
-  server.RegisterService(grpc_service);
+  server.RegisterService(std::make_unique<GreeterGrpcService>(main_service, handler));
   server.Run();
   t.join();
   return 0;

--- a/src/ray/rpc/test/grpc_server_client_test.cc
+++ b/src/ray/rpc/test/grpc_server_client_test.cc
@@ -111,9 +111,10 @@ class TestGrpcServerClientFixture : public ::testing::Test {
           handler_io_service_work_(handler_io_service_.get_executor());
       handler_io_service_.run();
     });
-    test_service_.reset(new TestGrpcService(handler_io_service_, test_service_handler_));
     grpc_server_.reset(new GrpcServer("test", 0, true));
-    grpc_server_->RegisterService(*test_service_, false);
+    grpc_server_->RegisterService(
+        std::make_unique<TestGrpcService>(handler_io_service_, test_service_handler_),
+        false);
     grpc_server_->Run();
 
     // Wait until server starts listening.
@@ -166,7 +167,6 @@ class TestGrpcServerClientFixture : public ::testing::Test {
   TestServiceHandler test_service_handler_;
   instrumented_io_context handler_io_service_;
   std::unique_ptr<std::thread> handler_thread_;
-  std::unique_ptr<TestGrpcService> test_service_;
   std::unique_ptr<GrpcServer> grpc_server_;
   grpc::CompletionQueue cq_;
   std::shared_ptr<grpc::Channel> channel_;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The GRPCServer should take ownership of GrpcService. This way the class that has the grpc server doesn't have to hold a grpc service for all of its services to keep them alive for the duration of the service. This decreases the amount of member variables in the class, simplifies lifetimes, and makes dependency injection easier in the future since you only have to inject a mock server, not mock services.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
