### PR TITLE
Fix iter_rows involving _get_max_chunk_size

### DIFF
--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -195,11 +195,6 @@ class ArrowBlockAccessor(TableBlockAccessor):
         if pyarrow is None:
             raise ImportError("Run `pip install pyarrow` for Arrow support")
         super().__init__(table)
-        # Set the max chunk size in rows for Arrow to Batches conversion in
-        # ArrowBlockAccessor.iter_rows().
-        self._max_chunk_size = _get_max_chunk_size(
-            self._table, ARROW_MAX_CHUNK_SIZE_BYTES
-        )
 
     def column_names(self) -> List[str]:
         return self._table.column_names
@@ -424,6 +419,10 @@ class ArrowBlockAccessor(TableBlockAccessor):
     ) -> Iterator[Union[Mapping, np.ndarray]]:
         table = self._table
         if public_row_format:
+            if not hasattr(self, "_max_chunk_size"):
+                self._max_chunk_size = _get_max_chunk_size(
+                    self._table, ARROW_MAX_CHUNK_SIZE_BYTES
+                )
             for batch in table.to_batches(max_chunksize=self._max_chunk_size):
                 yield from batch.to_pylist()
         else:

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -420,6 +420,8 @@ class ArrowBlockAccessor(TableBlockAccessor):
         table = self._table
         if public_row_format:
             if not hasattr(self, "_max_chunk_size"):
+                # Calling _get_max_chunk_size in constructor makes it slow, so we
+                # are calling it here only when needed.
                 self._max_chunk_size = _get_max_chunk_size(
                     self._table, ARROW_MAX_CHUNK_SIZE_BYTES
                 )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Fix `iter_rows` involving `_get_max_chunk_size`

- Calling `_get_max_chunk_size` in `ArrowBlockAccessor` constructor has overhead.
- So moving `_get_max_chunk_size` call into `iter_rows` conditionally only for `public_row_format`.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
