### PR TITLE
[core] Use core worker client pool in GCS

### DIFF
--- a/src/mock/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/mock/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -28,7 +28,8 @@ namespace gcs {
 class MockGcsActorManager : public GcsActorManager {
  public:
   MockGcsActorManager(RuntimeEnvManager &runtime_env_manager,
-                      GcsFunctionManager &function_manager)
+                      GcsFunctionManager &function_manager,
+                      rpc::CoreWorkerClientPool &worker_client_pool)
       : GcsActorManager(
             /*scheduler=*/
             nullptr,
@@ -38,7 +39,7 @@ class MockGcsActorManager : public GcsActorManager {
             runtime_env_manager,
             function_manager,
             [](const ActorID &) {},
-            [](const rpc::Address &) { return nullptr; }) {}
+            worker_client_pool) {}
 
   MOCK_METHOD(void,
               HandleRegisterActor,

--- a/src/ray/gcs/gcs_client/test/gcs_client_test.cc
+++ b/src/ray/gcs/gcs_client/test/gcs_client_test.cc
@@ -256,6 +256,7 @@ class GcsClientTest : public ::testing::TestWithParam<bool> {
     // the scenario of registration failure, we set the address to an illegal value.
     if (!is_detached) {
       rpc::Address address;
+      address.set_worker_id(WorkerID::FromRandom().Binary());
       address.set_ip_address("");
       message.mutable_caller_address()->CopyFrom(address);
     }

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -341,7 +341,7 @@ class GcsActorManager : public rpc::ActorInfoHandler {
       RuntimeEnvManager &runtime_env_manager,
       GcsFunctionManager &function_manager,
       std::function<void(const ActorID &)> destroy_owned_placement_group_if_needed,
-      const rpc::CoreWorkerClientFactoryFn &worker_client_factory = nullptr);
+      rpc::CoreWorkerClientPool &worker_client_pool);
 
   ~GcsActorManager() override = default;
 
@@ -714,9 +714,8 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   instrumented_io_context &io_context_;
   /// A publisher for publishing gcs messages.
   GcsPublisher *gcs_publisher_;
-  /// Factory to produce clients to workers. This is used to communicate with
-  /// actors and their owners.
-  rpc::CoreWorkerClientFactoryFn worker_client_factory_;
+  /// This is used to communicate with actors and their owners.
+  rpc::CoreWorkerClientPool &worker_client_pool_;
   /// A callback that is used to destroy placemenet group owned by the actor.
   /// This method MUST BE IDEMPOTENT because it can be called multiple times during
   /// actor destroy process.

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.cc
@@ -36,7 +36,7 @@ GcsActorScheduler::GcsActorScheduler(
     GcsActorSchedulerFailureCallback schedule_failure_handler,
     GcsActorSchedulerSuccessCallback schedule_success_handler,
     rpc::NodeManagerClientPool &raylet_client_pool,
-    rpc::CoreWorkerClientFactoryFn client_factory,
+    rpc::CoreWorkerClientPool &worker_client_pool,
     std::function<void(const NodeID &, const rpc::ResourcesData &)>
         normal_task_resources_changed_callback)
     : io_context_(io_context),
@@ -46,8 +46,9 @@ GcsActorScheduler::GcsActorScheduler(
       schedule_failure_handler_(std::move(schedule_failure_handler)),
       schedule_success_handler_(std::move(schedule_success_handler)),
       raylet_client_pool_(raylet_client_pool),
-      core_worker_clients_(client_factory),
-      normal_task_resources_changed_callback_(normal_task_resources_changed_callback) {
+      worker_client_pool_(worker_client_pool),
+      normal_task_resources_changed_callback_(
+          std::move(normal_task_resources_changed_callback)) {
   RAY_CHECK(schedule_failure_handler_ != nullptr && schedule_success_handler_ != nullptr);
 }
 
@@ -216,8 +217,6 @@ std::vector<ActorID> GcsActorScheduler::CancelOnNode(const NodeID &node_id) {
     if (iter != node_to_workers_when_creating_.end()) {
       for (auto &entry : iter->second) {
         actor_ids.emplace_back(entry.second->GetAssignedActorID());
-        // Remove core worker client.
-        core_worker_clients_.Disconnect(entry.first);
       }
       node_to_workers_when_creating_.erase(iter);
     }
@@ -265,8 +264,6 @@ ActorID GcsActorScheduler::CancelOnWorker(const NodeID &node_id,
     auto actor_iter = iter->second.find(worker_id);
     if (actor_iter != iter->second.end()) {
       assigned_actor_id = actor_iter->second->GetAssignedActorID();
-      // Remove core worker client.
-      core_worker_clients_.Disconnect(worker_id);
       iter->second.erase(actor_iter);
       if (iter->second.empty()) {
         node_to_workers_when_creating_.erase(iter);
@@ -416,7 +413,7 @@ void GcsActorScheduler::HandleWorkerLeaseGrantedReply(
     // Make sure to connect to the client before persisting actor info to GCS.
     // Without this, there could be a possible race condition. Related issues:
     // https://github.com/ray-project/ray/pull/9215/files#r449469320
-    core_worker_clients_.GetOrConnect(leased_worker->GetAddress());
+    worker_client_pool_.GetOrConnect(leased_worker->GetAddress());
     RAY_CHECK_OK(gcs_actor_table_.Put(actor->GetActorID(),
                                       actor->GetActorTableData(),
                                       {[this, actor, leased_worker](Status status) {
@@ -464,7 +461,7 @@ void GcsActorScheduler::CreateActorOnWorker(std::shared_ptr<GcsActor> actor,
   }
   request->mutable_resource_mapping()->CopyFrom(resources);
 
-  auto client = core_worker_clients_.GetOrConnect(worker->GetAddress());
+  auto client = worker_client_pool_.GetOrConnect(worker->GetAddress());
   client->PushNormalTask(
       std::move(request),
       [this, actor, worker](Status status, const rpc::PushTaskReply &reply) {
@@ -481,8 +478,6 @@ void GcsActorScheduler::CreateActorOnWorker(std::shared_ptr<GcsActor> actor,
             RAY_LOG(DEBUG) << "Worker " << worker_iter->first << " is in creating map.";
             // The worker is still in the creating map.
             if (status.ok()) {
-              // Remove related core worker client.
-              core_worker_clients_.Disconnect(actor->GetWorkerID());
               // Remove related worker in phase of creating.
               iter->second.erase(worker_iter);
               if (iter->second.empty()) {
@@ -547,7 +542,7 @@ bool GcsActorScheduler::KillActorOnWorker(const rpc::Address &worker_address,
     return false;
   }
 
-  auto cli = core_worker_clients_.GetOrConnect(worker_address);
+  auto cli = worker_client_pool_.GetOrConnect(worker_address);
   rpc::KillActorRequest request;
   // Set it to be Nil() since it hasn't been setup yet.
   request.set_intended_actor_id(actor_id.Binary());

--- a/src/ray/gcs/gcs_server/gcs_actor_scheduler.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_scheduler.h
@@ -107,7 +107,7 @@ class GcsActorSchedulerInterface {
 
   virtual std::string DebugString() const = 0;
 
-  virtual ~GcsActorSchedulerInterface() {}
+  virtual ~GcsActorSchedulerInterface() = default;
 };
 
 /// GcsActorScheduler is responsible for scheduling actors registered to GcsActorManager.
@@ -127,8 +127,7 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
   /// created on the worker successfully.
   /// \param raylet_client_pool Raylet client pool to
   /// construct connections to raylets.
-  /// \param client_factory Factory to create remote
-  /// core worker client, default factory will be used if not set.
+  /// \param worker_client_pool Pool to manage connections to core worker clients.
   explicit GcsActorScheduler(
       instrumented_io_context &io_context,
       GcsActorTable &gcs_actor_table,
@@ -137,9 +136,10 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
       GcsActorSchedulerFailureCallback schedule_failure_handler,
       GcsActorSchedulerSuccessCallback schedule_success_handler,
       rpc::NodeManagerClientPool &raylet_client_pool,
-      rpc::CoreWorkerClientFactoryFn client_factory = nullptr,
+      rpc::CoreWorkerClientPool &worker_client_pool,
       std::function<void(const NodeID &, const rpc::ResourcesData &)>
           normal_task_resources_changed_callback = nullptr);
+
   ~GcsActorScheduler() override = default;
 
   /// Schedule the specified actor.
@@ -390,8 +390,8 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
   absl::flat_hash_set<NodeID> nodes_of_releasing_unused_workers_;
   /// The cached raylet clients used to communicate with raylet.
   rpc::NodeManagerClientPool &raylet_client_pool_;
-  /// The cached core worker clients which are used to communicate with leased worker.
-  rpc::CoreWorkerClientPool core_worker_clients_;
+  /// Core worker client pool shared by the GCS.
+  rpc::CoreWorkerClientPool &worker_client_pool_;
 
   /// The resource changed listeners.
   std::vector<std::function<void()>> resource_changed_listeners_;

--- a/src/ray/gcs/gcs_server/gcs_job_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_job_manager.h
@@ -57,16 +57,15 @@ class GcsJobManager : public rpc::JobInfoHandler {
                          GcsFunctionManager &function_manager,
                          InternalKVInterface &internal_kv,
                          instrumented_io_context &io_context,
-                         rpc::CoreWorkerClientFactoryFn client_factory = nullptr)
+                         rpc::CoreWorkerClientPool &worker_client_pool)
       : gcs_table_storage_(gcs_table_storage),
         gcs_publisher_(gcs_publisher),
         runtime_env_manager_(runtime_env_manager),
         function_manager_(function_manager),
         internal_kv_(internal_kv),
         io_context_(io_context),
-        core_worker_clients_(client_factory) {
-    export_event_write_enabled_ = IsExportAPIEnabledDriverJob();
-  }
+        worker_client_pool_(worker_client_pool),
+        export_event_write_enabled_(IsExportAPIEnabledDriverJob()) {}
 
   void Initialize(const GcsInitData &gcs_init_data);
 
@@ -145,8 +144,7 @@ class GcsJobManager : public rpc::JobInfoHandler {
   GcsFunctionManager &function_manager_;
   InternalKVInterface &internal_kv_;
   instrumented_io_context &io_context_;
-  /// The cached core worker clients which are used to communicate with workers.
-  rpc::CoreWorkerClientPool core_worker_clients_;
+  rpc::CoreWorkerClientPool &worker_client_pool_;
 
   /// If true, driver job events are exported for Export API
   bool export_event_write_enabled_ = false;

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -771,6 +771,7 @@ void GcsServer::InstallEventListeners() {
         gcs_actor_manager_->OnNodeDead(node, node_ip_address);
         gcs_job_manager_->OnNodeDead(node_id);
         raylet_client_pool_->Disconnect(node_id);
+        worker_client_pool_.Disconnect(node_id);
         gcs_healthcheck_manager_->RemoveNode(node_id);
         pubsub_handler_->RemoveSubscriberFrom(node_id.Binary());
         gcs_autoscaler_state_manager_->OnNodeDead(node_id);

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -41,6 +41,7 @@
 #include "ray/rpc/client_call.h"
 #include "ray/rpc/gcs_server/gcs_rpc_server.h"
 #include "ray/rpc/node_manager/node_manager_client_pool.h"
+#include "ray/rpc/worker/core_worker_client_pool.h"
 #include "ray/util/throttler.h"
 
 namespace ray {
@@ -231,6 +232,8 @@ class GcsServer {
   rpc::ClientCallManager client_call_manager_;
   /// Node manager client pool.
   std::unique_ptr<rpc::NodeManagerClientPool> raylet_client_pool_;
+  // Core worker client pool.
+  rpc::CoreWorkerClientPool worker_client_pool_;
   /// The cluster resource scheduler.
   std::shared_ptr<ClusterResourceScheduler> cluster_resource_scheduler_;
   /// Local task manager.

--- a/src/ray/gcs/gcs_server/gcs_worker_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_worker_manager.cc
@@ -35,17 +35,13 @@ void GcsWorkerManager::HandleReportWorkerFailure(
     rpc::ReportWorkerFailureRequest request,
     rpc::ReportWorkerFailureReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
-  const rpc::Address worker_address = request.worker_failure().worker_address();
-  const auto worker_id = WorkerID::FromBinary(worker_address.worker_id());
+  const auto worker_id =
+      WorkerID::FromBinary(request.worker_failure().worker_address().worker_id());
   GetWorkerInfo(
       worker_id,
-      {[this,
-        reply,
-        send_reply_callback,
-        worker_id = std::move(worker_id),
-        request = std::move(request),
-        worker_address = std::move(worker_address)](
+      {[this, reply, send_reply_callback, worker_id, request = std::move(request)](
            const std::optional<rpc::WorkerTableData> &result) {
+         const auto &worker_address = request.worker_failure().worker_address();
          const auto node_id = NodeID::FromBinary(worker_address.raylet_id());
          std::string message =
              absl::StrCat("Reporting worker exit, worker id = ",

--- a/src/ray/gcs/gcs_server/gcs_worker_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_worker_manager.h
@@ -76,6 +76,8 @@ class GcsWorkerManager : public rpc::WorkerInfoHandler {
   instrumented_io_context &io_context_;
   GcsPublisher &gcs_publisher_;
   UsageStatsClient *usage_stats_client_;
+
+  /// Only listens for unexpected worker deaths not expected like node death.
   std::vector<std::function<void(std::shared_ptr<rpc::WorkerTableData>)>>
       worker_dead_listeners_;
 

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -156,6 +156,8 @@ class GcsActorManagerTest : public ::testing::Test {
     function_manager_ = std::make_unique<gcs::GcsFunctionManager>(*kv_, io_service_);
     auto scheduler = std::make_unique<MockActorScheduler>();
     mock_actor_scheduler_ = scheduler.get();
+    worker_client_pool_ = std::make_unique<rpc::CoreWorkerClientPool>(
+        [this](const rpc::Address &address) { return worker_client_; });
     gcs_actor_manager_ = std::make_unique<gcs::GcsActorManager>(
         std::move(scheduler),
         gcs_table_storage_.get(),
@@ -164,7 +166,7 @@ class GcsActorManagerTest : public ::testing::Test {
         *runtime_env_mgr_,
         *function_manager_,
         [](const ActorID &actor_id) {},
-        [this](const rpc::Address &addr) { return worker_client_; });
+        *worker_client_pool_);
 
     for (int i = 1; i <= 10; i++) {
       auto job_id = JobID::FromInt(i);
@@ -332,6 +334,7 @@ class GcsActorManagerTest : public ::testing::Test {
   // Actor scheduler's ownership lies in actor manager.
   MockActorScheduler *mock_actor_scheduler_ = nullptr;
   std::shared_ptr<MockWorkerClient> worker_client_;
+  std::unique_ptr<rpc::CoreWorkerClientPool> worker_client_pool_;
   absl::flat_hash_map<JobID, std::string> job_namespace_table_;
   std::unique_ptr<gcs::GcsActorManager> gcs_actor_manager_;
   std::shared_ptr<gcs::GcsPublisher> gcs_publisher_;

--- a/src/ray/gcs/gcs_server/test/gcs_actor_scheduler_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_scheduler_test.cc
@@ -78,6 +78,8 @@ class GcsActorSchedulerTest : public ::testing::Test {
         cluster_resource_scheduler_->GetClusterResourceManager(),
         *gcs_node_manager_,
         local_node_id_);
+    worker_client_pool_ = std::make_unique<rpc::CoreWorkerClientPool>(
+        [this](const rpc::Address &address) { return worker_client_; });
     gcs_actor_scheduler_ = std::make_shared<GcsServerMocker::MockedGcsActorScheduler>(
         io_context_->GetIoService(),
         *gcs_actor_table_,
@@ -94,8 +96,7 @@ class GcsActorSchedulerTest : public ::testing::Test {
           success_actors_.emplace_back(std::move(actor));
         },
         *raylet_client_pool_,
-        /*client_factory=*/
-        [this](const rpc::Address &address) { return worker_client_; },
+        *worker_client_pool_,
         /*normal_task_resources_changed_callback=*/
         [gcs_resource_manager](const NodeID &node_id,
                                const rpc::ResourcesData &resources) {
@@ -158,6 +159,7 @@ class GcsActorSchedulerTest : public ::testing::Test {
   std::shared_ptr<GcsServerMocker::MockedGcsActorTable> gcs_actor_table_;
   std::shared_ptr<GcsServerMocker::MockRayletClient> raylet_client_;
   std::shared_ptr<GcsServerMocker::MockWorkerClient> worker_client_;
+  std::unique_ptr<rpc::CoreWorkerClientPool> worker_client_pool_;
   std::shared_ptr<gcs::GcsNodeManager> gcs_node_manager_;
   std::unique_ptr<raylet::ILocalTaskManager> local_task_manager_;
   std::unique_ptr<ClusterResourceScheduler> cluster_resource_scheduler_;


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Replacing all uses of a core worker client factory / unshared client pool with a shared core worker client pool for the whole gcs server. This is needed to use the retryable grpc client in the gcs. Will be implementing retries for rpc's that exist and new gcs -> worker rpc's will need retries, ex. https://github.com/ray-project/ray/pull/51653
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
