### PR TITLE
[core] Fix Windows failures for `test_output.py`

### DIFF
--- a/python/ray/tests/test_label_utils.py
+++ b/python/ray/tests/test_label_utils.py
@@ -305,6 +305,4 @@ def test_validate_node_labels():
 
 
 if __name__ == "__main__":
-
-    # Skip test_basic_2_client_mode for now- the test suite is breaking.
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -338,7 +338,9 @@ while True:
 
             # Check that *no* unexpected messages are present.
             if unexpected_msg:
-                assert all([msg not in out_str for msg in unexpected_msg.split(",")]), out_str
+                assert all(
+                    [msg not in out_str for msg in unexpected_msg.split(",")]
+                ), out_str
 
             return True
 

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -334,11 +334,11 @@ while True:
                 out_str += l
 
             # Check that *all* expected messages are present.
-            assert all([msg in out_str for msg in expected_msg.split(",")])
+            assert all([msg in out_str for msg in expected_msg.split(",")]), out_str
 
             # Check that *no* unexpected messages are present.
             if unexpected_msg:
-                assert all([msg not in out_str for msg in unexpected_msg.split(",")])
+                assert all([msg not in out_str for msg in unexpected_msg.split(",")]), out_str
 
             return True
 
@@ -356,15 +356,15 @@ import sys
 import tempfile
 import ray
 
-temporary_python_file = '''
+f = tempfile.NamedTemporaryFile("w+", suffix=".py", prefix="_", delete=False)
+f.write('''
 def temporary_helper_function():
    return 1
-'''
+''')
+f.flush()
+f.close()
 
-with tempfile.NamedTemporaryFile("w+", suffix=".py", prefix="_", delete=True) as f:
-    f.write(temporary_python_file)
-    f.flush()
-
+try:
     # Get the module name and strip ".py" from the end.
     directory = os.path.dirname(f.name)
     module_name = os.path.basename(f.name)[:-3]
@@ -380,6 +380,8 @@ with tempfile.NamedTemporaryFile("w+", suffix=".py", prefix="_", delete=True) as
 
         def ready(self):
             pass
+finally:
+    os.unlink(f.name)
 
 ray.get(Foo.remote().ready.remote())
 """
@@ -397,14 +399,14 @@ import sys
 import tempfile
 import ray
 
-temporary_python_file = '''
-def temporary_helper_function():
-   return 1
-'''
-
-with tempfile.NamedTemporaryFile("w+", suffix=".py", prefix="_", delete=True) as f:
-    f.write(temporary_python_file)
+f = tempfile.NamedTemporaryFile("w+", suffix=".py", prefix="_", delete=False):
+try:
+    f.write('''
+    def temporary_helper_function():
+       return 1
+    ''')
     f.flush()
+    f.close()
 
     # Get the module name and strip ".py" from the end.
     directory = os.path.dirname(f.name)
@@ -417,6 +419,8 @@ with tempfile.NamedTemporaryFile("w+", suffix=".py", prefix="_", delete=True) as
     @ray.remote
     def foo():
         return module.temporary_python_file()
+finally:
+    os.unlink(f.name)
 
 ray.get(foo.remote())
 """

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -401,7 +401,7 @@ import sys
 import tempfile
 import ray
 
-f = tempfile.NamedTemporaryFile("w+", suffix=".py", prefix="_", delete=False):
+f = tempfile.NamedTemporaryFile("w+", suffix=".py", prefix="_", delete=False)
 try:
     f.write('''
     def temporary_helper_function():

--- a/python/ray/tests/test_output.py
+++ b/python/ray/tests/test_output.py
@@ -359,14 +359,14 @@ import tempfile
 import ray
 
 f = tempfile.NamedTemporaryFile("w+", suffix=".py", prefix="_", delete=False)
-f.write('''
+try:
+    f.write('''
 def temporary_helper_function():
    return 1
 ''')
-f.flush()
-f.close()
+    f.flush()
+    f.close()
 
-try:
     # Get the module name and strip ".py" from the end.
     directory = os.path.dirname(f.name)
     module_name = os.path.basename(f.name)[:-3]
@@ -404,9 +404,9 @@ import ray
 f = tempfile.NamedTemporaryFile("w+", suffix=".py", prefix="_", delete=False)
 try:
     f.write('''
-    def temporary_helper_function():
-       return 1
-    ''')
+def temporary_helper_function():
+   return 1
+''')
     f.flush()
     f.close()
 


### PR DESCRIPTION
- Permissions error due to temp file being held open.
- Not sure what the failure is for the autoscaler event test, so fixed the assertion to log the output string.