### PR TITLE
[core] Add as_completed and map_unordered APIs

### DIFF
--- a/doc/source/ray-core/api/core.rst
+++ b/doc/source/ray-core/api/core.rst
@@ -50,6 +50,8 @@ Objects
     ray.get
     ray.wait
     ray.put
+    ray.util.as_completed
+    ray.util.map_unordered
 
 .. _runtime-context-apis:
 

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -67,6 +67,7 @@ py_test_module_list(
         "test_reference_counting_2.py",
         "test_reference_counting_standalone.py",
         "test_runtime_env_agent.py",
+        "test_util_helpers.py",
     ],
     tags = [
         "exclusive",

--- a/python/ray/tests/test_util_helpers.py
+++ b/python/ray/tests/test_util_helpers.py
@@ -1,0 +1,188 @@
+import pytest
+import sys
+import ray
+from ray.util import as_completed, map_unordered
+from ray._common.test_utils import SignalActor
+
+
+@pytest.fixture(scope="module")
+def ray_init_4_cpu_shared():
+    ray.init(num_cpus=4)
+    yield
+    ray.shutdown()
+
+
+@pytest.mark.parametrize("yield_obj_refs", [True, False])
+def test_as_completed_chunk_size_1(ray_init_4_cpu_shared, yield_obj_refs):
+    """Test as_completed with chunk_size=1.
+
+    Use SignalActor to control task completion order and mimic time.sleep(x) behavior.
+
+    """
+    inputs = [10, 8, 6, 4, 2]
+
+    # Create signals for each task
+    signals = [SignalActor.remote() for _ in range(len(inputs))]
+
+    # Create tasks
+    @ray.remote
+    def f(x, signal):
+        ray.get(signal.wait.remote())
+        return x
+
+    # Submit tasks with their corresponding signals in the original order
+    refs = [f.remote(x, signal) for x, signal in zip(inputs, signals)]
+
+    # Use as_completed() lazily
+    it = as_completed(refs, chunk_size=1, yield_obj_refs=yield_obj_refs)
+
+    # Send signal in reverse order to mimic time.sleep(x), i.e.,
+    # smallest value releases first. At the same time, collect results
+
+    results = []
+    for signal in reversed(signals):
+        ray.get(signal.send.remote())
+        results.append(next(it))
+
+    if yield_obj_refs:
+        results = ray.get(results)
+
+    assert results == [2, 4, 6, 8, 10]
+
+
+@pytest.mark.parametrize("yield_obj_refs", [True, False])
+def test_as_completed_chunk_size_2(ray_init_4_cpu_shared, yield_obj_refs):
+    """Test as_completed with chunk_size=2.
+
+    Use SignalActor to control task completion order and mimic time.sleep(x) behavior.
+
+    """
+    inputs = [10, 8, 6, 4, 2]
+
+    # Create signals for each task
+    signals = [SignalActor.remote() for _ in range(len(inputs))]
+
+    # Create tasks
+    @ray.remote
+    def f(x, signal):
+        ray.get(signal.wait.remote())
+        return x
+
+    # Submit tasks with their corresponding signals in the original order
+    refs = [f.remote(x, signal) for x, signal in zip(inputs, signals)]
+
+    # Use as_completed() lazily
+    it = as_completed(refs, chunk_size=2, yield_obj_refs=yield_obj_refs)
+
+    # Send signal in reverse order to mimic time.sleep(x), i.e.,
+    # smallest value releases first. At the same time, collect results
+
+    results = []
+
+    ray.get(signals[4].send.remote())
+    ray.get(signals[3].send.remote())
+    results.append(next(it))
+    results.append(next(it))
+
+    ray.get(signals[2].send.remote())
+    ray.get(signals[1].send.remote())
+    results.append(next(it))
+    results.append(next(it))
+
+    ray.get(signals[0].send.remote())
+    results.append(next(it))
+
+    if yield_obj_refs:
+        results = ray.get(results)
+
+    assert results == [4, 2, 8, 6, 10]
+
+
+@pytest.mark.parametrize("yield_obj_refs", [True, False])
+def test_map_unordered_chunk_size_1(ray_init_4_cpu_shared, yield_obj_refs):
+    """Test map_unordered with chunk_size=1.
+
+    Use SignalActor to control task completion order and mimic time.sleep(x) behavior.
+
+    """
+    inputs = [10, 8, 6, 4, 2]
+
+    # Create signals for each task
+    signals = [SignalActor.remote() for _ in range(len(inputs))]
+
+    # Create tasks
+    @ray.remote
+    def f(args):
+        x, signal = args
+        ray.get(signal.wait.remote())
+        return x
+
+    # Submit tasks with their corresponding signals in the original order
+    it = map_unordered(
+        f, zip(inputs, signals), chunk_size=1, yield_obj_refs=yield_obj_refs
+    )
+
+    # Send signal in reverse order to mimic time.sleep(x), i.e.,
+    # smallest value releases first. At the same time, collect results
+
+    results = []
+    for signal in reversed(signals):
+        ray.get(signal.send.remote())
+        results.append(next(it))
+
+    if yield_obj_refs:
+        results = ray.get(results)
+
+    assert results == [2, 4, 6, 8, 10]
+
+
+@pytest.mark.parametrize("yield_obj_refs", [True, False])
+def test_map_unordered_chunk_size_2(ray_init_4_cpu_shared, yield_obj_refs):
+    """Test map_unordered with chunk_size=2.
+
+    Use SignalActor to control task completion order and mimic time.sleep(x) behavior.
+
+    """
+    inputs = [10, 8, 6, 4, 2]
+
+    # Create signals for each task
+    signals = [SignalActor.remote() for _ in range(len(inputs))]
+
+    # Create tasks
+    @ray.remote
+    def f(args):
+        x, signal = args
+        ray.get(signal.wait.remote())
+        return x
+
+    # Submit tasks with their corresponding signals in the original order
+    it = map_unordered(
+        f, zip(inputs, signals), chunk_size=2, yield_obj_refs=yield_obj_refs
+    )
+
+    # Send signal in reverse order to mimic time.sleep(x), i.e.,
+    # smallest value releases first. At the same time, collect results
+
+    results = []
+
+    ray.get(signals[4].send.remote())
+    ray.get(signals[3].send.remote())
+    results.append(next(it))
+    results.append(next(it))
+
+    ray.get(signals[2].send.remote())
+    ray.get(signals[1].send.remote())
+    results.append(next(it))
+    results.append(next(it))
+
+    ray.get(signals[0].send.remote())
+    results.append(next(it))
+
+    if yield_obj_refs:
+        results = ray.get(results)
+
+    assert results == [4, 2, 8, 6, 10]
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/util/__init__.py
+++ b/python/ray/util/__init__.py
@@ -13,6 +13,7 @@ from ray.util.annotations import PublicAPI
 from ray.util.check_serialize import inspect_serializability
 from ray.util.client_connect import connect, disconnect
 from ray.util.debug import disable_log_once_globally, enable_periodic_logging, log_once
+from ray.util.helpers import as_completed, map_unordered
 from ray.util.placement_group import (
     get_current_placement_group,
     get_placement_group,
@@ -52,6 +53,7 @@ def list_named_actors(all_namespaces: bool = False) -> List[str]:
 __all__ = [
     "accelerators",
     "ActorPool",
+    "as_completed",
     "disable_log_once_globally",
     "enable_periodic_logging",
     "iter",
@@ -63,6 +65,7 @@ __all__ = [
     "get_current_placement_group",
     "get_node_instance_id",
     "get_node_ip_address",
+    "map_unordered",
     "remove_placement_group",
     "ray_debugpy",
     "inspect_serializability",

--- a/python/ray/util/helpers.py
+++ b/python/ray/util/helpers.py
@@ -1,0 +1,255 @@
+from typing import TYPE_CHECKING, Any, Iterable, Iterator, Optional, Sequence, Union
+import ray
+from ray.util.annotations import PublicAPI
+
+if TYPE_CHECKING:
+    from ray import ObjectRef
+    from ray.remote_function import RemoteFunction
+
+
+# ray.wait() has a default num_returns of 1.
+# Using a slightly larger batch until the optimization is fully implemented, see
+# https://github.com/ray-project/ray/issues/49905
+DEFAULT_CHUNK_SIZE = 10
+DEFAULT_BACKPRESSURE_SIZE = 100
+
+
+def _wait_and_get_single_batch(
+    refs: "Sequence[ObjectRef]",
+    *,
+    chunk_size: int,
+    yield_obj_refs: bool = False,
+    **kwargs,
+) -> tuple[list[Union[Any, "ObjectRef"]], "list[ObjectRef]"]:
+    """Call ray.wait and explicitly return the ready objects/results
+    and remaining Ray remote refs.
+
+    Args:
+        refs: A list of Ray object refs.
+        chunk_size: The `num_returns` parameter to pass to `ray.wait()`.
+        yield_obj_refs: If True, return Ray remote refs instead of results (by calling :meth:`~ray.get`).
+        **kwargs: Additional keyword arguments to pass to `ray.wait()`.
+
+    Returns:
+        A tuple of two lists, ready and not ready. This is the same as the return value of `ray.wait()`.
+    """
+
+    if chunk_size < 1:
+        raise ValueError("`chunk_size` must be >= 1")
+
+    kwargs = kwargs or {}
+
+    # num_returns must be <= len(refs)
+    ready, refs = ray.wait(
+        refs,
+        num_returns=min(chunk_size, len(refs)),
+        **kwargs,
+    )
+
+    if not yield_obj_refs:
+        return ray.get(ready), refs
+
+    return ready, refs
+
+
+@PublicAPI(stability="alpha")
+def as_completed(
+    refs: "Sequence[ObjectRef]",
+    *,
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+    yield_obj_refs: bool = False,
+    **kwargs,
+) -> Iterator[Union[Any, "ObjectRef"]]:
+    """Given a list of Ray task references, yield results as they become available.
+
+    Unlike calling :meth:`~ray.get` on a list of references (i.e., `ray.get(refs)`) which
+    waits for all results to be ready, this function begins to yield result as soon as
+    a batch of `chunk_size` results are ready.
+
+    .. note::
+        Generally there is no guarantee on the order of results. For example, the first result
+        is not necessarily the first one completed, but rather the first one submitted in the
+        first available batch (See :meth:`~ray.wait` for more details about
+        preservation of submission order).
+
+    .. note::
+        Use this function instead of calling :meth:`~ray.get` inside a for loop. See
+        https://docs.ray.io/en/latest/ray-core/patterns/ray-get-loop.html for more details.
+
+    Example:
+        Suppose we have a function that sleeps for x seconds depending on the input.
+        We expect to obtain a partially sorted list of results.
+
+        .. testcode:: python
+            import ray
+            import time
+
+            @ray.remote
+            def f(x):
+                time.sleep(x)
+                return x
+
+            refs = [f.remote(i) for i in [10, 4, 6, 8, 2]]
+            for x in ray.util.as_completed(refs, chunk_size=2):
+                print(x)
+
+        .. testoutput::
+            :options: +MOCK
+
+            # Output:
+            4
+            2
+            6
+            8
+            10
+
+    Args:
+        refs: A list of Ray object refs.
+        chunk_size: The number of tasks to wait for in each iteration (default 10).
+            The parameter is passed as `num_returns` to :meth:`~ray.wait` internally.
+        yield_obj_refs: If True, return Ray remote refs instead of results (by calling :meth:`~ray.get`).
+        **kwargs: Additional keyword arguments to pass to :meth:`~ray.wait`, e.g.,
+            `timeout` and `fetch_local`.
+
+    Yields:
+        Union[Any, ObjectRef]: The results (or optionally their Ray references) of the Ray tasks as they complete.
+    """
+    if chunk_size < 1:
+        raise ValueError("`chunk_size` must be >= 1")
+
+    if "num_returns" in kwargs:
+        raise ValueError("Use the `chunksize` argument instead of `num_returns`.")
+
+    while refs:
+        results, refs = _wait_and_get_single_batch(
+            refs,
+            chunk_size=chunk_size,
+            yield_obj_refs=yield_obj_refs,
+            **kwargs,
+        )
+        yield from results
+
+
+@PublicAPI(stability="alpha")
+def map_unordered(
+    fn: "RemoteFunction",
+    items: Iterable[Any],
+    *,
+    backpressure_size: Optional[int] = DEFAULT_BACKPRESSURE_SIZE,
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+    yield_obj_refs: bool = False,
+    **kwargs,
+) -> Iterator[Union[Any, "ObjectRef"]]:
+    """Apply a Ray remote function to a list of items and return an iterator that yields
+    the completed results as they become available.
+
+    This helper function applies backpressure to control the number of pending tasks, following the
+    design pattern described in
+    https://docs.ray.io/en/latest/ray-core/patterns/limit-pending-tasks.html.
+
+    .. note::
+        There is generally no guarantee on the order of results.
+
+    Example:
+        Suppose we have a function that sleeps for x seconds depending on the input.
+        We expect to obtain a partially sorted list of results.
+
+        .. testcode:: python
+
+            import ray
+            import time
+
+            @ray.remote
+            def f(x):
+                time.sleep(x)
+                return x
+
+            # Example 1: chunk_size=2
+            for x in ray.util.map_unordered(f, [10, 4, 6, 8, 2], chunk_size=2):
+                print(x)
+
+        .. testoutput::
+            :options: +MOCK
+
+            4
+            2
+            6
+            8
+            10
+
+        .. testcode:: python
+
+            # Example 2: backpressure_size=2, chunk_size=1
+            for x in ray.util.map_unordered(f, [10, 4, 6, 8, 2], backpressure_size=2, chunk_size=1):
+                print(x)
+
+        .. testoutput::
+            :options: +MOCK
+
+            4
+            10
+            6
+            8
+            2
+
+    Args:
+        fn: A remote function to apply to the list of items. For more complex use cases, use Ray Data's
+            :meth:`~ray.data.Dataset.map` / :meth:`~ray.data.Dataset.map_batches` instead.
+        items: An iterable of items to apply the function to.
+        backpressure_size: Maximum number of in-flight tasks allowed before
+            calling a blocking :meth:`~ray.wait` (default 100). If None, no backpressure is applied.
+        chunk_size: The number of tasks to wait for when the number of in-flight tasks exceeds
+            `backpressure_size`. The parameter is passed as `num_returns` to :meth:`~ray.wait` internally.
+        yield_obj_refs: If True, return Ray remote refs instead of results (by calling :meth:`~ray.get`).
+        **kwargs: Additional keyword arguments to pass to :meth:`~ray.wait`, e.g.,
+            `timeout` and `fetch_local`.
+
+    Yields:
+        Union[Any, ObjectRef]: The results (or optionally their Ray references) of the Ray tasks as they complete.
+
+    .. seealso::
+
+        :meth:`~ray.util.as_completed`
+            Call this method for an existing list of Ray object refs.
+
+        :meth:`~ray.data.Dataset.map`
+            Use Ray Data APIs (e.g., :meth:`~ray.data.Dataset.map` and :meth:`~ray.data.Dataset.map_batches`)
+            for better control and complex use cases, e.g., functions with multiple arguments.
+
+    .. note::
+
+        This is an altenative to `pool.imap_unordered()` in Ray's Actor-based `multiprocessing.Pool`.
+        See https://docs.ray.io/en/latest/ray-more-libs/multiprocessing.html for more details.
+
+    """
+
+    if backpressure_size is None:
+        backpressure_size: float = float("inf")
+    elif backpressure_size <= 0:
+        raise ValueError("backpressure_size must be positive.")
+
+    if chunk_size < 1:
+        raise ValueError("`chunk_size` must be >= 1")
+
+    if "num_returns" in kwargs:
+        raise ValueError("Use the `chunk_size` argument instead of `num_returns`.")
+
+    refs = []
+    for item in items:
+        refs.append(fn.remote(item))
+
+        if len(refs) >= backpressure_size:
+            results, refs = _wait_and_get_single_batch(
+                refs,
+                chunk_size=chunk_size,
+                yield_obj_refs=yield_obj_refs,
+                **kwargs,
+            )
+            yield from results
+    else:
+        yield from as_completed(
+            refs,
+            chunk_size=chunk_size,
+            yield_obj_refs=yield_obj_refs,
+            **kwargs,
+        )


### PR DESCRIPTION
## Why are these changes needed?

This PR adds two public APIs:

- `as_completed` for "unordered ray.get"
- `map_unordered` for "unordered map"

As described in #52696 , many new users learned about the `@ray.remote` decorator but failed to scale up their applications. Therefore, it will be helpful to provide some helper functions that follow the design patterns on Ray's documentation:
https://docs.ray.io/en/latest/ray-core/patterns/index.html

These two functions are marked as alpha Public APIs because ideally they should be public and used by new users.

TODO:
- [x] add some examples in the docstrings

## Related issue number

Closes #52696 

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
