### PR TITLE
[Docs] Create lockfiles for various e2e tutorials

### DIFF
--- a/doc/source/ray-overview/examples/e2e-audio/ci/build.sh
+++ b/doc/source/ray-overview/examples/e2e-audio/ci/build.sh
@@ -4,13 +4,10 @@ set -exo pipefail
 
 # Install Python dependencies
 pip3 install --no-cache-dir \
-    "pytest>=8.3.5" \
-    "ruff>=0.11.5" \
-    "transformers>=4.51.3" \
-    "torchaudio" \
-    "datasets[audio]>=3.6.0" \
-    "accelerate" \
-    "huggingface_hub[hf_xet]" \
-    xgrammar \
-    pydantic \
-    flashinfer-python
+    accelerate==0.28.0 \
+    datasets[audio]==3.6.0 \
+    flashinfer-python==0.2.5 \
+    huggingface-hub[hf_xet]==0.27.0 \
+    pydantic==2.9.2 \
+    transformers==4.51.3 \
+    xgrammar==0.1.13

--- a/doc/source/ray-overview/examples/e2e-audio/ci/build.sh
+++ b/doc/source/ray-overview/examples/e2e-audio/ci/build.sh
@@ -7,7 +7,7 @@ pip3 install --no-cache-dir \
     accelerate==0.28.0 \
     datasets[audio]==3.6.0 \
     flashinfer-python==0.2.5 \
-    huggingface-hub[hf_xet]==0.27.0 \
+    huggingface-hub[hf_xet]==0.30.0 \
     pydantic==2.9.2 \
     transformers==4.51.3 \
     xgrammar==0.1.13

--- a/doc/source/ray-overview/examples/e2e-audio/requirements.in
+++ b/doc/source/ray-overview/examples/e2e-audio/requirements.in
@@ -1,4 +1,4 @@
-#transformers
+transformers
 torchaudio
 datasets[audio]
 accelerate

--- a/doc/source/ray-overview/examples/e2e-audio/requirements.in
+++ b/doc/source/ray-overview/examples/e2e-audio/requirements.in
@@ -1,0 +1,8 @@
+#transformers
+torchaudio
+datasets[audio]
+accelerate
+huggingface_hub[hf_xet]
+xgrammar
+pydantic
+flashinfer-python==0.2.5

--- a/doc/source/ray-overview/examples/e2e-audio/requirements.txt
+++ b/doc/source/ray-overview/examples/e2e-audio/requirements.txt
@@ -1,7 +1,7 @@
 accelerate==0.28.0
 datasets[audio]==3.6.0
 flashinfer-python==0.2.5
-huggingface-hub[hf_xet]==0.27.0
+huggingface-hub[hf_xet]==0.30.0
 pydantic==2.9.2
 transformers==4.51.3
 xgrammar==0.1.13

--- a/doc/source/ray-overview/examples/e2e-audio/requirements.txt
+++ b/doc/source/ray-overview/examples/e2e-audio/requirements.txt
@@ -1,11 +1,7 @@
-# install nightly due to
-# https://github.com/ray-project/ray/pull/51488
-#ray[data,llm]>=2.45  # provided by Anyscale's base image
-transformers>=4.51.3
-torchaudio
-datasets[audio]>=3.6.0
-accelerate
-huggingface_hub[hf_xet]
-xgrammar
-pydantic
-flashinfer-python
+accelerate==0.28.0
+datasets[audio]==3.6.0
+flashinfer-python==0.2.5
+huggingface-hub[hf_xet]==0.27.0
+pydantic==2.9.2
+transformers==4.51.3
+xgrammar==0.1.13

--- a/doc/source/ray-overview/examples/e2e-timeseries/requirements.in
+++ b/doc/source/ray-overview/examples/e2e-timeseries/requirements.in
@@ -1,0 +1,9 @@
+numpy
+pandas
+scikit-learn
+torch
+# ray[data,train,serve]==2.46.0
+aiohttp
+pyyaml
+s3fs
+nbformat

--- a/doc/source/ray-overview/examples/e2e-timeseries/requirements.txt
+++ b/doc/source/ray-overview/examples/e2e-timeseries/requirements.txt
@@ -1,9 +1,9 @@
-numpy
-pandas
-scikit-learn
-torch==2.7.0
-# ray[data,train,serve]==2.46.0
-aiohttp
-pyyaml
-s3fs
-nbformat
+--find-links https://data.pyg.org/whl/torch-2.3.0+cpu.html
+aiohttp==3.11.16
+nbformat==5.9.2
+numpy==1.26.4
+pandas==2.3.0
+pyyaml==6.0.1
+s3fs==2023.5.0
+scikit-learn==1.3.2
+torch==2.3.0

--- a/release/ray_release/byod/byod_e2e_audio.sh
+++ b/release/ray_release/byod/byod_e2e_audio.sh
@@ -4,13 +4,10 @@ set -exo pipefail
 
 # Install Python dependencies
 pip3 install --no-cache-dir \
-    "pytest>=8.3.5" \
-    "ruff>=0.11.5" \
-    "transformers>=4.51.3" \
-    "torchaudio" \
-    "datasets[audio]>=3.6.0" \
-    "accelerate" \
-    "huggingface_hub[hf_xet]" \
-    xgrammar \
-    pydantic \
-    flashinfer-python
+    accelerate==0.28.0 \
+    datasets[audio]==3.6.0 \
+    flashinfer-python==0.2.5 \
+    huggingface-hub[hf_xet]==0.27.0 \
+    pydantic==2.9.2 \
+    transformers==4.51.3 \
+    xgrammar==0.1.13

--- a/release/ray_release/byod/byod_e2e_audio.sh
+++ b/release/ray_release/byod/byod_e2e_audio.sh
@@ -7,7 +7,7 @@ pip3 install --no-cache-dir \
     accelerate==0.28.0 \
     datasets[audio]==3.6.0 \
     flashinfer-python==0.2.5 \
-    huggingface-hub[hf_xet]==0.27.0 \
+    huggingface-hub[hf_xet]==0.30.0 \
     pydantic==2.9.2 \
     transformers==4.51.3 \
     xgrammar==0.1.13

--- a/release/ray_release/byod/byod_e2e_timeseries.sh
+++ b/release/ray_release/byod/byod_e2e_timeseries.sh
@@ -7,4 +7,12 @@
 set -exo pipefail
 
 # Install Python dependencies.
-pip3 install --no-cache-dir numpy pandas scikit-learn torch==2.7.0 aiohttp pyyaml s3fs nbformat
+pip3 install --no-cache-dir \
+    aiohttp==3.11.16 \
+    nbformat==5.9.2 \
+    numpy==1.26.4 \
+    pandas==2.3.0 \
+    pyyaml==6.0.1 \
+    s3fs==2023.5.0 \
+    scikit-learn==1.3.2 \
+    torch==2.3.0


### PR DESCRIPTION
## Why are these changes needed?

Stabilize a few e2e tutorials using lockfiles.

Note: this PR targets docs/e2e-ts-notebook-3 to prevent conflicts

## Related issue number

NA

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
