### PR TITLE
[core] Creating an interface ObjectManager's for GrpcClientManager.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -325,7 +325,7 @@ ray_cc_library(
         ":object_manager_cc_grpc",
         "//src/ray/common:asio",
         "//src/ray/common:status",
-        "//src/ray/object_manager:object_manager_grpc_stub_manager",
+        "//src/ray/object_manager:object_manager_grpc_client_manager",
         "@boost//:asio",
         "@com_github_grpc_grpc//:grpc++",
     ],

--- a/src/ray/object_manager/BUILD.bazel
+++ b/src/ray/object_manager/BUILD.bazel
@@ -114,10 +114,13 @@ ray_cc_library(
 )
 
 ray_cc_library(
-    name = "object_manager_grpc_stub_manager",
-    hdrs = ["grpc_stub_manager.h"],
+    name = "object_manager_grpc_client_manager",
+    hdrs = ["grpc_client_manager.h"],
     deps = [
         "//:grpc_client",
+        "//:rpc_client_call",
+        "//src/ray/common:ray_config",
+        "@com_google_absl//absl/synchronization",
         "@com_github_grpc_grpc//:grpc++",
     ],
 )

--- a/src/ray/object_manager/grpc_client_manager.h
+++ b/src/ray/object_manager/grpc_client_manager.h
@@ -28,6 +28,7 @@ namespace ray::rpc {
 // Managers multiple gRPC clients. It's reponsible for initializing
 // gRPC clients with arguments, distributing requests between clients,
 // and destroying the clients.
+template <typename ServiceType>
 class GrpcClientManager {
  public:
   GrpcClientManager() = default;
@@ -40,7 +41,7 @@ class GrpcClientManager {
   virtual GrpcClient<ServiceType> *GetGrpcClient() = 0;
 };
 
-template <class ServiceType>
+template <typename ServiceType>
 class GrpcClientManagerImpl final : public GrpcClientManager<ServiceType> {
  public:
   GrpcClientManagerImpl(const std::string &address,


### PR DESCRIPTION
This is purely refactoring with no new logic:

- Rename `GrpcStubManager` to `GrpcClientManager`
- Turn `GrpcClientManager` into an abstract class with an implementation
