### PR TITLE
[core] Avoid unnecessary deserialization/serialization of CallerWorkerId

### DIFF
--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -475,6 +475,10 @@ WorkerID TaskSpecification::CallerWorkerId() const {
   return WorkerID::FromBinary(message_->caller_address().worker_id());
 }
 
+std::string TaskSpecification::CallerWorkerIdBinary() const {
+  return message_->caller_address().worker_id();
+}
+
 NodeID TaskSpecification::CallerNodeId() const {
   return NodeID::FromBinary(message_->caller_address().raylet_id());
 }

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -484,7 +484,11 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
 
   const rpc::Address &CallerAddress() const;
 
+  /// Get the worker ID of the caller.
   WorkerID CallerWorkerId() const;
+
+  /// Get the raw worker ID string of the caller.
+  std::string CallerWorkerIdBinary() const;
 
   NodeID CallerNodeId() const;
 

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -484,10 +484,8 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
 
   const rpc::Address &CallerAddress() const;
 
-  /// Get the worker ID of the caller.
   WorkerID CallerWorkerId() const;
 
-  /// Get the raw worker ID string of the caller.
   std::string CallerWorkerIdBinary() const;
 
   NodeID CallerNodeId() const;

--- a/src/ray/core_worker/transport/actor_task_submitter.cc
+++ b/src/ray/core_worker/transport/actor_task_submitter.cc
@@ -926,7 +926,7 @@ Status ActorTaskSubmitter::CancelTask(TaskSpecification task_spec, bool recursiv
     request.set_intended_task_id(task_spec.TaskIdBinary());
     request.set_force_kill(force_kill);
     request.set_recursive(recursive);
-    request.set_caller_worker_id(task_spec.CallerWorkerId().Binary());
+    request.set_caller_worker_id(task_spec.CallerWorkerIdBinary());
     client->CancelTask(request,
                        [this, task_spec = std::move(task_spec), recursive, task_id](
                            const Status &status, const rpc::CancelTaskReply &reply) {

--- a/src/ray/core_worker/transport/normal_task_submitter.cc
+++ b/src/ray/core_worker/transport/normal_task_submitter.cc
@@ -760,7 +760,7 @@ Status NormalTaskSubmitter::CancelTask(TaskSpecification task_spec,
   request.set_intended_task_id(task_spec.TaskIdBinary());
   request.set_force_kill(force_kill);
   request.set_recursive(recursive);
-  request.set_caller_worker_id(task_spec.CallerWorkerId().Binary());
+  request.set_caller_worker_id(task_spec.CallerWorkerIdBinary());
   client->CancelTask(
       request,
       [this,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`task_spec.CallerWorkerId().Binary()` has unnecessary deserialization/serialization.

To be more specific, `CallerWorkerId()` converts the worker ID from a binary string to the `WorkerID`, and `.Binary()` then converts it back to a binary string, which is unnecessary.

<!-- Please give a short summary of the change and the problem this solves. -->
To avoid this, `CallerWorkerIdBinary` is added, which could return the binary string directly.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
