### PR TITLE
[data] Refactor interface for actor_pool_map_operator

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1145,7 +1145,6 @@ python/ray/data/_internal/execution/legacy_compat.py
 --------------------
 python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
     DOC103: Method `ActorPoolMapOperator.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [data_context: DataContext, map_transformer: MapTransformer]. Arguments in the docstring but not in the function signature: [init_fn: , transform_fn: ].
-    DOC201: Method `_ActorPool.pick_actor` does not have a return section in docstring
 --------------------
 python/ray/data/_internal/execution/operators/base_physical_operator.py
     DOC101: Method `OneToOneOperator.__init__`: Docstring contains fewer arguments than in function signature.

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -1,7 +1,9 @@
+import abc
 import logging
 import time
 import uuid
 import warnings
+from abc import abstractmethod
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
@@ -11,6 +13,7 @@ from ray.core.generated import gcs_pb2
 from ray.data._internal.compute import ActorPoolStrategy
 from ray.data._internal.execution.autoscaler import AutoscalingActorPool
 from ray.data._internal.execution.bundle_queue import create_bundle_queue
+from ray.data._internal.execution.bundle_queue.bundle_queue import BundleQueue
 from ray.data._internal.execution.interfaces import (
     ExecutionOptions,
     ExecutionResources,
@@ -134,12 +137,21 @@ class ActorPoolMapOperator(MapOperator):
             per_actor_resource_usage,
             self.data_context._enable_actor_pool_on_exit_hook,
         )
+        self._actor_task_selector = self._create_task_selector(self._actor_pool)
         # A queue of bundles awaiting dispatch to actors.
         self._bundle_queue = create_bundle_queue()
         # Cached actor class.
         self._cls = None
         # Whether no more submittable bundles will be added.
         self._inputs_done = False
+
+        # Locality metrics
+        self._locality_hits = 0
+        self._locality_misses = 0
+
+    @staticmethod
+    def _create_task_selector(actor_pool: "_ActorPool") -> "_ActorTaskSelector":
+        return _ActorTaskSelectorImpl(actor_pool)
 
     def internal_queue_size(self) -> int:
         # NOTE: Internal queue size for ``ActorPoolMapOperator`` includes both
@@ -242,19 +254,14 @@ class ActorPoolMapOperator(MapOperator):
             * a task finishes,
             * a new worker has been created.
         """
-        while self._bundle_queue:
-            # Pick an actor from the pool.
-            if self._actor_locality_enabled:
-                actor = self._actor_pool.pick_actor(self._bundle_queue.peek())
-            else:
-                actor = self._actor_pool.pick_actor()
-            if actor is None:
-                # No actors available for executing the next task.
-                break
+        for bundle, actor in self._actor_task_selector.select_actors(
+            self._bundle_queue, self._actor_locality_enabled
+        ):
             # Submit the map task.
-            bundle = self._bundle_queue.pop()
             self._metrics.on_input_dequeued(bundle)
             input_blocks = [block for block, _ in bundle.blocks]
+            self._actor_pool.on_task_submitted(actor)
+
             ctx = TaskContext(
                 task_idx=self._next_data_task_idx,
                 op_name=self.name,
@@ -273,7 +280,7 @@ class ActorPoolMapOperator(MapOperator):
 
             def _task_done_callback(actor_to_return):
                 # Return the actor that was running the task to the pool.
-                self._actor_pool.return_actor(actor_to_return)
+                self._actor_pool.on_task_completed(actor_to_return)
                 # Dipsatch more tasks.
                 self._dispatch_tasks()
 
@@ -282,6 +289,15 @@ class ActorPoolMapOperator(MapOperator):
             self._submit_data_task(
                 gen, bundle, partial(_task_done_callback, actor_to_return=actor)
             )
+
+            # Update locality metrics
+            if (
+                self._actor_pool.running_actors()[actor].actor_location
+                in bundle.get_preferred_object_locations()
+            ):
+                self._locality_hits += 1
+            else:
+                self._locality_misses += 1
 
     def _refresh_actor_cls(self):
         """When `self._ray_remote_args_fn` is specified, this method should
@@ -330,8 +346,8 @@ class ActorPoolMapOperator(MapOperator):
     def progress_str(self) -> str:
         if self._actor_locality_enabled:
             return locality_string(
-                self._actor_pool._locality_hits,
-                self._actor_pool._locality_misses,
+                self._locality_hits,
+                self._locality_misses,
             )
         return "[locality off]"
 
@@ -389,8 +405,8 @@ class ActorPoolMapOperator(MapOperator):
     def _extra_metrics(self) -> Dict[str, Any]:
         res = {}
         if self._actor_locality_enabled:
-            res["locality_hits"] = self._actor_pool._locality_hits
-            res["locality_misses"] = self._actor_pool._locality_misses
+            res["locality_hits"] = self._locality_hits
+            res["locality_misses"] = self._locality_misses
         res["pending_actors"] = self._actor_pool.num_pending_actors()
         res["restarting_actors"] = self._actor_pool.num_restarting_actors()
         return res
@@ -504,6 +520,128 @@ class _ActorState:
     is_restarting: bool
 
 
+class _ActorTaskSelector(abc.ABC):
+    def __init__(self, actor_pool: "_ActorPool"):
+        """Initialize the actor task selector.
+
+        Args:
+            actor_pool: The actor pool to select tasks from.
+        """
+        self._actor_pool = actor_pool
+
+    @abstractmethod
+    def select_actors(
+        self, input_queue: BundleQueue, actor_locality_enabled: bool
+    ) -> Iterator[Tuple[RefBundle, ActorHandle]]:
+        """Select actors for bundles in the input queue.
+
+        Args:
+            input_queue: The input queue to select actors for.
+            actor_locality_enabled: Whether actor locality is enabled.
+
+        Returns:
+            Iterator of tuples of the bundle and the selected actor for that bundle.
+            Iteration stops when there are no more bundles to be selected in the input queue
+        """
+        pass
+
+
+class _ActorTaskSelectorImpl(_ActorTaskSelector):
+    def __init__(self, actor_pool: "_ActorPool"):
+        super().__init__(actor_pool)
+
+    def select_actors(
+        self, input_queue: BundleQueue, actor_locality_enabled: bool
+    ) -> Iterator[Tuple[RefBundle, ActorHandle]]:
+        """Picks actors for task submission based on busyness and locality."""
+        if not self._actor_pool.running_actors():
+            # Actor pool is empty or all actors are still pending.
+            return
+
+        while input_queue:
+            # Filter out actors that are invalid, i.e. actors with number of tasks in
+            # flight >= _max_tasks_in_flight or actor_state is not ALIVE.
+            bundle = input_queue.peek()
+            valid_actors = [
+                actor
+                for actor in self._actor_pool.running_actors()
+                if self._actor_pool.running_actors()[actor].num_tasks_in_flight
+                < self._actor_pool.max_tasks_in_flight_per_actor()
+                and not self._actor_pool.running_actors()[actor].is_restarting
+            ]
+
+            if not valid_actors:
+                # All actors are at capacity or actor state is not ALIVE.
+                return
+
+            # Rank all valid actors
+            ranks = self._rank_actors(
+                valid_actors, bundle if actor_locality_enabled else None
+            )
+
+            assert len(ranks) == len(
+                valid_actors
+            ), f"{len(ranks)} != {len(valid_actors)}"
+
+            # Pick the actor with the highest rank (lower value, higher rank)
+            target_actor_idx = min(range(len(valid_actors)), key=lambda idx: ranks[idx])
+
+            target_actor = valid_actors[target_actor_idx]
+
+            # We remove the bundle and yield the actor to the operator. We do not use pop()
+            # in case the queue has changed the order of the bundles.
+            input_queue.remove(bundle)
+            yield bundle, target_actor
+
+    def _rank_actors(
+        self,
+        actors: List[ActorHandle],
+        bundle: Optional[RefBundle],
+    ) -> List[Tuple[int, int]]:
+        """Return ranks for each actor based on node affinity with the blocks in the provided
+        bundle and current Actor's load.
+
+        The rank for each actor is a tuple of
+
+            1. Locality rank: a rank of a node Actor is scheduled on determined based on
+            the ranking of preferred locations for provided ``RefBundle`` (defined by
+            ``RefBundle.get_preferred_locations``). Lower is better.
+            2. Number of tasks currently executed by Actor. Lower is better.
+
+        Args:
+            actors: List of actors to rank
+            bundle: Optional bundle whose locality preferences should be considered
+
+        Returns:
+            List of (locality_rank, num_tasks) tuples, one per input actor
+        """
+        locs_priorities = (
+            {
+                # NOTE: We're negating total bytes to maintain an invariant
+                #       of the rank used -- lower value corresponding to a higher rank
+                node_id: -total_bytes
+                for node_id, total_bytes in bundle.get_preferred_object_locations().items()
+            }
+            if bundle is not None
+            else {}
+        )
+
+        ranks = [
+            (
+                # Priority/rank of the location (based on the object size).
+                # Defaults to int32 max value (ie no rank)
+                locs_priorities.get(
+                    self._actor_pool.running_actors()[actor].actor_location, INT32_MAX
+                ),
+                # Number of tasks currently in flight at the given actor
+                self._actor_pool.running_actors()[actor].num_tasks_in_flight,
+            )
+            for actor in actors
+        ]
+
+        return ranks
+
+
 class _ActorPool(AutoscalingActorPool):
     """A pool of actors for map task execution.
 
@@ -519,7 +657,7 @@ class _ActorPool(AutoscalingActorPool):
     def __init__(
         self,
         compute_strategy: ActorPoolStrategy,
-        create_actor_fn: Callable[[Dict[str, str]], Tuple[ActorHandle, ObjectRef[Any]]],
+        create_actor_fn: "Callable[[Dict[str, str]], Tuple[ActorHandle, ObjectRef[Any]]]",
         per_actor_resource_usage: ExecutionResources,
         _enable_actor_pool_on_exit_hook: bool = False,
     ):
@@ -556,10 +694,11 @@ class _ActorPool(AutoscalingActorPool):
         self._pending_actors: Dict[ObjectRef, ray.actor.ActorHandle] = {}
         # Map from actor handle to its logical ID.
         self._actor_to_logical_id: Dict[ray.actor.ActorHandle, str] = {}
-        # Track locality matching stats.
-        self._locality_hits: int = 0
-        self._locality_misses: int = 0
         self._enable_actor_pool_on_exit_hook = _enable_actor_pool_on_exit_hook
+        # Cached values for actor / task counts
+        self._num_restarting_actors: int = 0
+        self._num_active_actors: int = 0
+        self._total_num_tasks_in_flight: int = 0
 
     # === Overriding methods of AutoscalingActorPool ===
 
@@ -577,23 +716,15 @@ class _ActorPool(AutoscalingActorPool):
 
     def num_restarting_actors(self) -> int:
         """Restarting actors are all the running actors not in ALIVE state."""
-        return sum(
-            actor_state.is_restarting for actor_state in self._running_actors.values()
-        )
+        return self._num_restarting_actors
 
     def num_active_actors(self) -> int:
         """Active actors are all the running actors with inflight tasks."""
-        return sum(
-            1 if actor_state.num_tasks_in_flight > 0 else 0
-            for actor_state in self._running_actors.values()
-        )
+        return self._num_active_actors
 
     def num_alive_actors(self) -> int:
         """Alive actors are all the running actors in ALIVE state."""
-        return sum(
-            not actor_state.is_restarting
-            for actor_state in self._running_actors.values()
-        )
+        return len(self._running_actors) - self._num_restarting_actors
 
     def num_pending_actors(self) -> int:
         return len(self._pending_actors)
@@ -602,10 +733,7 @@ class _ActorPool(AutoscalingActorPool):
         return self._max_tasks_in_flight
 
     def current_in_flight_tasks(self) -> int:
-        return sum(
-            actor_state.num_tasks_in_flight
-            for actor_state in self._running_actors.values()
-        )
+        return self._total_num_tasks_in_flight
 
     def can_scale_down(self):
         """Returns whether Actor Pool is able to scale down.
@@ -664,9 +792,18 @@ class _ActorPool(AutoscalingActorPool):
 
     # === End of overriding methods of AutoscalingActorPool ===
 
+    def running_actors(self) -> Dict[ray.actor.ActorHandle, _ActorState]:
+        return self._running_actors
+
+    def on_task_submitted(self, actor: ray.actor.ActorHandle):
+        self._running_actors[actor].num_tasks_in_flight += 1
+        self._total_num_tasks_in_flight += 1
+        if self._running_actors[actor].num_tasks_in_flight == 1:
+            self._num_active_actors += 1
+
     def update_running_actor_state(
         self, actor: ray.actor.ActorHandle, is_restarting: bool
-    ):
+    ) -> None:
         """Update running actor state.
 
         Args:
@@ -674,7 +811,14 @@ class _ActorPool(AutoscalingActorPool):
             is_restarting: Whether running actor is restarting or alive.
         """
         assert actor in self._running_actors
+        if self._running_actors[actor].is_restarting == is_restarting:
+            return
+
         self._running_actors[actor].is_restarting = is_restarting
+        if is_restarting:
+            self._num_restarting_actors += 1
+        else:
+            self._num_restarting_actors -= 1
 
     def add_pending_actor(self, actor: ray.actor.ActorHandle, ready_ref: ray.ObjectRef):
         """Adds a pending actor to the pool.
@@ -710,108 +854,14 @@ class _ActorPool(AutoscalingActorPool):
         )
         return True
 
-    def pick_actor(
-        self, bundle: Optional[RefBundle] = None
-    ) -> Optional[ray.actor.ActorHandle]:
-        """Picks an actor for task submission based on busyness and locality.
-
-        None will be returned if all actors are either at capacity (according to
-        max_tasks_in_flight) or are still pending.
-
-        Args:
-            bundle: Try to pick an actor that is local for this bundle.
-        """
-        if not self._running_actors:
-            # Actor pool is empty or all actors are still pending.
-            return None
-
-        # Filter out actors that are invalid, i.e. actors with number of tasks in
-        # flight >= _max_tasks_in_flight or actor_state is not ALIVE.
-        valid_actors = [
-            actor
-            for actor in self._running_actors
-            if self._running_actors[actor].num_tasks_in_flight
-            < self._max_tasks_in_flight
-            and not self._running_actors[actor].is_restarting
-        ]
-
-        if not valid_actors:
-            # All actors are at capacity or actor state is not ALIVE.
-            return None
-
-        # Rank all valid actors
-        ranks = self._rank_actors(valid_actors, bundle)
-
-        assert len(ranks) == len(valid_actors), f"{len(ranks)} != {len(valid_actors)}"
-
-        # Pick the actor with the highest rank (lower value, higher rank)
-        target_actor_idx = min(range(len(valid_actors)), key=lambda idx: ranks[idx])
-
-        target_actor = valid_actors[target_actor_idx]
-        locality_rank, _ = ranks[target_actor_idx]
-
-        if bundle and locality_rank != INT32_MAX:
-            self._locality_hits += 1
-        else:
-            self._locality_misses += 1
-
-        self._running_actors[target_actor].num_tasks_in_flight += 1
-
-        return target_actor
-
-    def _rank_actors(
-        self,
-        actors: List[ActorHandle],
-        bundle: Optional[RefBundle],
-    ) -> List[Tuple[int, int]]:
-        """Return ranks for each actor based on node affinity with the blocks in the provided
-        bundle and current Actor's load.
-
-        The rank for each actor is a tuple of
-
-            1. Locality rank: a rank of a node Actor is scheduled on determined based on
-            the ranking of preferred locations for provided ``RefBundle`` (defined by
-            ``RefBundle.get_preferred_locations``). Lower is better.
-            2. Number of tasks currently executed by Actor. Lower is better.
-
-        Args:
-            actors: List of actors to rank
-            bundle: Optional bundle whose locality preferences should be considered
-
-        Returns:
-            List of (locality_rank, num_tasks) tuples, one per input actor
-        """
-        locs_priorities = (
-            {
-                # NOTE: We're negating total bytes to maintain an invariant
-                #       of the rank used -- lower value corresponding to a higher rank
-                node_id: -total_bytes
-                for node_id, total_bytes in bundle.get_preferred_object_locations().items()
-            }
-            if bundle is not None
-            else {}
-        )
-
-        ranks = [
-            (
-                # Priority/rank of the location (based on the object size).
-                # Defaults to int32 max value (ie no rank)
-                locs_priorities.get(
-                    self._running_actors[actor].actor_location, INT32_MAX
-                ),
-                # Number of tasks currently in flight at the given actor
-                self._running_actors[actor].num_tasks_in_flight,
-            )
-            for actor in actors
-        ]
-
-        return ranks
-
-    def return_actor(self, actor: ray.actor.ActorHandle):
-        """Returns the provided actor to the pool."""
+    def on_task_completed(self, actor: ray.actor.ActorHandle):
+        """Called when a task completes. Returns the provided actor to the pool."""
         assert actor in self._running_actors
         assert self._running_actors[actor].num_tasks_in_flight > 0
         self._running_actors[actor].num_tasks_in_flight -= 1
+        self._total_num_tasks_in_flight -= 1
+        if not self._running_actors[actor].num_tasks_in_flight:
+            self._num_active_actors -= 1
 
     def get_pending_actor_refs(self) -> List[ray.ObjectRef]:
         return list(self._pending_actors.keys())
@@ -837,10 +887,7 @@ class _ActorPool(AutoscalingActorPool):
 
     def num_idle_actors(self) -> int:
         """Return the number of idle actors in the pool."""
-        return sum(
-            1 if running_actor.num_tasks_in_flight == 0 else 0
-            for running_actor in self._running_actors.values()
-        )
+        return len(self._running_actors) - self._num_active_actors
 
     def _remove_inactive_actor(self) -> bool:
         """Kills a single pending or idle actor, if any actors are pending/idle.
@@ -928,6 +975,20 @@ class _ActorPool(AutoscalingActorPool):
         # object's lineage reconstruction.
         if actor not in self._running_actors:
             return None
+
+        # Update cached statistics before removing the actor
+        actor_state = self._running_actors[actor]
+
+        # Update total tasks in flight
+        self._total_num_tasks_in_flight -= actor_state.num_tasks_in_flight
+
+        # Update active actors count
+        if actor_state.num_tasks_in_flight > 0:
+            self._num_active_actors -= 1
+
+        # Update restarting actors count
+        if actor_state.is_restarting:
+            self._num_restarting_actors -= 1
 
         if self._enable_actor_pool_on_exit_hook:
             # Call `on_exit` to trigger `UDF.__del__` which may perform

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -5,7 +5,7 @@ import threading
 import time
 import unittest
 from typing import Any, Dict, Optional, Tuple
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from freezegun import freeze_time
@@ -14,11 +14,14 @@ import ray
 from ray._common.test_utils import wait_for_condition
 from ray.actor import ActorHandle
 from ray.data._internal.compute import ActorPoolStrategy
+from ray.data._internal.execution.bundle_queue import FIFOBundleQueue
 from ray.data._internal.execution.interfaces import ExecutionResources
 from ray.data._internal.execution.interfaces.physical_operator import _ActorPoolInfo
+from ray.data._internal.execution.interfaces.ref_bundle import RefBundle
 from ray.data._internal.execution.operators.actor_pool_map_operator import (
     ActorPoolMapOperator,
     _ActorPool,
+    _ActorTaskSelector,
 )
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.util import make_ref_bundles
@@ -48,6 +51,31 @@ class TestActorPool(unittest.TestCase):
 
     def teardown_class(self):
         ray.shutdown()
+
+    def _create_task_selector(self, pool: _ActorPool) -> _ActorTaskSelector:
+        return ActorPoolMapOperator._create_task_selector(pool)
+
+    def _pick_actor(
+        self,
+        pool: _ActorPool,
+        bundle: Optional[RefBundle] = None,
+        actor_locality_enabled: bool = False,
+    ) -> ActorHandle:
+        if bundle is None:
+            bundles = make_ref_bundles([[0]])
+        else:
+            bundles = [bundle]
+        queue = FIFOBundleQueue()
+        for bundle in bundles:
+            queue.add(bundle)
+        actor_task_selector = self._create_task_selector(pool)
+        it = actor_task_selector.select_actors(queue, actor_locality_enabled)
+        try:
+            actor = next(it)[1]
+            pool.on_task_submitted(actor)
+            return actor
+        except StopIteration:
+            return None
 
     def _create_actor_fn(
         self, labels: Dict[str, Any]
@@ -140,9 +168,10 @@ class TestActorPool(unittest.TestCase):
         # Test that pending actor is added in the correct state.
         pool = self._create_actor_pool()
         _, ready_ref = self._add_pending_actor(pool)
-        # Check that the pending actor is not pickable.
 
-        assert pool.pick_actor() is None
+        # Check that the pending actor is not pickable.
+        assert self._pick_actor(pool) is None
+
         # Check that the per-state pool sizes are as expected.
         assert pool.current_size() == 1
         assert pool.num_pending_actors() == 1
@@ -158,7 +187,7 @@ class TestActorPool(unittest.TestCase):
         pool = self._create_actor_pool()
         actor = self._add_ready_actor(pool)
         # Check that the actor is pickable.
-        picked_actor = pool.pick_actor()
+        picked_actor = self._pick_actor(pool)
         assert picked_actor == actor
         # Check that the per-state pool sizes are as expected.
         assert pool.current_size() == 1
@@ -175,7 +204,7 @@ class TestActorPool(unittest.TestCase):
 
         # Mark the actor as restarting and test pick_actor fails
         pool.update_running_actor_state(actor, True)
-        assert pool.pick_actor() is None
+        assert self._pick_actor(pool) is None
         assert pool.current_size() == 1
         assert pool.num_pending_actors() == 0
         assert pool.num_running_actors() == 1
@@ -190,7 +219,7 @@ class TestActorPool(unittest.TestCase):
 
         # Mark the actor as alive and test pick_actor succeeds
         pool.update_running_actor_state(actor, False)
-        picked_actor = pool.pick_actor()
+        picked_actor = self._pick_actor(pool)
         assert picked_actor == actor
         assert pool.current_size() == 1
         assert pool.num_pending_actors() == 0
@@ -205,7 +234,7 @@ class TestActorPool(unittest.TestCase):
         )
 
         # Return the actor
-        pool.return_actor(picked_actor)
+        pool.on_task_completed(picked_actor)
         assert pool.current_size() == 1
         assert pool.num_pending_actors() == 0
         assert pool.num_running_actors() == 1
@@ -223,7 +252,7 @@ class TestActorPool(unittest.TestCase):
         pool = self._create_actor_pool(max_tasks_in_flight=999)
         actor = self._add_ready_actor(pool)
         for _ in range(10):
-            picked_actor = pool.pick_actor()
+            picked_actor = self._pick_actor(pool)
             assert picked_actor == actor
 
     def test_return_actor(self):
@@ -231,14 +260,15 @@ class TestActorPool(unittest.TestCase):
         pool = self._create_actor_pool(max_tasks_in_flight=999)
         self._add_ready_actor(pool)
         for _ in range(10):
-            picked_actor = pool.pick_actor()
+            picked_actor = self._pick_actor(pool)
         # Return the actor as many times as it was picked.
         for _ in range(10):
-            pool.return_actor(picked_actor)
+            pool.on_task_completed(picked_actor)
+
         # Returning the actor more times than it has been picked should raise an
         # AssertionError.
         with pytest.raises(AssertionError):
-            pool.return_actor(picked_actor)
+            pool.on_task_completed(picked_actor)
         # Check that the per-state pool sizes are as expected.
         assert pool.current_size() == 1
         assert pool.num_pending_actors() == 0
@@ -252,23 +282,23 @@ class TestActorPool(unittest.TestCase):
         pool = self._create_actor_pool(max_tasks_in_flight=2)
         actor = self._add_ready_actor(pool)
         assert pool.num_free_task_slots() == 2
-        assert pool.pick_actor() == actor
+        assert self._pick_actor(pool) == actor
         assert pool.num_free_task_slots() == 1
-        assert pool.pick_actor() == actor
+        assert self._pick_actor(pool) == actor
         assert pool.num_free_task_slots() == 0
         # Check that the 3rd pick doesn't return the actor.
-        assert pool.pick_actor() is None
+        assert self._pick_actor(pool) is None
 
     def test_pick_ordering_lone_idle(self):
         # Test that a lone idle actor is the one that's picked.
         pool = self._create_actor_pool()
         self._add_ready_actor(pool)
         # Ensure that actor has been picked once.
-        pool.pick_actor()
+        self._pick_actor(pool)
         # Add a new, idle actor.
         actor2 = self._add_ready_actor(pool)
         # Check that picked actor is the idle newly added actor.
-        picked_actor = pool.pick_actor()
+        picked_actor = self._pick_actor(pool)
         assert picked_actor == actor2
 
     def test_pick_ordering_full_order(self):
@@ -277,7 +307,7 @@ class TestActorPool(unittest.TestCase):
         # Add 4 actors to the pool.
         actors = [self._add_ready_actor(pool) for _ in range(4)]
         # Pick 4 actors.
-        picked_actors = [pool.pick_actor() for _ in range(4)]
+        picked_actors = [self._pick_actor(pool) for _ in range(4)]
         # Check that the 4 distinct actors that were added to the pool were all
         # returned.
         assert set(picked_actors) == set(actors)
@@ -293,7 +323,7 @@ class TestActorPool(unittest.TestCase):
         pool = self._create_actor_pool(max_tasks_in_flight=2)
         # Add 4 actors to the pool.
         actors = [self._add_ready_actor(pool) for _ in range(4)]
-        picked_actors = [pool.pick_actor() for _ in range(8)]
+        picked_actors = [self._pick_actor(pool) for _ in range(8)]
         pick_counts = collections.Counter(picked_actors)
         # Check that picks were evenly distributed over the pool.
         assert len(pick_counts) == 4
@@ -301,20 +331,21 @@ class TestActorPool(unittest.TestCase):
             assert actor in actors
             assert count == 2
         # Check that the next pick doesn't return an actor.
-        assert pool.pick_actor() is None
+        assert self._pick_actor(pool) is None
 
     def test_pick_ordering_with_returns(self):
         # Test that pick ordering works with returns.
         pool = self._create_actor_pool()
         actor1 = self._add_ready_actor(pool)
         actor2 = self._add_ready_actor(pool)
-        picked_actors = [pool.pick_actor() for _ in range(2)]
+        picked_actors = [self._pick_actor(pool) for _ in range(2)]
         # Double-check that both actors were picked.
         assert set(picked_actors) == {actor1, actor2}
         # Return actor 2, implying that it's now idle.
-        pool.return_actor(actor2)
+        pool.on_task_completed(actor2)
         # Check that actor 2 is the next actor that's picked.
-        assert pool.pick_actor() == actor2
+        picked_actor = self._pick_actor(pool)
+        assert picked_actor == actor2
 
     def test_kill_inactive_pending_actor(self):
         # Test that a pending actor is killed on the kill_inactive_actor() call.
@@ -347,7 +378,7 @@ class TestActorPool(unittest.TestCase):
         # Check that an actor was killed.
         assert killed
         # Check that actor is not in pool.
-        assert pool.pick_actor() is None
+        assert self._pick_actor(pool) is None
         # Check that actor is dead.
         actor_id = actor._actor_id.hex()
         del actor
@@ -365,13 +396,15 @@ class TestActorPool(unittest.TestCase):
         pool = self._create_actor_pool()
         actor = self._add_ready_actor(pool)
         # Pick actor (and double-check that the actor was picked).
-        assert pool.pick_actor() == actor
+        picked_actor = self._pick_actor(pool)
+        assert picked_actor == actor
         # Kill inactive actor.
         killed = pool._remove_inactive_actor()
         # Check that an actor was NOT killed.
         assert not killed
         # Check that the active actor is still in the pool.
-        assert pool.pick_actor() == actor
+        picked_actor = self._pick_actor(pool)
+        assert picked_actor == actor
 
     def test_kill_inactive_pending_over_idle(self):
         # Test that a killing pending actors is prioritized over killing idle actors on
@@ -386,8 +419,9 @@ class TestActorPool(unittest.TestCase):
         # Check that an actor was killed.
         assert killed
         # Check that the idle actor is still in the pool.
-        assert pool.pick_actor() == idle_actor
-        pool.return_actor(idle_actor)
+        picked_actor = self._pick_actor(pool)
+        assert picked_actor == idle_actor
+        pool.on_task_completed(idle_actor)
         # Check that the pending actor is not in pool.
         assert pool.get_pending_actor_refs() == []
         # Check that actor is dead.
@@ -407,12 +441,12 @@ class TestActorPool(unittest.TestCase):
         pool = self._create_actor_pool()
         active_actor = self._add_ready_actor(pool)
         # Pick actor (and double-check that the actor was picked).
-        assert pool.pick_actor() == active_actor
+        assert self._pick_actor(pool) == active_actor
         idle_actor = self._add_ready_actor(pool)
         # Kill all actors, including active actors.
         pool.shutdown()
         # Check that the pool is empty.
-        assert pool.pick_actor() is None
+        assert self._pick_actor(pool) is None
 
         # Check that both actors are dead
         actor_id = active_actor._actor_id.hex()
@@ -436,92 +470,113 @@ class TestActorPool(unittest.TestCase):
         # Setup bundle mocks.
         bundles = make_ref_bundles([[0] for _ in range(5)])
 
-        def _rank_actors(bundle):
-            actors = [actor1, actor2]
-            ranks = pool._rank_actors(actors, bundle)
+        # Patch all bundles to return mocked preferred locations
+        def _get_preferred_locs():
+            # Node1 is higher in priority
+            return {"node1": 1024, "node2": 512}
 
-            assert len(ranks) == len(actors)
-
-            return list(zip(actors, ranks))
+        for b in bundles:
+            # monkeypatch the get_preferred_object_locations method
+            b.get_preferred_object_locations = _get_preferred_locs
 
         # Setup an actor on each node.
         actor1 = self._add_ready_actor(pool, node_id="node1")
         actor2 = self._add_ready_actor(pool, node_id="node2")
 
-        # Node1 is higher in priority
-        def _get_preferred_locs():
-            return {"node1": 1024, "node2": 512}
+        # Create the mock bundle queue
+        bundle_queue = FIFOBundleQueue()
+        for bundle in bundles:
+            bundle_queue.add(bundle)
+
+        # Create the mock task actor selector iterator
+        task_selector = self._create_task_selector(pool)
+        it = task_selector.select_actors(bundle_queue, actor_locality_enabled=True)
 
         # Actors on node1 should be preferred
-        with patch.object(
-            bundles[0], "get_preferred_object_locations", _get_preferred_locs
-        ):
-            ranked_actors = _rank_actors(bundles[0])
-            assert ranked_actors == [(actor1, (-1024, 0)), (actor2, (-512, 0))]
-
-            res1 = pool.pick_actor(bundles[0])
-            assert res1 == actor1
+        res1 = next(it)[1]
+        pool.on_task_submitted(res1)
+        assert res1 == actor1
 
         # Actors on node1 should be preferred still
-        with patch.object(
-            bundles[1], "get_preferred_object_locations", _get_preferred_locs
-        ):
-            ranked_actors = _rank_actors(bundles[1])
-            assert ranked_actors == [(actor1, (-1024, 1)), (actor2, (-512, 0))]
-
-            res2 = pool.pick_actor(bundles[1])
-            assert res2 == actor1
+        res2 = next(it)[1]
+        pool.on_task_submitted(res2)
+        assert res2 == actor1
 
         # Fallback to remote actors
-        with patch.object(
-            bundles[2], "get_preferred_object_locations", _get_preferred_locs
-        ):
-            ranked_actors = _rank_actors(bundles[2])
-            # NOTE: Actor 1 is at max requests in-flight hence excluded
-            assert ranked_actors == [(actor1, (-1024, 2)), (actor2, (-512, 0))]
-
-            res3 = pool.pick_actor(bundles[2])
-            assert res3 == actor2
+        res3 = next(it)[1]
+        pool.on_task_submitted(res3)
+        assert res3 == actor2
 
         # NOTE: Actor 2 is selected (since Actor 1 is at capacity)
-        with patch.object(
-            bundles[3], "get_preferred_object_locations", _get_preferred_locs
-        ):
-            res4 = pool.pick_actor(bundles[3])
-            assert res4 == actor2
+        res4 = next(it)[1]
+        pool.on_task_submitted(res4)
+        assert res4 == actor2
 
         # NOTE: Actor 2 is at max requests in-flight, hence excluded
-        with patch.object(
-            bundles[4], "get_preferred_object_locations", _get_preferred_locs
-        ):
-            res5 = pool.pick_actor(bundles[4])
-            assert res5 is None
+        try:
+            res5 = next(it)[1]
+        except StopIteration:
+            res5 = None
+        assert res5 is None
 
     def test_locality_based_actor_ranking_no_locations(self):
         pool = self._create_actor_pool(max_tasks_in_flight=2)
 
-        # Setup bundle mocks.
+        # Setup bundle mocks
         bundles = make_ref_bundles([[0] for _ in range(10)])
-        # Also test unknown location handling.
-        pool._get_preferred_locations = lambda b: []
 
-        # Setup two actors on the same node.
+        # Patch all bundles to return mocked preferred locations
+        for b in bundles:
+            # monkeypatch the get_preferred_object_locations method
+            b.get_preferred_object_locations = lambda: {}
+
+        # Create the mock bundle queue
+        bundle_queue = FIFOBundleQueue()
+        for bundle in bundles:
+            bundle_queue.add(bundle)
+
+        # Add one actor to the pool
         actor1 = self._add_ready_actor(pool, node_id="node1")
-        actor2 = self._add_ready_actor(pool, node_id="node2")
 
-        # Fake actor 2 as more busy.
-        pool._running_actors[actor2].num_tasks_in_flight = 1
-        res1 = pool.pick_actor(bundles[0])
+        # Create the mock task actor selector iterator
+        task_selector = self._create_task_selector(pool)
+        it = task_selector.select_actors(bundle_queue, actor_locality_enabled=True)
+
+        # Select one actor to schedule it on actor1
+        res1 = next(it)[1]
+        pool.on_task_submitted(res1)
         assert res1 == actor1
 
-        # Fake actor 2 as more busy again.
-        pool._running_actors[actor2].num_tasks_in_flight = 2
-        res2 = pool.pick_actor(bundles[0])
-        assert res2 == actor1
+        # Add another actor to the pool
+        actor2 = self._add_ready_actor(pool, node_id="node2")
+
+        # Re-create the mock task actor selector iterator
+        task_selector = self._create_task_selector(pool)
+        it = task_selector.select_actors(bundle_queue, actor_locality_enabled=True)
+
+        # Select and actor, it should be scheudled on actor2
+        res2 = next(it)[1]
+        pool.on_task_submitted(res2)
+        assert res2 == actor2
+
+        # Select another actor, it could be either actor1 or actor2
+        res3 = next(it)[1]
+        pool.on_task_submitted(res3)
+
+        # Select another actor, it should be the other actor
+        res4 = next(it)[1]
+        pool.on_task_submitted(res4)
+        if res3 == actor1:
+            assert res4 == actor2
+        else:
+            assert res4 == actor1
 
         # Nothing left
-        res3 = pool.pick_actor(bundles[0])
-        assert res3 is None
+        try:
+            res5 = next(it)[1]
+        except StopIteration:
+            res5 = None
+        assert res5 is None
 
 
 def test_min_max_resource_requirements(restore_data_context):


### PR DESCRIPTION
## Why are these changes needed?
This PR cleans up the separation between the actor selection logic and the actor pool that the selectors are selected from.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
