### PR TITLE
[Data] Remove assertion that actors with infinite retries can't be dead 

### DIFF
--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -425,9 +425,6 @@ class ActorPoolMapOperator(MapOperator):
             if actor_state in (None, gcs_pb2.ActorTableData.ActorState.DEAD):
                 # actor._get_local_state can return None if the state is Unknown
                 # If actor_state is None or dead, there is nothing to do.
-                if actor_state == gcs_pb2.ActorTableData.ActorState.DEAD:
-                    # Indefinite task retries have been disabled.
-                    assert self._ray_remote_args["max_restarts"] != -1
                 continue
             elif actor_state != gcs_pb2.ActorTableData.ActorState.ALIVE:
                 # The actors can be either ALIVE or RESTARTING here because they will


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If actors are force-killed with `ray.kill`, they can end up in the DEAD state even if max_restarts is infinite. This can cause our assertion to fail and lead to confusing errors.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
