### PR TITLE
[core] Support broadcast and reduce collective for compiled graphs

### DIFF
--- a/python/ray/dag/collective_node.py
+++ b/python/ray/dag/collective_node.py
@@ -17,7 +17,6 @@ from ray.experimental.util.types import (
     AllReduceOp,
     ReduceScatterOp,
     BroadcastOp,
-    ReduceOp,
     ReduceOperation,
 )
 from ray.util.annotations import DeveloperAPI

--- a/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
@@ -2058,7 +2058,7 @@ def test_torch_tensor_nccl_broadcast_wrong_root_node(ray_start_regular):
                 for i, worker in enumerate(workers)
             ]
 
-            collectives = collective.broadcast.bind(root_compute, computes)
+            collective.broadcast.bind(root_compute, computes)
 
 
 @pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 4}], indirect=True)
@@ -2070,7 +2070,7 @@ def test_torch_tensor_nccl_broadcast_no_root_node(ray_start_regular):
 
     with pytest.raises(
         TypeError,
-        match="BroadcastWrapper.bind\\(\\) missing 1 required positional argument",
+        match="missing 1 required positional argument",
     ):
         with InputNode() as inp:
             computes = [
@@ -2078,7 +2078,7 @@ def test_torch_tensor_nccl_broadcast_no_root_node(ray_start_regular):
                 for i, worker in enumerate(workers)
             ]
 
-            collectives = collective.broadcast.bind(computes)
+            collective.broadcast.bind(computes)
 
 
 if __name__ == "__main__":

--- a/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
@@ -2075,7 +2075,9 @@ def test_collective_operation_validation(ray_start_regular):
 
     with pytest.raises(
         TypeError,
-        match=re.escape("BroadcastWrapper.bind() missing 1 required keyword-only argument: 'dst'"),
+        match=re.escape(
+            "BroadcastWrapper.bind() missing 1 required keyword-only argument: 'dst'"
+        ),
     ):
         with InputNode() as inp:
             compute = workers[0].send_tensor.bind(inp)
@@ -2099,7 +2101,9 @@ def test_collective_operation_validation(ray_start_regular):
 
     with pytest.raises(
         TypeError,
-        match=re.escape("ReduceWrapper.bind() missing 1 required keyword-only argument: 'dst'"),
+        match=re.escape(
+            "ReduceWrapper.bind() missing 1 required keyword-only argument: 'dst'"
+        ),
     ):
         with InputNode() as inp:
             computes = [

--- a/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
@@ -550,6 +550,15 @@ def test_torch_tensor_custom_comm(ray_start_regular):
             self._inner.reducescatter(send_buf, recv_buf, op)
             recv_buf += 1
 
+        def broadcast(
+            self,
+            send_buf: "torch.Tensor",
+            recv_buf: "torch.Tensor",
+            root_rank: int,
+        ) -> None:
+            self._inner.broadcast(send_buf, recv_buf, root_rank)
+            recv_buf += 1
+
         @property
         def recv_stream(self):
             return self._inner.recv_stream
@@ -687,6 +696,14 @@ def test_torch_tensor_custom_comm_inited(ray_start_regular):
             send_buf: "torch.Tensor",
             recv_buf: "torch.Tensor",
             op: ReduceOp = ReduceOp.SUM,
+        ) -> None:
+            raise NotImplementedError
+
+        def broadcast(
+            self,
+            send_buf: "torch.Tensor",
+            recv_buf: "torch.Tensor",
+            root_rank: int,
         ) -> None:
             raise NotImplementedError
 
@@ -831,6 +848,14 @@ def test_torch_tensor_default_comm(ray_start_regular, transports):
             send_buf: "torch.Tensor",
             recv_buf: "torch.Tensor",
             op: ReduceOp = ReduceOp.SUM,
+        ) -> None:
+            raise NotImplementedError
+
+        def broadcast(
+            self,
+            send_buf: "torch.Tensor",
+            recv_buf: "torch.Tensor",
+            root_rank: int,
         ) -> None:
             raise NotImplementedError
 
@@ -988,6 +1013,14 @@ def test_torch_tensor_invalid_custom_comm(ray_start_regular):
             send_buf: "torch.Tensor",
             recv_buf: "torch.Tensor",
             op: ReduceOp = ReduceOp.SUM,
