### PR TITLE
[data/preprocessors] Add flatten functionality to Concatenator

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1454,10 +1454,6 @@ python/ray/data/preprocessor.py
 python/ray/data/preprocessors/chain.py
     DOC103: Method `Chain.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [*preprocessors: Preprocessor]. Arguments in the docstring but not in the function signature: [preprocessors: ].
 --------------------
-python/ray/data/preprocessors/concatenator.py
-    DOC104: Method `Concatenator.__init__`: Arguments are the same in the docstring and the function signature, but are in a different order.
-    DOC105: Method `Concatenator.__init__`: Argument names match, but type hints in these args do not match: columns, output_column_name, dtype, raise_if_missing
---------------------
 python/ray/data/preprocessors/normalizer.py
     DOC107: Method `Normalizer.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
 --------------------

--- a/python/ray/data/preprocessors/concatenator.py
+++ b/python/ray/data/preprocessors/concatenator.py
@@ -56,6 +56,16 @@ class Concatenator(Preprocessor):
         >>> concatenator.transform(ds)  # doctest: +SKIP
         Dataset(num_rows=3, schema={Y: object, concat_out: TensorDtype(shape=(2,), dtype=float32)})
 
+        When ``flatten=True``, nested vectors in the columns will be flattened during concatenation:
+
+        >>> df = pd.DataFrame({"X0": [[1, 2], [3, 4]], "X1": [0.5, 0.2]})
+        >>> ds = ray.data.from_pandas(df)  # doctest: +SKIP
+        >>> concatenator = Concatenator(columns=["X0", "X1"], flatten=True)
+        >>> concatenator.transform(ds).to_pandas()  # doctest: +SKIP
+           concat_out
+        0  [1.0, 2.0, 0.5]
+        1  [3.0, 4.0, 0.2]
+
     Args:
         output_column_name: The desired name for the new column.
             Defaults to ``"concat_out"``.
@@ -66,6 +76,8 @@ class Concatenator(Preprocessor):
         raise_if_missing: If ``True``, an error is raised if any
             of the columns in ``columns`` don't exist.
             Defaults to ``False``.
+        flatten: If ``True``, nested vectors in the columns will be flattened during
+            concatenation. Defaults to ``False``.
 
     Raises:
         ValueError: if `raise_if_missing` is `True` and a column in `columns` or
@@ -80,12 +92,14 @@ class Concatenator(Preprocessor):
         output_column_name: str = "concat_out",
         dtype: Optional[np.dtype] = None,
         raise_if_missing: bool = False,
+        flatten: bool = False,
     ):
         self.columns = columns
 
         self.output_column_name = output_column_name
         self.dtype = dtype
         self.raise_if_missing = raise_if_missing
+        self.flatten = flatten
 
     def _validate(self, df: pd.DataFrame) -> None:
         missing_columns = set(self.columns) - set(df)
@@ -101,7 +115,22 @@ class Concatenator(Preprocessor):
     def _transform_pandas(self, df: pd.DataFrame):
         self._validate(df)
 
-        concatenated = df[self.columns].to_numpy(dtype=self.dtype)
+        if self.flatten:
+            concatenated = df[self.columns].to_numpy()
+            concatenated = [
+                np.concatenate(
+                    [
+                        np.atleast_1d(elem)
+                        if self.dtype is None
+                        else np.atleast_1d(elem).astype(self.dtype)
+                        for elem in row
+                    ]
+                )
+                for row in concatenated
+            ]
+        else:
+            concatenated = df[self.columns].to_numpy(dtype=self.dtype)
+
         df = df.drop(columns=self.columns)
         # Use a Pandas Series for column assignment to get more consistent
         # behavior across Pandas versions.
@@ -114,6 +143,7 @@ class Concatenator(Preprocessor):
             "columns": None,
             "dtype": None,
             "raise_if_missing": False,
+            "flatten": False,
         }
 
         non_default_arguments = []

--- a/python/ray/data/preprocessors/concatenator.py
+++ b/python/ray/data/preprocessors/concatenator.py
@@ -67,10 +67,10 @@ class Concatenator(Preprocessor):
         1  [3.0, 4.0, 0.2]
 
     Args:
-        output_column_name: The desired name for the new column.
-            Defaults to ``"concat_out"``.
         columns: A list of columns to concatenate. The provided order of the columns
              will be retained during concatenation.
+        output_column_name: The desired name for the new column.
+            Defaults to ``"concat_out"``.
         dtype: The ``dtype`` to convert the output tensors to. If unspecified,
             the ``dtype`` is determined by standard coercion rules.
         raise_if_missing: If ``True``, an error is raised if any

--- a/python/ray/data/tests/preprocessors/test_concatenator.py
+++ b/python/ray/data/tests/preprocessors/test_concatenator.py
@@ -5,7 +5,7 @@ from pandas.testing import assert_frame_equal
 
 import ray
 from ray.data.exceptions import UserCodeException
