### PR TITLE
[dashboard] Fix retrieving IP address from the `GPUProfilingManager` on the dashboard agent

### DIFF
--- a/python/ray/dashboard/modules/reporter/gpu_profile_manager.py
+++ b/python/ray/dashboard/modules/reporter/gpu_profile_manager.py
@@ -3,7 +3,6 @@ import functools
 import logging
 import os
 import shutil
-import socket
 import subprocess
 from datetime import datetime
 from pathlib import Path
@@ -61,16 +60,14 @@ class GpuProfilingManager:
         "GPU profiling is not available for this process."
     )
 
-    def __init__(self, profile_dir_path: str):
+    def __init__(self, profile_dir_path: str, ip_address: str):
         # Dump trace files to: /tmp/ray/session_latest/logs/profiles/
         self._root_log_dir = Path(profile_dir_path)
         self._profile_dir_path = self._root_log_dir / "profiles"
         self._daemon_log_file_path = (
             self._profile_dir_path / f"dynolog_daemon_{os.getpid()}.log"
         )
-
-        hostname = socket.gethostname()
-        self._ip_address = socket.gethostbyname(hostname)
+        self._ip_address = ip_address
 
         self._dynolog_bin = shutil.which("dynolog")
         self._dyno_bin = shutil.which("dyno")

--- a/python/ray/dashboard/modules/reporter/gpu_profile_manager.py
+++ b/python/ray/dashboard/modules/reporter/gpu_profile_manager.py
@@ -60,7 +60,7 @@ class GpuProfilingManager:
         "GPU profiling is not available for this process."
     )
 
-    def __init__(self, profile_dir_path: str, ip_address: str):
+    def __init__(self, profile_dir_path: str, *, ip_address: str):
         # Dump trace files to: /tmp/ray/session_latest/logs/profiles/
         self._root_log_dir = Path(profile_dir_path)
         self._profile_dir_path = self._root_log_dir / "profiles"

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -438,7 +438,9 @@ class ReporterAgent(
         )
         self._gcs_pid = None
 
-        self._gpu_profiling_manager = GpuProfilingManager(self._log_dir)
+        self._gpu_profiling_manager = GpuProfilingManager(
+            profile_dir_path=self._log_dir, ip_address=self._ip
+        )
         self._gpu_profiling_manager.start_monitoring_daemon()
 
     async def GetTraceback(self, request, context):

--- a/python/ray/dashboard/modules/reporter/tests/test_gpu_profiler_manager.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_gpu_profiler_manager.py
@@ -37,7 +37,7 @@ def mock_subprocess_popen(monkeypatch):
     yield (mock_popen, mock_proc)
 
 
-MOCK_IP_ADDRESS = "127.0.0.1"
+LOCALHOST = "127.0.0.1"
 
 
 @pytest.fixture
@@ -51,7 +51,7 @@ def mock_asyncio_create_subprocess_exec(monkeypatch):
 
 
 def test_enabled(tmp_path, mock_node_has_gpus, mock_dynolog_binaries):
-    gpu_profiler = GpuProfilingManager(tmp_path, MOCK_IP_ADDRESS)
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address=LOCALHOST)
     assert gpu_profiler.enabled
 
 
@@ -59,19 +59,19 @@ def test_disabled_no_gpus(tmp_path, monkeypatch):
     monkeypatch.setattr(
         GpuProfilingManager, "node_has_gpus", classmethod(lambda cls: False)
     )
-    gpu_profiler = GpuProfilingManager(tmp_path, MOCK_IP_ADDRESS)
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address=LOCALHOST)
     assert not gpu_profiler.enabled
 
 
 def test_disabled_no_dynolog_bin(tmp_path, mock_node_has_gpus):
-    gpu_profiler = GpuProfilingManager(tmp_path, MOCK_IP_ADDRESS)
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address=LOCALHOST)
     assert not gpu_profiler.enabled
 
 
 def test_start_monitoring_daemon(
     tmp_path, mock_node_has_gpus, mock_dynolog_binaries, mock_subprocess_popen
 ):
-    gpu_profiler = GpuProfilingManager(tmp_path, MOCK_IP_ADDRESS)
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address=LOCALHOST)
 
     mocked_popen, mocked_proc = mock_subprocess_popen
     mocked_proc.pid = 123
@@ -95,7 +95,7 @@ def test_start_monitoring_daemon(
 
 @pytest.mark.asyncio
 async def test_gpu_profile_disabled(tmp_path):
-    gpu_profiler = GpuProfilingManager(tmp_path, MOCK_IP_ADDRESS)
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address=LOCALHOST)
     assert not gpu_profiler.enabled
 
     success, output = await gpu_profiler.gpu_profile(pid=123, num_iterations=1)
@@ -109,7 +109,7 @@ async def test_gpu_profile_disabled(tmp_path):
 async def test_gpu_profile_without_starting_daemon(
     tmp_path, mock_node_has_gpus, mock_dynolog_binaries
 ):
