### PR TITLE
[core][telemetry] move the open telemetry tests into a pytest module

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -113,17 +113,6 @@ steps:
         --test-env=TEST_EXTERNAL_REDIS=1
         --except-tags debug_tests,asan_tests,post_wheel_build,ha_integration,mem_pressure,tmpfs,container,manual,multi_gpu,spark_on_ray,ray_client,dask
 
-  - label: ":ray: core: open telemetry tests"
-    tags:
-      - python
-      - dashboard
-    instance_type: medium
-    commands:
-      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests:test_metrics_agent core
-        --install-mask all-ray-libraries
-        --test-env=RAY_experimental_enable_open_telemetry_on_agent=1
-        --test-env=RAY_experimental_enable_open_telemetry_on_core=1
-
   - label: ":ray: core: memory pressure tests"
     tags:
       - python

--- a/python/ray/tests/BUILD
+++ b/python/ray/tests/BUILD
@@ -80,6 +80,27 @@ py_test_module_list(
 
 py_test_module_list(
     size = "medium",
+    env = {
+        "RAY_experimental_enable_open_telemetry_on_agent": "1",
+        "RAY_experimental_enable_open_telemetry_on_core": "1",
+    },
+    files = [
+        "test_metrics_agent.py",
+    ],
+    name_suffix = "_open_telemetry",
+    tags = [
+        "exclusive",
+        "medium_size_python_tests_a_to_j",
+        "team:core",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test_module_list(
+    size = "medium",
     files = [
         "test_global_gc.py",
         "test_job.py",

--- a/src/ray/stats/metric_exporter_grpc_test.cc
+++ b/src/ray/stats/metric_exporter_grpc_test.cc
@@ -12,6 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifdef _WIN32
+// Prevent inclusion of winsock.h
+#define WIN32_LEAN_AND_MEAN
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#endif
+
 #include <chrono>
 #include <iostream>
 #include <vector>


### PR DESCRIPTION
Move the open telemetry test from a buildkite job to a pytest module. This will allow the tests to also run in windows + macos environment.

Test:
- CI