### PR TITLE
[core] Fix `test_object_spilling.py` on Windows

### DIFF
--- a/python/ray/tests/test_object_spilling.py
+++ b/python/ray/tests/test_object_spilling.py
@@ -785,11 +785,10 @@ def test_recover_from_spill_worker_failure(ray_start_regular):
     _run_spilling_workload()
 
     # Check that the spilled files are cleaned up after the workload finishes.
-    ray._private.worker._global_node._session_dir
-    node_id = ray.get_runtime_context().get_node_id()
     wait_for_condition(
         lambda: is_dir_empty(
-            Path(ray._private.worker._global_node._session_dir), node_id
+            Path(ray._private.worker._global_node._session_dir),
+            ray.get_runtime_context().get_node_id(),
         )
     )
 


### PR DESCRIPTION
I made the workload more stressful in https://github.com/ray-project/ray/pull/53803 by fetching all of the results concurrently. That seems to have caused Windows to time out: https://buildkite.com/ray-project/postmerge/builds/10876#01977755-755b-485e-bd13-f0ea3e33cc36/158-818

I won't pretend to fully understand why, but reverting to the old pattern in an attempt to fix it.

Also added an explicit wait for the dir to drain because there was an error during cleanup caused by it.