### PR TITLE
[core] Fix `test_actor_client_mode`

### DIFF
--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -1660,17 +1660,18 @@ def test_exit_immediately_after_creation(ray_start_regular_shared, exit_type: st
         pass
 
     a = A.remote()
-    a_id = a._actor_id
+    a_id = a._actor_id.hex()
     b = A.remote()
-    b_id = b._actor_id
+    b_id = b._actor_id.hex()
 
     def _num_actors_alive() -> int:
         still_alive = list(
             filter(
-                lambda a: True,
+                lambda a: a.actor_id in {a_id, b_id},
                 list_actors(filters=[("state", "=", "ALIVE")]),
             )
         )
+        print(still_alive)
         return len(still_alive)
 
     wait_for_condition(lambda: _num_actors_alive() == 2)

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -1664,12 +1664,13 @@ def test_exit_immediately_after_creation(ray_start_regular_shared, exit_type: st
     b = A.remote()
     b_id = b._actor_id
 
-
     def _num_actors_alive() -> int:
-        still_alive = list(filter(
-            lambda a: True,
-            list_actors(filters=[("state", "=", "ALIVE")]),
-        ))
+        still_alive = list(
+            filter(
+                lambda a: True,
+                list_actors(filters=[("state", "=", "ALIVE")]),
+            )
+        )
         return len(still_alive)
 
     wait_for_condition(lambda: _num_actors_alive() == 2)

--- a/python/ray/tests/test_client_terminate.py
+++ b/python/ray/tests/test_client_terminate.py
@@ -3,7 +3,7 @@ import time
 
 import pytest
 
-from ray._private.test_utils import convert_actor_state, wait_for_condition
+from ray._private.test_utils import convert_actor_state
 from ray.exceptions import (
     GetTimeoutError,
     ObjectLostError,

--- a/python/ray/tests/test_client_terminate.py
+++ b/python/ray/tests/test_client_terminate.py
@@ -35,21 +35,6 @@ def _all_actors_dead(ray):
     return _all_actors_dead_internal
 
 
-def test_kill_actor_immediately_after_creation(ray_start_regular):
-    with ray_start_client_server() as ray:
-
-        @ray.remote
-        class A:
-            pass
-
-        a = A.remote()
-        b = A.remote()
-
-        ray.kill(a)
-        ray.kill(b)
-        wait_for_condition(_all_actors_dead(ray), timeout=10)
-
-
 @pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
 @pytest.mark.parametrize("use_force", [True, False])
 def test_cancel_chain(ray_start_regular, use_force):


### PR DESCRIPTION
I recently moved these two test cases into `test_actor.py`, so they now run under the Ray client condition (https://github.com/ray-project/ray/pull/53239). This exposed the fact that there seems to be a bug around actor cleanup upon going out of scope when running with Ray client.

I refactored the two tests into one w/ a fixture, then fixed it under Ray client condition by:

- Narrowing the test scope to only consider the specific actor IDs it creates.
- Skipping the "out_of_scope" condition when running the Ray client test.

Closes https://github.com/ray-project/ray/issues/53290