+        ) -> None:
+            raise NotImplementedError
+
+        def broadcast(
+            self,
+            send_buf: "torch.Tensor",
+            recv_buf: "torch.Tensor",
+            root_rank: int,
         ) -> None:
             raise NotImplementedError
 
@@ -1351,6 +1384,7 @@ def test_torch_tensor_explicit_communicator(ray_start_regular):
         (collective.reducescatter, ReduceOp.PRODUCT),
         (collective.reducescatter, ReduceOp.MIN),
         (collective.reducescatter, ReduceOp.MAX),
+        (collective.broadcast, None),
     ],
 )
 def test_torch_tensor_nccl_collective_ops(ray_start_regular, operation, reduce_op):
@@ -1371,6 +1405,8 @@ def test_torch_tensor_nccl_collective_ops(ray_start_regular, operation, reduce_o
         ]
         if operation == collective.allgather:
             collectives = operation.bind(computes)
+        elif operation == collective.broadcast:
+            collectives = operation.bind(computes[0], computes)
         else:
             collectives = operation.bind(computes, op=reduce_op)
         recvs = [
@@ -1443,6 +1479,8 @@ def test_torch_tensor_nccl_collective_ops(ray_start_regular, operation, reduce_o
                 )
             else:
                 raise ValueError(f"Unknown reduce_op: {reduce_op}")
+        elif operation == collective.broadcast:
+            expected_tensors = [input_tensors[0] for _ in range(num_workers)]
         else:
             raise ValueError(f"Unknown operation: {operation}")
 
@@ -1536,6 +1574,52 @@ def test_torch_tensor_nccl_all_reduce_get_partial(ray_start_regular):
         assert metadata == (reduced_val, shape, dtype)
         tensor = tensor.to("cpu")
         expected_tensor_val = torch.ones(shape, dtype=dtype) * reduced_val
+        assert torch.equal(tensor, expected_tensor_val)
+
+
+@pytest.mark.skipif(not USE_GPU, reason="Skipping GPU Test")
+@pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
+def test_torch_tensor_nccl_broadcast_get_partial(ray_start_regular):
+    """
+    Test getting partial results from a broadcast does not hang.
+    """
+    assert (
+        sum(node["Resources"].get("GPU", 0) for node in ray.nodes()) > 1
+    ), "This test requires at least 2 GPUs"
+
+    actor_cls = TorchTensorWorker.options(num_cpus=0, num_gpus=1)
+
+    num_workers = 2
+    workers = [actor_cls.remote() for _ in range(num_workers)]
+
+    shape = (10,)
+    dtype = torch.float16
+
+    with InputNode() as inp:
+        computes = [
+            worker.compute_with_tuple_args.bind(inp, i)
+            for i, worker in enumerate(workers)
+        ]
+
+        collectives = collective.broadcast.bind(computes[0], computes)
+        recv_root = workers[0].recv.bind(collectives[0])
+        recv = workers[1].recv.bind(collectives[1])
+        tensor = workers[1].recv_tensor.bind(collectives[1])
+        dag = MultiOutputNode([recv_root, recv, tensor])
+
+    compiled_dag = dag.experimental_compile()
+
+    for i in range(3):
+        ref = compiled_dag.execute(
+            [(shape, dtype, i + idx + 1) for idx in range(num_workers)]
+        )
+        result = ray.get(ref)
+        _, metadata, tensor = result
+
+        root_val = i + 1
+        assert metadata == (root_val, shape, dtype)
+        tensor = tensor.to("cpu")
+        expected_tensor_val = torch.ones(shape, dtype=dtype) * root_val
         assert torch.equal(tensor, expected_tensor_val)
 
 
@@ -1683,6 +1767,15 @@ def test_torch_tensor_nccl_all_reduce_custom_comm(ray_start_regular):
             op: ReduceOp = ReduceOp.SUM,
         ) -> None:
             self._inner.reducescatter(send_buf, recv_buf, op)
+            recv_buf += 1
+
+        def broadcast(
+            self,
+            send_buf: "torch.Tensor",
+            recv_buf: "torch.Tensor",
+            root_rank: int,
+        ) -> None:
+            self._inner.broadcast(send_buf, recv_buf, root_rank)
             recv_buf += 1
 
         @property