-from ray.data.preprocessors import Concatenator
+from ray.data.preprocessors import Concatenator, OneHotEncoder
 
 
 class TestConcatenator:
@@ -89,6 +89,91 @@ class TestConcatenator:
             }
         )
         assert_frame_equal(concatenated_other_df, expected_df)
+
+    @pytest.mark.parametrize("col_b", [[[2, 3], [3, 4], [4, 5], [5, 6]], [2, 3, 4, 5]])
+    @pytest.mark.parametrize("flatten", [True, False])
+    def test_flatten(self, col_b, flatten):
+        col_a = [1, 2, 3, 4]
+        col_b = [np.array(v) for v in col_b] if isinstance(col_b[0], list) else col_b
+        df = pd.DataFrame({"a": col_a, "b": col_b})
+        ds = ray.data.from_pandas(df)
+        prep = Concatenator(columns=["a", "b"], flatten=flatten)
+        new_ds = prep.transform(ds)
+
+        for i, row in enumerate(new_ds.take()):
+            if flatten or not isinstance(col_b[i], np.ndarray):
+                # When flatten=True or when col_b contains simple values
+                if isinstance(col_b[i], np.ndarray):
+                    expected = np.concatenate([np.array([col_a[i]]), col_b[i]])
+                else:
+                    expected = np.array([col_a[i], col_b[i]])
+                assert np.array_equal(row["concat_out"], expected)
+            else:
+                # When flatten=False and col_b contains numpy arrays
+                # The output should be a list containing the scalar and the array
+                assert len(row["concat_out"]) == 2
+                assert row["concat_out"][0] == col_a[i]
+                assert np.array_equal(row["concat_out"][1], col_b[i])
+
+    @pytest.mark.parametrize("flatten", [True, False])
+    def test_concatenate_with_onehotencoder(self, flatten):
+        df = pd.DataFrame(
+            {
+                "color": ["red", "green", "blue", "red"],
+                "value": [1, 2, 3, 4],
+            }
+        )
+        ds = ray.data.from_pandas(df)
+        # OneHot encode the color column
+        encoder = OneHotEncoder(columns=["color"], output_columns=["color_encoded"])
+        encoder = encoder.fit(ds)
+        encoded_ds = encoder.transform(ds)
+        # Concatenate the one-hot encoded column with the value column
+        prep = Concatenator(
+            columns=["color_encoded", "value"],
+            output_column_name="features",
+            flatten=flatten,
+        )
+        new_ds = prep.transform(encoded_ds)
+        # Get the expected one-hot vectors
+        color_map = {"blue": [1, 0, 0], "green": [0, 1, 0], "red": [0, 0, 1]}
+        for i, row in enumerate(new_ds.take()):
+            if flatten:
+                expected = color_map[df["color"][i]] + [df["value"][i]]
+                assert np.array_equal(row["features"], np.array(expected))
+            else:
+                expected = [np.array(color_map[df["color"][i]]), df["value"][i]]
+                assert np.array_equal(row["features"][0], expected[0])
+                assert row["features"][1] == expected[1]
+
+    @pytest.mark.parametrize("flatten", [True, False])
+    def test_nested_list_with_dtype(self, flatten: bool):
+        # Tests Concatenator with nested lists and dtype: flattens and coerces when flatten=True,
+        # raises ValueError when flatten=False.
+        output_column = "c"
+        df = pd.DataFrame(
+            {
+                "a": [12.0],
+                "b": [[1, 0, 0, 0]],
+            }
+        )
+        prep = Concatenator(
+            columns=["a", "b"],
+            output_column_name=output_column,
+            dtype=np.float32,
+            flatten=flatten,
+        )
+
+        if flatten:
+            pd_ds = prep._transform_pandas(df)
+            expected_pd = pd.DataFrame(
+                {output_column: pd.Series([[12.0, 1.0, 0.0, 0.0, 0.0]])}
+            )
+            assert_frame_equal(pd_ds, expected_pd)
+        else:
+            # Only for flattened output do we expect the dtype coercion to apply
+            with pytest.raises(ValueError):
+                pd_ds = prep._transform_pandas(df)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Addresses #51757 

Adds a `flatten` boolean flag to the `Concatenator` preprocessor, which will flatten interior vectors when concatenating, for example when you use a OneHotEncoder.

I added tests for basic flattening functionality, verifying flatten=True vs False, as well as a special case with dtype coercion we found when testing with our own users internally.

I used the precommit steps for linting et al - I ultimately had to ignore pydoclint due to it complaining about typehints in the doc not matching - but when I added typehints, it complained that typehints in the docs are not supported. It also generated a huge change to the doc baseline file that seemed irrelevant to the PR - let me know if I should do something about this, but it seems this pydoclint would fail even before my changes. Happy to fixup with some guidance in a follow up commit.

## Why are these changes needed?

Details in #51757 - Concatenator doesn't work as expected once we changed encoders to output vectors in a single column. This adds a feature to support the previous expectations of the output of concatenator providing a flat vectorizable output.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
