### PR TITLE
[ObjectStore] Warn if object store is allocated < 50% of total memory for data workloads

### DIFF
--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -109,15 +109,19 @@ class ResourceManager:
 
     def _warn_about_object_store_memory_if_needed(self):
         """Warn if object store memory is configured below 50% of total memory."""
-        import ray
         from ray.data.context import WARN_PREFIX
         from ray.util.debug import log_once
 
-        cluster_resources = ray.cluster_resources()
-        total_memory = cluster_resources.get("memory", 0)
-        object_store_memory = cluster_resources.get("object_store_memory", 0)
+        total_resources = self._get_total_resources()
+        total_memory = total_resources.memory
+        object_store_memory = total_resources.object_store_memory
 
-        if total_memory > 0:
+        # Check if we have actual numeric values (not mocks or None)
+        if (
+            isinstance(total_memory, (int, float))
+            and isinstance(object_store_memory, (int, float))
+            and total_memory > 0
+        ):
             object_store_fraction = object_store_memory / total_memory
 
             if object_store_fraction < 0.5 and log_once(

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -129,7 +129,7 @@ class ResourceManager:
                     f"out of {total_memory/1e9:.1f}GB total). For optimal Ray Data performance, "
                     f"we recommend setting the object store to at least 50% of available memory. "
                     f"You can do this by setting the 'object_store_memory' parameter when calling "
-                    f"ray.init() or by setting the RAY_OBJECT_STORE_ALLOW_SLOW_STORAGE environment variable."
+                    f"ray.init() or by setting the RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION environment variable."
                 )
 
     def _estimate_object_store_memory(

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -132,7 +132,6 @@ class ResourceManager:
                     f"ray.init() or by setting the RAY_OBJECT_STORE_ALLOW_SLOW_STORAGE environment variable."
                 )
 
-
     def _estimate_object_store_memory(
         self, op: "PhysicalOperator", state: "OpState"
     ) -> int:

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -113,6 +113,9 @@ class ResourceManager:
         from ray.data.context import WARN_PREFIX
         from ray.util.debug import log_once
 
+        if not ray.is_initialized():
+            return
+
         cluster_resources = ray.cluster_resources()
         total_memory = cluster_resources.get("memory", 0)
         object_store_memory = cluster_resources.get("object_store_memory", 0)

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -109,19 +109,16 @@ class ResourceManager:
 
     def _warn_about_object_store_memory_if_needed(self):
         """Warn if object store memory is configured below 50% of total memory."""
+        import ray
         from ray.data.context import WARN_PREFIX
         from ray.util.debug import log_once
 
-        total_resources = self._get_total_resources()
-        total_memory = total_resources.memory
-        object_store_memory = total_resources.object_store_memory
+        cluster_resources = ray.cluster_resources()
+        total_memory = cluster_resources.get("memory", 0)
+        object_store_memory = cluster_resources.get("object_store_memory", 0)
 
         # Check if we have actual numeric values (not mocks or None)
-        if (
-            isinstance(total_memory, (int, float))
-            and isinstance(object_store_memory, (int, float))
-            and total_memory > 0
-        ):
+        if total_memory > 0:
             object_store_fraction = object_store_memory / total_memory
 
             if object_store_fraction < 0.5 and log_once(

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -105,6 +105,34 @@ class ResourceManager:
             )
         )
 
+        self._warn_about_object_store_memory_if_needed()
+
+    def _warn_about_object_store_memory_if_needed(self):
+        """Warn if object store memory is configured below 50% of total memory."""
+        import ray
+        from ray.data.context import WARN_PREFIX
+        from ray.util.debug import log_once
+
+        cluster_resources = ray.cluster_resources()
+        total_memory = cluster_resources.get("memory", 0)
+        object_store_memory = cluster_resources.get("object_store_memory", 0)
+
+        if total_memory > 0:
+            object_store_fraction = object_store_memory / total_memory
+
+            if object_store_fraction < 0.5 and log_once(
+                "ray_data_object_store_memory_warning"
+            ):
+                logger.warning(
+                    f"{WARN_PREFIX} Ray's object store is configured to use only "
+                    f"{object_store_fraction:.1%} of available memory ({object_store_memory/1e9:.1f}GB "
+                    f"out of {total_memory/1e9:.1f}GB total). For optimal Ray Data performance, "
+                    f"we recommend setting the object store to at least 50% of available memory. "
+                    f"You can do this by setting the 'object_store_memory' parameter when calling "
+                    f"ray.init() or by setting the RAY_OBJECT_STORE_ALLOW_SLOW_STORAGE environment variable."
+                )
+
+
     def _estimate_object_store_memory(
         self, op: "PhysicalOperator", state: "OpState"
     ) -> int:
@@ -669,7 +697,7 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
             self._op_budgets[op].gpu = float("inf")
 
         # A materializing operator like `AllToAllOperator` waits for all its input
-        # operator’s outputs before processing data. This often forces the input
+        # operator's outputs before processing data. This often forces the input
         # operator to exceed its object store memory budget. To prevent deadlock, we
         # disable object store memory backpressure for the input operator.
         for op in eligible_ops:

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -128,7 +128,9 @@ class TestResourceManager:
                 DataContext.get_current(),
             )
             expected_resource = ExecutionResources(4, 1, 0)
-            # The first call should call ray.cluster_resources().
+            # Reset call count after initialization (which now calls get_total_resources once)
+            get_total_resources.reset_mock()
+            # The first call should call get_total_resources().
             assert resource_manager.get_global_limits() == expected_resource
             assert get_total_resources.call_count == 1
             # The second call should return the cached value.
@@ -136,7 +138,7 @@ class TestResourceManager:
             assert get_total_resources.call_count == 1
             time.sleep(cache_interval_s)
             # After the cache interval, the third call should call
-            # ray.cluster_resources() again.
+            # get_total_resources() again.
             assert resource_manager.get_global_limits() == expected_resource
             assert get_total_resources.call_count == 2
 

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -128,7 +128,7 @@ class TestResourceManager:
                 DataContext.get_current(),
             )
             expected_resource = ExecutionResources(4, 1, 0)
-            # The first call should call get_total_resources().
+            # The first call should call ray.cluster_resources().
             assert resource_manager.get_global_limits() == expected_resource
             assert get_total_resources.call_count == 1
             # The second call should return the cached value.

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -128,8 +128,6 @@ class TestResourceManager:
                 DataContext.get_current(),
             )
             expected_resource = ExecutionResources(4, 1, 0)
-            # Reset call count after initialization (which now calls get_total_resources once)
-            get_total_resources.reset_mock()
             # The first call should call get_total_resources().
             assert resource_manager.get_global_limits() == expected_resource
             assert get_total_resources.call_count == 1
@@ -138,7 +136,7 @@ class TestResourceManager:
             assert get_total_resources.call_count == 1
             time.sleep(cache_interval_s)
             # After the cache interval, the third call should call
-            # get_total_resources() again.
+            # ray.cluster_resources() again.
             assert resource_manager.get_global_limits() == expected_resource
             assert get_total_resources.call_count == 2
 


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Logs a warning if the object store is given less < 50% memory for Data Workloads to minimize disk spilling 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
