### PR TITLE
make $100 banner dismissable

### DIFF
--- a/doc/source/_static/css/dismissable-banner.css
+++ b/doc/source/_static/css/dismissable-banner.css
@@ -1,0 +1,13 @@
+#close-banner {
+    background: none;
+    border: none;
+    color: inherit;
+    font-size: 1.2em;
+    cursor: pointer;
+    padding: 0 5px;
+    border-radius: 3px;
+    transition: background-color 0.2s ease;
+    position: absolute;
+    top: 8px;
+    right: 12px;
+}

--- a/doc/source/_static/js/dismissable-banner.js
+++ b/doc/source/_static/js/dismissable-banner.js
@@ -1,0 +1,24 @@
+// Dismissable banner functionality
+document.addEventListener('DOMContentLoaded', function () {
+  const banner = document.querySelector('.bd-header-announcement');
+  const closeButton = document.getElementById('close-banner');
+  const bannerKey = 'ray-docs-banner-dismissed';
+
+  // Check if banner was previously dismissed
+  if (localStorage.getItem(bannerKey) === 'true') {
+    if (banner) {
+      banner.style.display = 'none';
+    }
+    return;
+  }
+
+  // Add click handler for close button
+  if (closeButton) {
+    closeButton.addEventListener('click', function () {
+      if (banner) {
+        banner.style.display = 'none';
+        localStorage.setItem(bannerKey, 'true');
+      }
+    });
+  }
+});

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -307,7 +307,7 @@ html_theme = "pydata_sphinx_theme"
 # documentation.
 html_theme_options = {
     "use_edit_page_button": True,
-    "announcement": """Try Ray with $100 credit — <a target="_blank" href="https://console.anyscale.com/register/ha?render_flow=ray&utm_source=ray_docs&utm_medium=docs&utm_campaign=banner">Start now</a>.""",
+    "announcement": """Try Ray with $100 credit — <a target="_blank" href="https://console.anyscale.com/register/ha?render_flow=ray&utm_source=ray_docs&utm_medium=docs&utm_campaign=banner">Start now</a><button type="button" id="close-banner" aria-label="Close banner">&times;</button>""",
     "logo": {
         "svg": render_svg_logo("_static/img/ray_logo.svg"),
     },
@@ -554,6 +554,9 @@ def setup(app):
 
     app.add_js_file("js/assistant.js", defer="defer")
     app.add_css_file("css/assistant.css")
+
+    app.add_js_file("js/dismissable-banner.js", defer="defer")
+    app.add_css_file("css/dismissable-banner.css")
 
     base_path = pathlib.Path(__file__).parent
     github_docs = DownloadAndPreprocessEcosystemDocs(base_path)


### PR DESCRIPTION
## Why are these changes needed?

Adds a close button to the announcement banner for $100 so it can be dismissed
- adds html for the button
- adds JS to handle closing on click, saving to localstorage, and hiding it on page load if already dismissed
- css to style to close button

![Screenshot 2025-06-03 at 1 50 27 PM](https://github.com/user-attachments/assets/12f5bc21-c776-4e32-9ce5-b70f9c54da5d)
https://www.loom.com/share/d790863d26a84034928a7a6e7daa197f?sid=f4258cd1-be8f-489d-b33b-67b924180eff

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
