### PR TITLE
[Docs] Fixes for xgboost Jobs and Services

### DIFF
--- a/doc/source/ray-overview/examples/e2e-xgboost/dist_xgboost/serve.py
+++ b/doc/source/ray-overview/examples/e2e-xgboost/dist_xgboost/serve.py
@@ -43,12 +43,13 @@ class XGBoostModel:
         return await self.predict_batch(input_data)
 
 
-def main():
-    xgboost_model = XGBoostModel.bind(load_model_and_preprocessor)
-    _handle: DeploymentHandle = serve.run(
-        xgboost_model, name="xgboost-breast-cancer-classifier"
-    )
+xgboost_model = XGBoostModel.bind(load_model_and_preprocessor)
+_handle: DeploymentHandle = serve.run(
+    xgboost_model, name="xgboost-breast-cancer-classifier"
+)
 
+
+def main():
     sample_input = {
         "mean radius": 14.9,
         "mean texture": 22.53,

--- a/doc/source/ray-overview/examples/e2e-xgboost/notebooks/01-Distributed_Training.ipynb
+++ b/doc/source/ray-overview/examples/e2e-xgboost/notebooks/01-Distributed_Training.ipynb
@@ -699,7 +699,7 @@
    "source": [
     "## Model registry\n",
     "\n",
-    "Now that you've trained the model, save it to a model registry for future use. As this is a distributed training workload, the model registry storage needs to be accessible from all workers in the cluster. This storage can be S3, NFS, or another network-attached solution. Anyscale simplifies this process by automatically creating and mounting [shared storage options](https://docs.anyscale.com/configuration/storage/#storage-shared-across-nodes) on every cluster node, ensuring that model artifacts can be written and accessed consistently across the distributed environment.\n",
+    "Now that you've trained the model, save it to a model registry for future use. As this is a distributed training workload, the model registry storage needs to be accessible from all workers in the cluster. This storage can be S3, NFS, or another network-attached solution. Anyscale simplifies this process by automatically creating and mounting [shared storage options](https://docs.anyscale.com/configuration/storage/#storage-shared-across-nodes) on every cluster node, ensuring that model artifacts are readable and writable across the distributed environment.\n",
     "\n",
     "The MLflow tracking server stores experiment metadata and model artifacts in the shared storage location, making them available for future model serving, evaluation, or retraining workflows. Ray also integrates with [other experiment trackers](https://docs.ray.io/en/latest/train/user-guides/experiment-tracking.html)."
    ]

--- a/doc/source/ray-overview/examples/e2e-xgboost/notebooks/02-Validation.ipynb
+++ b/doc/source/ray-overview/examples/e2e-xgboost/notebooks/02-Validation.ipynb
@@ -218,7 +218,7 @@
     "<div class=\"alert alert-block alert\"> <b>💡 Ray Data best practices</b>\n",
     "\n",
     "- **Use `materialize()` during development**: The `materialize()` method executes and stores the dataset in Ray's shared memory object store. This behavior creates a checkpoint so future operations can start from this point instead of rerunning all operations from scratch.\n",
-    "- **Choose appropriate shuffling strategies**: Ray Data provides various [shuffling strategies](https://docs.ray.io/en/latest/data/shuffling-data.html) including local shuffles and per-epoch shuffles. This dataset needs to be shuffled becvause the original data is ordered by class.\n"
+    "- **Choose appropriate shuffling strategies**: Ray Data provides various [shuffling strategies](https://docs.ray.io/en/latest/data/shuffling-data.html) including local shuffles and per-epoch shuffles. You need to shuffle this dataset because the original data groups items by class.\n"
    ]
   },
   {
@@ -538,7 +538,7 @@
     "  -- python dist_xgboost/infer.py\n",
     "```\n",
     "\n",
-    "Note that in order for this command to succeed, first configure MLflow to store the artifacts in storage that's readable across clusters. Anyscale offers a variety of storage options that work out of the box, such as a [default storage bucket](https://docs.anyscale.com/configuration/storage/#anyscale-default-storage-bucket), as well as [automatically mounted network storage](https://docs.anyscale.com/configuration/storage/) that are shared at the cluster, user, and cloud levels. You could also set up your own network mounts or storage buckets."
+    "Note that in order for this command to succeed, first configure MLflow to store the artifacts in storage that's readable across clusters. Anyscale offers a variety of storage options that work out of the box, such as a [default storage bucket](https://docs.anyscale.com/configuration/storage/#anyscale-default-storage-bucket), as well as [automatically mounted network storage](https://docs.anyscale.com/configuration/storage/) shared at the cluster, user, and cloud levels. You could also set up your own network mounts or storage buckets."
    ]
   },
   {

--- a/doc/source/ray-overview/examples/e2e-xgboost/notebooks/02-Validation.ipynb
+++ b/doc/source/ray-overview/examples/e2e-xgboost/notebooks/02-Validation.ipynb
@@ -526,61 +526,19 @@
    "source": [
     "### Production deployment\n",
     "\n",
-    "You can wrap the training workload as a production-grade [Anyscale Job](https://docs.anyscale.com/platform/jobs/). See the [API ref](https://docs.anyscale.com/reference/job-api/):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5793f0ff",
-   "metadata": {
-    "tags": [
-     "remove-cell-ci"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "from dist_xgboost.constants import root_dir\n",
+    "You can wrap the training workload as a production-grade [Anyscale Job](https://docs.anyscale.com/platform/jobs/). See the [API ref](https://docs.anyscale.com/reference/job-api/):\n",
     "\n",
-    "os.environ[\"WORKING_DIR\"] = root_dir"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b54cbf81",
-   "metadata": {
-    "tags": [
-     "remove-cell-ci"
-    ]
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Output\n",
-      "(anyscale +0.9s) Submitting job with config JobConfig(name='validate-xboost-breast-cancer-model', image_uri=None, compute_config=None, env_vars=None, py_modules=None, py_executable=None, cloud=None, project=None, ray_version=None, job_queue_config=None).\n",
-      "(anyscale +6.4s) Building image. View it in the UI: https://console.anyscale.com/v2/container-images/apt_69tmk3lbw62tmn3w1zs6clbqu4/versions/bld_dlkap7igyq1fh7bp4vzav7q1c1\n",
-      "(anyscale +2m30.5s) Waiting for image build to complete. Elapsed time: 138 seconds.\n",
-      "(anyscale +2m30.5s) Image build succeeded.\n",
-      "(anyscale +2m30.7s) Uploading local dir '/home/ray/default/e2e-xgboost' to cloud storage.\n",
-      "(anyscale +2m31.6s) Including workspace-managed pip dependencies.\n",
-      "(anyscale +2m32.0s) Job 'validate-xboost-breast-cancer-model' submitted, ID: 'prodjob_lqitqksq7n6mcvjr4m2255f5yv'.\n",
-      "(anyscale +2m32.0s) View the job in the UI: https://console.anyscale.com/jobs/prodjob_lqitqksq7n6mcvjr4m2255f5yv\n",
-      "(anyscale +2m32.0s) Use `--wait` to wait for the job to run and stream logs.\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%bash\n",
+    "```bash\n",
     "# Production batch job.\n",
     "anyscale job submit --name=validate-xboost-breast-cancer-model \\\n",
     "  --containerfile=\"${WORKING_DIR}/containerfile\" \\\n",
     "  --working-dir=\"${WORKING_DIR}\" \\\n",
     "  --exclude=\"\" \\\n",
     "  --max-retries=0 \\\n",
-    "  -- python dist_xgboost/infer.py"
+    "  -- python dist_xgboost/infer.py\n",
+    "```\n",
+    "\n",
+    "Note that in order for this command to succeed, MLFlow needs to be configured to store the artifacts in storage that is readable across clusters. Anyscale offers a variety of storage options that work out of the box, such as a [default storage bucket](https://docs.anyscale.com/configuration/storage/#anyscale-default-storage-bucket), as well as [automatically mounted network storage](https://docs.anyscale.com/configuration/storage/) that are shared at the cluster, user, and cloud levels. You could also set up your own network mounts or storage buckets."
    ]
   },
   {

--- a/doc/source/ray-overview/examples/e2e-xgboost/notebooks/02-Validation.ipynb
+++ b/doc/source/ray-overview/examples/e2e-xgboost/notebooks/02-Validation.ipynb
@@ -538,7 +538,7 @@
     "  -- python dist_xgboost/infer.py\n",
     "```\n",
     "\n",
-    "Note that in order for this command to succeed, MLFlow needs to be configured to store the artifacts in storage that is readable across clusters. Anyscale offers a variety of storage options that work out of the box, such as a [default storage bucket](https://docs.anyscale.com/configuration/storage/#anyscale-default-storage-bucket), as well as [automatically mounted network storage](https://docs.anyscale.com/configuration/storage/) that are shared at the cluster, user, and cloud levels. You could also set up your own network mounts or storage buckets."
+    "Note that for this command to succeed, you need to configure MLflow to store the artifacts in storage that is readable across clusters. Anyscale offers a variety of storage options that work out of the box, such as a [default storage bucket](https://docs.anyscale.com/configuration/storage/#anyscale-default-storage-bucket), as well as [automatically mounted network storage](https://docs.anyscale.com/configuration/storage/) that are shared at the cluster, user, and cloud levels. You could also set up your own network mounts or storage buckets."
    ]
   },
   {

--- a/doc/source/ray-overview/examples/e2e-xgboost/notebooks/02-Validation.ipynb
+++ b/doc/source/ray-overview/examples/e2e-xgboost/notebooks/02-Validation.ipynb
@@ -46,7 +46,7 @@
     "\n",
     "✅ **Streaming execution** with Ray Data:\n",
     "- Starts processing chunks (\"blocks\") as they're loaded without needing to wait for entire dataset to load\n",
-    "- Reduces memory footprint, no OOMs, and speeds up time to first output\n",
+    "- Reduces memory footprint, no out-of-memory errors, and speeds up time to first output\n",
     "- Increases resource utilization by reducing idle time\n",
     "- Enables online-style inference pipelines with minimal latency\n",
     "\n",
@@ -218,7 +218,7 @@
     "<div class=\"alert alert-block alert\"> <b>💡 Ray Data best practices</b>\n",
     "\n",
     "- **Use `materialize()` during development**: The `materialize()` method executes and stores the dataset in Ray's shared memory object store. This behavior creates a checkpoint so future operations can start from this point instead of rerunning all operations from scratch.\n",
-    "- **Choose appropriate shuffling strategies**: Ray Data provides various [shuffling strategies](https://docs.ray.io/en/latest/data/shuffling-data.html) including local shuffles and per-epoch shuffles. Shuffle this dataset because the original data is ordered by class.\n"
+    "- **Choose appropriate shuffling strategies**: Ray Data provides various [shuffling strategies](https://docs.ray.io/en/latest/data/shuffling-data.html) including local shuffles and per-epoch shuffles. This dataset needs to be shuffled becvause the original data is ordered by class.\n"
    ]
   },
   {
@@ -538,7 +538,7 @@
     "  -- python dist_xgboost/infer.py\n",
     "```\n",
     "\n",
-    "Note that for this command to succeed, you need to configure MLflow to store the artifacts in storage that is readable across clusters. Anyscale offers a variety of storage options that work out of the box, such as a [default storage bucket](https://docs.anyscale.com/configuration/storage/#anyscale-default-storage-bucket), as well as [automatically mounted network storage](https://docs.anyscale.com/configuration/storage/) that are shared at the cluster, user, and cloud levels. You could also set up your own network mounts or storage buckets."
+    "Note that in order for this command to succeed, first configure MLflow to store the artifacts in storage that's readable across clusters. Anyscale offers a variety of storage options that work out of the box, such as a [default storage bucket](https://docs.anyscale.com/configuration/storage/#anyscale-default-storage-bucket), as well as [automatically mounted network storage](https://docs.anyscale.com/configuration/storage/) that are shared at the cluster, user, and cloud levels. You could also set up your own network mounts or storage buckets."
    ]
   },
   {

--- a/doc/source/ray-overview/examples/e2e-xgboost/notebooks/03-Serving.ipynb
+++ b/doc/source/ray-overview/examples/e2e-xgboost/notebooks/03-Serving.ipynb
@@ -631,7 +631,7 @@
     "\n",
     "Note that in order for this command to succeed, MLFlow needs to be configured to store the artifacts in storage that is readable across clusters. Anyscale offers a variety of storage options that work out of the box, such as a [default storage bucket](https://docs.anyscale.com/configuration/storage/#anyscale-default-storage-bucket), as well as [automatically mounted network storage](https://docs.anyscale.com/configuration/storage/) that are shared at the cluster, user, and cloud levels. You could also set up your own network mounts or storage buckets.\n",
     "\n",
-    "Running this command starts a service is in production. In the process, Anyscale creates and saves a container image to enable fast starting this service in the future. The link to the endpoint and the bearer token is printed be in the logs. After the service is running remotely, you need to use the bearer token to query it. Here's how you would modify the preceding `requests` code to use this token:\n",
+    "Running this command starts a service in production. In the process, Anyscale creates and saves a container image to enable fast starting this service in the future. The link to the endpoint and the bearer token is printed in the logs. After the service is running remotely, you need to use the bearer token to query it. Here's how you would modify the preceding `requests` code to use this token:\n",
     "\n",
     "```python\n",
     "# Service specific config. Replace with your own values from the preceding logs.\n",

--- a/doc/source/ray-overview/examples/e2e-xgboost/notebooks/03-Serving.ipynb
+++ b/doc/source/ray-overview/examples/e2e-xgboost/notebooks/03-Serving.ipynb
@@ -617,73 +617,21 @@
     "**Note**: \n",
     "- This example uses a `containerfile` to define dependencies, but you could easily use a pre-built image as well.\n",
     "- You can specify the compute as a [compute config](https://docs.anyscale.com/configuration/compute-configuration/) or inline in a [Service config](https://docs.anyscale.com/reference/service-api/) file.\n",
-    "- When you don't specify compute and you launch from a workspace, the default is the compute configuration of the workspace."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b22111af",
-   "metadata": {
-    "tags": [
-     "remove-cell-ci"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "from dist_xgboost.constants import root_dir\n",
+    "- When you don't specify compute and you launch from a workspace, the default is the compute configuration of the workspace.\n",
     "\n",
-    "os.environ[\"WORKING_DIR\"] = root_dir"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4fe314f1",
-   "metadata": {
-    "tags": [
-     "remove-cell-ci"
-    ]
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "(anyscale +1.4s) Starting new service 'xgboost-breast_cancer_all_features'.\n",
-      "(anyscale +2.4s) Building image. View it in the UI: https://console.anyscale.com/v2/container-images/apt_gdm4p6u38va8itd2rvpxclm9ms/versions/bld_q2a3b4eb3s4cns7qpu4bnr8eun\n",
-      "(anyscale +33m43.2s) Waiting for image build to complete. Elapsed time: 1938 seconds.\n",
-      "(anyscale +33m43.2s) Image build succeeded.\n",
-      "(anyscale +33m44.4s) Uploading local dir '/home/ray/default/e2e-xgboost' to cloud storage.\n",
-      "(anyscale +33m45.4s) Including workspace-managed pip dependencies.\n",
-      "(anyscale +33m45.8s) Service 'xgboost-breast_cancer_all_features' deployed (version ID: b8vzznu8).\n",
-      "(anyscale +33m45.8s) View the service in the UI: 'https://console.anyscale.com/services/service2_i7ku1lh6ahp49vj6aztaa4w1hp'\n",
-      "(anyscale +33m45.8s) Query the service once it's running using the following curl command (add the path you want to query):\n",
-      "(anyscale +33m45.8s) curl -H \"Authorization: Bearer tXhmYYY7qMbrb1ToO9_J3n5_kD7ym7Nirs8djtip7P0\" https://xgboost-breast-cancer-all-features-jgz99.cld-kvedzwag2qa8i5bj.s.anyscaleuserdata.com/\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%bash\n",
+    "\n",
+    "```bash\n",
     "# Production online service.\n",
     "anyscale service deploy dist_xgboost.serve:xgboost_model --name=xgboost-breast_cancer_all_features \\\n",
     "  --containerfile=\"${WORKING_DIR}/containerfile\" \\\n",
     "  --working-dir=\"${WORKING_DIR}\" \\\n",
-    "  --exclude=\"\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0f40d122",
-   "metadata": {
-    "tags": [
-     "remove-cell-ci"
-    ]
-   },
-   "source": [
-    "Your service is now in production. In the process, Anyscale created and saved a container image to enable fast starting this service in the future.\n",
+    "  --exclude=\"\"\n",
+    "```\n",
     "\n",
-    "The link to the endpoint and the bearer token should be in the logs. Now that the service is running remotely, you need to use the bearer token to query it. Here's how you would modify the preceding `requests` code to use this token:\n",
+    "\n",
+    "Note that in order for this command to succeed, MLFlow needs to be configured to store the artifacts in storage that is readable across clusters. Anyscale offers a variety of storage options that work out of the box, such as a [default storage bucket](https://docs.anyscale.com/configuration/storage/#anyscale-default-storage-bucket), as well as [automatically mounted network storage](https://docs.anyscale.com/configuration/storage/) that are shared at the cluster, user, and cloud levels. You could also set up your own network mounts or storage buckets.\n",
+    "\n",
+    "Running this command starts a service is in production. In the process, Anyscale creates and saves a container image to enable fast starting this service in the future. The link to the endpoint and the bearer token is printed be in the logs. After the service is running remotely, you need to use the bearer token to query it. Here's how you would modify the preceding `requests` code to use this token:\n",
     "\n",
     "```python\n",
     "# Service specific config. Replace with your own values from the preceding logs.\n",
@@ -696,32 +644,13 @@
     "headers = {\"Authorization\": f\"Bearer {token}\"}\n",
     "\n",
     "prediction = requests.post(url, json=sample_input, headers=headers).json()\n",
+    "```\n",
+    "\n",
+    "Don't forget to terminate the service once it is no longer needed:\n",
+    "\n",
+    "```bash\n",
+    "anyscale service terminate --name e2e-xgboost\n",
     "```"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a59344bc",
-   "metadata": {
-    "tags": [
-     "remove-cell-ci"
-    ]
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "(anyscale +1.8s) Service service2_9ucj98xf7yq9uvleyatqrbu2l1 terminate initiated.\n",
-      "(anyscale +1.8s) View the service in the UI at https://console.anyscale.com/services/service2_9ucj98xf7yq9uvleyatqrbu2l1\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%bash\n",
-    "# Terminate service.\n",
-    "anyscale service terminate --name e2e-xgboost"
    ]
   },
   {

--- a/doc/source/ray-overview/examples/e2e-xgboost/notebooks/03-Serving.ipynb
+++ b/doc/source/ray-overview/examples/e2e-xgboost/notebooks/03-Serving.ipynb
@@ -646,7 +646,7 @@
     "prediction = requests.post(url, json=sample_input, headers=headers).json()\n",
     "```\n",
     "\n",
-    "Don't forget to terminate the service once it is no longer needed:\n",
+    "Don't forget to terminate the service once it's no longer needed:\n",
     "\n",
     "```bash\n",
     "anyscale service terminate --name e2e-xgboost\n",

--- a/doc/source/ray-overview/examples/e2e-xgboost/notebooks/03-Serving.ipynb
+++ b/doc/source/ray-overview/examples/e2e-xgboost/notebooks/03-Serving.ipynb
@@ -28,7 +28,7 @@
     "[Ray Serve](https://docs.ray.io/en/latest/serve/index.html) is a highly scalable and flexible model serving library for building online inference APIs. You can:\n",
     "- Wrap models and business logic as separate [serve deployments](https://docs.ray.io/en/latest/serve/key-concepts.html#deployment) and [connect](https://docs.ray.io/en/latest/serve/model_composition.html) them together (pipeline, ensemble, etc.)\n",
     "- Avoid one large service that's network and compute bounded and an inefficient use of resources\n",
-    "- Utilize fractional heterogeneous [resources](https://docs.ray.io/en/latest/serve/resource-allocation.html), which is **not possible** with SageMaker, Vertex, KServe, etc., and horizontally scale, with `num_replicas`\n",
+    "- Utilize fractional heterogeneous [resources](https://docs.ray.io/en/latest/serve/resource-allocation.html), which **isn't possible** with SageMaker, Vertex, KServe, etc., and horizontally scale, with `num_replicas`\n",
     "- [Autoscale](https://docs.ray.io/en/latest/serve/autoscaling-guide.html) up and down based on traffic\n",
     "- Integrate with [FastAPI and HTTP](https://docs.ray.io/en/latest/serve/http-guide.html)\n",
     "- Set up a [gRPC service](https://docs.ray.io/en/latest/serve/advanced-guides/grpc-guide.html#set-up-a-grpc-service) to build distributed systems and microservices\n",
@@ -397,7 +397,7 @@
    "source": [
     "This approach works for processing an individual query, but isn't appropriate if you have many queries. Because `requests.post` is a blocking call, if you run it in a for loop you never benefit from Ray Serve's dynamic batching.\n",
     "\n",
-    "Instead, you want to fire many requests concurrently using asynchronous requests and let Ray Serve buffer and batch process them. You can use this approach with aiohttp:"
+    "Instead, you want to fire many requests concurrently using asynchronous requests and let Ray Serve buffer and batch process them. You can use this approach with `aiohttp`:"
    ]
   },
   {
@@ -599,7 +599,7 @@
     "\n",
     "<img src=\"https://raw.githubusercontent.com/anyscale/e2e-xgboost/refs/heads/main/images/canary.png\" width=1000>\n",
     "\n",
-    "[RayTurbo Serve](https://docs.anyscale.com/rayturbo/rayturbo-serve) on Anyscale has more functionality on top of Ray Serve:\n",
+    "[RayTurbo Serve](https://docs.anyscale.com/rayturbo/rayturbo-serve) on Anyscale has more capabilities on top of Ray Serve:\n",
     "- **fast autoscaling and model loading** to get services up and running even faster with [5x improvements](https://www.anyscale.com/blog/autoscale-large-ai-models-faster) even for LLMs\n",
     "- 54% **higher QPS** and up-to 3x **streaming tokens per second** for high traffic serving use-cases with no proxy bottlenecks\n",
     "- **replica compaction** into fewer nodes where possible to reduce resource fragmentation and improve hardware utilization\n",
@@ -629,9 +629,9 @@
     "```\n",
     "\n",
     "\n",
-    "Note that for this command to succeed, you need to configure MLflow to store the artifacts in storage that is readable across clusters. Anyscale offers a variety of storage options that work out of the box, such as a [default storage bucket](https://docs.anyscale.com/configuration/storage/#anyscale-default-storage-bucket), as well as [automatically mounted network storage](https://docs.anyscale.com/configuration/storage/) that are shared at the cluster, user, and cloud levels. You could also set up your own network mounts or storage buckets.\n",
+    "Note that for this command to succeed, you need to configure MLflow to store the artifacts in storage that's readable across clusters. Anyscale offers a variety of storage options that work out of the box, such as a [default storage bucket](https://docs.anyscale.com/configuration/storage/#anyscale-default-storage-bucket), as well as [automatically mounted network storage](https://docs.anyscale.com/configuration/storage/) shared at the cluster, user, and cloud levels. You could also set up your own network mounts or storage buckets.\n",
     "\n",
-    "Running this command starts a service in production. In the process, Anyscale creates and saves a container image to enable fast starting this service in the future. The link to the endpoint and the bearer token is printed in the logs. After the service is running remotely, you need to use the bearer token to query it. Here's how you would modify the preceding `requests` code to use this token:\n",
+    "Running this command starts a service in production. In the process, Anyscale creates and saves a container image to enable fast starting this service in the future. The link to the endpoint and the bearer token appears in the logs. After the service is running remotely, you need to use the bearer token to query it. Here's how you would modify the preceding `requests` code to use this token:\n",
     "\n",
     "```python\n",
     "# Service specific config. Replace with your own values from the preceding logs.\n",
@@ -646,7 +646,7 @@
     "prediction = requests.post(url, json=sample_input, headers=headers).json()\n",
     "```\n",
     "\n",
-    "Don't forget to terminate the service once it's no longer needed:\n",
+    "Don't forget to stop the service once it's no longer needed:\n",
     "\n",
     "```bash\n",
     "anyscale service terminate --name e2e-xgboost\n",

--- a/doc/source/ray-overview/examples/e2e-xgboost/notebooks/03-Serving.ipynb
+++ b/doc/source/ray-overview/examples/e2e-xgboost/notebooks/03-Serving.ipynb
@@ -629,7 +629,7 @@
     "```\n",
     "\n",
     "\n",
-    "Note that in order for this command to succeed, MLFlow needs to be configured to store the artifacts in storage that is readable across clusters. Anyscale offers a variety of storage options that work out of the box, such as a [default storage bucket](https://docs.anyscale.com/configuration/storage/#anyscale-default-storage-bucket), as well as [automatically mounted network storage](https://docs.anyscale.com/configuration/storage/) that are shared at the cluster, user, and cloud levels. You could also set up your own network mounts or storage buckets.\n",
+    "Note that for this command to succeed, you need to configure MLflow to store the artifacts in storage that is readable across clusters. Anyscale offers a variety of storage options that work out of the box, such as a [default storage bucket](https://docs.anyscale.com/configuration/storage/#anyscale-default-storage-bucket), as well as [automatically mounted network storage](https://docs.anyscale.com/configuration/storage/) that are shared at the cluster, user, and cloud levels. You could also set up your own network mounts or storage buckets.\n",
     "\n",
     "Running this command starts a service in production. In the process, Anyscale creates and saves a container image to enable fast starting this service in the future. The link to the endpoint and the bearer token is printed in the logs. After the service is running remotely, you need to use the bearer token to query it. Here's how you would modify the preceding `requests` code to use this token:\n",
     "\n",


### PR DESCRIPTION
## Why are these changes needed?

* moved serve handles to global scope so that Service launch commands work
* added discussion on Anyscale shared storage options
* added note that model artifacts need to be saved in shared storage in order to be accessible from Services and Jobs