### PR TITLE
[Data] Deflake `test_groupby_arrow_multi_agg`

### DIFF
--- a/python/ray/data/tests/test_all_to_all.py
+++ b/python/ray/data/tests/test_all_to_all.py
@@ -1392,15 +1392,8 @@ def test_groupby_arrow_multi_agg(
         for agg in ["sum", "min", "max", "mean", "std", "quantile"]
     }
 
-    def _round_to_14_digits(row):
-        return {
-            # NOTE: Pandas and Arrow diverge on 14th digit (due to different formula
-            #       used with diverging FP numerical stability), hence we round it up
-            k: round(v, 14)
-            for k, v in row.items()
-        }
-
-    assert _round_to_14_digits(expected_row) == _round_to_14_digits(result_row)
+    assert expected_row.keys() == result_row.keys()
+    assert all(result_row[k] == pytest.approx(expected_row[k]) for k in expected_row)
 
 
 @pytest.mark.parametrize("num_parts", [1, 30])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Follow-up to https://github.com/ray-project/ray/pull/53286.

This PR uses `pytest.approx` to prevent the test from failing due to minor floating point differences.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
