### PR TITLE
[RLlib] Wrapper which allows EnvRunners to operate on environments with Repeated observation spaces

### DIFF
--- a/rllib/env/wrappers/repeated_wrapper.py
+++ b/rllib/env/wrappers/repeated_wrapper.py
@@ -3,7 +3,6 @@ from gymnasium.spaces import Discrete, Box, Dict
 from ray.rllib.utils.spaces.repeated import Repeated
 import numpy as np
 import torch
-
 from ray.rllib.utils.annotations import PublicAPI
 
 

--- a/rllib/env/wrappers/repeated_wrapper.py
+++ b/rllib/env/wrappers/repeated_wrapper.py
@@ -8,9 +8,10 @@ from ray.rllib.utils.annotations import PublicAPI
 
 @PublicAPI
 class ObsVectorizationWrapper(gym.ObservationWrapper):
-    '''
-        Works around the crash currently associated with Repeated action spaces by mapping them to vectors. Includes a method for mapping them to the original space for encoding or other processing, either as batches or as individual observations. See examples/catalogs/attention_encoder.py for usage.
-    '''
+    """
+    Works around the crash currently associated with Repeated action spaces by mapping them to vectors. Includes a method for mapping them to the original space for encoding or other processing, either as batches or as individual observations. See examples/catalogs/attention_encoder.py for usage.
+    """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         original_obs_space = self.observation_space
@@ -24,118 +25,120 @@ class ObsVectorizationWrapper(gym.ObservationWrapper):
 
     #
     def observation(self, observation):
-        return self.__class__.serialize_obs(observation, self.observation_space.original)
+        return self.__class__.serialize_obs(
+            observation, self.observation_space.original
+        )
 
     @classmethod
     def serialize_obs(cls, obs, obs_s):
-      """ Convert a Dict or Repeated space into a [0, 1] vector with all relevant information """
-      if type(obs_s) == Repeated:
-        cs = obs_s.child_space
-        csl = cls.obs_length(cs)
-        ml = obs_s.max_len
-        l =  ml * (csl+1)
-        v = np.zeros(l, dtype=np.float32)
-        for o, sp, ix in zip(obs, range(0, l, csl), range(0, ml)):
-          v[ix] = 1
-          v[sp+ml:sp+ml+csl] = cls.serialize_obs(o, cs)
-        return v
-      elif type(obs_s) == Dict:
-        vl = []
-        cs = obs_s.spaces
-        for s in sorted(cs.keys()):
-          vl.append(cls.serialize_obs(obs[s], cs[s]))
-        return np.concatenate(vl)
-      elif type(obs_s) == Box:
-        return (obs - obs_s.low) / (obs_s.high - obs_s.low)
-      elif type(obs_s) == Discrete:
-        x = np.zeros(obs_s.n, dtype=np.float32)
-        x[obs] = 1
-        return x
+        """Convert a Dict or Repeated space into a [0, 1] vector with all relevant information"""
+        if type(obs_s) == Repeated:
+            cs = obs_s.child_space
+            csl = cls.obs_length(cs)
+            ml = obs_s.max_len
+            l = ml * (csl + 1)
+            v = np.zeros(l, dtype=np.float32)
+            for o, sp, ix in zip(obs, range(0, l, csl), range(0, ml)):
+                v[ix] = 1
+                v[sp + ml : sp + ml + csl] = cls.serialize_obs(o, cs)
+            return v
+        elif type(obs_s) == Dict:
+            vl = []
+            cs = obs_s.spaces
+            for s in sorted(cs.keys()):
+                vl.append(cls.serialize_obs(obs[s], cs[s]))
+            return np.concatenate(vl)
+        elif type(obs_s) == Box:
+            return (obs - obs_s.low) / (obs_s.high - obs_s.low)
+        elif type(obs_s) == Discrete:
+            x = np.zeros(obs_s.n, dtype=np.float32)
+            x[obs] = 1
+            return x
 
     @classmethod
     def restore_obs(cls, vec, obs_s):
-      """ Convert an observation vector back into its original format. """
-      if (len(vec.shape) == 2): # Handle batched observations
-        batch_list = []
-        for v in vec:
-          batch_list.append(cls.restore_obs(v, obs_s))
-        return batch_list
-      if type(obs_s) == Repeated:
-        rl = []
-        cs = obs_s.child_space
-        csl = cls.obs_length(cs)
-        ml = obs_s.max_len
-        l =  ml * (csl+1)
-        for sp, ix in zip(range(ml, l+ml, csl), range(0, ml)):
-          if (vec[ix] == 1):
-            rl.append(cls.restore_obs(vec[sp:sp+csl], cs))
-          else:
-            break
-        return rl
-      elif type(obs_s) == Dict:
-        d = {}
-        cs = obs_s.spaces
-        sp2 = 0
-        for s in sorted(cs.keys()):
-          d[s] = cls.restore_obs(vec[sp2:], cs[s])
-          sp2 += cls.obs_length(cs[s])
-        return d
-      elif type(obs_s) == Box:
-        vec = vec[:obs_s.shape[0]]
-        h, l = obs_s.high, obs_s.low
-        if (type(vec) == torch.Tensor):
-          h, l = torch.tensor(h).to(vec.device), torch.tensor(l).to(vec.device)
-        return vec * (h - l) + l
-      elif type(obs_s) == Discrete:
-        return vec[:obs_s.n].argmax()
+        """Convert an observation vector back into its original format."""
+        if len(vec.shape) == 2:  # Handle batched observations
+            batch_list = []
+            for v in vec:
+                batch_list.append(cls.restore_obs(v, obs_s))
+            return batch_list
+        if type(obs_s) == Repeated:
+            rl = []
+            cs = obs_s.child_space
+            csl = cls.obs_length(cs)
+            ml = obs_s.max_len
+            l = ml * (csl + 1)
+            for sp, ix in zip(range(ml, l + ml, csl), range(0, ml)):
+                if vec[ix] == 1:
+                    rl.append(cls.restore_obs(vec[sp : sp + csl], cs))
+                else:
+                    break
+            return rl
+        elif type(obs_s) == Dict:
+            d = {}
+            cs = obs_s.spaces
+            sp2 = 0
+            for s in sorted(cs.keys()):
+                d[s] = cls.restore_obs(vec[sp2:], cs[s])
+                sp2 += cls.obs_length(cs[s])
+            return d
+        elif type(obs_s) == Box:
+            vec = vec[: obs_s.shape[0]]
+            h, l = obs_s.high, obs_s.low
+            if type(vec) == torch.Tensor:
+                h, l = torch.tensor(h).to(vec.device), torch.tensor(l).to(vec.device)
+            return vec * (h - l) + l
+        elif type(obs_s) == Discrete:
+            return vec[: obs_s.n].argmax()
 
     @classmethod
     def restore_obs_batch(cls, vec, obs_s):
-      """
+        """
         Convert an observation vector back into its original format.
         This version of the function integrates Repeated spaces more neatly with attention/LSTM-based models, preserving the batch structure and supplementing it with a mask to indicate items' presence or absence.
