### PR TITLE
[Data] Update batch inference release test to use CPUs

### DIFF
--- a/release/nightly_tests/dataset/autoscaling_100_cpu_compute.yaml
+++ b/release/nightly_tests/dataset/autoscaling_100_cpu_compute.yaml
@@ -12,9 +12,8 @@ head_node_type:
 
 worker_node_types:
     - name: worker-node
-      # Anyscale workspaces use m5.2xlarge worker nodes by default. For consistency, we
-      # use GPU nodes with the same number of vCPUs and memory.
-      instance_type: g4dn.2xlarge
+      # Anyscale workspaces use m5.2xlarge worker nodes by default.
+      instance_type: m5.2xlarge
       min_workers: 0
       max_workers: 100
       use_spot: false

--- a/release/nightly_tests/dataset/batch_inference_mock_image_pipeline.py
+++ b/release/nightly_tests/dataset/batch_inference_mock_image_pipeline.py
@@ -18,6 +18,7 @@ import itertools
 from typing import List
 import string
 import random
+import time
 
 BUCKET = "anyscale-imagenet"
 WRITE_PATH = f"s3://ray-data-write-benchmark/{uuid.uuid4().hex}"
@@ -34,6 +35,10 @@ PATCH_SIZE = 256
 
 # Largest batch that can fit on a T4.
 BATCH_SIZE = 1200
+
+# On a T4 GPU, it takes ~11.3s to perform inference on 1200 images. So, the time per
+# image is 11.3s / 1200 ~= 0.0094s.
+INFERENCE_LATENCY_PER_IMAGE_S = 0.0094
 
 
 def parse_args() -> argparse.Namespace:
@@ -150,10 +155,25 @@ class EmbedPatches:
         self._device = device
 
     def __call__(self, batch: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
+        inputs = torch.as_tensor(batch.pop("patch"), device=self._device)
         with torch.inference_mode():
-            output = self._model(
-                torch.as_tensor(batch.pop("patch"), device=self._device)
-            )
+            output = self._model(inputs)
+            batch["embedding"] = output.cpu().numpy()
+            return batch
+
+
+class FakeEmbedPatches:
+    def __init__(self, model, _):
+        self._model = ray.get(model)
+        self._model.eval()
+
+    def __call__(self, batch: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
+        inputs = torch.as_tensor(batch.pop("patch"))
+        with torch.inference_mode():
+            # Simulate inference latency with a sleep
+            time.sleep(INFERENCE_LATENCY_PER_IMAGE_S * len(inputs))
+            # Generate fake embeddings
+            output = torch.rand((len(inputs), 1000), dtype=torch.float)
             batch["embedding"] = output.cpu().numpy()
             return batch
 

--- a/release/nightly_tests/dataset/batch_inference_mock_image_pipeline.py
+++ b/release/nightly_tests/dataset/batch_inference_mock_image_pipeline.py
@@ -209,7 +209,7 @@ def main(scale_factor: int):
             .flat_map(patch_image)
             .map_batches(ProcessPatches(transform))
             .map_batches(
-                EmbedPatches,
+                FakeEmbedPatches,
                 batch_size=BATCH_SIZE,
                 compute=ActorPoolStrategy(min_size=1, max_size=100),
                 num_gpus=1,

--- a/release/nightly_tests/dataset/batch_inference_mock_image_pipeline.py
+++ b/release/nightly_tests/dataset/batch_inference_mock_image_pipeline.py
@@ -163,7 +163,7 @@ class EmbedPatches:
 
 
 class FakeEmbedPatches:
-    def __init__(self, model, _):
+    def __init__(self, model, device):
         self._model = ray.get(model)
         self._model.eval()
 
@@ -212,7 +212,6 @@ def main(scale_factor: int):
                 FakeEmbedPatches,
                 batch_size=BATCH_SIZE,
                 compute=ActorPoolStrategy(min_size=1, max_size=100),
-                num_gpus=1,
                 fn_constructor_kwargs={"model": model_ref, "device": "cuda"},
             )
             .write_parquet(WRITE_PATH)

--- a/release/nightly_tests/dataset/fixed_size_100_cpu_compute.yaml
+++ b/release/nightly_tests/dataset/fixed_size_100_cpu_compute.yaml
@@ -12,9 +12,8 @@ head_node_type:
 
 worker_node_types:
     - name: worker-node
-      # Anyscale workspaces use m5.2xlarge worker nodes by default. For consistency, we
-      # use GPU nodes with the same number of vCPUs and memory.
-      instance_type: g4dn.2xlarge
+      # Anyscale workspaces use m5.2xlarge worker nodes by default.
+      instance_type: m5.2xlarge
       min_workers: 100
       max_workers: 100
       use_spot: false

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -488,7 +488,7 @@
   working_dir: nightly_tests
 
   cluster:
-    cluster_compute: dataset/autoscalling_100_gpu_compute.yaml
+    cluster_compute: dataset/autoscalling_100_cpu_compute.yaml
 
   run:
     timeout: 3600
@@ -506,7 +506,7 @@
   working_dir: nightly_tests
 
   cluster:
-    cluster_compute: dataset/fixed_size_100_gpu_compute.yaml
+    cluster_compute: dataset/fixed_size_100_cpu_compute.yaml
 
   run:
     timeout: 3600

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -488,7 +488,7 @@
   working_dir: nightly_tests
 
   cluster:
-    cluster_compute: dataset/autoscalling_100_cpu_compute.yaml
+    cluster_compute: dataset/autoscaling_100_cpu_compute.yaml
 
   run:
     timeout: 3600


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Running the job with GPUs is expensive, though running it on GPUs isn't strictly necessary to identify Ray Data performance issues. This PR updates the test to remove CUDA-specific code and simulate inference with a sleep.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
