### PR TITLE
[core] Speed up `test_placement_group_5.py`

### DIFF
--- a/python/ray/tests/test_placement_group_5.py
+++ b/python/ray/tests/test_placement_group_5.py
@@ -446,7 +446,7 @@ def test_placement_group_parallel_submission(ray_start_cluster):
         print("Testing strategy:", strategy)
         assert (
             ray.get([s.submit.remote(strategy) for s in submitters], timeout=30)
-            == ["OK"] * NUM_PARALLEL_PGS
+            == ["ok"] * NUM_PARALLEL_PGS
         )
 
 

--- a/python/ray/tests/test_placement_group_5.py
+++ b/python/ray/tests/test_placement_group_5.py
@@ -410,8 +410,9 @@ def test_placement_group_max_cpu_frac_edge_cases(ray_start_cluster):
 
 
 def test_placement_group_parallel_submission(ray_start_cluster):
+    NUM_PARALLEL_PGS = 5
     cluster = ray_start_cluster
-    cluster.add_node(num_cpus=1, resources={"custom_resource": 5})
+    cluster.add_node(num_cpus=1, resources={"custom_resource": NUM_PARALLEL_PGS})
     cluster.wait_for_nodes()
     ray.init(address=cluster.address)
 
@@ -440,7 +441,6 @@ def test_placement_group_parallel_submission(ray_start_cluster):
 
     # For each strategy, submit multiple placement groups in parallel and check that they
     # will all eventually be placed and their tasks executed.
-    NUM_PARALLEL_PGS = 5
     submitters = [Submitter.remote() for _ in range(NUM_PARALLEL_PGS)]
     for strategy in ["SPREAD", "STRICT_SPREAD", "PACK", "STRICT_PACK"]:
         print("Testing strategy:", strategy)

--- a/python/ray/tests/test_placement_group_5.py
+++ b/python/ray/tests/test_placement_group_5.py
@@ -1,5 +1,4 @@
 import asyncio
-from concurrent.futures import ThreadPoolExecutor
 import sys
 import time
 from functools import reduce

--- a/python/ray/tests/test_placement_group_5.py
+++ b/python/ray/tests/test_placement_group_5.py
@@ -427,10 +427,14 @@ def test_placement_group_parallel_submission(ray_start_cluster):
             )
             try:
                 ray.get(pg.ready())
-                pg_strategy = ray.util.scheduling_strategies.PlacementGroupSchedulingStrategy(
-                    placement_group=pg
+                pg_strategy = (
+                    ray.util.scheduling_strategies.PlacementGroupSchedulingStrategy(
+                        placement_group=pg
+                    )
                 )
-                return ray.get(task.options(scheduling_strategy=pg_strategy).remote(input))
+                return ray.get(
+                    task.options(scheduling_strategy=pg_strategy).remote(input)
+                )
             finally:
                 ray.util.remove_placement_group(pg)
 
@@ -439,7 +443,10 @@ def test_placement_group_parallel_submission(ray_start_cluster):
     submitters = [Submitter.remote() for _ in range(5)]
     for strategy in ["SPREAD", "STRICT_SPREAD", "PACK", "STRICT_PACK"]:
         print("Testing strategy:", strategy)
-        assert ray.get([s.submit.remote(strategy) for s in submitters], timeout=30) == ["OK"] * 5
+        assert (
+            ray.get([s.submit.remote(strategy) for s in submitters], timeout=30)
+            == ["OK"] * 5
+        )
 
 
 MyPlugin = "MyPlugin"

--- a/python/ray/tests/test_placement_group_5.py
+++ b/python/ray/tests/test_placement_group_5.py
@@ -438,14 +438,15 @@ def test_placement_group_parallel_submission(ray_start_cluster):
             finally:
                 ray.util.remove_placement_group(pg)
 
-    # For each strategy, submit 5 placement groups in parallel and check that they will
-    # all eventually be placed and their tasks executed.
-    submitters = [Submitter.remote() for _ in range(5)]
+    # For each strategy, submit multiple placement groups in parallel and check that they
+    # will all eventually be placed and their tasks executed.
+    NUM_PARALLEL_PGS = 5
+    submitters = [Submitter.remote() for _ in range(NUM_PARALLEL_PGS)]
     for strategy in ["SPREAD", "STRICT_SPREAD", "PACK", "STRICT_PACK"]:
         print("Testing strategy:", strategy)
         assert (
             ray.get([s.submit.remote(strategy) for s in submitters], timeout=30)
-            == ["OK"] * 5
+            == ["OK"] * NUM_PARALLEL_PGS
         )
 
 


### PR DESCRIPTION
Reduce the number of parallel task submissions (very stressful for CI) and remove parametrization to share the same Ray cluster.