### PR TITLE
[serve.llm] LLMRouter.check_health() should check LLMServer.check_health()

### DIFF
--- a/python/ray/llm/_internal/serve/deployments/routers/router.py
+++ b/python/ray/llm/_internal/serve/deployments/routers/router.py
@@ -232,10 +232,12 @@ class LLMRouter:
 
     async def check_health(self):
         await self._init_completed.wait()
-        await asyncio.gather(*[
-            handle.check_health.remote()
-            for handle in self._default_serve_handles.values()
-        ])
+        await asyncio.gather(
+            *[
+                handle.check_health.remote()
+                for handle in self._default_serve_handles.values()
+            ]
+        )
 
     def _get_configured_serve_handle(self, model_id: str):
         """Gets a ServeHandle to a model deployment.

--- a/python/ray/llm/_internal/serve/deployments/routers/router.py
+++ b/python/ray/llm/_internal/serve/deployments/routers/router.py
@@ -232,6 +232,10 @@ class LLMRouter:
 
     async def check_health(self):
         await self._init_completed.wait()
+        await asyncio.gather(*[
+            handle.check_health.remote()
+            for handle in self._default_serve_handles.values()
+        ])
 
     def _get_configured_serve_handle(self, model_id: str):
         """Gets a ServeHandle to a model deployment.

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_router.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_router.py
@@ -173,5 +173,6 @@ class TestRouter:
 
         assert server.check_health.remote.call_count == 1
 
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_router.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_router.py
@@ -1,3 +1,4 @@
+from unittest.mock import AsyncMock, MagicMock
 import pytest
 import sys
 
@@ -15,6 +16,10 @@ from ray.llm._internal.serve.deployments.llm.llm_server import LLMServer
 from ray.llm.tests.serve.mocks.mock_vllm_engine import MockVLLMEngine
 from ray import serve
 import openai
+
+from logging import getLogger
+
+logger = getLogger(__name__)
 
 
 @pytest.fixture(name="llm_config")
@@ -46,6 +51,8 @@ def create_router(llm_config: LLMConfig):
     serve.run(router)
 
     client = openai.Client(base_url="http://localhost:8000/v1", api_key="foo")
+    client._router = router
+    client._server_handles = [server]
     yield client
 
     serve.shutdown()
@@ -156,6 +163,21 @@ class TestRouter:
         assert autoscaling_config.initial_replicas == 5
         assert autoscaling_config.max_replicas == 5
 
+    @pytest.mark.asyncio
+    async def test_check_health(self, llm_config: LLMConfig):
+        """Test health check functionality."""
+
+        server = MagicMock()
+        server.llm_config = MagicMock()
+        server.llm_config.remote = AsyncMock(return_value=llm_config)
+        server.check_health = MagicMock()
+        server.check_health.remote = AsyncMock()
+
+        router = LLMRouter(llm_deployments=[server])
+
+        await router.check_health()
+
+        assert server.check_health.remote.call_count == 1
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_router.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_router.py
@@ -17,10 +17,6 @@ from ray.llm.tests.serve.mocks.mock_vllm_engine import MockVLLMEngine
 from ray import serve
 import openai
 
-from logging import getLogger
-
-logger = getLogger(__name__)
-
 
 @pytest.fixture(name="llm_config")
 def create_llm_config(stream_batching_interval_ms: Optional[int] = None):
@@ -51,8 +47,6 @@ def create_router(llm_config: LLMConfig):
     serve.run(router)
 
     client = openai.Client(base_url="http://localhost:8000/v1", api_key="foo")
-    client._router = router
-    client._server_handles = [server]
     yield client
 
     serve.shutdown()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Before this PR, router may report healthy before llm is ready.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
