### PR TITLE
Pass IP address to `GpuProfilingManager`

### DIFF
--- a/python/ray/dashboard/modules/reporter/gpu_profile_manager.py
+++ b/python/ray/dashboard/modules/reporter/gpu_profile_manager.py
@@ -3,7 +3,6 @@ import functools
 import logging
 import os
 import shutil
-import socket
 import subprocess
 from datetime import datetime
 from pathlib import Path
@@ -61,20 +60,17 @@ class GpuProfilingManager:
         "GPU profiling is not available for this process."
     )
 
-    def __init__(self, profile_dir_path: str):
+    def __init__(self, profile_dir_path: str, *, ip_address: str):
         # Dump trace files to: /tmp/ray/session_latest/logs/profiles/
+        self._ip_address = ip_address
         self._root_log_dir = Path(profile_dir_path)
         self._profile_dir_path = self._root_log_dir / "profiles"
         self._daemon_log_file_path = (
             self._profile_dir_path / f"dynolog_daemon_{os.getpid()}.log"
         )
 
-        hostname = socket.gethostname()
-        self._ip_address = socket.gethostbyname(hostname)
-
-        self._dynolog_bin = shutil.which("dynolog")
         self._dyno_bin = shutil.which("dyno")
-
+        self._dynolog_bin = shutil.which("dynolog")
         self._dynolog_daemon_process: Optional[subprocess.Popen] = None
 
         if not self.node_has_gpus():

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -439,7 +439,9 @@ class ReporterAgent(
         )
         self._gcs_pid = None
 
-        self._gpu_profiling_manager = GpuProfilingManager(self._log_dir, ip_address=self._ip)
+        self._gpu_profiling_manager = GpuProfilingManager(
+            self._log_dir, ip_address=self._ip
+        )
         self._gpu_profiling_manager.start_monitoring_daemon()
 
     async def GetTraceback(self, request, context):

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -383,6 +383,7 @@ class ReporterAgent(
         self._log_dir = dashboard_agent.log_dir
         self._is_head_node = self._ip == dashboard_agent.gcs_address.split(":")[0]
         self._hostname = socket.gethostname()
+        logger.info(self._hostname)
         # (pid, created_time) -> psutil.Process
         self._workers = {}
         # psutil.Process of the parent.
@@ -438,7 +439,7 @@ class ReporterAgent(
         )
         self._gcs_pid = None
 
-        self._gpu_profiling_manager = GpuProfilingManager(self._log_dir)
+        self._gpu_profiling_manager = GpuProfilingManager(self._log_dir, ip_address=self._ip)
         self._gpu_profiling_manager.start_monitoring_daemon()
 
     async def GetTraceback(self, request, context):

--- a/python/ray/dashboard/modules/reporter/tests/test_gpu_profiler_manager.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_gpu_profiler_manager.py
@@ -48,7 +48,7 @@ def mock_asyncio_create_subprocess_exec(monkeypatch):
 
 
 def test_enabled(tmp_path, mock_node_has_gpus, mock_dynolog_binaries):
-    gpu_profiler = GpuProfilingManager(tmp_path)
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address="127.0.0.1")
     assert gpu_profiler.enabled
 
 
@@ -56,19 +56,19 @@ def test_disabled_no_gpus(tmp_path, monkeypatch):
     monkeypatch.setattr(
         GpuProfilingManager, "node_has_gpus", classmethod(lambda cls: False)
     )
-    gpu_profiler = GpuProfilingManager(tmp_path)
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address="127.0.0.1")
     assert not gpu_profiler.enabled
 
 
 def test_disabled_no_dynolog_bin(tmp_path, mock_node_has_gpus):
-    gpu_profiler = GpuProfilingManager(tmp_path)
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address="127.0.0.1")
     assert not gpu_profiler.enabled
 
 
 def test_start_monitoring_daemon(
     tmp_path, mock_node_has_gpus, mock_dynolog_binaries, mock_subprocess_popen
 ):
-    gpu_profiler = GpuProfilingManager(tmp_path)
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address="127.0.0.1")
 
     mocked_popen, mocked_proc = mock_subprocess_popen
     mocked_proc.pid = 123
@@ -92,7 +92,7 @@ def test_start_monitoring_daemon(
 
 @pytest.mark.asyncio
 async def test_gpu_profile_disabled(tmp_path):
-    gpu_profiler = GpuProfilingManager(tmp_path)
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address="127.0.0.1")
     assert not gpu_profiler.enabled
 
     success, output = await gpu_profiler.gpu_profile(pid=123, num_iterations=1)
@@ -106,7 +106,7 @@ async def test_gpu_profile_disabled(tmp_path):
 async def test_gpu_profile_without_starting_daemon(
     tmp_path, mock_node_has_gpus, mock_dynolog_binaries
 ):
-    gpu_profiler = GpuProfilingManager(tmp_path)
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address="127.0.0.1")
     assert not gpu_profiler.is_monitoring_daemon_running
 
     with pytest.raises(RuntimeError, match="start_monitoring_daemon"):
@@ -117,7 +117,7 @@ async def test_gpu_profile_without_starting_daemon(
 async def test_gpu_profile_with_dead_daemon(
     tmp_path, mock_node_has_gpus, mock_dynolog_binaries, mock_subprocess_popen
 ):
-    gpu_profiler = GpuProfilingManager(tmp_path)
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address="127.0.0.1")
     gpu_profiler.start_monitoring_daemon()
 
     mocked_popen, mocked_proc = mock_subprocess_popen
@@ -140,7 +140,7 @@ async def test_gpu_profile_on_dead_process(
     mock_dynolog_binaries,
     mock_subprocess_popen,
 ):
-    gpu_profiler = GpuProfilingManager(tmp_path)
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address="127.0.0.1")
     gpu_profiler.start_monitoring_daemon()
 
     _, mocked_proc = mock_subprocess_popen
@@ -165,7 +165,7 @@ async def test_gpu_profile_no_matched_processes(
     mock_subprocess_popen,
     mock_asyncio_create_subprocess_exec,
 ):
-    gpu_profiler = GpuProfilingManager(tmp_path)
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address="127.0.0.1")
     gpu_profiler.start_monitoring_daemon()
 
     # Mock the daemon process
@@ -207,7 +207,7 @@ async def test_gpu_profile_timeout(
     mock_subprocess_popen,
     mock_asyncio_create_subprocess_exec,
 ):
-    gpu_profiler = GpuProfilingManager(tmp_path)
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address="127.0.0.1")
     gpu_profiler.start_monitoring_daemon()
 
     # Mock the daemon process
@@ -240,7 +240,7 @@ async def test_gpu_profile_process_dies_during_profiling(
     mock_subprocess_popen,
     mock_asyncio_create_subprocess_exec,
 ):
-    gpu_profiler = GpuProfilingManager(tmp_path)
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address="127.0.0.1")
     gpu_profiler.start_monitoring_daemon()
 
     # Mock the daemon process
@@ -276,7 +276,7 @@ async def test_gpu_profile_success(
     mock_subprocess_popen,
     mock_asyncio_create_subprocess_exec,
 ):
-    gpu_profiler = GpuProfilingManager(tmp_path)
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address="127.0.0.1")
     gpu_profiler.start_monitoring_daemon()
 
     # Mock the daemon process


### PR DESCRIPTION
The dashboard agent already resolves the IP, just need to thread it through.

The IP address resolution as written was failing on startup sometimes. I manually confirmed that it resolves the issue for me locally by running a local test case that previously failed for me ~10% of the time `test_multiprocessing.py`. With this change, it passed for ~30min straight running in a loop.