### PR TITLE
[Serve] Set the docs path after app is initialized on the replica

### DIFF
--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -731,16 +731,15 @@ class ApplicationState:
     def _check_routes(
         self, deployment_infos: Dict[str, DeploymentInfo]
     ) -> Tuple[str, str]:
-        """Check route prefixes and docs paths of deployments in app.
+        """Check route prefixes of deployments in app.
 
         There should only be one non-null route prefix. If there is one,
         set it as the application route prefix. This function must be
         run every control loop iteration because the target config could
         be updated without kicking off a new task.
 
-        Returns: tuple of route prefix, docs path.
-        Raises: RayServeException if more than one route prefix or docs
-            path is found among deployments.
+        Returns: route prefix.
+        Raises: RayServeException if more than one route prefix is found among deployments.
         """
         num_route_prefixes = 0
         route_prefix = None

--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -238,7 +238,6 @@ class ApplicationState:
         self._deployment_state_manager = deployment_state_manager
         self._endpoint_state = endpoint_state
         self._route_prefix: Optional[str] = None
-        self._docs_path: Optional[str] = None
         self._ingress_deployment_name: Optional[str] = None
 
         self._status: ApplicationStatus = ApplicationStatus.DEPLOYING
@@ -264,14 +263,7 @@ class ApplicationState:
 
     @property
     def docs_path(self) -> Optional[str]:
-        # if the docs path is set during the deploy app task, use that
-        # TODO (abrar): this can be dropped completely in favor of the
-        # deployment state manager once we have migrated all the tests
-        # to the new API.
-        if self._docs_path is not None:
-            return self._docs_path
-
-        # else get the docs path from the running deployments
+        # get the docs path from the running deployments
         # we are making an assumption that the docs path can only be set
         # on ingress deployments with fastapi.
         ingress_deployment = DeploymentID(self._ingress_deployment_name, self._name)
@@ -479,7 +471,7 @@ class ApplicationState:
 
         self._check_ingress_deployments(deployment_infos)
         # Check routes are unique in deployment infos
-        self._route_prefix, self._docs_path = self._check_routes(deployment_infos)
+        self._route_prefix = self._check_routes(deployment_infos)
 
         self._set_target_state(
             deployment_infos=deployment_infos,
@@ -703,7 +695,7 @@ class ApplicationState:
             overrided_infos = override_deployment_info(
                 deployment_infos, self._build_app_task_info.config
             )
-            self._route_prefix, self._docs_path = self._check_routes(overrided_infos)
+            self._route_prefix = self._check_routes(overrided_infos)
             return overrided_infos, BuildAppStatus.SUCCEEDED, ""
         except (TypeError, ValueError, RayServeException):
             return None, BuildAppStatus.FAILED, traceback.format_exc()
@@ -751,21 +743,13 @@ class ApplicationState:
             path is found among deployments.
         """
         num_route_prefixes = 0
-        num_docs_paths = 0
         route_prefix = None
-        # TODO(Ziy1-Tan): `docs_path` will be removed when
-        # https://github.com/ray-project/ray/issues/53023 is resolved.
-        # We can get it from DeploymentStateManager directly.
-        docs_path = None
         for info in deployment_infos.values():
             # Update route prefix of application, which may be updated
             # through a redeployed config.
             if info.route_prefix is not None:
                 route_prefix = info.route_prefix
                 num_route_prefixes += 1
-            if info.docs_path is not None:
-                docs_path = info.docs_path
-                num_docs_paths += 1
 
         if num_route_prefixes > 1:
             raise RayServeException(
@@ -773,17 +757,8 @@ class ApplicationState:
                 " Please specify only one route prefix for the application "
                 "to avoid this issue."
             )
