### PR TITLE
[core] Close FD in `test_label_utils.py` fixture

### DIFF
--- a/python/ray/tests/test_label_utils.py
+++ b/python/ray/tests/test_label_utils.py
@@ -100,6 +100,7 @@ def _tempfile(content: str) -> ContextManager[str]:
     try:
         f.write(content)
         f.flush()
+        f.close()
         yield f.name
     finally:
         os.unlink(f.name)


### PR DESCRIPTION
To fix Windows error: https://buildkite.com/ray-project/postmerge/builds/10533#0197207c-1a82-4cca-9e1d-6aedc6c3b017

Didn't actually close in previous PR :(