### PR TITLE
Updated GitHub PR stale workflow to exclude issues entirely.

### DIFF
--- a/.github/workflows/stale_pull_request.yaml
+++ b/.github/workflows/stale_pull_request.yaml
@@ -9,9 +9,6 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     permissions:
-      # Currently we are not planning on marking issues as stale, so this permission is read only.
-      # Just gonna leave this in here in case we need it in the future.
-      issues: read
       pull-requests: write # Required to add labels, comment, close PRs.
 
     steps:
@@ -21,8 +18,9 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
           # --- Ignore Issues ---
-          # Set to -1 so we never mark issues as stale.
+          # Set to -1 so we never mark issues as stale or closed.
           days-before-issue-stale: -1
+          day-before-issue-closed: -1
 
           # --- Pull Request Specific Settings ---
           # Number of days of inactivity before a Pull Request becomes stale (currently 2 weeks)


### PR DESCRIPTION
## Why are these changes needed?

Currently, the stale actions still pulls the `issues` even though we only want it to run on PRs. Therefore, I added stricter permissions for issues stale timeouts and removed the issues permissions entirely. This way, we won't waste GA operations on issues.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
