### PR TITLE
Increased stale bot GA operations per run, and fixed a typo.

### DIFF
--- a/.github/workflows/stale_pull_request.yaml
+++ b/.github/workflows/stale_pull_request.yaml
@@ -20,7 +20,7 @@ jobs:
           # --- Ignore Issues ---
           # Set to -1 so we never mark issues as stale or closed.
           days-before-issue-stale: -1
-          day-before-issue-closed: -1
+          days-before-issue-close: -1
 
           # --- Pull Request Specific Settings ---
           # Number of days of inactivity before a Pull Request becomes stale (currently 2 weeks)
@@ -62,8 +62,8 @@ jobs:
           exempt-all-pr-milestones: true
 
           # --- Shared Settings & Other Options ---
-          # Limit the number of actions per run
-          operations-per-run: 30
+          # Limit the number of actions per run. Increase from 30 to 300. 
+          operations-per-run: 300
 
           # Remove stale label from PRs on update (default is true)
           remove-pr-stale-when-updated: true

--- a/.github/workflows/stale_pull_request.yaml
+++ b/.github/workflows/stale_pull_request.yaml
@@ -62,8 +62,8 @@ jobs:
           exempt-all-pr-milestones: true
 
           # --- Shared Settings & Other Options ---
-          # Limit the number of actions per run. Increase from 30 to 300. 
-          operations-per-run: 300
+          # Limit the number of actions per run.
+          operations-per-run: 500
 
           # Remove stale label from PRs on update (default is true)
           remove-pr-stale-when-updated: true


### PR DESCRIPTION
## Why are these changes needed?

The [stale PR job ran successfully](https://github.com/ray-project/ray/actions/runs/15336406317/job/43154457113) yesterday but only managed to process 9 PRs before running out of GitHub API actions. The `operations-per-run` is currently set to 30 (same as the previous stale bot). However, we still have hundreds of open PRs and at the rate we are going it will take a little while before we finish processing them all.

Since we have about 5000 GitHub API Rate per hour, I've upped our `operations-per-run` to 500, so we can process more PRs. After it runs, we should still have 4500 left. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
