### PR TITLE
[core][telemetry] fix tsan issues

### DIFF
--- a/src/ray/telemetry/open_telemetry_metric_recorder.cc
+++ b/src/ray/telemetry/open_telemetry_metric_recorder.cc
@@ -97,16 +97,33 @@ void OpenTelemetryMetricRecorder::CollectGaugeMetricValues(
 
 void OpenTelemetryMetricRecorder::RegisterGaugeMetric(const std::string &name,
                                                       const std::string &description) {
-  std::lock_guard<std::mutex> lock(mutex_);
-  if (registered_instruments_.contains(name)) {
-    return;  // Already registered
+  std::string *name_ptr;
+  opentelemetry::nostd::shared_ptr<opentelemetry::metrics::ObservableInstrument>
+      instrument;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (registered_instruments_.contains(name)) {
+      return;  // Already registered
+    }
+    gauge_callback_names_.push_back(name);
+    name_ptr = &gauge_callback_names_.back();
+    instrument = GetMeter()->CreateDoubleObservableGauge(name, description, "");
+    observations_by_name_[name] = {};
+    registered_instruments_[name] = instrument;
   }
-  auto instrument = GetMeter()->CreateDoubleObservableGauge(name, description, "");
-  gauge_callback_names_.push_back(name);
-  instrument->AddCallback(&_DoubleGaugeCallback,
-                          static_cast<void *>(&gauge_callback_names_.back()));
-  observations_by_name_[name] = {};
-  registered_instruments_[name] = instrument;
+  // Important: Do not hold mutex_ (mutex A) when registering the callback.
+  //
+  // The callback function will be invoked later by the OpenTelemetry SDK,
+  // and it will attempt to acquire mutex_ (A) again. Meanwhile, both this function
+  // and the callback may also acquire an internal mutex (mutex B) owned by the
+  // instrument object.
+  //
+  // If we hold mutex A while registering the callback—and the callback later tries
+  // to acquire A while holding B—a lock-order inversion may occur, leading to
+  // a potential deadlock.
+  //
+  // To avoid this, ensure the callback is registered *after* releasing mutex_ (A).
+  instrument->AddCallback(&_DoubleGaugeCallback, static_cast<void *>(name_ptr));
 }
 
 void OpenTelemetryMetricRecorder::SetMetricValue(

--- a/src/ray/telemetry/tests/open_telemetry_metric_recorder_test.cc
+++ b/src/ray/telemetry/tests/open_telemetry_metric_recorder_test.cc
@@ -32,6 +32,11 @@ class OpenTelemetryMetricRecorderTest : public ::testing::Test {
         std::chrono::milliseconds(5000));
   }
 
+  static void TearDownTestSuite() {
+    // Cleanup if necessary
+    OpenTelemetryMetricRecorder::GetInstance().Shutdown();
+  }
+
  protected:
   OpenTelemetryMetricRecorder &recorder_;
 };


### PR DESCRIPTION
Fix tsan issues reported in https://buildkite.com/ray-project/postmerge/builds/10622/steps/canvas?jid=01973bb0-e45c-43d3-a9cd-f37f42009e95.
- The first is a deadlock issue caused by a mutex created by `OpenTelemetryMetricRecorder` hold by open telemetry itself. The fix is to make sure our mutex are not hold by open-telemetry, by minimizing the scope of our mutex.
- The second is a data race caused by the process shutdown and open telemetry shutdown. The fix is to make sure open telemetry is shutdown before the process shutdown.

Test:
- CI
- run tests locally