-      """
-      if (len(vec.shape) == 1):
-        vec = np.expand_dims(vec, 0)
-      if type(obs_s) == Repeated:
-        rl = []
-        cs = obs_s.child_space
-        csl = cls.obs_length(cs)
-        ml = obs_s.max_len
-        l =  ml * (csl+1)
-        mask = vec[:, :ml]
-        for sp in range(ml, l, csl):
-          rl.append(cls.restore_obs_batch(vec[:, sp:sp+csl], cs))
-        return (rl, mask)
-      elif type(obs_s) == Dict:
-        d = {}
-        cs = obs_s.spaces
-        sp2 = 0
-        for s in sorted(cs.keys()):
-          d[s] = cls.restore_obs_batch(vec[:, sp2:], cs[s])
-          sp2 += cls.obs_length(cs[s])
-        return d
-      elif type(obs_s) == Box:
-        vec = vec[:, :obs_s.shape[0]]
-        h, l = obs_s.high, obs_s.low
-        if (type(vec) == torch.Tensor):
-          h, l = torch.tensor(h).to(vec.device), torch.tensor(l).to(vec.device)
-        return vec * (h - l) + l
-      elif type(obs_s) == Discrete:
-        return vec[:, :obs_s.n].argmax(axis=1)
+        """
+        if len(vec.shape) == 1:
+            vec = np.expand_dims(vec, 0)
+        if type(obs_s) == Repeated:
+            rl = []
+            cs = obs_s.child_space
+            csl = cls.obs_length(cs)
+            ml = obs_s.max_len
+            l = ml * (csl + 1)
+            mask = vec[:, :ml]
+            for sp in range(ml, l, csl):
+                rl.append(cls.restore_obs_batch(vec[:, sp : sp + csl], cs))
+            return (rl, mask)
+        elif type(obs_s) == Dict:
+            d = {}
+            cs = obs_s.spaces
+            sp2 = 0
+            for s in sorted(cs.keys()):
+                d[s] = cls.restore_obs_batch(vec[:, sp2:], cs[s])
+                sp2 += cls.obs_length(cs[s])
+            return d
+        elif type(obs_s) == Box:
+            vec = vec[:, : obs_s.shape[0]]
+            h, l = obs_s.high, obs_s.low
+            if type(vec) == torch.Tensor:
+                h, l = torch.tensor(h).to(vec.device), torch.tensor(l).to(vec.device)
+            return vec * (h - l) + l
+        elif type(obs_s) == Discrete:
+            return vec[:, : obs_s.n].argmax(axis=1)
 
     @classmethod
     def obs_length(cls, obs_s):
-      """ Get the length of a Space's vector representation """
-      if type(obs_s) == Repeated:
-        # +1 accounts for the indicator variable that tells you an item exists.
-        return obs_s.max_len * (cls.obs_length(obs_s.child_space)+1)
-      elif type(obs_s) == Dict:
-        l = 0
-        for s in obs_s.spaces.values():
-          l += cls.obs_length(s)
-        return l
-      elif type(obs_s) == Box:
-        return obs_s.shape[0]
-      elif type(obs_s) == Discrete:
-        return obs_s.n
+        """Get the length of a Space's vector representation"""
+        if type(obs_s) == Repeated:
+            # +1 accounts for the indicator variable that tells you an item exists.
+            return obs_s.max_len * (cls.obs_length(obs_s.child_space) + 1)
+        elif type(obs_s) == Dict:
+            l = 0
+            for s in obs_s.spaces.values():
+                l += cls.obs_length(s)
+            return l
+        elif type(obs_s) == Box:
+            return obs_s.shape[0]
+        elif type(obs_s) == Discrete:
+            return obs_s.n

--- a/rllib/env/wrappers/repeated_wrapper.py
+++ b/rllib/env/wrappers/repeated_wrapper.py
@@ -1,0 +1,135 @@
+import gymnasium as gym
+from gymnasium.spaces import Discrete, Box, Dict
+from ray.rllib.utils.spaces.repeated import Repeated
+import numpy as np
+
+from ray.rllib.utils.annotations import PublicAPI
+
+
+@PublicAPI
+class ObsVectorizationWrapper(gym.ObservationWrapper):
+    '''
+        Works around the crash currently associated with Repeated action spaces by mapping them to vectors. Includes a method for mapping them to the original space for encoding or other processing, either as batches or as individual observations. See examples/catalogs/attention_encoder.py for usage.
+    '''
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        original_obs_space = self.observation_space
+        self.observation_space = gym.spaces.Box(
+            0.0,
+            1.0,
+            shape=(ObsVectorizationWrapper.obs_length(self.observation_space),),
+            dtype=np.float32,
+        )
+        self.observation_space.original = original_obs_space
+
+    #
+    def observation(self, observation):
+        return self.__class__.serialize_obs(observation, self.observation_space.original)
+
+    @classmethod
+    def serialize_obs(cls, obs, obs_s):
+      """ Convert a Dict or Repeated space into a [0, 1] vector with all relevant information """
+      if type(obs_s) == Repeated:
+        cs = obs_s.child_space
+        csl = cls.obs_length(cs)
+        ml = obs_s.max_len
+        l =  ml * (csl+1)
+        v = np.zeros(l, dtype=np.float32)
+        for o, sp, ix in zip(obs, range(0, l, csl), range(0, ml)):
+          v[ix] = 1
+          v[sp+ml:sp+ml+csl] = cls.serialize_obs(o, cs)
+        return v
+      elif type(obs_s) == Dict:
+        vl = []
+        cs = obs_s.spaces
+        for s in sorted(cs.keys()):
+          vl.append(cls.serialize_obs(obs[s], cs[s]))
+        return np.concatenate(vl)
+      elif type(obs_s) == Box:
+        return (obs - obs_s.low) / (obs_s.high - obs_s.low)
+      elif type(obs_s) == Discrete:
+        x = np.zeros(obs_s.n, dtype=np.float32)
+        x[obs] = 1
+        return x
+
+    @classmethod
+    def restore_obs(cls, vec, obs_s):
+      """ Convert an observation vector back into its original format. """
+      if (len(vec.shape) == 2): # Handle batched observations
+        batch_list = []
+        for v in vec:
+          batch_list.append(cls.restore_obs(v, obs_s))
+        return batch_list
+      if type(obs_s) == Repeated:
+        rl = []
+        cs = obs_s.child_space
+        csl = cls.obs_length(cs)
+        ml = obs_s.max_len
+        l =  ml * (csl+1)
+        for o, sp, ix in zip(obs, range(ml, l+ml, csl), range(0, ml)):
+          if (vec[ix] == 1):
+            rl.append(cls.restore_obs(vec[sp:sp+csl], cs))
+          else:
+            break
+        return rl
+      elif type(obs_s) == Dict:
+        d = {}
+        cs = obs_s.spaces
+        sp2 = 0
+        for s in sorted(cs.keys()):
+          d[s] = cls.restore_obs(vec[sp2:], cs[s])
+          sp2 += cls.obs_length(cs[s])
+        return d
+      elif type(obs_s) == Box:
+        vec = vec[:obs_s.shape[0]]
+        return vec * (obs_s.high - obs_s.low) + obs_s.low
+      elif type(obs_s) == Discrete:
+        return vec[:obs_s.n].argmax()
+
+    @classmethod
+    def restore_obs_batch(cls, vec, obs_s):
+      """
+        Convert an observation vector back into its original format.
+        This version of the function integrates Repeated spaces more neatly with attention/LSTM-based models, preserving the batch structure and supplementing it with a mask to indicate items' presence or absence.
+      """
+      if (len(vec.shape) == 1):
+        vec = np.expand_dims(vec, 0)
+      if type(obs_s) == Repeated:
+        rl = []
+        cs = obs_s.child_space
+        csl = cls.obs_length(cs)
+        ml = obs_s.max_len
+        l =  ml * (csl+1)
+        mask = vec[:, :ml]
+        for sp in range(ml, l, csl):
+          rl.append(cls.restore_obs_batch(vec[:, sp:sp+csl], cs))
+        return (rl, mask)
+      elif type(obs_s) == Dict:
+        d = {}
+        cs = obs_s.spaces
+        sp2 = 0
+        for s in sorted(cs.keys()):
+          d[s] = cls.restore_obs_batch(vec[:, sp2:], cs[s])
+          sp2 += cls.obs_length(cs[s])
+        return d
+      elif type(obs_s) == Box:
+        vec = vec[:, :obs_s.shape[0]]
+        return vec * (obs_s.high - obs_s.low) + obs_s.low
+      elif type(obs_s) == Discrete:
+        return vec[:, :obs_s.n].argmax(axis=1)
+
+    @classmethod
+    def obs_length(cls, obs_s):
+      """ Get the length of a Space's vector representation """
+      if type(obs_s) == Repeated:
+        # +1 accounts for the indicator variable that tells you an item exists.
+        return obs_s.max_len * (cls.obs_length(obs_s.child_space)+1)
+      elif type(obs_s) == Dict:
+        l = 0
+        for s in obs_s.spaces.values():
+          l += cls.obs_length(s)
+        return l
+      elif type(obs_s) == Box:
+        return obs_s.shape[0]
+      elif type(obs_s) == Discrete:
+        return obs_s.n

