### PR TITLE
[core] Skip cgroup privileged test on Windows builds

### DIFF
--- a/src/ray/common/cgroup/test/BUILD
+++ b/src/ray/common/cgroup/test/BUILD
@@ -7,6 +7,7 @@ ray_cc_test(
     tags = [
         "cgroup",
         "exclusive",
+        "no_windows",
         "team:core",
     ],
     deps = [


### PR DESCRIPTION
Failing: https://buildkite.com/ray-project/postmerge/builds/10495#019719b5-05c3-4c1e-b3d1-e5c6177a04ef/3306-3357