### PR TITLE
[Data] Fixed `BlockMetadata` derivation for `Read` operator

### DIFF
--- a/python/ray/data/BUILD
+++ b/python/ray/data/BUILD
@@ -1381,7 +1381,7 @@ py_test(
 
 py_test(
     name = "test_state_export",
-    size = "moderate",
+    size = "medium",
     srcs = ["tests/test_state_export.py"],
     tags = [
         "exclusive",

--- a/python/ray/data/BUILD
+++ b/python/ray/data/BUILD
@@ -1381,7 +1381,7 @@ py_test(
 
 py_test(
     name = "test_state_export",
-    size = "small",
+    size = "moderate",
     srcs = ["tests/test_state_export.py"],
     tags = [
         "exclusive",

--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -403,6 +403,7 @@ class ParquetDatasource(Datasource):
                 self._include_paths,
                 self._partitioning,
             )
+
             read_tasks.append(
                 ReadTask(
                     lambda f=fragments: read_fragments(

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -390,7 +390,6 @@ class ExecutionPlan:
 
     def input_files(self) -> Optional[List[str]]:
         """Get the input files of the dataset, if available."""
-        # TODO(justin): Remove Input Files from metadata.
         return self._logical_plan.dag.infer_metadata().input_files
 
     def meta_count(self) -> Optional[int]:

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -48,9 +48,10 @@ def _derive_metadata(read_task: ReadTask, read_task_ref: ObjectRef) -> BlockMeta
         )
 
     return BlockMetadata(
-        num_rows=len(read_task.paths),
+        num_rows=1,
         size_bytes=task_size,
-        input_files=read_task.paths,
+        exec_stats=None,
+        input_files=None,
     )
 
 

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -79,14 +79,16 @@ def plan_read_op(
         for read_task in read_tasks:
             read_task_ref = ray.put(read_task)
             ref_bundle = RefBundle(
-                tuple([
-                    (
-                        # TODO: figure out a better way to pass read
-                        # tasks other than ray.put().
-                        read_task_ref,
-                        _derive_metadata(read_task, read_task_ref),
-                    ),
-                ]),
+                tuple(
+                    [
+                        (
+                            # TODO: figure out a better way to pass read
+                            # tasks other than ray.put().
+                            read_task_ref,
+                            _derive_metadata(read_task, read_task_ref),
+                        ),
+                    ]
+                ),
                 # `owns_blocks` is False, because these refs are the root of the
                 # DAG. We shouldn't eagerly free them. Otherwise, the DAG cannot
                 # be reconstructed.

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -79,15 +79,13 @@ def plan_read_op(
         for read_task in read_tasks:
             read_task_ref = ray.put(read_task)
             ref_bundle = RefBundle(
-                tuple(
-                    [
-                        (
-                            # TODO: figure out a better way to pass read
-                            # tasks other than ray.put().
-                            read_task_ref,
-                            _derive_metadata(read_task, read_task_ref),
-                        ),
-                    ]
+                (
+                    (
+                        # TODO: figure out a better way to pass read
+                        # tasks other than ray.put().
+                        read_task_ref,
+                        _derive_metadata(read_task, read_task_ref),
+                    ),
                 ),
                 # `owns_blocks` is False, because these refs are the root of the
                 # DAG. We shouldn't eagerly free them. Otherwise, the DAG cannot

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -3,6 +3,7 @@ import warnings
 from typing import Iterable, List
 
 import ray
+from ray import ObjectRef
 from ray.data._internal.compute import TaskPoolStrategy
 from ray.data._internal.execution.interfaces import PhysicalOperator, RefBundle
 from ray.data._internal.execution.interfaces.task_context import TaskContext
@@ -28,7 +29,7 @@ TASK_SIZE_WARN_THRESHOLD_BYTES = 1024 * 1024  # 1 MiB
 logger = logging.getLogger(__name__)
 
 
-def cleaned_metadata(read_task: ReadTask, read_task_ref) -> BlockMetadata:
+def _derive_metadata(read_task: ReadTask, read_task_ref: ObjectRef) -> BlockMetadata:
     # NOTE: Use the `get_local_object_locations` API to get the size of the
     # serialized ReadTask, instead of pickling.
     # Because the ReadTask may capture ObjectRef objects, which cannot
@@ -46,14 +47,11 @@ def cleaned_metadata(read_task: ReadTask, read_task_ref) -> BlockMetadata:
             f"`self` or other large objects in '{read_task.read_fn.__name__}'."
         )
 
-    # Defensively compute the size of the block as the max size reported by the
-    # datasource and the actual read task size. This is to guard against issues
-    # with bad metadata reporting.
-    block_meta = read_task.metadata
-    if block_meta.size_bytes is None or task_size > block_meta.size_bytes:
-        block_meta.size_bytes = task_size
-
-    return block_meta
+    return BlockMetadata(
+        num_rows=len(read_task.paths),
+        size_bytes=task_size,
+        input_files=read_task.paths,
+    )
 
 
 def plan_read_op(
@@ -80,14 +78,14 @@ def plan_read_op(
         for read_task in read_tasks:
             read_task_ref = ray.put(read_task)
             ref_bundle = RefBundle(
-                [
+                tuple([
                     (
-                        # TODO(chengsu): figure out a better way to pass read
+                        # TODO: figure out a better way to pass read
                         # tasks other than ray.put().
                         read_task_ref,
-                        cleaned_metadata(read_task, read_task_ref),
-                    )
-                ],
+                        _derive_metadata(read_task, read_task_ref),
+                    ),
+                ]),
                 # `owns_blocks` is False, because these refs are the root of the
                 # DAG. We shouldn't eagerly free them. Otherwise, the DAG cannot
                 # be reconstructed.

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -1123,7 +1123,8 @@ class DatasetStatsSummary:
         total_wall_time = self.get_total_wall_time()
 
         def fmt_line(name: str, time: float) -> str:
-            return f"* {name}: {fmt(time)} ({time / total_wall_time * 100:.3f}%)\n"
+            fraction = time / total_wall_time if total_wall_time > 0 else 0
+            return f"* {name}: {fmt(time)} ({fraction * 100:.3f}%)\n"
 
         summaries = DatasetStatsSummary._collect_dataset_stats_summaries(self)
         out = "Runtime Metrics:\n"

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -150,16 +150,10 @@ class ReadTask(Callable[[], Iterable[Block]]):
         read_fn: Callable[[], Iterable[Block]],
         metadata: BlockMetadata,
         schema: Optional["Schema"] = None,
-        paths: Optional[List[str]] = None,
     ):
         self._metadata = metadata
         self._read_fn = read_fn
         self._schema = schema
-        self._paths = paths
-
-    @property
-    def paths(self) -> Optional[List[str]]:
-        return self._paths
 
     @property
     def metadata(self) -> BlockMetadata:

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -150,10 +150,16 @@ class ReadTask(Callable[[], Iterable[Block]]):
         read_fn: Callable[[], Iterable[Block]],
         metadata: BlockMetadata,
         schema: Optional["Schema"] = None,
+        paths: Optional[List[str]] = None,
     ):
         self._metadata = metadata
         self._read_fn = read_fn
         self._schema = schema
+        self._paths = paths
+
+    @property
+    def paths(self) -> Optional[List[str]]:
+        return self._paths
 
     @property
     def metadata(self) -> BlockMetadata:

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -305,6 +305,18 @@ def test_parquet_read_meta_provider(ray_start_regular_shared, fs, data_path):
 
     assert not ds._plan.has_computed_output()
 
+    expected_values = [
+        [1, "a"],
+        [2, "b"],
+        [3, "c"],
+        [4, "e"],
+        [5, "f"],
+        [6, "g"],
+    ]
+
+    values = [[s["one"], s["two"]] for s in ds.take()]
+    assert sorted(values) == expected_values
+
     #
     # Case 2: Test metadata fetching *failing* (falling back to actually
     #         executing the dataset)
@@ -335,9 +347,7 @@ def test_parquet_read_meta_provider(ray_start_regular_shared, fs, data_path):
 
     assert ds._plan.has_computed_output()
 
-    # Forces a data read.
-    values = [[s["one"], s["two"]] for s in ds.take()]
-    assert sorted(values) == [
+    expected_values = [
         [1, "a"],
         [2, "b"],
         [3, "c"],
@@ -345,6 +355,9 @@ def test_parquet_read_meta_provider(ray_start_regular_shared, fs, data_path):
         [5, "f"],
         [6, "g"],
     ]
+
+    values = [[s["one"], s["two"]] for s in ds.take()]
+    assert sorted(values) == expected_values
 
 
 @pytest.mark.parametrize(

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -321,8 +321,8 @@ def test_parquet_read_meta_provider(ray_start_regular_shared, fs, data_path):
     #   - Passed to ReadParquet hold metadata matching actual bundle
     #   - Produced by ReadParquet reflects actual amount of bytes read
     assert read_stats.base_name == "ReadParquet"
-    assert read_stats.extra_metrics.average_bytes_inputs_per_task < 5_000
-    assert read_stats.extra_metrics.bytes_task_outputs_generated == expected_byte_size
+    assert read_stats.extra_metrics['average_bytes_inputs_per_task'] < 5_000
+    assert read_stats.extra_metrics['bytes_task_outputs_generated'] == expected_byte_size
 
     assert sorted(values) == expected_values
 

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -315,6 +315,16 @@ def test_parquet_read_meta_provider(ray_start_regular_shared, fs, data_path):
 
     values = [(s["one"], s["two"]) for s in ds.take(60000)]
 
+    exec_stats = ds._plan.stats()
+    read_stats = exec_stats.parents[0]
+
+    # Assert that ref-bundles
+    #   - Passed to ReadParquet hold metadata matching actual bundle
+    #   - Produced by ReadParquet reflects actual amount of bytes read
+    assert read_stats.base_name == "ReadParquet"
+    assert read_stats.extra_metrics.average_bytes_inputs_per_task < 5_000
+    assert read_stats.extra_metrics.bytes_task_outputs_generated == expected_byte_size
+
     assert sorted(values) == expected_values
 
     #

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -321,8 +321,10 @@ def test_parquet_read_meta_provider(ray_start_regular_shared, fs, data_path):
     #   - Passed to ReadParquet hold metadata matching actual bundle
     #   - Produced by ReadParquet reflects actual amount of bytes read
     assert read_stats.base_name == "ReadParquet"
-    assert read_stats.extra_metrics['average_bytes_inputs_per_task'] < 5_000
-    assert read_stats.extra_metrics['bytes_task_outputs_generated'] == expected_byte_size
+    assert read_stats.extra_metrics["average_bytes_inputs_per_task"] < 5_000
+    assert (
+        read_stats.extra_metrics["bytes_task_outputs_generated"] == expected_byte_size
+    )
 
     assert sorted(values) == expected_values
 

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -321,7 +321,10 @@ def test_parquet_read_meta_provider(ray_start_regular_shared, fs, data_path):
     #   - Passed to ReadParquet hold metadata matching actual bundle
     #   - Produced by ReadParquet reflects actual amount of bytes read
     assert read_stats.base_name == "ReadParquet"
-    assert read_stats.extra_metrics["average_bytes_inputs_per_task"] < 5_000
+    # NOTE: Size of the task should be ~5kb, but could vary from platform to platform
+    #       alas for different Python versions. However, it is substantially smaller
+    #       than the dataset itself (~750kb)
+    assert read_stats.extra_metrics["average_bytes_inputs_per_task"] < 10_000
     assert (
         read_stats.extra_metrics["bytes_task_outputs_generated"] == expected_byte_size
     )

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -308,10 +308,9 @@ def test_parquet_read_meta_provider(ray_start_regular_shared, fs, data_path):
 
     assert not ds._plan.has_computed_output()
 
-    expected_values = list(zip(
-        range(60_000),
-        ["a", "b", "c"] * 10_000 + ["e", "f", "g"] * 10_000
-    ))
+    expected_values = list(
+        zip(range(60_000), ["a", "b", "c"] * 10_000 + ["e", "f", "g"] * 10_000)
+    )
 
     values = [(s["one"], s["two"]) for s in ds.take(60000)]
 

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -28,7 +28,7 @@ from ray.data._internal.datasource.parquet_datasource import (
 from ray.data._internal.execution.interfaces.ref_bundle import (
     _ref_bundles_iterator_to_block_refs_list,
 )
-from ray.data.block import BlockAccessor
+from ray.data.block import BlockAccessor, BlockMetadata
 from ray.data.context import DataContext
 from ray.data.datasource import DefaultFileMetadataProvider, ParquetMetadataProvider
 from ray.data.datasource.parquet_meta_provider import PARALLELIZE_META_FETCH_THRESHOLD
@@ -304,7 +304,7 @@ def test_parquet_read_meta_provider(ray_start_regular_shared, fs, data_path):
     assert ds.count() == expected_num_rows
     assert ds.size_bytes() == expected_byte_size
     assert ds.schema() == Schema(expected_schema)
-    assert set(ds.input_files()) == set([path1, path2])
+    assert set(ds.input_files()) == {path1, path2}
 
     assert not ds._plan.has_computed_output()
 
@@ -352,7 +352,7 @@ def test_parquet_read_meta_provider(ray_start_regular_shared, fs, data_path):
     assert ds.count() == expected_num_rows
     assert ds.size_bytes() == expected_byte_size
     assert ds.schema() == Schema(expected_schema)
-    assert set(ds.input_files()) == set([path1, path2])
+    assert set(ds.input_files()) == {path1, path2}
 
     assert ds._plan.has_computed_output()
 

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1604,9 +1604,6 @@ def test_spilled_stats(shutdown_only, verbose_stats_logs, restore_data_context):
         f"* Spilled to disk: M\n"
         f"* Restored from disk: M\n"
         f"\n"
-        f"Dataset memory:\n"
-        f"* Spilled to disk: M\n"
-        f"\n"
         f"Dataset throughput:\n"
         f"    * Ray Data throughput: N rows/s\n"
         f"    * Estimated single node throughput: N rows/s\n"
@@ -1616,7 +1613,7 @@ def test_spilled_stats(shutdown_only, verbose_stats_logs, restore_data_context):
     assert canonicalize(ds.stats(), filter_global_stats=False) == expected_stats
 
     # Around 100MB should be spilled (200MB - 100MB)
-    assert ds._plan.stats().dataset_bytes_spilled > 100e6
+    assert ds._plan.stats().global_bytes_spilled > 100e6
 
     ds = (
         ray.data.range(1000 * 80 * 80 * 4)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Currently, Planner incorrectly shapes the `BlockMetadata` for ref-bundles submitted to `Read` operator, carrying only the file-paths, while their corresponding metadata is actually being set as if these bundles were carrying actual data.

That in turn inflates Object Store utilization for the Read operator, subsequently triggering back-pressure being applied to it incorrectly.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
