### PR TITLE
[core] Deflake `test_object_spilling.py`

### DIFF
--- a/python/ray/tests/test_object_spilling.py
+++ b/python/ray/tests/test_object_spilling.py
@@ -6,9 +6,12 @@ import sys
 from datetime import datetime, timedelta
 from unittest.mock import patch
 from pathlib import Path
+import os
+
+import psutil
 import numpy as np
 import pytest
-import os
+
 
 import ray
 from ray._private.external_storage import (
@@ -743,25 +746,15 @@ async def test_spill_during_get(object_spilling_config, shutdown_only, is_async)
     ],
     indirect=True,
 )
-def test_spill_worker_failure(ray_start_regular):
-    def run_workload():
-        @ray.remote
-        def f():
-            return np.zeros(50 * 1024 * 1024, dtype=np.uint8)
+def test_recover_from_spill_worker_failure(ray_start_regular):
+    @ray.remote
+    def f():
+        return np.zeros(50 * 1024 * 1024, dtype=np.uint8)
 
-        ids = []
-        for _ in range(5):
-            x = f.remote()
-            ids.append(x)
-        for id in ids:
-            ray.get(id)
-        del ids
-
-    run_workload()
+    def _run_spilling_workload():
+        ray.get([f.remote() for _ in range(5)])
 
     def get_spill_worker():
-        import psutil
-
         for proc in psutil.process_iter():
             try:
                 name = ray._private.ray_constants.WORKER_PROCESS_TYPE_SPILL_WORKER_IDLE
@@ -778,20 +771,17 @@ def test_spill_worker_failure(ray_start_regular):
             except psutil.NoSuchProcess:
                 pass
 
-    # Spilling occurred. Get the PID of the spill worker.
+    # Run a workload that forces spilling to occur.
+    _run_spilling_workload()
+
+    # Get the PID of the spill worker that was created and kill it.
     spill_worker_proc = get_spill_worker()
     assert spill_worker_proc
-
-    # Kill the spill worker
     spill_worker_proc.kill()
     spill_worker_proc.wait()
 
-    # Now we trigger spilling again
-    run_workload()
-
-    # A new spill worker should be created
-    spill_worker_proc = get_spill_worker()
-    assert spill_worker_proc
+    # Run the workload again and ensure that it succeeds.
+    _run_spilling_workload()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Flake: https://buildkite.com/ray-project/postmerge/builds/10825#019767ae-c856-44d2-a2ce-5115c1c7e828/177-1225

Removing the assertion on an internal implementation detail, instead just checking that the spilling workload can succeed.