### PR TITLE
[core] Fix `test_runtime_env.py` in CI

### DIFF
--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -82,27 +82,6 @@ def test_decorator_complex(start_cluster_shared, runtime_env_class):
     assert ray.get(a.g.remote()) == "new2"
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Hangs on windows.")
-@pytest.mark.parametrize("runtime_env_class", [dict, RuntimeEnv])
-def test_failed_job_env_no_hang(shutdown_only, runtime_env_class):
-    """Test that after a failed job-level env, tasks can still be run."""
-    runtime_env_for_init = runtime_env_class(pip=["ray-doesnotexist-123"])
-    ray.init(runtime_env=runtime_env_for_init)
-
-    @ray.remote
-    def f():
-        import pip_install_test  # noqa: F401
-
-        return True
-
-    runtime_env_for_f = runtime_env_class(pip=["pip-install-test==0.5"])
-    assert ray.get(f.options(runtime_env=runtime_env_for_f).remote())
-
-    # Task with no runtime env should inherit the bad job env.
-    with pytest.raises(RuntimeEnvSetupError):
-        ray.get(f.remote())
-
-
 def test_to_make_ensure_runtime_env_api(start_cluster_shared):
     # make sure RuntimeEnv can be used in an be used interchangeably with
     # an unstructured dictionary in the relevant API calls.

--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -9,7 +9,6 @@ import sys
 import pytest
 
 import ray
-from ray.exceptions import RuntimeEnvSetupError
 from ray.runtime_env import RuntimeEnv, RuntimeEnvConfig
 
 

--- a/python/ray/tests/test_runtime_env_standalone.py
+++ b/python/ray/tests/test_runtime_env_standalone.py
@@ -370,10 +370,9 @@ class TestNoUserInfoInLogs:
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Hangs on windows.")
-@pytest.mark.parametrize("runtime_env_class", [dict, RuntimeEnv])
-def test_failed_job_env_no_hang(shutdown_only, runtime_env_class):
+def test_failed_job_env_no_hang(shutdown_only):
     """Test that after a failed job-level env, tasks can still be run."""
-    runtime_env_for_init = runtime_env_class(pip=["ray-doesnotexist-123"])
+    runtime_env_for_init = RuntimeEnv(pip=["ray-doesnotexist-123"])
     ray.init(runtime_env=runtime_env_for_init)
 
     @ray.remote
@@ -382,7 +381,7 @@ def test_failed_job_env_no_hang(shutdown_only, runtime_env_class):
 
         return True
 
-    runtime_env_for_f = runtime_env_class(pip=["pip-install-test==0.5"])
+    runtime_env_for_f = RuntimeEnv(pip=["pip-install-test==0.5"])
     assert ray.get(f.options(runtime_env=runtime_env_for_f).remote())
 
     # Task with no runtime env should inherit the bad job env.

--- a/python/ray/tests/test_runtime_env_standalone.py
+++ b/python/ray/tests/test_runtime_env_standalone.py
@@ -369,5 +369,26 @@ class TestNoUserInfoInLogs:
         )
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Hangs on windows.")
+@pytest.mark.parametrize("runtime_env_class", [dict, RuntimeEnv])
+def test_failed_job_env_no_hang(shutdown_only, runtime_env_class):
+    """Test that after a failed job-level env, tasks can still be run."""
+    runtime_env_for_init = runtime_env_class(pip=["ray-doesnotexist-123"])
+    ray.init(runtime_env=runtime_env_for_init)
+
+    @ray.remote
+    def f():
+        import pip_install_test  # noqa: F401
+
+        return True
+
+    runtime_env_for_f = runtime_env_class(pip=["pip-install-test==0.5"])
+    assert ray.get(f.options(runtime_env=runtime_env_for_f).remote())
+
+    # Task with no runtime env should inherit the bad job env.
+    with pytest.raises(RuntimeEnvSetupError):
+        ray.get(f.remote())
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))


### PR DESCRIPTION
I missed one of the tests that needed to be moved to `test_runtime_env_standalone.py`.

Example failure: https://buildkite.com/ray-project/postmerge/builds/10600#0197342f-47fc-409c-bcce-dd3f4dc08187/177-2106