### PR TITLE
[core] Add switch for the cache of runtime env

### DIFF
--- a/python/ray/tests/test_runtime_env.py
+++ b/python/ray/tests/test_runtime_env.py
@@ -3,6 +3,7 @@
 If you need a customized Ray instance (e.g., to change system config or env vars),
 put the test in `test_runtime_env_standalone.py`.
 """
+
 import os
 import sys
 
@@ -165,6 +166,28 @@ def test_runtime_env_config(start_cluster_shared):
         run(runtime_env)
         runtime_env = RuntimeEnv(config=RuntimeEnvConfig(**good_config))
         run(runtime_env)
+
+
+def test_runtime_env_config_disable_cache(start_cluster_shared):
+    _, address = start_cluster_shared
+
+    @ray.remote
+    def f():
+        return True
+
+    def run(runtime_env):
+        ray.shutdown()
+        ray.init(address, runtime_env=runtime_env)
+        assert ray.get(f.options(runtime_env=runtime_env).remote())
+
+    runtime_env = {"config": {"disable_cache": True}}
+    run(runtime_env)
+    runtime_env = {"config": RuntimeEnvConfig(disable_cache=True)}
+    run(runtime_env)
+    runtime_env = RuntimeEnv(config={"disable_cache": True})
+    run(runtime_env)
+    runtime_env = RuntimeEnv(config=RuntimeEnvConfig(disable_cache=True))
+    run(runtime_env)
 
 
 if __name__ == "__main__":

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -576,6 +576,8 @@ std::string TaskSpecification::DebugString() const {
              << runtime_env_info.runtime_env_config().eager_install();
       stream << ", setup_timeout_seconds="
              << runtime_env_info.runtime_env_config().setup_timeout_seconds();
+      stream << ", disable_cache="
+             << runtime_env_info.runtime_env_config().disable_cache();
     }
   }
 
@@ -605,6 +607,8 @@ std::string TaskSpecification::RuntimeEnvDebugString() const {
              << runtime_env_info.runtime_env_config().eager_install();
       stream << ", setup_timeout_seconds="
              << runtime_env_info.runtime_env_config().setup_timeout_seconds();
+      stream << ", disable_cache="
+             << runtime_env_info.runtime_env_config().disable_cache();
     }
   }
   return stream.str();

--- a/src/ray/gcs/gcs_server/gcs_job_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_job_manager.cc
@@ -81,6 +81,8 @@ void GcsJobManager::WriteDriverJobExportEvent(rpc::JobTableData job_data) const 
       job_data.config().runtime_env_info().runtime_env_config().eager_install());
   export_runtime_env_config->mutable_log_files()->CopyFrom(
       job_data.config().runtime_env_info().runtime_env_config().log_files());
+  export_runtime_env_config->set_disable_cache(
+      job_data.config().runtime_env_info().runtime_env_config().disable_cache());
 
   RayExportEvent(export_driver_job_data_ptr).SendEvent();
 }

--- a/src/ray/protobuf/export_runtime_env.proto
+++ b/src/ray/protobuf/export_runtime_env.proto
@@ -37,6 +37,8 @@ message ExportRuntimeEnvInfo {
     bool eager_install = 2;
     /// A list of files to stream the runtime env setup logs to.
     repeated string log_files = 3;
+    /// Indicates whether to cache the runtime environment on the cluster
+    bool disable_cache = 4;
   }
 
   /// The serialized runtime env passed from the user.

--- a/src/ray/protobuf/runtime_env_common.proto
+++ b/src/ray/protobuf/runtime_env_common.proto
@@ -34,6 +34,8 @@ message RuntimeEnvConfig {
   bool eager_install = 2;
   /// A list of files to stream the runtime env setup logs to.
   repeated string log_files = 3;
+  /// Indicates whether to cache the runtime environment on the cluster
+  bool disable_cache = 4;
 }
 
 /// The runtime env information which is transferred between ray core processes.


### PR DESCRIPTION
## Why are these changes needed?

Based on the premise of zero trust, the QoS is not always guarantee for server that managed URI of runtime env. So the job is failed maybe caused by server timeout, in this scenario the job should resubmit without modify and expected work well. 

## Related issue number


## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
