### PR TITLE
[Data] Refactor `Planner` to avoid storing plan-specific state

### DIFF
--- a/python/ray/data/_internal/logical/optimizers.py
+++ b/python/ray/data/_internal/logical/optimizers.py
@@ -75,9 +75,9 @@ def get_execution_plan(logical_plan: LogicalPlan) -> PhysicalPlan:
     (2) planning: convert logical to physical operators.
     (3) physical optimization: optimize physical operators.
     """
-    from ray.data._internal.planner.planner import Planner
+    from ray.data._internal.planner import create_planner
 
     optimized_logical_plan = LogicalOptimizer().optimize(logical_plan)
     logical_plan._dag = optimized_logical_plan.dag
-    physical_plan = Planner().plan(optimized_logical_plan)
+    physical_plan = create_planner().plan(optimized_logical_plan)
     return PhysicalOptimizer().optimize(physical_plan)

--- a/python/ray/data/_internal/planner/__init__.py
+++ b/python/ray/data/_internal/planner/__init__.py
@@ -1,0 +1,14 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ray.data._internal.planner.planner import Planner
+
+
+def create_planner() -> "Planner":
+    # Import here to avoid circular import.
+    from ray.data._internal.planner.planner import Planner
+
+    return Planner()
+
+
+__all__ = ["create_planner"]

--- a/python/ray/data/_internal/planner/planner.py
+++ b/python/ray/data/_internal/planner/planner.py
@@ -18,7 +18,7 @@ PlanLogicalOpFn = Callable[
 ]
 
 # A list of registered plan functions for logical operators.
-PLAN_LOGICAL_OP_FNS: List[Tuple[Type[LogicalOperator], PlanLogicalOpFn]] = []
+_PLAN_LOGICAL_OP_FNS: Dict[Type[LogicalOperator], PlanLogicalOpFn] = {}
 
 
 @DeveloperAPI
@@ -27,7 +27,12 @@ def register_plan_logical_op_fn(
     plan_fn: PlanLogicalOpFn,
 ):
     """Register a plan function for a logical operator type."""
-    PLAN_LOGICAL_OP_FNS.append((logical_op_type, plan_fn))
+    _PLAN_LOGICAL_OP_FNS[logical_op_type] = plan_fn
+
+
+@DeveloperAPI
+def get_plan_logical_op_fns():
+    return _PLAN_LOGICAL_OP_FNS.copy()
 
 
 def _register_default_plan_logical_op_fns():
@@ -163,52 +168,68 @@ class Planner:
     done by physical optimizer.
     """
 
-    def __init__(self):
-        self._physical_op_to_logical_op: Dict[PhysicalOperator, LogicalOperator] = {}
-
     def plan(self, logical_plan: LogicalPlan) -> PhysicalPlan:
         """Convert logical to physical operators recursively in post-order."""
