### PR TITLE
[core] Making NodeManager use ILocalTaskManager instead  of TaskManager.

### DIFF
--- a/src/mock/ray/raylet/local_task_manager.h
+++ b/src/mock/ray/raylet/local_task_manager.h
@@ -52,6 +52,24 @@ class MockLocalTaskManager : public ILocalTaskManager {
               AnyPendingTasksForResourceAcquisition,
               (int *num_pending_actor_creation, int *num_pending_tasks),
               (const, override));
+  MOCK_METHOD(void,
+              TaskFinished,
+              (std::shared_ptr<WorkerInterface> worker, RayTask *task),
+              (override));
+  MOCK_METHOD(void, TasksUnblocked, (const std::vector<TaskID> &ready_ids), (override));
+  MOCK_METHOD(void,
+              ReleaseWorkerResources,
+              (std::shared_ptr<WorkerInterface> worker),
+              (override));
+  MOCK_METHOD(bool,
+              ReleaseCpuResourcesFromBlockedWorker,
+              (std::shared_ptr<WorkerInterface> worker),
+              (override));
+  MOCK_METHOD(bool,
+              ReturnCpuResourcesToUnblockedWorker,
+              (std::shared_ptr<WorkerInterface> worker),
+              (override));
+  MOCK_METHOD(ResourceSet, CalcNormalTaskResources, (), (const, override));
   MOCK_METHOD(void, RecordMetrics, (), (const, override));
   MOCK_METHOD(void, DebugStr, (std::stringstream & buffer), (const, override));
   MOCK_METHOD(size_t, GetNumTaskSpilled, (), (const, override));

--- a/src/ray/raylet/local_task_manager.h
+++ b/src/ray/raylet/local_task_manager.h
@@ -25,17 +25,12 @@
 #include "absl/container/flat_hash_set.h"
 #include "ray/common/ray_object.h"
 #include "ray/common/task/task.h"
-#include "ray/common/task/task_common.h"
 #include "ray/raylet/dependency_manager.h"
 #include "ray/raylet/scheduling/cluster_resource_scheduler.h"
-#include "ray/raylet/scheduling/cluster_task_manager_interface.h"
 #include "ray/raylet/scheduling/internal.h"
 #include "ray/raylet/scheduling/local_task_manager_interface.h"
 #include "ray/raylet/worker.h"
 #include "ray/raylet/worker_pool.h"
