### PR TITLE
[core] Pin github URI in runtime_env tests

### DIFF
--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -54,7 +54,7 @@ ARCHIVE_NAME = "archive.zip"
 # This package contains a subdirectory called `test_module`.
 # Calling `test_module.one()` should return `2`.
 # If you find that confusing, take it up with @jiaodong...
-HTTPS_PACKAGE_URI = "https://github.com/shrekris-anyscale/test_module/archive/HEAD.zip"
+HTTPS_PACKAGE_URI = "https://github.com/shrekris-anyscale/test_module/archive/a885b80879665a49d5cd4c3ebd33bb6f865644e5.zip"
 S3_PACKAGE_URI = "s3://runtime-env-test/test_runtime_env.zip"
 S3_WHL_PACKAGE_URI = "s3://runtime-env-test/test_module-0.0.1-py3-none-any.whl"
 

--- a/python/ray/tests/test_runtime_env_working_dir.py
+++ b/python/ray/tests/test_runtime_env_working_dir.py
@@ -27,7 +27,7 @@ from ray._private.utils import get_directory_size_bytes
 # This package contains a subdirectory called `test_module`.
 # Calling `test_module.one()` should return `2`.
 # If you find that confusing, take it up with @jiaodong...
-HTTPS_PACKAGE_URI = "https://github.com/shrekris-anyscale/test_module/archive/HEAD.zip"
+HTTPS_PACKAGE_URI = "https://github.com/shrekris-anyscale/test_module/archive/a885b80879665a49d5cd4c3ebd33bb6f865644e5.zip"
 S3_PACKAGE_URI = "s3://runtime-env-test/test_runtime_env.zip"
 TEST_IMPORT_DIR = "test_import_dir"
 

--- a/python/ray/tests/test_runtime_env_working_dir_remote_uri.py
+++ b/python/ray/tests/test_runtime_env_working_dir_remote_uri.py
@@ -58,7 +58,7 @@ def make_task_actor(*, runtime_env: Optional[Dict]) -> Tuple:
 def test_failure_without_runtime_env(start_cluster_shared_two_nodes):
     """Sanity checks that the test task & actor fail without a runtime_env."""
     cluster, address = start_cluster_shared_two_nodes
-]
+
     task, actor = make_task_actor(runtime_env=None)
     task_obj_ref = task.remote()
     a = actor.remote()

--- a/python/ray/tests/test_runtime_env_working_dir_remote_uri.py
+++ b/python/ray/tests/test_runtime_env_working_dir_remote_uri.py
@@ -69,9 +69,14 @@ def test_failure_without_runtime_env(start_cluster_shared_two_nodes):
     with pytest.raises(ModuleNotFoundError):
         ray.get(actor_obj_ref)
 
+
 @pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
 @pytest.mark.parametrize("option", ["working_dir", "py_modules"])
-@pytest.mark.parametrize("remote_uri", [HTTPS_PACKAGE_URI, S3_PACKAGE_URI, S3_WHL_PACKAGE_URI], ids=["https", "s3", "whl"])
+@pytest.mark.parametrize(
+    "remote_uri",
+    [HTTPS_PACKAGE_URI, S3_PACKAGE_URI, S3_WHL_PACKAGE_URI],
+    ids=["https", "s3", "whl"],
+)
 @pytest.mark.parametrize("per_task_actor", [True, False])
 def test_remote_package_uri_multi_node(
     start_cluster_shared_two_nodes, option, remote_uri, per_task_actor

--- a/python/ray/tests/test_runtime_env_working_dir_remote_uri.py
+++ b/python/ray/tests/test_runtime_env_working_dir_remote_uri.py
@@ -11,10 +11,9 @@ from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 # This package contains a subdirectory called `test_module`.
 # Calling `test_module.one()` should return `2`.
-HTTPS_PACKAGE_URI = "https://github.com/shrekris-anyscale/test_module/archive/HEAD.zip"
+HTTPS_PACKAGE_URI = "https://github.com/shrekris-anyscale/test_module/archive/a885b80879665a49d5cd4c3ebd33bb6f865644e5.zip"
 S3_PACKAGE_URI = "s3://runtime-env-test/test_runtime_env.zip"
 S3_WHL_PACKAGE_URI = "s3://runtime-env-test/test_module-0.0.1-py3-none-any.whl"
-REMOTE_URIS = [HTTPS_PACKAGE_URI, S3_PACKAGE_URI]
 
 
 @pytest.fixture(scope="module")
@@ -59,7 +58,7 @@ def make_task_actor(*, runtime_env: Optional[Dict]) -> Tuple:
 def test_failure_without_runtime_env(start_cluster_shared_two_nodes):
     """Sanity checks that the test task & actor fail without a runtime_env."""
     cluster, address = start_cluster_shared_two_nodes
-
+]
     task, actor = make_task_actor(runtime_env=None)
     task_obj_ref = task.remote()
     a = actor.remote()
@@ -70,10 +69,9 @@ def test_failure_without_runtime_env(start_cluster_shared_two_nodes):
     with pytest.raises(ModuleNotFoundError):
         ray.get(actor_obj_ref)
 
-
 @pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
 @pytest.mark.parametrize("option", ["working_dir", "py_modules"])
-@pytest.mark.parametrize("remote_uri", [*REMOTE_URIS, S3_WHL_PACKAGE_URI])
+@pytest.mark.parametrize("remote_uri", [HTTPS_PACKAGE_URI, S3_PACKAGE_URI, S3_WHL_PACKAGE_URI], ids=["https", "s3", "whl"])
 @pytest.mark.parametrize("per_task_actor", [True, False])
 def test_remote_package_uri_multi_node(
     start_cluster_shared_two_nodes, option, remote_uri, per_task_actor


### PR DESCRIPTION
Also added `ids` for the fixture because there was an error uploading test metadata: https://buildkite.com/ray-project/postmerge/builds/10565#01972f08-ab62-4f7e-a172-54fc48a09f46/1145-1146