### PR TITLE
[chore] Exclude `syntax_error.py` from pydoclint 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,7 @@ repos:
     rev: "0.6.6"
     hooks:
       - id: pydoclint
+        exclude: ^python/ray/serve/tests/test_config_files/syntax_error\.py$
         args: [
           --style=google,
           --baseline=ci/lint/pydoclint-baseline.txt,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,11 +49,10 @@ repos:
     rev: "0.6.6"
     hooks:
       - id: pydoclint
-        exclude: ^python/ray/serve/tests/test_config_files/syntax_error\.py$
         args: [
           --style=google,
           --baseline=ci/lint/pydoclint-baseline.txt,
-          --exclude=thirdparty,
+          --exclude=thirdparty|^python/ray/serve/tests/test_config_files/syntax_error\.py$,
           # --generate-baseline=True, # Not generally needed, but documenting since this is how we generate the initial baseline
           --auto-regenerate-baseline=True,
           # Current settings (not because we think they're right, but because we

--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1917,9 +1917,6 @@ python/ray/serve/tests/test_callback.py
     DOC402: Function `ray_instance` has "yield" statements, but the docstring does not have a "Yields" section
     DOC404: Function `ray_instance` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
 --------------------
-python/ray/serve/tests/test_config_files/syntax_error.py
-    DOC002: Syntax errors; cannot parse this Python file. Error message: '(' was never closed (<unknown>, line 1)
---------------------
 python/ray/serve/tests/test_metrics.py
     DOC106: Method `TestRequestContextMetrics._generate_metrics_summary`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
     DOC107: Method `TestRequestContextMetrics._generate_metrics_summary`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This blocks one of my PRs.

* Without this PR
  <img width="1034" alt="image" src="https://github.com/user-attachments/assets/6e6216df-832a-4523-9576-9a16eab5602f" />

* With this PR
  <img width="897" alt="image" src="https://github.com/user-attachments/assets/18429fc5-a936-45b5-b216-49d139903249" />



## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
