### PR TITLE
Fix pickle error with remote code models in vLLM Ray worker process

### DIFF
--- a/python/ray/llm/_internal/serve/configs/server_models.py
+++ b/python/ray/llm/_internal/serve/configs/server_models.py
@@ -275,17 +275,6 @@ class LLMConfig(BaseModelExtended):
         self._infer_supports_vision(model_id_or_path)
         self._set_model_architecture(model_id_or_path)
 
-        # TODO(seiji): remove this once https://github.com/vllm-project/vllm/pull/19510 is merged
-        # It prevents a pickle error since this loads transformers_modules
-        try:
-            transformers.AutoProcessor.from_pretrained(
-                model_id_or_path,
-                trust_remote_code=trust_remote_code,
-            )
-        except Exception:
-            # Some models don't have processors, which is fine
-            pass
-
     @property
     def supports_vision(self) -> bool:
         return self._supports_vision

--- a/python/ray/llm/_internal/serve/configs/server_models.py
+++ b/python/ray/llm/_internal/serve/configs/server_models.py
@@ -275,11 +275,8 @@ class LLMConfig(BaseModelExtended):
         self._infer_supports_vision(model_id_or_path)
         self._set_model_architecture(model_id_or_path)
 
-        # Load AutoProcessor to trigger safe remote code import.
-        # This ensures that remote model configuration classes are imported
-        # with sanitized module names (hyphens -> underscores), making them
-        # pickle-safe for vLLM's multiprocessing.
         # TODO(seiji): remove this once https://github.com/vllm-project/vllm/pull/19510 is merged
