### PR TITLE
[serve] Increase httpx timeout to 30s for backpressure test

### DIFF
--- a/.buildkite/windows.rayci.yml
+++ b/.buildkite/windows.rayci.yml
@@ -2,8 +2,8 @@ group: windows tests
 sort_key: "~windows"
 steps:
   # block on premerge and microcheck
-  - block: "run windows tests"
-    if: build.env("BUILDKITE_PIPELINE_ID") == "0189942e-0876-4b8f-80a4-617f988ec59b" || build.env("BUILDKITE_PIPELINE_ID") == "018f4f1e-1b73-4906-9802-92422e3badaa"
+  #- block: "run windows tests"
+  #  if: build.env("BUILDKITE_PIPELINE_ID") == "0189942e-0876-4b8f-80a4-617f988ec59b" || build.env("BUILDKITE_PIPELINE_ID") == "018f4f1e-1b73-4906-9802-92422e3badaa"
 
   - name: windowsbuild
     wanda: ci/docker/windows.build.wanda.yaml
@@ -64,20 +64,21 @@ steps:
     depends_on: windowsbuild
 
   - label: ":ray-serve: serve: :windows: tests"
+    key: windows-serve-tests
     tags: serve
     job_env: WINDOWS
     instance_type: windows
-    parallelism: 2
+    #parallelism: 2
     commands:
       - bash ci/ray_ci/windows/install_tools.sh
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/... serve
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/tests:test_backpressure serve
         --build-name windowsbuild
         --operating-system windows
         --except-tags no_windows,use_all_core_windows
         --test-env=CI="1"
         --test-env=RAY_CI_POST_WHEEL_TESTS="1"
         --test-env=USERPROFILE
-        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
+        #--workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
     depends_on: windowsbuild
 
   - label: ":ray-serve: serve: :windows: enormous tests"

--- a/.buildkite/windows.rayci.yml
+++ b/.buildkite/windows.rayci.yml
@@ -2,8 +2,8 @@ group: windows tests
 sort_key: "~windows"
 steps:
   # block on premerge and microcheck
-  #- block: "run windows tests"
-  #  if: build.env("BUILDKITE_PIPELINE_ID") == "0189942e-0876-4b8f-80a4-617f988ec59b" || build.env("BUILDKITE_PIPELINE_ID") == "018f4f1e-1b73-4906-9802-92422e3badaa"
+  - block: "run windows tests"
+    if: build.env("BUILDKITE_PIPELINE_ID") == "0189942e-0876-4b8f-80a4-617f988ec59b" || build.env("BUILDKITE_PIPELINE_ID") == "018f4f1e-1b73-4906-9802-92422e3badaa"
 
   - name: windowsbuild
     wanda: ci/docker/windows.build.wanda.yaml
@@ -64,21 +64,20 @@ steps:
     depends_on: windowsbuild
 
   - label: ":ray-serve: serve: :windows: tests"
-    key: windows-serve-tests
     tags: serve
     job_env: WINDOWS
     instance_type: windows
-    #parallelism: 2
+    parallelism: 2
     commands:
       - bash ci/ray_ci/windows/install_tools.sh
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/tests:test_backpressure serve
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/... serve
         --build-name windowsbuild
         --operating-system windows
         --except-tags no_windows,use_all_core_windows
         --test-env=CI="1"
         --test-env=RAY_CI_POST_WHEEL_TESTS="1"
         --test-env=USERPROFILE
-        #--workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
+        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
     depends_on: windowsbuild
 
   - label: ":ray-serve: serve: :windows: enormous tests"

--- a/python/ray/serve/tests/test_backpressure.py
+++ b/python/ray/serve/tests/test_backpressure.py
@@ -67,7 +67,7 @@ def test_http_backpressure(serve_instance):
 
     @ray.remote(num_cpus=0)
     def do_request(msg: str) -> Tuple[int, str]:
-        r = httpx.request("GET", "http://localhost:8000/", json={"msg": msg}, timeout=10.0)
+        r = httpx.request("GET", "http://localhost:8000/", json={"msg": msg}, timeout=30.0)
         return r.status_code, r.text
 
     # First response should block. Until the signal is sent, all subsequent requests

--- a/python/ray/serve/tests/test_backpressure.py
+++ b/python/ray/serve/tests/test_backpressure.py
@@ -67,7 +67,7 @@ def test_http_backpressure(serve_instance):
 
     @ray.remote(num_cpus=0)
     def do_request(msg: str) -> Tuple[int, str]:
-        r = httpx.request("GET", "http://localhost:8000/", json={"msg": msg})
+        r = httpx.request("GET", "http://localhost:8000/", json={"msg": msg}, timeout=None)
         return r.status_code, r.text
 
     # First response should block. Until the signal is sent, all subsequent requests

--- a/python/ray/serve/tests/test_backpressure.py
+++ b/python/ray/serve/tests/test_backpressure.py
@@ -1,6 +1,5 @@
 import sys
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
-import time
 from typing import Tuple
 
 import grpc
@@ -68,10 +67,8 @@ def test_http_backpressure(serve_instance):
 
     @ray.remote(num_cpus=0)
     def do_request(msg: str) -> Tuple[int, str]:
-        start_time = time.time()
-        r = httpx.request("GET", "http://localhost:8000/", json={"msg": msg}, timeout=30.0)
-        end_time = time.time()
-        return r.status_code, r.text, end_time - start_time
+        r = httpx.request("GET", "http://localhost:8000/", json={"msg": msg}, timeout=10.0)
+        return r.status_code, r.text
 
     # First response should block. Until the signal is sent, all subsequent requests
     # will be queued in the handle.
@@ -84,16 +81,15 @@ def test_http_backpressure(serve_instance):
     second_ref = do_request.remote("hi-2")
     _, pending = ray.wait([second_ref], timeout=0.1)
     for _ in range(10):
-        status_code, text, time_taken = ray.get(do_request.remote(("hi-err")))
-        print(f"Time taken: {time_taken} seconds")
+        status_code, text = ray.get(do_request.remote(("hi-err")))
         assert status_code == 503
         assert text.startswith("Request dropped due to backpressure")
 
     # Send the signal; the first request will be unblocked and the second should
     # subsequently get scheduled and executed.
     ray.get(signal_actor.send.remote())
-    assert ray.get(first_ref)[:2] == (200, "hi-1")
-    assert ray.get(second_ref)[:2] == (200, "hi-2")
+    assert ray.get(first_ref) == (200, "hi-1")
+    assert ray.get(second_ref) == (200, "hi-2")
 
     ray.get(signal_actor.send.remote(clear=True))
     wait_for_condition(lambda: ray.get(signal_actor.cur_num_waiters.remote()) == 0)

--- a/python/ray/serve/tests/test_backpressure.py
+++ b/python/ray/serve/tests/test_backpressure.py
@@ -67,7 +67,9 @@ def test_http_backpressure(serve_instance):
 
     @ray.remote(num_cpus=0)
     def do_request(msg: str) -> Tuple[int, str]:
-        r = httpx.request("GET", "http://localhost:8000/", json={"msg": msg}, timeout=30.0)
+        r = httpx.request(
+            "GET", "http://localhost:8000/", json={"msg": msg}, timeout=30.0
+        )
         return r.status_code, r.text
 
     # First response should block. Until the signal is sent, all subsequent requests


### PR DESCRIPTION
The test is failing on windows because of httpx client timeout. Previously with the `requests` library, there was no timeout set. Removing this timeout for httpx passes the test on windows: https://buildkite.com/ray-project/microcheck/builds/18192/steps/canvas?sid=01975bcb-eac1-4804-a269-858ffdb32cf2.