### PR TITLE
[core] Increase timeout for ref counting test

### DIFF
--- a/python/ray/tests/test_reference_counting_2.py
+++ b/python/ray/tests/test_reference_counting_2.py
@@ -44,7 +44,9 @@ def one_cpu_100MiB_shared():
     ray.shutdown()
 
 
-def _fill_object_store_and_get(obj, succeed=True, object_MiB=20, num_objects=5, timeout_s=10):
+def _fill_object_store_and_get(
+    obj, succeed=True, object_MiB=20, num_objects=5, timeout_s=10
+):
     for _ in range(num_objects):
         ray.put(np.zeros(object_MiB * 1024 * 1024, dtype=np.uint8))
 
@@ -58,7 +60,9 @@ def _fill_object_store_and_get(obj, succeed=True, object_MiB=20, num_objects=5, 
         )
     else:
         wait_for_condition(
-            lambda: not ray._private.worker.global_worker.core_worker.object_exists(obj),
+            lambda: not ray._private.worker.global_worker.core_worker.object_exists(
+                obj
+            ),
             timeout=timeout_s,
         )
 

--- a/python/ray/tests/test_reference_counting_2.py
+++ b/python/ray/tests/test_reference_counting_2.py
@@ -44,7 +44,7 @@ def one_cpu_100MiB_shared():
     ray.shutdown()
 
 
-def _fill_object_store_and_get(obj, succeed=True, object_MiB=20, num_objects=5):
+def _fill_object_store_and_get(obj, succeed=True, object_MiB=20, num_objects=5, timeout_s=10):
     for _ in range(num_objects):
         ray.put(np.zeros(object_MiB * 1024 * 1024, dtype=np.uint8))
 
@@ -53,11 +53,13 @@ def _fill_object_store_and_get(obj, succeed=True, object_MiB=20, num_objects=5):
 
     if succeed:
         wait_for_condition(
-            lambda: ray._private.worker.global_worker.core_worker.object_exists(obj)
+            lambda: ray._private.worker.global_worker.core_worker.object_exists(obj),
+            timeout=timeout_s,
         )
     else:
         wait_for_condition(
-            lambda: not ray._private.worker.global_worker.core_worker.object_exists(obj)
+            lambda: not ray._private.worker.global_worker.core_worker.object_exists(obj),
+            timeout=timeout_s,
         )
 
 
@@ -255,7 +257,7 @@ def test_recursively_pass_returned_object_ref(
     del outer_oid
 
     # Reference should be gone, check that returned ID gets evicted.
-    _fill_object_store_and_get(inner_oid_bytes, succeed=False)
+    _fill_object_store_and_get(inner_oid_bytes, succeed=False, timeout_s=20)
 
 
 # Call a recursive chain of tasks. The final task in the chain returns an

--- a/python/ray/tests/test_reference_counting_2.py
+++ b/python/ray/tests/test_reference_counting_2.py
@@ -11,6 +11,7 @@ import pickle
 import signal
 import sys
 import time
+from typing import Union
 
 import numpy as np
 import pytest
@@ -45,7 +46,12 @@ def one_cpu_100MiB_shared():
 
 
 def _fill_object_store_and_get(
-    obj, succeed=True, object_MiB=20, num_objects=5, timeout_s=10
+    obj: Union[ray.ObjectRef, bytes],
+    *,
+    succeed: bool = True,
+    object_MiB: float = 20,
+    num_objects: int = 5,
+    timeout_s: float = 10.0,
 ):
     for _ in range(num_objects):
         ray.put(np.zeros(object_MiB * 1024 * 1024, dtype=np.uint8))


### PR DESCRIPTION
This times out periodically on Windows: https://buildkite.com/ray-project/postmerge/builds/10493#01971949-edad-453f-bfed-2de1ac612345/1998-2167

Might just be a Windows slowness issue, so let's see. Has no effect on happy path.