### PR TITLE
[train][template] Pip install with python block instead

### DIFF
--- a/doc/source/train/examples/pytorch/distributing-pytorch/README.ipynb
+++ b/doc/source/train/examples/pytorch/distributing-pytorch/README.ipynb
@@ -30,14 +30,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "shellscript"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "pip install torch torchvision"
+    "! pip install torch torchvision"
    ]
   },
   {

--- a/doc/source/train/examples/pytorch/distributing-pytorch/README.ipynb
+++ b/doc/source/train/examples/pytorch/distributing-pytorch/README.ipynb
@@ -33,7 +33,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install torch torchvision"
+    "!pip install torch torchvision"
    ]
   },
   {

--- a/doc/source/train/examples/pytorch/distributing-pytorch/README.ipynb
+++ b/doc/source/train/examples/pytorch/distributing-pytorch/README.ipynb
@@ -30,10 +30,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
    "outputs": [],
    "source": [
-    "!pip install torch torchvision"
+    "%%bash\n",
+    "pip install torch torchvision"
    ]
   },
   {

--- a/doc/source/train/examples/pytorch/distributing-pytorch/README.md
+++ b/doc/source/train/examples/pytorch/distributing-pytorch/README.md
@@ -17,7 +17,7 @@ First, install and import the required Python modules.
 
 
 ```python
-! pip install torch torchvision
+!pip install torch torchvision
 ```
 
 

--- a/doc/source/train/examples/pytorch/distributing-pytorch/README.md
+++ b/doc/source/train/examples/pytorch/distributing-pytorch/README.md
@@ -17,7 +17,7 @@ First, install and import the required Python modules.
 
 
 ```python
-pip install torch torchvision
+! pip install torch torchvision
 ```
 
 

--- a/doc/source/train/examples/pytorch/distributing-pytorch/README.md
+++ b/doc/source/train/examples/pytorch/distributing-pytorch/README.md
@@ -16,8 +16,9 @@ In this step you train a PyTorch VisionTransformer model to recognize objects us
 First, install and import the required Python modules.
 
 
-```python
-!pip install torch torchvision
+```bash
+%%bash
+pip install torch torchvision
 ```
 
 


### PR DESCRIPTION
Needed because the previous `pip install` was not propagating the pip packages to the workers.

Was able to run all in jupyter notebook in workspace.