### PR TITLE
[dashboard] Support to overwrite the _client_max_size of http request entity

### DIFF
--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -595,4 +595,6 @@ RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_CORE = env_bool(
 
 # The default maximum size of the http request entity.
 # Used to overwrite the _client_max_size of BaseRequest.
-RAY_HTTP_REQUEST_ENTITY_MAX_SIZE = env_integer("RAY_HTTP_REQUEST_ENTITY_MAX_SIZE", 1024**2)
+RAY_HTTP_REQUEST_ENTITY_MAX_SIZE = env_integer(
+    "RAY_HTTP_REQUEST_ENTITY_MAX_SIZE", 1024**2
+)

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -592,3 +592,7 @@ RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_AGENT = env_bool(
 RAY_EXPERIMENTAL_ENABLE_OPEN_TELEMETRY_ON_CORE = env_bool(
     "RAY_experimental_enable_open_telemetry_on_core", False
 )
+
+# The default maximum size of the http request entity.
+# Used to overwrite the _client_max_size of BaseRequest.
+RAY_HTTP_REQUEST_ENTITY_MAX_SIZE = env_integer("RAY_HTTP_REQUEST_ENTITY_MAX_SIZE", 1024**2)

--- a/python/ray/dashboard/modules/job/job_head.py
+++ b/python/ray/dashboard/modules/job/job_head.py
@@ -52,7 +52,7 @@ from ray.dashboard.modules.version import CURRENT_VERSION, VersionResponse
 from ray.dashboard.subprocesses.module import SubprocessModule
 from ray.dashboard.subprocesses.routes import SubprocessRouteTable as routes
 from ray.dashboard.subprocesses.utils import ResponseType
-
+import ray._private.ray_constants as ray_constants
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
@@ -463,6 +463,7 @@ class JobHead(SubprocessModule):
         )
         logger.info(f"Uploading package {package_uri} to the GCS.")
         try:
+            req = req.clone(client_max_size = ray_constants.RAY_HTTP_REQUEST_ENTITY_MAX_SIZE)
             data = await req.read()
             await get_or_create_event_loop().run_in_executor(
                 None,

--- a/python/ray/dashboard/modules/job/job_head.py
+++ b/python/ray/dashboard/modules/job/job_head.py
@@ -53,6 +53,7 @@ from ray.dashboard.subprocesses.module import SubprocessModule
 from ray.dashboard.subprocesses.routes import SubprocessRouteTable as routes
 from ray.dashboard.subprocesses.utils import ResponseType
 import ray._private.ray_constants as ray_constants
+
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
@@ -463,7 +464,9 @@ class JobHead(SubprocessModule):
         )
         logger.info(f"Uploading package {package_uri} to the GCS.")
         try:
-            req = req.clone(client_max_size = ray_constants.RAY_HTTP_REQUEST_ENTITY_MAX_SIZE)
+            req = req.clone(
+                client_max_size=ray_constants.RAY_HTTP_REQUEST_ENTITY_MAX_SIZE
+            )
             data = await req.read()
             await get_or_create_event_loop().run_in_executor(
                 None,

--- a/python/ray/dashboard/modules/job/tests/test_http_job_server.py
+++ b/python/ray/dashboard/modules/job/tests/test_http_job_server.py
@@ -977,9 +977,10 @@ async def test_get_upload_package(ray_start_context, tmp_path):
     await download_and_unpack_package(package_uri, str(tmp_path), gcs_client)
     assert (package_file.with_suffix("") / filename).read_bytes() == file_content
 
+
 @pytest.mark.asyncio
 async def test_overwrite_http_request_entity_size(ray_start_context, tmp_path):
-    os.environ[ray_constants.RAY_HTTP_REQUEST_ENTITY_MAX_SIZE] = '1'
+    os.environ[ray_constants.RAY_HTTP_REQUEST_ENTITY_MAX_SIZE] = "1"
     assert wait_until_server_available(ray_start_context["webui_url"])
     webui_url = format_web_url(ray_start_context["webui_url"])
     gcs_client = ray._private.worker.global_worker.gcs_client
@@ -1012,6 +1013,7 @@ async def test_overwrite_http_request_entity_size(ray_start_context, tmp_path):
 
     await download_and_unpack_package(package_uri, str(tmp_path), gcs_client)
     assert (package_file.with_suffix("") / filename).read_bytes() == file_content
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
I think we should support adjusting the max size of the request entity in the upload_package in job_head, some packages can easily exceed the default limit of 1m.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

https://github.com/ray-project/ray/issues/53879

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
