### PR TITLE
make constant for x-request-id

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -259,6 +259,9 @@ SERVE_LOG_EXTRA_FIELDS = "ray_serve_extra_fields"
 # Serve HTTP request header key for routing requests.
 SERVE_MULTIPLEXED_MODEL_ID = "serve_multiplexed_model_id"
 
+# HTTP request ID
+SERVE_HTTP_REQUEST_ID_HEADER = "x-request-id"
+
 # Feature flag to turn on node locality routing for proxies. On by default.
 RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING = (
     os.environ.get("RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING", "1") == "1"

--- a/python/ray/serve/_private/http_util.py
+++ b/python/ray/serve/_private/http_util.py
@@ -21,7 +21,7 @@ from uvicorn.lifespan.on import LifespanOn
 
 from ray._private.pydantic_compat import IS_PYDANTIC_2
 from ray.serve._private.common import RequestMetadata
-from ray.serve._private.constants import SERVE_LOGGER_NAME
+from ray.serve._private.constants import SERVE_HTTP_REQUEST_ID_HEADER, SERVE_LOGGER_NAME
 from ray.serve._private.utils import generate_request_id, serve_encoders
 from ray.serve.config import HTTPOptions
 from ray.serve.exceptions import RayServeException
@@ -560,11 +560,11 @@ class RequestIdMiddleware:
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send):
         headers = MutableHeaders(scope=scope)
-        if "x-request-id" not in headers:
+        if SERVE_HTTP_REQUEST_ID_HEADER not in headers:
             request_id = generate_request_id()
-            headers.append("x-request-id", request_id)
-        elif "x-request-id" in headers:
-            request_id = headers["x-request-id"]
+            headers.append(SERVE_HTTP_REQUEST_ID_HEADER, request_id)
+        elif SERVE_HTTP_REQUEST_ID_HEADER in headers:
+            request_id = headers[SERVE_HTTP_REQUEST_ID_HEADER]
 
         async def send_with_request_id(message: Message):
             if message["type"] == "http.response.start":

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -33,6 +33,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_PROXY_GC_THRESHOLD,
     REQUEST_LATENCY_BUCKETS_MS,
     SERVE_CONTROLLER_NAME,
+    SERVE_HTTP_REQUEST_ID_HEADER,
     SERVE_LOGGER_NAME,
     SERVE_MULTIPLEXED_MODEL_ID,
     SERVE_NAMESPACE,
@@ -902,7 +903,7 @@ class HTTPProxy(GenericProxy):
                 multiplexed_model_id = value.decode()
                 handle = handle.options(multiplexed_model_id=multiplexed_model_id)
                 request_context_info["multiplexed_model_id"] = multiplexed_model_id
-            if key.decode() == "x-request-id":
+            if key.decode() == SERVE_HTTP_REQUEST_ID_HEADER:
                 request_context_info["request_id"] = value.decode()
         ray.serve.context._serve_request_context.set(
             ray.serve.context._RequestContext(**request_context_info)

--- a/python/ray/serve/tests/test_http_headers.py
+++ b/python/ray/serve/tests/test_http_headers.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI
 
 import ray
 from ray import serve
+from ray.serve._private.constants import SERVE_HTTP_REQUEST_ID_HEADER
 from ray.serve._private.utils import generate_request_id
 
 
@@ -26,7 +27,7 @@ def test_request_id_header_by_default(serve_instance):
     serve.run(Model.bind())
     resp = httpx.get("http://localhost:8000")
     assert resp.status_code == 200
-    assert resp.text == resp.headers["x-request-id"]
+    assert resp.text == resp.headers[SERVE_HTTP_REQUEST_ID_HEADER]
 
     def is_valid_uuid(num: str):
         try:
@@ -104,8 +105,8 @@ def test_set_request_id_headers_with_two_attributes(serve_instance):
     )
 
     assert resp.status_code == 200
-    assert "x-request-id" in resp.headers
-    assert resp.text == resp.headers["x-request-id"]
+    assert SERVE_HTTP_REQUEST_ID_HEADER in resp.headers
+    assert resp.text == resp.headers[SERVE_HTTP_REQUEST_ID_HEADER]
 
 
 def test_reuse_request_id(serve_instance):
@@ -137,7 +138,7 @@ def test_reuse_request_id(serve_instance):
     async def send_request(
         session: ClientSession, body: Dict[str, Any], request_id: Optional[str]
     ) -> Tuple[str, str]:
-        headers = {"x-request-id": request_id}
+        headers = {SERVE_HTTP_REQUEST_ID_HEADER: request_id}
         url = "http://localhost:8000/hello"
 
         async with session.post(url=url, headers=headers, json=body) as response:
@@ -147,7 +148,7 @@ def test_reuse_request_id(serve_instance):
             # Ensure the request id from the serve context is set correctly.
             assert result["serve_context_request_id"] == request_id
             # Ensure the request id from the response header is returned correctly.
-            assert response.headers["x-request-id"] == request_id
+            assert response.headers[SERVE_HTTP_REQUEST_ID_HEADER] == request_id
 
     async def main():
         """Sending 20 requests in parallel all with the same request id, but with


### PR DESCRIPTION
## Why are these changes needed?

Make `x-request-id` a constant.