--- a/rllib/env/wrappers/repeated_wrapper.py
+++ b/rllib/env/wrappers/repeated_wrapper.py
@@ -32,7 +32,7 @@ class ObsVectorizationWrapper(gym.ObservationWrapper):
     @classmethod
     def serialize_obs(cls, obs, obs_s):
         """Convert a Dict or Repeated space into a [0, 1] vector with all relevant information"""
-        if type(obs_s) == Repeated:
+        if type(obs_s) is Repeated:
             cs = obs_s.child_space
             csl = cls.obs_length(cs)
             ml = obs_s.max_len
@@ -42,15 +42,15 @@ class ObsVectorizationWrapper(gym.ObservationWrapper):
                 v[ix] = 1
                 v[sp + ml : sp + ml + csl] = cls.serialize_obs(o, cs)
             return v
-        elif type(obs_s) == Dict:
+        elif type(obs_s) is Dict:
             vl = []
             cs = obs_s.spaces
             for s in sorted(cs.keys()):
                 vl.append(cls.serialize_obs(obs[s], cs[s]))
             return np.concatenate(vl)
-        elif type(obs_s) == Box:
+        elif type(obs_s) is Box:
             return (obs - obs_s.low) / (obs_s.high - obs_s.low)
-        elif type(obs_s) == Discrete:
+        elif type(obs_s) is Discrete:
             x = np.zeros(obs_s.n, dtype=np.float32)
             x[obs] = 1
             return x
@@ -63,7 +63,7 @@ class ObsVectorizationWrapper(gym.ObservationWrapper):
             for v in vec:
                 batch_list.append(cls.restore_obs(v, obs_s))
             return batch_list
-        if type(obs_s) == Repeated:
+        if type(obs_s) is Repeated:
             rl = []
             cs = obs_s.child_space
             csl = cls.obs_length(cs)
@@ -75,7 +75,7 @@ class ObsVectorizationWrapper(gym.ObservationWrapper):
                 else:
                     break
             return rl
-        elif type(obs_s) == Dict:
+        elif type(obs_s) is Dict:
             d = {}
             cs = obs_s.spaces
             sp2 = 0
@@ -83,13 +83,13 @@ class ObsVectorizationWrapper(gym.ObservationWrapper):
                 d[s] = cls.restore_obs(vec[sp2:], cs[s])
                 sp2 += cls.obs_length(cs[s])
             return d
-        elif type(obs_s) == Box:
+        elif type(obs_s) is Box:
             vec = vec[: obs_s.shape[0]]
             h, l = obs_s.high, obs_s.low
-            if type(vec) == torch.Tensor:
+            if type(vec) is torch.Tensor:
                 h, l = torch.tensor(h).to(vec.device), torch.tensor(l).to(vec.device)
             return vec * (h - l) + l
-        elif type(obs_s) == Discrete:
+        elif type(obs_s) is Discrete:
             return vec[: obs_s.n].argmax()
 
     @classmethod
@@ -100,7 +100,7 @@ class ObsVectorizationWrapper(gym.ObservationWrapper):
         """
         if len(vec.shape) == 1:
             vec = np.expand_dims(vec, 0)
-        if type(obs_s) == Repeated:
+        if type(obs_s) is Repeated:
             rl = []
             cs = obs_s.child_space
             csl = cls.obs_length(cs)
@@ -110,7 +110,7 @@ class ObsVectorizationWrapper(gym.ObservationWrapper):
             for sp in range(ml, l, csl):
                 rl.append(cls.restore_obs_batch(vec[:, sp : sp + csl], cs))
             return (rl, mask)
-        elif type(obs_s) == Dict:
+        elif type(obs_s) is Dict:
             d = {}
             cs = obs_s.spaces
             sp2 = 0
@@ -118,27 +118,27 @@ class ObsVectorizationWrapper(gym.ObservationWrapper):
                 d[s] = cls.restore_obs_batch(vec[:, sp2:], cs[s])
                 sp2 += cls.obs_length(cs[s])
             return d
-        elif type(obs_s) == Box:
+        elif type(obs_s) is Box:
             vec = vec[:, : obs_s.shape[0]]
             h, l = obs_s.high, obs_s.low
-            if type(vec) == torch.Tensor:
+            if type(vec) is torch.Tensor:
                 h, l = torch.tensor(h).to(vec.device), torch.tensor(l).to(vec.device)
             return vec * (h - l) + l
-        elif type(obs_s) == Discrete:
+        elif type(obs_s) is Discrete:
             return vec[:, : obs_s.n].argmax(axis=1)
 
     @classmethod
     def obs_length(cls, obs_s):
         """Get the length of a Space's vector representation"""
-        if type(obs_s) == Repeated:
+        if type(obs_s) is Repeated:
             # +1 accounts for the indicator variable that tells you an item exists.
             return obs_s.max_len * (cls.obs_length(obs_s.child_space) + 1)
-        elif type(obs_s) == Dict:
+        elif type(obs_s) is Dict:
             l = 0
             for s in obs_s.spaces.values():
                 l += cls.obs_length(s)
             return l
-        elif type(obs_s) == Box:
+        elif type(obs_s) is Box:
             return obs_s.shape[0]
-        elif type(obs_s) == Discrete:
+        elif type(obs_s) is Discrete:
             return obs_s.n

