### PR TITLE
[train] fix TensorflowTrainer docstring

### DIFF
--- a/python/ray/train/tensorflow/tensorflow_trainer.py
+++ b/python/ray/train/tensorflow/tensorflow_trainer.py
@@ -88,6 +88,7 @@ class TensorflowTrainer(DataParallelTrainer):
         import os
         import tempfile
         import tensorflow as tf
+        import numpy as np
 
         import ray
         from ray import train
@@ -129,7 +130,7 @@ class TensorflowTrainer(DataParallelTrainer):
                     checkpoint=checkpoint,
                 )
 
-        train_dataset = ray.data.from_items([{"x": x, "y": x + 1} for x in range(32)])
+        train_dataset = ray.data.from_items([{"x": np.array([x], dtype=np.float32), "y": x + 1} for x in range(32)])
         trainer = TensorflowTrainer(
             train_loop_per_worker=train_loop_per_worker,
             scaling_config=ScalingConfig(num_workers=3, use_gpu=True),


### PR DESCRIPTION
Original example was originally failing sometimes with:
```
 2 root error(s) found.
   (0) INTERNAL:  Blas xGEMV launch failed : a.shape=[1,1,1], b.shape=[1,1,1], m=1, n=1, k=1
 	 [[{{node sequential/dense/MatMul}}]]
 	 [[div_no_nan/Reshape_1/_64]]
   (1) INTERNAL:  Blas xGEMV launch failed : a.shape=[1,1,1], b.shape=[1,1,1], m=1, n=1, k=1
	 [[{{node sequential/dense/MatMul}}]]
```

Seems like this was because the input batches had shape `(batch_size,)` rather than `(batch-size,1)`. Fixing this by updating the dataset to use `np.array([x], dtype=np.float32)` instead of a scalar `x`.