### PR TITLE
[core] Fix race condition in raylet graceful shutdown

### DIFF
--- a/src/ray/raylet/agent_manager.cc
+++ b/src/ray/raylet/agent_manager.cc
@@ -94,13 +94,15 @@ void AgentManager::StartAgent() {
                "- The agent failed to start because of unexpected error or port "
                "conflict. Read the log `cat "
                "/tmp/ray/session_latest/logs/{dashboard_agent|runtime_env_agent}.log`. "
-               "\n"
+               "You can find the log file structure here "
+               "https://docs.ray.io/en/master/ray-observability/user-guides/"
+               "configure-logging.html#logging-directory-structure.\n"
                "- The agent is killed by the OS (e.g., out of memory).";
         rpc::NodeDeathInfo node_death_info;
         node_death_info.set_reason(rpc::NodeDeathInfo::UNEXPECTED_TERMINATION);
         node_death_info.set_reason_message(
             options_.agent_name +
-            " unexpectedly exited with exit code 0 and raylet fate-shares with it.");
+            " failed and raylet fate-shares with it.");
         shutdown_raylet_gracefully_(node_death_info);
         // If the process is not terminated within 10 seconds, forcefully kill raylet
         // itself.

--- a/src/ray/raylet/agent_manager.cc
+++ b/src/ray/raylet/agent_manager.cc
@@ -83,37 +83,29 @@ void AgentManager::StartAgent() {
                   << " exited, exit code " << exit_code << ".";
 
     if (fate_shares_.load()) {
-      if (exit_code == 0) {
-        RAY_LOG(ERROR)
-            << "The raylet exited immediately because one Ray agent failed with exit code 0"
-            << ", agent_name = " << options_.agent_name << ".\n"
-            << "The raylet fate shares with the agent. This can happen because\n"
-               "- The version of `grpcio` doesn't follow Ray's requirement. "
-               "Agent can segfault with the incorrect `grpcio` version. "
-               "Check the grpcio version `pip freeze | grep grpcio`.\n"
-               "- The agent failed to start because of unexpected error or port "
-               "conflict. Read the log `cat "
-               "/tmp/ray/session_latest/logs/{dashboard_agent|runtime_env_agent}.log`. "
-               "You can find the log file structure here "
-               "https://docs.ray.io/en/master/ray-observability/user-guides/"
-               "configure-logging.html#logging-directory-structure.\n"
-               "- The agent is killed by the OS (e.g., out of memory).";
-        rpc::NodeDeathInfo node_death_info;
-        node_death_info.set_reason(rpc::NodeDeathInfo::UNEXPECTED_TERMINATION);
-        node_death_info.set_reason_message(
-            options_.agent_name +
-            " failed and raylet fate-shares with it.");
-        shutdown_raylet_gracefully_(node_death_info);
-        // If the process is not terminated within 10 seconds, forcefully kill raylet
-        // itself.
-        delay_executor_([]() { QuickExit(); }, /*ms*/ 10000);
-      } else {
-        // Agent exited with a non-zero code, indicating a hard failure.
-        // The raylet should also exit ungracefully and immediately.
-        RAY_LOG(FATAL)
-            << "The raylet exited immediately because agent '" << options_.agent_name
-            << "' failed unexpectedly with non-zero exit code " << exit_code;
-      }
+      RAY_LOG(ERROR)
+          << "The raylet exited immediately because one Ray agent failed, agent_name = "
+          << options_.agent_name
+          << ".\n"
+             "The raylet fate shares with the agent. This can happen because\n"
+             "- The version of `grpcio` doesn't follow Ray's requirement. "
+             "Agent can segfault with the incorrect `grpcio` version. "
+             "Check the grpcio version `pip freeze | grep grpcio`.\n"
+             "- The agent failed to start because of unexpected error or port conflict. "
+             "Read the log `cat "
+             "/tmp/ray/session_latest/logs/{dashboard_agent|runtime_env_agent}.log`. "
+             "You can find the log file structure here "
+             "https://docs.ray.io/en/master/ray-observability/user-guides/"
+             "configure-logging.html#logging-directory-structure.\n"
+             "- The agent is killed by the OS (e.g., out of memory).";
+      rpc::NodeDeathInfo node_death_info;
+      node_death_info.set_reason(rpc::NodeDeathInfo::UNEXPECTED_TERMINATION);
+      node_death_info.set_reason_message(options_.agent_name +
+                                         " failed and raylet fate-shares with it.");
+      shutdown_raylet_gracefully_(node_death_info);
+      // If the process is not terminated within 10 seconds, forcefully kill raylet
+      // itself.
+      delay_executor_([]() { QuickExit(); }, /*ms*/ 10000);
     }
   });
 }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -3113,7 +3113,10 @@ std::unique_ptr<AgentManager> NodeManager::CreateDashboardAgentManager(
       [this](std::function<void()> task, uint32_t delay_ms) {
         return execute_after(io_service_, task, std::chrono::milliseconds(delay_ms));
       },
-      shutdown_raylet_gracefully_);
+      [this](const rpc::NodeDeathInfo &death_info) {
+        is_shutdown_request_received_ = true;
+        shutdown_raylet_gracefully_(death_info);
+      });
 }
 
 std::unique_ptr<AgentManager> NodeManager::CreateRuntimeEnvAgentManager(
@@ -3145,7 +3148,10 @@ std::unique_ptr<AgentManager> NodeManager::CreateRuntimeEnvAgentManager(
       [this](std::function<void()> task, uint32_t delay_ms) {
         return execute_after(io_service_, task, std::chrono::milliseconds(delay_ms));
       },
-      shutdown_raylet_gracefully_);
+      [this](const rpc::NodeDeathInfo &death_info) {
+        is_shutdown_request_received_ = true;
+        shutdown_raylet_gracefully_(death_info);
+      });
 }
 
 }  // namespace ray::raylet

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -834,7 +834,7 @@ void NodeManager::NodeRemoved(const NodeID &node_id) {
   RAY_LOG(DEBUG).WithField(node_id) << "[NodeRemoved] Received callback from node id ";
 
   if (node_id == self_node_id_) {
-    if (!is_shutdown_request_received_) {
+    if (!is_shutting_down_) {
       std::ostringstream error_message;
       error_message
           << "[Timeout] Exiting because this node manager has mistakenly been marked as "
@@ -2054,7 +2054,7 @@ void NodeManager::HandleShutdownRaylet(rpc::ShutdownRayletRequest request,
   if (!request.graceful()) {
     std::_Exit(EXIT_SUCCESS);
   }
-  if (is_shutdown_request_received_) {
+  if (is_shutting_down_) {
     RAY_LOG(INFO) << "Node already has received the shutdown request. The shutdown "
                      "request RPC is ignored.";
     return;
@@ -2069,7 +2069,7 @@ void NodeManager::HandleShutdownRaylet(rpc::ShutdownRayletRequest request,
     node_death_info.set_reason_message("Terminated by autoscaler.");
     shutdown_raylet_gracefully_(node_death_info);
   };
-  is_shutdown_request_received_ = true;
+  is_shutting_down_ = true;
   send_reply_callback(Status::OK(), shutdown_after_reply, shutdown_after_reply);
 }
 
@@ -3114,8 +3114,8 @@ std::unique_ptr<AgentManager> NodeManager::CreateDashboardAgentManager(
         return execute_after(io_service_, task, std::chrono::milliseconds(delay_ms));
       },
       [this](const rpc::NodeDeathInfo &death_info) {
-        is_shutdown_request_received_ = true;
-        shutdown_raylet_gracefully_(death_info);
+        this->is_shutting_down_ = true;
+        this->shutdown_raylet_gracefully_(death_info);
       });
 }
 
@@ -3149,8 +3149,8 @@ std::unique_ptr<AgentManager> NodeManager::CreateRuntimeEnvAgentManager(
         return execute_after(io_service_, task, std::chrono::milliseconds(delay_ms));
       },
       [this](const rpc::NodeDeathInfo &death_info) {
-        is_shutdown_request_received_ = true;
-        shutdown_raylet_gracefully_(death_info);
+        this->is_shutting_down_ = true;
+        this->shutdown_raylet_gracefully_(death_info);
       });
 }
 

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -926,8 +926,8 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   /// indicate network issues (dropped/duplicated/ooo packets, etc).
   int64_t next_resource_seq_no_;
 
-  /// Whether or not if the shutdown raylet request has been received.
-  bool is_shutdown_request_received_ = false;
+  /// Whether or not if the shutdown raylet request has been initiated and in progress.
+  bool is_shutting_down_ = false;
 
   /// Ray syncer for synchronization
   syncer::RaySyncer ray_syncer_;


### PR DESCRIPTION
## Why are these changes needed?

See #53739 for more details. Here's the sequence of events that leads to the flaky behavior:

1. **Agent is Killed:** The test sends a `SIGKILL` to an agent process (e.g., `dashboard_agent`).
2. **Graceful Shutdown Initiated:** Because raylet and the agent share fate, irrespective of the `waitpid` status, the `AgentManager` triggers a [graceful shutdown](https://github.com/ray-project/ray/blob/d3fd0d255c00755b4eb2e6e2cd5a8f764e6898aa/src/ray/raylet/agent_manager.cc#L105) of the raylet. This is a slow, multi-step process. This can be seen in the raylet logs: `Raylet graceful shutdown triggered, reason = UNEXPECTED_TERMINATION`.
3. **Race Condition:** While the raylet is busy with its slow, graceful shutdown, it may stop responding to heartbeats from the GCS in a timely manner. The GCS eventually times out, marks the raylet node as `DEAD`, and notifies the raylet of this status change.
4. **Fatal Crash:** The raylet, upon receiving the `DEAD` status from the GCS for itself, interprets this as an unexpected and fatal error (since it's not aware it's in a planned shutdown). It then crashes immediately, which can be seen in the raylet logs: `[Timeout] Exiting because this node manager has mistakenly been marked as dead by the GCS`.

### Proposed Fix

In `node_manager.cc`, when creating the `AgentManager` instances, the `shutdown_raylet_gracefully_` callback should be wrapped in a lambda that first sets `is_shutdown_request_received_ = true`. This will prevent the `NodeRemoved` callback from incorrectly triggering a fatal crash during an intentional graceful shutdown.

## Related issue number

#53739 
