### PR TITLE
[runtime env] Fix failed to create runtime env for plugin if download package failed

### DIFF
--- a/python/ray/_private/runtime_env/plugin.py
+++ b/python/ray/_private/runtime_env/plugin.py
@@ -252,8 +252,20 @@ async def create_for_plugin_if_needed(
     for uri in uris:
         if uri not in uri_cache:
             logger.debug(f"Cache miss for URI {uri}.")
-            size_bytes = await plugin.create(uri, runtime_env, context, logger=logger)
-            uri_cache.add(uri, size_bytes, logger=logger)
+            try:
+                size_bytes = await plugin.create(
+                    uri, runtime_env, context, logger=logger
+                )
+            except Exception:
+                logger.info(
+                    "Failed to create runtime env for `%s` plugin.", plugin.name
+                )
+                size_bytes = 0
+
+            if size_bytes != 0:
+                uri_cache.add(uri, size_bytes, logger=logger)
+            else:
+                uris.remove(uri)
         else:
             logger.info(
                 f"Runtime env {plugin.name} {uri} is already installed "

--- a/python/ray/_private/runtime_env/plugin.py
+++ b/python/ray/_private/runtime_env/plugin.py
@@ -256,16 +256,17 @@ async def create_for_plugin_if_needed(
                 size_bytes = await plugin.create(
                     uri, runtime_env, context, logger=logger
                 )
-            except Exception:
+            except Exception as e:
                 logger.info(
                     "Failed to create runtime env for `%s` plugin.", plugin.name
                 )
                 size_bytes = 0
-
-            if size_bytes != 0:
-                uri_cache.add(uri, size_bytes, logger=logger)
-            else:
-                uris.remove(uri)
+                raise e
+            finally:
+                if size_bytes != 0:
+                    uri_cache.add(uri, size_bytes, logger=logger)
+                else:
+                    uris.remove(uri)
         else:
             logger.info(
                 f"Runtime env {plugin.name} {uri} is already installed "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Once the remote package download failed, user must replace a new URI and resubmit the job.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
