### PR TITLE
(serve.llm) Make _LLMServerBase.__init__ synchronous

### DIFF
--- a/python/ray/llm/_internal/serve/deployments/llm/llm_server.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/llm_server.py
@@ -77,10 +77,9 @@ class _LLMServerBase(ABC):
     need to implement an async constructor, an async predict, and check_health method.
     """
 
-    # TODO (Kourosh): I don't know why this is an async init. Need to fix.
-    async def __init__(self, llm_config: LLMConfig):
+    def __init__(self, llm_config: LLMConfig):
         """
-        Constructor takes in an LLMConfig object and start the underlying engine.
+        Constructor takes in an LLMConfig object and stores the configuration.
         """
         self._llm_config = llm_config
 
@@ -435,7 +434,7 @@ class LLMServer(_LLMServerBase):
             model_downloader: Dependency injection for the model downloader object.
                 Defaults to be initialized with `LoraModelLoader`.
         """
-        await super().__init__(llm_config)
+        super().__init__(llm_config)
 
         self._engine_cls = engine_cls or self._default_engine_cls
         self.engine = self._get_engine_class(self._llm_config)

--- a/python/ray/llm/_internal/serve/deployments/prefill_decode_disagg/prefill_decode_disagg.py
+++ b/python/ray/llm/_internal/serve/deployments/prefill_decode_disagg/prefill_decode_disagg.py
@@ -70,7 +70,7 @@ class PDProxyServer(LLMServer):
         decode_server: The decode server deployment handle.
     """
 
-    async def __init__(
+    def __init__(
         self,
         llm_config: LLMConfig,
         prefill_server: DeploymentHandle,
@@ -89,7 +89,7 @@ class PDProxyServer(LLMServer):
         # endpoint can work correctly.
         # TODO(lk-chen): refactor LLMRouter <-> LLMServer such that router query model_id through
         # API, instead of passing it in as an argument.
-        await super().__init__(
+        super().__init__(
             llm_config,
             engine_cls=FakeEngine,
         )


### PR DESCRIPTION
Refactor: Base class _LLMServerBase.__init__ was unnecessarily async when it only does synchronous operations (storing the llm_config). This change:

- Removes async from _LLMServerBase.__init__ since it has no async operations
- Updates LLMServer.__init__ to call super().__init__() without await
- Keeps LLMServer.__init__ async which actually needs it for engine initialization (await self._start_engine())
- Addresses [TODO](https://github.com/ray-project/ray/blob/62e3169e3d2709df03d16606a806f9d28cd709e6/python/ray/llm/_internal/serve/deployments/llm/llm_server.py#L80)

Methods should only be async if they perform async operations. The concrete implementation remains async where it's actually needed for LLM engine startup.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
