### PR TITLE
[kuberay] log actionable err msg when required TPU node selectors missing

### DIFF
--- a/python/ray/tests/kuberay/test_autoscaling_config.py
+++ b/python/ray/tests/kuberay/test_autoscaling_config.py
@@ -3,18 +3,21 @@ from pathlib import Path
 import platform
 import requests
 import sys
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Type
 from unittest import mock
 import yaml
 
 import pytest
 
 from ray.autoscaler._private.kuberay.autoscaling_config import (
+    GKE_TPU_ACCELERATOR_LABEL,
+    GKE_TPU_TOPOLOGY_LABEL,
     _derive_autoscaling_config_from_ray_cr,
     AutoscalingConfigProducer,
     _round_up_k8s_quantity,
     _get_num_tpus,
     _get_custom_resources,
+    _get_ray_resources_from_group_spec,
 )
 from ray.autoscaler._private.kuberay.utils import tpu_node_selectors_to_type
 
@@ -242,6 +245,27 @@ def _get_autoscaling_config_with_options() -> dict:
     return config
 
 
+def _get_tpu_group_with_no_node_selectors() -> dict[str, Any]:
+    cr = get_basic_ray_cr()
+    tpu_group = cr["spec"]["workerGroupSpecs"][2]
+    tpu_group["template"]["spec"].pop("nodeSelector", None)
+    return tpu_group
+
+
+def _get_tpu_group_without_accelerator_node_selector() -> dict[str, Any]:
+    cr = get_basic_ray_cr()
+    tpu_group = cr["spec"]["workerGroupSpecs"][2]
+    tpu_group["template"]["spec"]["nodeSelector"].pop(GKE_TPU_ACCELERATOR_LABEL, None)
+    return tpu_group
+
+
+def _get_tpu_group_without_topology_node_selector() -> dict[str, Any]:
+    cr = get_basic_ray_cr()
+    tpu_group = cr["spec"]["workerGroupSpecs"][2]
+    tpu_group["template"]["spec"]["nodeSelector"].pop(GKE_TPU_TOPOLOGY_LABEL, None)
+    return tpu_group
+
+
 @pytest.mark.parametrize(
     "input,output",
     [
@@ -344,7 +368,7 @@ TEST_DATA = (
 def test_autoscaling_config(
     ray_cr_in: Dict[str, Any],
     expected_config_out: Optional[Dict[str, Any]],
-    expected_error: Optional[Exception],
+    expected_error: Optional[Type[Exception]],
     expected_error_message: Optional[str],
     expected_log_warning: Optional[str],
 ):
@@ -550,6 +574,114 @@ def test_get_num_tpus(ray_cr_in: Dict[str, Any], expected_num_tpus: int):
             assert num_tpus == expected_num_tpus
         else:
             assert num_tpus is None
+
+
+RAY_RESOURCES_PARAM_ARGS = ",".join(
+    [
+        "group_spec",
+        "is_head",
+        "expected_resources",
+    ]
+)
+RAY_RESOURCES_TEST_DATA = (
+    []
+    if platform.system() == "Windows"
+    else [
+        pytest.param(
+            get_basic_ray_cr()["spec"]["headGroupSpec"],
+            True,
+            {
+                "CPU": 1,
+                "memory": 1000000000,
+                "Custom1": 1,
+                "Custom2": 5,
+            },
+            id="head-group",
+        ),
+        pytest.param(
+            get_basic_ray_cr()["spec"]["workerGroupSpecs"][0],
+            False,
+            {
+                "CPU": 1,
+                "memory": 536870912,
+                "Custom2": 5,
+                "Custom3": 1,
+            },
+            id="cpu-group",
+        ),
+        pytest.param(
+            get_basic_ray_cr()["spec"]["workerGroupSpecs"][1],
+            False,
+            {
+                "CPU": 1,
+                "memory": 536870912,
+                "Custom2": 5,
+                "Custom3": 1,
+                "GPU": 3,
+            },
+            id="gpu-group",
+        ),
+        pytest.param(
+            get_basic_ray_cr()["spec"]["workerGroupSpecs"][2],
+            False,
+            {
+                "CPU": 1,
+                "memory": 536870912,
+                "Custom2": 5,
+                "Custom3": 1,
+                "TPU": 4,
+                "TPU-v4-16-head": 1,
+            },
+            id="tpu-group",
+        ),
+        pytest.param(
+            _get_tpu_group_with_no_node_selectors(),
+            False,
+            {
+                "CPU": 1,
+                "memory": 536870912,
+                "Custom2": 5,
+                "Custom3": 1,
+                "TPU": 4,
+            },
+            id="tpu-group-no-node-selectors",
+        ),
+        pytest.param(
+            _get_tpu_group_without_accelerator_node_selector(),
+            False,
+            {
+                "CPU": 1,
+                "memory": 536870912,
+                "Custom2": 5,
+                "Custom3": 1,
+                "TPU": 4,
+            },
+            id="tpu-group-no-accelerator-node-selector",
+        ),
+        pytest.param(
+            _get_tpu_group_without_topology_node_selector(),
+            False,
+            {
+                "CPU": 1,
+                "memory": 536870912,
+                "Custom2": 5,
+                "Custom3": 1,
+                "TPU": 4,
+            },
+            id="tpu-group-no-topology-node-selector",
+        ),
+    ]
+)
+
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="Not relevant.")
+@pytest.mark.parametrize(RAY_RESOURCES_PARAM_ARGS, RAY_RESOURCES_TEST_DATA)
+def test_get_ray_resources_from_group_spec(
+    group_spec: Dict[str, Any],
+    is_head: bool,
+    expected_resources: Dict[str, Any],
+):
+    assert _get_ray_resources_from_group_spec(group_spec, is_head) == expected_resources
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
instead of raising a `KeyError`. The required node selectors are
`cloud.google.com/gke-tpu-topology` or `cloud.google.com/gke-tpu-accelerator`.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
