### PR TITLE
[core] Deflake `test_reference_counting.py`

### DIFF
--- a/python/ray/tests/test_reference_counting.py
+++ b/python/ray/tests/test_reference_counting.py
@@ -241,7 +241,9 @@ def test_pending_task_dependency_pinning(one_cpu_100MiB_shared, check_refcounts_
 # and should be evicted after it returns.
 @pytest.mark.parametrize("use_ray_put", [False, True])
 @pytest.mark.parametrize("failure", [False, True])
-def test_basic_serialized_reference(one_cpu_100MiB_shared, use_ray_put, failure, check_refcounts_empty):
+def test_basic_serialized_reference(
+    one_cpu_100MiB_shared, use_ray_put, failure, check_refcounts_empty
+):
     @ray.remote(max_retries=0)
     def pending(ref, dep):
         ray.get(ref[0])
@@ -277,7 +279,9 @@ def test_basic_serialized_reference(one_cpu_100MiB_shared, use_ray_put, failure,
 @pytest.mark.parametrize(
     "use_ray_put,failure", [(False, False), (False, True), (True, False), (True, True)]
 )
-def test_recursive_serialized_reference(one_cpu_100MiB_shared, use_ray_put, failure, check_refcounts_empty):
+def test_recursive_serialized_reference(
+    one_cpu_100MiB_shared, use_ray_put, failure, check_refcounts_empty
+):
     @ray.remote(max_retries=1)
     def recursive(ref, signal, max_depth, depth=0):
         ray.get(ref[0])
@@ -448,7 +452,9 @@ def test_basic_nested_ids(one_cpu_100MiB_shared, check_refcounts_empty):
 
 # Test that a reference borrowed by an actor constructor is freed if the actor is
 # cancelled before being scheduled.
-def test_actor_constructor_borrow_cancellation(one_cpu_100MiB_shared, check_refcounts_empty):
+def test_actor_constructor_borrow_cancellation(
+    one_cpu_100MiB_shared, check_refcounts_empty
+):
     # Schedule the actor with a non-existent resource so it's guaranteed to never be
     # scheduled.
     @ray.remote(resources={"nonexistent_resource": 1})

--- a/python/ray/tests/test_reference_counting.py
+++ b/python/ray/tests/test_reference_counting.py
@@ -241,9 +241,7 @@ def test_pending_task_dependency_pinning(one_cpu_100MiB_shared):
 # and should be evicted after it returns.
 @pytest.mark.parametrize("use_ray_put", [False, True])
 @pytest.mark.parametrize("failure", [False, True])
-def test_basic_serialized_reference(
-    one_cpu_100MiB_shared, use_ray_put, failure
-):
+def test_basic_serialized_reference(one_cpu_100MiB_shared, use_ray_put, failure):
     @ray.remote(max_retries=0)
     def pending(ref, dep):
         ray.get(ref[0])
@@ -279,9 +277,7 @@ def test_basic_serialized_reference(
 @pytest.mark.parametrize(
     "use_ray_put,failure", [(False, False), (False, True), (True, False), (True, True)]
 )
-def test_recursive_serialized_reference(
-    one_cpu_100MiB_shared, use_ray_put, failure
-):
+def test_recursive_serialized_reference(one_cpu_100MiB_shared, use_ray_put, failure):
     @ray.remote(max_retries=1)
     def recursive(ref, signal, max_depth, depth=0):
         ray.get(ref[0])
@@ -452,9 +448,7 @@ def test_basic_nested_ids(one_cpu_100MiB_shared):
 
 # Test that a reference borrowed by an actor constructor is freed if the actor is
 # cancelled before being scheduled.
-def test_actor_constructor_borrow_cancellation(
-    one_cpu_100MiB_shared
-):
+def test_actor_constructor_borrow_cancellation(one_cpu_100MiB_shared):
     # Schedule the actor with a non-existent resource so it's guaranteed to never be
     # scheduled.
     @ray.remote(resources={"nonexistent_resource": 1})


### PR DESCRIPTION
Since converting to a shared fixture, the test has been [flaking](https://buildkite.com/ray-project/postmerge/builds/10401#01970e33-da98-4806-8975-111a279ed170/177-1248) in CI.

I tracked this down to a cyclic reference in the failure condition of `test_basic_serialized_reference` that was causing a reference to be "leaked" until the garbage collector runs. I tried reproducing it outside of the `pytest` setup and was not able to, so might be a quirk related to `pytest`.

Deflaking by:

- Adding a `gc.collect()` inside the ref count checking logic.
- Adding a fixture to assert that all refs are cleared between tests to help avoid & track down future issues.

Closes https://github.com/ray-project/ray/issues/43983