### PR TITLE
[Doc] Bind the version of kuberay to v1.3.0 in related docs

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides/configuring-autoscaling.ipynb
+++ b/doc/source/cluster/kubernetes/user-guides/configuring-autoscaling.ipynb
@@ -1086,7 +1086,7 @@
     "2. **Stability**\n",
     "Autoscaler V2 makes significant improvements to idle node handling. The V1 autoscaler could stop nodes that became active during termination processing, potentially failing tasks or actors. V2 uses Ray's graceful draining mechanism, which safely stops idle nodes without disrupting ongoing work.\n",
     "\n",
-    "[ray-cluster.autoscaler-v2.yaml](https://github.com/ray-project/kuberay/blob/master/ray-operator/config/samples/ray-cluster.autoscaler-v2.yaml) is an example YAML file of a RayCluster with Autoscaler V2 enabled that works with the latest KubeRay version.\n",
+    "[ray-cluster.autoscaler-v2.yaml](https://github.com/ray-project/kuberay/blob/v1.3.0/ray-operator/config/samples/ray-cluster.autoscaler-v2.yaml) is an example YAML file of a RayCluster with Autoscaler V2 enabled that works with the latest KubeRay version.\n",
     "\n",
     "If you're using KubeRay >= 1.4.0, enable V2 by setting `RayCluster.spec.autoscalerOptions.version: v2`.\n",
     "\n",


### PR DESCRIPTION
## Why are these changes needed?

Current ray's doc has a description of [how to enable autoscaler V2](https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/configuring-autoscaling.html#autoscaler-v2-with-kuberay). However, the ray-cluster.autoscaler-v2.yaml example to the https://github.com/ray-project/kuberay/blob/master/ray-operator/config/samples/ray-cluster.autoscaler-v2.yaml which does not have related configuration of RAY_enable_autoscaler_v2. This is because that [commit-a9c48c](https://github.com/ray-project/kuberay/commit/a9c48c150b3cb99aec4b29e434d7a1861c96d36a) introduced a new feature, which has not been released yet.

To reduce such problem, we should make the ray's doc bind to a specific released kuberay version.

## Related issue number

Closes #53655

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
