### PR TITLE
[core]: Use a temporary file to share default worker path in runtime env

### DIFF
--- a/python/ray/_private/runtime_env/image_uri.py
+++ b/python/ray/_private/runtime_env/image_uri.py
@@ -39,7 +39,7 @@ async def _create_impl(image_uri: str, logger: logging.Logger):
                 f"Podman command failed: cmd={cmd}, stdout={stdout.decode()}, stderr={stderr.decode()}"
             )
             raise RuntimeError(
-                f"Podman command failed with return code {process.returncode}"
+                f"Podman command failed: cmd={cmd}, returncode={process.returncode}"
             )
 
         if not os.path.exists(result_file):

--- a/python/ray/_private/runtime_env/image_uri.py
+++ b/python/ray/_private/runtime_env/image_uri.py
@@ -36,7 +36,7 @@ async def _create_impl(image_uri: str, logger: logging.Logger):
 
         if process.returncode != 0:
             logger.error(
-                f"Podman failed: stdout={stdout.decode()}, stderr={stderr.decode()}"
+                f"Podman command failed: cmd={cmd}, stdout={stdout.decode()}, stderr={stderr.decode()}"
             )
             raise RuntimeError(
                 f"Podman command failed with return code {process.returncode}"

--- a/python/ray/_private/runtime_env/image_uri.py
+++ b/python/ray/_private/runtime_env/image_uri.py
@@ -11,6 +11,8 @@ default_logger = logging.getLogger(__name__)
 
 
 async def _create_impl(image_uri: str, logger: logging.Logger):
+    # Pull image if it doesn't exist
+    # Also get path to `default_worker.py` inside the image.
     with tempfile.TemporaryDirectory() as tmpdir:
         result_file = os.path.join(tmpdir, "worker_path.txt")
 
@@ -43,14 +45,17 @@ async def _create_impl(image_uri: str, logger: logging.Logger):
             )
 
         if not os.path.exists(result_file):
-            raise FileNotFoundError("Worker path file not created when getting worker path for image {image_uri}")
+            raise FileNotFoundError(
+                "Worker path file not created when getting worker path for image {image_uri}"
+            )
 
         with open(result_file, "r") as f:
             worker_path = f.read().strip()
 
         if not worker_path.endswith(".py"):
-            logger.error(f"Invalid worker path: {worker_path}")
-            raise ValueError("Invalid worker path inferred in image {image_uri}: {worker_path}")
+            raise ValueError(
+                "Invalid worker path inferred in image {image_uri}: {worker_path}"
+            )
 
         logger.info(f"Inferred worker path in image {image_uri}: {worker_path}")
         return worker_path

--- a/python/ray/_private/runtime_env/image_uri.py
+++ b/python/ray/_private/runtime_env/image_uri.py
@@ -32,10 +32,10 @@ async def _create_impl(image_uri: str, logger: logging.Logger):
             *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
         )
 
-        _, stderr = await process.communicate()
+        stdout, stderr = await process.communicate()
 
         if process.returncode != 0:
-            logger.error(f"Podman failed: {stderr.decode()}")
+            logger.error(f"Podman failed: stdout={stdout.decode()}, stderr={stderr.decode()}")
             raise RuntimeError(
                 f"Podman command failed with return code {process.returncode}"
             )

--- a/python/ray/_private/runtime_env/image_uri.py
+++ b/python/ray/_private/runtime_env/image_uri.py
@@ -52,7 +52,7 @@ async def _create_impl(image_uri: str, logger: logging.Logger):
             logger.error(f"Invalid worker path: {worker_path}")
             raise ValueError("Invalid worker path inferred in image {image_uri}: {worker_path}")
 
-        logger.info(f"Extracted worker path: {worker_path}")
+        logger.info(f"Inferred worker path in image {image_uri}: {worker_path}")
         return worker_path
 
 

--- a/python/ray/_private/runtime_env/image_uri.py
+++ b/python/ray/_private/runtime_env/image_uri.py
@@ -43,7 +43,7 @@ async def _create_impl(image_uri: str, logger: logging.Logger):
             )
 
         if not os.path.exists(result_file):
-            raise FileNotFoundError("Worker path file not created")
+            raise FileNotFoundError("Worker path file not created when getting worker path for image {image_uri}")
 
         with open(result_file, "r") as f:
             worker_path = f.read().strip()

--- a/python/ray/_private/runtime_env/image_uri.py
+++ b/python/ray/_private/runtime_env/image_uri.py
@@ -35,7 +35,9 @@ async def _create_impl(image_uri: str, logger: logging.Logger):
         stdout, stderr = await process.communicate()
 
         if process.returncode != 0:
-            logger.error(f"Podman failed: stdout={stdout.decode()}, stderr={stderr.decode()}")
+            logger.error(
+                f"Podman failed: stdout={stdout.decode()}, stderr={stderr.decode()}"
+            )
             raise RuntimeError(
                 f"Podman command failed with return code {process.returncode}"
             )

--- a/python/ray/_private/runtime_env/image_uri.py
+++ b/python/ray/_private/runtime_env/image_uri.py
@@ -26,8 +26,18 @@ async def _create_impl(image_uri: str, logger: logging.Logger):
         ),
     ]
     logger.info("Pulling image %s", image_uri)
