### PR TITLE
[train][template] Remove clock emoji which does not always render well

### DIFF
--- a/doc/source/train/examples/pytorch/distributing-pytorch/README.ipynb
+++ b/doc/source/train/examples/pytorch/distributing-pytorch/README.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Distributing your PyTorch Training Code with Ray Train and Ray Data\n",
     "\n",
-    "**⏱️ Time to complete**: 10 min\n",
+    "**Time to complete**: 10 min\n",
     "\n",
     "This template shows you how to distribute your PyTorch training code with Ray Train and Ray Data, getting performance and usability improvements along the way.\n",
     "\n",

--- a/doc/source/train/examples/pytorch/distributing-pytorch/README.md
+++ b/doc/source/train/examples/pytorch/distributing-pytorch/README.md
@@ -1,6 +1,6 @@
 # Distributing your PyTorch Training Code with Ray Train and Ray Data
 
-**⏱️ Time to complete**: 10 min
+**Time to complete**: 10 min
 
 This template shows you how to distribute your PyTorch training code with Ray Train and Ray Data, getting performance and usability improvements along the way.
 


### PR DESCRIPTION
Example screenshot of a case where the clock emoji doesn't render:

<img width="1904" alt="Screenshot 2025-06-19 at 2 57 32 PM" src="https://github.com/user-attachments/assets/74d03104-bc9c-421a-b80a-65edc294ab29" />

It still looks fine in a Jupyter notebook viewer (ex: vscode):

<img width="1920" alt="Screenshot 2025-06-19 at 2 58 52 PM" src="https://github.com/user-attachments/assets/10bdf3c4-252f-4bce-99b7-4e94ea37590b" />

Removing it just to be safe. 

