### PR TITLE
[core] Increase instance sizes for wheel / HA tests

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -238,7 +238,7 @@ steps:
 
   - label: ":ray: core: wheel tests"
     tags: linux_wheels
-    instance_type: medium
+    instance_type: large
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //doc/... core
         --install-mask all-ray-libraries
@@ -418,7 +418,7 @@ steps:
     tags:
       - python
       - docker
-    instance_type: medium
+    instance_type: large
     commands:
       - bazel run //ci/ray_ci:build_in_docker -- docker --platform cpu --canonical-tag ha_integration
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... core --only-tags ha_integration
@@ -433,7 +433,7 @@ steps:
       - python
       - docker
       - oss
-    instance_type: medium
+    instance_type: large
     commands:
       - bazel run //ci/ray_ci:build_in_docker -- docker --platform cpu
         --canonical-tag test_container

--- a/.buildkite/kuberay.rayci.yml
+++ b/.buildkite/kuberay.rayci.yml
@@ -9,7 +9,7 @@ steps:
     tags:
       - python
       - docker
-    instance_type: medium
+    instance_type: large
     commands:
       - bash ci/k8s/run-operator-tests.sh
     docker_network: "host"

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -88,7 +88,7 @@ steps:
     tags:
       - serve
       - linux_wheels
-    instance_type: medium
+    instance_type: large
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/... //doc/... serve
         --build-type wheel
@@ -156,7 +156,7 @@ steps:
     tags:
       - serve
       - python
-    instance_type: medium
+    instance_type: large
     commands:
       - bazel run //ci/ray_ci:build_in_docker -- docker --platform cpu --canonical-tag ha_integration
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/tests/... serve


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Many of my pr's that change any gcs code fail on these because of bazel oom's on medium sized instances. It seems specific to ci steps that are building wheels or doing HA things.

Examples on 3 separate pr's:
https://buildkite.com/ray-project/premerge/builds/41945#_
https://buildkite.com/ray-project/premerge/builds/41876
https://buildkite.com/ray-project/premerge/builds/41774#01975b1b-3ca8-477a-a2a0-2efbc6099c4d

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
