### PR TITLE
[RLlib; docs] Fix docstring example for custom MultiRLModule with shared encoder.

### DIFF
--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -4592,10 +4592,6 @@ class AlgorithmConfig(_Config):
                 multi_rl_module_spec.remove_modules(module_id)
                 continue
 
-            policy_spec = policy_dict.get(module_id)
-            if policy_spec is None:
-                policy_spec = policy_dict[DEFAULT_MODULE_ID]
-
             if module_spec.module_class is None:
                 if isinstance(default_rl_module_spec, RLModuleSpec):
                     module_spec.module_class = default_rl_module_spec.module_class
@@ -4639,10 +4635,18 @@ class AlgorithmConfig(_Config):
                     )
             # TODO (sven): Find a good way to pack module specific parameters from
             # the algorithms into the `model_config_dict`.
-            if module_spec.observation_space is None:
-                module_spec.observation_space = policy_spec.observation_space
-            if module_spec.action_space is None:
-                module_spec.action_space = policy_spec.action_space
+            if (
+                module_spec.observation_space is None
+                or module_spec.action_space is None
+            ):
+                policy_spec = policy_dict.get(
+                    module_id, policy_dict.get(DEFAULT_MODULE_ID)
+                )
+                if policy_spec is not None:
+                    if module_spec.observation_space is None:
+                        module_spec.observation_space = policy_spec.observation_space
+                    if module_spec.action_space is None:
+                        module_spec.action_space = policy_spec.action_space
             # In case the `RLModuleSpec` does not have a model config dict, we use the
             # the one defined by the auto keys and the `model_config_dict` arguments in
             # `self.rl_module()`.

--- a/rllib/core/rl_module/rl_module.py
+++ b/rllib/core/rl_module/rl_module.py
@@ -95,8 +95,6 @@ class RLModuleSpec:
             raise ValueError("RLModule class is not set.")
         if self.observation_space is None:
             raise ValueError("Observation space is not set.")
-        if self.action_space is None:
-            raise ValueError("Action space is not set.")
 
         try:
             module = self.module_class(

--- a/rllib/examples/rl_modules/classes/vpg_using_shared_encoder_rlm.py
+++ b/rllib/examples/rl_modules/classes/vpg_using_shared_encoder_rlm.py
@@ -52,7 +52,7 @@ class VPGMultiRLModuleWithSharedEncoder(MultiRLModule):
 
         .. testcode::
 
-    # __sphinx_doc_how_to_run_begin__
+            # __sphinx_doc_how_to_run_begin__
             import gymnasium as gym
             from ray.rllib.algorithms.ppo import PPOConfig
             from ray.rllib.core import MultiRLModuleSpec, RLModuleSpec
@@ -80,6 +80,7 @@ class VPGMultiRLModuleWithSharedEncoder(MultiRLModule):
                                 module_class=SharedEncoder,
                                 model_config={"embedding_dim": EMBEDDING_DIM},
                                 observation_space=single_agent_env.observation_space,
+                                action_space=single_agent_env.action_space,
                             ),
                             # Large policy net.
                             "p0": RLModuleSpec(
@@ -102,8 +103,8 @@ class VPGMultiRLModuleWithSharedEncoder(MultiRLModule):
                 )
             )
             algo = config.build()
-            print(algo.get_module())
-    # __sphinx_doc_how_to_run_end__
+            print(algo.get_module("p0"))
+            # __sphinx_doc_how_to_run_end__
 
         Also note that in order to learn properly, a special, multi-agent Learner
         accounting for the shared encoder must be setup. This Learner should have only


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

Fix docstring example for custom MultiRLModule with shared encoder.
* Needed action_space definition on shared encoder module.
* do not require action_space to be defined in `RLModuleSpec` when `build` is called. The spec may be for a component that doesn't care about that space (like a shared encoder or a value function).

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
