### PR TITLE
[CI] Re-enable isort for all remaining files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,9 +41,6 @@ repos:
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]
-      - id: ruff
-        args: [ --select, "I", --fix, --exit-non-zero-on-fix ]
-        files: '^python/ray/serve/|^python/ray/train|^python/ray/data|^python/ray/_private/|^python/ray/llm/|^python/ray/tune/'
 
   - repo: https://github.com/jsh9/pydoclint
     rev: "0.6.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,6 @@ ignore = [
     "B027",
     "B904",
     "C419",
-    # Below are auto-fixable rules
-    "I001",
 ]
 
 [tool.ruff.lint.flake8-quotes]

--- a/python/ray/_common/tests/test_test_utils.py
+++ b/python/ray/_common/tests/test_test_utils.py
@@ -1,9 +1,11 @@
-import pytest
 import sys
-import ray
-from ray._common.test_utils import SignalActor, Semaphore
-from ray._private.test_utils import wait_for_condition
 import time
+
+import pytest
+
+import ray
+from ray._common.test_utils import Semaphore, SignalActor
+from ray._private.test_utils import wait_for_condition
 
 
 @pytest.fixture(scope="module")

--- a/python/ray/_common/tests/test_utils.py
+++ b/python/ray/_common/tests/test_utils.py
@@ -1,13 +1,13 @@
 import asyncio
-import warnings
 import sys
+import warnings
 
 import pytest
 
 from ray._common.utils import (
+    _BACKGROUND_TASKS,
     get_or_create_event_loop,
     run_background_task,
-    _BACKGROUND_TASKS,
 )
 
 

--- a/python/ray/_common/utils.py
+++ b/python/ray/_common/utils.py
@@ -1,7 +1,6 @@
 import asyncio
 import importlib
 import sys
-
 from typing import Coroutine
 
 

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -1,6 +1,6 @@
 import inspect
 import logging
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 
 import ray._private.ray_constants as ray_constants
 import ray._private.signature as signature
