### PR TITLE
[Serve.llm] Add test to guard against upstream StatLogger changes

### DIFF
--- a/python/ray/llm/tests/serve/gpu/deployments/llm/test_engine_metrics.py
+++ b/python/ray/llm/tests/serve/gpu/deployments/llm/test_engine_metrics.py
@@ -1,0 +1,48 @@
+import pytest
+import sys
+import os
+
+from ray.llm._internal.serve.deployments.llm.vllm.vllm_loggers import (
+    RayPrometheusStatLogger,
+)
+from ray.llm._internal.utils import try_import
+from vllm import AsyncEngineArgs
+
+from vllm.v1.engine.async_llm import AsyncLLM
+from vllm.sampling_params import SamplingParams
+
+
+vllm = try_import("vllm")
+
+
+@pytest.mark.asyncio
+async def test_engine_metrics():
+    """
+    Test that the stat logger can be created successfully.
+    """
+
+    # Set VLLM_USE_V1 to 1 to use V1 APIs
+    os.environ["VLLM_USE_V1"] = "1"
+    engine_args = AsyncEngineArgs(
+        model="unsloth/Llama-3.2-1B-Instruct",
+        dtype="auto",
+        disable_log_stats=False,
+    )
+
+    engine = AsyncLLM.from_engine_args(
+        engine_args, stat_loggers=[RayPrometheusStatLogger]
+    )
+
+    for i, prompt in enumerate(["What is the capital of France?", "What is 2+2?"]):
+        results = engine.generate(
+            request_id=f"request-id-{i}",
+            prompt=prompt,
+            sampling_params=SamplingParams(max_tokens=10),
+        )
+
+        async for _ in results:
+            pass
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/release/llm_tests/serve/test_llm_serve_integration.py
+++ b/release/llm_tests/serve/test_llm_serve_integration.py
@@ -1,30 +1,25 @@
 import pytest
 import sys
-import os
 
 from ray.llm._internal.serve.deployments.llm.vllm.vllm_loggers import (
     RayPrometheusStatLogger,
 )
-from ray.llm._internal.utils import try_import
 from vllm import AsyncEngineArgs
 
 from vllm.v1.engine.async_llm import AsyncLLM
 from vllm.sampling_params import SamplingParams
 
 
-vllm = try_import("vllm")
-
-
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope="function")
 async def test_engine_metrics():
     """
     Test that the stat logger can be created successfully.
+    Keeping this test small to focus on instantiating the
+    derived class correctly.
     """
 
-    # Set VLLM_USE_V1 to 1 to use V1 APIs
-    os.environ["VLLM_USE_V1"] = "1"
     engine_args = AsyncEngineArgs(
-        model="unsloth/Llama-3.2-1B-Instruct",
+        model="Qwen/Qwen2.5-0.5B-Instruct",
         dtype="auto",
         disable_log_stats=False,
     )

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4260,6 +4260,27 @@
     long_running: false
     script: pytest -vs test_llm_serve_correctness.py
 
+- name: llm_serve_integration
+  frequency: nightly
+  python: "3.11"
+  group: llm-serve
+  team: llm
+  working_dir: llm_tests/serve
+
+  cluster:
+    byod:
+      type: llm-cu124
+      runtime_env:
+        - VLLM_USE_V1=1
+    cluster_compute: llm_g5-4xlarge.yaml
+    # NOTE: Important for getting the correct secrets
+    cloud_id: cld_wy5a6nhazplvu32526ams61d98
+    project_id: prj_lhlrf1u5yv8qz9qg3xzw8fkiiq
+  run:
+    timeout: 3600
+    long_running: false
+    script: pytest -vs test_llm_serve_integration.py
+
 
 ##############
 # LLM Batch


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
RayPrometheusStatLogger inherits from StatLoggerBase in vLLM. We need to make sure this code path is exercised to ensure our implementation stays compliant with vLLM's abstract base class.

This is needed until vLLM 0.9.0, when we will switch to the implementation which landed in https://github.com/vllm-project/vllm/pull/17925.

## Related issue number

Guard against issue #53335, close [LLM-1969](https://anyscale1.atlassian.net/browse/LLM-1969?atlOrigin=eyJpIjoiMDQ1ZmQ1N2RmOGQyNDY5ZGI0NmRlMDM2YWM3OTQxOWMiLCJwIjoiaiJ9)

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
