### PR TITLE
Add perf metrics for 2.47.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 83.984384,
+    "_dashboard_memory_usage_mb": 97.234944,
     "_dashboard_test_success": true,
-    "_peak_memory": 4.21,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1129\t6.64GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3412\t1.72GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4757\t0.95GiB\tpython distributed/test_many_actors.py\n2692\t0.44GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3612\t0.22GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n583\t0.18GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n4124\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n2914\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3528\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n4126\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
-    "actors_per_second": 634.2824761754516,
+    "_peak_memory": 4.28,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3425\t1.73GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5661\t0.91GiB\tpython distributed/test_many_actors.py\n2885\t0.46GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3635\t0.24GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n1163\t0.12GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4144\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3541\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n2795\t0.08GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4146\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru\n5890\t0.07GiB\tray::DashboardTester.run",
+    "actors_per_second": 603.3663040344126,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 634.2824761754516
+            "perf_metric_value": 603.3663040344126
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 8.293
+            "perf_metric_value": 11.228
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2283.949
+            "perf_metric_value": 2354.269
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4974.655
+            "perf_metric_value": 4910.504
         }
     ],
     "success": "1",
-    "time": 15.765846252441406
+    "time": 16.57367992401123
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 93.069312,
+    "_dashboard_memory_usage_mb": 95.789056,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.2,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3564\t0.51GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2570\t0.27GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4982\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3763\t0.13GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n1062\t0.13GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4270\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n2625\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3680\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n5279\t0.08GiB\tray::StateAPIGeneratorActor.start\n3766\t0.08GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import sp",
+    "_peak_memory": 2.25,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n5089\t0.5GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2709\t0.29GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n1064\t0.19GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n6617\t0.17GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n5288\t0.13GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n5798\t0.11GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n5205\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n6901\t0.09GiB\tray::StateAPIGeneratorActor.start\n2646\t0.08GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n5291\t0.08GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import sp",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 221.2222291023174
+            "perf_metric_value": 195.47122183821068
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.658
+            "perf_metric_value": 5.428
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 16.67
+            "perf_metric_value": 14.373
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 51.794
+            "perf_metric_value": 53.397
         }
     ],
     "success": "1",
-    "tasks_per_second": 221.2222291023174,
-    "time": 304.5203413963318,
+    "tasks_per_second": 195.47122183821068,
+    "time": 305.1158425807953,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,32 +1,32 @@
 {
-    "_dashboard_memory_usage_mb": 85.512192,
+    "_dashboard_memory_usage_mb": 84.566016,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.72,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n2059\t7.21GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3429\t0.96GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n2686\t0.43GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4793\t0.37GiB\tpython distributed/test_many_pgs.py\n583\t0.19GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3627\t0.1GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n2527\t0.1GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l\n4136\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n2951\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n3545\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash",
+    "_peak_memory": 2.65,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1132\t7.98GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3429\t0.87GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n5026\t0.37GiB\tpython distributed/test_many_pgs.py\n2887\t0.32GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n583\t0.18GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n4146\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3629\t0.1GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n2773\t0.09GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l\n2772\t0.08GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n4148\t0.08GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/_private/ru",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13.650631601393242
+            "perf_metric_value": 13.186074855517864
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.856
+            "perf_metric_value": 4.652
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 6.696
+            "perf_metric_value": 8.386
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 275.082
+            "perf_metric_value": 368.285
         }
     ],
-    "pgs_per_second": 13.650631601393242,
+    "pgs_per_second": 13.186074855517864,
     "success": "1",
-    "time": 73.25668358802795
+    "time": 75.83757948875427
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 92.213248,
+    "_dashboard_memory_usage_mb": 93.548544,
     "_dashboard_test_success": true,
