### PR TITLE
[Data] Improve handling of `pandas.NA`

### DIFF
--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -24,7 +24,6 @@ from ray.air.util.tensor_extensions.arrow import (
     convert_to_pyarrow_array,
     pyarrow_table_from_pydict,
 )
-from ray.anyscale.data._internal.arrow_block import ArrowBlockMixin
 from ray.data._internal.arrow_ops import transform_polars, transform_pyarrow
 from ray.data._internal.arrow_ops.transform_pyarrow import shuffle
 from ray.data._internal.row import TableRow
@@ -192,7 +191,7 @@ def _get_max_chunk_size(
         return max(1, int(max_chunk_size_bytes / avg_row_size))
 
 
-class ArrowBlockAccessor(ArrowBlockMixin, TableBlockAccessor):
+class ArrowBlockAccessor(TableBlockAccessor):
     ROW_TYPE = ArrowRow
 
     def __init__(self, table: "pyarrow.Table"):

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -24,6 +24,7 @@ from ray.air.util.tensor_extensions.arrow import (
     convert_to_pyarrow_array,
     pyarrow_table_from_pydict,
 )
+from ray.anyscale.data._internal.arrow_block import ArrowBlockMixin
 from ray.data._internal.arrow_ops import transform_polars, transform_pyarrow
 from ray.data._internal.arrow_ops.transform_pyarrow import shuffle
 from ray.data._internal.row import TableRow
@@ -137,6 +138,9 @@ class ArrowRow(TableRow):
     def __len__(self):
         return self._row.num_columns
 
+    def as_pydict(self) -> Dict[str, Any]:
+        return dict(self.items())
+
 
 class ArrowBlockBuilder(TableBlockBuilder):
     def __init__(self):
@@ -188,7 +192,7 @@ def _get_max_chunk_size(
         return max(1, int(max_chunk_size_bytes / avg_row_size))
 
 
-class ArrowBlockAccessor(TableBlockAccessor):
+class ArrowBlockAccessor(ArrowBlockMixin, TableBlockAccessor):
     ROW_TYPE = ArrowRow
 
     def __init__(self, table: "pyarrow.Table"):

--- a/python/ray/data/_internal/row.py
+++ b/python/ray/data/_internal/row.py
@@ -1,5 +1,6 @@
+import abc
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, Dict
 
 
 class TableRow(Mapping):
@@ -24,10 +25,13 @@ class TableRow(Mapping):
         """
         self._row = row
 
-    def as_pydict(self) -> dict:
+    @abc.abstractmethod
+    def as_pydict(self) -> Dict[str, Any]:
+        """Convert to a normal Python dict.
+
+        This can create a new copy of the row.
         """
-        Convert to a normal Python dict. This will create a new copy of the row."""
-        return dict(self.items())
+        ...
 
     def __str__(self):
         return str(self.as_pydict())

--- a/python/ray/data/tests/test_pandas_block.py
+++ b/python/ray/data/tests/test_pandas_block.py
@@ -456,5 +456,15 @@ class TestSizeBytes:
         assert bytes_size == pytest.approx(true_size, rel=0.1), (bytes_size, true_size)
 
 
+def test_iter_rows_with_na(ray_start_regular_shared):
+    block = pd.DataFrame({"col": [pd.NA]})
+    block_accessor = PandasBlockAccessor.for_block(block)
+
+    rows = block_accessor.iter_rows(public_row_format=True)
+
+    # We should return None for NaN values.
+    assert list(rows) == [{"col": None}]
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This change standardizes null handling across internal block formats by converting pd.NA to None. Since different formats (e.g., Pandas and Arrow) use different null representations, this ensures consistent semantics when converting between them. In particular, we treat pd.NA as a null value, while preserving np.nan as a distinct floating-point NaN.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
