### PR TITLE
[Data] Improve `read_text` trailing newline semantics

### DIFF
--- a/python/ray/data/_internal/datasource/text_datasource.py
+++ b/python/ray/data/_internal/datasource/text_datasource.py
@@ -31,7 +31,7 @@ class TextDatasource(FileBasedDatasource):
 
         builder = DelegatingBlockBuilder()
 
-        lines = data.decode(self.encoding).split("\n")
+        lines = data.decode(self.encoding).splitlines()
         for line in lines:
             if self.drop_empty_lines and line.strip() == "":
                 continue

--- a/python/ray/data/tests/test_text.py
+++ b/python/ray/data/tests/test_text.py
@@ -19,6 +19,7 @@ from ray.data.datasource import (
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.mock_http_server import *  # noqa
 from ray.data.tests.test_partitioning import PathPartitionEncoder
+from ray.data.tests.util import Counter
 from ray.tests.conftest import *  # noqa
 
 
@@ -116,9 +117,7 @@ def test_read_text_meta_provider(
         )
 
 
-@pytest.mark.parametrize("style", [PartitionStyle.HIVE, PartitionStyle.DIRECTORY])
 def test_read_text_partitioned_with_filter(
-    style,
     shutdown_only,
     tmp_path,
     write_base_partitioned_df,
@@ -128,35 +127,45 @@ def test_read_text_partitioned_with_filter(
         dataframe.to_string(path, index=False, header=False, **kwargs)
 
     partition_keys = ["one"]
+    kept_file_counter = Counter.remote()
+    skipped_file_counter = Counter.remote()
 
     def skip_unpartitioned(kv_dict):
-        return bool(kv_dict)
+        keep = bool(kv_dict)
+        counter = kept_file_counter if keep else skipped_file_counter
+        ray.get(counter.increment.remote())
+        return keep
 
-    base_dir = os.path.join(tmp_path, style.value)
-    partition_path_encoder = PathPartitionEncoder.of(
-        style=style,
-        base_dir=base_dir,
-        field_names=partition_keys,
-    )
-    write_base_partitioned_df(
-        partition_keys,
-        partition_path_encoder,
-        df_to_text,
-    )
-    df_to_text(pd.DataFrame({"1": [1]}), os.path.join(base_dir, "test.txt"))
-    partition_path_filter = PathPartitionFilter.of(
-        style=style,
-        base_dir=base_dir,
-        field_names=partition_keys,
-        filter_fn=skip_unpartitioned,
-    )
-    ds = ray.data.read_text(base_dir, partition_filter=partition_path_filter)
-    assert_base_partitioned_ds(
-        ds,
-        schema=Schema(pa.schema([("text", pa.string())])),
-        sorted_values=["1 a", "1 b", "1 c", "3 e", "3 f", "3 g"],
-        ds_take_transform_fn=_to_lines,
-    )
+    for style in [PartitionStyle.HIVE, PartitionStyle.DIRECTORY]:
+        base_dir = os.path.join(tmp_path, style.value)
+        partition_path_encoder = PathPartitionEncoder.of(
+            style=style,
+            base_dir=base_dir,
+            field_names=partition_keys,
+        )
+        write_base_partitioned_df(
+            partition_keys,
+            partition_path_encoder,
+            df_to_text,
+        )
+        df_to_text(pd.DataFrame({"1": [1]}), os.path.join(base_dir, "test.txt"))
+        partition_path_filter = PathPartitionFilter.of(
+            style=style,
+            base_dir=base_dir,
+            field_names=partition_keys,
+            filter_fn=skip_unpartitioned,
+        )
+        ds = ray.data.read_text(base_dir, partition_filter=partition_path_filter)
+        assert_base_partitioned_ds(
+            ds,
+            schema=Schema(pa.schema([("text", pa.string())])),
+            sorted_values=["1 a", "1 b", "1 c", "3 e", "3 f", "3 g"],
+            ds_take_transform_fn=_to_lines,
+        )
+        assert ray.get(kept_file_counter.get.remote()) == 2
+        assert ray.get(skipped_file_counter.get.remote()) == 1
+        ray.get(kept_file_counter.reset.remote())
+        ray.get(skipped_file_counter.reset.remote())
 
 
 def test_read_text_remote_args(ray_start_cluster, tmp_path):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`read_text` currently treats a trailing newline as an empty line, which can lead to unexpected results. This isn’t consistent with how standard Python methods like `str.splitlines()` behave. Since trailing newlines are common in text files, this PR updates the behavior to ignore them.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
