### PR TITLE
[data] allow max_calls to be a static but not dynamic option

### DIFF
--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -349,6 +349,9 @@ class MapOperator(OneToOneOperator, InternalQueueOperatorMixin, ABC):
     ) -> Dict[str, Any]:
         ray_remote_args = copy.deepcopy(self._ray_remote_args)
 
+        # Remove max_calls from the dynamic options.
+        ray_remote_args.pop("max_calls", None)
+
         # Override parameters from user provided remote args function.
         if self._ray_remote_args_fn:
             new_remote_args = self._ray_remote_args_fn()

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -3220,6 +3220,26 @@ def test_with_column_alias_expressions(
     pd.testing.assert_frame_equal(result_df, non_aliased_df)
 
 
+def test_map_with_max_calls():
+
+    ds = ray.data.range(10)
+
+    # OK to set 'max_calls' as static option
+    ds = ds.map(lambda x: x, max_calls=1)
+
+    assert ds.count() == 10
+
+    ds = ray.data.range(10)
+
+    # Not OK to set 'max_calls' as dynamic option
+    with pytest.raises(ValueError):
+        ds = ds.map(
+            lambda x: x,
+            ray_remote_args_fn=lambda: {"max_calls": 1},
+        )
+        ds.take_all()
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, passing `max_calls` as `ray_remote_args` in `ds.map` raises a slightly misleading error about `max_calls` being used in `.options` (i.e., dynamic options). However, it should be at least allowed to be a static option (e.g., `@ray.remote(max_calls=1)`)

This PR fixes this so that users can specify `max_calls` (as `ray_remote_args`). An error will be raised if `max_calls` is used as a dynamic option via `ray_remote_args_fn`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
