### PR TITLE
[train] Log controller state transitions

### DIFF
--- a/python/ray/train/v2/_internal/callbacks/state_manager.py
+++ b/python/ray/train/v2/_internal/callbacks/state_manager.py
@@ -66,6 +66,8 @@ class StateManagerCallback(ControllerCallback, WorkerGroupCallback):
         if previous_state._state_type == current_state._state_type:
             return
 
+        logger.info(f"Changed state from {previous_state} to {current_state}")
+
         if isinstance(current_state, SchedulingState):
             # TODO: This should probably always be ResizeDecision.
             if isinstance(current_state.scaling_decision, ResizeDecision):

--- a/python/ray/train/v2/_internal/callbacks/state_manager.py
+++ b/python/ray/train/v2/_internal/callbacks/state_manager.py
@@ -66,7 +66,7 @@ class StateManagerCallback(ControllerCallback, WorkerGroupCallback):
         if previous_state._state_type == current_state._state_type:
             return
 
-        logger.info(f"Changed state from {previous_state} to {current_state}")
+        logger.info(f"[State Transition] {previous_state} -> {current_state}.")
 
         if isinstance(current_state, SchedulingState):
             # TODO: This should probably always be ResizeDecision.

--- a/python/ray/train/v2/_internal/callbacks/state_manager.py
+++ b/python/ray/train/v2/_internal/callbacks/state_manager.py
@@ -66,7 +66,10 @@ class StateManagerCallback(ControllerCallback, WorkerGroupCallback):
         if previous_state._state_type == current_state._state_type:
             return
 
-        logger.info(f"[State Transition] {previous_state} -> {current_state}.")
+        logger.info(
+            f"[State Transition] {previous_state._state_type.state_name} -> "
+            f"{current_state._state_type.state_name}."
+        )
 
         if isinstance(current_state, SchedulingState):
             # TODO: This should probably always be ResizeDecision.

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -194,7 +194,7 @@ class TrainController:
         self,
         failure_decision: FailureDecision,
         worker_group_status: WorkerGroupPollStatus,
-    ) -> TrainControllerState:
+    ) -> TrainControllerLoopIterationResult:
         """Executes failure handling decisions (ex: restart, terminate)."""
         assert worker_group_status.errors
 


### PR DESCRIPTION
Ran `pytest python/ray/train/v2/tests/test_state.py -v -s` which produced 

```
...
python/ray/train/v2/tests/test_state.py::test_callback_controller_state_transitions 2025-05-28 11:54:30,140	INFO worker.py:1906 -- Started a local Ray instance. View the dashboard at http://127.0.0.1:8265 
2025-05-28 11:54:30,591	INFO state_manager.py:69 -- [State Transition] INITIALIZING -> SCHEDULING.
2025-05-28 11:54:30,906	INFO state_manager.py:69 -- [State Transition] SCHEDULING -> RUNNING.
2025-05-28 11:54:30,907	INFO state_manager.py:69 -- [State Transition] RUNNING -> RESTARTING.
2025-05-28 11:54:30,908	INFO state_manager.py:69 -- [State Transition] RESTARTING -> SCHEDULING.
2025-05-28 11:54:30,908	INFO state_manager.py:69 -- [State Transition] SCHEDULING -> RUNNING.
2025-05-28 11:54:30,909	INFO state_manager.py:69 -- [State Transition] RUNNING -> RESIZING.
2025-05-28 11:54:30,909	INFO state_manager.py:69 -- [State Transition] RESIZING -> SCHEDULING.
2025-05-28 11:54:30,910	INFO state_manager.py:69 -- [State Transition] SCHEDULING -> RESCHEDULING.
2025-05-28 11:54:30,910	INFO state_manager.py:69 -- [State Transition] RESCHEDULING -> SCHEDULING.
2025-05-28 11:54:30,910	INFO state_manager.py:69 -- [State Transition] SCHEDULING -> RUNNING.
2025-05-28 11:54:30,911	INFO state_manager.py:69 -- [State Transition] RUNNING -> FINISHED.
PASSED
...
```