### PR TITLE
[core][telemetry] set RAY_experimental_enable_open_telemetry_on_agent to False

### DIFF
--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -589,5 +589,5 @@ RAY_METRIC_CARDINALITY_LEVEL = os.environ.get("RAY_metric_cardinality_level", "l
 # component. This flag is only used during the migration of the  metric collection
 # backend from OpenCensus to OpenTelemetry. It will be removed in the future.
 RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_AGENT = env_bool(
-    "RAY_experimental_enable_open_telemetry_on_agent", True
+    "RAY_experimental_enable_open_telemetry_on_agent", False
 )

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -543,7 +543,7 @@ RAY_CONFIG(std::string, metric_cardinality_level, "legacy")
 /// Whether enable OpenTelemetry as the metrics collection backend on the driver
 /// component. This flag is only used during the migration of the  metric collection
 /// backend from OpenCensus to OpenTelemetry. It will be removed in the future.
-RAY_CONFIG(bool, experimental_enable_open_telemetry_on_agent, true)
+RAY_CONFIG(bool, experimental_enable_open_telemetry_on_agent, false)
 
 /// Comma separated list of components we enable grpc metrics collection for.
 /// Only effective if `enable_metrics_collection` is also true. Will have some performance


### PR DESCRIPTION
A previous PR (https://github.com/ray-project/ray/pull/53098) implements migrates dashboard agent to export metrics via open telemetry, and set the feature to turn on by default. That was useful for testing but let's set it to False by default and slow roll this through the anyscale platform.

Test:
- CI