### PR TITLE
[ci] allow adding byod post install script without CI team approval

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -129,6 +129,10 @@
 
 /release/ray_release @ray-project/ray-ci
 
+# Allow people to add BYOD post-installation shell scripts
+# on their own.
+/release/ray_release/*.sh
+
 /.github/ISSUE_TEMPLATE/ @aslonnie
 
 /.github/workflows/ @ray-project/ray-ci


### PR DESCRIPTION
so that writing docs is not blocked by CI team approval