@@ -1944,6 +2037,48 @@ def test_torch_nccl_channel_with_all_local_readers(ray_start_regular):
         ),
     ):
         dag.experimental_compile()
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 4}], indirect=True)
+def test_torch_tensor_nccl_broadcast_wrong_root_node(ray_start_regular):
+    actor_cls = TorchTensorWorker.options(num_cpus=0, num_gpus=1)
+
+    num_workers = 2
+    root_worker = actor_cls.remote()
+    workers = [actor_cls.remote() for _ in range(num_workers)]
+
+    with pytest.raises(
+        ValueError,
+        match="Expected the root node to be an input node",
+    ):
+        with InputNode() as inp:
+            root_compute = root_worker.compute_with_tuple_args.bind(inp, 0)
+            computes = [
+                worker.compute_with_tuple_args.bind(inp, i)
+                for i, worker in enumerate(workers)
+            ]
+
+            collectives = collective.broadcast.bind(root_compute, computes)
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 4}], indirect=True)
+def test_torch_tensor_nccl_broadcast_no_root_node(ray_start_regular):
+    actor_cls = TorchTensorWorker.options(num_cpus=0, num_gpus=1)
+
+    num_workers = 2
+    workers = [actor_cls.remote() for _ in range(num_workers)]
+
+    with pytest.raises(
+        TypeError,
+        match="BroadcastWrapper.bind\\(\\) missing 1 required positional argument",
+    ):
+        with InputNode() as inp:
+            computes = [
+                worker.compute_with_tuple_args.bind(inp, i)
+                for i, worker in enumerate(workers)
+            ]
+
+            collectives = collective.broadcast.bind(computes)
 
 
 if __name__ == "__main__":

--- a/python/ray/experimental/channel/communicator.py
+++ b/python/ray/experimental/channel/communicator.py
@@ -174,6 +174,15 @@ class Communicator(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def broadcast(
+        self,
+        send_buf: "torch.Tensor",
+        recv_buf: "torch.Tensor",
+        root: int,
+    ) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
     def destroy(self) -> None:
         """
         Destroy the GPU communicator.

--- a/python/ray/experimental/channel/communicator.py
+++ b/python/ray/experimental/channel/communicator.py
@@ -183,6 +183,16 @@ class Communicator(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def reduce(
+        self,
+        send_buf: "torch.Tensor",
+        recv_buf: "torch.Tensor",
+        root: int,
+        op: ReduceOp,
+    ) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
     def destroy(self) -> None:
         """
         Destroy the GPU communicator.

--- a/python/ray/experimental/channel/communicator.py
+++ b/python/ray/experimental/channel/communicator.py
@@ -178,7 +178,7 @@ class Communicator(ABC):
         self,
         send_buf: "torch.Tensor",
         recv_buf: "torch.Tensor",
-        root: int,
+        src_rank: int,
     ) -> None:
         raise NotImplementedError
 
@@ -187,7 +187,7 @@ class Communicator(ABC):
         self,
         send_buf: "torch.Tensor",
         recv_buf: "torch.Tensor",
-        root: int,
+        dst_rank: int,
         op: ReduceOp,
     ) -> None:
         raise NotImplementedError

--- a/python/ray/experimental/channel/cpu_communicator.py
+++ b/python/ray/experimental/channel/cpu_communicator.py
@@ -158,6 +158,14 @@ class CPUCommunicator(Communicator):
     ):
         raise NotImplementedError
 
+    def broadcast(
+        self,
+        send_buf: "torch.Tensor",
+        recv_buf: "torch.Tensor",
+        root: int,
+    ):
+        raise NotImplementedError
+
     def destroy(self) -> None:
         for barrier in self.barriers:
             ray.kill(barrier)

--- a/python/ray/experimental/channel/cpu_communicator.py
+++ b/python/ray/experimental/channel/cpu_communicator.py
@@ -162,7 +162,7 @@ class CPUCommunicator(Communicator):
         self,
         send_buf: "torch.Tensor",
         recv_buf: "torch.Tensor",
-        root: int,
+        src_rank: int,
     ):
         raise NotImplementedError
 
@@ -170,7 +170,7 @@ class CPUCommunicator(Communicator):
         self,
         send_buf: "torch.Tensor",
         recv_buf: "torch.Tensor",