-    "_peak_memory": 3.85,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3411\t1.09GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n6752\t0.75GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3611\t0.45GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n2810\t0.28GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3614\t0.17GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import sp\n1134\t0.12GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4128\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3527\t0.09GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n2907\t0.09GiB\t/usr/bin/python3 /app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/product/\n6977\t0.08GiB\tray::StateAPIGeneratorActor.start",
+    "_peak_memory": 3.93,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n2030\t8.2GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3385\t1.12GiB\t/home/ray/anaconda3/lib/python3.9/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/s\n4770\t0.75GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3585\t0.45GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import spa\n2715\t0.29GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n587\t0.19GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n3588\t0.17GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.9 -c from multiprocessing.spawn import sp\n4100\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 -u /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/a\n3501\t0.1GiB\t/home/ray/anaconda3/bin/python3.9 /home/ray/anaconda3/lib/python3.9/site-packages/ray/dashboard/dash\n5080\t0.08GiB\tray::StateAPIGeneratorActor.start",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 350.23203445104895
+            "perf_metric_value": 361.68471844760444
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,21 +18,21 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.941
+            "perf_metric_value": 5.127
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 437.195
+            "perf_metric_value": 483.057
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 675.061
+            "perf_metric_value": 774.804
         }
     ],
     "success": "1",
