### PR TITLE
[core] Add timeout to `ray.get` call in `test_update_object_location_batch_failure`

### DIFF
--- a/python/ray/tests/test_failure.py
+++ b/python/ray/tests/test_failure.py
@@ -772,7 +772,7 @@ def test_update_object_location_batch_failure(
                 node_id=head_node_id, soft=False
             )
         ).remote(obj_ref)
-        assert ray.get(consume_ref) > 0
+        assert ray.get(consume_ref, timeout=10) > 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This test periodically hangs: https://buildkite.com/ray-project/postmerge/builds/10825#019767ae-c85b-4b6c-b57e-88bc1dfaadd9/177-1508

For now, at least adding a timeout to not stall CI.