### PR TITLE
[core] refactor: consolidate `_common` test files under `_common/tests` directory

### DIFF
--- a/python/ray/_common/test_utils.py
+++ b/python/ray/_common/test_utils.py
@@ -1,7 +1,61 @@
-# Backward compatibility imports
-# These classes have been moved to ray._common.tests.test_utils
-# This file maintains backward compatibility for existing imports
+"""Test utilities for Ray.
 
-from ray._common.tests.test_utils import SignalActor, Semaphore
+This module contains test utility classes that are distributed with the Ray package
+and can be used by external libraries and tests. These utilities must remain in
+_common/ (not in tests/) to be accessible in the Ray package distribution.
+"""
+
+import asyncio
+
+import ray
+
+
+@ray.remote(num_cpus=0)
+class SignalActor:
+    """A Ray actor for coordinating test execution through signals.
+
+    Useful for testing async coordination, waiting for specific states,
+    and synchronizing multiple actors or tasks in tests.
+    """
+
+    def __init__(self):
+        self.ready_event = asyncio.Event()
+        self.num_waiters = 0
+
+    def send(self, clear: bool = False):
+        self.ready_event.set()
+        if clear:
+            self.ready_event.clear()
+
+    async def wait(self, should_wait: bool = True):
+        if should_wait:
+            self.num_waiters += 1
+            await self.ready_event.wait()
+            self.num_waiters -= 1
+
+    async def cur_num_waiters(self) -> int:
+        return self.num_waiters
+
+
+@ray.remote(num_cpus=0)
+class Semaphore:
+    """A Ray actor implementing a semaphore for test coordination.
+
+    Useful for testing resource limiting, concurrency control,
+    and coordination between multiple actors or tasks.
+    """
+
+    def __init__(self, value: int = 1):
+        self._sema = asyncio.Semaphore(value=value)
+
+    async def acquire(self):
+        await self._sema.acquire()
+
+    async def release(self):
+        self._sema.release()
+
+    async def locked(self) -> bool:
+        return self._sema.locked()
+
 
 __all__ = ["SignalActor", "Semaphore"]

--- a/python/ray/_common/test_utils.py
+++ b/python/ray/_common/test_utils.py
@@ -1,39 +1,7 @@
-import asyncio
+# Backward compatibility imports
+# These classes have been moved to ray._common.tests.test_utils
+# This file maintains backward compatibility for existing imports
 
-import ray
+from ray._common.tests.test_utils import SignalActor, Semaphore
 
-
-@ray.remote(num_cpus=0)
-class SignalActor:
-    def __init__(self):
-        self.ready_event = asyncio.Event()
-        self.num_waiters = 0
-
-    def send(self, clear: bool = False):
-        self.ready_event.set()
-        if clear:
-            self.ready_event.clear()
-
-    async def wait(self, should_wait: bool = True):
-        if should_wait:
-            self.num_waiters += 1
-            await self.ready_event.wait()
-            self.num_waiters -= 1
-
-    async def cur_num_waiters(self) -> int:
-        return self.num_waiters
-
-
-@ray.remote(num_cpus=0)
-class Semaphore:
-    def __init__(self, value: int = 1):
-        self._sema = asyncio.Semaphore(value=value)
-
-    async def acquire(self):
-        await self._sema.acquire()
-
-    async def release(self):
-        self._sema.release()
-
-    async def locked(self) -> bool:
-        return self._sema.locked()
+__all__ = ["SignalActor", "Semaphore"]

