### PR TITLE
[core] Control whether to construct a default concurrency group executor when max-concurrency=1 and there are other concurrency groups for an actor

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -972,3 +972,6 @@ RAY_CONFIG(int64_t, raylet_check_for_unexpected_worker_disconnect_interval_ms, 1
 /// for tasks with smaller sequence numbers to show up. If timed out, the task will
 /// be cancelled.
 RAY_CONFIG(int64_t, actor_scheduling_queue_max_reorder_wait_seconds, 30)
+
+/// Whether to disable the default concurrency group executor to be initialized.
+RAY_CONFIG(bool, disable_default_executor_initial, false)

--- a/src/ray/core_worker/fiber.h
+++ b/src/ray/core_worker/fiber.h
@@ -94,9 +94,13 @@ using FiberChannel = boost::fibers::unbuffered_channel<std::function<void()>>;
 class FiberState {
  public:
   static bool NeedDefaultExecutor(int32_t max_concurrency_in_default_group,
-                                  bool has_other_concurrency_groups) {
+                                  bool has_other_concurrency_groups,
+                                  bool disable_default_executor_initial) {
     RAY_UNUSED(max_concurrency_in_default_group);
     RAY_UNUSED(has_other_concurrency_groups);
+    /// If you explicitly specify that the creation of a default concurrency group
+    /// is prohibited, you need to set it to true.
+    RAY_UNUSED(disable_default_executor_initial);
     /// asyncio mode always need a default executor.
     return true;
   }

--- a/src/ray/core_worker/transport/concurrency_group_manager.cc
+++ b/src/ray/core_worker/transport/concurrency_group_manager.cc
@@ -44,12 +44,20 @@ ConcurrencyGroupManager<ExecutorType>::ConcurrencyGroupManager(
     name_to_executor_index_[name] = executor;
   }
 
+  /// If you explicitly specify that the creation of a default concurrency group
+  /// is prohibited, you need to set it to true.
+  bool disable_default_executor_initial =
+  RayConfig::instance().disable_default_executor_initial();
+
   // If max concurrency of default group is 1 and there is no other concurrency group of
   // this actor, the tasks of default group will be performed in main thread instead of
   // any executor pool, otherwise tasks in any concurrency group should be performed in
   // the thread pools instead of main thread.
+  // However, if you need to set disable_default_executor_initial to true, the default
+  // concurrency group executor will be disable to be initialized.
   if (ExecutorType::NeedDefaultExecutor(max_concurrency_for_default_concurrency_group,
-                                        !concurrency_groups.empty())) {
+                                        !concurrency_groups.empty(),
+                                        disable_default_executor_initial)) {
     default_executor_ = std::make_shared<ExecutorType>(
         max_concurrency_for_default_concurrency_group, initialize_thread_callback_);
   }

--- a/src/ray/core_worker/transport/concurrency_group_manager.cc
+++ b/src/ray/core_worker/transport/concurrency_group_manager.cc
@@ -47,7 +47,7 @@ ConcurrencyGroupManager<ExecutorType>::ConcurrencyGroupManager(
   /// If you explicitly specify that the creation of a default concurrency group
   /// is prohibited, you need to set it to true.
   bool disable_default_executor_initial =
-  RayConfig::instance().disable_default_executor_initial();
+      RayConfig::instance().disable_default_executor_initial();
 
   // If max concurrency of default group is 1 and there is no other concurrency group of
   // this actor, the tasks of default group will be performed in main thread instead of

--- a/src/ray/core_worker/transport/thread_pool.h
+++ b/src/ray/core_worker/transport/thread_pool.h
@@ -33,11 +33,13 @@ namespace core {
 class BoundedExecutor {
  public:
   static bool NeedDefaultExecutor(int32_t max_concurrency_in_default_group,
-                                  bool has_other_concurrency_groups) {
+                                  bool has_other_concurrency_groups,
+                                  bool disable_default_executor_initial) {
     if (max_concurrency_in_default_group == 0) {
       return false;
     }
-    return max_concurrency_in_default_group > 1 || has_other_concurrency_groups;
+    return max_concurrency_in_default_group > 1 ||
+    has_other_concurrency_groups && !disable_default_executor_initial
   }
 
   /// Create a thread pool with `max_concurrency` threads, and execute

--- a/src/ray/core_worker/transport/thread_pool.h
+++ b/src/ray/core_worker/transport/thread_pool.h
@@ -39,7 +39,7 @@ class BoundedExecutor {
       return false;
     }
     return max_concurrency_in_default_group > 1 ||
-    has_other_concurrency_groups && !disable_default_executor_initial
+           has_other_concurrency_groups && !disable_default_executor_initial
   }
 
   /// Create a thread pool with `max_concurrency` threads, and execute

--- a/src/ray/core_worker/transport/thread_pool.h
+++ b/src/ray/core_worker/transport/thread_pool.h
@@ -39,7 +39,7 @@ class BoundedExecutor {
       return false;
     }
     return max_concurrency_in_default_group > 1 ||
-           has_other_concurrency_groups && !disable_default_executor_initial
+           has_other_concurrency_groups && !disable_default_executor_initial;
   }
 
   /// Create a thread pool with `max_concurrency` threads, and execute

--- a/src/ray/core_worker/transport/thread_pool.h
+++ b/src/ray/core_worker/transport/thread_pool.h
@@ -39,7 +39,7 @@ class BoundedExecutor {
       return false;
     }
     return max_concurrency_in_default_group > 1 ||
-           has_other_concurrency_groups && !disable_default_executor_initial;
+           (has_other_concurrency_groups && !disable_default_executor_initial);
   }
 
   /// Create a thread pool with `max_concurrency` threads, and execute


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
If use ray actor to perform some obstructive operations, and these operations contain logic that must be executed in the main thread, such as executing python's signal.signal(sigterm, handler), this requires execution in the main thread. 

Therefore, it can be controlled through a parameter that when max-concurrency=1 of an actor and there are other concurrency_groups simultaneously for this actor, the default concurrency group executor is not initialized. And the specified actor tasks can be executed in the main thread and the other actor tasks can be executed in the corresponding concurrency group executors.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/ray-project/ray/issues/53771

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