-    gpu_profiler = GpuProfilingManager(tmp_path, MOCK_IP_ADDRESS)
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address=LOCALHOST)
     assert not gpu_profiler.is_monitoring_daemon_running
 
     with pytest.raises(RuntimeError, match="start_monitoring_daemon"):
@@ -120,7 +120,7 @@ async def test_gpu_profile_without_starting_daemon(
 async def test_gpu_profile_with_dead_daemon(
     tmp_path, mock_node_has_gpus, mock_dynolog_binaries, mock_subprocess_popen
 ):
-    gpu_profiler = GpuProfilingManager(tmp_path, MOCK_IP_ADDRESS)
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address=LOCALHOST)
     gpu_profiler.start_monitoring_daemon()
 
     mocked_popen, mocked_proc = mock_subprocess_popen
@@ -143,7 +143,7 @@ async def test_gpu_profile_on_dead_process(
     mock_dynolog_binaries,
     mock_subprocess_popen,
 ):
-    gpu_profiler = GpuProfilingManager(tmp_path, MOCK_IP_ADDRESS)
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address=LOCALHOST)
     gpu_profiler.start_monitoring_daemon()
 
     _, mocked_proc = mock_subprocess_popen
@@ -168,7 +168,7 @@ async def test_gpu_profile_no_matched_processes(
     mock_subprocess_popen,
     mock_asyncio_create_subprocess_exec,
 ):
-    gpu_profiler = GpuProfilingManager(tmp_path, MOCK_IP_ADDRESS)
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address=LOCALHOST)
     gpu_profiler.start_monitoring_daemon()
 
     # Mock the daemon process
@@ -210,7 +210,7 @@ async def test_gpu_profile_timeout(
     mock_subprocess_popen,
     mock_asyncio_create_subprocess_exec,
 ):
-    gpu_profiler = GpuProfilingManager(tmp_path, MOCK_IP_ADDRESS)
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address=LOCALHOST)
     gpu_profiler.start_monitoring_daemon()
 
     # Mock the daemon process
@@ -243,7 +243,7 @@ async def test_gpu_profile_process_dies_during_profiling(
     mock_subprocess_popen,
     mock_asyncio_create_subprocess_exec,
 ):
-    gpu_profiler = GpuProfilingManager(tmp_path, MOCK_IP_ADDRESS)
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address=LOCALHOST)
     gpu_profiler.start_monitoring_daemon()
 
     # Mock the daemon process
@@ -279,7 +279,7 @@ async def test_gpu_profile_success(
     mock_subprocess_popen,
     mock_asyncio_create_subprocess_exec,
 ):
-    gpu_profiler = GpuProfilingManager(tmp_path, MOCK_IP_ADDRESS)
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address=LOCALHOST)
     gpu_profiler.start_monitoring_daemon()
 
     # Mock the daemon process

--- a/python/ray/dashboard/modules/reporter/tests/test_gpu_profiler_manager.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_gpu_profiler_manager.py
@@ -37,6 +37,9 @@ def mock_subprocess_popen(monkeypatch):
     yield (mock_popen, mock_proc)
 
 
+MOCK_IP_ADDRESS = "127.0.0.1"
+
+
 @pytest.fixture
 def mock_asyncio_create_subprocess_exec(monkeypatch):
     mock_create_subprocess_exec = AsyncMock()
@@ -48,7 +51,7 @@ def mock_asyncio_create_subprocess_exec(monkeypatch):
 
 
 def test_enabled(tmp_path, mock_node_has_gpus, mock_dynolog_binaries):
-    gpu_profiler = GpuProfilingManager(tmp_path)
+    gpu_profiler = GpuProfilingManager(tmp_path, MOCK_IP_ADDRESS)
     assert gpu_profiler.enabled
 
 
@@ -56,19 +59,19 @@ def test_disabled_no_gpus(tmp_path, monkeypatch):
     monkeypatch.setattr(
         GpuProfilingManager, "node_has_gpus", classmethod(lambda cls: False)
     )
-    gpu_profiler = GpuProfilingManager(tmp_path)
+    gpu_profiler = GpuProfilingManager(tmp_path, MOCK_IP_ADDRESS)
     assert not gpu_profiler.enabled
 
 
 def test_disabled_no_dynolog_bin(tmp_path, mock_node_has_gpus):
-    gpu_profiler = GpuProfilingManager(tmp_path)
+    gpu_profiler = GpuProfilingManager(tmp_path, MOCK_IP_ADDRESS)
     assert not gpu_profiler.enabled
 
 
 def test_start_monitoring_daemon(
     tmp_path, mock_node_has_gpus, mock_dynolog_binaries, mock_subprocess_popen
 ):
-    gpu_profiler = GpuProfilingManager(tmp_path)
+    gpu_profiler = GpuProfilingManager(tmp_path, MOCK_IP_ADDRESS)
 
     mocked_popen, mocked_proc = mock_subprocess_popen
     mocked_proc.pid = 123
