### PR TITLE
[core] Bump timeout in `test_task_events_2.py`

### DIFF
--- a/python/ray/tests/test_task_events_2.py
+++ b/python/ray/tests/test_task_events_2.py
@@ -480,6 +480,7 @@ def test_fault_tolerance_nested_actors_failed(shutdown_only):
         verify_tasks_running_or_terminated,
         task_pids=ray.get(pid_actor.get_pids.remote()),
         expect_num_tasks=4,
+        timeout=30,
     )
 
 


### PR DESCRIPTION
Flaky on Windows, let's see if the timeout is too short.