-        # NOTE(zcin) This will not catch multiple FastAPI deployments in the application
-        # if user sets the docs path to None in their FastAPI app.
-        if num_docs_paths > 1:
-            raise RayServeException(
-                f'Found multiple deployments in application "{self._name}" that have '
-                "a docs path. This may be due to using multiple FastAPI deployments "
-                "in your application. Please only include one deployment with a docs "
-                "path in your application to avoid this issue."
-            )
 
-        return route_prefix, docs_path
+        return route_prefix
 
     def _reconcile_target_deployments(self) -> None:
         """Reconcile target deployments in application target state.
@@ -1227,7 +1202,6 @@ def build_serve_application(
                     deployment_config=deployment._deployment_config,
                     version=code_version,
                     route_prefix="/" if is_ingress else None,
-                    docs_path=deployment._docs_path,
                 )
             )
         if num_ingress_deployments > 1:

--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -324,9 +324,7 @@ class ApplicationState:
         # Restore route prefix and docs path from checkpointed deployments when
         # the imperatively started application is restarting with controller.
         if checkpoint_data.deployment_infos is not None:
-            self._route_prefix, self._docs_path = self._check_routes(
-                checkpoint_data.deployment_infos
-            )
+            self._route_prefix = self._check_routes(checkpoint_data.deployment_infos)
 
     def _set_target_state(
         self,
@@ -509,9 +507,7 @@ class ApplicationState:
                     self._target_state.deployment_infos,
                     config,
                 )
-                self._route_prefix, self._docs_path = self._check_routes(
-                    overrided_infos
-                )
+                self._route_prefix = self._check_routes(overrided_infos)
                 self._set_target_state(
                     # Code version doesn't change.
                     code_version=self._target_state.code_version,

--- a/python/ray/serve/_private/client.py
+++ b/python/ray/serve/_private/client.py
@@ -270,7 +270,6 @@ class ServeControllerClient:
                     deployment_config=deployment._deployment_config,
                     version=deployment._version or get_random_string(),
                     route_prefix=app.route_prefix if is_ingress else None,
-                    docs_path=deployment._docs_path,
                 )
 
                 deployment_args_proto = DeploymentArgs()
@@ -289,8 +288,6 @@ class ServeControllerClient:
                 if deployment_args["route_prefix"]:
                     deployment_args_proto.route_prefix = deployment_args["route_prefix"]
                 deployment_args_proto.ingress = deployment_args["ingress"]
-                if deployment_args["docs_path"]:
-                    deployment_args_proto.docs_path = deployment_args["docs_path"]
 
                 deployment_args_list.append(deployment_args_proto.SerializeToString())
 

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -776,9 +776,6 @@ class ServeController:
                         "route_prefix": (
                             args.route_prefix if args.HasField("route_prefix") else None
                         ),
-                        "docs_path": (
-                            args.docs_path if args.HasField("docs_path") else None
-                        ),
                     }
                 )
             name_to_deployment_args[name] = deployment_args_deserialized

--- a/python/ray/serve/_private/deploy_utils.py
+++ b/python/ray/serve/_private/deploy_utils.py
@@ -22,7 +22,6 @@ def get_deploy_args(
     deployment_config: Optional[Union[DeploymentConfig, Dict[str, Any]]] = None,
     version: Optional[str] = None,
     route_prefix: Optional[str] = None,
-    docs_path: Optional[str] = None,
 ) -> Dict:
     """
     Takes a deployment's configuration, and returns the arguments needed
@@ -44,7 +43,6 @@ def get_deploy_args(
         "replica_config_proto_bytes": replica_config.to_proto_bytes(),
         "route_prefix": route_prefix,
         "deployer_job_id": ray.get_runtime_context().get_job_id(),
-        "docs_path": docs_path,
         "ingress": ingress,
     }
 
