### PR TITLE
[core] Fix `test_multi_tenancy.py` on Windows

### DIFF
--- a/python/ray/tests/test_multi_tenancy.py
+++ b/python/ray/tests/test_multi_tenancy.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 import os
+import subprocess
 import sys
 import tempfile
 import time
@@ -253,7 +254,11 @@ os._exit(0)
 
     # Run a driver that spawns many tasks and blocks until the first result is ready,
     # so at least one worker should have registered.
-    run_string_as_driver(driver_code)
+    try:
+        run_string_as_driver(driver_code)
+    except subprocess.CalledProcessError:
+        # The driver exits with non-zero status Windows due to ungraceful os._exit.
+        pass
 
     # Verify that the workers spawned by the old driver go away.
     wait_for_condition(lambda: len(get_workers()) <= 2)


### PR DESCRIPTION
Process exits ungracefully when you `os._exit` on Windows: https://buildkite.com/ray-project/postmerge/builds/10736#01975889-d332-47e0-8290-284c63ec43b3/1834-1905