@@ -92,7 +95,7 @@ def test_start_monitoring_daemon(
 
 @pytest.mark.asyncio
 async def test_gpu_profile_disabled(tmp_path):
-    gpu_profiler = GpuProfilingManager(tmp_path)
+    gpu_profiler = GpuProfilingManager(tmp_path, MOCK_IP_ADDRESS)
     assert not gpu_profiler.enabled
 
     success, output = await gpu_profiler.gpu_profile(pid=123, num_iterations=1)
@@ -106,7 +109,7 @@ async def test_gpu_profile_disabled(tmp_path):
 async def test_gpu_profile_without_starting_daemon(
     tmp_path, mock_node_has_gpus, mock_dynolog_binaries
 ):
-    gpu_profiler = GpuProfilingManager(tmp_path)
+    gpu_profiler = GpuProfilingManager(tmp_path, MOCK_IP_ADDRESS)
     assert not gpu_profiler.is_monitoring_daemon_running
 
     with pytest.raises(RuntimeError, match="start_monitoring_daemon"):
@@ -117,7 +120,7 @@ async def test_gpu_profile_without_starting_daemon(
 async def test_gpu_profile_with_dead_daemon(
     tmp_path, mock_node_has_gpus, mock_dynolog_binaries, mock_subprocess_popen
 ):
-    gpu_profiler = GpuProfilingManager(tmp_path)
+    gpu_profiler = GpuProfilingManager(tmp_path, MOCK_IP_ADDRESS)
     gpu_profiler.start_monitoring_daemon()
 
     mocked_popen, mocked_proc = mock_subprocess_popen
@@ -140,7 +143,7 @@ async def test_gpu_profile_on_dead_process(
     mock_dynolog_binaries,
     mock_subprocess_popen,
 ):
-    gpu_profiler = GpuProfilingManager(tmp_path)
+    gpu_profiler = GpuProfilingManager(tmp_path, MOCK_IP_ADDRESS)
     gpu_profiler.start_monitoring_daemon()
 
     _, mocked_proc = mock_subprocess_popen
@@ -165,7 +168,7 @@ async def test_gpu_profile_no_matched_processes(
     mock_subprocess_popen,
     mock_asyncio_create_subprocess_exec,
 ):
-    gpu_profiler = GpuProfilingManager(tmp_path)
+    gpu_profiler = GpuProfilingManager(tmp_path, MOCK_IP_ADDRESS)
     gpu_profiler.start_monitoring_daemon()
 
     # Mock the daemon process
@@ -207,7 +210,7 @@ async def test_gpu_profile_timeout(
     mock_subprocess_popen,
     mock_asyncio_create_subprocess_exec,
 ):
-    gpu_profiler = GpuProfilingManager(tmp_path)
+    gpu_profiler = GpuProfilingManager(tmp_path, MOCK_IP_ADDRESS)
     gpu_profiler.start_monitoring_daemon()
 
     # Mock the daemon process
@@ -240,7 +243,7 @@ async def test_gpu_profile_process_dies_during_profiling(
     mock_subprocess_popen,
     mock_asyncio_create_subprocess_exec,
 ):
-    gpu_profiler = GpuProfilingManager(tmp_path)
+    gpu_profiler = GpuProfilingManager(tmp_path, MOCK_IP_ADDRESS)
     gpu_profiler.start_monitoring_daemon()
 
     # Mock the daemon process
@@ -276,7 +279,7 @@ async def test_gpu_profile_success(
     mock_subprocess_popen,
     mock_asyncio_create_subprocess_exec,
 ):
-    gpu_profiler = GpuProfilingManager(tmp_path)
+    gpu_profiler = GpuProfilingManager(tmp_path, MOCK_IP_ADDRESS)
     gpu_profiler.start_monitoring_daemon()
 
     # Mock the daemon process


### PR DESCRIPTION
## Summary

The current code to get the current IP address errors for some versions of MacOS. Instead, we can pass in the IP address from the dashboard agent directly.

```python
hostname = socket.gethostname()
self._ip_address = socket.gethostbyname(hostname)
```

This code flakily fails on some Mac versions with this error:
```python
Traceback (most recent call last):
  File "/Users/eoakes/code/ray/python/ray/dashboard/agent.py", line 451, in <module>
    loop.run_until_complete(agent.run())
  File "/Users/eoakes/miniconda3/envs/ray/lib/python3.12/asyncio/base_events.py", line 686, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/eoakes/code/ray/python/ray/dashboard/agent.py", line 166, in run
    modules = self._load_modules()
              ^^^^^^^^^^^^^^^^^^^^
  File "/Users/eoakes/code/ray/python/ray/dashboard/agent.py", line 146, in _load_modules
    c = cls(self)
        ^^^^^^^^^
  File "/Users/eoakes/code/ray/python/ray/dashboard/modules/reporter/reporter_agent.py", line 441, in __init__
    self._gpu_profiling_manager = GpuProfilingManager(self._log_dir)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/eoakes/code/ray/python/ray/dashboard/modules/reporter/gpu_profile_manager.py", line 73, in __init__
    self._ip_address = socket.gethostbyname(hostname)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
socket.gaierror: [Errno 8] nodename nor servname provided, or not known
```