### PR TITLE
consume autoscaling metrics from both handle and replica

### DIFF
--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -307,7 +307,6 @@ class AutoscalingState:
         for id in self._running_replicas:
             if id in self._replica_requests:
                 total_requests += self._replica_requests[id].running_requests
-
         return total_requests
 
 

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -10,7 +10,6 @@ from ray.serve._private.common import (
     TargetCapacityDirection,
 )
 from ray.serve._private.constants import (
-    RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE,
     RAY_SERVE_MIN_HANDLE_METRICS_TIMEOUT_S,
     SERVE_LOGGER_NAME,
 )
@@ -293,27 +292,21 @@ class AutoscalingState:
         If there are 0 running replicas, then returns the total number
         of requests queued at handles
 
-        If the flag RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE is
-        set to 1, the returned average includes both queued and ongoing
-        requests. Otherwise, the returned average includes only ongoing
-        requests.
+        This code assumes that the metrics are either emmited on handles
+        or on replicas, but not both. Its the responsibility of the writer
+        to ensure enclusivity of the metrics.
         """
 
         total_requests = 0
 
-        if (
-            RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE
-            or len(self._running_replicas) == 0
-        ):
-            for handle_metric in self._handle_requests.values():
-                total_requests += handle_metric.queued_requests
-                for id in self._running_replicas:
-                    if id in handle_metric.running_requests:
-                        total_requests += handle_metric.running_requests[id]
-        else:
+        for handle_metric in self._handle_requests.values():
+            total_requests += handle_metric.queued_requests
             for id in self._running_replicas:
-                if id in self._replica_requests:
-                    total_requests += self._replica_requests[id].running_requests
+                if id in handle_metric.running_requests:
+                    total_requests += handle_metric.running_requests[id]
+        for id in self._running_replicas:
+            if id in self._replica_requests:
+                total_requests += self._replica_requests[id].running_requests
 
         return total_requests
 

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -217,7 +217,9 @@ class TestAutoscalingMetrics:
         wait_for_condition(check_num_requests_ge, client=client, id=dep_id, expected=45)
         print("Confirmed many queries are inflight.")
 
-        wait_for_condition(check_num_replicas_eq, name="A", target=5, app_name="app1")
+        wait_for_condition(
+            check_num_replicas_eq, name="A", target=5, app_name="app1", timeout=20
+        )
         print("Confirmed deployment scaled to 5 replicas.")
 
         # Wait for all requests to be scheduled to replicas so they'll be failed

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -414,7 +414,9 @@ def test_e2e_scale_up_down_basic(min_replicas, serve_instance_with_signal):
     signal.send.remote()
 
     # As the queue is drained, we should scale back down.
-    wait_for_condition(check_num_replicas_lte, name="A", target=min_replicas)
+    wait_for_condition(
+        check_num_replicas_lte, name="A", target=min_replicas, timeout=20
+    )
 
     # Make sure start time did not change for the deployment
     assert get_deployment_start_time(client._controller, "A") == start_time


### PR DESCRIPTION
The additional check on read is redundant because the writer of metrics already ensures exclusivity.

Had to increase timeout on 2 tests. I dont know why it was failing. Best guess is that its a timing issue