### PR TITLE
[Doc][Fix] reveal the falsely hidden export command in the KubeRay GCS FT guide

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-ft.ipynb
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-ft.ipynb
@@ -539,7 +539,6 @@
      "slide_type": ""
     },
     "tags": [
-     "remove-cell",
      "nbval-ignore-output",
      "remove-output"
     ]


### PR DESCRIPTION
## Why are these changes needed?

The `export YOUR_WORKER_POD=$(kubectl get pods -l ...)` command should not be hidden; otherwise, users will not be able to follow the guide.


## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
