### PR TITLE
[core] Skip `test_reference_counting_2.py::test_recursively_pass_returned_object_ref` on Windows

### DIFF
--- a/python/ray/tests/test_reference_counting_2.py
+++ b/python/ray/tests/test_reference_counting_2.py
@@ -211,6 +211,7 @@ def test_pass_returned_object_ref(one_cpu_100MiB_shared, use_ray_put, failure):
 # returned by another task to the end of the chain. The reference should still
 # exist while the final task in the chain is running and should be removed once
 # it finishes.
+@pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
 @pytest.mark.parametrize(
     "use_ray_put,failure", [(False, False), (False, True), (True, False), (True, True)]
 )


### PR DESCRIPTION
Very flaky on Windows. Complicated test case that's going to hard to track down.