### PR TITLE
[core] Cleanup naming in core worker scheduling queues

### DIFF
--- a/src/ray/core_worker/test/task_receiver_test.cc
+++ b/src/ray/core_worker/test/task_receiver_test.cc
@@ -117,12 +117,12 @@ class MockTaskReceiver : public TaskReceiver {
  public:
   MockTaskReceiver(instrumented_io_context &task_execution_service,
                    worker::TaskEventBuffer &task_event_buffer,
-                   const TaskHandler &task_handler,
+                   const ExecuteTaskCallback &execute_task,
                    std::function<std::function<void()>()> initialize_thread_callback,
                    const OnActorCreationTaskDone &actor_creation_task_done_)
       : TaskReceiver(task_execution_service,
                      task_event_buffer,
-                     task_handler,
+                     execute_task,
                      initialize_thread_callback,
                      actor_creation_task_done_) {}
 

--- a/src/ray/core_worker/transport/actor_scheduling_queue.cc
+++ b/src/ray/core_worker/transport/actor_scheduling_queue.cc
@@ -92,7 +92,7 @@ void ActorSchedulingQueue::EnqueueTask(
   }
   RAY_LOG(DEBUG) << "Enqueue " << seq_no << " cur seqno " << next_seq_no_;
 
-  pending_actor_tasks_[seq_no] = InboundRequest(std::move(accept_request),
+  pending_actor_tasks_[seq_no] = QueuedTask(std::move(accept_request),
                                                 std::move(reject_request),
                                                 std::move(send_reply_callback),
                                                 task_spec);
@@ -235,7 +235,7 @@ void ActorSchedulingQueue::OnSequencingWaitTimeout() {
 }
 
 void ActorSchedulingQueue::AcceptRequestOrRejectIfCanceled(TaskID task_id,
-                                                           InboundRequest &request) {
+                                                           QueuedTask &request) {
   bool is_canceled = false;
   {
     absl::MutexLock lock(&mu_);

--- a/src/ray/core_worker/transport/actor_scheduling_queue.cc
+++ b/src/ray/core_worker/transport/actor_scheduling_queue.cc
@@ -78,7 +78,7 @@ void ActorSchedulingQueue::EnqueueTask(
     int64_t client_processed_up_to,
     std::function<void(const TaskSpecification &, rpc::SendReplyCallback)> execute_task_callback,
     std::function<void(const TaskSpecification &, const Status &, rpc::SendReplyCallback)>
-        reject_task_callback,
+        cancel_task_callback,
     rpc::SendReplyCallback send_reply_callback,
     TaskSpecification task_spec) {
   // A seq_no of -1 means no ordering constraint. Actor tasks must be executed in order.
@@ -93,7 +93,7 @@ void ActorSchedulingQueue::EnqueueTask(
   RAY_LOG(DEBUG) << "Enqueue " << seq_no << " cur seqno " << next_seq_no_;
 
   pending_actor_tasks_[seq_no] = QueuedTask(std::move(execute_task_callback),
-                                                std::move(reject_task_callback),
+                                                std::move(cancel_task_callback),
                                                 std::move(send_reply_callback),
                                                 task_spec);
   {

--- a/src/ray/core_worker/transport/actor_scheduling_queue.cc
+++ b/src/ray/core_worker/transport/actor_scheduling_queue.cc
@@ -76,9 +76,9 @@ size_t ActorSchedulingQueue::Size() const {
 void ActorSchedulingQueue::EnqueueTask(
     int64_t seq_no,
     int64_t client_processed_up_to,
-    std::function<void(const TaskSpecification &, rpc::SendReplyCallback)> accept_request,
+    std::function<void(const TaskSpecification &, rpc::SendReplyCallback)> execute_task_callback,
     std::function<void(const TaskSpecification &, const Status &, rpc::SendReplyCallback)>
-        reject_request,
+        reject_task_callback,
     rpc::SendReplyCallback send_reply_callback,
     TaskSpecification task_spec) {
   // A seq_no of -1 means no ordering constraint. Actor tasks must be executed in order.
@@ -92,8 +92,8 @@ void ActorSchedulingQueue::EnqueueTask(
   }
   RAY_LOG(DEBUG) << "Enqueue " << seq_no << " cur seqno " << next_seq_no_;
 
-  pending_actor_tasks_[seq_no] = QueuedTask(std::move(accept_request),
-                                                std::move(reject_request),
+  pending_actor_tasks_[seq_no] = QueuedTask(std::move(execute_task_callback),
+                                                std::move(reject_task_callback),
                                                 std::move(send_reply_callback),
                                                 task_spec);
   {

--- a/src/ray/core_worker/transport/actor_scheduling_queue.cc
+++ b/src/ray/core_worker/transport/actor_scheduling_queue.cc
@@ -72,8 +72,8 @@ size_t ActorSchedulingQueue::Size() const {
   return 0;
 }
 
-/// Add a new actor task's callbacks to the worker queue.
-void ActorSchedulingQueue::Add(
+/// Enqueue a task to be executed on this worker.
+void ActorSchedulingQueue::EnqueueTask(
     int64_t seq_no,
     int64_t client_processed_up_to,
     std::function<void(const TaskSpecification &, rpc::SendReplyCallback)> accept_request,

--- a/src/ray/core_worker/transport/actor_scheduling_queue.h
+++ b/src/ray/core_worker/transport/actor_scheduling_queue.h
@@ -79,9 +79,9 @@ class ActorSchedulingQueue : public SchedulingQueue {
   void ScheduleRequests() override;
 
  private:
-  /// Accept the given InboundRequest or reject it if a task id is canceled via
+  /// Accept the given QueuedTask or reject it if a task id is canceled via
   /// CancelTaskIfFound.
-  void AcceptRequestOrRejectIfCanceled(TaskID task_id, InboundRequest &request);
+  void AcceptRequestOrRejectIfCanceled(TaskID task_id, QueuedTask &request);
 
   /// Called when we time out waiting for an earlier task to show up.
   void OnSequencingWaitTimeout();
@@ -89,7 +89,7 @@ class ActorSchedulingQueue : public SchedulingQueue {
   const int64_t reorder_wait_seconds_ =
       ::RayConfig::instance().actor_scheduling_queue_max_reorder_wait_seconds();
   /// Sorted map of (accept, rej) task callbacks keyed by their sequence number.
-  std::map<int64_t, InboundRequest> pending_actor_tasks_;
+  std::map<int64_t, QueuedTask> pending_actor_tasks_;
   /// The next sequence number we are waiting for to arrive.
   int64_t next_seq_no_ = 0;
   /// Timer for waiting on dependencies. Note that this is set on the task main

--- a/src/ray/core_worker/transport/actor_scheduling_queue.h
+++ b/src/ray/core_worker/transport/actor_scheduling_queue.h
@@ -58,15 +58,15 @@ class ActorSchedulingQueue : public SchedulingQueue {
 
   size_t Size() const override;
 
-  /// Enqueue a task to be executed on this worker.
-  void Enqueue(int64_t seq_no,
+  /// EnqueueTask a task to be executed on this worker.
+  void EnqueueTask(int64_t seq_no,
                int64_t client_processed_up_to,
                std::function<void(const TaskSpecification &, rpc::SendReplyCallback)>
-                   accept_request,
+                   execute_task_callback,
                std::function<void(const TaskSpecification &,
                                   const Status &,
                                   rpc::SendReplyCallback)> reject_request,
-               rpc::SendReplyCallback send_reply_callback,
+               rpc::SendReplyCallback cancel_task_callback,
                TaskSpecification task_spec) override;
 
   /// Cancel the actor task in the queue.

--- a/src/ray/core_worker/transport/actor_scheduling_queue.h
+++ b/src/ray/core_worker/transport/actor_scheduling_queue.h
@@ -58,16 +58,16 @@ class ActorSchedulingQueue : public SchedulingQueue {
 
   size_t Size() const override;
 
-  /// Add a new actor task's callbacks to the worker queue.
-  void Add(int64_t seq_no,
-           int64_t client_processed_up_to,
-           std::function<void(const TaskSpecification &, rpc::SendReplyCallback)>
-               accept_request,
-           std::function<void(const TaskSpecification &,
-                              const Status &,
-                              rpc::SendReplyCallback)> reject_request,
-           rpc::SendReplyCallback send_reply_callback,
-           TaskSpecification task_spec) override;
+  /// Enqueue a task to be executed on this worker.
+  void Enqueue(int64_t seq_no,
+               int64_t client_processed_up_to,
+               std::function<void(const TaskSpecification &, rpc::SendReplyCallback)>
+                   accept_request,
+               std::function<void(const TaskSpecification &,
+                                  const Status &,
+                                  rpc::SendReplyCallback)> reject_request,
+               rpc::SendReplyCallback send_reply_callback,
+               TaskSpecification task_spec) override;
 
   /// Cancel the actor task in the queue.
   /// Tasks are in the queue if it is either queued, or executing.

--- a/src/ray/core_worker/transport/normal_scheduling_queue.cc
+++ b/src/ray/core_worker/transport/normal_scheduling_queue.cc
@@ -37,8 +37,8 @@ size_t NormalSchedulingQueue::Size() const {
   return pending_normal_tasks_.size();
 }
 
-/// Add a new task's callbacks to the worker queue.
-void NormalSchedulingQueue::Add(
+/// Enqueue a task to be executed on this worker.
+void NormalSchedulingQueue::EnqueueTask(
     int64_t seq_no,
     int64_t client_processed_up_to,
     std::function<void(const TaskSpecification &, rpc::SendReplyCallback)> accept_request,

--- a/src/ray/core_worker/transport/normal_scheduling_queue.cc
+++ b/src/ray/core_worker/transport/normal_scheduling_queue.cc
@@ -50,7 +50,6 @@ void NormalSchedulingQueue::Add(
   // Normal tasks should not have ordering constraints.
   RAY_CHECK(seq_no == -1);
   // Create a InboundRequest object for the new task, and add it to the queue.
-
   pending_normal_tasks_.push_back(InboundRequest(std::move(accept_request),
                                                  std::move(reject_request),
                                                  std::move(send_reply_callback),

--- a/src/ray/core_worker/transport/normal_scheduling_queue.cc
+++ b/src/ray/core_worker/transport/normal_scheduling_queue.cc
@@ -49,19 +49,19 @@ void NormalSchedulingQueue::EnqueueTask(
   absl::MutexLock lock(&mu_);
   // Normal tasks should not have ordering constraints.
   RAY_CHECK(seq_no == -1);
-  // Create a InboundRequest object for the new task, and add it to the queue.
-  pending_normal_tasks_.push_back(InboundRequest(std::move(accept_request),
+  // Create a QueuedTask object for the new task, and add it to the queue.
+  pending_normal_tasks_.push_back(QueuedTask(std::move(accept_request),
                                                  std::move(reject_request),
                                                  std::move(send_reply_callback),
                                                  std::move(task_spec)));
 }
 
-// Search for an InboundRequest associated with the task that we are trying to cancel.
-// If found, remove the InboundRequest from the queue and return true. Otherwise,
+// Search for an QueuedTask associated with the task that we are trying to cancel.
+// If found, remove the QueuedTask from the queue and return true. Otherwise,
 // return false.
 bool NormalSchedulingQueue::CancelTaskIfFound(TaskID task_id) {
   absl::MutexLock lock(&mu_);
-  for (std::deque<InboundRequest>::reverse_iterator it = pending_normal_tasks_.rbegin();
+  for (std::deque<QueuedTask>::reverse_iterator it = pending_normal_tasks_.rbegin();
        it != pending_normal_tasks_.rend();
        ++it) {
     if (it->TaskID() == task_id) {
@@ -76,7 +76,7 @@ bool NormalSchedulingQueue::CancelTaskIfFound(TaskID task_id) {
 /// Schedules as many requests as possible in sequence.
 void NormalSchedulingQueue::ScheduleRequests() {
   while (true) {
-    InboundRequest head;
+    QueuedTask head;
     {
       absl::MutexLock lock(&mu_);
       if (!pending_normal_tasks_.empty()) {

--- a/src/ray/core_worker/transport/normal_scheduling_queue.h
+++ b/src/ray/core_worker/transport/normal_scheduling_queue.h
@@ -37,16 +37,16 @@ class NormalSchedulingQueue : public SchedulingQueue {
   bool TaskQueueEmpty() const override;
   size_t Size() const override;
 
-  /// Add a new task's callbacks to the worker queue.
-  void Add(int64_t seq_no,
-           int64_t client_processed_up_to,
-           std::function<void(const TaskSpecification &, rpc::SendReplyCallback)>
-               accept_request,
-           std::function<void(const TaskSpecification &,
-                              const Status &,
-                              rpc::SendReplyCallback)> reject_request,
-           rpc::SendReplyCallback send_reply_callback,
-           TaskSpecification task_spec) override;
+  /// Enqueue a task to be executed on this worker.
+  void EnqueueTask(int64_t seq_no,
+                   int64_t client_processed_up_to,
+                   std::function<void(const TaskSpecification &, rpc::SendReplyCallback)>
+                       accept_request,
+                   std::function<void(const TaskSpecification &,
+                                      const Status &,
+                                      rpc::SendReplyCallback)> reject_request,
+                   rpc::SendReplyCallback send_reply_callback,
+                   TaskSpecification task_spec) override;
 
   // Search for an InboundRequest associated with the task that we are trying to cancel.
   // If found, remove the InboundRequest from the queue and return true. Otherwise,

--- a/src/ray/core_worker/transport/normal_scheduling_queue.h
+++ b/src/ray/core_worker/transport/normal_scheduling_queue.h
@@ -48,8 +48,8 @@ class NormalSchedulingQueue : public SchedulingQueue {
                    rpc::SendReplyCallback send_reply_callback,
                    TaskSpecification task_spec) override;
 
-  // Search for an InboundRequest associated with the task that we are trying to cancel.
-  // If found, remove the InboundRequest from the queue and return true. Otherwise,
+  // Search for an QueuedTask associated with the task that we are trying to cancel.
+  // If found, remove the QueuedTask from the queue and return true. Otherwise,
   // return false.
   bool CancelTaskIfFound(TaskID task_id) override;
 
@@ -60,7 +60,7 @@ class NormalSchedulingQueue : public SchedulingQueue {
   /// Protects access to the dequeue below.
   mutable absl::Mutex mu_;
   /// Queue with (accept, rej) callbacks for non-actor tasks
-  std::deque<InboundRequest> pending_normal_tasks_ ABSL_GUARDED_BY(mu_);
+  std::deque<QueuedTask> pending_normal_tasks_ ABSL_GUARDED_BY(mu_);
   friend class SchedulingQueueTest;
 };
 

--- a/src/ray/core_worker/transport/out_of_order_actor_scheduling_queue.cc
+++ b/src/ray/core_worker/transport/out_of_order_actor_scheduling_queue.cc
@@ -72,7 +72,7 @@ void OutOfOrderActorSchedulingQueue::ScheduleRequests() {
   RAY_LOG(FATAL) << "ScheduleRequests() not implemented for actor queues";
 }
 
-void OutOfOrderActorSchedulingQueue::Add(
+void OutOfOrderActorSchedulingQueue::EnqueueTask(
     int64_t seq_no,
     int64_t client_processed_up_to,
     std::function<void(const TaskSpecification &, rpc::SendReplyCallback)> accept_request,

--- a/src/ray/core_worker/transport/out_of_order_actor_scheduling_queue.h
+++ b/src/ray/core_worker/transport/out_of_order_actor_scheduling_queue.h
@@ -78,13 +78,13 @@ class OutOfOrderActorSchedulingQueue : public SchedulingQueue {
   void ScheduleRequests() override;
 
  private:
-  void RunRequest(InboundRequest request);
+  void RunRequest(QueuedTask request);
 
-  void RunRequestWithSatisfiedDependencies(InboundRequest &request);
+  void RunRequestWithSatisfiedDependencies(QueuedTask &request);
 
-  /// Accept the given InboundRequest or reject it if a task id is canceled via
+  /// Accept the given QueuedTask or reject it if a task id is canceled via
   /// CancelTaskIfFound.
-  void AcceptRequestOrRejectIfCanceled(TaskID task_id, InboundRequest &request);
+  void AcceptRequestOrRejectIfCanceled(TaskID task_id, QueuedTask &request);
 
   instrumented_io_context &task_execution_service_;
   /// The id of the thread that constructed this scheduling queue.
@@ -107,7 +107,7 @@ class OutOfOrderActorSchedulingQueue : public SchedulingQueue {
   /// This can happen if transient network error happens after an actor
   /// task is submitted and received by the actor and the caller retries
   /// the same task.
-  absl::flat_hash_map<TaskID, InboundRequest> queued_actor_tasks_ ABSL_GUARDED_BY(mu_);
+  absl::flat_hash_map<TaskID, QueuedTask> queued_actor_tasks_ ABSL_GUARDED_BY(mu_);
   /// A map of actor task IDs -> is_canceled.
   // Pending means tasks are queued or running.
   absl::flat_hash_map<TaskID, bool> pending_task_id_to_is_canceled ABSL_GUARDED_BY(mu_);

--- a/src/ray/core_worker/transport/out_of_order_actor_scheduling_queue.h
+++ b/src/ray/core_worker/transport/out_of_order_actor_scheduling_queue.h
@@ -57,16 +57,16 @@ class OutOfOrderActorSchedulingQueue : public SchedulingQueue {
 
   size_t Size() const override;
 
-  /// Add a new actor task's callbacks to the worker queue.
-  void Add(int64_t seq_no,
-           int64_t client_processed_up_to,
-           std::function<void(const TaskSpecification &, rpc::SendReplyCallback)>
-               accept_request,
-           std::function<void(const TaskSpecification &,
-                              const Status &,
-                              rpc::SendReplyCallback)> reject_request,
-           rpc::SendReplyCallback send_reply_callback,
-           TaskSpecification task_spec) override;
+  /// Enqueue a task for execution on this worker.
+  void EnqueueTask(int64_t seq_no,
+                   int64_t client_processed_up_to,
+                   std::function<void(const TaskSpecification &, rpc::SendReplyCallback)>
+                       accept_request,
+                   std::function<void(const TaskSpecification &,
+                                      const Status &,
+                                      rpc::SendReplyCallback)> reject_request,
+                   rpc::SendReplyCallback send_reply_callback,
+                   TaskSpecification task_spec) override;
 
   /// Cancel the actor task in the queue.
   /// Tasks are in the queue if it is either queued, or executing.

--- a/src/ray/core_worker/transport/scheduling_queue.h
+++ b/src/ray/core_worker/transport/scheduling_queue.h
@@ -27,15 +27,16 @@ namespace core {
 class SchedulingQueue {
  public:
   virtual ~SchedulingQueue() = default;
-  virtual void Add(int64_t seq_no,
-                   int64_t client_processed_up_to,
-                   std::function<void(const TaskSpecification &, rpc::SendReplyCallback)>
-                       accept_request,
-                   std::function<void(const TaskSpecification &,
-                                      const Status &,
-                                      rpc::SendReplyCallback)> reject_request,
-                   rpc::SendReplyCallback send_reply_callback,
-                   TaskSpecification task_spec) = 0;
+  virtual void EnqueueTask(
+      int64_t seq_no,
+      int64_t client_processed_up_to,
+      std::function<void(const TaskSpecification &, rpc::SendReplyCallback)>
+          execute_task_callback,
+      std::function<void(const TaskSpecification &,
+                         const Status &,
+                         rpc::SendReplyCallback)> cancel_task_callback,
+      rpc::SendReplyCallback send_reply_callback,
+      TaskSpecification task_spec) = 0;
   virtual void ScheduleRequests() = 0;
   virtual bool TaskQueueEmpty() const = 0;
   virtual size_t Size() const = 0;

--- a/src/ray/core_worker/transport/scheduling_util.cc
+++ b/src/ray/core_worker/transport/scheduling_util.cc
@@ -21,9 +21,9 @@
 namespace ray {
 namespace core {
 
-InboundRequest::InboundRequest() {}
+QueuedTask::QueuedTask() {}
 
-InboundRequest::InboundRequest(
+QueuedTask::QueuedTask(
     std::function<void(const TaskSpecification &, rpc::SendReplyCallback)>
         execute_task_callback,
     std::function<void(const TaskSpecification &, const Status &, rpc::SendReplyCallback)>
@@ -36,27 +36,27 @@ InboundRequest::InboundRequest(
       task_spec_(std::move(task_spec)),
       pending_dependencies_(task_spec_.GetDependencies()) {}
 
-void InboundRequest::Accept() {
+void QueuedTask::Accept() {
   execute_task_callback_(task_spec_, std::move(send_reply_callback_));
 }
-void InboundRequest::Cancel(const Status &status) {
+void QueuedTask::Cancel(const Status &status) {
   cancel_task_callback_(task_spec_, status, std::move(send_reply_callback_));
 }
 
-bool InboundRequest::CanExecute() const { return pending_dependencies_.empty(); }
-ray::TaskID InboundRequest::TaskID() const { return task_spec_.TaskId(); }
-uint64_t InboundRequest::AttemptNumber() const { return task_spec_.AttemptNumber(); }
-const std::string &InboundRequest::ConcurrencyGroupName() const {
+bool QueuedTask::CanExecute() const { return pending_dependencies_.empty(); }
+ray::TaskID QueuedTask::TaskID() const { return task_spec_.TaskId(); }
+uint64_t QueuedTask::AttemptNumber() const { return task_spec_.AttemptNumber(); }
+const std::string &QueuedTask::ConcurrencyGroupName() const {
   return task_spec_.ConcurrencyGroupName();
 }
-ray::FunctionDescriptor InboundRequest::FunctionDescriptor() const {
+ray::FunctionDescriptor QueuedTask::FunctionDescriptor() const {
   return task_spec_.FunctionDescriptor();
 }
-const std::vector<rpc::ObjectReference> &InboundRequest::PendingDependencies() const {
+const std::vector<rpc::ObjectReference> &QueuedTask::PendingDependencies() const {
   return pending_dependencies_;
 };
-void InboundRequest::MarkDependenciesSatisfied() { pending_dependencies_.clear(); }
-const TaskSpecification &InboundRequest::TaskSpec() const { return task_spec_; }
+void QueuedTask::MarkDependenciesSatisfied() { pending_dependencies_.clear(); }
+const TaskSpecification &QueuedTask::TaskSpec() const { return task_spec_; }
 
 DependencyWaiterImpl::DependencyWaiterImpl(DependencyWaiterInterface &dependency_client)
     : dependency_client_(dependency_client) {}

--- a/src/ray/core_worker/transport/scheduling_util.cc
+++ b/src/ray/core_worker/transport/scheduling_util.cc
@@ -25,22 +25,22 @@ InboundRequest::InboundRequest() {}
 
 InboundRequest::InboundRequest(
     std::function<void(const TaskSpecification &, rpc::SendReplyCallback)>
-        accept_callback,
+        execute_task_callback,
     std::function<void(const TaskSpecification &, const Status &, rpc::SendReplyCallback)>
-        reject_callback,
+        cancel_task_callback,
     rpc::SendReplyCallback send_reply_callback,
     TaskSpecification task_spec)
-    : accept_callback_(std::move(accept_callback)),
-      reject_callback_(std::move(reject_callback)),
+    : execute_task_callback_(std::move(execute_task_callback)),
+      cancel_task_callback_(std::move(cancel_task_callback)),
       send_reply_callback_(std::move(send_reply_callback)),
       task_spec_(std::move(task_spec)),
       pending_dependencies_(task_spec_.GetDependencies()) {}
 
 void InboundRequest::Accept() {
-  accept_callback_(task_spec_, std::move(send_reply_callback_));
+  execute_task_callback_(task_spec_, std::move(send_reply_callback_));
 }
 void InboundRequest::Cancel(const Status &status) {
-  reject_callback_(task_spec_, status, std::move(send_reply_callback_));
+  cancel_task_callback_(task_spec_, status, std::move(send_reply_callback_));
 }
 
 bool InboundRequest::CanExecute() const { return pending_dependencies_.empty(); }

--- a/src/ray/core_worker/transport/scheduling_util.h
+++ b/src/ray/core_worker/transport/scheduling_util.h
@@ -31,10 +31,10 @@ class InboundRequest {
  public:
   InboundRequest();
   InboundRequest(std::function<void(const TaskSpecification &, rpc::SendReplyCallback)>
-                     accept_callback,
+                     execute_task_callback,
                  std::function<void(const TaskSpecification &,
                                     const Status &,
-                                    rpc::SendReplyCallback)> reject_callback,
+                                    rpc::SendReplyCallback)> cancel_task_callback,
                  rpc::SendReplyCallback send_reply_callback,
                  TaskSpecification task_spec);
 
@@ -50,9 +50,10 @@ class InboundRequest {
   const TaskSpecification &TaskSpec() const;
 
  private:
-  std::function<void(const TaskSpecification &, rpc::SendReplyCallback)> accept_callback_;
+  std::function<void(const TaskSpecification &, rpc::SendReplyCallback)>
+      execute_task_callback_;
   std::function<void(const TaskSpecification &, const Status &, rpc::SendReplyCallback)>
-      reject_callback_;
+      cancel_task_callback_;
   rpc::SendReplyCallback send_reply_callback_;
 
   TaskSpecification task_spec_;

--- a/src/ray/core_worker/transport/scheduling_util.h
+++ b/src/ray/core_worker/transport/scheduling_util.h
@@ -27,10 +27,10 @@ namespace ray {
 namespace core {
 
 /// Object dependency and RPC state of an inbound request.
-class InboundRequest {
+class QueuedTask {
  public:
-  InboundRequest();
-  InboundRequest(std::function<void(const TaskSpecification &, rpc::SendReplyCallback)>
+  QueuedTask();
+  QueuedTask(std::function<void(const TaskSpecification &, rpc::SendReplyCallback)>
                      execute_task_callback,
                  std::function<void(const TaskSpecification &,
                                     const Status &,

--- a/src/ray/core_worker/transport/task_receiver.cc
+++ b/src/ray/core_worker/transport/task_receiver.cc
@@ -70,7 +70,7 @@ void TaskReceiver::HandleTask(rpc::PushTaskRequest request,
     std::vector<std::pair<ObjectID, bool>> streaming_generator_returns;
     bool is_retryable_error = false;
     std::string application_error;
-    auto status = task_handler_(task_spec,
+    auto status = execute_task_(task_spec,
                                 std::move(resource_ids),
                                 &return_objects,
                                 &dynamic_return_objects,

--- a/src/ray/core_worker/transport/task_receiver.h
+++ b/src/ray/core_worker/transport/task_receiver.h
@@ -49,7 +49,7 @@ namespace core {
 
 class TaskReceiver {
  public:
-  using TaskHandler = std::function<Status(
+  using ExecuteTaskCallback = std::function<Status(
       const TaskSpecification &task_spec,
       std::optional<ResourceMappingType> resource_ids,
       std::vector<std::pair<ObjectID, std::shared_ptr<RayObject>>> *return_objects,
@@ -64,10 +64,10 @@ class TaskReceiver {
 
   TaskReceiver(instrumented_io_context &task_execution_service,
                worker::TaskEventBuffer &task_event_buffer,
-               TaskHandler task_handler,
+               ExecuteTaskCallback execute_task,
                std::function<std::function<void()>()> initialize_thread_callback,
                const OnActorCreationTaskDone &actor_creation_task_done)
-      : task_handler_(std::move(task_handler)),
+      : execute_task_(std::move(execute_task)),
         task_execution_service_(task_execution_service),
         task_event_buffer_(task_event_buffer),
         initialize_thread_callback_(std::move(initialize_thread_callback)),
@@ -123,8 +123,8 @@ class TaskReceiver {
   absl::flat_hash_map<ActorID, std::vector<ConcurrencyGroup>> concurrency_groups_cache_;
 
  private:
-  /// The callback function to process a task.
-  TaskHandler task_handler_;
+  /// The callback function to execute a task.
+  ExecuteTaskCallback execute_task_;
   /// The event loop for running tasks on.
   instrumented_io_context &task_execution_service_;
   worker::TaskEventBuffer &task_event_buffer_;


### PR DESCRIPTION
Found myself confused in many places reading this code. Cleaning up the naming to be more direct.

- "accept" and "task handler" -> "execute task"
- "add" -> "enqueue task"

Will keep chipping away at this.