### PR TITLE
[ci] Add `spark_on_ray` tag to `_ALL_TAGS` set used in determining tests to run

### DIFF
--- a/ci/pipeline/determine_tests_to_run.py
+++ b/ci/pipeline/determine_tests_to_run.py
@@ -15,7 +15,7 @@ _ALL_TAGS = set(
     lint python cpp core_cpp java workflow compiled_graphs dashboard ray_client
     data serve ml tune train llm rllib rllib_gpu rllib_directly
     linux_wheels macos_wheels docker doc python_dependencies tools
-    release_tests compiled_python k8s_doc
+    release_tests compiled_python k8s_doc spark_on_ray
     """.split()
 )
 


### PR DESCRIPTION
## Why are these changes needed?

It seems like `spark_on_ray` tests never ran. Effectively, any changes in `ray/util/spark` were not covered by `premerge` ci check. The issue was discovered in #53287 where I did some refactoring which affected a file in `ray/util/spark` and `premerge` ci was [failing](https://buildkite.com/ray-project/premerge/builds/41453#01973f92-646f-43ce-a63d-cfc6241aff89) to init due to:
```
[2025-06-05T10:11:55Z]   File "/var/lib/buildkite-agent/builds/bk-runner-queue-small-pr-i-06fc793a90043f43b-1/ray-project/premerge/ci/pipeline/determine_tests_to_run.py", line 224, in <module>
[2025-06-05T10:11:55Z]     assert tag in _ALL_TAGS, f"Unknown tag {tag}"
[2025-06-05T10:11:55Z] AssertionError: Unknown tag spark_on_ray
```

This PR adds `spark_on_ray` tag to `_ALL_TAGS` set in `determine_tests_to_run.py`.