@@ -56,7 +54,6 @@ def deploy_args_to_deployment_info(
     deployment_config_proto_bytes: bytes,
     replica_config_proto_bytes: bytes,
     deployer_job_id: Union[str, bytes],
-    docs_path: Optional[str],
     app_name: Optional[str] = None,
     ingress: bool = False,
     route_prefix: Optional[str] = None,
@@ -88,7 +85,6 @@ def deploy_args_to_deployment_info(
         deployer_job_id=deployer_job_id,
         start_time_ms=int(time.time() * 1000),
         route_prefix=route_prefix,
-        docs_path=docs_path,
         ingress=ingress,
     )
 

--- a/python/ray/serve/_private/deployment_info.py
+++ b/python/ray/serve/_private/deployment_info.py
@@ -20,7 +20,6 @@ class DeploymentInfo:
         version: Optional[str] = None,
         end_time_ms: Optional[int] = None,
         route_prefix: str = None,
-        docs_path: str = None,
         ingress: bool = False,
         target_capacity: Optional[float] = None,
         target_capacity_direction: Optional[TargetCapacityDirection] = None,
@@ -39,7 +38,6 @@ class DeploymentInfo:
         self._cached_actor_def = None
 
         self.route_prefix = route_prefix
-        self.docs_path = docs_path
         self.ingress = ingress
 
         self.target_capacity = target_capacity
@@ -70,7 +68,6 @@ class DeploymentInfo:
             version=version or self.version,
             end_time_ms=self.end_time_ms,
             route_prefix=route_prefix or self.route_prefix,
-            docs_path=self.docs_path,
             ingress=self.ingress,
             target_capacity=self.target_capacity,
             target_capacity_direction=self.target_capacity_direction,

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -994,10 +994,12 @@ class ReplicaActor:
     ) -> ReplicaMetadata:
         """Handles initializing the replica.
 
-        Returns: 3-tuple containing
+        Returns: 5-tuple containing
             1. DeploymentConfig of the replica
             2. DeploymentVersion of the replica
             3. Initialization duration in seconds
+            4. Port
+            5. Serve docs_path
         """
         # Unused `_after` argument is for scheduling: passing an ObjectRef
         # allows delaying this call until after the `_after` call has returned.

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -999,7 +999,7 @@ class ReplicaActor:
             2. DeploymentVersion of the replica
             3. Initialization duration in seconds
             4. Port
