### PR TITLE
[core][2/N] Avoid unnecessary deserialization/serialization of ObjectId

### DIFF
--- a/cpp/src/ray/runtime/task/task_executor.cc
+++ b/cpp/src/ray/runtime/task/task_executor.cc
@@ -300,7 +300,7 @@ void TaskExecutor::Invoke(
   ArgsBufferList args_buffer;
   for (size_t i = 0; i < task_spec.NumArgs(); i++) {
     if (task_spec.ArgByRef(i)) {
-      const auto &id = task_spec.ArgId(i).Binary();
+      const auto &id = task_spec.GetArgRawObjectId(i);
       msgpack::sbuffer sbuf;
       sbuf.write(id.data(), id.size());
       args_buffer.push_back(std::move(sbuf));

--- a/cpp/src/ray/runtime/task/task_executor.cc
+++ b/cpp/src/ray/runtime/task/task_executor.cc
@@ -300,7 +300,7 @@ void TaskExecutor::Invoke(
   ArgsBufferList args_buffer;
   for (size_t i = 0; i < task_spec.NumArgs(); i++) {
     if (task_spec.ArgByRef(i)) {
-      const auto &id = task_spec.GetArgRawObjectId(i);
+      const auto &id = task_spec.GetArgObjectIdBinary(i);
       msgpack::sbuffer sbuf;
       sbuf.write(id.data(), id.size());
       args_buffer.push_back(std::move(sbuf));

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -290,6 +290,13 @@ ObjectID TaskSpecification::ArgId(size_t arg_index) const {
   return ObjectID::Nil();
 }
 
+std::string TaskSpecification::GetArgRawObjectId(size_t arg_index) const {
+  if (message_->args(arg_index).has_object_ref()) {
+    return message_->args(arg_index).object_ref().object_id();
+  }
+  return ObjectID::Nil().Binary();
+}
+
 const rpc::ObjectReference &TaskSpecification::ArgRef(size_t arg_index) const {
   RAY_CHECK(ArgByRef(arg_index));
   return message_->args(arg_index).object_ref();

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -283,14 +283,14 @@ bool TaskSpecification::ArgByRef(size_t arg_index) const {
          !message_->args(arg_index).is_inlined();
 }
 
-ObjectID TaskSpecification::ArgId(size_t arg_index) const {
+ObjectID TaskSpecification::GetArgObjectId(size_t arg_index) const {
   if (message_->args(arg_index).has_object_ref()) {
     return ObjectID::FromBinary(message_->args(arg_index).object_ref().object_id());
   }
   return ObjectID::Nil();
 }
 
-std::string TaskSpecification::GetArgRawObjectId(size_t arg_index) const {
+std::string TaskSpecification::GetArgObjectIdBinary(size_t arg_index) const {
   if (message_->args(arg_index).has_object_ref()) {
     return message_->args(arg_index).object_ref().object_id();
   }
@@ -356,7 +356,7 @@ std::vector<ObjectID> TaskSpecification::GetDependencyIds() const {
   std::vector<ObjectID> dependencies;
   for (size_t i = 0; i < NumArgs(); ++i) {
     if (ArgByRef(i)) {
-      dependencies.push_back(ArgId(i));
+      dependencies.push_back(GetArgObjectId(i));
     }
   }
   return dependencies;

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -339,13 +339,13 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
   ///
   /// \param arg_index The index of the argument.
   /// \return The ID of the argument.
-  ObjectID ArgId(size_t arg_index) const;
+  ObjectID GetArgObjectId(size_t arg_index) const;
 
   /// Get the raw object ID of the argument at the given index.
   ///
   /// \param arg_index The index of the argument.
   /// \return The raw object ID string of the argument.
-  std::string GetArgRawObjectId(size_t arg_index) const;
+  std::string GetArgObjectIdBinary(size_t arg_index) const;
 
   /// Get the reference of the argument at the given index.
   ///

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -335,8 +335,22 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
   /// Return true if the argument is passed by reference.
   bool ArgByRef(size_t arg_index) const;
 
+  /// Get the ID of the argument at the given index.
+  ///
+  /// \param arg_index The index of the argument.
+  /// \return The ID of the argument.
   ObjectID ArgId(size_t arg_index) const;
 
+  /// Get the raw object ID of the argument at the given index.
+  ///
+  /// \param arg_index The index of the argument.
+  /// \return The raw object ID string of the argument.
+  std::string GetArgRawObjectId(size_t arg_index) const;
+
+  /// Get the reference of the argument at the given index.
+  ///
+  /// \param arg_index The index of the argument.
+  /// \return The reference of the argument.
   const rpc::ObjectReference &ArgRef(size_t arg_index) const;
 
   ObjectID ReturnId(size_t return_index) const;

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -3808,7 +3808,7 @@ Status CoreWorker::GetAndPinArgsForExecutor(const TaskSpecification &task,
       args->push_back(std::make_shared<RayObject>(
           std::move(data), std::move(metadata), task.ArgInlinedRefs(i), copy_data));
       auto &arg_ref = arg_refs->emplace_back();
-      arg_ref.set_object_id(task.ArgId(i).Binary());
+      arg_ref.set_object_id(task.GetArgRawObjectId(i));
       // The task borrows all ObjectIDs that were serialized in the inlined
       // arguments. The task will receive references to these IDs, so it is
       // possible for the task to continue borrowing these arguments by the

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -3787,7 +3787,7 @@ Status CoreWorker::GetAndPinArgsForExecutor(const TaskSpecification &task,
       // otherwise, the put is a no-op.
       if (!options_.is_local_mode) {
         RAY_UNUSED(memory_store_->Put(RayObject(rpc::ErrorType::OBJECT_IN_PLASMA),
-                                      task.ArgId(i)));
+                                      task.GetArgObjectId(i)));
       }
     } else {
       // A pass-by-value argument.
@@ -3808,7 +3808,7 @@ Status CoreWorker::GetAndPinArgsForExecutor(const TaskSpecification &task,
       args->push_back(std::make_shared<RayObject>(
           std::move(data), std::move(metadata), task.ArgInlinedRefs(i), copy_data));
       auto &arg_ref = arg_refs->emplace_back();
-      arg_ref.set_object_id(task.GetArgRawObjectId(i));
+      arg_ref.set_object_id(task.GetArgObjectIdBinary(i));
       // The task borrows all ObjectIDs that were serialized in the inlined
       // arguments. The task will receive references to these IDs, so it is
       // possible for the task to continue borrowing these arguments by the

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -224,8 +224,8 @@ std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(
   std::vector<ObjectID> task_deps;
   for (size_t i = 0; i < spec.NumArgs(); i++) {
     if (spec.ArgByRef(i)) {
-      task_deps.push_back(spec.ArgId(i));
-      RAY_LOG(DEBUG) << "Adding arg ID " << spec.ArgId(i);
+      task_deps.push_back(spec.GetArgObjectId(i));
+      RAY_LOG(DEBUG) << "Adding arg ID " << spec.GetArgObjectId(i);
     } else {
       const auto &inlined_refs = spec.ArgInlinedRefs(i);
       for (const auto &inlined_ref : inlined_refs) {
@@ -351,7 +351,7 @@ bool TaskManager::ResubmitTask(const TaskID &task_id, std::vector<ObjectID> *tas
   task_deps->reserve(spec.NumArgs());
   for (size_t i = 0; i < spec.NumArgs(); i++) {
     if (spec.ArgByRef(i)) {
-      task_deps->emplace_back(spec.ArgId(i));
+      task_deps->emplace_back(spec.GetArgObjectId(i));
     } else {
       const auto &inlined_refs = spec.ArgInlinedRefs(i);
       for (const auto &inlined_ref : inlined_refs) {
@@ -1173,7 +1173,7 @@ void TaskManager::RemoveFinishedTaskReferences(
   std::vector<ObjectID> plasma_dependencies;
   for (size_t i = 0; i < spec.NumArgs(); i++) {
     if (spec.ArgByRef(i)) {
-      plasma_dependencies.push_back(spec.ArgId(i));
+      plasma_dependencies.push_back(spec.GetArgObjectId(i));
     } else {
       const auto &inlined_refs = spec.ArgInlinedRefs(i);
       for (const auto &inlined_ref : inlined_refs) {
@@ -1241,7 +1241,7 @@ int64_t TaskManager::RemoveLineageReference(const ObjectID &object_id,
     // for each of the task's args.
     for (size_t i = 0; i < it->second.spec.NumArgs(); i++) {
       if (it->second.spec.ArgByRef(i)) {
-        released_objects->push_back(it->second.spec.ArgId(i));
+        released_objects->push_back(it->second.spec.GetArgObjectId(i));
       } else {
         const auto &inlined_refs = it->second.spec.ArgInlinedRefs(i);
         for (const auto &inlined_ref : inlined_refs) {

--- a/src/ray/core_worker/transport/dependency_resolver.cc
+++ b/src/ray/core_worker/transport/dependency_resolver.cc
@@ -32,7 +32,7 @@ void InlineDependencies(
   size_t found = 0;
   for (size_t i = 0; i < task.NumArgs(); i++) {
     if (task.ArgByRef(i)) {
-      const auto &id = task.ArgId(i);
+      const auto &id = task.GetArgObjectId(i);
       const auto &it = dependencies.find(id);
       if (it != dependencies.end()) {
         RAY_CHECK(it->second);
@@ -76,7 +76,7 @@ void LocalDependencyResolver::ResolveDependencies(
   absl::flat_hash_set<ActorID> actor_dependency_ids;
   for (size_t i = 0; i < task.NumArgs(); i++) {
     if (task.ArgByRef(i)) {
-      local_dependency_ids.insert(task.ArgId(i));
+      local_dependency_ids.insert(task.GetArgObjectId(i));
     }
     for (const auto &in : task.ArgInlinedRefs(i)) {
       auto object_id = ObjectID::FromBinary(in.object_id());


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

```cpp
task.ArgId(i).Binary()
```
* `ArgId(i)` deserializes binary to `ObjectId`.
* `Binary()` serializes `ObjectId` to binary.

speedup ~17% (https://github.com/ray-project/ray/pull/53574#issuecomment-2942718323)

* Rename `ArgId` to `GetArgObjectId`
* Add `GetArgObjectIdBinary`

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
