### PR TITLE
Revert "Revert "[core][telemetry/03] add OpenTelemetryMetricRecorder c++ client""

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -965,6 +965,8 @@ pyx_library(
             ],
         }),
         linkstatic = 1,
+        # This is needed since Windows has long file path issues and command length limits
+        features = ["compiler_param_file"],
     ),
     deps = [
         "//:exported_internal",

--- a/src/ray/stats/BUILD.bazel
+++ b/src/ray/stats/BUILD.bazel
@@ -25,6 +25,7 @@ ray_cc_library(
         "//src/ray/util",
         "//src/ray/util:logging",
         "//src/ray/util:size_literals",
+        "//src/ray/telemetry:open_telemetry_metric_recorder",
         "@com_github_jupp0r_prometheus_cpp//pull",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:flat_hash_map",

--- a/src/ray/telemetry/BUILD.bazel
+++ b/src/ray/telemetry/BUILD.bazel
@@ -1,0 +1,16 @@
+load("//bazel:ray.bzl", "ray_cc_library", "ray_cc_test")
+
+ray_cc_library(
+    name = "open_telemetry_metric_recorder",
+    srcs = [
+        "open_telemetry_metric_recorder.cc",
+    ],
+    hdrs = [
+        "open_telemetry_metric_recorder.h",
+    ],
+    deps = [
+        "@io_opentelemetry_cpp//api",
+        "@io_opentelemetry_cpp//exporters/otlp:otlp_grpc_metric_exporter",
+        "@io_opentelemetry_cpp//sdk/src/metrics",
+    ],
+)

--- a/src/ray/telemetry/open_telemetry_metric_recorder.cc
+++ b/src/ray/telemetry/open_telemetry_metric_recorder.cc
@@ -1,0 +1,59 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "ray/telemetry/open_telemetry_metric_recorder.h"
+
+#include <opentelemetry/exporters/otlp/otlp_grpc_metric_exporter.h>
+#include <opentelemetry/metrics/provider.h>
+#include <opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader.h>
+#include <opentelemetry/sdk/metrics/instruments.h>
+
+#include <cassert>
+#include <chrono>
+
+namespace ray {
+namespace telemetry {
+
+OpenTelemetryMetricRecorder &OpenTelemetryMetricRecorder::GetInstance() {
+  static auto *instance = new OpenTelemetryMetricRecorder();
+  return *instance;
+}
+
+void OpenTelemetryMetricRecorder::RegisterGrpcExporter(
+    const std::string &endpoint,
+    std::chrono::milliseconds interval,
+    std::chrono::milliseconds timeout) {
+  // Create an OTLP exporter
+  opentelemetry::exporter::otlp::OtlpGrpcMetricExporterOptions exporter_options;
+  exporter_options.endpoint = endpoint;
+  auto exporter = std::make_unique<opentelemetry::exporter::otlp::OtlpGrpcMetricExporter>(
+      exporter_options);
+
+  // Initialize the OpenTelemetry SDK and create a Meter
+  opentelemetry::sdk::metrics::PeriodicExportingMetricReaderOptions reader_options;
+  reader_options.export_interval_millis = interval;
+  reader_options.export_timeout_millis = timeout;
+  auto reader =
+      std::make_unique<opentelemetry::sdk::metrics::PeriodicExportingMetricReader>(
+          std::move(exporter), reader_options);
+  meter_provider_->AddMetricReader(std::move(reader));
+}
+
+OpenTelemetryMetricRecorder::OpenTelemetryMetricRecorder() {
+  // Default constructor
+  meter_provider_ = std::make_shared<opentelemetry::sdk::metrics::MeterProvider>();
+  opentelemetry::metrics::Provider::SetMeterProvider(meter_provider_);
+}
+
+}  // namespace telemetry
+}  // namespace ray

--- a/src/ray/telemetry/open_telemetry_metric_recorder.cc
+++ b/src/ray/telemetry/open_telemetry_metric_recorder.cc
@@ -15,6 +15,7 @@
 
 #include <opentelemetry/exporters/otlp/otlp_grpc_metric_exporter.h>
 #include <opentelemetry/metrics/provider.h>
+#include <opentelemetry/nostd/shared_ptr.h>
 #include <opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader.h>
 #include <opentelemetry/sdk/metrics/instruments.h>
 
@@ -52,7 +53,9 @@ void OpenTelemetryMetricRecorder::RegisterGrpcExporter(
 OpenTelemetryMetricRecorder::OpenTelemetryMetricRecorder() {
   // Default constructor
   meter_provider_ = std::make_shared<opentelemetry::sdk::metrics::MeterProvider>();
-  opentelemetry::metrics::Provider::SetMeterProvider(meter_provider_);
+  opentelemetry::metrics::Provider::SetMeterProvider(
+      opentelemetry::nostd::shared_ptr<opentelemetry::metrics::MeterProvider>(
+          meter_provider_));
 }
 
 }  // namespace telemetry

--- a/src/ray/telemetry/open_telemetry_metric_recorder.h
+++ b/src/ray/telemetry/open_telemetry_metric_recorder.h
@@ -1,0 +1,51 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <opentelemetry/metrics/meter.h>
+#include <opentelemetry/sdk/metrics/meter_provider.h>
+
+#include <chrono>
+
+namespace ray {
+namespace telemetry {
+
+// OpenTelemetryMetricRecorder is a singleton class that initializes the OpenTelemetry
+// grpc exporter and creates a Meter for recording metrics. It is responsible for
+// exporting metrics to a repoter_agent.py endpoint at a given interval.
+class OpenTelemetryMetricRecorder {
+ public:
+  // Returns the singleton instance of OpenTelemetryMetricRecorder. This should be
+  // called after Register() to ensure the instance is initialized.
+  static OpenTelemetryMetricRecorder &GetInstance();
+
+  // Registers the OpenTelemetryMetricRecorder with the specified grpc endpoint,
+  // interval and timeout. This should be called only once per process.
+  void RegisterGrpcExporter(const std::string &endpoint,
+                            std::chrono::milliseconds interval,
+                            std::chrono::milliseconds timeout);
+
+  // Delete copy constructors and assignment operators. Skip generation of the move
+  // constructors and assignment operators.
+  OpenTelemetryMetricRecorder(const OpenTelemetryMetricRecorder &) = delete;
+  OpenTelemetryMetricRecorder &operator=(const OpenTelemetryMetricRecorder &) = delete;
+  ~OpenTelemetryMetricRecorder() = default;
+
+ private:
+  OpenTelemetryMetricRecorder();
+  std::shared_ptr<opentelemetry::sdk::metrics::MeterProvider> meter_provider_;
+};
+}  // namespace telemetry
+}  // namespace ray

--- a/src/ray/telemetry/tests/BUILD
+++ b/src/ray/telemetry/tests/BUILD
@@ -1,0 +1,12 @@
+load("//bazel:ray.bzl", "ray_cc_test")
+
+ray_cc_test(
+    name = "open_telemetry_metric_recorder_test",
+    size = "small",
+    srcs = ["open_telemetry_metric_recorder_test.cc"],
+    tags = ["team:core"],
+    deps = [
+        "//src/ray/telemetry:open_telemetry_metric_recorder",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/src/ray/telemetry/tests/open_telemetry_metric_recorder_test.cc
+++ b/src/ray/telemetry/tests/open_telemetry_metric_recorder_test.cc
@@ -1,0 +1,39 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/telemetry/open_telemetry_metric_recorder.h"
+
+#include "gtest/gtest.h"
+
+namespace ray {
+namespace telemetry {
+
+class OpenTelemetryMetricRecorderTest : public ::testing::Test {
+ public:
+  OpenTelemetryMetricRecorderTest()
+      : recorder_(OpenTelemetryMetricRecorder::GetInstance()) {}
+
+ protected:
+  OpenTelemetryMetricRecorder &recorder_;
+};
+
+TEST_F(OpenTelemetryMetricRecorderTest, TestRegister) {
+  // Check if the recorder is initialized correctly
+  ASSERT_NO_THROW(recorder_.RegisterGrpcExporter("somehost:1234",
+                                                 std::chrono::milliseconds(10000),
+                                                 std::chrono::milliseconds(5000)));
+}
+
+}  // namespace telemetry
+}  // namespace ray

--- a/thirdparty/patches/grpc-cython-copts.patch
+++ b/thirdparty/patches/grpc-cython-copts.patch
@@ -20,7 +20,7 @@ diff --git bazel/cython_library.bzl bazel/cython_library.bzl
          name: Name for the rule.
          deps: C/C++ dependencies of the Cython (e.g. Numpy headers).
 +        cc_kwargs: cc_binary extra arguments such as copts, linkstatic, linkopts, features
-@@ -57,7 +59,8 @@ def pyx_library(name, deps = [], py_deps = [], srcs = [], **kwargs):
+@@ -57,7 +59,9 @@ def pyx_library(name, deps = [], py_deps = [], srcs = [], **kwargs):
 -        shared_object_name = stem + ".so"
 +        shared_object_name = stem + ".so"
          native.cc_binary(
@@ -32,6 +32,7 @@ diff --git bazel/cython_library.bzl bazel/cython_library.bzl
 +            deps = deps + ["@local_config_python//:python_headers"] + cc_kwargs.pop("deps", []),
 -            defines = defines,
 +            defines = defines,
++            features = cc_kwargs.pop("features", []),
 -            linkshared = 1,
 +            linkshared = cc_kwargs.pop("linkshared", 1),
 +            **cc_kwargs


### PR DESCRIPTION
Reverts ray-project/ray#53421. The original PR was broken on windows build, so it was reverted. This is the same PR but with the window fix.