### PR TITLE
[ci] Fix `test_ray_init.py` on Windows

### DIFF
--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -361,6 +361,7 @@ def runtime_env_working_dir():
 @pytest.fixture
 def py_module_whl():
     f = tempfile.NamedTemporaryFile(suffix=".whl", delete=False)
+    f.close()
     yield f.name
     os.unlink(f.name)
 

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -360,8 +360,9 @@ def runtime_env_working_dir():
 
 @pytest.fixture
 def py_module_whl():
-    with tempfile.NamedTemporaryFile(suffix=".whl") as tmp_file:
-        yield tmp_file.name
+    f = tempfile.NamedTemporaryFile(suffix=".whl", delete=False)
+    yield f.name
+    os.unlink(f.name)
 
 
 def test_ray_init_with_runtime_env_as_dict(


### PR DESCRIPTION
Test was failing due to permissions error trying to re-open file on Windows. Refactored fixture to avoid holding the file descriptor open.