### PR TITLE
[Core] Fix the issue where a valid RestartActor rpc is ignored

### DIFF
--- a/python/ray/tests/test_actor_lineage_reconstruction.py
+++ b/python/ray/tests/test_actor_lineage_reconstruction.py
@@ -23,7 +23,7 @@ def test_actor_reconstruction_triggered_by_lineage_reconstruction(
     # This test also injects network failure to make sure relevant rpcs are retried.
     monkeypatch.setenv(
         "RAY_testing_rpc_failure",
-        "ray::rpc::ActorInfoGcsService.grpc_client.RestartActor=5:25:25,"
+        "ray::rpc::ActorInfoGcsService.grpc_client.RestartActorForLineageReconstruction=5:25:25,"
         "ray::rpc::ActorInfoGcsService.grpc_client.ReportActorOutOfScope=5:25:25",
     )
     cluster = ray_start_cluster

--- a/src/mock/ray/core_worker/actor_creator.h
+++ b/src/mock/ray/core_worker/actor_creator.h
@@ -33,7 +33,7 @@ class MockActorCreatorInterface : public ActorCreatorInterface {
                const rpc::ClientCallback<rpc::CreateActorReply> &callback),
               (override));
   MOCK_METHOD(Status,
-              AsyncRestartActor,
+              AsyncRestartActorForLineageReconstruction,
               (const ActorID &actor_id,
                uint64_t num_restarts,
                gcs::StatusCallback callback),

--- a/src/ray/core_worker/actor_creator.h
+++ b/src/ray/core_worker/actor_creator.h
@@ -41,9 +41,10 @@ class ActorCreatorInterface {
   virtual Status AsyncRegisterActor(const TaskSpecification &task_spec,
                                     gcs::StatusCallback callback) = 0;
 
-  virtual Status AsyncRestartActor(const ActorID &actor_id,
-                                   uint64_t num_restarts_due_to_lineage_reconstructions,
-                                   gcs::StatusCallback callback) = 0;
+  virtual Status AsyncRestartActorForLineageReconstruction(
+      const ActorID &actor_id,
+      uint64_t num_restarts_due_to_lineage_reconstructions,
+      gcs::StatusCallback callback) = 0;
 
   virtual Status AsyncReportActorOutOfScope(
       const ActorID &actor_id,
@@ -108,10 +109,11 @@ class DefaultActorCreator : public ActorCreatorInterface {
         });
   }
 
-  Status AsyncRestartActor(const ActorID &actor_id,
-                           uint64_t num_restarts_due_to_lineage_reconstructions,
-                           gcs::StatusCallback callback) override {
-    return gcs_client_->Actors().AsyncRestartActor(
+  Status AsyncRestartActorForLineageReconstruction(
+      const ActorID &actor_id,
+      uint64_t num_restarts_due_to_lineage_reconstructions,
+      gcs::StatusCallback callback) override {
+    return gcs_client_->Actors().AsyncRestartActorForLineageReconstruction(
         actor_id, num_restarts_due_to_lineage_reconstructions, callback);
   }
 

--- a/src/ray/core_worker/actor_creator.h
+++ b/src/ray/core_worker/actor_creator.h
@@ -42,7 +42,7 @@ class ActorCreatorInterface {
                                     gcs::StatusCallback callback) = 0;
 
   virtual Status AsyncRestartActor(const ActorID &actor_id,
-                                   uint64_t num_restarts,
+                                   uint64_t num_restarts_due_to_lineage_reconstructions,
                                    gcs::StatusCallback callback) = 0;
 
   virtual Status AsyncReportActorOutOfScope(
@@ -109,9 +109,10 @@ class DefaultActorCreator : public ActorCreatorInterface {
   }
 
   Status AsyncRestartActor(const ActorID &actor_id,
-                           uint64_t num_restarts,
+                           uint64_t num_restarts_due_to_lineage_reconstructions,
                            gcs::StatusCallback callback) override {
-    return gcs_client_->Actors().AsyncRestartActor(actor_id, num_restarts, callback);
+    return gcs_client_->Actors().AsyncRestartActor(
+        actor_id, num_restarts_due_to_lineage_reconstructions, callback);
   }
 
   Status AsyncReportActorOutOfScope(const ActorID &actor_id,

--- a/src/ray/core_worker/test/dependency_resolver_test.cc
+++ b/src/ray/core_worker/test/dependency_resolver_test.cc
@@ -152,7 +152,7 @@ class MockActorCreator : public ActorCreatorInterface {
   }
 
   Status AsyncRestartActor(const ActorID &actor_id,
-                           uint64_t num_restarts,
+                           uint64_t num_restarts_due_to_lineage_reconstructions,
                            gcs::StatusCallback callback) override {
     return Status::OK();
   }

--- a/src/ray/core_worker/test/dependency_resolver_test.cc
+++ b/src/ray/core_worker/test/dependency_resolver_test.cc
@@ -151,9 +151,10 @@ class MockActorCreator : public ActorCreatorInterface {
     return Status::OK();
   }
 
-  Status AsyncRestartActor(const ActorID &actor_id,
-                           uint64_t num_restarts_due_to_lineage_reconstructions,
-                           gcs::StatusCallback callback) override {
+  Status AsyncRestartActorForLineageReconstruction(
+      const ActorID &actor_id,
+      uint64_t num_restarts_due_to_lineage_reconstructions,
+      gcs::StatusCallback callback) override {
     return Status::OK();
   }
 

--- a/src/ray/core_worker/test/normal_task_submitter_test.cc
+++ b/src/ray/core_worker/test/normal_task_submitter_test.cc
@@ -385,9 +385,10 @@ class MockActorCreator : public ActorCreatorInterface {
     return Status::OK();
   }
 
-  Status AsyncRestartActor(const ActorID &actor_id,
-                           uint64_t num_restarts_due_to_lineage_reconstructions,
-                           gcs::StatusCallback callback) override {
+  Status AsyncRestartActorForLineageReconstruction(
+      const ActorID &actor_id,
+      uint64_t num_restarts_due_to_lineage_reconstructions,
+      gcs::StatusCallback callback) override {
     return Status::OK();
   }
 

--- a/src/ray/core_worker/test/normal_task_submitter_test.cc
+++ b/src/ray/core_worker/test/normal_task_submitter_test.cc
@@ -386,7 +386,7 @@ class MockActorCreator : public ActorCreatorInterface {
   }
 
   Status AsyncRestartActor(const ActorID &actor_id,
-                           uint64_t num_restarts,
+                           uint64_t num_restarts_due_to_lineage_reconstructions,
                            gcs::StatusCallback callback) override {
     return Status::OK();
   }

--- a/src/ray/core_worker/transport/actor_task_submitter.h
+++ b/src/ray/core_worker/transport/actor_task_submitter.h
@@ -405,8 +405,10 @@ class ActorTaskSubmitter : public ActorTaskSubmitterInterface {
       const absl::flat_hash_map<TaskAttempt, rpc::ClientCallback<rpc::PushTaskReply>>
           &inflight_task_callbacks) ABSL_LOCKS_EXCLUDED(mu_);
 
-  /// Restart the actor from DEAD by sending a RestartActor rpc to GCS.
-  void RestartActor(const ActorID &actor_id) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+  /// Restart the actor from DEAD by sending a RestartActorForLineageReconstruction rpc to
+  /// GCS.
+  void RestartActorForLineageReconstruction(const ActorID &actor_id)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
   void NotifyGCSWhenActorOutOfScope(const ActorID &actor_id,
                                     uint64_t num_restarts_due_to_lineage_reconstructions);

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -307,13 +307,15 @@ Status ActorInfoAccessor::SyncListNamedActors(
   return status;
 }
 
-Status ActorInfoAccessor::AsyncRestartActor(const ray::ActorID &actor_id,
-                                            uint64_t num_restarts,
-                                            const ray::gcs::StatusCallback &callback,
-                                            int64_t timeout_ms) {
+Status ActorInfoAccessor::AsyncRestartActor(
+    const ray::ActorID &actor_id,
+    uint64_t num_restarts_due_to_lineage_reconstruction,
+    const ray::gcs::StatusCallback &callback,
+    int64_t timeout_ms) {
   rpc::RestartActorRequest request;
   request.set_actor_id(actor_id.Binary());
-  request.set_num_restarts(num_restarts);
+  request.set_num_restarts_due_to_lineage_reconstruction(
+      num_restarts_due_to_lineage_reconstruction);
   client_impl_->GetGcsRpcClient().RestartActor(
       request,
       [callback](const Status &status, rpc::RestartActorReply &&reply) {

--- a/src/ray/gcs/gcs_client/accessor.cc
+++ b/src/ray/gcs/gcs_client/accessor.cc
@@ -307,18 +307,19 @@ Status ActorInfoAccessor::SyncListNamedActors(
   return status;
 }
 
-Status ActorInfoAccessor::AsyncRestartActor(
+Status ActorInfoAccessor::AsyncRestartActorForLineageReconstruction(
     const ray::ActorID &actor_id,
     uint64_t num_restarts_due_to_lineage_reconstruction,
     const ray::gcs::StatusCallback &callback,
     int64_t timeout_ms) {
-  rpc::RestartActorRequest request;
+  rpc::RestartActorForLineageReconstructionRequest request;
   request.set_actor_id(actor_id.Binary());
   request.set_num_restarts_due_to_lineage_reconstruction(
       num_restarts_due_to_lineage_reconstruction);
-  client_impl_->GetGcsRpcClient().RestartActor(
+  client_impl_->GetGcsRpcClient().RestartActorForLineageReconstruction(
       request,
-      [callback](const Status &status, rpc::RestartActorReply &&reply) {
+      [callback](const Status &status,
+                 rpc::RestartActorForLineageReconstructionReply &&reply) {
         callback(status);
       },
       timeout_ms);

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -143,7 +143,7 @@ class ActorInfoAccessor {
                                     int64_t timeout_ms = -1);
 
   virtual Status AsyncRestartActor(const ActorID &actor_id,
-                                   uint64_t num_restarts,
+                                   uint64_t num_restarts_due_to_lineage_reconstructions,
                                    const StatusCallback &callback,
                                    int64_t timeout_ms = -1);
 

--- a/src/ray/gcs/gcs_client/accessor.h
+++ b/src/ray/gcs/gcs_client/accessor.h
@@ -142,10 +142,11 @@ class ActorInfoAccessor {
                                     const StatusCallback &callback,
                                     int64_t timeout_ms = -1);
 
-  virtual Status AsyncRestartActor(const ActorID &actor_id,
-                                   uint64_t num_restarts_due_to_lineage_reconstructions,
-                                   const StatusCallback &callback,
-                                   int64_t timeout_ms = -1);
+  virtual Status AsyncRestartActorForLineageReconstruction(
+      const ActorID &actor_id,
+      uint64_t num_restarts_due_to_lineage_reconstructions,
+      const StatusCallback &callback,
+      int64_t timeout_ms = -1);
 
   /// Register actor to GCS synchronously.
   ///

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -276,7 +276,8 @@ class GcsActor {
 
 using RegisterActorCallback =
     std::function<void(std::shared_ptr<GcsActor>, const Status &status)>;
-using RestartActorCallback = std::function<void(std::shared_ptr<GcsActor>)>;
+using RestartActorForLineageReconstructionCallback =
+    std::function<void(std::shared_ptr<GcsActor>)>;
 using CreateActorCallback = std::function<void(
     std::shared_ptr<GcsActor>, const rpc::PushTaskReply &reply, const Status &status)>;
 
@@ -348,9 +349,10 @@ class GcsActorManager : public rpc::ActorInfoHandler {
                            rpc::RegisterActorReply *reply,
                            rpc::SendReplyCallback send_reply_callback) override;
 
-  void HandleRestartActor(rpc::RestartActorRequest request,
-                          rpc::RestartActorReply *reply,
-                          rpc::SendReplyCallback send_reply_callback) override;
+  void HandleRestartActorForLineageReconstruction(
+      rpc::RestartActorForLineageReconstructionRequest request,
+      rpc::RestartActorForLineageReconstructionReply *reply,
+      rpc::SendReplyCallback send_reply_callback) override;
 
   void HandleCreateActor(rpc::CreateActorRequest request,
                          rpc::CreateActorReply *reply,
@@ -667,11 +669,11 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   /// messages from a driver/worker caused by some network problems.
   absl::flat_hash_map<ActorID, std::vector<RegisterActorCallback>>
       actor_to_register_callbacks_;
-  /// Callbacks of pending `RestartActor` requests.
+  /// Callbacks of pending `RestartActorForLineageReconstruction` requests.
   /// Maps actor ID to actor restart callbacks, which is used to filter duplicated
   /// messages from a driver/worker caused by some network problems.
-  absl::flat_hash_map<ActorID, std::vector<RestartActorCallback>>
-      actor_to_restart_callbacks_;
+  absl::flat_hash_map<ActorID, std::vector<RestartActorForLineageReconstructionCallback>>
+      actor_to_restart_for_lineage_reconstruction_callbacks_;
   /// Callbacks of actor creation requests.
   /// Maps actor ID to actor creation callbacks, which is used to filter duplicated
   /// messages come from a Driver/Worker caused by some network problems.

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -256,6 +256,49 @@ class GcsActorManagerTest : public ::testing::Test {
     promise.get_future().get();
   }
 
+  rpc::RestartActorReply RestartActor(const ActorID &actor_id,
+                                      size_t num_restarts_due_to_lineage_reconstruction) {
+    rpc::RestartActorRequest request;
+    request.set_actor_id(actor_id.Binary());
+    request.set_num_restarts_due_to_lineage_reconstruction(
+        num_restarts_due_to_lineage_reconstruction);
+    rpc::RestartActorReply reply;
+    std::promise<bool> promise;
+    io_service_.post(
+        [this, &request, &reply, &promise]() {
+          gcs_actor_manager_->HandleRestartActor(
+              request,
+              &reply,
+              [&promise](Status status,
+                         std::function<void()> success,
+                         std::function<void()> failure) { promise.set_value(true); });
+        },
+        "test");
+    promise.get_future().get();
+    return reply;
+  }
+
+  void ReportActorOutOfScope(const ActorID &actor_id,
+                             size_t num_restarts_due_to_lineage_reconstrcution) {
+    rpc::ReportActorOutOfScopeRequest request;
+    request.set_actor_id(actor_id.Binary());
+    request.set_num_restarts_due_to_lineage_reconstruction(
+        num_restarts_due_to_lineage_reconstrcution);
+    rpc::ReportActorOutOfScopeReply reply;
+    std::promise<bool> promise;
+    io_service_.post(
+        [this, &request, &reply, &promise]() {
+          gcs_actor_manager_->HandleReportActorOutOfScope(
+              request,
+              &reply,
+              [&promise](Status status,
+                         std::function<void()> success,
+                         std::function<void()> failure) { promise.set_value(true); });
+        },
+        "test");
+    promise.get_future().get();
+  }
+
   std::shared_ptr<gcs::GcsActor> CreateActorAndWaitTilAlive(const JobID &job_id) {
     auto registered_actor = RegisterActor(job_id);
     rpc::CreateActorRequest create_actor_request;
@@ -1425,6 +1468,179 @@ TEST_F(GcsActorManagerTest, TestKillActorWhenActorIsCreating) {
 
   // Make sure the actor is restarting.
   ASSERT_EQ(actor->GetState(), rpc::ActorTableData::RESTARTING);
+}
+
+TEST_F(GcsActorManagerTest, TestRestartActorDueToLineageReconstruction) {
+  auto job_id = JobID::FromInt(1);
+  auto registered_actor = RegisterActor(job_id, /*max_restarts*/ -1);
+  rpc::CreateActorRequest create_actor_request;
+  create_actor_request.mutable_task_spec()->CopyFrom(
+      registered_actor->GetCreationTaskSpecification().GetMessage());
+
+  std::vector<std::shared_ptr<gcs::GcsActor>> created_actors;
+  RAY_CHECK_OK(gcs_actor_manager_->CreateActor(
+      create_actor_request,
+      [&created_actors](std::shared_ptr<gcs::GcsActor> actor,
+                        const rpc::PushTaskReply &reply,
+                        const Status &status) { created_actors.emplace_back(actor); }));
+
+  ASSERT_EQ(created_actors.size(), 0);
+  ASSERT_EQ(mock_actor_scheduler_->actors.size(), 1);
+  auto actor = mock_actor_scheduler_->actors.back();
+  mock_actor_scheduler_->actors.pop_back();
+
+  // Check that the actor is in state `ALIVE`.
+  auto address = RandomAddress();
+  auto node_id = NodeID::FromBinary(address.raylet_id());
+  actor->UpdateAddress(address);
+  gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
+  WaitActorCreated(actor->GetActorID());
+  ASSERT_EQ(created_actors.size(), 1);
+
+  // Remove worker and then check that the actor is being restarted.
+  EXPECT_CALL(*mock_actor_scheduler_, CancelOnNode(node_id));
+  OnNodeDead(node_id);
+  ASSERT_EQ(actor->GetState(), rpc::ActorTableData::RESTARTING);
+
+  // Add node and check that the actor is restarted.
+  ASSERT_EQ(mock_actor_scheduler_->actors.size(), 1);
+  mock_actor_scheduler_->actors.clear();
+  ASSERT_EQ(created_actors.size(), 1);
+  auto node_id2 = NodeID::FromRandom();
+  address.set_raylet_id(node_id2.Binary());
+  actor->UpdateAddress(address);
+  gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
+  WaitActorCreated(actor->GetActorID());
+  ASSERT_EQ(created_actors.size(), 1);
+  ASSERT_EQ(actor->GetState(), rpc::ActorTableData::ALIVE);
+  ASSERT_EQ(actor->GetNodeID(), node_id2);
+  ASSERT_EQ(actor->GetActorTableData().num_restarts(), 1);
+  ASSERT_EQ(actor->GetActorTableData().num_restarts_due_to_lineage_reconstruction(), 0);
+
+  // The actor is out of scope and dead.
+  ReportActorOutOfScope(actor->GetActorID(),
+                        /*num_restarts_due_to_lineage_reconstruction=*/0);
+  ASSERT_EQ(actor->GetState(), rpc::ActorTableData::DEAD);
+
+  // Restart the actor due to linage reconstruction.
+  RestartActor(actor->GetActorID(), /*num_restarts_due_to_lineage_reconstruction=*/1);
+  ASSERT_EQ(actor->GetState(), rpc::ActorTableData::RESTARTING);
+
+  // Add node and check that the actor is restarted.
+  ASSERT_EQ(mock_actor_scheduler_->actors.size(), 1);
+  mock_actor_scheduler_->actors.clear();
+  ASSERT_EQ(created_actors.size(), 1);
+  auto node_id3 = NodeID::FromRandom();
+  address.set_raylet_id(node_id3.Binary());
+  actor->UpdateAddress(address);
+  gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
+  WaitActorCreated(actor->GetActorID());
+  ASSERT_EQ(created_actors.size(), 1);
+  ASSERT_EQ(actor->GetState(), rpc::ActorTableData::ALIVE);
+  ASSERT_EQ(actor->GetNodeID(), node_id3);
+  ASSERT_EQ(actor->GetActorTableData().num_restarts(), 2);
+  ASSERT_EQ(actor->GetActorTableData().num_restarts_due_to_lineage_reconstruction(), 1);
+
+  // Restart an invalid or permanently dead actor should fail.
+  auto reply = RestartActor(ActorID::Of(actor->GetActorID().JobId(), RandomTaskId(), 0),
+                            /*num_restarts_due_to_lineage_reconstruction=*/0);
+  ASSERT_EQ(reply.status().code(), static_cast<int>(StatusCode::Invalid));
+}
+
+TEST_F(GcsActorManagerTest, TestIdempotencyOfRestartActorDueToLineageReconstruction) {
+  auto job_id = JobID::FromInt(1);
+  auto registered_actor = RegisterActor(job_id, /*max_restarts*/ -1);
+  rpc::CreateActorRequest create_actor_request;
+  create_actor_request.mutable_task_spec()->CopyFrom(
+      registered_actor->GetCreationTaskSpecification().GetMessage());
+
+  std::vector<std::shared_ptr<gcs::GcsActor>> created_actors;
+  RAY_CHECK_OK(gcs_actor_manager_->CreateActor(
+      create_actor_request,
+      [&created_actors](std::shared_ptr<gcs::GcsActor> actor,
+                        const rpc::PushTaskReply &reply,
+                        const Status &status) { created_actors.emplace_back(actor); }));
+
+  ASSERT_EQ(created_actors.size(), 0);
+  ASSERT_EQ(mock_actor_scheduler_->actors.size(), 1);
+  auto actor = mock_actor_scheduler_->actors.back();
+  mock_actor_scheduler_->actors.pop_back();
+
+  // Check that the actor is in state `ALIVE`.
+  auto address = RandomAddress();
+  actor->UpdateAddress(address);
+  gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
+  WaitActorCreated(actor->GetActorID());
+  ASSERT_EQ(created_actors.size(), 1);
+
+  // The actor is out of scope and dead.
+  ReportActorOutOfScope(actor->GetActorID(),
+                        /*num_restarts_due_to_lineage_reconstruction=*/0);
+  ASSERT_EQ(actor->GetState(), rpc::ActorTableData::DEAD);
+
+  // Test the case where the RestartActor rpc is received and being handled
+  // and then the connection is lost and the caller resends the same request.
+  // The second RestartActor rpc should be deduplicated and not be handled again,
+  // instead it should be replied with the same reply as the first one.
+  rpc::RestartActorRequest request;
+  request.set_actor_id(actor->GetActorID().Binary());
+  request.set_num_restarts_due_to_lineage_reconstruction(1);
+  rpc::RestartActorReply reply1;
+  rpc::RestartActorReply reply2;
+  std::promise<bool> promise1;
+  std::promise<bool> promise2;
+  io_service_.post(
+      [this, &request, &reply1, &reply2, &promise1, &promise2]() {
+        gcs_actor_manager_->HandleRestartActor(
+            request,
+            &reply1,
+            [&reply1, &promise1](Status status,
+                                 std::function<void()> success,
+                                 std::function<void()> failure) {
+              ASSERT_EQ(reply1.status().code(), static_cast<int>(StatusCode::OK));
+              promise1.set_value(true);
+            });
+        gcs_actor_manager_->HandleRestartActor(
+            request,
+            &reply2,
+            [&reply2, &promise2](Status status,
+                                 std::function<void()> success,
+                                 std::function<void()> failure) {
+              ASSERT_EQ(reply2.status().code(), static_cast<int>(StatusCode::OK));
+              promise2.set_value(true);
+            });
+      },
+      "test");
+  promise1.get_future().get();
+  promise2.get_future().get();
+  ASSERT_EQ(actor->GetState(), rpc::ActorTableData::RESTARTING);
+
+  // Add node and check that the actor is restarted.
+  ASSERT_EQ(mock_actor_scheduler_->actors.size(), 1);
+  mock_actor_scheduler_->actors.clear();
+  ASSERT_EQ(created_actors.size(), 1);
+  auto node_id = NodeID::FromRandom();
+  address.set_raylet_id(node_id.Binary());
+  actor->UpdateAddress(address);
+  gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
+  WaitActorCreated(actor->GetActorID());
+  ASSERT_EQ(created_actors.size(), 1);
+  ASSERT_EQ(actor->GetState(), rpc::ActorTableData::ALIVE);
+  ASSERT_EQ(actor->GetNodeID(), node_id);
+  // Two duplicate RestartActor rpcs should only trigger the restart once.
+  ASSERT_EQ(actor->GetActorTableData().num_restarts(), 1);
+  ASSERT_EQ(actor->GetActorTableData().num_restarts_due_to_lineage_reconstruction(), 1);
+
+  // Test the case where the RestartActor rpc is replied but the reply is lost
+  // and the caller resends the same request. The second RestartActor rpc should
+  // be directly replied without triggering another restart of the actor.
+  auto reply = RestartActor(actor->GetActorID(),
+                            /*num_restarts_due_to_lineage_reconstruction=*/1);
+  ASSERT_EQ(reply.status().code(), static_cast<int>(StatusCode::OK));
+  // Make sure the actor is not restarted again.
+  ASSERT_EQ(actor->GetState(), rpc::ActorTableData::ALIVE);
+  ASSERT_EQ(actor->GetActorTableData().num_restarts(), 1);
+  ASSERT_EQ(actor->GetActorTableData().num_restarts_due_to_lineage_reconstruction(), 1);
 }
 
 TEST_F(GcsActorManagerTest, TestDestroyActorWhenActorIsCreating) {

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -180,7 +180,8 @@ message ReportActorOutOfScopeReply {
 service ActorInfoGcsService {
   // Register actor to gcs service.
   rpc RegisterActor(RegisterActorRequest) returns (RegisterActorReply);
-  rpc RestartActorForLineageReconstruction(RestartActorForLineageReconstructionRequest) returns (RestartActorForLineageReconstructionReply);
+  rpc RestartActorForLineageReconstruction(RestartActorForLineageReconstructionRequest)
+      returns (RestartActorForLineageReconstructionReply);
   // Create actor which local dependencies are resolved.
   rpc CreateActor(CreateActorRequest) returns (CreateActorReply);
   // Get actor data from GCS Service by actor id.

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -400,8 +400,9 @@ message RegisterActorReply {
 
 message RestartActorRequest {
   bytes actor_id = 1;
-  // The target number of restarts.
-  uint64 num_restarts = 2;
+  // The target number of restarts due to lineage reconstructions.
+  // This is used to filter out stale message.
+  uint64 num_restarts_due_to_lineage_reconstruction = 2;
 }
 
 message RestartActorReply {

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -180,7 +180,7 @@ message ReportActorOutOfScopeReply {
 service ActorInfoGcsService {
   // Register actor to gcs service.
   rpc RegisterActor(RegisterActorRequest) returns (RegisterActorReply);
-  rpc RestartActor(RestartActorRequest) returns (RestartActorReply);
+  rpc RestartActorForLineageReconstruction(RestartActorForLineageReconstructionRequest) returns (RestartActorForLineageReconstructionReply);
   // Create actor which local dependencies are resolved.
   rpc CreateActor(CreateActorRequest) returns (CreateActorReply);
   // Get actor data from GCS Service by actor id.
@@ -398,14 +398,14 @@ message RegisterActorReply {
   GcsStatus status = 1;
 }
 
-message RestartActorRequest {
+message RestartActorForLineageReconstructionRequest {
   bytes actor_id = 1;
   // The target number of restarts due to lineage reconstructions.
   // This is used to filter out stale message.
   uint64 num_restarts_due_to_lineage_reconstruction = 2;
 }
 
-message RestartActorReply {
+message RestartActorForLineageReconstructionReply {
   GcsStatus status = 1;
 }
 

--- a/src/ray/rpc/gcs_server/gcs_rpc_client.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_client.h
@@ -284,7 +284,7 @@ class GcsRpcClient {
                              /*method_timeout_ms*/ -1, )
 
   VOID_GCS_RPC_CLIENT_METHOD(ActorInfoGcsService,
-                             RestartActor,
+                             RestartActorForLineageReconstruction,
                              actor_info_grpc_client_,
                              /*method_timeout_ms*/ -1, )
 

--- a/src/ray/rpc/gcs_server/gcs_rpc_server.h
+++ b/src/ray/rpc/gcs_server/gcs_rpc_server.h
@@ -229,9 +229,10 @@ class ActorInfoGcsServiceHandler {
                                    RegisterActorReply *reply,
                                    SendReplyCallback send_reply_callback) = 0;
 
-  virtual void HandleRestartActor(RestartActorRequest request,
-                                  RestartActorReply *reply,
-                                  SendReplyCallback send_reply_callback) = 0;
+  virtual void HandleRestartActorForLineageReconstruction(
+      RestartActorForLineageReconstructionRequest request,
+      RestartActorForLineageReconstructionReply *reply,
+      SendReplyCallback send_reply_callback) = 0;
 
   virtual void HandleCreateActor(CreateActorRequest request,
                                  CreateActorReply *reply,
@@ -282,7 +283,7 @@ class ActorInfoGrpcService : public GrpcService {
     /// Register/Create Actor RPC takes long time, we shouldn't limit them to avoid
     /// distributed deadlock.
     ACTOR_INFO_SERVICE_RPC_HANDLER(RegisterActor, -1);
-    ACTOR_INFO_SERVICE_RPC_HANDLER(RestartActor, -1);
+    ACTOR_INFO_SERVICE_RPC_HANDLER(RestartActorForLineageReconstruction, -1);
     ACTOR_INFO_SERVICE_RPC_HANDLER(CreateActor, -1);
 
     /// Others need back pressure.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

To make `RestartActor` rpc idempotent for transient network error retries, we have an idempotency token in the `RestartActorRequest` which is supposed to be `num_restarts_due_to_lineage_reconstruction` but mistakenly used `num_restarts`, the consequence is that a valid RestartActor rpc is treated as stale and be ignored. Sequence of events that can cause issues are:

1. A actor is initially created (`num_restarts` = 0, `num_restarts_due_to_lineage_reconstruction` = 0)
2. Actor is restarted due to worker process crash and GCS restarted it (`num_restarts` = 1, `num_restarts_due_to_lineage_reconstruction` = 0)
3. Actor goes out of scope and becomes DEAD (`num_restarts` = 1, `num_restarts_due_to_lineage_reconstruction` = 0)
4. Actor needs to be restarted due to linage reconstruction and the RestartActorRequest has `num_restarts` set to 1 (should be `num_restarts_due_to_lineage_reconstruction` set to 1). One thing to note is that the caller passes in the right value (i.e. `num_restarts_due_to_lineage_reconstruction` but we treated it as `num_restarts` which is wrong) https://github.com/ray-project/ray/blob/8b3d977d09c5b3716852d5f45cac26861a1cc6dd/src/ray/core_worker/transport/actor_task_submitter.cc#L351
5. In `GcsActorManager::HandleRestartActor`, we compared `num_restarts` in `RestartActorRequest` and `num_restarts` of the actor and they are the same so we thought this is stale message and ignored.  Instead, we should compare `num_restarts_due_to_lineage_reconstruction` in `RestartActorRequest` and `num_restarts_due_to_lineage_reconstruction` of the actor (1 vs 0) and proceed with the actual restart.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
