### PR TITLE
[core] Speed up `test_actor_advanced.py`

### DIFF
--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -1098,7 +1098,9 @@ def test_get_actor_from_concurrent_tasks(shutdown_only):
                 actor = ray.get_actor(actor_name)
             except Exception:
                 print("Get failed, trying to create")
-                actor = Actor.options(name=actor_name).remote()
+                # Actor must be detached so it outlives this task and other tasks can
+                # get a handle to it.
+                actor = Actor.options(name=actor_name, lifetime="detached").remote()
         except Exception:
             # Multiple tasks may have reached the creation block above.
             # Only one will succeed and the others will get an error, in which case
@@ -1145,6 +1147,9 @@ def test_get_or_create_actor_from_multiple_threads(shutdown_only):
         a = Actor.options(
             name="test_actor",
             get_if_exists=True,
+            # Actor must be detached so it outlives this function and other threads
+            # can get a handle to it.
+            lifetime="detached",
         ).remote()
 
         return ray.get(a.get_actor_id.remote())

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -21,28 +21,6 @@ from ray._private.ray_constants import gcs_actor_scheduling_enabled
 from ray.experimental.internal_kv import _internal_kv_get, _internal_kv_put
 
 
-def test_remote_functions_not_scheduled_on_actors(ray_start_regular):
-    # Make sure that regular remote functions are not scheduled on actors.
-
-    @ray.remote
-    class Actor:
-        def __init__(self):
-            pass
-
-        def get_id(self):
-            return ray.get_runtime_context().get_worker_id()
-
-    a = Actor.remote()
-    actor_id = ray.get(a.get_id.remote())
-
-    @ray.remote
-    def f():
-        return ray.get_runtime_context().get_worker_id()
-
-    resulting_ids = ray.get([f.remote() for _ in range(100)])
-    assert actor_id not in resulting_ids
-
-
 def test_actors_on_nodes_with_no_cpus(ray_start_no_cpu):
     @ray.remote
     class Foo:

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -3,7 +3,6 @@ import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 
-import numpy as np
 import pytest
 
 import ray
@@ -368,24 +367,6 @@ def test_nested_fork(setup_queue_actor):
     for i in range(num_forks):
         filtered_items = [item[1] for item in items if item[0] == i]
         assert filtered_items == list(range(num_items_per_fork))
-
-
-@pytest.mark.skip("Garbage collection for distributed actor handles not implemented.")
-def test_garbage_collection(setup_queue_actor):
-    queue = setup_queue_actor
-
-    @ray.remote
-    def fork(queue):
-        for i in range(10):
-            x = queue.enqueue.remote(0, i)
-            time.sleep(0.1)
-        return ray.get(x)
-
-    x = fork.remote(queue)
-    ray.get(queue.read.remote())
-    del queue
-
-    print(ray.get(x))
 
 
 def test_calling_put_on_actor_handle(ray_start_regular):

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -1067,7 +1067,7 @@ def test_get_actor_after_killed(shutdown_only):
         def ready(self):
             return True
 
-    actor = A.options(name="actor", namespace="namespace", lifetime="detached").remote()
+    actor = A.options(name="actor", namespace="namespace").remote()
     ray.kill(actor)
     with pytest.raises(ValueError):
         ray.get_actor("actor", namespace="namespace")
@@ -1075,7 +1075,6 @@ def test_get_actor_after_killed(shutdown_only):
     actor = A.options(
         name="actor_2",
         namespace="namespace",
-        lifetime="detached",
         max_restarts=1,
         max_task_retries=-1,
     ).remote()
@@ -1099,7 +1098,7 @@ def test_get_actor_from_concurrent_tasks(shutdown_only):
                 actor = ray.get_actor(actor_name)
             except Exception:
                 print("Get failed, trying to create")
-                actor = Actor.options(name=actor_name, lifetime="detached").remote()
+                actor = Actor.options(name=actor_name).remote()
         except Exception:
             # Multiple tasks may have reached the creation block above.
             # Only one will succeed and the others will get an error, in which case
@@ -1145,9 +1144,7 @@ def test_get_or_create_actor_from_multiple_threads(shutdown_only):
     def _create_or_get_actor(*args):
         a = Actor.options(
             name="test_actor",
-            namespace="test_namespace",
             get_if_exists=True,
-            lifetime="detached",
         ).remote()
 
         return ray.get(a.get_actor_id.remote())

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -1,9 +1,6 @@
 import os
-import random
 import sys
-import threading
 import time
-import traceback
 from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -181,7 +181,6 @@ def test_actor_init_fails(ray_start_cluster_head):
     @ray.remote(max_restarts=1, max_task_retries=-1)
     class Actor:
         def __init__(self):
-            print("inc!")
             ray.get(counter.inc.remote())
 
     # Create many actors and wait for one of them to start initializing.


### PR DESCRIPTION
`test_create_actor_race_condition` previously took ~55s locally, now down to ~5s.

- Removed outer loop running the test 50 times (excessive).
- Added assertion that only one actor is actually created. Previously there could still be a race to create the actor.
- Converted to use concurrent futures thread pool.

`test_get_actor_race_condition` previously took ~10s locally, now down to ~4s.

- Removed outer loop running the test 50 times (excessive).
- Added assertion that only one actor is actually created. Previously there could still be a race to create the actor.

Reduced the number of actors on a few other tests and deleted two skipped/useless ones.

Test passed in 237s on this [premerge](https://buildkite.com/ray-project/premerge/builds/41870#0197600a-f4bf-414c-838d-eb5cb05c821d/185-1140).
Test passed in 350s on latest [postmerge](https://buildkite.com/ray-project/postmerge/builds/10777#01975fbd-c04e-4cf5-8efe-2aa2d7c5c3b3/177-1163).