--- a/rllib/examples/catalogs/attention_encoder.py
+++ b/rllib/examples/catalogs/attention_encoder.py
@@ -1,0 +1,88 @@
+"""
+This example demonstrates the use of a custom masked self-attention encoder (based off of https://arxiv.org/abs/1909.07528) to handle variable-length Repeated observation spaces.
+
+It demonstrates:
+
+ - How to write a custom catalog and pytorch Encoder
+ - How to operate upon a Repeated observation space when training a model
+
+"""
+
+# __sphinx_doc_begin__
+import gymnasium as gym
+import numpy as np
+
+from ray.rllib.algorithms.ppo.ppo import PPOConfig
+from ray.rllib.algorithms.ppo.ppo_catalog import PPOCatalog
+from ray.rllib.core.rl_module.rl_module import RLModuleSpec
+from ray.tune.registry import register_env
+
+from ray.rllib.env.wrappers.repeated_wrapper import ObsVectorizationWrapper
+from ray.rllib.examples.catalogs.models.attention_encoder import AttentionEncoderConfig
+from ray.rllib.examples.envs.classes.repeated_obs_env import RepeatedObsEnv
+
+# TODO: Remove
+from ray.rllib.utils.metrics import (
+    DIFF_NUM_GRAD_UPDATES_VS_SAMPLER_POLICY,
+    ENV_RUNNER_RESULTS,
+    EPISODE_RETURN_MEAN,
+    EVALUATION_RESULTS,
+    NUM_ENV_STEPS_TRAINED,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+)
+
+# Define a PPO Catalog that we can use to inject our attention-based Encoder into RLlib's
+# decision tree of what model to choose
+class AttentionPPOCatalog(PPOCatalog):
+    '''
+      A special PPO catalog producing an encoder that handles dictionaries of (potentially Repeated) action spaces in the same manner as https://arxiv.org/abs/1909.07528.
+    '''
+    @classmethod
+    def _get_encoder_config(cls,observation_space: gym.Space,**kwargs,):
+      return AttentionEncoderConfig(observation_space, **kwargs)
+
+register_env("env", lambda cfg: ObsVectorizationWrapper(RepeatedObsEnv(cfg)))
+
+# Create a generic config with our enhanced Catalog
+ppo_config = (
+    PPOConfig()
+    .environment(
+        env="env",
+        env_config={
+            'max_voter_pairs': 5,
+            'num_values': 2,
+            'random_seed': 0
+        },
+    )
+    .framework("torch")
+    .env_runners(
+        num_env_runners=0,
+        num_envs_per_env_runner=1,
+    )
+    .training(
+        train_batch_size=256,
+    )
+    .rl_module(rl_module_spec=RLModuleSpec(
+          catalog_class=AttentionPPOCatalog,
+          model_config={
+              "attention_emb_dim": 128,
+              "head_fcnet_hiddens": (256,256),
+              'vf_share_layers': False,
+          }
+        ),
+    )
+)
+
+algo = ppo_config.build_algo()
+
+# TODO: Switch this to the experiment setup used by everything else.
+num_iters = 100
+
+for i in range(num_iters):
+  results = algo.train()
+  if ENV_RUNNER_RESULTS in results:
+      mean_return = results[ENV_RUNNER_RESULTS].get(
+          EPISODE_RETURN_MEAN, np.nan
+      )
+      print(f"iter={i} R={mean_return}")
+# __sphinx_doc_end__

--- a/rllib/examples/catalogs/attention_encoder.py
+++ b/rllib/examples/catalogs/attention_encoder.py
@@ -51,7 +51,7 @@ parser.add_argument("--num-values", type=int, default=2)
 parser.add_argument("--attn-dim", type=int, default=128)
 
 
-# Define a PPO Catalog that tells Rllib to use our custom encoder
+# Define a PPO Catalog that tells RLlib to use our custom encoder
 class AttentionPPOCatalog(PPOCatalog):
     """
     A special PPO catalog producing an encoder that handles dictionaries of (potentially Repeated) action spaces in the same manner as https://arxiv.org/abs/1909.07528.
@@ -68,7 +68,7 @@ class AttentionPPOCatalog(PPOCatalog):
 
 if __name__ == "__main__":
     args = parser.parse_args()
-    # The wrapper allows Repeated observations to be batched successfully by Rllib.
+    # The wrapper allows Repeated observations to be batched successfully by RLlib.
     register_env("env", lambda cfg: ObsVectorizationWrapper(RepeatedObsEnv(cfg)))
 
     # Define our config

--- a/rllib/examples/catalogs/attention_encoder.py
+++ b/rllib/examples/catalogs/attention_encoder.py
@@ -42,24 +42,29 @@ from ray.rllib.utils.metrics import (
 )
 
 # Handle command line args
-parser = add_rllib_example_script_args(
-    default_reward=0.8, default_iters=50
-)
+parser = add_rllib_example_script_args(default_reward=0.8, default_iters=50)
 parser.set_defaults(
     enable_new_api_stack=True,
 )
-parser.add_argument("--max-voter-pairs",type=int,default=5)
-parser.add_argument("--num-values",type=int,default=2)
-parser.add_argument("--attn-dim",type=int,default=128)
+parser.add_argument("--max-voter-pairs", type=int, default=5)
+parser.add_argument("--num-values", type=int, default=2)
+parser.add_argument("--attn-dim", type=int, default=128)
+
 
 # Define a PPO Catalog that tells Rllib to use our custom encoder
 class AttentionPPOCatalog(PPOCatalog):
-    '''
-      A special PPO catalog producing an encoder that handles dictionaries of (potentially Repeated) action spaces in the same manner as https://arxiv.org/abs/1909.07528.
-    '''
+    """
+    A special PPO catalog producing an encoder that handles dictionaries of (potentially Repeated) action spaces in the same manner as https://arxiv.org/abs/1909.07528.
+    """
+
     @classmethod
-    def _get_encoder_config(cls,observation_space: gym.Space,**kwargs,):
-      return AttentionEncoderConfig(observation_space, **kwargs)
+    def _get_encoder_config(
+        cls,
+        observation_space: gym.Space,
+        **kwargs,
+    ):
+        return AttentionEncoderConfig(observation_space, **kwargs)
+
 
 if __name__ == "__main__":
     args = parser.parse_args()
@@ -72,22 +77,23 @@ if __name__ == "__main__":
         .environment(
             env="env",
             env_config={
-                'max_voter_pairs': args.max_voter_pairs,
-                'num_values': args.num_values,
-                'random_seed': 0
+                "max_voter_pairs": args.max_voter_pairs,
+                "num_values": args.num_values,
+                "random_seed": 0,
             },
         )
         .framework("torch")
         .training(
             train_batch_size=256,
         )
-        .rl_module(rl_module_spec=RLModuleSpec(
-              catalog_class=AttentionPPOCatalog,
-              model_config={
-                  "attention_emb_dim": args.attn_dim,
-                  "head_fcnet_hiddens": (256,256),
-                  'vf_share_layers': False,
-              }
+        .rl_module(
+            rl_module_spec=RLModuleSpec(
+                catalog_class=AttentionPPOCatalog,
+                model_config={
+                    "attention_emb_dim": args.attn_dim,
+                    "head_fcnet_hiddens": (256, 256),
+                    "vf_share_layers": False,
+                },
             ),
         )
     )
@@ -100,7 +106,8 @@ if __name__ == "__main__":
     }
 
     # Run the experiment.
-    run_rllib_example_script_experiment(config,
+    run_rllib_example_script_experiment(
+        config,
         args,
         stop=stop,
         success_metric={

--- a/rllib/examples/catalogs/attention_encoder.py
+++ b/rllib/examples/catalogs/attention_encoder.py
@@ -5,7 +5,7 @@ It demonstrates:
 
  - How to write a custom catalog and pytorch Encoder
  - How to operate upon a Repeated observation space when training a model
- 
+
 How to run this script
 ----------------------
 `python [script file name].py

--- a/rllib/examples/catalogs/attention_encoder.py
+++ b/rllib/examples/catalogs/attention_encoder.py
@@ -19,9 +19,6 @@ For logging to your WandB account, use:
 `--wandb-key=[your WandB API key] --wandb-project=[some project name]
 --wandb-run-name=[optional: WandB run name (within the defined project)]`
 """
