### PR TITLE
[runtime_env] add env to configure s3 addressing style

### DIFF
--- a/python/ray/_private/runtime_env/protocol.py
+++ b/python/ray/_private/runtime_env/protocol.py
@@ -60,13 +60,25 @@ class ProtocolsProvider:
         elif protocol == "s3":
             try:
                 import boto3
+                from botocore.config import Config
                 from smart_open import open as open_file
             except ImportError:
                 raise ImportError(
                     "You must `pip install smart_open[s3]` "
                     "to fetch URIs in s3 bucket. " + cls._MISSING_DEPENDENCIES_WARNING
                 )
-            tp = {"client": boto3.client("s3")}
+            tp = {
+                "client": boto3.client(
+                    "s3",
+                    config=Config(
+                        s3={
+                            "addressing_style": os.environ.get(
+                                "AWS_ADDRESSING_STYLE", "auto"
+                            )
+                        }
+                    ),
+                )
+            }
         elif protocol == "gs":
             try:
                 from google.cloud import storage  # noqa: F401


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?


Currently, when we use runtime_env to download and unpack packages from S3 compatible storage, it might use [path style access](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html).

However, the current [S3 client code](https://github.com/ray-project/ray/blob/0258042ce75580036923720cb97d14168c573c72/python/ray/_private/runtime_env/protocol.py#L69) didn't support that. It needs to specify [addressing_style config](https://boto3.amazonaws.com/v1/documentation/api/1.9.42/guide/s3.html):

```
boto3.client('s3', 'us-west-2', config=Config(s3={'addressing_style': 'path'}))
```


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

fix https://github.com/ray-project/ray/issues/53893

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
