### PR TITLE
[core] disable so_reuseaddr when creating grpc server

### DIFF
--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -28,6 +28,10 @@
 #include "ray/rpc/common.h"
 #include "ray/util/thread_utils.h"
 
+#ifndef GRPC_ARG_ALLOW_REUSEADDR
+#define GRPC_ARG_ALLOW_REUSEADDR "grpc.so_reuseaddr"
+#endif
+
 namespace ray {
 namespace rpc {
 
@@ -65,10 +69,12 @@ void GrpcServer::Run() {
   std::string server_address((listen_to_localhost_only_ ? "127.0.0.1:" : "0.0.0.0:") +
                              std::to_string(port_));
   grpc::ServerBuilder builder;
-  // Disable the SO_REUSEPORT option. We don't need it in ray. If the option is enabled
-  // (default behavior in grpc), we may see multiple workers listen on the same port and
-  // the requests sent to this port may be handled by any of the workers.
+  // Disable the SO_REUSEPORT and SO_REUSEADDR option. We don't need it in ray.
+  // If the option is enabled (default behavior in grpc), we may see multiple workers
+  // listen on the same port and the requests sent to this port may be handled by any
+  // of the workers.
   builder.AddChannelArgument(GRPC_ARG_ALLOW_REUSEPORT, 0);
+  builder.AddChannelArgument(GRPC_ARG_ALLOW_REUSEADDR, 0);
   builder.AddChannelArgument(GRPC_ARG_MAX_SEND_MESSAGE_LENGTH,
                              RayConfig::instance().max_grpc_message_size());
   builder.AddChannelArgument(GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
