### PR TITLE
[train] add trace to WorkerHealthCheckFailedError

### DIFF
--- a/python/ray/train/v2/_internal/exceptions.py
+++ b/python/ray/train/v2/_internal/exceptions.py
@@ -41,6 +41,9 @@ class WorkerHealthCheckFailedError(RayTrainError):
     def __reduce__(self):
         return (self.__class__, (self._message, self.health_check_failure))
 
+    def __str__(self):
+        return self._message + "\n" + str(self.health_check_failure)
+
 
 class WorkerGroupStartupTimeoutError(RayTrainError):
     """Exception raised when the worker group startup times out.


### PR DESCRIPTION
Improve the string representation of `WorkerHealthCheckFailedError` to also include the base reason why the health check failed.

**Repro**
```python
import torch
import ray.train
from ray.train.torch import TorchTrainer

def train_func():
    x = torch.tensor([1.0], device=torch.device("cuda"))
    ray.train.report({"x": x})

trainer = TorchTrainer(train_func, scaling_config=ray.train.ScalingConfig(use_gpu=True))
trainer.fit()
```

**Before**
```
Terminating training worker group after encountering failure(s) on 1 worker(s):
[Rank 0]
A worker health check failed.
Worker info: Worker(
  actor=Actor(RayTrainWorker, d60c89b07cc4662cf2e3bdde07000000),
  metadata=ActorMetadata(
    hostname='ip-10-0-97-173',
    node_id='c3caabc03a219ac24d7db2c91ea0c9f62f02d5ac56c301bacceb1291',
    node_ip='10.0.97.173',
    pid=21785,
    accelerator_ids={'GPU': ['0']},
  ),
  distributed_context=DistributedContext(world_rank=0, world_size=1, local_rank=0, local_world_size=1, node_rank=0),
  log_file_path='/tmp/ray/session_2025-06-06_12-48-00_927737_2713/logs/train/ray-train-app-worker-7babcde8cfa5b228be37776e8812a75f993d156f235d070633f1afa2.log',
)
```

**After**
```
Terminating training worker group after encountering failure(s) on 1 worker(s):
[Rank 0]
A worker health check failed.
Worker info: Worker(
  actor=Actor(RayTrainWorker, d60c89b07cc4662cf2e3bdde07000000),
  metadata=ActorMetadata(
    hostname='ip-10-0-97-173',
    node_id='c3caabc03a219ac24d7db2c91ea0c9f62f02d5ac56c301bacceb1291',
    node_ip='10.0.97.173',
    pid=21785,
    accelerator_ids={'GPU': ['0']},
  ),
  distributed_context=DistributedContext(world_rank=0, world_size=1, local_rank=0, local_world_size=1, node_rank=0),
  log_file_path='/tmp/ray/session_2025-06-06_12-48-00_927737_2713/logs/train/ray-train-app-worker-7babcde8cfa5b228be37776e8812a75f993d156f235d070633f1afa2.log',
)
System error: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.
traceback: Traceback (most recent call last):
  File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/serialization.py", line 460, in deserialize_objects
    obj = self._deserialize_object(data, metadata, object_ref)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/serialization.py", line 317, in _deserialize_object
    return self._deserialize_msgpack_data(data, metadata_fields)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/serialization.py", line 272, in _deserialize_msgpack_data
    python_objects = self._deserialize_pickle5_data(pickle5_data)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/serialization.py", line 262, in _deserialize_pickle5_data
    obj = pickle.loads(in_band)
          ^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/torch/storage.py", line 381, in _load_from_bytes
    return torch.load(io.BytesIO(b))
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/torch/serialization.py", line 1040, in load
    return _legacy_load(opened_file, map_location, pickle_module, **pickle_load_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/torch/serialization.py", line 1272, in _legacy_load
    result = unpickler.load()
             ^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/torch/serialization.py", line 1205, in persistent_load
    obj = restore_location(obj, location)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/torch/serialization.py", line 390, in default_restore_location
    result = fn(storage, location)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/torch/serialization.py", line 265, in _cuda_deserialize
    device = validate_cuda_device(location)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/torch/serialization.py", line 249, in validate_cuda_device
    raise RuntimeError('Attempting to deserialize object on a CUDA '
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.
```
