### PR TITLE
Fix python executable path for ray nsight configuration

### DIFF
--- a/python/ray/_private/runtime_env/nsight.py
+++ b/python/ray/_private/runtime_env/nsight.py
@@ -71,8 +71,7 @@ class NsightPlugin(RuntimeEnvPlugin):
         nsight_config_copy["o"] = str(Path(self._nsight_dir) / "empty")
         nsight_cmd = parse_nsight_config(nsight_config_copy)
         try:
-            python_executable = sys.executable or "python"
-            nsight_cmd = nsight_cmd + [python_executable, "-c", '""']
+            nsight_cmd = nsight_cmd + [sys.executable, "-c", '""']
             process = await asyncio.create_subprocess_exec(
                 *nsight_cmd,
                 stdout=subprocess.PIPE,

--- a/python/ray/_private/runtime_env/nsight.py
+++ b/python/ray/_private/runtime_env/nsight.py
@@ -71,7 +71,8 @@ class NsightPlugin(RuntimeEnvPlugin):
         nsight_config_copy["o"] = str(Path(self._nsight_dir) / "empty")
         nsight_cmd = parse_nsight_config(nsight_config_copy)
         try:
-            nsight_cmd = nsight_cmd + ["python", "-c", '""']
+            python_executable = sys.executable or "python"
+            nsight_cmd = nsight_cmd + [python_executable, "-c", '""']
             process = await asyncio.create_subprocess_exec(
                 *nsight_cmd,
                 stdout=subprocess.PIPE,


### PR DESCRIPTION
## Why are these changes needed?

Not all systems are guaranteed to have "python" be the way that the python interpreter is invoked on the command line. The proper way to find python is to use `sys.executable`. This hardcoded "python" was breaking workflows within my Ubuntu 22.04 training environment.

## Related issue number

Closes #53597 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(