### PR TITLE
[core] Fix test_reference_counting

### DIFF
--- a/python/ray/tests/test_reference_counting.py
+++ b/python/ray/tests/test_reference_counting.py
@@ -56,21 +56,19 @@ def _fill_object_store_and_get(obj, succeed=True, object_MiB=20, num_objects=5):
         )
 
 
-def _check_refcounts(expected):
-    actual = ray._private.worker.global_worker.core_worker.get_all_reference_counts()
-    assert len(expected) == len(actual)
-    for object_ref, (local, submitted) in expected.items():
-        hex_id = object_ref.hex().encode("ascii")
-        assert hex_id in actual
-        assert local == actual[hex_id]["local"]
-        assert submitted == actual[hex_id]["submitted"]
-
-
 def check_refcounts(expected, timeout=10):
     start = time.time()
     while True:
         try:
-            _check_refcounts(expected)
+            actual = (
+                ray._private.worker.global_worker.core_worker.get_all_reference_counts()
+            )
+            assert len(expected) == len(actual)
+            for object_ref, (local, submitted) in expected.items():
+                hex_id = object_ref.hex().encode("ascii")
+                assert hex_id in actual
+                assert local == actual[hex_id]["local"]
+                assert submitted == actual[hex_id]["submitted"]
             break
         except AssertionError as e:
             if time.time() - start > timeout:
@@ -175,6 +173,48 @@ def test_dependency_refcounts(one_cpu_100MiB_shared):
     check_refcounts({dep: (1, 0), result: (1, 0)})
     del dep, result
     check_refcounts({})
+
+
+# Test that a reference borrowed by an actor constructor is freed if the actor is
+# cancelled before being scheduled.
+def test_actor_constructor_borrow_cancellation(one_cpu_100MiB_shared):
+    # Schedule the actor with a non-existent resource so it's guaranteed to never be
+    # scheduled.
+    @ray.remote(resources={"nonexistent_resource": 1})
+    class Actor:
+        def __init__(self, obj_containing_ref):
+            raise ValueError(
+                "The actor constructor should not be reached; the actor creation task "
+                "should be cancelled before the actor is scheduled."
+            )
+
+        def should_not_be_run(self):
+            raise ValueError("This method should never be reached.")
+
+    # Test with implicit cancellation by letting the actor handle go out-of-scope.
+    def test_implicit_cancel():
+        ref = ray.put(1)
+        _ = Actor.remote({"foo": ref})
+
+    test_implicit_cancel()
+
+    # Confirm that the ref object is not leaked.
+    check_refcounts({})
+
+    # Test with explicit cancellation via ray.kill().
+    ref = ray.put(1)
+    a = Actor.remote({"foo": ref})
+    ray.kill(a)
+    del ref
+
+    # Confirm that the ref object is not leaked.
+    check_refcounts({})
+
+    # Check that actor death cause is propagated.
+    with pytest.raises(
+        ray.exceptions.RayActorError, match="it was killed by `ray.kill"
+    ):
+        ray.get(a.should_not_be_run.remote())
 
 
 def test_basic_pinning(one_cpu_100MiB_shared):
@@ -436,49 +476,6 @@ def test_basic_nested_ids(one_cpu_100MiB_shared):
     # Remove the outer reference and check that the inner object gets evicted.
     del outer_oid
     _fill_object_store_and_get(inner_oid_bytes, succeed=False)
-
-
-# Test that a reference borrowed by an actor constructor is freed if the actor is
-# cancelled before being scheduled.
-def test_actor_constructor_borrow_cancellation(one_cpu_100MiB_shared):
-    # Schedule the actor with a non-existent resource so it's guaranteed to never be
-    # scheduled.
-    @ray.remote(resources={"nonexistent_resource": 1})
-    class Actor:
-        def __init__(self, obj_containing_ref):
-            raise ValueError(
-                "The actor constructor should not be reached; the actor creation task "
-                "should be cancelled before the actor is scheduled."
-            )
-
-        def should_not_be_run(self):
-            raise ValueError("This method should never be reached.")
-
-    # Test with implicit cancellation by letting the actor handle go out-of-scope.
-    def test_implicit_cancel():
-        ref = ray.put(1)
-        print(Actor.remote({"foo": ref}))
-
-    test_implicit_cancel()
-
-    # Confirm that the ref object is not leaked.
-    check_refcounts({})
-
-    # Test with explicit cancellation via ray.kill().
-    ref = ray.put(1)
-    a = Actor.remote({"foo": ref})
-    ray.kill(a)
-    del ref
-
-    # Confirm that the ref object is not leaked.
-    check_refcounts({})
-
-    # Check that actor death cause is propagated.
-    with pytest.raises(
-        ray.exceptions.RayActorError, match="it was killed by `ray.kill"
-    ) as exc_info:
-        ray.get(a.should_not_be_run.remote())
-    print(exc_info._excinfo[1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
test_actor_constructor_borrow_cancellation in test_reference_counting was failing after https://github.com/ray-project/ray/pull/53239

It was failing because refs from previous tests were left over and when using the shared fixture, the `check_refcounts` call would include references from previous tests. This moves the test right after a test that confirms that ref counts are empty. All the tests that use `check_refcounts` are now all adjacent to each other too.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