-
-# __sphinx_doc_begin__
->>>>>>> Initial addition of changes. Will polish shortly.
 import gymnasium as gym
 import numpy as np
 

--- a/rllib/examples/catalogs/attention_encoder.py
+++ b/rllib/examples/catalogs/attention_encoder.py
@@ -20,6 +20,8 @@ For logging to your WandB account, use:
 --wandb-run-name=[optional: WandB run name (within the defined project)]`
 """
 
+# __sphinx_doc_begin__
+>>>>>>> Initial addition of changes. Will polish shortly.
 import gymnasium as gym
 import numpy as np
 
@@ -35,7 +37,6 @@ from ray.rllib.utils.test_utils import (
 from ray.rllib.env.wrappers.repeated_wrapper import ObsVectorizationWrapper
 from ray.rllib.examples.catalogs.models.attention_encoder import AttentionEncoderConfig
 from ray.rllib.examples.envs.classes.repeated_obs_env import RepeatedObsEnv
-
 
 from ray.rllib.utils.metrics import (
     ENV_RUNNER_RESULTS,

--- a/rllib/examples/catalogs/attention_encoder.py
+++ b/rllib/examples/catalogs/attention_encoder.py
@@ -20,7 +20,6 @@ For logging to your WandB account, use:
 --wandb-run-name=[optional: WandB run name (within the defined project)]`
 """
 import gymnasium as gym
-import numpy as np
 
 from ray.rllib.algorithms.ppo.ppo import PPOConfig
 from ray.rllib.algorithms.ppo.ppo_catalog import PPOCatalog

--- a/rllib/examples/catalogs/attention_encoder.py
+++ b/rllib/examples/catalogs/attention_encoder.py
@@ -5,10 +5,21 @@ It demonstrates:
 
  - How to write a custom catalog and pytorch Encoder
  - How to operate upon a Repeated observation space when training a model
+ 
+How to run this script
+----------------------
+`python [script file name].py
 
+For debugging, use the following additional command line options
+`--no-tune --num-env-runners=0`
+which should allow you to set breakpoints anywhere in the RLlib code and
+have the execution stop there for inspection and debugging.
+
+For logging to your WandB account, use:
+`--wandb-key=[your WandB API key] --wandb-project=[some project name]
+--wandb-run-name=[optional: WandB run name (within the defined project)]`
 """
 
-# __sphinx_doc_begin__
 import gymnasium as gym
 import numpy as np
 
@@ -16,23 +27,34 @@ from ray.rllib.algorithms.ppo.ppo import PPOConfig
 from ray.rllib.algorithms.ppo.ppo_catalog import PPOCatalog
 from ray.rllib.core.rl_module.rl_module import RLModuleSpec
 from ray.tune.registry import register_env
+from ray.rllib.utils.test_utils import (
+    add_rllib_example_script_args,
+    run_rllib_example_script_experiment,
+)
 
 from ray.rllib.env.wrappers.repeated_wrapper import ObsVectorizationWrapper
 from ray.rllib.examples.catalogs.models.attention_encoder import AttentionEncoderConfig
 from ray.rllib.examples.envs.classes.repeated_obs_env import RepeatedObsEnv
 
-# TODO: Remove
+
 from ray.rllib.utils.metrics import (
-    DIFF_NUM_GRAD_UPDATES_VS_SAMPLER_POLICY,
     ENV_RUNNER_RESULTS,
     EPISODE_RETURN_MEAN,
-    EVALUATION_RESULTS,
-    NUM_ENV_STEPS_TRAINED,
-    NUM_ENV_STEPS_SAMPLED_LIFETIME,
+    TRAINING_ITERATION_TIMER,
 )
 
