### PR TITLE
[core] Allow custom grpc channel arguments

### DIFF
--- a/src/ray/object_manager/grpc_stub_manager.h
+++ b/src/ray/object_manager/grpc_stub_manager.h
@@ -52,6 +52,8 @@ class GrpcStubManager {
   GrpcStubManager(GrpcStubManager &&) = default;
   GrpcStubManager &operator=(GrpcStubManager &&) = default;
 
+  ~GrpcStubManager() = default;
+
   // Get a grpc client in round-robin style.
   GrpcClient<T> *GetGrpcClient() {
     absl::MutexLock lock(&client_index_mutex_);

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -106,8 +106,8 @@ class GrpcClient {
   GrpcClient(const std::string &address,
              const int port,
              ClientCallManager &call_manager,
-             grpc::ChannelArguments channel_arguments = CreateDefaultChannelArguments(),
-             bool use_tls = false)
+             bool use_tls = false,
+             grpc::ChannelArguments channel_arguments = CreateDefaultChannelArguments())
       : client_call_manager_(call_manager),
         channel_(BuildChannel(address, port, std::move(channel_arguments))),
         stub_(GrpcService::NewStub(channel_)),

--- a/src/ray/rpc/grpc_client.h
+++ b/src/ray/rpc/grpc_client.h
@@ -98,19 +98,20 @@ class GrpcClient {
   GrpcClient(std::shared_ptr<grpc::Channel> channel,
              ClientCallManager &call_manager,
              bool use_tls = false)
-      : client_call_manager_(call_manager), use_tls_(use_tls) {
-    channel_ = std::move(channel);
-    stub_ = GrpcService::NewStub(channel_);
-  }
+      : client_call_manager_(call_manager),
+        channel_(std::move(channel)),
+        stub_(GrpcService::NewStub(channel_)),
+        use_tls_(use_tls) {}
 
   GrpcClient(const std::string &address,
              const int port,
              ClientCallManager &call_manager,
+             grpc::ChannelArguments channel_arguments = CreateDefaultChannelArguments(),
              bool use_tls = false)
-      : client_call_manager_(call_manager), use_tls_(use_tls) {
-    channel_ = BuildChannel(address, port, CreateDefaultChannelArguments());
-    stub_ = GrpcService::NewStub(channel_);
-  }
+      : client_call_manager_(call_manager),
+        channel_(BuildChannel(address, port, std::move(channel_arguments))),
+        stub_(GrpcService::NewStub(channel_)),
+        use_tls_(use_tls) {}
 
   /// Create a new `ClientCall` and send request.
   ///
@@ -152,7 +153,7 @@ class GrpcClient {
           *stub_,
           prepare_async_function,
           request,
-          [callback](const Status &status, Reply &&reply) {
+          [callback](const Status &status, const Reply &) {
             callback(Status::RpcError("Unavailable", grpc::StatusCode::UNAVAILABLE),
                      Reply());
           },
@@ -186,10 +187,10 @@ class GrpcClient {
 
  private:
   ClientCallManager &client_call_manager_;
-  /// The gRPC-generated stub.
-  std::unique_ptr<typename GrpcService::Stub> stub_;
   /// The channel of the stub.
   std::shared_ptr<grpc::Channel> channel_;
+  /// The gRPC-generated stub.
+  std::unique_ptr<typename GrpcService::Stub> stub_;
   /// Whether CallMethod is invoked.
   std::atomic<bool> call_method_invoked_ = false;
   /// Whether to use TLS.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Makes things more flexible by allowing grpc clients to be created with custom channel arguments.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
