### PR TITLE
[Data] Fixing PyArrow overflow handling

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1047,9 +1047,6 @@ python/ray/dashboard/utils.py
 python/ray/data/_internal/arrow_ops/transform_pyarrow.py
     DOC201: Function `combine_chunks` does not have a return section in docstring
     DOC201: Function `combine_chunked_array` does not have a return section in docstring
-    DOC101: Function `_try_combine_chunks_safe`: Docstring contains fewer arguments than in function signature.
-    DOC107: Function `_try_combine_chunks_safe`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
-    DOC103: Function `_try_combine_chunks_safe`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [array: 'pyarrow.ChunkedArray', max_chunk_size: ].
 --------------------
 python/ray/data/_internal/block_batching/iter_batches.py
     DOC103: Function `_format_in_threadpool`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [batch_iter: Iterator[Batch]]. Arguments in the docstring but not in the function signature: [logical_batch_iterator: ].

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -25,6 +25,7 @@ from ray.data._internal.numpy_support import (
 from ray.data._internal.util import GiB
 from ray.util import log_once
 from ray.util.annotations import DeveloperAPI, PublicAPI
+from ray.util.common import INT32_MAX
 
 PYARROW_VERSION = get_pyarrow_version()
 # Minimum version of Arrow that supports subclassable ExtensionScalars.
@@ -321,7 +322,7 @@ def _infer_pyarrow_type(
         #
         #       Check out test cases for this method for an additional context.
         if isinstance(obj, (str, bytes)):
-            return len(obj) > INT32_OVERFLOW_THRESHOLD
+            return len(obj) > INT32_MAX
 
         return False
 

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -22,7 +22,6 @@ from ray.data._internal.numpy_support import (
     convert_to_numpy,
     _convert_datetime_to_np_datetime,
 )
-from ray.data._internal.util import GiB
 from ray.util import log_once
 from ray.util.annotations import DeveloperAPI, PublicAPI
 from ray.util.common import INT32_MAX

--- a/python/ray/air/util/tensor_extensions/arrow.py
+++ b/python/ray/air/util/tensor_extensions/arrow.py
@@ -35,10 +35,6 @@ MIN_PYARROW_VERSION_CHUNKED_ARRAY_TO_NUMPY_ZERO_COPY_ONLY = parse_version("13.0.
 
 NUM_BYTES_PER_UNICODE_CHAR = 4
 
-# NOTE: Overflow threshold in bytes for most Arrow types using int32 as
-#       its offsets
-INT32_OVERFLOW_THRESHOLD = 2 * GiB
-
 
 logger = logging.getLogger(__name__)
 

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -830,10 +830,13 @@ def _try_combine_chunks_safe(
         with potentially smaller number of chunks that have resulted from clumping
         the original ones)
 
+    Args:
+        array: The PyArrow ChunkedArray to safely combine.
+
     Returns:
-        - pa.Array if it's possible to combine provided pa.ChunkedArray into single
-        contiguous array
-        - pa.ChunkedArray (albeit with chunks re-combined) if it's not possible to
+        - ``pyarrow.Array`` if it's possible to combine provided ``pyarrow.ChunkedArray``
+        into single contiguous array
+        - ``pyarrow.ChunkedArray`` (albeit with chunks re-combined) if it's not possible to
         produce single pa.Array
     """
 

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -812,7 +812,7 @@ _VARIABLE_WIDTH_INT32_OFFSET_PA_TYPE_PREDICATES = [
 
 
 def _try_combine_chunks_safe(
-    array: "pyarrow.ChunkedArray"
+    array: "pyarrow.ChunkedArray",
 ) -> Union["pyarrow.Array", "pyarrow.ChunkedArray"]:
     """This method provides a safe way of combining `ChunkedArray`s exceeding 2 GiB
     in size, which aren't using "large_*" types (and therefore relying on int32
@@ -851,11 +851,11 @@ def _try_combine_chunks_safe(
     #   - It's type is a variable-width type using int64 offsets (large_list,
     #     large_string, etc)
     #   - It's cumulative byte-size is < INT32_MAX
-    if not any(
-        p(array.type) for p in _VARIABLE_WIDTH_INT32_OFFSET_PA_TYPE_PREDICATES
-    ) or any(
-        p(array.type) for p in _VARIABLE_WIDTH_INT64_OFFSET_PA_TYPE_PREDICATES
-    ) or array.nbytes < INT32_MAX:
+    if (
+        not any(p(array.type) for p in _VARIABLE_WIDTH_INT32_OFFSET_PA_TYPE_PREDICATES)
+        or any(p(array.type) for p in _VARIABLE_WIDTH_INT64_OFFSET_PA_TYPE_PREDICATES)
+        or array.nbytes < INT32_MAX
+    ):
         return array.combine_chunks()
 
     # In this case it's actually *NOT* safe to try to directly combine

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -802,6 +802,8 @@ _VARIABLE_WIDTH_INT64_OFFSET_PA_TYPE_PREDICATES = [
 _VARIABLE_WIDTH_INT32_OFFSET_PA_TYPE_PREDICATES = [
     pyarrow.types.is_string,
     pyarrow.types.is_string_view,
+    pyarrow.types.is_binary,
+    pyarrow.types.is_binary_view,
     pyarrow.types.is_list,
     pyarrow.types.is_list_view,
     # Modeled as list<struct<key, val>>
@@ -849,6 +851,12 @@ def _try_combine_chunks_safe(
     #   - It's type is a variable-width type using int64 offsets (large_list,
     #     large_string, etc)
     #   - It's cumulative byte-size is < INT32_MAX
+    print(f">>> [DBG] {array.nbytes} {array.type}, {INT32_MAX} {not any(
+        p(array.type) for p in _VARIABLE_WIDTH_INT32_OFFSET_PA_TYPE_PREDICATES
+    ) }, {any(
+        p(array.type) for p in _VARIABLE_WIDTH_INT64_OFFSET_PA_TYPE_PREDICATES
+    )}")
+
     if not any(
         p(array.type) for p in _VARIABLE_WIDTH_INT32_OFFSET_PA_TYPE_PREDICATES
     ) or any(

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -18,6 +18,8 @@ except ImportError:
     pyarrow = None
 
 
+# Minimum version support {String,List,Binary}View types
+MIN_PYARROW_VERSION_VIEW_TYPES = parse_version("16.0.0")
 MIN_PYARROW_VERSION_TYPE_PROMOTION = parse_version("14.0.0")
 
 
@@ -801,14 +803,20 @@ _VARIABLE_WIDTH_INT64_OFFSET_PA_TYPE_PREDICATES = [
 # List of variable-width types using int32 offsets
 _VARIABLE_WIDTH_INT32_OFFSET_PA_TYPE_PREDICATES = [
     pyarrow.types.is_string,
-    pyarrow.types.is_string_view,
     pyarrow.types.is_binary,
-    pyarrow.types.is_binary_view,
     pyarrow.types.is_list,
-    pyarrow.types.is_list_view,
     # Modeled as list<struct<key, val>>
     pyarrow.types.is_map,
 ]
+
+if PYARROW_VERSION > MIN_PYARROW_VERSION_VIEW_TYPES:
+    _VARIABLE_WIDTH_INT32_OFFSET_PA_TYPE_PREDICATES.extend(
+        [
+            pyarrow.types.is_string_view,
+            pyarrow.types.is_binary_view,
+            pyarrow.types.is_list_view,
+        ]
+    )
 
 
 def _try_combine_chunks_safe(

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -851,12 +851,6 @@ def _try_combine_chunks_safe(
     #   - It's type is a variable-width type using int64 offsets (large_list,
     #     large_string, etc)
     #   - It's cumulative byte-size is < INT32_MAX
-    print(f">>> [DBG] {array.nbytes} {array.type}, {INT32_MAX} {not any(
-        p(array.type) for p in _VARIABLE_WIDTH_INT32_OFFSET_PA_TYPE_PREDICATES
-    ) }, {any(
-        p(array.type) for p in _VARIABLE_WIDTH_INT64_OFFSET_PA_TYPE_PREDICATES
-    )}")
-
     if not any(
         p(array.type) for p in _VARIABLE_WIDTH_INT32_OFFSET_PA_TYPE_PREDICATES
     ) or any(

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -6,8 +6,8 @@ from packaging.version import parse as parse_version
 
 from ray._private.arrow_utils import get_pyarrow_version
 from ray._private.ray_constants import env_integer
+from ray._private.utils import INT32_MAX
 from ray.air.util.tensor_extensions.arrow import (
-    INT32_OVERFLOW_THRESHOLD,
     MIN_PYARROW_VERSION_CHUNKED_ARRAY_TO_NUMPY_ZERO_COPY_ONLY,
     PYARROW_VERSION,
 )
@@ -790,8 +790,27 @@ def combine_chunked_array(
         return _try_combine_chunks_safe(array)
 
 
+# List of variable-width types using int64 offsets
+_VARIABLE_WIDTH_INT64_OFFSET_PA_TYPE_PREDICATES = [
+    pyarrow.types.is_large_list,
+    pyarrow.types.is_large_string,
+    pyarrow.types.is_large_binary,
+]
+
+
+# List of variable-width types using int32 offsets
+_VARIABLE_WIDTH_INT32_OFFSET_PA_TYPE_PREDICATES = [
+    pyarrow.types.is_string,
+    pyarrow.types.is_string_view,
+    pyarrow.types.is_list,
+    pyarrow.types.is_list_view,
+    # Modeled as list<struct<key, val>>
+    pyarrow.types.is_map,
+]
+
+
 def _try_combine_chunks_safe(
-    array: "pyarrow.ChunkedArray", max_chunk_size=INT32_OVERFLOW_THRESHOLD
+    array: "pyarrow.ChunkedArray"
 ) -> Union["pyarrow.Array", "pyarrow.ChunkedArray"]:
     """This method provides a safe way of combining `ChunkedArray`s exceeding 2 GiB
     in size, which aren't using "large_*" types (and therefore relying on int32
@@ -824,53 +843,53 @@ def _try_combine_chunks_safe(
         array
     ), f"Arrow `ExtensionType`s are not accepted (got {array.type})"
 
-    int64_type_predicates = [
-        pa.types.is_large_list,
-        pa.types.is_large_string,
-        pa.types.is_large_binary,
-        pa.types.is_large_unicode,
-    ]
-
-    if array.nbytes < max_chunk_size or any(
-        p(array.type) for p in int64_type_predicates
-    ):
-        # It's safe to combine provided `ChunkedArray` in either of 2 cases:
-        #   - It's cumulative size is < 2 GiB
-        #   - It's of 'large' kind (ie one using int64 offsets internally)
+    # It's safe to combine provided `ChunkedArray` in either of 2 cases:
+    #   - It's type is NOT a variable-width type (list, binary, string, map),
+    #     using int32 offsets into underlying data (bytes) array
+    #   - It's type is a variable-width type using int64 offsets (large_list,
+    #     large_string, etc)
+    #   - It's cumulative byte-size is < INT32_MAX
+    if not any(
+        p(array.type) for p in _VARIABLE_WIDTH_INT32_OFFSET_PA_TYPE_PREDICATES
+    ) or any(
+        p(array.type) for p in _VARIABLE_WIDTH_INT64_OFFSET_PA_TYPE_PREDICATES
+    ) or array.nbytes < INT32_MAX:
         return array.combine_chunks()
 
     # In this case it's actually *NOT* safe to try to directly combine
     # Arrow's `ChunkedArray` and is impossible to produce single, contiguous
     # `Array` since
-    #     - It's estimated to hold > 2 GiB
-    #     - Its type is not of the "large" kind (and hence is using int32
-    #       offsets internally, which would overflow)
+    #     - It's of variable-width type that uses int32 offsets
+    #     - It's cumulative estimated byte-size is > INT32_MAX (2 GiB)
     #
     # In this case instead of combining into single contiguous array, we
-    # instead just "clump" existing chunks into bigger ones, but no bigger
-    # than 2 GiB each.
+    # instead "clump" existing chunks into ones such that each of these is < INT32_MAX.
     #
     # NOTE: This branch actually returns `ChunkedArray` and not an `Array`
 
-    # To stay under 2 GiB limit we are slicing provided list of chunks into
-    # slices no larger than 2 GiB (as compared to just directly using `concat_arrays`)
-    slices = []
+    new_chunks = []
 
-    cur_slice_start = 0
-    cur_slice_size_bytes = 0
+    cur_chunk_group = []
+    cur_chunk_group_size = 0
 
-    for i, chunk in enumerate(array.chunks):
+    for chunk in array.chunks:
         chunk_size = chunk.nbytes
 
-        if cur_slice_size_bytes + chunk_size > max_chunk_size:
-            slices.append(array.chunks[cur_slice_start:i])
+        assert chunk_size <= INT32_MAX
 
-            cur_slice_start = i
-            cur_slice_size_bytes = 0
+        if cur_chunk_group_size + chunk_size > INT32_MAX:
+            # Combine an accumulated group, append to the new list of chunks
+            if cur_chunk_group:
+                new_chunks.append(pa.concat_arrays(cur_chunk_group))
 
-        cur_slice_size_bytes += chunk_size
+            cur_chunk_group = []
+            cur_chunk_group_size = 0
+
+        cur_chunk_group.append(chunk)
+        cur_chunk_group_size += chunk_size
 
     # Add remaining chunks as last slice
-    slices.append(array.chunks[cur_slice_start:])
+    if cur_chunk_group:
+        new_chunks.append(pa.concat_arrays(cur_chunk_group))
 
-    return pa.chunked_array([pa.concat_arrays(s) for s in slices])
+    return pa.chunked_array(new_chunks)

--- a/python/ray/data/tests/test_arrow_block.py
+++ b/python/ray/data/tests/test_arrow_block.py
@@ -293,20 +293,20 @@ def test_combine_chunked_fixed_width_array_large():
 
 
 @pytest.mark.parametrize(
-    "array_type,input_factory", [
+    "array_type,input_factory",
+    [
         (
             pa.binary(),
             lambda num_bytes: np.arange(num_bytes, dtype=np.uint8).tobytes(),
         ),
         (
             pa.string(),
-            lambda num_bytes: base64.encodebytes(np.arange(num_bytes, dtype=np.int8).tobytes()).decode("ascii"),
+            lambda num_bytes: base64.encodebytes(
+                np.arange(num_bytes, dtype=np.int8).tobytes()
+            ).decode("ascii"),
         ),
-        (
-            pa.list_(pa.uint8()),
-            lambda num_bytes: np.arange(num_bytes, dtype=np.uint8)
-        ),
-    ]
+        (pa.list_(pa.uint8()), lambda num_bytes: np.arange(num_bytes, dtype=np.uint8)),
+    ],
 )
 def test_combine_chunked_variable_width_array_large(array_type, input_factory):
     """Verifies `combine_chunked_array` on variable-width arrays > 2 GiB,
@@ -314,7 +314,9 @@ def test_combine_chunked_variable_width_array_large(array_type, input_factory):
     larger ones up to INT32_MAX in size"""
 
     one_half_gb_arr = pa.array([input_factory(GiB / 2)], type=array_type)
-    chunked_arr = pa.chunked_array([one_half_gb_arr, one_half_gb_arr, one_half_gb_arr, one_half_gb_arr])
+    chunked_arr = pa.chunked_array(
+        [one_half_gb_arr, one_half_gb_arr, one_half_gb_arr, one_half_gb_arr]
+    )
 
     # 2 GiB + offsets (4 x int32)
     num_bytes = chunked_arr.nbytes

--- a/python/ray/data/tests/test_arrow_block.py
+++ b/python/ray/data/tests/test_arrow_block.py
@@ -1,5 +1,4 @@
 import base64
-import gc
 import os
 import sys
 import types


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Current int32 offsets overflow handling is missing appropriate handling of the fixed-width types (any types not involving arbitrary length types like strings, lists, binary, etc).

As a result this has been incorrectly enforcing the 2Gb limit on blocks that actually don't have that limit. This PR addresses that.

Changes

1. Make sure overflow handling only applied to variable-width types
2. Fixed chunking method to prevent adding empty chunks
3. Updated tests

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
