### PR TITLE
[docs][Serve] Add clarification for health check and FT of serve deployments

### DIFF
--- a/doc/source/serve/production-guide/fault-tolerance.md
+++ b/doc/source/serve/production-guide/fault-tolerance.md
@@ -37,6 +37,16 @@ You can also use the deployment options to customize how frequently Serve runs t
 :language: python
 ```
 
+In this example, `check_health` raises an error if the connection to an external database is lost. The Serve controller periodically calls this method on each replica of the deployment. If the method raises an exception for a replica, Serve marks that replica as unhealthy and restarts it. Health checks are configured and performed on a per-replica basis.
+
+:::{note}
+You shouldn't call ``check_health`` directly through a deployment handle (e.g., ``await deployment_handle.check_health.remote()``). This would invoke the health check on a single, arbitrary replica. The ``check_health`` method is designed as an interface for the Serve controller, not for direct user calls.
+:::
+
+:::{note}
+In a composable deployment graph, each deployment is responsible for its own health, independent of the other deployments it's bound to. For example, in an application defined by ``app = ParentDeployment.bind(ChildDeployment.bind())``, ``ParentDeployment`` doesn't restart if ``ChildDeployment`` replicas fail their health checks. When the ``ChildDeployment`` replicas recover, the handle in ``ParentDeployment`` updates automatically to route requests to the healthy replicas.
+:::
+
 ### Worker node recovery
 
 :::{admonition} KubeRay Required


### PR DESCRIPTION
This PR adds clarifications to the fault tolerance documentation for Serve deployments.

* Provides details on how the Serve controller handles health checks for replicas.
* Includes notes warning against directly calling the check_health method and explaining the behavior in composable deployment graphs.