### PR TITLE
Fix uv tests on macos x86_64

### DIFF
--- a/python/ray/tests/test_runtime_env_uv_run.py
+++ b/python/ray/tests/test_runtime_env_uv_run.py
@@ -20,7 +20,7 @@ from ray._private.test_utils import (
 
 @pytest.fixture(scope="function")
 def with_uv():
-    arch = "aarch64" if platform.machine() in ["aarch64", "arm64"] else "i686"
+    arch = "aarch64" if platform.machine() in ["aarch64", "arm64"] else "x86_64"
     system = "unknown-linux-gnu" if platform.system() == "Linux" else "apple-darwin"
     name = f"uv-{arch}-{system}"
     url = f"https://github.com/astral-sh/uv/releases/download/0.5.27/{name}.tar.gz"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This fixes the architecture when downloading uv. Before we used i686 which is only available on linux (and even on linux it is actually not the right architecture, x86_64 is better). Because i686 is not available on mac os, it gave a 404 error when downloading uv.

Slightly more incremental than https://github.com/ray-project/ray/pull/53685

Fixes https://github.com/ray-project/ray/issues/53650

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
