### PR TITLE
[core] Mock mutable object provider for node manager

### DIFF
--- a/src/mock/ray/core_worker/experimental_mutable_object_provider.h
+++ b/src/mock/ray/core_worker/experimental_mutable_object_provider.h
@@ -1,0 +1,70 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "gmock/gmock.h"
+#include "ray/core_worker/experimental_mutable_object_provider.h"
+
+namespace ray {
+namespace core {
+namespace experimental {
+
+class MockMutableObjectProvider : public MutableObjectProviderInterface {
+ public:
+  MOCK_METHOD(void, RegisterReaderChannel, (const ObjectID &object_id), (override));
+  MOCK_METHOD(void,
+              RegisterWriterChannel,
+              (const ObjectID &writer_object_id,
+               const std::vector<NodeID> &remote_reader_node_ids),
+              (override));
+  MOCK_METHOD(void,
+              HandleRegisterMutableObject,
+              (const ObjectID &writer_object_id,
+               int64_t num_readers,
+               const ObjectID &reader_object_id),
+              (override));
+  MOCK_METHOD(void,
+              HandlePushMutableObject,
+              (const rpc::PushMutableObjectRequest &request,
+               rpc::PushMutableObjectReply *reply),
+              (override));
+  MOCK_METHOD(Status,
+              WriteAcquire,
+              (const ObjectID &object_id,
+               int64_t data_size,
+               const uint8_t *metadata,
+               int64_t metadata_size,
+               int64_t num_readers,
+               std::shared_ptr<Buffer> &data,
+               int64_t timeout_ms),
+              (override));
+  MOCK_METHOD(Status, WriteRelease, (const ObjectID &object_id), (override));
+  MOCK_METHOD(Status,
+              ReadAcquire,
+              (const ObjectID &object_id,
+               std::shared_ptr<RayObject> &result,
+               int64_t timeout_ms),
+              (override));
+  MOCK_METHOD(Status, ReadRelease, (const ObjectID &object_id), (override));
+  MOCK_METHOD(Status, SetError, (const ObjectID &object_id), (override));
+  MOCK_METHOD(Status,
+              GetChannelStatus,
+              (const ObjectID &object_id, bool is_reader),
+              (override));
+};
+
+}  // namespace experimental
+}  // namespace core
+}  // namespace ray