-# Define a PPO Catalog that we can use to inject our attention-based Encoder into RLlib's
-# decision tree of what model to choose
+# Handle command line args
+parser = add_rllib_example_script_args(
+    default_reward=0.8, default_iters=50
+)
+parser.set_defaults(
+    enable_new_api_stack=True,
+)
+parser.add_argument("--max-voter-pairs",type=int,default=5)
+parser.add_argument("--num-values",type=int,default=2)
+parser.add_argument("--attn-dim",type=int,default=128)
+
+# Define a PPO Catalog that tells Rllib to use our custom encoder
 class AttentionPPOCatalog(PPOCatalog):
     '''
       A special PPO catalog producing an encoder that handles dictionaries of (potentially Repeated) action spaces in the same manner as https://arxiv.org/abs/1909.07528.
@@ -41,48 +63,49 @@ class AttentionPPOCatalog(PPOCatalog):
     def _get_encoder_config(cls,observation_space: gym.Space,**kwargs,):
       return AttentionEncoderConfig(observation_space, **kwargs)
 
-register_env("env", lambda cfg: ObsVectorizationWrapper(RepeatedObsEnv(cfg)))
+if __name__ == "__main__":
+    args = parser.parse_args()
+    # The wrapper allows Repeated observations to be batched successfully by Rllib.
+    register_env("env", lambda cfg: ObsVectorizationWrapper(RepeatedObsEnv(cfg)))
 
-# Create a generic config with our enhanced Catalog
-ppo_config = (
-    PPOConfig()
-    .environment(
-        env="env",
-        env_config={
-            'max_voter_pairs': 5,
-            'num_values': 2,
-            'random_seed': 0
+    # Define our config
+    config = (
+        PPOConfig()
+        .environment(
+            env="env",
+            env_config={
+                'max_voter_pairs': args.max_voter_pairs,
+                'num_values': args.num_values,
+                'random_seed': 0
+            },
+        )
+        .framework("torch")
+        .training(
+            train_batch_size=256,
+        )
+        .rl_module(rl_module_spec=RLModuleSpec(
+              catalog_class=AttentionPPOCatalog,
+              model_config={
+                  "attention_emb_dim": args.attn_dim,
+                  "head_fcnet_hiddens": (256,256),
+                  'vf_share_layers': False,
+              }
+            ),
+        )
+    )
+
+    # Set the stopping arguments.
+    EPISODE_RETURN_MEAN_KEY = f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}"
+    stop = {
+        TRAINING_ITERATION_TIMER: args.stop_iters,
+        EPISODE_RETURN_MEAN_KEY: args.stop_reward,
+    }
+
+    # Run the experiment.
+    run_rllib_example_script_experiment(config,
+        args,
+        stop=stop,
+        success_metric={
+            f"{ENV_RUNNER_RESULTS}/{EPISODE_RETURN_MEAN}": args.stop_reward,
         },
     )
-    .framework("torch")
-    .env_runners(
-        num_env_runners=0,
-        num_envs_per_env_runner=1,
-    )
-    .training(
-        train_batch_size=256,
-    )
-    .rl_module(rl_module_spec=RLModuleSpec(
-          catalog_class=AttentionPPOCatalog,
-          model_config={
-              "attention_emb_dim": 128,
-              "head_fcnet_hiddens": (256,256),
-              'vf_share_layers': False,
-          }
-        ),
-    )
-)
-
-algo = ppo_config.build_algo()
-
-# TODO: Switch this to the experiment setup used by everything else.
-num_iters = 100
-
-for i in range(num_iters):
-  results = algo.train()
-  if ENV_RUNNER_RESULTS in results:
-      mean_return = results[ENV_RUNNER_RESULTS].get(
-          EPISODE_RETURN_MEAN, np.nan
-      )
-      print(f"iter={i} R={mean_return}")
-# __sphinx_doc_end__

--- a/rllib/examples/catalogs/models/attention_encoder.py
+++ b/rllib/examples/catalogs/models/attention_encoder.py
@@ -1,0 +1,85 @@
+"""
+This file implements a self-attention Encoder (see https://arxiv.org/abs/1909.07528) for handling variable-length Repeated observation spaces. It expects a Dict observation space with Discrete, Box, or Repeated (of Discrete or Box) subspaces.
+
+This is an example of using custom encoders to efficiently process structured
+"""
+from ray.rllib.core.models.torch.base import TorchModel
+from ray.rllib.core.models.base import Encoder, ENCODER_OUT
+from ray.rllib.core.models.configs import ModelConfig
+from gymnasium.spaces import Discrete, Box, Dict
+from ray.rllib.utils.spaces.repeated import Repeated
+import torch
+from torch import nn
+
+from ray.rllib.env.wrappers.repeated_wrapper import ObsVectorizationWrapper
+
+class AttentionEncoder(TorchModel, Encoder):
+    '''
+      An Encoder that takes a Dict of multiple spaces, including Discrete, Box, and Repeated, and uses an attention layer to convert this variable-length input into a fixed-length featurized learned representation.
+    '''
+    def __init__(self, config):
+        super().__init__(config)
+        self.observation_space = config.observation_space.original
+        self.emb_dim = config.emb_dim
+        # Use an attention layer to reduce observations to a fixed length
+        self.mha = nn.MultiheadAttention(self.emb_dim, 4, batch_first=True)
+        self.residual = nn.Linear(self.emb_dim, self.emb_dim)
+        # We expect a dict of Boxes, Discretes, or Repeateds composed of same.
+        embs = {}
+        for n, s in self.observation_space.spaces.items():
+          if (type(s)==Repeated):
+            s = s.child_space # embed layer applies to child space
+          if (type(s)==Box):
+            embs[n] = nn.Linear(s.shape[0], self.emb_dim)
+          elif (type(s)==Discrete):
+            embs[n] = nn.Embedding(s.n, self.emb_dim)
+          else:
+            raise Exception("Unsupported observation subspace")
+        self.embs = nn.ModuleDict(embs)
+
+    def _forward(self, input_dict, **kwargs):
+        N = input_dict['obs'].shape[0]
+        vec = input_dict['obs']
+        # The original space we mapped from.
+        obs_s = self.observation_space
+        obs = ObsVectorizationWrapper.restore_obs_batch(vec, obs_s)
+        embeddings = []
+        masks = []
+        for s in sorted(obs.keys()):
+          v = obs[s]
+          if type(obs_s[s]) == Repeated:
+            mask = v[1]
+            v = torch.stack(v[0]).permute(1,0,2) # seq_len, batch_size, unit_size
+          elif type(obs_s[s]) in [Box, Discrete]:
+            mask = torch.ones((N,1)) # Fixed elements are always there
+            v = v.unsqueeze(1)
+          embedded = self.embs[s](v)
+          embeddings.append(embedded)
+          masks.append(mask)
+        # All entities have embeddings. Apply masked residual self-attention and then mean-pool.
+        x = torch.concatenate(embeddings,dim=1) # batch_size, seq_len, unit_size
+        mask = torch.concatenate(masks, dim=1)  # batch_size, seq_len
+        # Attention
+        x_attn, _ = self.mha(x, x, x,key_padding_mask=mask,need_weights=False)
+        x = self.residual(x_attn) + x
+        # Masked mean-pooling.
+        mask = mask.unsqueeze(dim=2)
+        x = x * mask  # Mask x to exclude nonexistent entries from mean pool op
+        x = x.mean(dim=1) * mask.shape[1] / mask.sum(dim=1) # Adjust mean
+        return {ENCODER_OUT: x}
+
+class AttentionEncoderConfig(ModelConfig):
+    '''
+      Produces an AttentionEncoder.
+
+      kwargs:
+       * attention_emb_dim: The embedding dimension of the attention layer.
+    '''
+    def __init__(self, observation_space, **kwargs):
+        self.observation_space = observation_space
+        self.emb_dim = kwargs['model_config_dict']['attention_emb_dim']
+        self.output_dims = (self.emb_dim,)
+    def build(self, framework):
+        return AttentionEncoder(self)
+    def output_dims(self):
+      return self.output_dims

--- a/rllib/examples/catalogs/models/attention_encoder.py
+++ b/rllib/examples/catalogs/models/attention_encoder.py
@@ -51,7 +51,7 @@ class AttentionEncoder(TorchModel, Encoder):
             mask = v[1]
             v = torch.stack(v[0]).permute(1,0,2) # seq_len, batch_size, unit_size
           elif type(obs_s[s]) in [Box, Discrete]:
-            mask = torch.ones((N,1)) # Fixed elements are always there
+            mask = torch.ones((N,1)).to(v.device) # Fixed elements are always there
             v = v.unsqueeze(1)
           embedded = self.embs[s](v)
           embeddings.append(embedded)
@@ -82,4 +82,4 @@ class AttentionEncoderConfig(ModelConfig):
     def build(self, framework):
         return AttentionEncoder(self)
     def output_dims(self):
-      return self.output_dims
+        return self.output_dims

--- a/rllib/examples/catalogs/models/attention_encoder.py
+++ b/rllib/examples/catalogs/models/attention_encoder.py
@@ -4,17 +4,19 @@ This file implements a self-attention Encoder (see https://arxiv.org/abs/1909.07
 from ray.rllib.core.models.torch.base import TorchModel
 from ray.rllib.core.models.base import Encoder, ENCODER_OUT
 from ray.rllib.core.models.configs import ModelConfig
-from gymnasium.spaces import Discrete, Box, Dict
+from gymnasium.spaces import Discrete, Box
 from ray.rllib.utils.spaces.repeated import Repeated
 import torch
 from torch import nn
 
 from ray.rllib.env.wrappers.repeated_wrapper import ObsVectorizationWrapper
 
+
 class AttentionEncoder(TorchModel, Encoder):
-    '''
-      An Encoder that takes a Dict of multiple spaces, including Discrete, Box, and Repeated, and uses an attention layer to convert this variable-length input into a fixed-length featurized learned representation.
-    '''
+    """
+    An Encoder that takes a Dict of multiple spaces, including Discrete, Box, and Repeated, and uses an attention layer to convert this variable-length input into a fixed-length featurized learned representation.
+    """
+
     def __init__(self, config):
         super().__init__(config)
         self.observation_space = config.observation_space.original
@@ -25,59 +27,65 @@ class AttentionEncoder(TorchModel, Encoder):
         # We expect a dict of Boxes, Discretes, or Repeateds composed of same.
         embs = {}
         for n, s in self.observation_space.spaces.items():
-          if (type(s) is Repeated):
-            s = s.child_space # embed layer applies to child space
-          if (type(s) is Box):
-            embs[n] = nn.Linear(s.shape[0], self.emb_dim)
-          elif (type(s) is Discrete):
-            embs[n] = nn.Embedding(s.n, self.emb_dim)
-          else:
-            raise Exception("Unsupported observation subspace")
+            if type(s) is Repeated:
+                s = s.child_space  # embed layer applies to child space
+            if type(s) is Box:
+                embs[n] = nn.Linear(s.shape[0], self.emb_dim)
+            elif type(s) is Discrete:
+                embs[n] = nn.Embedding(s.n, self.emb_dim)
+            else:
+                raise Exception("Unsupported observation subspace")
         self.embs = nn.ModuleDict(embs)
 
     def _forward(self, input_dict, **kwargs):
-        N = input_dict['obs'].shape[0]
-        vec = input_dict['obs']
+        N = input_dict["obs"].shape[0]
+        vec = input_dict["obs"]
         # The original space we mapped from.
         obs_s = self.observation_space
         obs = ObsVectorizationWrapper.restore_obs_batch(vec, obs_s)
         embeddings = []
         masks = []
         for s in sorted(obs.keys()):
-          v = obs[s]
-          if type(obs_s[s]) is Repeated:
-            mask = v[1]
-            v = torch.stack(v[0]).permute(1,0,2) # seq_len, batch_size, unit_size
-          elif type(obs_s[s]) in [Box, Discrete]:
-            mask = torch.ones((N,1)).to(v.device) # Fixed elements are always there
-            v = v.unsqueeze(1)
-          embedded = self.embs[s](v)
-          embeddings.append(embedded)
-          masks.append(mask)
+            v = obs[s]
+            if type(obs_s[s]) is Repeated:
+                mask = v[1]
+                v = torch.stack(v[0]).permute(1, 0, 2)  # seq_len, batch_size, unit_size
+            elif type(obs_s[s]) in [Box, Discrete]:
+                mask = torch.ones((N, 1)).to(
+                    v.device
+                )  # Fixed elements are always there
+                v = v.unsqueeze(1)
+            embedded = self.embs[s](v)
+            embeddings.append(embedded)
+            masks.append(mask)
         # All entities have embeddings. Apply masked residual self-attention and then mean-pool.
-        x = torch.concatenate(embeddings,dim=1) # batch_size, seq_len, unit_size
+        x = torch.concatenate(embeddings, dim=1)  # batch_size, seq_len, unit_size
         mask = torch.concatenate(masks, dim=1)  # batch_size, seq_len
         # Attention
-        x_attn, _ = self.mha(x, x, x,key_padding_mask=mask,need_weights=False)
+        x_attn, _ = self.mha(x, x, x, key_padding_mask=mask, need_weights=False)
         x = self.residual(x_attn) + x
         # Masked mean-pooling.
         mask = mask.unsqueeze(dim=2)
         x = x * mask  # Mask x to exclude nonexistent entries from mean pool op
-        x = x.mean(dim=1) * mask.shape[1] / mask.sum(dim=1) # Adjust mean
+        x = x.mean(dim=1) * mask.shape[1] / mask.sum(dim=1)  # Adjust mean
         return {ENCODER_OUT: x}
 
-class AttentionEncoderConfig(ModelConfig):
-    '''
-      Produces an AttentionEncoder.
 