-    "tasks_per_second": 350.23203445104895,
-    "time": 328.5524995326996,
+    "tasks_per_second": 361.68471844760444,
+    "time": 327.6483895778656,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.46.0"}
+{"release_version": "2.47.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        7484.128019312722,
-        222.23612905590366
+        8564.967370806118,
+        316.2973325544422
     ],
     "1_1_actor_calls_concurrent": [
-        5210.654473422534,
-        148.8482302145678
+        5454.916872293855,
+        175.5566303981581
     ],
     "1_1_actor_calls_sync": [
-        2020.4236901532247,
-        18.458813788356412
+        2043.0981415735505,
+        11.868484382865416
     ],
     "1_1_async_actor_calls_async": [
-        4133.0146320984095,
-        158.06597563376883
+        4447.509230034982,
+        102.76620673255381
     ],
     "1_1_async_actor_calls_sync": [
-        1483.660979687764,
-        23.548334544330253
+        1457.3163933993856,
+        15.06851286203659
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2744.6685159840754,
-        60.78673286688515
+        2723.6213791034843,
+        159.2909083490649
     ],
     "1_n_actor_calls_async": [
-        8318.094433102775,
-        220.7257975463937
+        8471.080848855601,
+        112.46370801552791
     ],
     "1_n_async_actor_calls_async": [
-        7563.184192111071,
-        157.70699676551294
+        7686.919019356983,
+        74.93714508344017
     ],
     "client__1_1_actor_calls_async": [
-        1069.1602586173547,
-        8.291193112362643
+        1104.3962578235257,
+        9.729829574557723
     ],
     "client__1_1_actor_calls_concurrent": [
-        1050.6282351078878,
-        11.652242761910356
+        1092.6331677147311,
+        7.227061388462997
     ],
     "client__1_1_actor_calls_sync": [
-        525.9274124240096,
-        3.4715440434472495
+        542.1463689306149,
+        6.246053973889882
     ],
     "client__get_calls": [
-        1160.5254002780266,
-        16.558088205324744
+        1126.760374919516,
+        73.52620710354205
     ],
     "client__put_calls": [
-        790.7920510051757,
-        21.308859484909945
+        833.1799373566209,
+        13.615006550691389
     ],
     "client__put_gigabytes": [
-        0.1529268174148042,
-        0.0010070926819979113
+        0.15685350675842372,
+        0.00026774531056997854
     ],
     "client__tasks_and_get_batch": [
-        0.9480091293556955,
-        0.07641810889693526
+        0.9823727578985482,
+        0.01966665636257355
     ],
     "client__tasks_and_put_batch": [
-        14569.862277318796,
-        259.9296680300632
+        15223.405047862869,
+        171.6098128264957
     ],
     "multi_client_put_calls_Plasma_Store": [
-        15796.693450669514,
-        300.97046947045953
+        16421.348280509366,
+        290.8207979928712
     ],
     "multi_client_put_gigabytes": [
-        39.896743394372585,
-        2.347460003874646
+        41.257079800367904,
+        2.6183498603210547
     ],
     "multi_client_tasks_async": [
-        21959.60128713229,
-        815.6916566872305
+        21723.782174482185,
+        1805.2045183724206
     ],
     "n_n_actor_calls_async": [
-        27465.39608393524,
-        762.3570217280651
+        27316.33569086324,
+        621.3372235949856
     ],
     "n_n_actor_calls_with_arg_async": [
-        2709.168840517713,
-        50.58648732986629
+        2786.245634719011,
+        34.885677239448235
     ],
     "n_n_async_actor_calls_async": [
-        23716.451989299432,
-        762.9269367240967
+        23567.440791904985,
+        645.0366051803348
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10723.171694846082
+            "perf_metric_value": 10480.861987286593
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5113.112753017668
+            "perf_metric_value": 5288.8489928059735
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 15796.693450669514
+            "perf_metric_value": 16421.348280509366
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 20.105537951105227
+            "perf_metric_value": 19.317397230591656
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.997593980449436
+            "perf_metric_value": 5.276513588704411
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 39.896743394372585
+            "perf_metric_value": 41.257079800367904
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12.796724102063072
+            "perf_metric_value": 13.67606354603752
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4.773703805756311
+            "perf_metric_value": 4.969890417989956
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 969.5757440611114
+            "perf_metric_value": 972.8756609112446
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8081.168521067462
+            "perf_metric_value": 8252.29953409769
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 21959.60128713229
+            "perf_metric_value": 21723.782174482185
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2020.4236901532247
+            "perf_metric_value": 2043.0981415735505
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7484.128019312722
+            "perf_metric_value": 8564.967370806118
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5210.654473422534
+            "perf_metric_value": 5454.916872293855
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8318.094433102775
+            "perf_metric_value": 8471.080848855601
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 27465.39608393524
+            "perf_metric_value": 27316.33569086324
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2709.168840517713
+            "perf_metric_value": 2786.245634719011
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1483.660979687764
+            "perf_metric_value": 1457.3163933993856
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4133.0146320984095
+            "perf_metric_value": 4447.509230034982
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2744.6685159840754
+            "perf_metric_value": 2723.6213791034843
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7563.184192111071
+            "perf_metric_value": 7686.919019356983
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23716.451989299432
+            "perf_metric_value": 23567.440791904985
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 768.9082534403586
+            "perf_metric_value": 776.8780725651964
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1160.5254002780266
+            "perf_metric_value": 1126.760374919516
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 790.7920510051757
+            "perf_metric_value": 833.1799373566209
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.1529268174148042
+            "perf_metric_value": 0.15685350675842372
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 14569.862277318796
+            "perf_metric_value": 15223.405047862869
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 525.9274124240096
+            "perf_metric_value": 542.1463689306149
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1069.1602586173547
+            "perf_metric_value": 1104.3962578235257
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1050.6282351078878
+            "perf_metric_value": 1092.6331677147311
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.9480091293556955
+            "perf_metric_value": 0.9823727578985482
         }
     ],
     "placement_group_create/removal": [
-        768.9082534403586,
-        7.490796352327158
+        776.8780725651964,
+        8.574597174124973
     ],
     "single_client_get_calls_Plasma_Store": [
-        10723.171694846082,
-        273.67271154030044
+        10480.861987286593,
+        281.0869635986496
     ],
     "single_client_get_object_containing_10k_refs": [
-        12.796724102063072,
-        0.24376172143785838
+        13.67606354603752,
+        0.08528277795408241
     ],
     "single_client_put_calls_Plasma_Store": [
-        5113.112753017668,
-        59.15893774584755
+        5288.8489928059735,
+        55.89863056597994
     ],
     "single_client_put_gigabytes": [
-        20.105537951105227,
-        6.880575059253889
+        19.317397230591656,
+        8.666136439796578
     ],
     "single_client_tasks_and_get_batch": [
-        5.997593980449436,
-        3.075195708468554
+        5.276513588704411,
+        3.0852219239384886
     ],
     "single_client_tasks_async": [
-        8081.168521067462,
-        372.9673263202764
+        8252.29953409769,
+        452.1445849539273
     ],
     "single_client_tasks_sync": [
-        969.5757440611114,
-        8.434453318133698
+        972.8756609112446,
+        11.748533624810394
     ],
     "single_client_wait_1k_refs": [
-        4.773703805756311,
-        0.0966549450132402
+        4.969890417989956,
+        0.05375073006772334
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 12.241764013000008,
+    "broadcast_time": 17.513639377999993,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.241764013000008
+            "perf_metric_value": 17.513639377999993
         }
     ],
     "success": "1"

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 18.764070391999994,
-    "get_time": 24.086921284,
+    "args_time": 18.652252868999994,
+    "get_time": 23.628181659000006,
     "large_object_size": 107374182400,