@@ -13,6 +13,11 @@ from ray._private.client_mode_hook import (
     client_mode_convert_actor,
     client_mode_hook,
     client_mode_should_convert,
+)
+from ray._private.custom_types import (
+    TENSOR_TRANSPORT,
+    TypeTensorTransport,
+    TypeTensorTransportEnum,
 )
 from ray._private.inspect_util import (
     is_class_method,
@@ -27,6 +32,7 @@ from ray._raylet import (
     PythonFunctionDescriptor,
     raise_sys_exit_with_custom_error_message,
 )
+from ray.core.generated.common_pb2 import OBJECT_STORE, TensorTransport
 from ray.exceptions import AsyncioActorExit
 from ray.util.annotations import DeveloperAPI, PublicAPI
 from ray.util.placement_group import _configure_placement_group_based_on_context
@@ -39,12 +45,6 @@ from ray.util.tracing.tracing_helper import (
     _tracing_actor_creation,
     _tracing_actor_method_invocation,
 )
-from ray._private.custom_types import (
-    TENSOR_TRANSPORT,
-    TypeTensorTransport,
-    TypeTensorTransportEnum,
-)
-from ray.core.generated.common_pb2 import TensorTransport, OBJECT_STORE
 
 if TYPE_CHECKING:
     pass

--- a/python/ray/air/__init__.py
+++ b/python/ray/air/__init__.py
@@ -1,3 +1,4 @@
+import ray.data  # noqa: F401  # TODO: This is a hack to avoid circular import
 from ray.air.config import (
     CheckpointConfig,
     FailureConfig,
@@ -7,7 +8,6 @@ from ray.air.config import (
 from ray.air.data_batch_type import DataBatchType
 from ray.air.execution.resources.request import AcquiredResources, ResourceRequest
 from ray.air.result import Result
-import ray.data  # noqa: F401  # TODO: This is a hack to avoid circular import
 
 __all__ = [
     "DataBatchType",

--- a/python/ray/air/_internal/device_manager/npu.py
+++ b/python/ray/air/_internal/device_manager/npu.py
@@ -6,8 +6,8 @@ import torch
 
 import ray
 import ray._private.ray_constants as ray_constants
-from ray.air._internal.device_manager.torch_device_manager import TorchDeviceManager
 from ray._private.accelerators.npu import ASCEND_RT_VISIBLE_DEVICES_ENV_VAR
+from ray.air._internal.device_manager.torch_device_manager import TorchDeviceManager
 
 
 def is_package_present(package_name: str) -> bool:

--- a/python/ray/air/_internal/torch_utils.py
+++ b/python/ray/air/_internal/torch_utils.py
@@ -1,20 +1,20 @@
 import warnings
-from typing import Any, Dict, List, Optional, Union, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 import numpy as np
 import pandas as pd
-import torch
 import pyarrow
+import torch
 
 from ray.air._internal.device_manager import get_torch_device_manager_by_context
 from ray.air.util.data_batch_conversion import _unwrap_ndarray_object_type_if_needed
 from ray.data.collate_fn import (
-    TensorBatchType,
     TensorBatchReturnType,
-    _is_tensor,
-    _is_tensor_sequence,
+    TensorBatchType,
     _is_nested_tensor_sequence,
+    _is_tensor,
     _is_tensor_mapping,
+    _is_tensor_sequence,
     _is_tensor_sequence_mapping,
 )
 
@@ -352,8 +352,8 @@ def arrow_batch_to_tensors(
         A dictionary of column name to list of tensors. For non-chunked columns,
         the list will contain a single tensor.
     """
-    from ray.data._internal.arrow_ops import transform_pyarrow
     from ray.data._internal.arrow_block import ArrowBlockAccessor
+    from ray.data._internal.arrow_ops import transform_pyarrow
 
     if combine_chunks:
         numpy_batch = ArrowBlockAccessor(batch).to_batch_format("numpy")

--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -1,7 +1,8 @@
 import logging
+import os
+import warnings
 from collections import Counter, defaultdict
 from dataclasses import _MISSING_TYPE, dataclass, fields
-import os
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -14,7 +15,6 @@ from typing import (
     Tuple,
     Union,
 )
-import warnings
 
 import pyarrow.fs
 

--- a/python/ray/air/tests/test_air_usage.py
+++ b/python/ray/air/tests/test_air_usage.py
@@ -210,10 +210,10 @@ def test_tag_air_entrypoint(ray_start_4_cpus, mock_record, entrypoint, tuner, tr
 )
 def test_tag_train_entrypoint(mock_record):
     """Test that Train v2 entrypoints are recorded correctly."""
-    from ray.train.v2.torch.torch_trainer import TorchTrainer
-    from ray.train.v2.tensorflow.tensorflow_trainer import TensorflowTrainer
-    from ray.train.v2.xgboost.xgboost_trainer import XGBoostTrainer
     from ray.train.v2.lightgbm.lightgbm_trainer import LightGBMTrainer
+    from ray.train.v2.tensorflow.tensorflow_trainer import TensorflowTrainer
+    from ray.train.v2.torch.torch_trainer import TorchTrainer
+    from ray.train.v2.xgboost.xgboost_trainer import XGBoostTrainer
 
     trainer_classes = [
         TorchTrainer,

--- a/python/ray/air/tests/test_arrow.py
+++ b/python/ray/air/tests/test_arrow.py
@@ -9,10 +9,10 @@ from packaging.version import parse as parse_version
 from ray._private.arrow_utils import get_pyarrow_version
 from ray.air.util.tensor_extensions.arrow import (
     ArrowConversionError,
+    ArrowTensorArray,
     _convert_to_pyarrow_native_array,
     _infer_pyarrow_type,
     convert_to_pyarrow_array,
-    ArrowTensorArray,
 )
 from ray.air.util.tensor_extensions.utils import create_ragged_ndarray
 from ray.data import DataContext

--- a/python/ray/air/tests/test_integration_wandb.py
+++ b/python/ray/air/tests/test_integration_wandb.py
@@ -50,10 +50,10 @@ from ray.air.integrations.wandb import (
     WANDB_POPULATE_RUN_LOCATION_HOOK,
     WANDB_PROJECT_ENV_VAR,
     WANDB_SETUP_API_KEY_HOOK,
+    RunDisabled,
     WandbLoggerCallback,
     _QueueItem,
     _WandbLoggingActor,
-    RunDisabled,
     setup_wandb,
 )
 from ray.air.tests.mocked_wandb_integration import (

--- a/python/ray/air/util/object_extensions/arrow.py
+++ b/python/ray/air/util/object_extensions/arrow.py
@@ -6,8 +6,8 @@ import pyarrow as pa
 from packaging.version import parse as parse_version
 
 import ray.air.util.object_extensions.pandas
-from ray._private.serialization import pickle_dumps
 from ray._private.arrow_utils import get_pyarrow_version
+from ray._private.serialization import pickle_dumps
 from ray.util.annotations import PublicAPI
 
 MIN_PYARROW_VERSION_SCALAR_SUBCLASS = parse_version("9.0.0")

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -1,10 +1,9 @@
 import abc
-from datetime import datetime
-
 import itertools
 import json
 import logging
 import sys
+from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -13,14 +12,14 @@ from packaging.version import parse as parse_version
 
 from ray._private.arrow_utils import get_pyarrow_version
 from ray.air.util.tensor_extensions.utils import (
-    _is_ndarray_variable_shaped_tensor,
-    create_ragged_ndarray,
-    _should_convert_to_tensor,
     ArrayLike,
+    _is_ndarray_variable_shaped_tensor,
+    _should_convert_to_tensor,
+    create_ragged_ndarray,
 )
 from ray.data._internal.numpy_support import (
-    convert_to_numpy,
     _convert_datetime_to_np_datetime,
+    convert_to_numpy,
 )
 from ray.data._internal.util import GiB
 from ray.util import log_once

--- a/python/ray/air/util/tensor_extensions/utils.py
+++ b/python/ray/air/util/tensor_extensions/utils.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import TYPE_CHECKING, Any, Sequence, Union, List, Protocol
+from typing import TYPE_CHECKING, Any, List, Protocol, Sequence, Union
 
 import numpy as np
 

--- a/python/ray/autoscaler/_private/gcp/config.py
+++ b/python/ray/autoscaler/_private/gcp/config.py
@@ -16,8 +16,7 @@ from google.oauth2 import service_account
 from google.oauth2.credentials import Credentials as OAuthCredentials
 from googleapiclient import discovery, errors
 
-from ray._private.accelerators import TPUAcceleratorManager
-from ray._private.accelerators import tpu
+from ray._private.accelerators import TPUAcceleratorManager, tpu
 from ray.autoscaler._private.gcp.node import MAX_POLLS, POLL_INTERVAL, GCPNodeType
 from ray.autoscaler._private.util import check_legacy_fields
 

--- a/python/ray/autoscaler/_private/gcp/node_provider.py
+++ b/python/ray/autoscaler/_private/gcp/node_provider.py
@@ -18,8 +18,8 @@ from ray.autoscaler._private.gcp.config import (
 # The logic has been abstracted away here to allow for different GCP resources
 # (API endpoints), which can differ widely, making it impossible to use
 # the same logic for everything.
-from ray.autoscaler._private.gcp.node import GCPTPU  # noqa
 from ray.autoscaler._private.gcp.node import (
+    GCPTPU,  # noqa
     GCPCompute,
     GCPNode,
     GCPNodeType,

--- a/python/ray/autoscaler/_private/monitor.py
+++ b/python/ray/autoscaler/_private/monitor.py
@@ -15,6 +15,7 @@ from typing import Any, Callable, Dict, Optional, Union
 import ray
 import ray._private.ray_constants as ray_constants
 import ray._private.utils
+from ray._private import logging_utils
 from ray._private.event.event_logger import get_event_logger
 from ray._private.ray_logging import setup_component_logger
 from ray._raylet import GcsClient
@@ -40,7 +41,6 @@ from ray.experimental.internal_kv import (
     _internal_kv_initialized,
     _internal_kv_put,
 )
-from ray._private import logging_utils
 
 try:
     import prometheus_client

--- a/python/ray/autoscaler/local/coordinator_server.py
+++ b/python/ray/autoscaler/local/coordinator_server.py
@@ -6,8 +6,8 @@ locally in LocalNodeProvider. To start the webserver the user runs:
 import argparse
 import json
 import logging
-import threading
 import socket
+import threading
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 
 from ray.autoscaler._private.local.node_provider import LocalNodeProvider

--- a/python/ray/autoscaler/sdk/sdk.py
+++ b/python/ray/autoscaler/sdk/sdk.py
@@ -8,8 +8,10 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Union
 
 from ray.autoscaler._private import commands
 from ray.autoscaler._private.cli_logger import cli_logger
-from ray.autoscaler._private.event_system import CreateClusterEvent  # noqa: F401
-from ray.autoscaler._private.event_system import global_event_system  # noqa: F401
+from ray.autoscaler._private.event_system import (
+    CreateClusterEvent,  # noqa: F401
+    global_event_system,  # noqa: F401
+)
 from ray.util.annotations import DeveloperAPI
 
 

--- a/python/ray/autoscaler/v2/instance_manager/reconciler.py
+++ b/python/ray/autoscaler/v2/instance_manager/reconciler.py
@@ -36,12 +36,10 @@ from ray.core.generated.autoscaler_pb2 import (
     PendingInstance,
     PendingInstanceRequest,
 )
-from ray.core.generated.instance_manager_pb2 import GetInstanceManagerStateRequest
-from ray.core.generated.instance_manager_pb2 import Instance as IMInstance
 from ray.core.generated.instance_manager_pb2 import (
+    GetInstanceManagerStateRequest,
+    Instance as IMInstance,
     InstanceUpdateEvent as IMInstanceUpdateEvent,
-)
-from ray.core.generated.instance_manager_pb2 import (
     NodeKind,
     StatusCode,
     UpdateInstanceManagerStateRequest,

--- a/python/ray/autoscaler/v2/monitor.py
+++ b/python/ray/autoscaler/v2/monitor.py
@@ -14,6 +14,7 @@ from typing import Optional
 import ray
 import ray._private.ray_constants as ray_constants
 import ray._private.utils
+from ray._private import logging_utils
 from ray._private.event.event_logger import get_event_logger
 from ray._private.ray_logging import setup_component_logger
 from ray._private.usage.usage_lib import record_extra_usage_tag
@@ -35,7 +36,6 @@ from ray.autoscaler.v2.metrics_reporter import AutoscalerMetricsReporter
 from ray.core.generated.autoscaler_pb2 import AutoscalingState
 from ray.core.generated.event_pb2 import Event as RayEvent
 from ray.core.generated.usage_pb2 import TagKey
-from ray._private import logging_utils
 
 try:
     import prometheus_client

--- a/python/ray/autoscaler/v2/utils.py
+++ b/python/ray/autoscaler/v2/utils.py
@@ -39,8 +39,6 @@ from ray.core.generated.autoscaler_pb2 import (
     NodeStatus,
     PlacementConstraint,
     ResourceRequest,
-)
-from ray.core.generated.autoscaler_pb2 import (
     ResourceRequestByCount as ResourceRequestByCountProto,
 )
 from ray.experimental.internal_kv import internal_kv_get_gcs_client

--- a/python/ray/client_builder.py
+++ b/python/ray/client_builder.py
@@ -15,8 +15,7 @@ from ray._private.ray_constants import (
     RAY_RUNTIME_ENV_ENVIRONMENT_VARIABLE,
 )
 from ray._private.utils import check_ray_client_dependencies_installed, split_address
-from ray._private.worker import BaseContext
-from ray._private.worker import init as ray_driver_init
+from ray._private.worker import BaseContext, init as ray_driver_init
 from ray.job_config import JobConfig
 from ray.util.annotations import Deprecated, PublicAPI
 

--- a/python/ray/dashboard/modules/metrics/dashboards/train_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/train_dashboard_panels.py
@@ -2,8 +2,8 @@
 from ray.dashboard.modules.metrics.dashboards.common import (
     DashboardConfig,
     Panel,
-    Target,
     Row,
+    Target,
 )
 
 

--- a/python/ray/experimental/channel/common.py
+++ b/python/ray/experimental/channel/common.py
@@ -19,8 +19,8 @@ from typing import (
 import ray
 import ray.exceptions
 from ray.experimental.channel.communicator import Communicator
-from ray.experimental.channel.utils import get_devices
 from ray.experimental.channel.serialization_context import _SerializationContext
+from ray.experimental.channel.utils import get_devices
 from ray.util.annotations import DeveloperAPI, PublicAPI
 
 # The context singleton on this process.

--- a/python/ray/experimental/channel/nccl_group.py
+++ b/python/ray/experimental/channel/nccl_group.py
@@ -5,8 +5,8 @@ from typing import TYPE_CHECKING, Callable, List, Optional, Tuple
 import ray
 from ray.exceptions import RayChannelError
 from ray.experimental.channel.communicator import Communicator, TorchTensorAllocator
-from ray.experimental.util.types import ReduceOp
 from ray.experimental.channel.utils import get_devices
+from ray.experimental.util.types import ReduceOp
 
 if TYPE_CHECKING:
     import cupy as cp

--- a/python/ray/experimental/channel/serialization_context.py
+++ b/python/ray/experimental/channel/serialization_context.py
@@ -167,8 +167,8 @@ class _SerializationContext:
         tensor_device_type: str,
         target_device: Device,
     ):
-        import torch
         import numpy as np
+        import torch
 
         if target_device == Device.DEFAULT:
             target_device_type = tensor_device_type

--- a/python/ray/experimental/channel/utils.py
+++ b/python/ray/experimental/channel/utils.py
@@ -1,7 +1,7 @@
+import os
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import ray
-import os
 
 if TYPE_CHECKING:
     import torch

--- a/python/ray/experimental/collective/operations.py
+++ b/python/ray/experimental/collective/operations.py
@@ -10,9 +10,9 @@ from ray.dag.constants import (
 )
 from ray.experimental.channel.torch_tensor_type import Communicator, TorchTensorType
 from ray.experimental.util.types import (
-    ReduceOp,
     AllGatherOp,
     AllReduceOp,
+    ReduceOp,
     ReduceScatterOp,
     _CollectiveOp,
 )

--- a/python/ray/runtime_context.py
+++ b/python/ray/runtime_context.py
@@ -1,6 +1,6 @@
 import logging
-from typing import Any, Dict, List, Optional
 import threading
+from typing import Any, Dict, List, Optional
 
 import ray._private.worker
 from ray._private.client_mode_hook import client_mode_hook

--- a/python/ray/runtime_env/runtime_env.py
+++ b/python/ray/runtime_env/runtime_env.py
@@ -13,8 +13,8 @@ from ray._private.runtime_env.pip import get_uri as get_pip_uri
 from ray._private.runtime_env.plugin_schema_manager import RuntimeEnvPluginSchemaManager
 from ray._private.runtime_env.uv import get_uri as get_uv_uri
 from ray._private.runtime_env.validation import (
-    OPTION_TO_VALIDATION_FN,
     OPTION_TO_NO_PATH_VALIDATION_FN,
+    OPTION_TO_VALIDATION_FN,
 )
 from ray._private.thirdparty.dacite import from_dict
 from ray.core.generated.runtime_env_common_pb2 import (


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This is the final follow-up for https://github.com/ray-project/ray/pull/52712. Re-enable isort for all remaining files because there are only 30+ files left, which I think is reviewable.

Removed the second `ruff` hook in `.pre-commit-config.yaml` and the ignored `I001` rule in `pyproject.toml`.

Note: The "I" rule has been selected in L16 in `pyproject.toml`

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