-        root: int,
+        dst_rank: int,
         op: ReduceOp = ReduceOp.SUM,
     ):
         raise NotImplementedError

--- a/python/ray/experimental/channel/cpu_communicator.py
+++ b/python/ray/experimental/channel/cpu_communicator.py
@@ -166,6 +166,15 @@ class CPUCommunicator(Communicator):
     ):
         raise NotImplementedError
 
+    def reduce(
+        self,
+        send_buf: "torch.Tensor",
+        recv_buf: "torch.Tensor",
+        root: int,
+        op: ReduceOp = ReduceOp.SUM,
+    ):
+        raise NotImplementedError
+
     def destroy(self) -> None:
         for barrier in self.barriers:
             ray.kill(barrier)

--- a/python/ray/experimental/channel/nccl_group.py
+++ b/python/ray/experimental/channel/nccl_group.py
@@ -332,6 +332,27 @@ class _NcclGroup(Communicator):
             *operation_args,
         )
 
+    def broadcast(
+        self,
+        send_buf: "torch.Tensor",
+        recv_buf: "torch.Tensor",
+        root: int,
+    ):
+        operation_args = [
+            self.nccl_util.get_tensor_ptr(send_buf),
+            self.nccl_util.get_tensor_ptr(recv_buf),
+            send_buf.numel(),
+            self.nccl_util.get_nccl_tensor_dtype(send_buf),
+            root,
+            self._cuda_stream.ptr,
+        ]
+        self._exec_collective(
+            send_buf,
+            recv_buf,
+            self._comm.broadcast,
+            *operation_args,
+        )
+
     @property
     def recv_stream(self):
         import torch

--- a/python/ray/experimental/channel/nccl_group.py
+++ b/python/ray/experimental/channel/nccl_group.py
@@ -336,14 +336,14 @@ class _NcclGroup(Communicator):
         self,
         send_buf: "torch.Tensor",
         recv_buf: "torch.Tensor",
-        root: int,
+        src_rank: int,
     ):
         operation_args = [
             self.nccl_util.get_tensor_ptr(send_buf),
             self.nccl_util.get_tensor_ptr(recv_buf),
             send_buf.numel(),
             self.nccl_util.get_nccl_tensor_dtype(send_buf),
-            root,
+            src_rank,
             self._cuda_stream.cuda_stream,
         ]
         self._exec_collective(
@@ -357,7 +357,7 @@ class _NcclGroup(Communicator):
         self,
         send_buf: "torch.Tensor",
         recv_buf: "torch.Tensor",
-        root: int,
+        dst_rank: int,
         op: ReduceOp = ReduceOp.SUM,
     ):
         operation_args = [
@@ -366,7 +366,7 @@ class _NcclGroup(Communicator):
             send_buf.numel(),
             self.nccl_util.get_nccl_tensor_dtype(send_buf),
             op.value,
-            root,
+            dst_rank,
             self._cuda_stream.cuda_stream,
         ]
         self._exec_collective(

--- a/python/ray/experimental/channel/nccl_group.py
+++ b/python/ray/experimental/channel/nccl_group.py
@@ -344,7 +344,7 @@ class _NcclGroup(Communicator):
             send_buf.numel(),
             self.nccl_util.get_nccl_tensor_dtype(send_buf),
             root,
-            self._cuda_stream.ptr,
+            self._cuda_stream.cuda_stream,
         ]
         self._exec_collective(
             send_buf,

--- a/python/ray/experimental/channel/nccl_group.py
+++ b/python/ray/experimental/channel/nccl_group.py
@@ -353,6 +353,29 @@ class _NcclGroup(Communicator):
             *operation_args,
         )
 
+    def reduce(
+        self,
+        send_buf: "torch.Tensor",
+        recv_buf: "torch.Tensor",
+        root: int,
+        op: ReduceOp = ReduceOp.SUM,
+    ):
+        operation_args = [
+            self.nccl_util.get_tensor_ptr(send_buf),
+            self.nccl_util.get_tensor_ptr(recv_buf),
+            send_buf.numel(),
+            self.nccl_util.get_nccl_tensor_dtype(send_buf),
+            op.value,
+            root,
+            self._cuda_stream.cuda_stream,
+        ]
+        self._exec_collective(
+            send_buf,
+            recv_buf,
+            self._comm.reduce,
+            *operation_args,
+        )
+
     @property
     def recv_stream(self):
         import torch

