### PR TITLE
add back run on anyscale button

### DIFF
--- a/doc/source/ray-overview/examples/entity-recognition-with-llms/README.ipynb
+++ b/doc/source/ray-overview/examples/entity-recognition-with-llms/README.ipynb
@@ -6,6 +6,10 @@
    "source": [
     "# Entity Recognition with LLMs\n",
     "\n",
+    "<a href=\"https://console.anyscale.com/register/ha?render_flow=ray&utm_source=ray_docs&utm_medium=docs&utm_campaign=entity-recognition-with-llms&redirectTo=/v2/template-preview/entity-recognition-with-llms\\\">\n",
+    "<img src=\"https://raw.githubusercontent.com/ray-project/ray/c34b74c22a9390aa89baf80815ede59397786d2e/doc/source/_static/img/run-on-anyscale.svg\" alt=\\\"Run on Anyscale\\\">\n",
+    "</a>\n",
+    "<br></br>\n",
     "<div align=\"left\">\n",
     "<a href=\"https://github.com/anyscale/e2e-llm-workflows\" role=\"button\"><img src=\"https://img.shields.io/static/v1?label=&amp;message=View%20On%20GitHub&amp;color=586069&amp;logo=github&amp;labelColor=2f363d\"></a>&nbsp;\n",
     "</div>"


### PR DESCRIPTION
Adding back "Run on Anyscale" button after a Anyscale PR was merged to show the button on Ray docs but not Anyscale template previews


<img width="1285" alt="Screenshot 2025-06-09 at 7 28 25 PM" src="https://github.com/user-attachments/assets/02b3e795-a5cc-4350-bbaa-d1afe3572fe0" />


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
