### PR TITLE
[core] Deflake test_gcs_connection_no_leak

### DIFF
--- a/python/ray/tests/test_advanced_9.py
+++ b/python/ray/tests/test_advanced_9.py
@@ -275,7 +275,8 @@ def test_gcs_connection_no_leak(ray_start_cluster):
 
     with ray.init(cluster.address):
         # Wait for workers  to be ready.
-        _ = [ray.get(A.remote().ready.remote()) for _ in range(2)]
+        actors = [A.remote() for _ in range(2)]
+        _ = [ray.get(actor.ready.remote()) for actor in actors]
         # Note: `fds_without_workers` need to be recorded *after* `ray.init`, because
         # a prestarted worker is started on the first driver init. This worker keeps 1
         # connection to the GCS, and it stays alive even after the driver exits. If

--- a/python/ray/tests/test_advanced_9.py
+++ b/python/ray/tests/test_advanced_9.py
@@ -19,6 +19,7 @@ from ray._private.test_utils import (
 from ray._common.test_utils import Semaphore
 from ray.experimental.internal_kv import _internal_kv_list
 from ray.tests.conftest import call_ray_start
+import time
 
 
 @pytest.fixture
@@ -275,7 +276,7 @@ def test_gcs_connection_no_leak(ray_start_cluster):
 
     with ray.init(cluster.address):
         # Wait for workers  to be ready.
-        wait_for_condition(lambda: len(ray.util.state.list_workers()) == 2)
+        time.sleep(10)
         # Note: `fds_without_workers` need to be recorded *after* `ray.init`, because
         # a prestarted worker is started on the first driver init. This worker keeps 1
         # connection to the GCS, and it stays alive even after the driver exits. If


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
test_gcs_connection_no_leak was flaky after https://github.com/ray-project/ray/pull/53305. This fixes it by creating an actor that makes sure it has made a successful connection to the gcs through the kv service before getting the # of connections.

This fixes it, starting an actor and making sure it works, and then 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