-        physical_dag = self._plan(logical_plan.dag, logical_plan.context)
-        physical_plan = PhysicalPlan(
-            physical_dag,
-            self._physical_op_to_logical_op,
-            logical_plan.context,
+        plan_fns = get_plan_logical_op_fns()
+        physical_dag, op_map = plan_recursively(
+            logical_plan.dag, plan_fns, logical_plan.context
         )
+        physical_plan = PhysicalPlan(physical_dag, op_map, logical_plan.context)
         return physical_plan
 
-    def _plan(
-        self, logical_op: LogicalOperator, data_context: DataContext
-    ) -> PhysicalOperator:
-        # Plan the input dependencies first.
-        physical_children = []
-        for child in logical_op.input_dependencies:
-            physical_children.append(self._plan(child, data_context))
 
-        physical_op = None
-        for op_type, plan_fn in PLAN_LOGICAL_OP_FNS:
-            if isinstance(logical_op, op_type):
-                # We will call `set_logical_operators()` in the following for-loop,
-                # no need to do it here.
-                physical_op = plan_fn(logical_op, physical_children, data_context)
-                break
+@DeveloperAPI
+def plan_recursively(
+    logical_op: LogicalOperator,
+    plan_fns: Dict[Type[LogicalOperator], PlanLogicalOpFn],
+    data_context: DataContext,
+) -> Tuple[PhysicalOperator, Dict[LogicalOperator, PhysicalOperator]]:
+    """Plan a logical operator and its input dependencies recursively.
 
-        if physical_op is None:
-            raise ValueError(
-                f"Found unknown logical operator during planning: {logical_op}"
-            )
+    Args:
+        logical_op: The logical operator to plan.
+        plan_fns: A dictionary of planning functions for different logical operator
+            types.
+        data_context: The data context.
 
-        # Traverse up the DAG, and set the mapping from physical to logical operators.
-        # At this point, all physical operators without logical operators set
-        # must have been created by the current logical operator.
-        queue = [physical_op]
-        while queue:
-            curr_physical_op = queue.pop()
-            # Once we find an operator with a logical operator set, we can stop.
-            if curr_physical_op._logical_operators:
-                break
+    Returns:
+        A tuple of the physical operator corresponding to the logical operator, and
+        a mapping from physical to logical operators.
+    """
+    op_map: Dict[PhysicalOperator, LogicalOperator] = {}
 
-            curr_physical_op.set_logical_operators(logical_op)
-            queue.extend(physical_op.input_dependencies)
+    # Plan the input dependencies first.
+    physical_children = []
+    for child in logical_op.input_dependencies:
+        physical_child, child_op_map = plan_recursively(child, plan_fns, data_context)
+        physical_children.append(physical_child)
+        op_map.update(child_op_map)
 
-        self._physical_op_to_logical_op[physical_op] = logical_op
-        return physical_op
+    physical_op = None
+    for op_type, plan_fn in plan_fns.items():
+        if isinstance(logical_op, op_type):
+            # We will call `set_logical_operators()` in the following for-loop,
+            # no need to do it here.
+            physical_op = plan_fn(logical_op, physical_children, data_context)
+            break
+
+    if physical_op is None:
+        raise ValueError(
+            f"Found unknown logical operator during planning: {logical_op}"
+        )
+
+    # Traverse up the DAG, and set the mapping from physical to logical operators.
+    # At this point, all physical operators without logical operators set
+    # must have been created by the current logical operator.
+    queue = [physical_op]
+    while queue:
+        curr_physical_op = queue.pop()
+        # Once we find an operator with a logical operator set, we can stop.
+        if curr_physical_op._logical_operators:
+            break
+
+        curr_physical_op.set_logical_operators(logical_op)
+        queue.extend(physical_op.input_dependencies)
+
+    op_map[physical_op] = logical_op
+    return physical_op, op_map

--- a/python/ray/data/_internal/planner/planner.py
+++ b/python/ray/data/_internal/planner/planner.py
@@ -183,7 +183,7 @@ def plan_recursively(
     logical_op: LogicalOperator,
     plan_fns: Dict[Type[LogicalOperator], PlanLogicalOpFn],
     data_context: DataContext,
-) -> Tuple[PhysicalOperator, Dict[LogicalOperator, PhysicalOperator]]:
+) -> Tuple[PhysicalOperator, Dict[PhysicalOperator, LogicalOperator]]:
     """Plan a logical operator and its input dependencies recursively.
 
     Args:

--- a/python/ray/data/tests/test_execution_optimizer.py
+++ b/python/ray/data/tests/test_execution_optimizer.py
@@ -47,8 +47,8 @@ from ray.data._internal.logical.optimizers import PhysicalOptimizer
 from ray.data._internal.logical.rules.configure_map_task_memory import (
     ConfigureMapTaskMemoryUsingOutputSize,
 )
+from ray.data._internal.planner import create_planner
 from ray.data._internal.planner.exchange.sort_task_spec import SortKey
-from ray.data._internal.planner.planner import Planner
 from ray.data._internal.stats import DatasetStats
 from ray.data.aggregate import Count
 from ray.data.block import BlockMetadata
@@ -77,7 +77,7 @@ def _check_valid_plan_and_result(
 
 def test_read_operator(ray_start_regular_shared_2_cpus):
     ctx = DataContext.get_current()
-    planner = Planner()
+    planner = create_planner()
     op = get_parquet_read_logical_op()
     plan = LogicalPlan(op, ctx)
     physical_op = planner.plan(plan).dag
@@ -113,7 +113,7 @@ def test_read_operator_emits_warning_for_large_read_tasks():
 def test_split_blocks_operator(ray_start_regular_shared_2_cpus):
     ctx = DataContext.get_current()
 
-    planner = Planner()
+    planner = create_planner()
     op = get_parquet_read_logical_op(parallelism=10)
     logical_plan = LogicalPlan(op, ctx)
     physical_plan = planner.plan(logical_plan)
@@ -156,7 +156,7 @@ def test_from_operators(ray_start_regular_shared_2_cpus):
         FromPandas,
     ]
     for op_cls in op_classes:
-        planner = Planner()
+        planner = create_planner()
         op = op_cls([], [])
         plan = LogicalPlan(op, ctx)
         physical_op = planner.plan(plan).dag
@@ -227,7 +227,7 @@ def test_map_operator_udf_name(ray_start_regular_shared_2_cpus):
 def test_map_batches_operator(ray_start_regular_shared_2_cpus):
     ctx = DataContext.get_current()
 
-    planner = Planner()
+    planner = create_planner()
     read_op = get_parquet_read_logical_op()
     op = MapBatches(
         read_op,
@@ -255,7 +255,7 @@ def test_map_batches_e2e(ray_start_regular_shared_2_cpus):
 def test_map_rows_operator(ray_start_regular_shared_2_cpus):
     ctx = DataContext.get_current()
 
-    planner = Planner()
+    planner = create_planner()
     read_op = get_parquet_read_logical_op()
     op = MapRows(
         read_op,
@@ -282,7 +282,7 @@ def test_map_rows_e2e(ray_start_regular_shared_2_cpus):
 def test_filter_operator(ray_start_regular_shared_2_cpus):
     ctx = DataContext.get_current()
 
-    planner = Planner()
+    planner = create_planner()
     read_op = get_parquet_read_logical_op()
     op = Filter(
         read_op,
@@ -324,7 +324,7 @@ def test_project_operator_select(ray_start_regular_shared_2_cpus):
     assert isinstance(op, Project), op.name
     assert op.cols == cols
 
-    physical_plan = Planner().plan(logical_plan)
+    physical_plan = create_planner().plan(logical_plan)
     physical_plan = PhysicalOptimizer().optimize(physical_plan)
     physical_op = physical_plan.dag
     assert isinstance(physical_op, TaskPoolMapOperator)
@@ -348,7 +348,7 @@ def test_project_operator_rename(ray_start_regular_shared_2_cpus):
     assert not op.cols
     assert op.cols_rename == cols_rename
 
-    physical_plan = Planner().plan(logical_plan)
+    physical_plan = create_planner().plan(logical_plan)
     physical_plan = PhysicalOptimizer().optimize(physical_plan)
     physical_op = physical_plan.dag
     assert isinstance(physical_op, TaskPoolMapOperator)
@@ -358,7 +358,7 @@ def test_project_operator_rename(ray_start_regular_shared_2_cpus):
 def test_flat_map(ray_start_regular_shared_2_cpus):
     ctx = DataContext.get_current()
 
-    planner = Planner()
+    planner = create_planner()
     read_op = get_parquet_read_logical_op()
     op = FlatMap(
         read_op,
@@ -423,7 +423,7 @@ def test_random_sample_e2e(ray_start_regular_shared_2_cpus):
 def test_random_shuffle_operator(ray_start_regular_shared_2_cpus):
     ctx = DataContext.get_current()
 
-    planner = Planner()
+    planner = create_planner()
     read_op = get_parquet_read_logical_op()
     op = RandomShuffle(
         read_op,
@@ -462,7 +462,7 @@ def test_random_shuffle_e2e(ray_start_regular_shared_2_cpus, configure_shuffle_m
 def test_repartition_operator(ray_start_regular_shared_2_cpus, shuffle):
     ctx = DataContext.get_current()
 
-    planner = Planner()
+    planner = create_planner()
     read_op = get_parquet_read_logical_op()
     op = Repartition(read_op, num_outputs=5, shuffle=shuffle)
     plan = LogicalPlan(op, ctx)
@@ -543,7 +543,7 @@ def test_write_operator(ray_start_regular_shared_2_cpus, tmp_path):
     ctx = DataContext.get_current()
 
     concurrency = 2
-    planner = Planner()
+    planner = create_planner()
     datasink = ParquetDatasink(tmp_path)
     read_op = get_parquet_read_logical_op()
     op = Write(
@@ -569,7 +569,7 @@ def test_sort_operator(
 ):
     ctx = DataContext.get_current()
 
-    planner = Planner()
+    planner = create_planner()
     read_op = get_parquet_read_logical_op()
     op = Sort(
         read_op,
@@ -708,7 +708,7 @@ def test_batch_format_on_aggregate(ray_start_regular_shared_2_cpus):
 def test_aggregate_operator(ray_start_regular_shared_2_cpus):
     ctx = DataContext.get_current()
 
-    planner = Planner()
+    planner = create_planner()
     read_op = get_parquet_read_logical_op()
     op = Aggregate(
         read_op,
@@ -778,7 +778,7 @@ def test_aggregate_validate_keys(ray_start_regular_shared_2_cpus):
 def test_zip_operator(ray_start_regular_shared_2_cpus):
     ctx = DataContext.get_current()
 
-    planner = Planner()
+    planner = create_planner()
     read_op1 = get_parquet_read_logical_op()
     read_op2 = get_parquet_read_logical_op()
     op = Zip(read_op1, read_op2)

--- a/python/ray/data/tests/test_operator_fusion.py
+++ b/python/ray/data/tests/test_operator_fusion.py
@@ -25,7 +25,7 @@ from ray.data._internal.logical.operators.map_operator import (
 from ray.data._internal.logical.operators.read_operator import Read
 from ray.data._internal.logical.optimizers import PhysicalOptimizer, get_execution_plan
 from ray.data._internal.plan import ExecutionPlan
-from ray.data._internal.planner.planner import Planner
+from ray.data._internal.planner import create_planner
 from ray.data._internal.stats import DatasetStats
 from ray.data.context import DataContext
 from ray.data.tests.conftest import *  # noqa
@@ -38,7 +38,7 @@ def test_read_map_batches_operator_fusion(ray_start_regular_shared_2_cpus):
     ctx = DataContext.get_current()
 
     # Test that Read is fused with MapBatches.
-    planner = Planner()
+    planner = create_planner()
     read_op = get_parquet_read_logical_op(parallelism=1)
     op = MapBatches(
         read_op,
@@ -67,7 +67,7 @@ def test_read_map_chain_operator_fusion(ray_start_regular_shared_2_cpus):
     ctx = DataContext.get_current()
 
     # Test that a chain of different map operators are fused.
-    planner = Planner()
+    planner = create_planner()
     read_op = get_parquet_read_logical_op(parallelism=1)
     map1 = MapRows(read_op, lambda x: x)
     map2 = MapBatches(map1, lambda x: x)
@@ -117,7 +117,7 @@ def test_read_map_batches_operator_fusion_compatible_remote_args(
         ({"scheduling_strategy": "SPREAD"}, {}),
     ]
     for up_remote_args, down_remote_args in compatiple_remote_args_pairs:
-        planner = Planner()
+        planner = create_planner()
         read_op = get_parquet_read_logical_op(
             ray_remote_args={"resources": {"non-existent": 1}},
             parallelism=1,
@@ -164,7 +164,7 @@ def test_read_map_batches_operator_fusion_incompatible_remote_args(
         ({"scheduling_strategy": "SPREAD"}, {"scheduling_strategy": "PACK"}),
     ]
     for up_remote_args, down_remote_args in incompatible_remote_args_pairs:
-        planner = Planner()
+        planner = create_planner()
         read_op = get_parquet_read_logical_op(
             ray_remote_args={"resources": {"non-existent": 1}}
         )
@@ -198,7 +198,7 @@ def test_read_map_batches_operator_fusion_compute_tasks_to_actors(
 
     # Test that a task-based map operator is fused into an actor-based map operator when
     # the former comes before the latter.
-    planner = Planner()
+    planner = create_planner()
     read_op = get_parquet_read_logical_op(parallelism=1)
     op = MapBatches(read_op, lambda x: x)
     op = MapBatches(op, lambda x: x, compute=ray.data.ActorPoolStrategy())
@@ -220,7 +220,7 @@ def test_read_map_batches_operator_fusion_compute_read_to_actors(
     ctx = DataContext.get_current()
 
     # Test that reads fuse into an actor-based map operator.
-    planner = Planner()
+    planner = create_planner()
     read_op = get_parquet_read_logical_op(parallelism=1)
     op = MapBatches(read_op, lambda x: x, compute=ray.data.ActorPoolStrategy())
     logical_plan = LogicalPlan(op, ctx)
@@ -241,7 +241,7 @@ def test_read_map_batches_operator_fusion_incompatible_compute(
     ctx = DataContext.get_current()
 
     # Test that map operators are not fused when compute strategies are incompatible.
-    planner = Planner()
+    planner = create_planner()
     read_op = get_parquet_read_logical_op(parallelism=1)
     op = MapBatches(read_op, lambda x: x, compute=ray.data.ActorPoolStrategy())
     op = MapBatches(op, lambda x: x)
@@ -715,7 +715,7 @@ def test_zero_copy_fusion_eliminate_build_output_blocks(
     ctx = DataContext.get_current()
 
     # Test the EliminateBuildOutputBlocks optimization rule.
-    planner = Planner()
+    planner = create_planner()
     read_op = get_parquet_read_logical_op()
     op = MapBatches(read_op, lambda x: x)
     logical_plan = LogicalPlan(op, ctx)

--- a/python/ray/data/tests/test_randomize_block_order.py
+++ b/python/ray/data/tests/test_randomize_block_order.py
@@ -14,7 +14,7 @@ from ray.data._internal.logical.operators.map_operator import AbstractUDFMap, Ma
 from ray.data._internal.logical.operators.read_operator import Read
 from ray.data._internal.logical.optimizers import LogicalOptimizer
 from ray.data._internal.logical.rules.randomize_blocks import ReorderRandomizeBlocksRule
-from ray.data._internal.planner.planner import Planner
+from ray.data._internal.planner import create_planner
 from ray.data.context import DataContext
 from ray.data.tests.test_util import get_parquet_read_logical_op
 from ray.data.tests.util import extract_values
@@ -23,7 +23,7 @@ from ray.data.tests.util import extract_values
 def test_randomize_blocks_operator(ray_start_regular_shared):
     ctx = DataContext.get_current()
 
-    planner = Planner()
+    planner = create_planner()
     read_op = get_parquet_read_logical_op()
     op = RandomizeBlocks(
         read_op,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The current `Planner` implementation stores plan-specific state (like the `op_map`) as a class attribute. This makes the planner technically stateful across calls, which could lead to incorrect results if `.plan()` is called multiple times on the same instance:

```
planner = Planner()
planner.plan(logical_plan1)
# This will lead to incorrect results because it reuses state form the first plan
planner.plan(logical_plan2)
```

While this doesn’t currently happen in practice, it’s fragile and could easily lead to bugs.

This PR refactors the planner to avoid storing any state tied to a specific plan, making it safe to reuse across multiple calls.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