--- a/src/ray/core_worker/experimental_mutable_object_provider.h
+++ b/src/ray/core_worker/experimental_mutable_object_provider.h
@@ -28,28 +28,22 @@ namespace experimental {
 // This class coordinates the transfer of mutable objects between different nodes. It
 // handles mutable objects that are received from remote nodes, and it also observes local
 // mutable objects and pushes them to remote nodes as needed.
-class MutableObjectProvider {
+class MutableObjectProviderInterface {
  public:
-  using RayletFactory = std::function<std::shared_ptr<MutableObjectReaderInterface>(
-      const NodeID &, rpc::ClientCallManager &)>;
-
-  MutableObjectProvider(plasma::PlasmaClientInterface &plasma,
-                        RayletFactory factory,
-                        std::function<Status(void)> check_signals);
-
-  ~MutableObjectProvider();
+  virtual ~MutableObjectProviderInterface() = default;
 
   /// Registers a reader channel for `object_id` on this node.
   /// \param[in] object_id The ID of the object.
-  void RegisterReaderChannel(const ObjectID &object_id);
+  virtual void RegisterReaderChannel(const ObjectID &object_id) = 0;
 
   /// Registers a writer channel for `object_id` on this node. On each write to this
   /// channel, the write will be sent via RPC to node `node_id`.
   ///
   /// \param[in] object_id The ID of the object.
   /// \param[in] remote_reader_node_ids The list of remote reader's node ids.
-  void RegisterWriterChannel(const ObjectID &writer_object_id,
-                             const std::vector<NodeID> &remote_reader_node_ids);
+  virtual void RegisterWriterChannel(
+      const ObjectID &writer_object_id,
+      const std::vector<NodeID> &remote_reader_node_ids) = 0;
 
   /// Handles an RPC request from another note to register a mutable object on this node.
   /// The remote node writes the object and this node reads the object. This node is
@@ -59,14 +53,14 @@ class MutableObjectProvider {
   /// \param[in] reader_object_id The ID of the corresponding object on this node. When
   /// this node is notified of a write via HandlePushMutableObject(), the
   /// `reader_object_id` object is updated with the write.
-  void HandleRegisterMutableObject(const ObjectID &writer_object_id,
-                                   int64_t num_readers,
-                                   const ObjectID &reader_object_id);
+  virtual void HandleRegisterMutableObject(const ObjectID &writer_object_id,
+                                           int64_t num_readers,
+                                           const ObjectID &reader_object_id) = 0;
 
   /// RPC callback for when a writer pushes a mutable object over the network to a reader
   /// on this node.
-  void HandlePushMutableObject(const rpc::PushMutableObjectRequest &request,
-                               rpc::PushMutableObjectReply *reply);
+  virtual void HandlePushMutableObject(const rpc::PushMutableObjectRequest &request,
+                                       rpc::PushMutableObjectReply *reply) = 0;
 
   /// Acquires a write lock on the object that prevents readers from reading
   /// until we are done writing. This is safe for concurrent writers.
@@ -87,20 +81,20 @@ class MutableObjectProvider {
   /// and return either OK or TimedOut without blocking. If this is -1, the method
   /// will block indefinitely until the write lock is acquired.
   /// \return The return status.
-  Status WriteAcquire(const ObjectID &object_id,
-                      int64_t data_size,
-                      const uint8_t *metadata,
-                      int64_t metadata_size,
-                      int64_t num_readers,
-                      std::shared_ptr<Buffer> &data,
-                      int64_t timeout_ms = -1);
+  virtual Status WriteAcquire(const ObjectID &object_id,
+                              int64_t data_size,
+                              const uint8_t *metadata,
+                              int64_t metadata_size,
+                              int64_t num_readers,
+                              std::shared_ptr<Buffer> &data,
+                              int64_t timeout_ms = -1) = 0;
 
   /// Releases an acquired write lock on the object, allowing readers to read.
   /// This is the equivalent of "Seal" for normal objects.
   ///
   /// \param[in] object_id The ID of the object.
   /// \return The return status.
-  Status WriteRelease(const ObjectID &object_id);
+  virtual Status WriteRelease(const ObjectID &object_id) = 0;
 
   /// Acquires a read lock on the object that prevents the writer from writing
   /// again until we are done reading the current value.
@@ -114,22 +108,22 @@ class MutableObjectProvider {
   /// will block indefinitely until the read lock is acquired.
   /// \return The return status. The ReadAcquire can fail if there have already
   /// been `num_readers` for the current value.
-  Status ReadAcquire(const ObjectID &object_id,
-                     std::shared_ptr<RayObject> &result,
-                     int64_t timeout_ms = -1);
+  virtual Status ReadAcquire(const ObjectID &object_id,
+                             std::shared_ptr<RayObject> &result,
+                             int64_t timeout_ms = -1) = 0;
 
   /// Releases the object, allowing it to be written again. If the caller did
   /// not previously ReadAcquire the object, then this first blocks until the
   /// latest value is available to read, then releases the value.
   ///
   /// \param[in] object_id The ID of the object.
-  Status ReadRelease(const ObjectID &object_id);
+  virtual Status ReadRelease(const ObjectID &object_id) = 0;
 
   /// Sets the error bit, causing all future readers and writers to raise an
   /// error on acquire.
   ///
   /// \param[in] object_id The ID of the object.
-  Status SetError(const ObjectID &object_id);
+  virtual Status SetError(const ObjectID &object_id) = 0;
 
   /// Returns the current status of the channel for the object. Possible statuses are:
   /// 1. Status::OK()
@@ -142,7 +136,51 @@ class MutableObjectProvider {
   /// \param[in] object_id The ID of the object.
   /// \param[in] is_reader Whether the channel is a reader channel.
   /// \return Current status of the channel.
-  Status GetChannelStatus(const ObjectID &object_id, bool is_reader);
+  virtual Status GetChannelStatus(const ObjectID &object_id, bool is_reader) = 0;
+};
+
+class MutableObjectProvider : public MutableObjectProviderInterface {
+ public:
+  using RayletFactory = std::function<std::shared_ptr<MutableObjectReaderInterface>(
+      const NodeID &, rpc::ClientCallManager &)>;
+
+  MutableObjectProvider(plasma::PlasmaClientInterface &plasma,
+                        RayletFactory factory,
+                        std::function<Status(void)> check_signals);
+
+  ~MutableObjectProvider() override;
+
+  void RegisterReaderChannel(const ObjectID &object_id) override;
+
+  void RegisterWriterChannel(const ObjectID &writer_object_id,
+                             const std::vector<NodeID> &remote_reader_node_ids) override;
+
+  void HandleRegisterMutableObject(const ObjectID &writer_object_id,
+                                   int64_t num_readers,
+                                   const ObjectID &reader_object_id) override;
+
+  void HandlePushMutableObject(const rpc::PushMutableObjectRequest &request,
+                               rpc::PushMutableObjectReply *reply) override;
+
+  Status WriteAcquire(const ObjectID &object_id,
+                      int64_t data_size,
+                      const uint8_t *metadata,
+                      int64_t metadata_size,
+                      int64_t num_readers,
+                      std::shared_ptr<Buffer> &data,
+                      int64_t timeout_ms = -1) override;
+
+  Status WriteRelease(const ObjectID &object_id) override;
+
+  Status ReadAcquire(const ObjectID &object_id,
+                     std::shared_ptr<RayObject> &result,
+                     int64_t timeout_ms = -1) override;
+
+  Status ReadRelease(const ObjectID &object_id) override;
+
+  Status SetError(const ObjectID &object_id) override;
+
+  Status GetChannelStatus(const ObjectID &object_id, bool is_reader) override;
 
  private:
   struct LocalReaderInfo {

--- a/src/ray/raylet/raylet.h
+++ b/src/ray/raylet/raylet.h
@@ -109,6 +109,8 @@ class Raylet {
   rpc::ClientCallManager client_call_manager_;
 
   rpc::CoreWorkerClientPool worker_rpc_pool_;
+
+  plasma::PlasmaClient plasma_client_;
 };
 
 }  // namespace ray::raylet

--- a/src/ray/raylet/test/node_manager_test.cc
+++ b/src/ray/raylet/test/node_manager_test.cc
@@ -20,6 +20,7 @@
 #include <utility>
 
 #include "gmock/gmock.h"
+#include "mock/ray/core_worker/experimental_mutable_object_provider.h"
 #include "mock/ray/gcs/gcs_client/gcs_client.h"
 #include "mock/ray/object_manager/object_directory.h"
 #include "mock/ray/object_manager/object_manager.h"
@@ -205,8 +206,9 @@ class NodeManagerTest : public ::testing::Test {
     mock_object_directory_ = object_directory.get();
     auto object_manager = std::make_unique<MockObjectManager>();
     mock_object_manager_ = object_manager.get();
-    auto mock_store_client = std::make_unique<plasma::MockPlasmaClient>();
-    mock_store_client_ = mock_store_client.get();
+    auto mutable_object_provider =
+        std::make_unique<core::experimental::MockMutableObjectProvider>();
+    mock_mutable_object_provider_ = mutable_object_provider.get();
     node_manager_ = std::make_unique<NodeManager>(io_service_,
                                                   NodeID::FromRandom(),
                                                   "test_node_name",
@@ -217,7 +219,9 @@ class NodeManagerTest : public ::testing::Test {
                                                   std::move(core_worker_subscriber),
                                                   std::move(object_directory),
                                                   std::move(object_manager),
-                                                  std::move(mock_store_client),
+                                                  mock_store_client_,
+                                                  std::move(mutable_object_provider),
+                                                  /*shutdown_raylet_gracefully=*/
                                                   [](const auto &) {});
   }
 
@@ -229,7 +233,8 @@ class NodeManagerTest : public ::testing::Test {
       std::make_shared<gcs::MockGcsClient>();
   MockObjectDirectory *mock_object_directory_;
   MockObjectManager *mock_object_manager_;
-  plasma::MockPlasmaClient *mock_store_client_;
+  core::experimental::MockMutableObjectProvider *mock_mutable_object_provider_;
+  plasma::MockPlasmaClient mock_store_client_;
 
   std::unique_ptr<NodeManager> node_manager_;
 };


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
node_manager_test is failing on windows after adding the test. It's because you can't create a mutable object provider on windows. Mocking out and injecting mutable object provider now.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/53291
<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
