### PR TITLE
[Core] Remove Unnecessary Checks in GRPC Server Shutdown Process

### DIFF
--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -198,7 +198,7 @@ void GrpcServer::PollEventsFromCompletionQueue(int index) {
                                  gpr_time_from_millis(250, GPR_TIMESPAN));
     auto status = cqs_[index]->AsyncNext(&tag, &ok, deadline);
     if (status == grpc::CompletionQueue::SHUTDOWN) {
-      // If the completion queue status is SHUTDOWN, meaining the queue has been
+      // If the completion queue status is SHUTDOWN, meaning the queue has been
       // drained. We can now exit the loop.
       break;
     } else if (status == grpc::CompletionQueue::TIMEOUT) {

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -197,11 +197,9 @@ void GrpcServer::PollEventsFromCompletionQueue(int index) {
     auto deadline = gpr_time_add(gpr_now(GPR_CLOCK_REALTIME),
                                  gpr_time_from_millis(250, GPR_TIMESPAN));
     auto status = cqs_[index]->AsyncNext(&tag, &ok, deadline);
-    if (status == grpc::CompletionQueue::SHUTDOWN ||
-        (status == grpc::CompletionQueue::TIMEOUT && shutdown_)) {
-      // If we timed out and shutdown, then exit immediately. This should not
-      // be needed, but gRPC seems to not return SHUTDOWN correctly in these
-      // cases (e.g., test_wait will hang on shutdown without this check).
+    if (status == grpc::CompletionQueue::SHUTDOWN) {
+      // If the completion queue status is SHUTDOWN, meaining the queue has been
+      // drained. We can now exit the loop.
       break;
     } else if (status == grpc::CompletionQueue::TIMEOUT) {
       continue;

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -43,7 +43,6 @@ void GrpcServer::Init() {
 
 void GrpcServer::Shutdown() {
   if (!is_closed_) {
-    shutdown_ = true;
     // Drain the executor threads.
     // Shutdown the server with an immediate deadline.
     // TODO(edoakes): do we want to do this in all cases?

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -42,7 +42,7 @@ void GrpcServer::Init() {
 }
 
 void GrpcServer::Shutdown() {
-  if (!is_closed_) {
+  if (!is_shutdown_) {
     // Drain the executor threads.
     // Shutdown the server with an immediate deadline.
     // TODO(edoakes): do we want to do this in all cases?
@@ -53,7 +53,7 @@ void GrpcServer::Shutdown() {
     for (auto &polling_thread : polling_threads_) {
       polling_thread.join();
     }
-    is_closed_ = true;
+    is_shutdown_ = true;
     RAY_LOG(DEBUG) << "gRPC server of " << name_ << " shutdown.";
     server_.reset();
   }
@@ -168,7 +168,7 @@ void GrpcServer::Run() {
     polling_threads_.emplace_back(&GrpcServer::PollEventsFromCompletionQueue, this, i);
   }
   // Set the server as running.
-  is_closed_ = false;
+  is_shutdown_ = false;
 }
 
 void GrpcServer::RegisterService(std::unique_ptr<grpc::Service> &&grpc_service) {

--- a/src/ray/rpc/grpc_server.h
+++ b/src/ray/rpc/grpc_server.h
@@ -115,10 +115,10 @@ class GrpcServer {
   /// Initialize and run this server.
   void Run();
 
-  // Shutdown this server. Note that this function implements a mechanism to avoid
-  // going through shutdown process again after the function is successfully returned.
-  // However, the method is not thread safe. The caller of the method should guarantee
-  // that potential multiple calls to the method should be sequential.
+  // Shutdown this server.
+  // NOTE: The method is idempotent but NOT THREAD-SAFE. Multiple sequential calls are
+  // safe (subsequent calls are no-ops). Concurrent calls will cause undefined behavior.
+  // Caller must ensure only one thread calls this method at a time.
   void Shutdown();
 
   /// Get the port of this gRPC server.

--- a/src/ray/rpc/grpc_server.h
+++ b/src/ray/rpc/grpc_server.h
@@ -118,7 +118,7 @@ class GrpcServer {
   // Shutdown this server. Note that this function implements a mechanism to avoid
   // going through shutdown process again after the function is successfully returned.
   // However, the method is not thread safe. The caller of the method should guarantee
-  // that potential multiple calls to the method should be sequencial.
+  // that potential multiple calls to the method should be sequential.
   void Shutdown();
 
   /// Get the port of this gRPC server.

--- a/src/ray/rpc/grpc_server.h
+++ b/src/ray/rpc/grpc_server.h
@@ -103,7 +103,7 @@ class GrpcServer {
         port_(port),
         listen_to_localhost_only_(listen_to_localhost_only),
         cluster_id_(ClusterID::Nil()),
-        is_closed_(true),
+        is_shutdown_(true),
         num_threads_(num_threads),
         keepalive_time_ms_(keepalive_time_ms) {
     Init();
@@ -166,8 +166,8 @@ class GrpcServer {
   const bool listen_to_localhost_only_;
   /// Token representing ID of this cluster.
   ClusterID cluster_id_;
-  /// Indicates whether this server has been closed.
-  std::atomic<bool> is_closed_;
+  /// Indicates whether this server is in shutdown state.
+  std::atomic<bool> is_shutdown_;
   /// The `grpc::Service` objects which should be registered to `ServerBuilder`.
   std::vector<std::unique_ptr<grpc::Service>> grpc_services_;
   /// The `GrpcService`(defined below) objects which contain grpc::Service objects not in


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

This PR removes the unnecessary check during the GRPC server shutdown logic to avoid the potential `ASSERTION FAILED: queue.num_items() == 0` issue. 

More context: 

Per [`CompletionQueue` class reference](https://grpc.github.io/grpc/cpp/classgrpc_1_1_completion_queue.html#a40efddadd9073386fbcb4f46e8325670), during the process of shutdown the completion queue, before deleting the object, we should make sure the queue is drained. In another word, we should make sure `AsyncNext` returning `NextStatus::SHUTDOWN`. Otherwise, when deleting the `CompletionQueue` object, the `ASSERTION FAILED: queue.num_items() == 0` will be thrown.

In today's Ray's GRPC shutdown logic, it almost follows the same. The only difference is that, it also checks`status == grpc::CompletionQueue::TIMEOUT && shutdown_` and if true, it will think the queue is drained as well. However, the `shutdown_` variable is set before the queue is drained, so the additional check can potentially break the draining of the queue early and triggers the `ASSERTION FAILED` error. 

This PR removes the check to make sure the `CompletionQueue` draining will not be early terminated. It also passes all the premerge tests so the issue mentioned in the previous comment most likely due to other bugs and has already been resolved. So the change should be safe to check in. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
