### PR TITLE
[ci] Run flaky tests once per build (down from twice)

### DIFF
--- a/ci/ray_ci/tester_container.py
+++ b/ci/ray_ci/tester_container.py
@@ -16,7 +16,8 @@ from ray_release.test_automation.ci_state_machine import CITestStateMachine
 from ray_release.configs.global_config import get_global_config
 
 
-RUN_PER_FLAKY_TEST = 2
+# We will run each flaky test this number of times per CI job independent of pass/fail.
+RUN_PER_FLAKY_TEST = 1
 
 
 class TesterContainer(Container):


### PR DESCRIPTION
We currently have many flaky tests, especially on Windows. This causes the builds to be extremely long and sometimes time out.

This change reduces the number of baseline runs per CI job from 1 to 2. This should ~halve the run time for this build at the cost of it taking two CI jobs instead of one to promote a test out of flaky status.