-            5. Serve docs_path
+            5. FastAPI `docs_path`, if relevant (i.e. this is an ingress deployment integrated with FastAPI).
         """
         # Unused `_after` argument is for scheduling: passing an ObjectRef
         # allows delaying this call until after the `_after` call has returned.

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -307,11 +307,6 @@ def ingress(app: Union[ASGIApp, Callable]) -> Callable:
                         cls.__del__(self)
 
         ASGIIngressWrapper.__name__ = cls.__name__
-        if hasattr(frozen_app_or_func, "docs_url"):
-            # TODO (abrar): fastapi apps instantiated by builder function will set
-            # the docs path on application state via the replica.
-            # This split in logic is not desirable, we should consolidate the two.
-            ASGIIngressWrapper.__fastapi_docs_path__ = frozen_app_or_func.docs_url
 
         return ASGIIngressWrapper
 

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -110,7 +110,6 @@ class Deployment:
         self._version = version
         self._deployment_config = deployment_config
         self._replica_config = replica_config
-        self._docs_path = None
 
     def _validate_name(self, name: str):
         if not isinstance(name, str):

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -1,4 +1,3 @@
-import inspect
 import logging
 import warnings
 from copy import deepcopy
@@ -106,20 +105,12 @@ class Deployment:
         self._validate_name(name)
         if not (version is None or isinstance(version, str)):
             raise TypeError("version must be a string.")
-        docs_path = None
-        if (
-            inspect.isclass(replica_config.deployment_def)
-            and hasattr(replica_config.deployment_def, "__module__")
-            and replica_config.deployment_def.__module__ == "ray.serve.api"
-            and hasattr(replica_config.deployment_def, "__fastapi_docs_path__")
-        ):
-            docs_path = replica_config.deployment_def.__fastapi_docs_path__
 
         self._name = name
         self._version = version
         self._deployment_config = deployment_config
         self._replica_config = replica_config
-        self._docs_path = docs_path
+        self._docs_path = None
 
     def _validate_name(self, name: str):
         if not isinstance(name, str):

--- a/python/ray/serve/tests/unit/test_application_state.py
+++ b/python/ray/serve/tests/unit/test_application_state.py
@@ -167,7 +167,7 @@ def mocked_application_state_manager() -> (
     yield application_state_manager, deployment_state_manager, kv_store
 
 
-def deployment_params(name: str, route_prefix: str = None, docs_path: str = None):
+def deployment_params(name: str, route_prefix: str = None):
     return {
         "deployment_name": name,
         "deployment_config_proto_bytes": DeploymentConfig(
@@ -178,13 +178,12 @@ def deployment_params(name: str, route_prefix: str = None, docs_path: str = None
         ).to_proto_bytes(),
         "deployer_job_id": "random",
         "route_prefix": route_prefix,
-        "docs_path": docs_path,
         "ingress": False,
     }
 
 
-def deployment_info(name: str, route_prefix: str = None, docs_path: str = None):
-    params = deployment_params(name, route_prefix, docs_path)
+def deployment_info(name: str, route_prefix: str = None):
+    params = deployment_params(name, route_prefix)
     return deploy_args_to_deployment_info(**params, app_name="test_app")
 
 
@@ -512,12 +511,11 @@ def test_deploy_and_delete_app(mocked_application_state):
     d2_id = DeploymentID(name="d2", app_name="test_app")
     app_state.deploy_app(
         {
-            "d1": deployment_info("d1", "/hi", "/documentation"),
+            "d1": deployment_info("d1", "/hi"),
             "d2": deployment_info("d2"),
         }
     )
     assert app_state.route_prefix == "/hi"
-    assert app_state.docs_path == "/documentation"
 
     app_status = app_state.get_application_status_info()
     assert app_status.status == ApplicationStatus.DEPLOYING
@@ -677,7 +675,7 @@ def test_app_unhealthy(mocked_application_state):
 
 
 @patch("ray.serve._private.application_state.build_serve_application", Mock())
-@patch("ray.get", Mock(return_value=([deployment_params("a", "/old", "/docs")], None)))
+@patch("ray.get", Mock(return_value=([deployment_params("a", "/old")], None)))
 @patch("ray.serve._private.application_state.check_obj_ref_ready_nowait")
 def test_apply_app_configs_succeed(check_obj_ref_ready_nowait):
     """Test deploying through config successfully.
@@ -715,7 +713,6 @@ def test_apply_app_configs_succeed(check_obj_ref_ready_nowait):
     assert app_state.status == ApplicationStatus.DEPLOYING
     assert app_state.target_deployments == ["a"]
     assert app_state.route_prefix == "/new"
-    assert app_state.docs_path == "/docs"
 
     # Set healthy
     deployment_state_manager.set_deployment_healthy(deployment_id)
@@ -768,7 +765,7 @@ def test_apply_app_configs_fail(check_obj_ref_ready_nowait):
     Mock(return_value="123"),
 )
 @patch("ray.serve._private.application_state.build_serve_application", Mock())
-@patch("ray.get", Mock(return_value=([deployment_params("a", "/old", "/docs")], None)))
+@patch("ray.get", Mock(return_value=([deployment_params("a", "/old")], None)))
 @patch("ray.serve._private.application_state.check_obj_ref_ready_nowait")
 def test_apply_app_configs_deletes_existing(check_obj_ref_ready_nowait):
     """Test that apply_app_configs deletes existing apps that aren't in the new list.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

- remove the `__fastapi_docs_path__` class attribute and set the `docs_path` when ASGI app builder funtion have been evaluated on the replica.

## Related issue number

Closes https://github.com/ray-project/ray/issues/53023

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
