### PR TITLE
[Data] add switch for optimizer rules

### DIFF
--- a/python/ray/data/_internal/logical/optimizers.py
+++ b/python/ray/data/_internal/logical/optimizers.py
@@ -14,6 +14,7 @@ from ray.data._internal.logical.rules.inherit_batch_format import InheritBatchFo
 from ray.data._internal.logical.rules.inherit_target_max_block_size import (
     InheritTargetMaxBlockSizeRule,
 )
+from ray.data._internal.logical.rules.limit_pushdown import LimitPushdownRule
 from ray.data._internal.logical.rules.operator_fusion import FuseOperators
 from ray.data._internal.logical.rules.randomize_blocks import ReorderRandomizeBlocksRule
 from ray.data._internal.logical.rules.set_read_parallelism import SetReadParallelismRule
@@ -26,6 +27,7 @@ _LOGICAL_RULESET = Ruleset(
     [
         ReorderRandomizeBlocksRule,
         InheritBatchFormatRule,
+        LimitPushdownRule,
     ]
 )
 
@@ -58,6 +60,9 @@ class LogicalOptimizer(Optimizer):
     def rules(self) -> List[Rule]:
         return [rule_cls() for rule_cls in get_logical_ruleset()]
 
+    def active_rules(self) -> List[Rule]:
+        return [rule_cls() for rule_cls in get_logical_ruleset().get_active_rules()]
+
 
 class PhysicalOptimizer(Optimizer):
     """The optimizer for physical operators."""
@@ -65,6 +70,9 @@ class PhysicalOptimizer(Optimizer):
     @property
     def rules(self) -> List[Rule]:
         return [rule_cls() for rule_cls in get_physical_ruleset()]
+
+    def active_rules(self) -> List[Rule]:
+        return [rule_cls() for rule_cls in get_physical_ruleset().get_active_rules()]
 
 
 def get_execution_plan(logical_plan: LogicalPlan) -> PhysicalPlan:

--- a/python/ray/data/_internal/logical/rules/limit_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/limit_pushdown.py
@@ -22,6 +22,10 @@ class LimitPushdownRule(Rule):
     Limit operator, i.e. `Limit[n] -> Limit[m]` becomes `Limit[min(n, m)]`.
     """
 
+    def enabled(self) -> bool:
+        self._enabled = False
+        return False
+
     def apply(self, plan: LogicalPlan) -> LogicalPlan:
         optimized_dag = self._apply_limit_pushdown(plan.dag)
         optimized_dag = self._apply_limit_fusion(optimized_dag)

--- a/python/ray/data/_internal/logical/ruleset.py
+++ b/python/ray/data/_internal/logical/ruleset.py
@@ -40,6 +40,18 @@ class Ruleset:
 
         self._rules.remove(rule)
 
+    def get_active_rules(self) -> List[Rule]:
+        return [rule for rule in self._rules if rule.enabled]
+
+    def get_rule_by_name(self, name: str) -> Optional[Rule]:
+        for rule_type in self._rules:
+            class_name = rule_type.__name__
+            full_class_path = f"{rule_type.__module__}.{class_name}"
+
+            if name in (class_name, full_class_path):
+                return rule_type
+        return None
+
     def __iter__(self) -> Iterator[Type[Rule]]:
         """Iterate over the rules in this ruleset.
 

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -445,6 +445,19 @@ class DataContext:
     # retry task may still be scheduled to this actor and it will fail.
     _enable_actor_pool_on_exit_hook: bool = False
 
+    optimizer_rules = {}
+
+    def set_optimizer_rule_enabled(self, rule_name: str, enabled: bool):
+        from ray.data._internal.logical.optimizers import (
+            get_logical_ruleset,
+            get_physical_ruleset,
+        )
+
+        for ruleset in [get_logical_ruleset(), get_physical_ruleset()]:
+            rule = ruleset.get_rule_by_name(rule_name)
+            if rule:
+                rule.enabled = enabled
+
     def __post_init__(self):
         # The additonal ray remote args that should be added to
         # the task-pool-based data tasks.

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -1136,6 +1136,26 @@ def test_limit_pushdown(ray_start_regular_shared_2_cpus):
     )
 
 
+def test_set_optimizer_rule_enabled(ray_start_regular_shared_2_cpus):
+    from ray.data._internal.logical.optimizers import get_logical_ruleset
+    from ray.data.context import DataContext
+
+    ctx = DataContext.get_current()
+
+    original_value = ctx.optimizer_rules.get("LimitPushdownRule", False)
+
+    try:
+        ctx.set_optimizer_rule_enabled("LimitPushdownRule", True)
+        assert get_logical_ruleset().get_rule_by_name("LimitPushdownRule").enabled
+
+        test_limit_pushdown(ray_start_regular_shared_2_cpus)
+
+        ctx.set_optimizer_rule_enabled("LimitPushdownRule", False)
+        assert not get_logical_ruleset().get_rule_by_name("LimitPushdownRule").enabled
+
+    finally:
+        ctx.set_optimizer_rule_enabled("LimitPushdownRule", original_value)
+
 def test_execute_to_legacy_block_list(
     ray_start_regular_shared_2_cpus,
 ):


### PR DESCRIPTION
1. This PR sets switches for each optimizer rule, and the switches can be adjusted dynamically to solve the problems at hand.
2. At the same time, the limit push - down UT is also turned on, and it seems that a check for whether the line number has been changed has been added.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