-    worker_path = await check_output_cmd(pull_image_cmd, logger=logger)
-    return worker_path.strip()
+    output = await check_output_cmd(pull_image_cmd, logger=logger)
+
+    lines = output.strip().split("\n")
+    worker_path = lines[-1].strip()
+
+    if not worker_path.endswith(".py"):
+        logger.error(f"Invalid worker path extracted: {worker_path}")
+        logger.error(f"Full output was: {output}")
+        raise ValueError("Failed to extract valid worker path from podman output")
+
+    logger.info(f"Extracted worker path: {worker_path}")
+    return worker_path
 
 
 def _modify_context_impl(

--- a/python/ray/_private/runtime_env/image_uri.py
+++ b/python/ray/_private/runtime_env/image_uri.py
@@ -50,7 +50,7 @@ async def _create_impl(image_uri: str, logger: logging.Logger):
 
         if not worker_path.endswith(".py"):
             logger.error(f"Invalid worker path: {worker_path}")
-            raise ValueError("Invalid worker path extracted")
+            raise ValueError("Invalid worker path inferred in image {image_uri}: {worker_path}")
 
         logger.info(f"Extracted worker path: {worker_path}")
         return worker_path

--- a/python/ray/_private/runtime_env/image_uri.py
+++ b/python/ray/_private/runtime_env/image_uri.py
@@ -14,6 +14,7 @@ async def _create_impl(image_uri: str, logger: logging.Logger):
     # Pull image if it doesn't exist
     # Also get path to `default_worker.py` inside the image.
     with tempfile.TemporaryDirectory() as tmpdir:
+        os.chmod(tmpdir, 0o777)
         result_file = os.path.join(tmpdir, "worker_path.txt")
         get_worker_path_script = """
 import ray._private.workers.default_worker as dw
@@ -41,11 +42,8 @@ with open('/shared/worker_path.txt', 'w') as f:
         stdout, stderr = await process.communicate()
 
         if process.returncode != 0:
-            logger.error(
-                f"Podman command failed: cmd={cmd}, stdout={stdout.decode()}, stderr={stderr.decode()}"
-            )
             raise RuntimeError(
-                f"Podman command failed: cmd={cmd}, returncode={process.returncode}"
+                f"Podman command failed: cmd={cmd}, returncode={process.returncode}, stdout={stdout.decode()}, stderr={stderr.decode()}"
             )
 
         if not os.path.exists(result_file):

--- a/python/ray/_private/runtime_env/image_uri.py
+++ b/python/ray/_private/runtime_env/image_uri.py
@@ -32,8 +32,9 @@ async def _create_impl(image_uri: str, logger: logging.Logger):
     worker_path = lines[-1].strip()
 
     if not worker_path.endswith(".py"):
-        logger.error(f"Invalid worker path extracted: {worker_path}")
-        logger.error(f"Full output was: {output}")
+        logger.error(
+            f"Invalid worker path extracted: {worker_path} from output: {output}"
+        )
         raise ValueError("Failed to extract valid worker path from podman output")
 
     logger.info(f"Extracted worker path: {worker_path}")

--- a/python/ray/_private/runtime_env/image_uri.py
+++ b/python/ray/_private/runtime_env/image_uri.py
@@ -46,7 +46,7 @@ async def _create_impl(image_uri: str, logger: logging.Logger):
 
         if not os.path.exists(result_file):
             raise FileNotFoundError(
-                "Worker path file not created when getting worker path for image {image_uri}"
+                f"Worker path file not created when getting worker path for image {image_uri}"
             )
 
         with open(result_file, "r") as f:
@@ -54,7 +54,7 @@ async def _create_impl(image_uri: str, logger: logging.Logger):
 
         if not worker_path.endswith(".py"):
             raise ValueError(
-                "Invalid worker path inferred in image {image_uri}: {worker_path}"
+                f"Invalid worker path inferred in image {image_uri}: {worker_path}"
             )
 
         logger.info(f"Inferred worker path in image {image_uri}: {worker_path}")

--- a/python/ray/tests/conftest_docker.py
+++ b/python/ray/tests/conftest_docker.py
@@ -181,10 +181,16 @@ def run_in_container(cmds: List[List[str]], container_id: str):
     for cmd in cmds:
         docker_cmd = ["docker", "exec", container_id] + cmd
         print(f"Executing command: {docker_cmd}", time.time())
-        resp = subprocess.check_output(docker_cmd, stderr=subprocess.STDOUT)
-        output = resp.decode("utf-8").strip()
-        print(f"Output: {output}")
-        outputs.append(output)
+        try:
+            resp = subprocess.check_output(docker_cmd, stderr=subprocess.STDOUT)
+            output = resp.decode("utf-8").strip()
+            print(f"Output: {output}")
+            outputs.append(output)
+        except subprocess.CalledProcessError as e:
+            error_output = e.output.decode("utf-8") if e.output else "No output"
+            print(f"Command failed with return code {e.returncode}")
+            print(f"Full error output:\n{error_output}")
+            raise
 
     return outputs
 


### PR DESCRIPTION
## Why are these changes needed?

When submitting containerized jobs to a Kubernetes cluster using Ray, the podman image pull output can include extra lines when pulling an image for the first time. Previously, the code attempted to parse the image URI from the last line of podman output, which was fragile and could result in failures if the output format changed or additional logs were present. This caused containers to fail to start and jobs to remain pending.

This PR updates the logic to use a temporary file to communicate the default worker path, making the process more robust and less dependent on the output format.

## Related issue number

https://github.com/ray-project/ray/issues/37293

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
