### PR TITLE
ray: fix handling large chunks

### DIFF
--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -863,7 +863,8 @@ def _try_combine_chunks_safe(
         chunk_size = chunk.nbytes
 
         if cur_slice_size_bytes + chunk_size > max_chunk_size:
-            slices.append(array.chunks[cur_slice_start:i])
+            if cur_slice_start != i:
+                slices.append(array.chunks[cur_slice_start:i])
 
             cur_slice_start = i
             cur_slice_size_bytes = 0

--- a/python/ray/data/tests/test_transform_pyarrow.py
+++ b/python/ray/data/tests/test_transform_pyarrow.py
@@ -13,8 +13,8 @@ from ray._private.arrow_utils import get_pyarrow_version
 from ray.air.util.tensor_extensions.arrow import ArrowTensorTypeV2
 from ray.data import DataContext
 from ray.data._internal.arrow_ops.transform_pyarrow import (
-    MIN_PYARROW_VERSION_TYPE_PROMOTION,
     MIN_NUM_CHUNKS_TO_TRIGGER_COMBINE_CHUNKS,
+    MIN_PYARROW_VERSION_TYPE_PROMOTION,
     concat,
     hash_partition,
     shuffle,


### PR DESCRIPTION
Ray wasn't correctly handling large chunked pyarrow arrays in the case when the first chunk is already past the max size. This will trigger a pyarrow internal error since our list of slices will contain an empty array within it. Fix this by checking for a non-empty slice before appending.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/ - Ran pyarrow tests
- Testing Strategy
   - [x] Unit tests
