### PR TITLE
[ci] migrate all copy_files call into bazel run

### DIFF
--- a/ci/build/upload_build_info.sh
+++ b/ci/build/upload_build_info.sh
@@ -31,6 +31,4 @@ mkdir -p "$BAZEL_LOG_DIR"
 
 ./ci/build/get_build_info.py > "$BAZEL_LOG_DIR"/metadata.json
 
-pip install -U --ignore-installed -c "${RAY_DIR}/python/requirements_compiled.txt" \
-  aws_requests_auth requests
-python .buildkite/copy_files.py --destination logs --path "$BAZEL_LOG_DIR"
+ bazel run .buildkite:copy_files -- --destination logs --path "$BAZEL_LOG_DIR"

--- a/ci/ray_ci/macos/macos_ci_build.sh
+++ b/ci/ray_ci/macos/macos_ci_build.sh
@@ -18,7 +18,7 @@ build_x86_64() {
   # Cleanup environments
   rm -rf /tmp/bazel_event_logs
   # shellcheck disable=SC2317
-  cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }
+  cleanup() { if [[ "${BUILDKITE_PULL_REQUEST}" = "false" ]]; then ./ci/build/upload_build_info.sh; fi }
   trap cleanup EXIT
   (which bazel && bazel clean) || true
   # TODO(simon): make sure to change both PR and wheel builds