-      kwargs:
-       * attention_emb_dim: The embedding dimension of the attention layer.
-    '''
+class AttentionEncoderConfig(ModelConfig):
+    """
+    Produces an AttentionEncoder.
+
+    kwargs:
+     * attention_emb_dim: The embedding dimension of the attention layer.
+    """
+
     def __init__(self, observation_space, **kwargs):
         self.observation_space = observation_space
-        self.emb_dim = kwargs['model_config_dict']['attention_emb_dim']
+        self.emb_dim = kwargs["model_config_dict"]["attention_emb_dim"]
         self.output_dims = (self.emb_dim,)
+
     def build(self, framework):
         return AttentionEncoder(self)
+
     def output_dims(self):
         return self.output_dims

--- a/rllib/examples/catalogs/models/attention_encoder.py
+++ b/rllib/examples/catalogs/models/attention_encoder.py
@@ -1,7 +1,5 @@
 """
 This file implements a self-attention Encoder (see https://arxiv.org/abs/1909.07528) for handling variable-length Repeated observation spaces. It expects a Dict observation space with Discrete, Box, or Repeated (of Discrete or Box) subspaces.
-
-This is an example of using custom encoders to efficiently process structured
 """
 from ray.rllib.core.models.torch.base import TorchModel
 from ray.rllib.core.models.base import Encoder, ENCODER_OUT
@@ -27,11 +25,11 @@ class AttentionEncoder(TorchModel, Encoder):
         # We expect a dict of Boxes, Discretes, or Repeateds composed of same.
         embs = {}
         for n, s in self.observation_space.spaces.items():
-          if (type(s)==Repeated):
+          if (type(s is Repeated):
             s = s.child_space # embed layer applies to child space
-          if (type(s)==Box):
+          if (type(s is Box):
             embs[n] = nn.Linear(s.shape[0], self.emb_dim)
-          elif (type(s)==Discrete):
+          elif (type(s) is Discrete):
             embs[n] = nn.Embedding(s.n, self.emb_dim)
           else:
             raise Exception("Unsupported observation subspace")
@@ -47,7 +45,7 @@ class AttentionEncoder(TorchModel, Encoder):
         masks = []
         for s in sorted(obs.keys()):
           v = obs[s]
-          if type(obs_s[s]) == Repeated:
+          if type(obs_s[s]) is Repeated:
             mask = v[1]
             v = torch.stack(v[0]).permute(1,0,2) # seq_len, batch_size, unit_size
           elif type(obs_s[s]) in [Box, Discrete]:

--- a/rllib/examples/catalogs/models/attention_encoder.py
+++ b/rllib/examples/catalogs/models/attention_encoder.py
@@ -25,9 +25,9 @@ class AttentionEncoder(TorchModel, Encoder):
         # We expect a dict of Boxes, Discretes, or Repeateds composed of same.
         embs = {}
         for n, s in self.observation_space.spaces.items():
-          if (type(s is Repeated):
+          if (type(s) is Repeated):
             s = s.child_space # embed layer applies to child space
-          if (type(s is Box):
+          if (type(s) is Box):
             embs[n] = nn.Linear(s.shape[0], self.emb_dim)
           elif (type(s) is Discrete):
             embs[n] = nn.Embedding(s.n, self.emb_dim)

--- a/rllib/examples/envs/classes/repeated_obs_env.py
+++ b/rllib/examples/envs/classes/repeated_obs_env.py
@@ -5,10 +5,11 @@ from ray.rllib.utils.spaces.repeated import Repeated
 
 
 class RepeatedObsEnv(gym.Env):
-    '''
-      An environment to test the handling of Repeated observation spaces. Multiple types of entity must be related to each other in varying quantities.
-      Each voter has a set of values, which determine their vote by some hidden linear function. Given a list of voters' values and the set of weights that map their values to their voting decision, predict whether a specific (non-voting) citizen will be happy with the outcome of a referendum.
-    '''
+    """
+    An environment to test the handling of Repeated observation spaces. Multiple types of entity must be related to each other in varying quantities.
+    Each voter has a set of values, which determine their vote by some hidden linear function. Given a list of voters' values and the set of weights that map their values to their voting decision, predict whether a specific (non-voting) citizen will be happy with the outcome of a referendum.
+    """
+
     def __init__(self, config):
         super().__init__()
         np.random.seed(config["random_seed"] if "random_seed" in config else 0)

--- a/rllib/examples/envs/classes/repeated_obs_env.py
+++ b/rllib/examples/envs/classes/repeated_obs_env.py
@@ -7,10 +7,9 @@ from ray.rllib.utils.spaces.repeated import Repeated
 class RepeatedObsEnv(gym.Env):
     '''
       An environment to test the handling of Repeated observation spaces. Multiple types of entity must be related to each other in varying quantities.
