### PR TITLE
removing doc105 to fix pydoclint error

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1456,7 +1456,6 @@ python/ray/data/preprocessors/chain.py
 --------------------
 python/ray/data/preprocessors/concatenator.py
     DOC104: Method `Concatenator.__init__`: Arguments are the same in the docstring and the function signature, but are in a different order.
-    DOC105: Method `Concatenator.__init__`: Argument names match, but type hints in these args do not match: columns, output_column_name, dtype, raise_if_missing
 --------------------
 python/ray/data/preprocessors/normalizer.py
     DOC107: Method `Normalizer.__init__`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints


### PR DESCRIPTION
Blocking premerge ci
precommit pydoclint job failing
https://github.com/ray-project/ray/pull/53378#issuecomment-2917811018

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