--- a/python/ray/experimental/collective/__init__.py
+++ b/python/ray/experimental/collective/__init__.py
@@ -2,6 +2,7 @@ from ray.experimental.collective.operations import (
     allgather,
     allreduce,
     reducescatter,
+    broadcast,
 )
 from ray.experimental.collective.collective import (
     get_collective_groups,
@@ -14,6 +15,7 @@ __all__ = [
     "allgather",
     "allreduce",
     "reducescatter",
+    "broadcast",
     "get_collective_groups",
     "create_collective_group",
     "destroy_collective_group",

--- a/python/ray/experimental/collective/__init__.py
+++ b/python/ray/experimental/collective/__init__.py
@@ -3,6 +3,7 @@ from ray.experimental.collective.operations import (
     allreduce,
     reducescatter,
     broadcast,
+    reduce,
 )
 from ray.experimental.collective.collective import (
     get_collective_groups,
@@ -16,6 +17,7 @@ __all__ = [
     "allreduce",
     "reducescatter",
     "broadcast",
+    "reduce",
     "get_collective_groups",
     "create_collective_group",
     "destroy_collective_group",

--- a/python/ray/experimental/collective/conftest.py
+++ b/python/ray/experimental/collective/conftest.py
@@ -71,6 +71,14 @@ class AbstractNcclGroup(Communicator):
     ) -> None:
         raise NotImplementedError
 
+    def broadcast(
+        self,
+        send_buf: "torch.Tensor",
+        recv_buf: "torch.Tensor",
+        root: int,
+    ) -> None:
+        raise NotImplementedError
+
     @property
     def recv_stream(self):
         return None

--- a/python/ray/experimental/collective/conftest.py
+++ b/python/ray/experimental/collective/conftest.py
@@ -79,6 +79,15 @@ class AbstractNcclGroup(Communicator):
     ) -> None:
         raise NotImplementedError
 
+    def reduce(
+        self,
+        send_buf: "torch.Tensor",
+        recv_buf: "torch.Tensor",
+        root: int,
+        op: ReduceOp = ReduceOp.SUM,
+    ) -> None:
+        raise NotImplementedError
+
     @property
     def recv_stream(self):
         return None

--- a/python/ray/experimental/util/types.py
+++ b/python/ray/experimental/util/types.py
@@ -35,6 +35,12 @@ class ReduceScatterOp(_CollectiveOp):
     reduceOp: ReduceOp = ReduceOp.SUM
 
 
+@PublicAPI
+@dataclass
+class BroadcastOp(_CollectiveOp):
+    pass
+
+
 @PublicAPI(stability="alpha")
 class Device(Enum):
     DEFAULT = "default"

--- a/python/ray/experimental/util/types.py
+++ b/python/ray/experimental/util/types.py
@@ -41,6 +41,12 @@ class BroadcastOp(_CollectiveOp):
     pass
 
 
+@PublicAPI
+@dataclass
+class ReduceOperation(_CollectiveOp):
+    reduceOp: ReduceOp = ReduceOp.SUM
+
+
 @PublicAPI(stability="alpha")
 class Device(Enum):
     DEFAULT = "default"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`allreduce`, `reducescatter`, `allgather` collectives are supported in compiled graphs. As part of the effort (#47983) of supporting collective operations in compiled graphs, we aim to also support broadcast and reduce.

Sample usage:
```
# Broadcast (providing root node to broadcast tensors from)
collectives = collective.broadcast.bind(workers[0].send_tensor.bind(inp), dst=workers)

# Reduce (providing root node to reduce tensors to and the reduction operation)
computes = [
    worker.send_tensor.bind(tensor) for worker, tensor in zip(workers, inp)
]
collectives = collective.reduce.bind(computes, dst=workers[0], op=reduce_op)

recvs = [
    worker.recv_tensor.bind(collective)
    for worker, collective in zip(workers, collectives)
]
dag = MultiOutputNode(recvs)
```

## Related issue number

<!-- For example: "Closes #1234" -->
Resolves #49325 and #49324 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