-
       Each voter has a set of values, which determine their vote by some hidden linear function. Given a list of voters' values and the set of weights that map their values to their voting decision, predict whether a specific (non-voting) citizen will be happy with the outcome of a referendum.
     '''
-    def __init__(self, config={}):
+    def __init__(self, config):
         super().__init__()
         np.random.seed(config["random_seed"] if "random_seed" in config else 0)
         self.max_voter_pairs = (

--- a/rllib/examples/envs/classes/repeated_obs_env.py
+++ b/rllib/examples/envs/classes/repeated_obs_env.py
@@ -12,35 +12,47 @@ class RepeatedObsEnv(gym.Env):
     '''
     def __init__(self, config={}):
         super().__init__()
-        np.random.seed(config['random_seed'] if 'random_seed' in config else 0)
-        self.max_voter_pairs = config['max_voter_pairs'] if 'max_voter_pairs' in config else 5
-        self.num_values = config['num_values'] if 'num_values' in config else 5
-        self.observation_space = Dict({
-            'voters': Repeated(Box(-1,1,shape=(self.num_values,)), self.max_voter_pairs*2+1),
-            'value_mapping': Box(-1,1,shape=(self.num_values,)),
-            'citizen': Box(-1,1,shape=(self.num_values,))
-        })
+        np.random.seed(config["random_seed"] if "random_seed" in config else 0)
+        self.max_voter_pairs = (
+            config["max_voter_pairs"] if "max_voter_pairs" in config else 5
+        )
+        self.num_values = config["num_values"] if "num_values" in config else 5
+        self.observation_space = Dict(
+            {
+                "voters": Repeated(
+                    Box(-1, 1, shape=(self.num_values,)), self.max_voter_pairs * 2 + 1
+                ),
+                "value_mapping": Box(-1, 1, shape=(self.num_values,)),
+                "citizen": Box(-1, 1, shape=(self.num_values,)),
+            }
+        )
         self.action_space = Discrete(2)
 
     def new_obs(self):
-      self.voters = []
-      for i in range(self.num_voters):
-        self.voters.append(np.random.rand(self.num_values).astype(np.float32) * 2 - 1)
-      return {
-          'voters': self.voters,
-          'value_mapping': self.value_mapping,
-          'citizen': self.citizen
-      }
+        self.voters = []
+        for i in range(self.num_voters):
+            self.voters.append(
+                np.random.rand(self.num_values).astype(np.float32) * 2 - 1
+            )
+        return {
+            "voters": self.voters,
+            "value_mapping": self.value_mapping,
+            "citizen": self.citizen,
+        }
 
     def step(self, action):
-        outcome = (np.array(self.voters) @ self.value_mapping.T > 0).sum() > self.max_voter_pairs
+        outcome = (
+            np.array(self.voters) @ self.value_mapping.T > 0
+        ).sum() > self.max_voter_pairs
         citizen_outcome = (self.citizen @ self.value_mapping.T) > 0
-        reward = 1 if ((outcome==citizen_outcome) == (action==1)) else 0
+        reward = 1 if ((outcome == citizen_outcome) == (action == 1)) else 0
         return self.new_obs(), reward, True, False, {}
 
     def reset(self, *, seed=None, options=None):
         np.random.seed(seed)
-        self.num_voters = np.random.randint(0, self.max_voter_pairs+1) * 2 + 1
-        self.value_mapping = (np.random.rand(self.num_values).astype(np.float32) - 0.5) * 2
+        self.num_voters = np.random.randint(0, self.max_voter_pairs + 1) * 2 + 1
+        self.value_mapping = (
+            np.random.rand(self.num_values).astype(np.float32) - 0.5
+        ) * 2
         self.citizen = (np.random.rand(self.num_values).astype(np.float32) - 0.5) * 2
         return self.new_obs(), {}

--- a/rllib/examples/envs/classes/repeated_obs_env.py
+++ b/rllib/examples/envs/classes/repeated_obs_env.py
@@ -1,0 +1,46 @@
+import gymnasium as gym
+import numpy as np
+from gymnasium.spaces import Discrete, Box, Dict
+from ray.rllib.utils.spaces.repeated import Repeated
+
+
+class RepeatedObsEnv(gym.Env):
+    '''
+      An environment to test the handling of Repeated observation spaces. Multiple types of entity must be related to each other in varying quantities.
+
+      Each voter has a set of values, which determine their vote by some hidden linear function. Given a list of voters' values and the set of weights that map their values to their voting decision, predict whether a specific (non-voting) citizen will be happy with the outcome of a referendum.
+    '''
+    def __init__(self, config={}):
+        super().__init__()
+        np.random.seed(config['random_seed'] if 'random_seed' in config else 0)
+        self.max_voter_pairs = config['max_voter_pairs'] if 'max_voter_pairs' in config else 5
+        self.num_values = config['num_values'] if 'num_values' in config else 5
+        self.observation_space = Dict({
+            'voters': Repeated(Box(-1,1,shape=(self.num_values,)), self.max_voter_pairs*2+1),
+            'value_mapping': Box(-1,1,shape=(self.num_values,)),
+            'citizen': Box(-1,1,shape=(self.num_values,))
+        })
+        self.action_space = Discrete(2)
+
+    def new_obs(self):
+      self.voters = []
+      for i in range(self.num_voters):
+        self.voters.append(np.random.rand(self.num_values).astype(np.float32) * 2 - 1)
+      return {
+          'voters': self.voters,
+          'value_mapping': self.value_mapping,
+          'citizen': self.citizen
+      }
+
+    def step(self, action):
+        outcome = (np.array(self.voters) @ self.value_mapping.T > 0).sum() > self.max_voter_pairs
+        citizen_outcome = (self.citizen @ self.value_mapping.T) > 0
+        reward = 1 if ((outcome==citizen_outcome) == (action==1)) else 0
+        return self.new_obs(), reward, True, False, {}
+
+    def reset(self, *, seed=None, options=None):
+        np.random.seed(seed)
+        self.num_voters = np.random.randint(0, self.max_voter_pairs+1) * 2 + 1
+        self.value_mapping = (np.random.rand(self.num_values).astype(np.float32) - 0.5) * 2
+        self.citizen = (np.random.rand(self.num_values).astype(np.float32) - 0.5) * 2
+        return self.new_obs(), {}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Initially, this was composed solely of the wrapper, which allows developers to work around the error that fires when using an environment with Repeated observation spaces (#52093 and #53327).

Following from that, I noticed the only two examples of Catalog use were labeled as old-API-stack and hybrid-API-stack, and there were no example scripts demonstrating use of a variable-length observation space. I did my best to create a new example that demonstrates both. 

Note: I had some trouble finding Catalog examples using the new API; if there's something that should be done differently _(I'd appreciate it if someone could look at the line specifying the custom Catalog to the RL module)_, please let me know and I'll change it accordingly.

## Related issue number

<!-- For example: "Closes #1234" -->

Allows #52093 and #53327 to complete their tasks.

## Checks

- [X] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [X] I've run `scripts/format.sh` to lint the changes in this PR.
- [X] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [X] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [X] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
