### PR TITLE
[core][telemetry/02-bis] update enable_open_telemetry flag

### DIFF
--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -592,9 +592,10 @@ RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_AGENT = env_bool(
     "RAY_experimental_enable_open_telemetry_on_agent", False
 )
 
-# Whether enable OpenTelemetry as the metrics collection backend on the worker
-# component. This flag is only used during the migration of the  metric collection
-# backend from OpenCensus to OpenTelemetry. It will be removed in the future.
-RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_CORE_WORKER = env_bool(
-    "RAY_experimental_enable_open_telemetry_on_core_worker", False
+# Whether enable OpenTelemetry as the metrics collection backend on the core worker
+# components (core workers, gcs server, raylet, etc.). This flag is only used during 
+# the migration of the  metric collection backend from OpenCensus to OpenTelemetry. 
+# It will be removed in the future.
+RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_CORE = env_bool(
+    "RAY_experimental_enable_open_telemetry_on_core", False
 )

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -593,8 +593,8 @@ RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_AGENT = env_bool(
 )
 
 # Whether enable OpenTelemetry as the metrics collection backend on the core worker
-# components (core workers, gcs server, raylet, etc.). This flag is only used during 
-# the migration of the  metric collection backend from OpenCensus to OpenTelemetry. 
+# components (core workers, gcs server, raylet, etc.). This flag is only used during
+# the migration of the  metric collection backend from OpenCensus to OpenTelemetry.
 # It will be removed in the future.
 RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_CORE = env_bool(
     "RAY_experimental_enable_open_telemetry_on_core", False

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -592,7 +592,7 @@ RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_AGENT = env_bool(
     "RAY_experimental_enable_open_telemetry_on_agent", False
 )
 
-# Whether enable OpenTelemetry as the metrics collection backend on the core worker
+# Whether enable OpenTelemetry as the metrics collection backend on the core
 # components (core workers, gcs server, raylet, etc.). This flag is only used during
 # the migration of the  metric collection backend from OpenCensus to OpenTelemetry.
 # It will be removed in the future.

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -24,7 +24,7 @@ from ray._private.metrics_agent import Gauge, MetricsAgent, Record
 from ray._private.ray_constants import (
     DEBUG_AUTOSCALING_STATUS,
     RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_AGENT,
-    RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_CORE_WORKER,
+    RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_CORE,
     env_integer,
 )
 from ray._raylet import WorkerID, GCS_PID_KEY
@@ -510,7 +510,7 @@ class ReporterAgent(
         """
         # This method suppposes to forward data to self._open_telemetry_metric_recorder
         # to record them to Prometheus. Currently, that logic is not yet implemented.
-        # Unless RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_CORE_WORKER is set to True,
+        # Unless RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_CORE is set to True,
         # this is a no-op.
         pass
 
@@ -1374,7 +1374,7 @@ class ReporterAgent(
     async def run(self, server):
         if server:
             reporter_pb2_grpc.add_ReporterServiceServicer_to_server(self, server)
-            if RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_CORE_WORKER:
+            if RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_CORE:
                 metrics_service_pb2_grpc.add_MetricsServiceServicer_to_server(
                     self, server
                 )

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -545,7 +545,7 @@ RAY_CONFIG(std::string, metric_cardinality_level, "legacy")
 /// backend from OpenCensus to OpenTelemetry. It will be removed in the future.
 RAY_CONFIG(bool, experimental_enable_open_telemetry_on_agent, false)
 
-/// Whether enable OpenTelemetry as the metrics collection backend on the core worker
+/// Whether enable OpenTelemetry as the metrics collection backend on the core
 /// components (core workers, gcs server, raylet, etc.). This flag is only used during
 /// the migration of the  metric collection backend from OpenCensus to OpenTelemetry.
 /// It will be removed in the future.

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -546,8 +546,8 @@ RAY_CONFIG(std::string, metric_cardinality_level, "legacy")
 RAY_CONFIG(bool, experimental_enable_open_telemetry_on_agent, false)
 
 /// Whether enable OpenTelemetry as the metrics collection backend on the core worker
-/// components (core workers, gcs server, raylet, etc.). This flag is only used during 
-/// the migration of the  metric collection backend from OpenCensus to OpenTelemetry. 
+/// components (core workers, gcs server, raylet, etc.). This flag is only used during
+/// the migration of the  metric collection backend from OpenCensus to OpenTelemetry.
 /// It will be removed in the future.
 RAY_CONFIG(bool, experimental_enable_open_telemetry_on_core, false)
 

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -545,10 +545,11 @@ RAY_CONFIG(std::string, metric_cardinality_level, "legacy")
 /// backend from OpenCensus to OpenTelemetry. It will be removed in the future.
 RAY_CONFIG(bool, experimental_enable_open_telemetry_on_agent, false)
 
-/// Whether enable OpenTelemetry as the metrics collection backend on the worker
-/// component. This flag is only used during the migration of the  metric collection
-/// backend from OpenCensus to OpenTelemetry. It will be removed in the future.
-RAY_CONFIG(bool, experimental_enable_open_telemetry_on_core_worker, false)
+/// Whether enable OpenTelemetry as the metrics collection backend on the core worker
+/// components (core workers, gcs server, raylet, etc.). This flag is only used during 
+/// the migration of the  metric collection backend from OpenCensus to OpenTelemetry. 
+/// It will be removed in the future.
+RAY_CONFIG(bool, experimental_enable_open_telemetry_on_core, false)
 
 /// Comma separated list of components we enable grpc metrics collection for.
 /// Only effective if `enable_metrics_collection` is also true. Will have some performance


### PR DESCRIPTION
Update the name of enable_open_telemetry flag to indicate the facts that it includes raylet, gcs server, etc. in addition to just core workers.

Test:
- CI