### PR TITLE
[train] Fix release test missing data key

### DIFF
--- a/release/train_tests/benchmark/image_classification/jpeg/factory.py
+++ b/release/train_tests/benchmark/image_classification/jpeg/factory.py
@@ -85,7 +85,8 @@ class ImageClassificationJpegRayDataLoaderFactory(
                 - "val": Validation dataset without transforms
         """
         train_dir = self._dataset_dirs[DatasetKey.TRAIN]
-        val_dir = self._dataset_dirs[DatasetKey.VALID]
+        # TODO: The validation dataset directory is not partitioned by class.
+        val_dir = train_dir
 
         filesystem = (
             self.get_s3fs_with_boto_creds() if train_dir.startswith("s3://") else None


### PR DESCRIPTION
## Summary

The Jpeg dataset validation directory doesn't have a directory structure with the class names, which is an assumption of the `read_images` code right now. Switches to using a subset of the training dataset instead and adds a TODO to fix the validation dataset loading.