### PR TITLE
handle task cancellation error

### DIFF
--- a/python/ray/serve/_private/request_router/replica_wrapper.py
+++ b/python/ray/serve/_private/request_router/replica_wrapper.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Optional, Set, Tuple, Union
 import ray
 from ray import ObjectRef, ObjectRefGenerator
 from ray.actor import ActorHandle
+from ray.exceptions import TaskCancelledError
 from ray.serve._private.common import (
     ReplicaID,
     ReplicaQueueLengthInfo,
@@ -115,6 +116,9 @@ class ActorReplicaWrapper(ReplicaWrapper):
             )
             ray.cancel(obj_ref_gen)
             raise e from None
+        except TaskCancelledError:
+            logger.info("Request already cancelled.")
+            raise asyncio.CancelledError()
 
 
 @PublicAPI(stability="alpha")

--- a/python/ray/serve/_private/request_router/replica_wrapper.py
+++ b/python/ray/serve/_private/request_router/replica_wrapper.py
@@ -117,7 +117,6 @@ class ActorReplicaWrapper(ReplicaWrapper):
             ray.cancel(obj_ref_gen)
             raise e from None
         except TaskCancelledError:
-            logger.info("Request already cancelled.")
             raise asyncio.CancelledError()
 
 

--- a/python/ray/serve/tests/test_actor_replica_wrapper.py
+++ b/python/ray/serve/tests/test_actor_replica_wrapper.py
@@ -9,6 +9,7 @@ import ray
 from ray import ObjectRef, ObjectRefGenerator
 from ray._common.test_utils import SignalActor
 from ray._common.utils import get_or_create_event_loop
+from ray.exceptions import TaskCancelledError
 from ray.serve._private.common import (
     DeploymentID,
     ReplicaID,
@@ -67,6 +68,11 @@ class FakeReplicaActor:
             executing_signal_actor = kwargs.pop("executing_signal_actor")
             async with send_signal_on_cancellation(cancelled_signal_actor):
                 await executing_signal_actor.send.remote()
+
+        # Special case: if "raise_task_cancelled_error" is in kwargs, raise TaskCancelledError
+        # This simulates the scenario where the underlying Ray task gets cancelled
+        if kwargs.pop("raise_task_cancelled_error", False):
+            raise TaskCancelledError()
 
         yield pickle.dumps(self._replica_queue_length_info)
         if not self._replica_queue_length_info.accepted:
@@ -201,6 +207,38 @@ async def test_send_request_with_rejection_cancellation(setup_fake_replica):
         await send_request_task
 
     await cancelled_signal_actor.wait.remote()
+
+
+@pytest.mark.asyncio
+async def test_send_request_with_rejection_task_cancelled_error(setup_fake_replica):
+    """
+    Test that TaskCancelledError from the underlying Ray task gets converted to
+    asyncio.CancelledError when sending request with rejection.
+    """
+    actor_handle = setup_fake_replica.actor_handle
+    replica = RunningReplica(setup_fake_replica)
+
+    # Set up the replica to accept the request
+    ray.get(
+        actor_handle.set_replica_queue_length_info.remote(
+            ReplicaQueueLengthInfo(accepted=True, num_ongoing_requests=5),
+        )
+    )
+
+    pr = PendingRequest(
+        args=["Hello"],
+        kwargs={
+            "raise_task_cancelled_error": True
+        },  # This will trigger TaskCancelledError
+        metadata=RequestMetadata(
+            request_id="abc",
+            internal_request_id="def",
+        ),
+    )
+
+    # The TaskCancelledError should be caught and converted to asyncio.CancelledError
+    with pytest.raises(asyncio.CancelledError):
+        await replica.send_request(pr, with_rejection=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
don't know for sure, but seems like a race condition between when the cancel happens and attempt to access the ray task result causes `RayTaskCancelled` exception.

Used the repro script in the ticket to confirm that the issue is resolved https://github.com/ray-project/ray/issues/53639. 