### PR TITLE
[Serve.llm] Disable TP=2 VLM batch test

### DIFF
--- a/release/llm_tests/batch/test_batch_vllm.py
+++ b/release/llm_tests/batch/test_batch_vllm.py
@@ -184,8 +184,11 @@ def delete_torch_compile_cache_on_worker():
     [
         # LLaVA model with TP=1, PP=1, concurrency=1
         ("llava-hf/llava-1.5-7b-hf", 1, 1, 1, 60),
+        
+        # todo(seiji): Commenting out due to https://github.com/ray-project/ray/issues/53824
+        # Need to follow up once torch_compile_cache issue is fixed or PyTorch 2.8
         # Pixtral model with TP=2, PP=1, concurrency=2
-        ("mistral-community/pixtral-12b", 2, 1, 2, 60),
+        # ("mistral-community/pixtral-12b", 2, 1, 2, 60),
     ],
 )
 def test_vllm_vision_language_models(

--- a/release/llm_tests/batch/test_batch_vllm.py
+++ b/release/llm_tests/batch/test_batch_vllm.py
@@ -184,17 +184,19 @@ def delete_torch_compile_cache_on_worker():
     [
         # LLaVA model with TP=1, PP=1, concurrency=1
         ("llava-hf/llava-1.5-7b-hf", 1, 1, 1, 60),
-        
-        # todo(seiji): Commenting out due to https://github.com/ray-project/ray/issues/53824
-        # Need to follow up once torch_compile_cache issue is fixed or PyTorch 2.8
         # Pixtral model with TP=2, PP=1, concurrency=2
-        # ("mistral-community/pixtral-12b", 2, 1, 2, 60),
+        ("mistral-community/pixtral-12b", 2, 1, 2, 60),
     ],
 )
 def test_vllm_vision_language_models(
     model_source, tp_size, pp_size, concurrency, sample_size
 ):
     """Test vLLM with vision language models using different configurations."""
+
+    # todo(seiji): Commenting out due to https://github.com/ray-project/ray/issues/53824
+    # Need to follow up once torch_compile_cache issue is fixed or PyTorch 2.8
+    if model_source == "mistral-community/pixtral-12b":
+        pytest.skip("Skipping test due to torch_compile_cache issue")
 
     ray.get(delete_torch_compile_cache_on_worker.remote())
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Failing due to https://github.com/ray-project/ray/issues/53824. Relatively rare configuration and and likely downstream of vLLM: https://github.com/vllm-project/vllm/issues/18851.

## Related issue number

Revisit once https://github.com/ray-project/ray/issues/53824, https://github.com/vllm-project/vllm/issues/18851 is closed or PyTorch 2.8, when vLLM will no longer need to monkeypatch to access torch compile.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