-    "large_object_time": 29.323037406000026,
+    "large_object_time": 31.68795370199996,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 18.764070391999994
+            "perf_metric_value": 18.652252868999994
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.8424495409999935
+            "perf_metric_value": 5.746812922999993
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 24.086921284
+            "perf_metric_value": 23.628181659000006
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 199.93470425
+            "perf_metric_value": 191.054997937
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 29.323037406000026
+            "perf_metric_value": 31.68795370199996
         }
     ],
-    "queued_time": 199.93470425,
-    "returns_time": 5.8424495409999935,
+    "queued_time": 191.054997937,
+    "returns_time": 5.746812922999993,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,14 +1,14 @@
 {
-    "avg_iteration_time": 1.1950538015365602,
-    "max_iteration_time": 3.303210973739624,
-    "min_iteration_time": 0.09052538871765137,
+    "avg_iteration_time": 1.2808940172195435,
+    "max_iteration_time": 4.63950514793396,
+    "min_iteration_time": 0.04738187789916992,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.1950538015365602
+            "perf_metric_value": 1.2808940172195435
         }
     ],
     "success": 1,
-    "total_time": 119.50550389289856
+    "total_time": 128.08953142166138
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,45 +3,45 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 7.1579203605651855
+            "perf_metric_value": 7.109558343887329
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.4845627784729
+            "perf_metric_value": 12.841860675811768
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 33.596983671188354
+            "perf_metric_value": 75.95891981124878
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2.0442848205566406
+            "perf_metric_value": 1.8998584747314453
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1825.3072292804718
+            "perf_metric_value": 1895.0614984035492
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.55708404702971
+            "perf_metric_value": 0.8238578546534603
         }
     ],
-    "stage_0_time": 7.1579203605651855,
-    "stage_1_avg_iteration_time": 12.4845627784729,
-    "stage_1_max_iteration_time": 12.942049741744995,
-    "stage_1_min_iteration_time": 11.020888566970825,
-    "stage_1_time": 124.84568572044373,
-    "stage_2_avg_iteration_time": 33.596983671188354,
-    "stage_2_max_iteration_time": 34.238181352615356,
-    "stage_2_min_iteration_time": 32.854965925216675,
-    "stage_2_time": 167.985454082489,
-    "stage_3_creation_time": 2.0442848205566406,
-    "stage_3_time": 1825.3072292804718,
-    "stage_4_spread": 0.55708404702971,
+    "stage_0_time": 7.109558343887329,
+    "stage_1_avg_iteration_time": 12.841860675811768,
+    "stage_1_max_iteration_time": 13.259673357009888,
+    "stage_1_min_iteration_time": 11.788132190704346,
+    "stage_1_time": 128.4186725616455,
+    "stage_2_avg_iteration_time": 75.95891981124878,
+    "stage_2_max_iteration_time": 98.3136260509491,
+    "stage_2_min_iteration_time": 34.82487988471985,
+    "stage_2_time": 379.7951889038086,
+    "stage_3_creation_time": 1.8998584747314453,
+    "stage_3_time": 1895.0614984035492,
+    "stage_4_spread": 0.8238578546534603,
     "success": 1
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 1.5207665240240509,
-    "avg_pg_remove_time_ms": 1.2291068678679091,
+    "avg_pg_create_time_ms": 1.5610519054053393,
+    "avg_pg_remove_time_ms": 1.2877582522523479,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.5207665240240509
+            "perf_metric_value": 1.5610519054053393
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.2291068678679091
+            "perf_metric_value": 1.2877582522523479
         }
     ],
     "success": 1


