### PR TITLE
Fix torchrec release test collate function

### DIFF
--- a/release/train_tests/benchmark/image_classification/factory.py
+++ b/release/train_tests/benchmark/image_classification/factory.py
@@ -1,7 +1,7 @@
 # Standard library imports
 import logging
 import time
-from typing import Dict, Tuple, Iterator, Generator, Optional, Union, Type
+from typing import Dict, Tuple, Iterator, Generator, Optional, Union
 
 # Third-party imports
 import torch
@@ -9,7 +9,7 @@ import pyarrow
 import ray
 import ray.data
 import ray.train
-from ray.data.iterator import ArrowBatchCollateFn
+from ray.data.collate_fn import ArrowBatchCollateFn, CollateFn
 
 # Local imports
 from config import BenchmarkConfig
@@ -232,8 +232,8 @@ class ImageClassificationRayDataLoaderFactory(RayDataLoaderFactory):
     def __init__(self, benchmark_config: BenchmarkConfig):
         super().__init__(benchmark_config)
 
-    def _get_collate_fn_cls(self) -> Type[ArrowBatchCollateFn]:
-        return CustomArrowCollateFn
+    def _get_collate_fn(self) -> Optional[CollateFn]:
+        return CustomArrowCollateFn(device=ray.train.torch.get_device())
 
 
 class ImageClassificationMockDataLoaderFactory(BaseDataLoaderFactory):

--- a/release/train_tests/benchmark/recsys/criteo.py
+++ b/release/train_tests/benchmark/recsys/criteo.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Dict, List, Tuple
+from typing import TYPE_CHECKING, Dict, List, Tuple
 
 import boto3
 import json
@@ -10,6 +10,9 @@ import pyarrow.csv
 import ray.data
 
 from constants import DatasetKey
+
+if TYPE_CHECKING:
+    from torchrec.datasets.utils import Batch
 
 logger = logging.getLogger(__name__)
 
@@ -120,7 +123,7 @@ def mock_dataloader(num_batches: int, batch_size: int):
         yield batch
 
 
-def convert_to_torchrec_batch_format(batch: Dict[str, np.ndarray]):
+def convert_to_torchrec_batch_format(batch: Dict[str, np.ndarray]) -> "Batch":
     """Convert to a Batch, packaging sparse features as a KJT."""
     import torch
 


### PR DESCRIPTION
## Summary

Fixes the `RecsysRayDataLoaderFactory._get_collate_fn` method to return the new collate function callable class interface introduced by https://github.com/ray-project/ray/pull/52548.