### PR TITLE
[core][1/N] Avoid unnecessary deserialization/serialization of TaskId

### DIFF
--- a/cpp/src/ray/runtime/task/task_executor.cc
+++ b/cpp/src/ray/runtime/task/task_executor.cc
@@ -300,7 +300,7 @@ void TaskExecutor::Invoke(
   ArgsBufferList args_buffer;
   for (size_t i = 0; i < task_spec.NumArgs(); i++) {
     if (task_spec.ArgByRef(i)) {
-      const auto &id = task_spec.GetArgObjectIdBinary(i);
+      const auto &id = task_spec.ArgObjectIdBinary(i);
       msgpack::sbuffer sbuf;
       sbuf.write(id.data(), id.size());
       args_buffer.push_back(std::move(sbuf));

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -142,6 +142,10 @@ TaskID TaskSpecification::TaskId() const {
   return TaskID::FromBinary(message_->task_id());
 }
 
+std::string TaskSpecification::GetTaskIdBinary() const {
+  return message_->task_id().empty() ? TaskID::Nil().Binary() : message_->task_id();
+}
+
 TaskAttempt TaskSpecification::GetTaskAttempt() const {
   return std::make_pair(TaskId(), AttemptNumber());
 }

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -142,8 +142,11 @@ TaskID TaskSpecification::TaskId() const {
   return TaskID::FromBinary(message_->task_id());
 }
 
-std::string TaskSpecification::GetTaskIdBinary() const {
-  return message_->task_id().empty() ? TaskID::Nil().Binary() : message_->task_id();
+std::string TaskSpecification::TaskIdBinary() const {
+  if (message_->task_id().empty()) {
+    return TaskID::Nil().Binary();
+  }
+  return message_->task_id();
 }
 
 TaskAttempt TaskSpecification::GetTaskAttempt() const {
@@ -287,14 +290,14 @@ bool TaskSpecification::ArgByRef(size_t arg_index) const {
          !message_->args(arg_index).is_inlined();
 }
 
-ObjectID TaskSpecification::GetArgObjectId(size_t arg_index) const {
+ObjectID TaskSpecification::ArgObjectId(size_t arg_index) const {
   if (message_->args(arg_index).has_object_ref()) {
     return ObjectID::FromBinary(message_->args(arg_index).object_ref().object_id());
   }
   return ObjectID::Nil();
 }
 
-std::string TaskSpecification::GetArgObjectIdBinary(size_t arg_index) const {
+std::string TaskSpecification::ArgObjectIdBinary(size_t arg_index) const {
   if (message_->args(arg_index).has_object_ref()) {
     return message_->args(arg_index).object_ref().object_id();
   }
@@ -360,7 +363,7 @@ std::vector<ObjectID> TaskSpecification::GetDependencyIds() const {
   std::vector<ObjectID> dependencies;
   for (size_t i = 0; i < NumArgs(); ++i) {
     if (ArgByRef(i)) {
-      dependencies.push_back(GetArgObjectId(i));
+      dependencies.push_back(ArgObjectId(i));
     }
   }
   return dependencies;

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -292,6 +292,9 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
   // TODO(swang): Finalize and document these methods.
   TaskID TaskId() const;
 
+  // Get the task id in binary format.
+  std::string GetTaskIdBinary() const;
+
   JobID JobId() const;
 
   const rpc::JobConfig &JobConfig() const;

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -293,7 +293,7 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
   TaskID TaskId() const;
 
   // Get the task id in binary format.
-  std::string GetTaskIdBinary() const;
+  std::string TaskIdBinary() const;
 
   JobID JobId() const;
 
@@ -342,13 +342,13 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
   ///
   /// \param arg_index The index of the argument.
   /// \return The ID of the argument.
-  ObjectID GetArgObjectId(size_t arg_index) const;
+  ObjectID ArgObjectId(size_t arg_index) const;
 
   /// Get the raw object ID of the argument at the given index.
   ///
   /// \param arg_index The index of the argument.
   /// \return The raw object ID string of the argument.
-  std::string GetArgObjectIdBinary(size_t arg_index) const;
+  std::string ArgObjectIdBinary(size_t arg_index) const;
 
   /// Get the reference of the argument at the given index.
   ///

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -3787,7 +3787,7 @@ Status CoreWorker::GetAndPinArgsForExecutor(const TaskSpecification &task,
       // otherwise, the put is a no-op.
       if (!options_.is_local_mode) {
         RAY_UNUSED(memory_store_->Put(RayObject(rpc::ErrorType::OBJECT_IN_PLASMA),
-                                      task.GetArgObjectId(i)));
+                                      task.ArgObjectId(i)));
       }
     } else {
       // A pass-by-value argument.
@@ -3808,7 +3808,7 @@ Status CoreWorker::GetAndPinArgsForExecutor(const TaskSpecification &task,
       args->push_back(std::make_shared<RayObject>(
           std::move(data), std::move(metadata), task.ArgInlinedRefs(i), copy_data));
       auto &arg_ref = arg_refs->emplace_back();
-      arg_ref.set_object_id(task.GetArgObjectIdBinary(i));
+      arg_ref.set_object_id(task.ArgObjectIdBinary(i));
       // The task borrows all ObjectIDs that were serialized in the inlined
       // arguments. The task will receive references to these IDs, so it is
       // possible for the task to continue borrowing these arguments by the
@@ -4626,7 +4626,7 @@ void CoreWorker::HandleGetCoreWorkerStats(rpc::GetCoreWorkerStatsRequest request
   if (request.include_task_info()) {
     task_manager_->FillTaskInfo(reply, limit);
     for (const auto &current_running_task : running_tasks_) {
-      reply->add_running_task_ids(current_running_task.second.GetTaskIdBinary());
+      reply->add_running_task_ids(current_running_task.second.TaskIdBinary());
     }
   }
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -4626,7 +4626,7 @@ void CoreWorker::HandleGetCoreWorkerStats(rpc::GetCoreWorkerStatsRequest request
   if (request.include_task_info()) {
     task_manager_->FillTaskInfo(reply, limit);
     for (const auto &current_running_task : running_tasks_) {
-      reply->add_running_task_ids(current_running_task.second.TaskId().Binary());
+      reply->add_running_task_ids(current_running_task.second.GetTaskIdBinary());
     }
   }
 

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -1560,7 +1560,7 @@ void TaskManager::FillTaskInfo(rpc::GetCoreWorkerStatsReply *reply,
     if (!node_id.IsNil()) {
       entry->set_node_id(node_id.Binary());
     }
-    entry->set_task_id(task_spec.TaskId().Binary());
+    entry->set_task_id(task_spec.GetTaskIdBinary());
     entry->set_parent_task_id(task_spec.ParentTaskId().Binary());
     const auto &resources_map = task_spec.GetRequiredResources().GetResourceMap();
     entry->mutable_required_resources()->insert(resources_map.begin(),

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -224,8 +224,8 @@ std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(
   std::vector<ObjectID> task_deps;
   for (size_t i = 0; i < spec.NumArgs(); i++) {
     if (spec.ArgByRef(i)) {
-      task_deps.push_back(spec.GetArgObjectId(i));
-      RAY_LOG(DEBUG) << "Adding arg ID " << spec.GetArgObjectId(i);
+      task_deps.push_back(spec.ArgObjectId(i));
+      RAY_LOG(DEBUG) << "Adding arg ID " << spec.ArgObjectId(i);
     } else {
       const auto &inlined_refs = spec.ArgInlinedRefs(i);
       for (const auto &inlined_ref : inlined_refs) {
@@ -351,7 +351,7 @@ bool TaskManager::ResubmitTask(const TaskID &task_id, std::vector<ObjectID> *tas
   task_deps->reserve(spec.NumArgs());
   for (size_t i = 0; i < spec.NumArgs(); i++) {
     if (spec.ArgByRef(i)) {
-      task_deps->emplace_back(spec.GetArgObjectId(i));
+      task_deps->emplace_back(spec.ArgObjectId(i));
     } else {
       const auto &inlined_refs = spec.ArgInlinedRefs(i);
       for (const auto &inlined_ref : inlined_refs) {
@@ -1173,7 +1173,7 @@ void TaskManager::RemoveFinishedTaskReferences(
   std::vector<ObjectID> plasma_dependencies;
   for (size_t i = 0; i < spec.NumArgs(); i++) {
     if (spec.ArgByRef(i)) {
-      plasma_dependencies.push_back(spec.GetArgObjectId(i));
+      plasma_dependencies.push_back(spec.ArgObjectId(i));
     } else {
       const auto &inlined_refs = spec.ArgInlinedRefs(i);
       for (const auto &inlined_ref : inlined_refs) {
@@ -1241,7 +1241,7 @@ int64_t TaskManager::RemoveLineageReference(const ObjectID &object_id,
     // for each of the task's args.
     for (size_t i = 0; i < it->second.spec.NumArgs(); i++) {
       if (it->second.spec.ArgByRef(i)) {
-        released_objects->push_back(it->second.spec.GetArgObjectId(i));
+        released_objects->push_back(it->second.spec.ArgObjectId(i));
       } else {
         const auto &inlined_refs = it->second.spec.ArgInlinedRefs(i);
         for (const auto &inlined_ref : inlined_refs) {
@@ -1560,7 +1560,7 @@ void TaskManager::FillTaskInfo(rpc::GetCoreWorkerStatsReply *reply,
     if (!node_id.IsNil()) {
       entry->set_node_id(node_id.Binary());
     }
-    entry->set_task_id(task_spec.GetTaskIdBinary());
+    entry->set_task_id(task_spec.TaskIdBinary());
     entry->set_parent_task_id(task_spec.ParentTaskId().Binary());
     const auto &resources_map = task_spec.GetRequiredResources().GetResourceMap();
     entry->mutable_required_resources()->insert(resources_map.begin(),

--- a/src/ray/core_worker/test/actor_task_submitter_test.cc
+++ b/src/ray/core_worker/test/actor_task_submitter_test.cc
@@ -672,12 +672,12 @@ TEST_P(ActorTaskSubmitterTest, TestActorRestartFailInflightTasks) {
   // Submit retries for task2 and task3.
   auto task2_second_attempt = CreateActorTaskHelper(actor_id, caller_worker_id, 3);
   task2_second_attempt.GetMutableMessage().set_task_id(
-      task2_first_attempt.GetTaskIdBinary());
+      task2_first_attempt.TaskIdBinary());
   task2_second_attempt.GetMutableMessage().set_attempt_number(
       task2_first_attempt.AttemptNumber() + 1);
   auto task3_second_attempt = CreateActorTaskHelper(actor_id, caller_worker_id, 4);
   task3_second_attempt.GetMutableMessage().set_task_id(
-      task3_first_attempt.GetTaskIdBinary());
+      task3_first_attempt.TaskIdBinary());
   task3_second_attempt.GetMutableMessage().set_attempt_number(
       task3_first_attempt.AttemptNumber() + 1);
   ASSERT_TRUE(submitter_.SubmitTask(task2_second_attempt).ok());

--- a/src/ray/core_worker/test/actor_task_submitter_test.cc
+++ b/src/ray/core_worker/test/actor_task_submitter_test.cc
@@ -672,12 +672,12 @@ TEST_P(ActorTaskSubmitterTest, TestActorRestartFailInflightTasks) {
   // Submit retries for task2 and task3.
   auto task2_second_attempt = CreateActorTaskHelper(actor_id, caller_worker_id, 3);
   task2_second_attempt.GetMutableMessage().set_task_id(
-      task2_first_attempt.TaskId().Binary());
+      task2_first_attempt.GetTaskIdBinary());
   task2_second_attempt.GetMutableMessage().set_attempt_number(
       task2_first_attempt.AttemptNumber() + 1);
   auto task3_second_attempt = CreateActorTaskHelper(actor_id, caller_worker_id, 4);
   task3_second_attempt.GetMutableMessage().set_task_id(
-      task3_first_attempt.TaskId().Binary());
+      task3_first_attempt.GetTaskIdBinary());
   task3_second_attempt.GetMutableMessage().set_attempt_number(
       task3_first_attempt.AttemptNumber() + 1);
   ASSERT_TRUE(submitter_.SubmitTask(task2_second_attempt).ok());

--- a/src/ray/core_worker/test/normal_task_submitter_test.cc
+++ b/src/ray/core_worker/test/normal_task_submitter_test.cc
@@ -2059,8 +2059,7 @@ TEST(NormalTaskSubmitterTest, TestKillExecutingTask) {
 
   // Try force kill, exiting the worker
   ASSERT_TRUE(submitter.CancelTask(task, true, false).ok());
-  ASSERT_EQ(worker_client->kill_requests.front().intended_task_id(),
-            task.GetTaskIdBinary());
+  ASSERT_EQ(worker_client->kill_requests.front().intended_task_id(), task.TaskIdBinary());
   ASSERT_TRUE(worker_client->ReplyPushTask(Status::IOError("workerdying"), true));
   ASSERT_EQ(worker_client->callbacks.size(), 0);
   ASSERT_EQ(raylet_client->num_workers_returned, 0);
@@ -2077,8 +2076,7 @@ TEST(NormalTaskSubmitterTest, TestKillExecutingTask) {
   // Try non-force kill, worker returns normally
   ASSERT_TRUE(submitter.CancelTask(task, false, false).ok());
   ASSERT_TRUE(worker_client->ReplyPushTask());
-  ASSERT_EQ(worker_client->kill_requests.front().intended_task_id(),
-            task.GetTaskIdBinary());
+  ASSERT_EQ(worker_client->kill_requests.front().intended_task_id(), task.TaskIdBinary());
   ASSERT_EQ(worker_client->callbacks.size(), 0);
   ASSERT_EQ(raylet_client->num_workers_returned, 1);
   ASSERT_EQ(raylet_client->num_workers_returned_exiting, 0);

--- a/src/ray/core_worker/test/normal_task_submitter_test.cc
+++ b/src/ray/core_worker/test/normal_task_submitter_test.cc
@@ -2060,7 +2060,7 @@ TEST(NormalTaskSubmitterTest, TestKillExecutingTask) {
   // Try force kill, exiting the worker
   ASSERT_TRUE(submitter.CancelTask(task, true, false).ok());
   ASSERT_EQ(worker_client->kill_requests.front().intended_task_id(),
-            task.TaskId().Binary());
+            task.GetTaskIdBinary());
   ASSERT_TRUE(worker_client->ReplyPushTask(Status::IOError("workerdying"), true));
   ASSERT_EQ(worker_client->callbacks.size(), 0);
   ASSERT_EQ(raylet_client->num_workers_returned, 0);
@@ -2078,7 +2078,7 @@ TEST(NormalTaskSubmitterTest, TestKillExecutingTask) {
   ASSERT_TRUE(submitter.CancelTask(task, false, false).ok());
   ASSERT_TRUE(worker_client->ReplyPushTask());
   ASSERT_EQ(worker_client->kill_requests.front().intended_task_id(),
-            task.TaskId().Binary());
+            task.GetTaskIdBinary());
   ASSERT_EQ(worker_client->callbacks.size(), 0);
   ASSERT_EQ(raylet_client->num_workers_returned, 1);
   ASSERT_EQ(raylet_client->num_workers_returned_exiting, 0);

--- a/src/ray/core_worker/transport/actor_task_submitter.cc
+++ b/src/ray/core_worker/transport/actor_task_submitter.cc
@@ -923,7 +923,7 @@ Status ActorTaskSubmitter::CancelTask(TaskSpecification task_spec, bool recursiv
 
     const auto &client = queue->second.rpc_client;
     auto request = rpc::CancelTaskRequest();
-    request.set_intended_task_id(task_spec.TaskId().Binary());
+    request.set_intended_task_id(task_spec.GetTaskIdBinary());
     request.set_force_kill(force_kill);
     request.set_recursive(recursive);
     request.set_caller_worker_id(task_spec.CallerWorkerId().Binary());

--- a/src/ray/core_worker/transport/actor_task_submitter.cc
+++ b/src/ray/core_worker/transport/actor_task_submitter.cc
@@ -923,7 +923,7 @@ Status ActorTaskSubmitter::CancelTask(TaskSpecification task_spec, bool recursiv
 
     const auto &client = queue->second.rpc_client;
     auto request = rpc::CancelTaskRequest();
-    request.set_intended_task_id(task_spec.GetTaskIdBinary());
+    request.set_intended_task_id(task_spec.TaskIdBinary());
     request.set_force_kill(force_kill);
     request.set_recursive(recursive);
     request.set_caller_worker_id(task_spec.CallerWorkerId().Binary());

--- a/src/ray/core_worker/transport/dependency_resolver.cc
+++ b/src/ray/core_worker/transport/dependency_resolver.cc
@@ -32,7 +32,7 @@ void InlineDependencies(
   size_t found = 0;
   for (size_t i = 0; i < task.NumArgs(); i++) {
     if (task.ArgByRef(i)) {
-      const auto &id = task.GetArgObjectId(i);
+      const auto &id = task.ArgObjectId(i);
       const auto &it = dependencies.find(id);
       if (it != dependencies.end()) {
         RAY_CHECK(it->second);
@@ -76,7 +76,7 @@ void LocalDependencyResolver::ResolveDependencies(
   absl::flat_hash_set<ActorID> actor_dependency_ids;
   for (size_t i = 0; i < task.NumArgs(); i++) {
     if (task.ArgByRef(i)) {
-      local_dependency_ids.insert(task.GetArgObjectId(i));
+      local_dependency_ids.insert(task.ArgObjectId(i));
     }
     for (const auto &in : task.ArgInlinedRefs(i)) {
       auto object_id = ObjectID::FromBinary(in.object_id());

--- a/src/ray/core_worker/transport/normal_task_submitter.cc
+++ b/src/ray/core_worker/transport/normal_task_submitter.cc
@@ -757,7 +757,7 @@ Status NormalTaskSubmitter::CancelTask(TaskSpecification task_spec,
 
   RAY_CHECK(client != nullptr);
   auto request = rpc::CancelTaskRequest();
-  request.set_intended_task_id(task_spec.TaskId().Binary());
+  request.set_intended_task_id(task_spec.GetTaskIdBinary());
   request.set_force_kill(force_kill);
   request.set_recursive(recursive);
   request.set_caller_worker_id(task_spec.CallerWorkerId().Binary());

--- a/src/ray/core_worker/transport/normal_task_submitter.cc
+++ b/src/ray/core_worker/transport/normal_task_submitter.cc
@@ -757,7 +757,7 @@ Status NormalTaskSubmitter::CancelTask(TaskSpecification task_spec,
 
   RAY_CHECK(client != nullptr);
   auto request = rpc::CancelTaskRequest();
-  request.set_intended_task_id(task_spec.GetTaskIdBinary());
+  request.set_intended_task_id(task_spec.TaskIdBinary());
   request.set_force_kill(force_kill);
   request.set_recursive(recursive);
   request.set_caller_worker_id(task_spec.CallerWorkerId().Binary());

--- a/src/ray/gcs/pb_util.h
+++ b/src/ray/gcs/pb_util.h
@@ -227,7 +227,7 @@ inline void FillTaskInfo(rpc::TaskInfoEntry *task_info,
   task_info->set_scheduling_state(rpc::TaskStatus::NIL);
   task_info->set_job_id(task_spec.JobId().Binary());
 
-  task_info->set_task_id(task_spec.GetTaskIdBinary());
+  task_info->set_task_id(task_spec.TaskIdBinary());
   // NOTE: we set the parent task id of a task to be submitter's task id, where
   // the submitter depends on the owner coreworker's:
   // - if the owner coreworker runs a normal task, the submitter's task id is the task id.
@@ -267,7 +267,7 @@ inline void FillExportTaskInfo(rpc::ExportTaskEventData::TaskInfoEntry *task_inf
   task_info->set_language(task_spec.GetLanguage());
   task_info->set_func_or_class_name(task_spec.FunctionDescriptor()->CallString());
 
-  task_info->set_task_id(task_spec.GetTaskIdBinary());
+  task_info->set_task_id(task_spec.TaskIdBinary());
   // NOTE: we set the parent task id of a task to be submitter's task id, where
   // the submitter depends on the owner coreworker's:
   // - if the owner coreworker runs a normal task, the submitter's task id is the task id.

--- a/src/ray/gcs/pb_util.h
+++ b/src/ray/gcs/pb_util.h
@@ -227,7 +227,7 @@ inline void FillTaskInfo(rpc::TaskInfoEntry *task_info,
   task_info->set_scheduling_state(rpc::TaskStatus::NIL);
   task_info->set_job_id(task_spec.JobId().Binary());
 
-  task_info->set_task_id(task_spec.TaskId().Binary());
+  task_info->set_task_id(task_spec.GetTaskIdBinary());
   // NOTE: we set the parent task id of a task to be submitter's task id, where
   // the submitter depends on the owner coreworker's:
   // - if the owner coreworker runs a normal task, the submitter's task id is the task id.
@@ -267,7 +267,7 @@ inline void FillExportTaskInfo(rpc::ExportTaskEventData::TaskInfoEntry *task_inf
   task_info->set_language(task_spec.GetLanguage());
   task_info->set_func_or_class_name(task_spec.FunctionDescriptor()->CallString());
 
-  task_info->set_task_id(task_spec.TaskId().Binary());
+  task_info->set_task_id(task_spec.GetTaskIdBinary());
   // NOTE: we set the parent task id of a task to be submitter's task id, where
   // the submitter depends on the owner coreworker's:
   // - if the owner coreworker runs a normal task, the submitter's task id is the task id.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

```cpp
task_spec.TaskId().Binary()
```
* `TaskId()` deserializes binary to TaskId.
* `Binary()` serializes `TaskId` to binary.

This PR:
* renames `TaskId` to `GetTaskId`
* adds `GetTaskIdBinary`

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