+        # It prevents a pickle error since this loads transformers_modules
         try:
             transformers.AutoProcessor.from_pretrained(
                 model_id_or_path,

--- a/python/ray/llm/_internal/serve/deployments/llm/llm_engine.py
+++ b/python/ray/llm/_internal/serve/deployments/llm/llm_engine.py
@@ -1,6 +1,8 @@
 import abc
 from typing import AsyncGenerator, Optional
 
+from transformers.dynamic_module_utils import init_hf_modules
+
 from ray.llm._internal.serve.configs.server_models import (
     DiskMultiplexConfig,
     GenerationRequest,
@@ -15,6 +17,10 @@ class LLMEngine(abc.ABC):
 
     def __init__(self, llm_config: LLMConfig):
         self._llm_config = llm_config
+
+        # Ensure transformers_modules is initialized early in worker processes.
+        # This is critical for models with trust_remote_code=True to avoid pickle errors.
+        init_hf_modules()
 
     @abc.abstractmethod
     async def start(self):

--- a/release/llm_tests/serve/test_llm_serve_integration.py
+++ b/release/llm_tests/serve/test_llm_serve_integration.py
@@ -90,8 +90,8 @@ def remote_model_app(request):
 class TestRemoteCode:
     """Tests for remote code model loading behavior."""
 
-    def _check_for_running_app(self):
-        """Check if the application is running successfully."""
+    def _is_default_app_running(self):
+        """Check if the default application is running successfully."""
         try:
             default_app = serve.status().applications[SERVE_DEFAULT_APP_NAME]
             return default_app.status == ApplicationStatus.RUNNING
@@ -107,8 +107,8 @@ class TestRemoteCode:
         that does require remote code.
         """
         app = remote_model_app
-
-        serve.run(app, blocking=False)
+        with pytest.raises(RuntimeError, match="Deploying application default failed"):
+            serve.run(app, blocking=False)
 
         def check_for_failed_deployment():
             """Check if the application deployment has failed."""
@@ -123,7 +123,7 @@ class TestRemoteCode:
             wait_for_condition(check_for_failed_deployment, timeout=120)
         except TimeoutError:
             # If deployment didn't fail, check if it succeeded
-            if self._check_for_running_app():
+            if self._is_default_app_running():
                 pytest.fail(
                     "App deployed successfully without trust_remote_code=True. "
                     "This model may not actually require remote code. "
@@ -142,7 +142,7 @@ class TestRemoteCode:
         serve.run(app, blocking=False)
 
         # Wait for the application to be running (timeout after 5 minutes)
-        wait_for_condition(self._check_for_running_app, timeout=300)
+        wait_for_condition(self._is_default_app_running, timeout=300)
 
 
 if __name__ == "__main__":

--- a/release/llm_tests/serve/test_llm_serve_integration.py
+++ b/release/llm_tests/serve/test_llm_serve_integration.py
@@ -1,6 +1,8 @@
 import pytest
 import sys
 
+from ray import serve
+from ray.serve.llm import LLMConfig, build_openai_app
 from ray.llm._internal.serve.deployments.llm.vllm.vllm_loggers import (
     RayPrometheusStatLogger,
 )
@@ -8,6 +10,9 @@ from vllm import AsyncEngineArgs
 
 from vllm.v1.engine.async_llm import AsyncLLM
 from vllm.sampling_params import SamplingParams
+from ray._common.test_utils import wait_for_condition
+from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
+from ray.serve.schema import ApplicationStatus
 
 
 @pytest.mark.asyncio(scope="function")
@@ -37,6 +42,55 @@ async def test_engine_metrics():
 
         async for _ in results:
             pass
+
+
+@pytest.mark.asyncio(scope="function")
+async def test_remote_code_model():
+    """
+    Tests that a remote code model can be loaded successfully. This is important
+    to avoid regressions for pickling issues for custom huggingface configs.
+    It may be a bit big/end-to-end, but it's good to have coverage for DeepSeek models
+    in general.
+    """
+
+    llm_config = LLMConfig(
+        model_loading_config=dict(
+            model_id="deepseek",
+            model_source="deepseek-ai/DeepSeek-V2-Lite",
+        ),
+        runtime_env=dict(env_vars={"VLLM_USE_V1": "1"}),
+        deployment_config=dict(
+            autoscaling_config=dict(min_replicas=1, max_replicas=1),
+        ),
+        engine_kwargs=dict(
+            tensor_parallel_size=2,
+            pipeline_parallel_size=2,
+            gpu_memory_utilization=0.92,
+            dtype="auto",
+            max_num_seqs=40,
+            max_model_len=16384,
+            enable_chunked_prefill=True,
+            enable_prefix_caching=True,
+            trust_remote_code=True,
+        ),
+    )
+
+    app = build_openai_app({"llm_configs": [llm_config]})
+    serve.run(app, blocking=False)
+
+    def check_for_running_app():
+        """Check if the application is running successfully."""
+        try:
+            default_app = serve.status().applications[SERVE_DEFAULT_APP_NAME]
+            return default_app.status == ApplicationStatus.RUNNING
+        except (KeyError, AttributeError):
+            return False
+
+    # Wait for the application to be running (timeout after 5 minutes)
+    wait_for_condition(check_for_running_app, timeout=300)
+
+    # Clean up the deployment
+    serve.shutdown()
 
 
 if __name__ == "__main__":

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4300,7 +4300,7 @@
       type: llm-cu128
       runtime_env:
         - VLLM_USE_V1=1
-    cluster_compute: llm_g5-4xlarge.yaml
+    cluster_compute: llm_four_L4_gpu_head_node.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
     project_id: prj_lhlrf1u5yv8qz9qg3xzw8fkiiq


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Since #53621, vLLM engines running DeepSeek-V2-Lite and related models that fetch remote code fail with pickle errors, since the engine only registers custom configs to serialize by value (and avoid the pickle error) if `transformers_modules` can be imported.

```
# vllm/transformers_utils/config.py
def maybe_register_config_serialize_by_value() -> None:
    try:
        import transformers_modules
    except ImportError:
        # the config does not need trust_remote_code
        return
...
```

We relied on a call to `AutoProcessor.from_pretrained` to initialize `transformers_modules`, so that `maybe_register_config_serialize_by_value` would execute correctly when AsyncLLM starts. This was removed in https://github.com/ray-project/ray/pull/53621. Now we can use `init_hf_modules` so to accomplish the same result more directly.

We could also fix this upstream with https://github.com/vllm-project/vllm/pull/19510.


Traceback:
```
(ServeController pid=14535) Traceback (most recent call last):
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/_private/deployment_state.py", line 718, in check_ready
(ServeController pid=14535)     ) = ray.get(self._ready_obj_ref)
(ServeController pid=14535)         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/auto_init_hook.py", line 22, in auto_init_wrapper
(ServeController pid=14535)     return fn(*args, **kwargs)
(ServeController pid=14535)            ^^^^^^^^^^^^^^^^^^^
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/client_mode_hook.py", line 104, in wrapper
(ServeController pid=14535)     return func(*args, **kwargs)
(ServeController pid=14535)            ^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/worker.py", line 2847, in get
(ServeController pid=14535)     values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
(ServeController pid=14535)                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/worker.py", line 947, in get_objects
(ServeController pid=14535)     raise value.as_instanceof_cause()
(ServeController pid=14535) ray.exceptions.RayTaskError(RuntimeError): ray::ServeReplica:default:LLMDeploymentdeepseek.initialize_and_get_metadata() (pid=32141, ip=10.0.127.215, actor_id=b962327f5b252ba15620da8102000000, repr=<ray.serve._private.replica.ServeReplica:default:LLMDeploymentdeepseek object at 0x7ae2c961c7d0>)
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/concurrent/futures/_base.py", line 449, in result
(ServeController pid=14535)     return self.__get_result()
(ServeController pid=14535)            ^^^^^^^^^^^^^^^^^^^
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
(ServeController pid=14535)     raise self._exception
(ServeController pid=14535)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/_private/replica.py", line 1022, in initialize_and_get_metadata
(ServeController pid=14535)     await self._replica_impl.initialize(deployment_config)
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/_private/replica.py", line 730, in initialize
(ServeController pid=14535)     raise RuntimeError(traceback.format_exc()) from None
(ServeController pid=14535) RuntimeError: Traceback (most recent call last):
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/_private/replica.py", line 703, in initialize
(ServeController pid=14535)     self._user_callable_asgi_app = await asyncio.wrap_future(
(ServeController pid=14535)                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/_private/replica.py", line 1442, in initialize_callable
(ServeController pid=14535)     await self._call_func_or_gen(
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/serve/_private/replica.py", line 1388, in _call_func_or_gen
(ServeController pid=14535)     result = await result
(ServeController pid=14535)              ^^^^^^^^^^^^
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/llm/_internal/serve/deployments/llm/llm_server.py", line 442, in __init__
(ServeController pid=14535)     await asyncio.wait_for(self._start_engine(), timeout=ENGINE_START_TIMEOUT_S)
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/asyncio/tasks.py", line 489, in wait_for
(ServeController pid=14535)     return fut.result()
(ServeController pid=14535)            ^^^^^^^^^^^^
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/llm/_internal/serve/deployments/llm/llm_server.py", line 488, in _start_engine
(ServeController pid=14535)     await self.engine.start()
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py", line 280, in start
(ServeController pid=14535)     self.engine = await self._start_engine()
(ServeController pid=14535)                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py", line 337, in _start_engine
(ServeController pid=14535)     return await self._start_engine_v1()
(ServeController pid=14535)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py", line 405, in _start_engine_v1
(ServeController pid=14535)     return self._start_async_llm_engine(
(ServeController pid=14535)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/llm/_internal/serve/deployments/llm/vllm/vllm_engine.py", line 528, in _start_async_llm_engine
(ServeController pid=14535)     engine = vllm.engine.async_llm_engine.AsyncLLMEngine(
(ServeController pid=14535)              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/engine/async_llm.py", line 123, in __init__
(ServeController pid=14535)     self.engine_core = core_client_class(
(ServeController pid=14535)                        ^^^^^^^^^^^^^^^^^^
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/engine/core_client.py", line 734, in __init__
(ServeController pid=14535)     super().__init__(
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/engine/core_client.py", line 404, in __init__
(ServeController pid=14535)     self.resources.local_engine_manager = CoreEngineProcManager(
(ServeController pid=14535)                                           ^^^^^^^^^^^^^^^^^^^^^^
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/utils.py", line 142, in __init__
(ServeController pid=14535)     proc.start()
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/multiprocessing/process.py", line 121, in start
(ServeController pid=14535)     self._popen = self._Popen(self)
(ServeController pid=14535)                   ^^^^^^^^^^^^^^^^^
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/multiprocessing/context.py", line 288, in _Popen
(ServeController pid=14535)     return Popen(process_obj)
(ServeController pid=14535)            ^^^^^^^^^^^^^^^^^^
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/multiprocessing/popen_spawn_posix.py", line 32, in __init__
(ServeController pid=14535)     super().__init__(process_obj)
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/multiprocessing/popen_fork.py", line 19, in __init__
(ServeController pid=14535)     self._launch(process_obj)
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/multiprocessing/popen_spawn_posix.py", line 47, in _launch
(ServeController pid=14535)     reduction.dump(process_obj, fp)
(ServeController pid=14535)   File "/home/ray/anaconda3/lib/python3.11/multiprocessing/reduction.py", line 60, in dump
(ServeController pid=14535)     ForkingPickler(file, protocol).dump(obj)
(ServeController pid=14535) _pickle.PicklingError: Can't pickle <class 'transformers_modules.deepseek-ai.DeepSeek-V2-Lite.604d5664dddd88a0433dbae533b7fe9472482de0.configuration_deepseek.DeepseekV2Config'>: import of module 'transformers_modules.deepseek-ai.DeepSeek-V2-Lite.604d5664dddd88a0433dbae533b7fe9472482de0.configuration_deepseek' failed
```

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
