### PR TITLE
[serve.llm] [cleanup] Add LLMConfig.parse_from() api

### DIFF
--- a/python/ray/llm/_internal/serve/configs/server_models.py
+++ b/python/ray/llm/_internal/serve/configs/server_models.py
@@ -503,13 +503,13 @@ def _is_yaml_file(filename: str) -> bool:
     return False
 
 
-def _parse_path_args(path: str) -> List[LLMConfig]:
+def _parse_path_args(path: str) -> List["ray.serve.llm.LLMConfig"]:
     assert os.path.exists(
         path
     ), f"Could not load model from {path}, as it does not exist."
     if os.path.isfile(path):
         with open(path, "r") as f:
-            llm_config = LLMConfig.parse_yaml(f)
+            llm_config = ray.serve.llm.LLMConfig.parse_yaml(f)
             return [llm_config]
     elif os.path.isdir(path):
         apps = []
@@ -517,7 +517,7 @@ def _parse_path_args(path: str) -> List[LLMConfig]:
             for p in files:
                 if _is_yaml_file(p):
                     with open(os.path.join(root, p), "r") as f:
-                        llm_config = LLMConfig.parse_yaml(f)
+                        llm_config = ray.serve.llm.LLMConfig.parse_yaml(f)
                         apps.append(llm_config)
         return apps
     else:

--- a/python/ray/llm/_internal/serve/configs/server_models.py
+++ b/python/ray/llm/_internal/serve/configs/server_models.py
@@ -528,7 +528,7 @@ def _parse_path_args(path: str) -> List[LLMConfig]:
 
 def parse_args(
     args: Union[str, LLMConfig, Any, Sequence[Union[LLMConfig, str, Any]]],
-) -> List[LLMConfig]:
+) -> List["ray.serve.llm.LLMConfig"]:
     """Parse the input args and return a standardized list of LLMConfig objects
 
     Supported args format:
@@ -538,20 +538,21 @@ def parse_args(
     4. A dict or LLMConfig object
     5. A list of dicts or LLMConfig objects
     """
+    PublicLLMConfigCls = ray.serve.llm.LLMConfig
 
     raw_models = [args]
     if isinstance(args, list):
         raw_models = args
 
     # For each
-    models: List[LLMConfig] = []
+    models: List[PublicLLMConfigCls] = []
     for raw_model in raw_models:
         if isinstance(raw_model, str):
             if os.path.exists(raw_model):
                 parsed_models = _parse_path_args(raw_model)
             else:
                 try:
-                    llm_config = LLMConfig.parse_yaml(raw_model)
+                    llm_config = PublicLLMConfigCls.parse_yaml(raw_model)
                     parsed_models = [llm_config]
                 except pydantic.ValidationError as e:
                     raise ValueError(
@@ -561,10 +562,10 @@ def parse_args(
                     ) from e
         else:
             try:
-                llm_config = LLMConfig.model_validate(raw_model)
+                llm_config = PublicLLMConfigCls.model_validate(raw_model)
                 parsed_models = [llm_config]
             except pydantic.ValidationError:
-                parsed_models = [LLMConfig.model_validate(raw_model)]
+                parsed_models = [PublicLLMConfigCls.model_validate(raw_model)]
         models += parsed_models
 
     return models

--- a/python/ray/llm/tests/serve/cpu/configs/test_models.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_models.py
@@ -321,6 +321,18 @@ class TestPublicLLMConfig:
                 )
             )
 
+    def test_extend_config(self):
+        """Test that public users can define their own config that uses LLMConfig."""
+        class MyLLMConfig(pydantic.BaseModel):
+            llm_config: PublicLLMConfig
+
+        my_llm_config = MyLLMConfig(
+            llm_config=PublicLLMConfig.parse_from(
+                f"{CONFIG_DIRS_PATH}/matching_configs/hf_prompt_format.yaml"
+            )[0]
+        )
+        assert my_llm_config.llm_config.model_id == "mistral-community/pixtral-12b"
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/llm/tests/serve/cpu/configs/test_models.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_models.py
@@ -323,6 +323,7 @@ class TestPublicLLMConfig:
 
     def test_extend_config(self):
         """Test that public users can define their own config that uses LLMConfig."""
