### PR TITLE
[core] Early return and cleanup around WarnResourceDeadlock

### DIFF
--- a/src/mock/ray/raylet/local_task_manager.h
+++ b/src/mock/ray/raylet/local_task_manager.h
@@ -48,12 +48,9 @@ class MockLocalTaskManager : public ILocalTaskManager {
                int64_t backlog_size),
               (override));
   MOCK_METHOD(void, ClearWorkerBacklog, (const WorkerID &worker_id), (override));
-  MOCK_METHOD(bool,
+  MOCK_METHOD(const RayTask *,
               AnyPendingTasksForResourceAcquisition,
-              (RayTask * example,
-               bool *any_pending,
-               int *num_pending_actor_creation,
-               int *num_pending_tasks),
+              (int *num_pending_actor_creation, int *num_pending_tasks),
               (const, override));
   MOCK_METHOD(void, RecordMetrics, (), (const, override));
   MOCK_METHOD(void, DebugStr, (std::stringstream & buffer), (const, override));

--- a/src/mock/ray/raylet/worker_pool.h
+++ b/src/mock/ray/raylet/worker_pool.h
@@ -28,10 +28,11 @@ class MockWorkerPool : public WorkerPoolInterface {
               PushWorker,
               (const std::shared_ptr<WorkerInterface> &worker),
               (override));
-  MOCK_METHOD((const std::vector<std::shared_ptr<WorkerInterface>>),
+  MOCK_METHOD((std::vector<std::shared_ptr<WorkerInterface>>),
               GetAllRegisteredWorkers,
               (bool filter_dead_workers, bool filter_io_workers),
               (const, override));
+  MOCK_METHOD(bool, IsWorkerAvailableForScheduling, (), (const, override));
   MOCK_METHOD(std::shared_ptr<WorkerInterface>,
               GetRegisteredWorker,
               (const WorkerID &worker_id),

--- a/src/ray/raylet/local_task_manager.cc
+++ b/src/ray/raylet/local_task_manager.cc
@@ -901,11 +901,9 @@ bool LocalTaskManager::CancelTask(
       scheduling_failure_message);
 }
 
-bool LocalTaskManager::AnyPendingTasksForResourceAcquisition(
-    RayTask *exemplar,
-    bool *any_pending,
-    int *num_pending_actor_creation,
-    int *num_pending_tasks) const {
+const RayTask *LocalTaskManager::AnyPendingTasksForResourceAcquisition(
+    int *num_pending_actor_creation, int *num_pending_tasks) const {
+  const RayTask *exemplar = nullptr;
   // We are guaranteed that these tasks are blocked waiting for resources after a
   // call to ScheduleAndDispatchTasks(). They may be waiting for workers as well, but
   // this should be a transient condition only.
@@ -938,14 +936,12 @@ bool LocalTaskManager::AnyPendingTasksForResourceAcquisition(
         *num_pending_tasks += 1;
       }
 
-      if (!*any_pending) {
-        *exemplar = task;
-        *any_pending = true;
+      if (exemplar == nullptr) {
+        exemplar = &task;
       }
     }
   }
-  // If there's any pending task, at this point, there's no progress being made.
-  return *any_pending;
+  return exemplar;
 }
 
 void LocalTaskManager::Dispatch(

--- a/src/ray/raylet/local_task_manager.h
+++ b/src/ray/raylet/local_task_manager.h
@@ -125,17 +125,14 @@ class LocalTaskManager : public ILocalTaskManager {
                    rpc::RequestWorkerLeaseReply::SchedulingFailureType failure_type,
                    const std::string &scheduling_failure_message) override;
 
-  /// Return if any tasks are pending resource acquisition.
+  /// Return with an exemplar if any tasks are pending resource acquisition.
   ///
-  /// \param[out] example: An example task that is deadlocking.
-  /// \param[in,out] any_pending: True if there's any pending example.
   /// \param[in,out] num_pending_actor_creation: Number of pending actor creation tasks.
   /// \param[in,out] num_pending_tasks: Number of pending tasks.
-  /// \return True if any progress is any tasks are pending.
-  bool AnyPendingTasksForResourceAcquisition(RayTask *example,
-                                             bool *any_pending,
-                                             int *num_pending_actor_creation,
-                                             int *num_pending_tasks) const override;
+  /// \return An example task that is deadlocking if any tasks are pending resource
+  /// acquisition.
+  const RayTask *AnyPendingTasksForResourceAcquisition(
+      int *num_pending_actor_creation, int *num_pending_tasks) const override;
 
   /// Call once a task finishes (i.e. a worker is returned).
   ///

--- a/src/ray/raylet/local_task_manager_test.cc
+++ b/src/ray/raylet/local_task_manager_test.cc
@@ -42,28 +42,36 @@ class MockWorkerPool : public WorkerPoolInterface {
  public:
   MockWorkerPool() : num_pops(0) {}
 
-  void PopWorker(const TaskSpecification &task_spec, const PopWorkerCallback &callback) {
+  void PopWorker(const TaskSpecification &task_spec,
+                 const PopWorkerCallback &callback) override {
     num_pops++;
     const int runtime_env_hash = task_spec.GetRuntimeEnvHash();
     callbacks[runtime_env_hash].push_back(callback);
   }
 
-  void PushWorker(const std::shared_ptr<WorkerInterface> &worker) {
+  void PushWorker(const std::shared_ptr<WorkerInterface> &worker) override {
     workers.push_front(worker);
   }
 
-  const std::vector<std::shared_ptr<WorkerInterface>> GetAllRegisteredWorkers(
-      bool filter_dead_workers, bool filter_io_workers) const {
+  std::vector<std::shared_ptr<WorkerInterface>> GetAllRegisteredWorkers(
+      bool filter_dead_workers, bool filter_io_workers) const override {
     RAY_CHECK(false) << "Not used.";
     return {};
   }
 
-  std::shared_ptr<WorkerInterface> GetRegisteredWorker(const WorkerID &worker_id) const {
+  bool IsWorkerAvailableForScheduling() const override {
+    RAY_CHECK(false) << "Not used.";
+    return false;
+  }
+
+  std::shared_ptr<WorkerInterface> GetRegisteredWorker(
+      const WorkerID &worker_id) const override {
     RAY_CHECK(false) << "Not used.";
     return nullptr;
   };
 
-  std::shared_ptr<WorkerInterface> GetRegisteredDriver(const WorkerID &worker_id) const {
+  std::shared_ptr<WorkerInterface> GetRegisteredDriver(
+      const WorkerID &worker_id) const override {
     RAY_CHECK(false) << "Not used.";
     return nullptr;
   }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -855,24 +855,20 @@ void NodeManager::QueryAllWorkerStates(
 // Note that this can print the false negative messages
 // e.g., there are many actors taking up resources for a long time.
 void NodeManager::WarnResourceDeadlock() {
-  ray::RayTask exemplar;
-  bool any_pending = false;
   int pending_actor_creations = 0;
   int pending_tasks = 0;
-  std::string available_resources;
 
   // Check if any progress is being made on this raylet.
-  for (const auto &worker : worker_pool_.GetAllRegisteredWorkers()) {
-    if (worker->IsAvailableForScheduling()) {
-      // Progress is being made in a task, don't warn.
-      resource_deadlock_warned_ = 0;
-      return;
-    }
+  if (worker_pool_.IsWorkerAvailableForScheduling()) {
+    // Progress is being made in a task, don't warn.
+    resource_deadlock_warned_ = 0;
+    return;
   }
 
+  auto exemplar = cluster_task_manager_->AnyPendingTasksForResourceAcquisition(
+      &pending_actor_creations, &pending_tasks);
   // Check if any tasks are blocked on resource acquisition.
-  if (!cluster_task_manager_->AnyPendingTasksForResourceAcquisition(
-          &exemplar, &any_pending, &pending_actor_creations, &pending_tasks)) {
+  if (exemplar == nullptr) {
     // No pending tasks, no need to warn.
     resource_deadlock_warned_ = 0;
     return;
@@ -883,7 +879,7 @@ void NodeManager::WarnResourceDeadlock() {
   // case resource_deadlock_warned_:  0 => first time, don't do anything yet
   // case resource_deadlock_warned_:  1 => second time, print a warning
   // case resource_deadlock_warned_: >1 => global gc but don't print any warnings
-  if (any_pending && resource_deadlock_warned_++ > 0) {
+  if (resource_deadlock_warned_++ > 0) {
     // Actor references may be caught in cycles, preventing them from being deleted.
     // Trigger global GC to hopefully free up resource slots.
     TriggerGlobalGC();
@@ -893,9 +889,8 @@ void NodeManager::WarnResourceDeadlock() {
       return;
     }
 
-    std::ostringstream error_message;
-    error_message
-        << "The actor or task with ID " << exemplar.GetTaskSpecification().TaskId()
+    RAY_LOG(WARNING)
+        << "The actor or task with ID " << exemplar->GetTaskSpecification().TaskId()
         << " cannot be scheduled right now. You can ignore this message if this "
         << "Ray cluster is expected to auto-scale or if you specified a "
         << "runtime_env for this actor or task, which may take time to install.  "
@@ -903,16 +898,13 @@ void NodeManager::WarnResourceDeadlock() {
         << "by actors. To resolve the issue, consider creating fewer actors or "
         << "increasing the resources available to this Ray cluster.\n"
         << "Required resources for this actor or task: "
-        << exemplar.GetTaskSpecification().GetRequiredPlacementResources().DebugString()
+        << exemplar->GetTaskSpecification().GetRequiredPlacementResources().DebugString()
         << "\n"
         << "Available resources on this node: "
         << cluster_resource_scheduler_->GetClusterResourceManager()
                .GetNodeResourceViewString(scheduling::NodeID(self_node_id_.Binary()))
         << " In total there are " << pending_tasks << " pending tasks and "
         << pending_actor_creations << " pending actors on this node.";
-
-    std::string error_message_str = error_message.str();
-    RAY_LOG(WARNING) << error_message_str;
     RAY_LOG_EVERY_MS(WARNING, 10 * 1000) << cluster_task_manager_->DebugStr();
   }
   // Try scheduling tasks. Without this, if there's no more tasks coming in, deadlocked

--- a/src/ray/raylet/scheduling/cluster_task_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_task_manager.cc
@@ -353,9 +353,9 @@ void ClusterTaskManager::FillResourceUsage(rpc::ResourcesData &data) {
   cluster_resource_scheduler_.GetLocalResourceManager().PopulateResourceViewSyncMessage(
       resource_view_sync_message);
   (*data.mutable_resources_total()) =
-      std::move(resource_view_sync_message.resources_total());
+      std::move(*resource_view_sync_message.mutable_resources_total());
   (*data.mutable_resources_available()) =
-      std::move(resource_view_sync_message.resources_available());
+      std::move(*resource_view_sync_message.mutable_resources_available());
   data.set_object_pulls_queued(resource_view_sync_message.object_pulls_queued());
   data.set_idle_duration_ms(resource_view_sync_message.idle_duration_ms());
   data.set_is_draining(resource_view_sync_message.is_draining());
@@ -363,11 +363,9 @@ void ClusterTaskManager::FillResourceUsage(rpc::ResourcesData &data) {
       resource_view_sync_message.draining_deadline_timestamp_ms());
 }
 
-bool ClusterTaskManager::AnyPendingTasksForResourceAcquisition(
-    RayTask *exemplar,
-    bool *any_pending,
-    int *num_pending_actor_creation,
-    int *num_pending_tasks) const {
+const RayTask *ClusterTaskManager::AnyPendingTasksForResourceAcquisition(
+    int *num_pending_actor_creation, int *num_pending_tasks) const {
+  const RayTask *exemplar = nullptr;
   // We are guaranteed that these tasks are blocked waiting for resources after a
   // call to ScheduleAndDispatchTasks(). They may be waiting for workers as well, but
   // this should be a transient condition only.
@@ -400,18 +398,16 @@ bool ClusterTaskManager::AnyPendingTasksForResourceAcquisition(
         *num_pending_tasks += 1;
       }
 
-      if (!*any_pending) {
-        *exemplar = task;
-        *any_pending = true;
+      if (exemplar == nullptr) {
+        exemplar = &task;
       }
     }
   }
 
-  local_task_manager_.AnyPendingTasksForResourceAcquisition(
-      exemplar, any_pending, num_pending_actor_creation, num_pending_tasks);
-
-  // If there's any pending task, at this point, there's no progress being made.
-  return *any_pending;
+  auto local_task_exemplar = local_task_manager_.AnyPendingTasksForResourceAcquisition(
+      num_pending_actor_creation, num_pending_tasks);
+  // Prefer returning the cluster task manager exemplar if it exists.
+  return exemplar == nullptr ? local_task_exemplar : exemplar;
 }
 
 void ClusterTaskManager::RecordMetrics() const {

--- a/src/ray/raylet/scheduling/cluster_task_manager.h
+++ b/src/ray/raylet/scheduling/cluster_task_manager.h
@@ -131,17 +131,14 @@ class ClusterTaskManager : public ClusterTaskManagerInterface {
   /// the only fields used.
   void FillResourceUsage(rpc::ResourcesData &data) override;
 
-  /// Return if any tasks are pending resource acquisition.
+  /// Return with an exemplar if any tasks are pending resource acquisition.
   ///
-  /// \param[out] example: An example task that is deadlocking.
-  /// \param[in,out] any_pending: True if there's any pending example.
   /// \param[in,out] num_pending_actor_creation: Number of pending actor creation tasks.
   /// \param[in,out] num_pending_tasks: Number of pending tasks.
-  /// \return True if any progress is any tasks are pending.
-  bool AnyPendingTasksForResourceAcquisition(RayTask *example,
-                                             bool *any_pending,
-                                             int *num_pending_actor_creation,
-                                             int *num_pending_tasks) const override;
+  /// \return An example task that is deadlocking if any tasks are pending resource
+  /// acquisition.
+  const RayTask *AnyPendingTasksForResourceAcquisition(
+      int *num_pending_actor_creation, int *num_pending_tasks) const override;
 
   // Schedule and dispatch tasks.
   void ScheduleAndDispatchTasks() override;

--- a/src/ray/raylet/scheduling/cluster_task_manager_interface.h
+++ b/src/ray/raylet/scheduling/cluster_task_manager_interface.h
@@ -102,17 +102,14 @@ class ClusterTaskManagerInterface {
                                     rpc::RequestWorkerLeaseReply *reply,
                                     rpc::SendReplyCallback send_reply_callback) = 0;
 
-  /// Return if any tasks are pending resource acquisition.
+  /// Return with an exemplar if any tasks are pending resource acquisition.
   ///
-  /// \param[in] exemplar An example task that is deadlocking.
   /// \param[in] num_pending_actor_creation Number of pending actor creation tasks.
   /// \param[in] num_pending_tasks Number of pending tasks.
-  /// \param[in] any_pending True if there's any pending exemplar.
-  /// \return True if any progress is any tasks are pending.
-  virtual bool AnyPendingTasksForResourceAcquisition(RayTask *exemplar,
-                                                     bool *any_pending,
-                                                     int *num_pending_actor_creation,
-                                                     int *num_pending_tasks) const = 0;
+  /// \return An example task that is deadlocking if any tasks are pending resource
+  /// acquisition.
+  virtual const RayTask *AnyPendingTasksForResourceAcquisition(
+      int *num_pending_actor_creation, int *num_pending_tasks) const = 0;
 
   /// The helper to dump the debug state of the cluster task manater.
   virtual std::string DebugStr() const = 0;

--- a/src/ray/raylet/scheduling/local_task_manager_interface.h
+++ b/src/ray/raylet/scheduling/local_task_manager_interface.h
@@ -65,10 +65,8 @@ class ILocalTaskManager {
 
   virtual void ClearWorkerBacklog(const WorkerID &worker_id) = 0;
 
-  virtual bool AnyPendingTasksForResourceAcquisition(RayTask *example,
-                                                     bool *any_pending,
-                                                     int *num_pending_actor_creation,
-                                                     int *num_pending_tasks) const = 0;
+  virtual const RayTask *AnyPendingTasksForResourceAcquisition(
+      int *num_pending_actor_creation, int *num_pending_tasks) const = 0;
 
   virtual void RecordMetrics() const = 0;
 
@@ -123,11 +121,9 @@ class NoopLocalTaskManager : public ILocalTaskManager {
 
   void ClearWorkerBacklog(const WorkerID &worker_id) override {}
 
-  bool AnyPendingTasksForResourceAcquisition(RayTask *example,
-                                             bool *any_pending,
-                                             int *num_pending_actor_creation,
-                                             int *num_pending_tasks) const override {
-    return false;
+  const RayTask *AnyPendingTasksForResourceAcquisition(
+      int *num_pending_actor_creation, int *num_pending_tasks) const override {
+    return nullptr;
   }
 
   void RecordMetrics() const override{};

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -1629,7 +1629,7 @@ inline bool WorkerPool::IsIOWorkerType(const rpc::WorkerType &worker_type) const
          worker_type == rpc::WorkerType::RESTORE_WORKER;
 }
 
-const std::vector<std::shared_ptr<WorkerInterface>> WorkerPool::GetAllRegisteredWorkers(
+std::vector<std::shared_ptr<WorkerInterface>> WorkerPool::GetAllRegisteredWorkers(
     bool filter_dead_workers, bool filter_io_workers) const {
   std::vector<std::shared_ptr<WorkerInterface>> workers;
 
@@ -1653,7 +1653,21 @@ const std::vector<std::shared_ptr<WorkerInterface>> WorkerPool::GetAllRegistered
   return workers;
 }
 
-const std::vector<std::shared_ptr<WorkerInterface>> WorkerPool::GetAllRegisteredDrivers(
+bool WorkerPool::IsWorkerAvailableForScheduling() const {
+  for (const auto &entry : states_by_lang_) {
+    for (const auto &worker : entry.second.registered_workers) {
+      if (!worker->IsRegistered()) {
+        continue;
+      }
+      if (worker->IsAvailableForScheduling()) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+std::vector<std::shared_ptr<WorkerInterface>> WorkerPool::GetAllRegisteredDrivers(
     bool filter_dead_drivers) const {
   std::vector<std::shared_ptr<WorkerInterface>> drivers;
 

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -160,8 +160,11 @@ class WorkerPoolInterface {
   /// non-retriable workers that are still registered.
   ///
   /// \return A list containing all the workers.
-  virtual const std::vector<std::shared_ptr<WorkerInterface>> GetAllRegisteredWorkers(
+  virtual std::vector<std::shared_ptr<WorkerInterface>> GetAllRegisteredWorkers(
       bool filter_dead_workers = false, bool filter_io_workers = false) const = 0;
+
+  /// Checks if any registered worker is available for scheduling.
+  virtual bool IsWorkerAvailableForScheduling() const = 0;
 
   /// Get registered worker process by id or nullptr if not found.
   virtual std::shared_ptr<WorkerInterface> GetRegisteredWorker(
@@ -462,8 +465,10 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   /// non-retriable workers that are still registered.
   ///
   /// \return A list containing all the workers.
-  const std::vector<std::shared_ptr<WorkerInterface>> GetAllRegisteredWorkers(
+  std::vector<std::shared_ptr<WorkerInterface>> GetAllRegisteredWorkers(
       bool filter_dead_workers = false, bool filter_io_workers = false) const override;
+
+  bool IsWorkerAvailableForScheduling() const override;
 
   /// Get all the registered drivers.
   ///
@@ -471,7 +476,7 @@ class WorkerPool : public WorkerPoolInterface, public IOWorkerPoolInterface {
   /// that are still registered.
   ///
   /// \return A list containing all the drivers.
-  const std::vector<std::shared_ptr<WorkerInterface>> GetAllRegisteredDrivers(
+  std::vector<std::shared_ptr<WorkerInterface>> GetAllRegisteredDrivers(
       bool filter_dead_drivers = false) const;
 
   /// Returns debug string for class.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
When looking for a resource deadlock, the first thing done is to check if there's any workers available. Right now that involves getting a vector of all the workers and then checking.
Created a new worker pool IsAvailableForScheduling that will just return out if there's one available.

AnyPendingTasksForResourceAcquisition (also called to check for resource deadlock) was a kind of messy with a return value and four out parameters. Simplified down to a return value and two out parameters.

The moves in FillResourceUsage weren't actually moving anything because it was using the const protobuf accessors. Fixed that.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
