### PR TITLE
[core] Skip graceful shutdown test on Windows

### DIFF
--- a/python/ray/tests/test_worker_graceful_shutdown.py
+++ b/python/ray/tests/test_worker_graceful_shutdown.py
@@ -9,6 +9,7 @@ import ray
 from ray._private.test_utils import SignalActor, wait_for_condition
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't handle SIGTERM gracefully.")
 @pytest.mark.parametrize("actor_type", ["asyncio", "threaded"])
 def test_ray_get_during_graceful_shutdown(ray_start_regular_shared, actor_type: str):
     """Test that ray.get works as expected when draining tasks during shutdown.

--- a/python/ray/tests/test_worker_graceful_shutdown.py
+++ b/python/ray/tests/test_worker_graceful_shutdown.py
@@ -9,7 +9,9 @@ import ray
 from ray._private.test_utils import SignalActor, wait_for_condition
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't handle SIGTERM gracefully.")
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Windows doesn't handle SIGTERM gracefully."
+)
 @pytest.mark.parametrize("actor_type", ["asyncio", "threaded"])
 def test_ray_get_during_graceful_shutdown(ray_start_regular_shared, actor_type: str):
     """Test that ray.get works as expected when draining tasks during shutdown.


### PR DESCRIPTION
This test was added in https://github.com/ray-project/ray/pull/53002. SIGTERM is non-graceful shutdown in Windows except for the driver, so the test isn't relevant. Skip it.