### PR TITLE
[data] fix flakey schema

### DIFF
--- a/python/ray/data/BUILD
+++ b/python/ray/data/BUILD
@@ -382,6 +382,17 @@ py_test(
 )
 
 py_test(
+    name = "test_deduping_schema",
+    size = "small",
+    srcs = ["tests/test_deduping_schema.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [],
+)
+
+py_test(
     name = "test_ecosystem",
     size = "small",
     srcs = ["tests/test_ecosystem.py"],

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -756,15 +756,12 @@ def dedupe_schemas_with_validation(
     # Note, often times the refbundles correspond to only one schema. We can reduce the
     # memory footprint of multiple schemas by keeping only one copy.
     diverged = False
-    if old_schema is None:
+    if not old_schema:
         return bundle, diverged
 
     # This check is fast assuming pyarrow schemas
     if old_schema == bundle.schema:
-        return (
-            bundle,
-            diverged,
-        )
+        return bundle, diverged
 
     diverged = True
     if warn:

--- a/python/ray/data/tests/test_deduping_schema.py
+++ b/python/ray/data/tests/test_deduping_schema.py
@@ -43,6 +43,7 @@ def test_dedupe_schema_handle_empty(
     else:
         # old_schema is valid
         assert diverged, (old_schema, incoming_schema)
+        assert incoming_schema != old_schema, (old_schema, incoming_schema)
         assert old_schema == out_bundle.schema, (old_schema, incoming_schema)
 
 
@@ -68,3 +69,9 @@ def test_dedupe_schema_divergence(
         assert out_bundle.schema == pa.schema(list(old_schema) + list(incoming_schema))
     else:
         assert out_bundle.schema == old_schema
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/tests/test_deduping_schema.py
+++ b/python/ray/data/tests/test_deduping_schema.py
@@ -1,0 +1,68 @@
+import pyarrow as pa
+import pytest
+from typing import Optional
+from ray.data._internal.execution.interfaces.ref_bundle import RefBundle
+from ray.data._internal.execution.streaming_executor_state import (
+    dedupe_schemas_with_validation,
+)
+from ray.data.block import Schema
+
+
+@pytest.mark.parametrize(
+    "incoming_schema",
+    [
+        pa.schema([pa.field("uuid", pa.string())]),  # NOTE: diff from old_schema
+        pa.schema([]),  # Empty Schema
+        None,  # Null Schema
+    ],
+)
+@pytest.mark.parametrize(
+    "old_schema",
+    [
+        pa.schema([pa.field("id", pa.int64())]),
+        pa.schema([]),  # Empty Schema
+        None,  # Null Schema
+    ],
+)
+def test_dedupe_schema_handle_empty(
+    old_schema: Optional["Schema"],
+    incoming_schema: Optional["Schema"],
+):
+
+    incoming_bundle = RefBundle([], owns_blocks=False, schema=incoming_schema)
+    out_bundle, diverged = dedupe_schemas_with_validation(
+        old_schema, incoming_bundle, allow_divergent=False, warn=False
+    )
+
+    if old_schema is None or len(old_schema) == 0:
+        # old_schema is invalid
+        assert not diverged, (old_schema, incoming_schema)
+        assert out_bundle.schema == incoming_schema, (old_schema, incoming_schema)
+    else:
+        # old_schema is valid
+        assert diverged, (old_schema, incoming_schema)
+        assert old_schema == out_bundle.schema, (old_schema, incoming_schema)
+
+
+@pytest.mark.parametrize("allow_divergent", [False, True])
+@pytest.mark.parametrize(
+    "incoming_schema", [pa.schema([pa.field("uuid", pa.string())])]
+)
+@pytest.mark.parametrize("old_schema", [pa.schema([pa.field("id", pa.int64())])])
+def test_dedupe_schema_divergence(
+    allow_divergent: bool,
+    old_schema: Optional["Schema"],
+    incoming_schema: Optional["Schema"],
+):
+
+    incoming_bundle = RefBundle([], owns_blocks=False, schema=incoming_schema)
+    out_bundle, diverged = dedupe_schemas_with_validation(
+        old_schema, incoming_bundle, allow_divergent=allow_divergent, warn=False
+    )
+
+    assert diverged
+
+    if allow_divergent:
+        assert out_bundle.schema == pa.schema(list(old_schema) + list(incoming_schema))
+    else:
+        assert out_bundle.schema == old_schema

--- a/python/ray/data/tests/test_deduping_schema.py
+++ b/python/ray/data/tests/test_deduping_schema.py
@@ -1,6 +1,8 @@
+from typing import Optional
+
 import pyarrow as pa
 import pytest
-from typing import Optional
+
 from ray.data._internal.execution.interfaces.ref_bundle import RefBundle
 from ray.data._internal.execution.streaming_executor_state import (
     dedupe_schemas_with_validation,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Consider the following code
```python
ds = ray.data.range(10)
ds = ds.repartition()
ds = ds.map_batches(lambda x : x)
it1, it2 = ds.split(2)
# repr(it2) doesn't contain schema sometimes???
```
^ This is flakey

```python
ds = ray.data.range(10)
ds = ds.repartition()
# ds = ds.map_batches(lambda x : x)
it1, it2 = ds.split(2)
# repr(it2) contains schema??? 
```
^ This isn't flakey???

Explanation:
- There are many scenarios where we produce empty blocks (ie, in shuffle task map where we slice the blocks and send them to reduce).
- Empty blocks in pyarrow still have a schema
- When deduping a schema, we default take the FIRST schema as the source of truth. However, we should take the first NON-EMPTY schema, because order is non-deterministic. But that's what i was doing before https://github.com/ray-project/ray/pull/53454. with the check`schema is None`. Oh wait, it should be `not schema` (this covers `None` and empty schemas)
- The first block of code failed because the user mapped empty block -> empty block. In our code, *with a UDF function*, empty blocks have no schema
- The second block of code secretly succeeded because the user did not use UDF. Instead, we created empty blocks with the original schema.


I ran it a gazillion times, it should not be flakey anymore
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