+
         class MyLLMConfig(pydantic.BaseModel):
             llm_config: PublicLLMConfig
 

--- a/python/ray/serve/llm/__init__.py
+++ b/python/ray/serve/llm/__init__.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, List, Sequence, Union
 
 from ray.llm._internal.serve.configs.server_models import (
     CloudMirrorConfig as _CloudMirrorConfig,
@@ -6,6 +6,7 @@ from ray.llm._internal.serve.configs.server_models import (
     LLMServingArgs as _LLMServingArgs,
     LoraConfig as _LoraConfig,
     ModelLoadingConfig as _ModelLoadingConfig,
+    parse_args as _parse_llm_configs,
 )
 from ray.llm._internal.serve.deployments.llm.llm_server import (
     LLMServer as _LLMServer,
@@ -28,7 +29,31 @@ if TYPE_CHECKING:
 class LLMConfig(_LLMConfig):
     """The configuration for starting an LLM deployment."""
 
-    pass
+    @staticmethod
+    def parse_from(
+        args: Union[str, "LLMConfig", Sequence[Union["LLMConfig", str]]]
+    ) -> List["LLMConfig"]:
+        """Parse the input args and return a standardized list of LLMConfig objects.
+
+        Supported args format:
+        1. The path to a yaml file defining your LLMConfig
+        2. A list of yaml files defining multiple LLMConfigs
+        3. A dict or LLMConfig object
+        4. A list of dicts or LLMConfig objects
+
+        Examples:
+            .. testcode::
+                :skipif: True
+
+                from ray.serve.llm import LLMConfig
+
+                # Parse a single LLMConfig from a yaml file
+                llm_configs = LLMConfig.parse_from("path/to/llm_config.yaml")
+                assert len(llm_configs) == 1
+
+                print(llm_configs[0])
+        """
+        return _parse_llm_configs(args)
 
 
 @PublicAPI(stability="alpha")

--- a/python/ray/serve/llm/__init__.py
+++ b/python/ray/serve/llm/__init__.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, List, Sequence, Union
+from typing import TYPE_CHECKING, List, Optional, Sequence, Union
 
 from ray.llm._internal.serve.configs.server_models import (
     CloudMirrorConfig as _CloudMirrorConfig,

--- a/python/ray/serve/llm/__init__.py
+++ b/python/ray/serve/llm/__init__.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Optional
 
 from ray.llm._internal.serve.configs.server_models import (
     CloudMirrorConfig as _CloudMirrorConfig,
@@ -6,7 +6,6 @@ from ray.llm._internal.serve.configs.server_models import (
     LLMServingArgs as _LLMServingArgs,
     LoraConfig as _LoraConfig,
     ModelLoadingConfig as _ModelLoadingConfig,
-    parse_args as _parse_llm_configs,
 )
 from ray.llm._internal.serve.deployments.llm.llm_server import (
     LLMServer as _LLMServer,
@@ -29,31 +28,7 @@ if TYPE_CHECKING:
 class LLMConfig(_LLMConfig):
     """The configuration for starting an LLM deployment."""
 
-    @staticmethod
-    def parse_from(
-        args: Union[str, "LLMConfig", Sequence[Union["LLMConfig", str]]]
-    ) -> List["LLMConfig"]:
-        """Parse the input args and return a standardized list of LLMConfig objects.
-
-        Supported args format:
-        1. The path to a yaml file defining your LLMConfig
-        2. A list of yaml files defining multiple LLMConfigs
-        3. A dict or LLMConfig object
-        4. A list of dicts or LLMConfig objects
-
-        Examples:
-            .. testcode::
-                :skipif: True
-
-                from ray.serve.llm import LLMConfig
-
-                # Parse a single LLMConfig from a yaml file
-                llm_configs = LLMConfig.parse_from("path/to/llm_config.yaml")
-                assert len(llm_configs) == 1
-
-                print(llm_configs[0])
-        """
-        return _parse_llm_configs(args)
+    pass
 
 
 @PublicAPI(stability="alpha")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Resolves the TODO, `prefill_decode_disagg.py` uses ray.serve.llm public API instead of internal API.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