@@ -43,21 +43,20 @@ build_x86_64() {
   bash ./java/build-jar-multiplatform.sh darwin
   # Upload the wheels and jars
   # We don't want to push on PRs, in fact, the copy_files will fail because unauthenticated.
-  if [ "$BUILDKITE_PULL_REQUEST" != "false" ]; then exit 0; fi
-  pip install -q docker aws_requests_auth boto3
+  if [[ "$BUILDKITE_PULL_REQUEST" != "false" ]]; then exit 0; fi
   # Upload to branch directory.
-  python .buildkite/copy_files.py --destination branch_wheels --path ./.whl
-  python .buildkite/copy_files.py --destination branch_jars --path ./.jar/darwin
+  bazel run .buildkite:copy_files -- --destination branch_wheels --path ./.whl
+  bazel run .buildkite:copy_files -- --destination branch_jars --path ./.jar/darwin
   # Upload to latest directory.
-  if [ "$BUILDKITE_BRANCH" = "master" ]; then python .buildkite/copy_files.py --destination wheels --path ./.whl; fi
-  if [ "$BUILDKITE_BRANCH" = "master" ]; then python .buildkite/copy_files.py --destination jars --path ./.jar/darwin; fi
+  if [[ "$BUILDKITE_BRANCH" = "master" ]]; then bazel run .buildkite:copy_files -- --destination wheels --path ./.whl; fi
+  if [[ "$BUILDKITE_BRANCH" = "master" ]]; then bazel run .buildkite:copy_files -- --destination jars --path ./.jar/darwin; fi
 }
 
 build_aarch64() {
   # Cleanup environments
   rm -rf /tmp/bazel_event_logs
   # shellcheck disable=SC2317
-  cleanup() { if [ "${BUILDKITE_PULL_REQUEST}" = "false" ]; then ./ci/build/upload_build_info.sh; fi }
+  cleanup() { if [[ "${BUILDKITE_PULL_REQUEST}" = "false" ]]; then ./ci/build/upload_build_info.sh; fi }
   trap cleanup EXIT
   (which bazel && bazel clean) || true
   brew install pkg-config nvm node || true
@@ -84,14 +83,13 @@ build_aarch64() {
   bash ./java/build-jar-multiplatform.sh darwin
   # Upload the wheels and jars
   # We don't want to push on PRs, in fact, the copy_files will fail because unauthenticated.
-  if [ "$BUILDKITE_PULL_REQUEST" != "false" ]; then exit 0; fi
-  python -m pip install -q docker aws_requests_auth boto3
+  if [[ "$BUILDKITE_PULL_REQUEST" != "false" ]]; then exit 0; fi
   # Upload to branch directory.
-  python .buildkite/copy_files.py --destination branch_wheels --path ./.whl
-  python .buildkite/copy_files.py --destination branch_jars --path ./.jar/darwin
+  bazel run .buildkite:copy_files -- --destination branch_wheels --path ./.whl
+  bazel run .buildkite:copy_files -- --destination branch_jars --path ./.jar/darwin
   # Upload to latest directory.
-  if [ "$BUILDKITE_BRANCH" = "master" ]; then python .buildkite/copy_files.py --destination wheels --path ./.whl; fi
-  if [ "$BUILDKITE_BRANCH" = "master" ]; then python .buildkite/copy_files.py --destination jars --path ./.jar/darwin; fi
+  if [[ "$BUILDKITE_BRANCH" = "master" ]]; then bazel run .buildkite:copy_files -- --destination wheels --path ./.whl; fi
+  if [[ "$BUILDKITE_BRANCH" = "master" ]]; then bazel run .buildkite:copy_files -- --destination jars --path ./.jar/darwin; fi
 }
 
 "$@"

--- a/ci/ray_ci/ray_docker_container.py
+++ b/ci/ray_ci/ray_docker_container.py
@@ -46,8 +46,7 @@ class RayDockerContainer(DockerContainer):
         ]
         if self._should_upload():
             cmds += [
-                "pip install -q aws_requests_auth requests",
-                "python .buildkite/copy_files.py --destination docker_login",
+                "bazel run .buildkite:copy_files -- --destination docker_login",
             ]
             for alias in self._get_image_names():
                 cmds += [

--- a/ci/ray_ci/test_ray_docker_container.py
+++ b/ci/ray_ci/test_ray_docker_container.py
@@ -108,7 +108,7 @@ class TestRayDockerContainer(RayCITestBase):
             cuda = "cu12.1.1-cudnn8"
             container = RayDockerContainer(v, cuda, "ray")
             container.run()
-            assert len(self.cmds) == 19
+            assert len(self.cmds) == 18
             assert self.cmds[0] == (
                 "./ci/build/build-ray-docker.sh "
                 f"ray-{RAY_VERSION}-{cv}-{cv}-manylinux2014_x86_64.whl "
@@ -117,14 +117,13 @@ class TestRayDockerContainer(RayCITestBase):
                 f"rayproject/ray:{sha}-{pv}-cu121 "
                 f"ray:{sha}-{pv}-cu121_pip-freeze.txt"
             )
-            assert self.cmds[1] == "pip install -q aws_requests_auth requests"
             assert (
-                self.cmds[2]
-                == "python .buildkite/copy_files.py --destination docker_login"
+                self.cmds[1]
+                == "bazel run .buildkite:copy_files -- --destination docker_login"
             )
-            for i in range(3, 11):  # check nightly.date.sha alias
+            for i in range(2, 10):  # check nightly.date.sha alias
                 assert f"/ray:nightly.{formatted_date}.{sha}" in self.cmds[i]
-            for i in range(11, len(self.cmds)):  # check nightly alias
+            for i in range(10, len(self.cmds)):  # check nightly alias
                 assert "/ray:nightly-" in self.cmds[i]
 
             # Run with specific python version and ray-llm image
@@ -135,7 +134,7 @@ class TestRayDockerContainer(RayCITestBase):
             cuda = "cu12.4.1-cudnn"
             container = RayDockerContainer(v, cuda, "ray-llm")
             container.run()
-            assert len(self.cmds) == 7
+            assert len(self.cmds) == 6
             assert self.cmds[0] == (
                 "./ci/build/build-ray-docker.sh "
                 f"ray-{RAY_VERSION}-{cv}-{cv}-manylinux2014_x86_64.whl "
@@ -144,14 +143,13 @@ class TestRayDockerContainer(RayCITestBase):
                 f"rayproject/ray-llm:{sha}-{pv}-cu124 "
                 f"ray-llm:{sha}-{pv}-cu124_pip-freeze.txt"
             )
-            assert self.cmds[1] == "pip install -q aws_requests_auth requests"
             assert (
-                self.cmds[2]
-                == "python .buildkite/copy_files.py --destination docker_login"
+                self.cmds[1]
+                == "bazel run .buildkite:copy_files -- --destination docker_login"
             )
-            for i in range(3, 5):  # check nightly.date.sha alias
+            for i in range(2, 4):  # check nightly.date.sha alias
                 assert f"/ray-llm:nightly.{formatted_date}.{sha}" in self.cmds[i]
-            for i in range(5, len(self.cmds)):  # check nightly alias
+            for i in range(4, len(self.cmds)):  # check nightly alias
                 assert "/ray-llm:nightly-" in self.cmds[i]
 
             # Run with non-default python version and ray-ml image
@@ -161,7 +159,7 @@ class TestRayDockerContainer(RayCITestBase):
             pv = self.get_python_version(v)
             container = RayDockerContainer(v, "cpu", "ray-ml")
             container.run()
-            assert len(self.cmds) == 7
+            assert len(self.cmds) == 6
             assert self.cmds[0] == (
                 "./ci/build/build-ray-docker.sh "
                 f"ray-{RAY_VERSION}-{cv}-{cv}-manylinux2014_x86_64.whl "
@@ -170,14 +168,13 @@ class TestRayDockerContainer(RayCITestBase):
                 f"rayproject/ray-ml:{sha}-{pv}-cpu "
                 f"ray-ml:{sha}-{pv}-cpu_pip-freeze.txt"
             )
-            assert self.cmds[1] == "pip install -q aws_requests_auth requests"
             assert (
-                self.cmds[2]
-                == "python .buildkite/copy_files.py --destination docker_login"
+                self.cmds[1]
+                == "bazel run .buildkite:copy_files -- --destination docker_login"
             )
-            for i in range(3, 5):  # check nightly.date.sha alias
+            for i in range(2, 4):  # check nightly.date.sha alias
                 assert f"/ray-ml:nightly.{formatted_date}.{sha}" in self.cmds[i]
-            for i in range(5, len(self.cmds)):  # check nightly alias
+            for i in range(4, len(self.cmds)):  # check nightly alias
                 assert "/ray-ml:nightly-" in self.cmds[i]
 
     def test_run_daytime(self) -> None:


### PR DESCRIPTION
on all platforms. this uses hermetic python and avoids the need to install dependencies