### PR DESCRIPTION
```
REGRESSION 12.02%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 5.997593980449436 to 5.276513588704411 in microbenchmark.json
REGRESSION 11.64%: tasks_per_second (THROUGHPUT) regresses from 221.2222291023174 to 195.47122183821068 in benchmarks/many_nodes.json
REGRESSION 4.87%: actors_per_second (THROUGHPUT) regresses from 634.2824761754516 to 603.3663040344126 in benchmarks/many_actors.json
REGRESSION 3.92%: single_client_put_gigabytes (THROUGHPUT) regresses from 20.105537951105227 to 19.317397230591656 in microbenchmark.json
REGRESSION 3.40%: pgs_per_second (THROUGHPUT) regresses from 13.650631601393242 to 13.186074855517864 in benchmarks/many_pgs.json
REGRESSION 2.91%: client__get_calls (THROUGHPUT) regresses from 1160.5254002780266 to 1126.760374919516 in microbenchmark.json
REGRESSION 2.26%: single_client_get_calls_Plasma_Store (THROUGHPUT) regresses from 10723.171694846082 to 10480.861987286593 in microbenchmark.json
REGRESSION 1.78%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1483.660979687764 to 1457.3163933993856 in microbenchmark.json
REGRESSION 1.07%: multi_client_tasks_async (THROUGHPUT) regresses from 21959.60128713229 to 21723.782174482185 in microbenchmark.json
REGRESSION 0.77%: 1_1_async_actor_calls_with_args_async (THROUGHPUT) regresses from 2744.6685159840754 to 2723.6213791034843 in microbenchmark.json
REGRESSION 0.63%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 23716.451989299432 to 23567.440791904985 in microbenchmark.json
REGRESSION 0.54%: n_n_actor_calls_async (THROUGHPUT) regresses from 27465.39608393524 to 27316.33569086324 in microbenchmark.json
REGRESSION 126.09%: stage_2_avg_iteration_time (LATENCY) regresses from 33.596983671188354 to 75.95891981124878 in stress_tests/stress_test_many_tasks.json
REGRESSION 47.89%: stage_4_spread (LATENCY) regresses from 0.55708404702971 to 0.8238578546534603 in stress_tests/stress_test_many_tasks.json
REGRESSION 43.06%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 12.241764013000008 to 17.513639377999993 in scalability/object_store.json
REGRESSION 35.39%: dashboard_p50_latency_ms (LATENCY) regresses from 8.293 to 11.228 in benchmarks/many_actors.json
REGRESSION 33.88%: dashboard_p99_latency_ms (LATENCY) regresses from 275.082 to 368.285 in benchmarks/many_pgs.json
REGRESSION 25.24%: dashboard_p95_latency_ms (LATENCY) regresses from 6.696 to 8.386 in benchmarks/many_pgs.json
REGRESSION 20.64%: dashboard_p50_latency_ms (LATENCY) regresses from 3.856 to 4.652 in benchmarks/many_pgs.json
REGRESSION 14.78%: dashboard_p99_latency_ms (LATENCY) regresses from 675.061 to 774.804 in benchmarks/many_tasks.json
REGRESSION 10.49%: dashboard_p95_latency_ms (LATENCY) regresses from 437.195 to 483.057 in benchmarks/many_tasks.json
REGRESSION 8.07%: 107374182400_large_object_time (LATENCY) regresses from 29.323037406000026 to 31.68795370199996 in scalability/single_node.json
REGRESSION 7.18%: avg_iteration_time (LATENCY) regresses from 1.1950538015365602 to 1.2808940172195435 in stress_tests/stress_test_dead_actors.json
REGRESSION 4.77%: avg_pg_remove_time_ms (LATENCY) regresses from 1.2291068678679091 to 1.2877582522523479 in stress_tests/stress_test_placement_group.json
REGRESSION 3.82%: stage_3_time (LATENCY) regresses from 1825.3072292804718 to 1895.0614984035492 in stress_tests/stress_test_many_tasks.json
REGRESSION 3.09%: dashboard_p99_latency_ms (LATENCY) regresses from 51.794 to 53.397 in benchmarks/many_nodes.json
REGRESSION 3.08%: dashboard_p95_latency_ms (LATENCY) regresses from 2283.949 to 2354.269 in benchmarks/many_actors.json
REGRESSION 2.86%: stage_1_avg_iteration_time (LATENCY) regresses from 12.4845627784729 to 12.841860675811768 in stress_tests/stress_test_many_tasks.json
REGRESSION 2.65%: avg_pg_create_time_ms (LATENCY) regresses from 1.5207665240240509 to 1.5610519054053393 in stress_tests/stress_test_placement_group.json
```