### PR TITLE
[core] Warning when creating actor with restarts and arguments in plasma

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2715,19 +2715,22 @@ Status CoreWorker::CreateActor(const RayFunction &function,
   }
 
   if (task_spec.MaxActorRestarts() != 0) {
-    bool log_message = false;
+    bool actor_restart_warning = false;
     for (size_t i = 0; i < task_spec.NumArgs(); i++) {
       if (task_spec.ArgByRef(i) || !task_spec.ArgInlinedRefs(i).empty()) {
-        log_message = true;
+        actor_restart_warning = true;
         break;
       }
     }
-    if (log_message) {
+    if (actor_restart_warning) {
       RAY_LOG(ERROR)
-          << "Actor " << task_spec.ActorCreationId()
+          << "Actor " << (actor_name.empty() ? "" : (actor_name + " "))
+          << "with class name: " << function.GetFunctionDescriptor()->ClassName()
+          << " and ID: " << task_spec.ActorCreationId()
           << " has arguments in the object store and max_restarts is not equal to 0. If "
              "the arguments in the object store go out of scope or are lost, the "
-             "actor restart will fail.";
+             "actor restart will fail. See "
+             "https://github.com/ray-project/ray/issues/53727 for more details.";
     }
   }
 

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2711,45 +2711,62 @@ Status CoreWorker::CreateActor(const RayFunction &function,
       local_mode_named_actor_registry_.emplace(actor_name, actor_id);
     }
     ExecuteTaskLocalMode(task_spec);
-  } else {
-    task_manager_->AddPendingTask(
-        rpc_address_,
-        task_spec,
-        CurrentCallSite(),
-        // Actor creation task retry happens on GCS not on core worker.
-        /*max_retries*/ 0);
+    return Status::OK();
+  }
 
-    if (actor_name.empty()) {
-      io_service_.post(
-          [this, task_spec = std::move(task_spec)]() {
-            RAY_UNUSED(actor_creator_->AsyncRegisterActor(
-                task_spec, [this, task_spec](Status status) {
-                  if (!status.ok()) {
-                    RAY_LOG(ERROR).WithField(task_spec.ActorCreationId())
-                        << "Failed to register actor. Error message: " << status;
-                    task_manager_->FailPendingTask(task_spec.TaskId(),
-                                                   rpc::ErrorType::ACTOR_CREATION_FAILED,
-                                                   &status);
-                  } else {
-                    RAY_UNUSED(actor_task_submitter_->SubmitActorCreationTask(task_spec));
-                  }
-                }));
-          },
-          "ActorCreator.AsyncRegisterActor");
-    } else {
-      // For named actor, we still go through the sync way because for
-      // functions like list actors these actors need to be there, especially
-      // for local driver. But the current code all go through the gcs right now.
-      auto status = actor_creator_->RegisterActor(task_spec);
-      if (!status.ok()) {
-        return status;
+  if (task_spec.MaxActorRestarts() != 0) {
+    bool log_message = false;
+    for (size_t i = 0; i < task_spec.NumArgs(); i++) {
+      if (task_spec.ArgByRef(i) || !task_spec.ArgInlinedRefs(i).empty()) {
+        log_message = true;
+        break;
       }
-      io_service_.post(
-          [this, task_spec = std::move(task_spec)]() {
-            RAY_UNUSED(actor_task_submitter_->SubmitActorCreationTask(task_spec));
-          },
-          "CoreWorker.SubmitTask");
     }
+    if (log_message) {
+      RAY_LOG(ERROR)
+          << "Actor " << task_spec.ActorCreationId()
+          << " has arguments in the object store and max_restarts is not equal to 0. If "
+             "the arguments in the object store go out of scope locally or are lost, the "
+             "actor restart will fail.";
+    }
+  }
+
+  task_manager_->AddPendingTask(
+      rpc_address_,
+      task_spec,
+      CurrentCallSite(),
+      // Actor creation task retry happens on GCS not on core worker.
+      /*max_retries*/ 0);
+
+  if (actor_name.empty()) {
+    io_service_.post(
+        [this, task_spec = std::move(task_spec)]() {
+          RAY_UNUSED(actor_creator_->AsyncRegisterActor(
+              task_spec, [this, task_spec](Status status) {
+                if (!status.ok()) {
+                  RAY_LOG(ERROR).WithField(task_spec.ActorCreationId())
+                      << "Failed to register actor. Error message: " << status;
+                  task_manager_->FailPendingTask(
+                      task_spec.TaskId(), rpc::ErrorType::ACTOR_CREATION_FAILED, &status);
+                } else {
+                  RAY_UNUSED(actor_task_submitter_->SubmitActorCreationTask(task_spec));
+                }
+              }));
+        },
+        "ActorCreator.AsyncRegisterActor");
+  } else {
+    // For named actor, we still go through the sync way because for
+    // functions like list actors these actors need to be there, especially
+    // for local driver. But the current code all go through the gcs right now.
+    auto status = actor_creator_->RegisterActor(task_spec);
+    if (!status.ok()) {
+      return status;
+    }
+    io_service_.post(
+        [this, task_spec = std::move(task_spec)]() {
+          RAY_UNUSED(actor_task_submitter_->SubmitActorCreationTask(task_spec));
+        },
+        "CoreWorker.SubmitTask");
   }
   return Status::OK();
 }

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2726,7 +2726,7 @@ Status CoreWorker::CreateActor(const RayFunction &function,
       RAY_LOG(ERROR)
           << "Actor " << task_spec.ActorCreationId()
           << " has arguments in the object store and max_restarts is not equal to 0. If "
-             "the arguments in the object store go out of scope locally or are lost, the "
+             "the arguments in the object store go out of scope or are lost, the "
              "actor restart will fail.";
     }
   }

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2725,9 +2725,9 @@ Status CoreWorker::CreateActor(const RayFunction &function,
     if (actor_restart_warning) {
       RAY_LOG(ERROR)
           << "Actor " << (actor_name.empty() ? "" : (actor_name + " "))
-          << "with class name: " << function.GetFunctionDescriptor()->ClassName()
-          << " and ID: " << task_spec.ActorCreationId()
-          << " has arguments in the object store and max_restarts is not equal to 0. If "
+          << "with class name: '" << function.GetFunctionDescriptor()->ClassName()
+          << "' and ID: '" << task_spec.ActorCreationId()
+          << "' has constructor arguments in the object store and max_restarts > 0. If "
              "the arguments in the object store go out of scope or are lost, the "
              "actor restart will fail. See "
              "https://github.com/ray-project/ray/issues/53727 for more details.";


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Currently actor restarts won't because lineage ref counting doesn't work for actors with restarts. See description here https://github.com/ray-project/ray/pull/51653#issuecomment-2960275776.

Minimal repro
```
cluster = ray_start_cluster
cluster.add_node(num_cpus=0)  # head
ray.init(address=cluster.address)
worker1 = cluster.add_node(num_cpus=1)

@ray.remote(num_cpus=1, max_restarts=1)
class Actor:
    def __init__(self, config):
        self.config = config

    def ping(self):
        return self.config

# Arg is >100kb so will go in the object store
actor = Actor.remote(np.zeros(100 * 1024 * 1024, dtype=np.uint8))
ray.get(actor.ping.remote())

worker2 = cluster.add_node(num_cpus=1)
cluster.remove_node(worker1, allow_graceful=True)

# This line will break
ray.get(actor.ping.remote())
```

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