-#include "ray/rpc/grpc_client.h"
-#include "ray/rpc/node_manager/node_manager_client.h"
-#include "ray/rpc/node_manager/node_manager_server.h"
 
 namespace ray {
 namespace raylet {
@@ -105,7 +100,7 @@ class LocalTaskManager : public ILocalTaskManager {
   /// dependencies are resolved.
   ///
   /// \param ready_ids: The tasks which are now ready to be dispatched.
-  void TasksUnblocked(const std::vector<TaskID> &ready_ids);
+  void TasksUnblocked(const std::vector<TaskID> &ready_ids) override;
 
   /// Return the finished task and release the worker resources.
   /// This method will be removed and can be replaced by `ReleaseWorkerResources` directly
@@ -113,7 +108,7 @@ class LocalTaskManager : public ILocalTaskManager {
   ///
   /// \param worker: The worker which was running the task.
   /// \param task: Output parameter.
-  void TaskFinished(std::shared_ptr<WorkerInterface> worker, RayTask *task);
+  void TaskFinished(std::shared_ptr<WorkerInterface> worker, RayTask *task) override;
 
   /// Attempt to cancel all queued tasks that match the predicate.
   ///
@@ -137,7 +132,7 @@ class LocalTaskManager : public ILocalTaskManager {
   /// Call once a task finishes (i.e. a worker is returned).
   ///
   /// \param worker: The worker which was running the task.
-  void ReleaseWorkerResources(std::shared_ptr<WorkerInterface> worker);
+  void ReleaseWorkerResources(std::shared_ptr<WorkerInterface> worker) override;
 
   /// When a task is blocked in ray.get or ray.wait, the worker who is executing the task
   /// should give up the CPU resources allocated for the running task for the time being
@@ -146,7 +141,7 @@ class LocalTaskManager : public ILocalTaskManager {
   /// \param worker: The worker who will give up the CPU resources.
   /// \return true if the cpu resources of the specified worker are released successfully,
   /// else false.
-  bool ReleaseCpuResourcesFromBlockedWorker(std::shared_ptr<WorkerInterface> worker);
+  bool ReleaseCpuResourcesFromBlockedWorker(std::shared_ptr<WorkerInterface> worker) override;
 
   /// When a task is no longer blocked in a ray.get or ray.wait, the CPU resources that
   /// the worker gave up should be returned to it.
@@ -154,12 +149,12 @@ class LocalTaskManager : public ILocalTaskManager {
   /// \param worker The blocked worker.
   /// \return true if the cpu resources are returned back to the specified worker, else
   /// false.
-  bool ReturnCpuResourcesToUnblockedWorker(std::shared_ptr<WorkerInterface> worker);
+  bool ReturnCpuResourcesToUnblockedWorker(std::shared_ptr<WorkerInterface> worker) override;
 
   /// TODO(Chong-Li): Removing this and maintaining normal task resources by local
   /// resource manager.
   /// Calculate normal task resources.
-  ResourceSet CalcNormalTaskResources() const;
+  ResourceSet CalcNormalTaskResources() const override;
 
   void SetWorkerBacklog(SchedulingClass scheduling_class,
                         const WorkerID &worker_id,

--- a/src/ray/raylet/local_task_manager.h
+++ b/src/ray/raylet/local_task_manager.h
@@ -141,7 +141,8 @@ class LocalTaskManager : public ILocalTaskManager {
   /// \param worker: The worker who will give up the CPU resources.
   /// \return true if the cpu resources of the specified worker are released successfully,
   /// else false.
-  bool ReleaseCpuResourcesFromBlockedWorker(std::shared_ptr<WorkerInterface> worker) override;
+  bool ReleaseCpuResourcesFromBlockedWorker(
+      std::shared_ptr<WorkerInterface> worker) override;
 
   /// When a task is no longer blocked in a ray.get or ray.wait, the CPU resources that
   /// the worker gave up should be returned to it.
@@ -149,7 +150,8 @@ class LocalTaskManager : public ILocalTaskManager {
   /// \param worker The blocked worker.
   /// \return true if the cpu resources are returned back to the specified worker, else
   /// false.
-  bool ReturnCpuResourcesToUnblockedWorker(std::shared_ptr<WorkerInterface> worker) override;
+  bool ReturnCpuResourcesToUnblockedWorker(
+      std::shared_ptr<WorkerInterface> worker) override;
 
   /// TODO(Chong-Li): Removing this and maintaining normal task resources by local
   /// resource manager.

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -268,7 +268,7 @@ int main(int argc, char *argv[]) {
   /// usage. ClusterTaskManager is responsible for queuing, spilling back, and
   /// dispatching tasks.
   std::shared_ptr<ray::ClusterResourceScheduler> cluster_resource_scheduler;
-  std::shared_ptr<ray::raylet::LocalTaskManager> local_task_manager;
+  std::shared_ptr<ray::raylet::ILocalTaskManager> local_task_manager;
   std::shared_ptr<ray::raylet::ClusterTaskManagerInterface> cluster_task_manager;
   /// The raylet client to initiate the pubsub to core workers (owners).
   /// It is used to subscribe objects to evict.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -117,7 +117,7 @@ NodeManager::NodeManager(
     rpc::CoreWorkerClientPool &worker_rpc_pool,
     std::shared_ptr<pubsub::SubscriberInterface> core_worker_subscriber,
     std::shared_ptr<ClusterResourceScheduler> cluster_resource_scheduler,
-    std::shared_ptr<LocalTaskManager> local_task_manager,
+    std::shared_ptr<ILocalTaskManager> local_task_manager,
     std::shared_ptr<ClusterTaskManagerInterface> cluster_task_manager,
     std::shared_ptr<IObjectDirectory> object_directory,
     std::shared_ptr<ObjectManagerInterface> object_manager,

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -140,7 +140,7 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
       rpc::CoreWorkerClientPool &worker_rpc_pool,
       std::shared_ptr<pubsub::SubscriberInterface> core_worker_subscriber,
       std::shared_ptr<ClusterResourceScheduler> cluster_resource_scheduler,
-      std::shared_ptr<LocalTaskManager> local_task_manager,
+      std::shared_ptr<ILocalTaskManager> local_task_manager,
       std::shared_ptr<ClusterTaskManagerInterface> cluster_task_manager,
       std::shared_ptr<IObjectDirectory> object_directory,
       std::shared_ptr<ObjectManagerInterface> object_manager,
@@ -878,7 +878,7 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   /// usage. ClusterTaskManager is responsible for queuing, spilling back, and
   /// dispatching tasks.
   std::shared_ptr<ClusterResourceScheduler> cluster_resource_scheduler_;
-  std::shared_ptr<LocalTaskManager> local_task_manager_;
+  std::shared_ptr<ILocalTaskManager> local_task_manager_;
   std::shared_ptr<ClusterTaskManagerInterface> cluster_task_manager_;
 
   absl::flat_hash_map<ObjectID, std::unique_ptr<RayObject>> pinned_objects_;

--- a/src/ray/raylet/scheduling/local_task_manager_interface.h
+++ b/src/ray/raylet/scheduling/local_task_manager_interface.h
@@ -19,13 +19,14 @@
 #include <string>
 
 #include "absl/container/flat_hash_map.h"
-#include "ray/common/ray_object.h"
 #include "ray/common/task/task.h"
-#include "ray/common/task/task_common.h"
 #include "ray/raylet/scheduling/internal.h"
 
 namespace ray {
 namespace raylet {
+
+// Forward declaration
+class WorkerInterface;
 
 /// Manages the lifetime of a task on the local node. It receives request from
 /// cluster_task_manager and tries to execute the task locally.
@@ -68,6 +69,18 @@ class ILocalTaskManager {
   virtual const RayTask *AnyPendingTasksForResourceAcquisition(
       int *num_pending_actor_creation, int *num_pending_tasks) const = 0;
 
+  virtual void TasksUnblocked(const std::vector<TaskID> &ready_ids) = 0;
+
+  virtual void TaskFinished(std::shared_ptr<WorkerInterface> worker, RayTask *task) = 0;
+
+  virtual void ReleaseWorkerResources(std::shared_ptr<WorkerInterface> worker) = 0;
+
+  virtual bool ReleaseCpuResourcesFromBlockedWorker(std::shared_ptr<WorkerInterface> worker) = 0;
+
+  virtual bool ReturnCpuResourcesToUnblockedWorker(std::shared_ptr<WorkerInterface> worker) = 0;
+
+  virtual ResourceSet CalcNormalTaskResources() const = 0;
+
   virtual void RecordMetrics() const = 0;
 
   virtual void DebugStr(std::stringstream &buffer) const = 0;
@@ -82,7 +95,7 @@ class ILocalTaskManager {
 /// we should make `ClusterTaskManager` not aware of `LocalTaskManager`.
 class NoopLocalTaskManager : public ILocalTaskManager {
  public:
-  NoopLocalTaskManager() {}
+  NoopLocalTaskManager() = default;
 
   /// Queue task and schedule.
   void QueueAndScheduleTask(std::shared_ptr<internal::Work> work) override {
@@ -124,6 +137,24 @@ class NoopLocalTaskManager : public ILocalTaskManager {
   const RayTask *AnyPendingTasksForResourceAcquisition(
       int *num_pending_actor_creation, int *num_pending_tasks) const override {
     return nullptr;
+  }
+
+  void TasksUnblocked(const std::vector<TaskID> &ready_ids) override {}
+
+  void TaskFinished(std::shared_ptr<WorkerInterface> worker, RayTask *task) override {}
+
+  void ReleaseWorkerResources(std::shared_ptr<WorkerInterface> worker) override {}
+
+  bool ReleaseCpuResourcesFromBlockedWorker(std::shared_ptr<WorkerInterface> worker) override {
+    return false;
+  }
+
+  bool ReturnCpuResourcesToUnblockedWorker(std::shared_ptr<WorkerInterface> worker) override {
+    return false;
+  }
+
+  ResourceSet CalcNormalTaskResources() const override {
+    return ResourceSet();
   }
 
   void RecordMetrics() const override{};

--- a/src/ray/raylet/scheduling/local_task_manager_interface.h
+++ b/src/ray/raylet/scheduling/local_task_manager_interface.h
@@ -75,9 +75,11 @@ class ILocalTaskManager {
 
   virtual void ReleaseWorkerResources(std::shared_ptr<WorkerInterface> worker) = 0;
 
-  virtual bool ReleaseCpuResourcesFromBlockedWorker(std::shared_ptr<WorkerInterface> worker) = 0;
+  virtual bool ReleaseCpuResourcesFromBlockedWorker(
+      std::shared_ptr<WorkerInterface> worker) = 0;
 
-  virtual bool ReturnCpuResourcesToUnblockedWorker(std::shared_ptr<WorkerInterface> worker) = 0;
+  virtual bool ReturnCpuResourcesToUnblockedWorker(
+      std::shared_ptr<WorkerInterface> worker) = 0;
 
   virtual ResourceSet CalcNormalTaskResources() const = 0;
 
@@ -145,17 +147,17 @@ class NoopLocalTaskManager : public ILocalTaskManager {
 
   void ReleaseWorkerResources(std::shared_ptr<WorkerInterface> worker) override {}
 
-  bool ReleaseCpuResourcesFromBlockedWorker(std::shared_ptr<WorkerInterface> worker) override {
+  bool ReleaseCpuResourcesFromBlockedWorker(
+      std::shared_ptr<WorkerInterface> worker) override {
     return false;
   }
 
-  bool ReturnCpuResourcesToUnblockedWorker(std::shared_ptr<WorkerInterface> worker) override {
+  bool ReturnCpuResourcesToUnblockedWorker(
+      std::shared_ptr<WorkerInterface> worker) override {
     return false;
   }
 
-  ResourceSet CalcNormalTaskResources() const override {
-    return ResourceSet();
-  }
+  ResourceSet CalcNormalTaskResources() const override { return ResourceSet(); }
 
   void RecordMetrics() const override{};
 


### PR DESCRIPTION
This will allow unit tests of NodeManager to use a Fake implementation of LocalTaskManager where appropriate.

I've created CORE-1644 as a follow-up to remove usage of NoopLocalTaskManager from the GCS which is a clear encapsulation leak. 