--- a/python/ray/_common/tests/BUILD
+++ b/python/ray/_common/tests/BUILD
@@ -4,7 +4,7 @@ load("//bazel:python.bzl", "py_test_module_list")
 py_test_module_list(
     size = "small",
     files = [
-        "test_test_utils.py",
+        "test_signal_semaphore_utils.py",
         "test_utils.py",
     ],
     tags = [

--- a/python/ray/_common/tests/test_signal_semaphore_utils.py
+++ b/python/ray/_common/tests/test_signal_semaphore_utils.py
@@ -1,7 +1,7 @@
 import pytest
 import sys
 import ray
-from ray._common.test_utils import SignalActor, Semaphore
+from ray._common.tests.test_utils import SignalActor, Semaphore
 from ray._private.test_utils import wait_for_condition
 import time
 

--- a/python/ray/_common/tests/test_signal_semaphore_utils.py
+++ b/python/ray/_common/tests/test_signal_semaphore_utils.py
@@ -1,19 +1,28 @@
+"""Tests for Ray test utility classes.
+
+This module contains pytest-based tests for SignalActor and Semaphore classes
+from ray._common.test_utils. These test utility classes are used for coordination
+and synchronization in Ray tests.
+"""
+
 import pytest
 import sys
 import ray
-from ray._common.tests.test_utils import SignalActor, Semaphore
+from ray._common.test_utils import SignalActor, Semaphore
 from ray._private.test_utils import wait_for_condition
 import time
 
 
 @pytest.fixture(scope="module")
 def ray_init():
+    """Initialize Ray for the test module."""
     ray.init(num_cpus=4)
     yield
     ray.shutdown()
 
 
 def test_signal_actor_basic(ray_init):
+    """Test basic SignalActor functionality - send and wait operations."""
     signal = SignalActor.remote()
 
     # Test initial state
@@ -26,6 +35,7 @@ def test_signal_actor_basic(ray_init):
 
 
 def test_signal_actor_multiple_waiters(ray_init):
+    """Test SignalActor with multiple waiters and signal clearing."""
     signal = SignalActor.remote()
 
     # Create multiple waiters
@@ -56,6 +66,7 @@ def test_signal_actor_multiple_waiters(ray_init):
 
 
 def test_semaphore_basic(ray_init):
+    """Test basic Semaphore functionality - acquire, release, and lock status."""
     sema = Semaphore.remote(value=2)
 
     # Test initial state
@@ -72,6 +83,7 @@ def test_semaphore_basic(ray_init):
 
 
 def test_semaphore_concurrent(ray_init):
+    """Test Semaphore with concurrent workers to verify resource limiting."""
     sema = Semaphore.remote(value=2)
 
     def worker():

--- a/python/ray/_common/tests/test_utils.py
+++ b/python/ray/_common/tests/test_utils.py
@@ -1,9 +1,15 @@
+"""Tests for Ray utility functions.
+
+This module contains pytest-based tests for utility functions in ray._common.utils.
+Test utility classes (SignalActor, Semaphore) are in ray._common.test_utils to
+ensure they're included in the Ray package distribution.
+"""
+
 import asyncio
 import warnings
 import sys
 
 import pytest
-import ray
 
 from ray._common.utils import (
     get_or_create_event_loop,
@@ -11,49 +17,10 @@ from ray._common.utils import (
     _BACKGROUND_TASKS,
 )
 
-# Export test utility classes for use by other test files
-__all__ = ["SignalActor", "Semaphore"]
 
-
-# Test utility classes (moved from _common/test_utils.py)
-@ray.remote(num_cpus=0)
-class SignalActor:
-    def __init__(self):
-        self.ready_event = asyncio.Event()
-        self.num_waiters = 0
-
-    def send(self, clear: bool = False):
-        self.ready_event.set()
-        if clear:
-            self.ready_event.clear()
-
-    async def wait(self, should_wait: bool = True):
-        if should_wait:
-            self.num_waiters += 1
-            await self.ready_event.wait()
-            self.num_waiters -= 1
-
-    async def cur_num_waiters(self) -> int:
-        return self.num_waiters
-
-
-@ray.remote(num_cpus=0)
-class Semaphore:
-    def __init__(self, value: int = 1):
-        self._sema = asyncio.Semaphore(value=value)
-
-    async def acquire(self):
-        await self._sema.acquire()
-
-    async def release(self):
-        self._sema.release()
-
-    async def locked(self) -> bool:
-        return self._sema.locked()
-
-
-# Tests for utility functions
 class TestGetOrCreateEventLoop:
+    """Tests for the get_or_create_event_loop utility function."""
+
     def test_existing_event_loop(self):
         # With running event loop
         expect_loop = asyncio.new_event_loop()
@@ -76,6 +43,7 @@ class TestGetOrCreateEventLoop:
 
 @pytest.mark.asyncio
 async def test_run_background_task():
+    """Test the run_background_task utility function."""
     result = {}
 
     async def co():

--- a/python/ray/_common/tests/test_utils.py
+++ b/python/ray/_common/tests/test_utils.py
@@ -3,6 +3,7 @@ import warnings
 import sys
 
 import pytest
+import ray
 
 from ray._common.utils import (
     get_or_create_event_loop,
@@ -10,7 +11,48 @@ from ray._common.utils import (
     _BACKGROUND_TASKS,
 )
 
+# Export test utility classes for use by other test files
+__all__ = ["SignalActor", "Semaphore"]
 
+
+# Test utility classes (moved from _common/test_utils.py)
+@ray.remote(num_cpus=0)
+class SignalActor:
+    def __init__(self):
+        self.ready_event = asyncio.Event()
+        self.num_waiters = 0
+
+    def send(self, clear: bool = False):
+        self.ready_event.set()
+        if clear:
+            self.ready_event.clear()
+
+    async def wait(self, should_wait: bool = True):
+        if should_wait:
+            self.num_waiters += 1
+            await self.ready_event.wait()
+            self.num_waiters -= 1
+
+    async def cur_num_waiters(self) -> int:
+        return self.num_waiters
+
+
+@ray.remote(num_cpus=0)
+class Semaphore:
+    def __init__(self, value: int = 1):
+        self._sema = asyncio.Semaphore(value=value)
+
+    async def acquire(self):
+        await self._sema.acquire()
+
+    async def release(self):
+        self._sema.release()
+
+    async def locked(self) -> bool:
+        return self._sema.locked()
+
+
+# Tests for utility functions
 class TestGetOrCreateEventLoop:
     def test_existing_event_loop(self):
         # With running event loop


### PR DESCRIPTION
## Why are these changes needed?

In #53457 we moved signal and semaphore to `_common/` which is used in `serve` tests. However, after that, `_common` had two `test_utils` which was confusing. This PR reorganizes the test utilities and their tests for better clarity:

**Key Changes:**
- Keep `SignalActor` and `Semaphore` test utility classes in `_common/test_utils.py` to ensure they're included in Ray package distribution (external libraries need access to these)
- Separate tests for utility functions into `_common/tests/test_utils.py` (tests for `ray._common.utils` functions)
- Rename and move tests for test utility classes to `_common/tests/test_signal_semaphore_utils.py` (tests for `SignalActor` and `Semaphore`)
- Add comprehensive documentation and comments explaining the organization

**Final Organization:**
- `_common/test_utils.py`: Test utility classes (`SignalActor`, `Semaphore`) - distributed with Ray package
- `_common/tests/test_utils.py`: Tests for Ray utility functions (`get_or_create_event_loop`, `run_background_task`)  
- `_common/tests/test_signal_semaphore_utils.py`: Tests for test utility classes

This resolves the confusion of having multiple `test_utils` files while ensuring test utilities remain accessible to external libraries that depend on Ray. The separation maintains clear boundaries between utility classes (for distribution) and their tests (for development).