### PR TITLE
[core] Rename `GcsFunctionManager` and use fake in test

### DIFF
--- a/src/mock/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/mock/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -28,7 +28,7 @@ namespace gcs {
 class MockGcsActorManager : public GcsActorManager {
  public:
   MockGcsActorManager(RuntimeEnvManager &runtime_env_manager,
-                      GcsFunctionManager &function_manager,
+                      GCSFunctionManager &function_manager,
                       rpc::CoreWorkerClientPool &worker_client_pool)
       : GcsActorManager(
             /*scheduler=*/

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.cc
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.cc
@@ -338,7 +338,7 @@ GcsActorManager::GcsActorManager(
     instrumented_io_context &io_context,
     GcsPublisher *gcs_publisher,
     RuntimeEnvManager &runtime_env_manager,
-    GcsFunctionManager &function_manager,
+    GCSFunctionManager &function_manager,
     std::function<void(const ActorID &)> destroy_owned_placement_group_if_needed,
     rpc::CoreWorkerClientPool &worker_client_pool)
     : gcs_actor_scheduler_(std::move(scheduler)),

--- a/src/ray/gcs/gcs_server/gcs_actor_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_actor_manager.h
@@ -343,7 +343,7 @@ class GcsActorManager : public rpc::ActorInfoHandler {
       instrumented_io_context &io_context,
       GcsPublisher *gcs_publisher,
       RuntimeEnvManager &runtime_env_manager,
-      GcsFunctionManager &function_manager,
+      GCSFunctionManager &function_manager,
       std::function<void(const ActorID &)> destroy_owned_placement_group_if_needed,
       rpc::CoreWorkerClientPool &worker_client_pool);
 
@@ -727,7 +727,7 @@ class GcsActorManager : public rpc::ActorInfoHandler {
   /// Runtime environment manager for GC purpose
   RuntimeEnvManager &runtime_env_manager_;
   /// Function manager for GC purpose
-  GcsFunctionManager &function_manager_;
+  GCSFunctionManager &function_manager_;
 
   UsageStatsClient *usage_stats_client_;
   /// Run a function on a delay. This is useful for guaranteeing data will be

--- a/src/ray/gcs/gcs_server/gcs_function_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_function_manager.h
@@ -29,9 +29,9 @@ namespace gcs {
 ///    - function/actor exporting
 ///    - function/actor importing
 ///    - function/actor code life cycle management.
-class GcsFunctionManager {
+class GCSFunctionManager {
  public:
-  explicit GcsFunctionManager(InternalKVInterface &kv,
+  explicit GCSFunctionManager(InternalKVInterface &kv,
                               instrumented_io_context &io_context)
       : kv_(kv), io_context_(io_context) {}
 

--- a/src/ray/gcs/gcs_server/gcs_job_manager.h
+++ b/src/ray/gcs/gcs_server/gcs_job_manager.h
@@ -54,7 +54,7 @@ class GcsJobManager : public rpc::JobInfoHandler {
   explicit GcsJobManager(GcsTableStorage &gcs_table_storage,
                          GcsPublisher &gcs_publisher,
                          RuntimeEnvManager &runtime_env_manager,
-                         GcsFunctionManager &function_manager,
+                         GCSFunctionManager &function_manager,
                          InternalKVInterface &internal_kv,
                          instrumented_io_context &io_context,
                          rpc::CoreWorkerClientPool &worker_client_pool)
@@ -141,7 +141,7 @@ class GcsJobManager : public rpc::JobInfoHandler {
   absl::flat_hash_map<JobID, std::shared_ptr<rpc::JobConfig>> cached_job_configs_;
 
   ray::RuntimeEnvManager &runtime_env_manager_;
-  GcsFunctionManager &function_manager_;
+  GCSFunctionManager &function_manager_;
   InternalKVInterface &internal_kv_;
   instrumented_io_context &io_context_;
   rpc::CoreWorkerClientPool &worker_client_pool_;

--- a/src/ray/gcs/gcs_server/gcs_server.cc
+++ b/src/ray/gcs/gcs_server/gcs_server.cc
@@ -565,7 +565,7 @@ void GcsServer::InitRaySyncer(const GcsInitData &gcs_init_data) {
 }
 
 void GcsServer::InitFunctionManager() {
-  function_manager_ = std::make_unique<GcsFunctionManager>(
+  function_manager_ = std::make_unique<GCSFunctionManager>(
       kv_manager_->GetInstance(), io_context_provider_.GetDefaultIOContext());
 }
 

--- a/src/ray/gcs/gcs_server/gcs_server.h
+++ b/src/ray/gcs/gcs_server/gcs_server.h
@@ -263,7 +263,7 @@ class GcsServer {
   /// [gcs_placement_group_scheduler_] depends on [raylet_client_pool_].
   std::unique_ptr<GcsPlacementGroupScheduler> gcs_placement_group_scheduler_;
   /// Function table manager.
-  std::unique_ptr<GcsFunctionManager> function_manager_;
+  std::unique_ptr<GCSFunctionManager> function_manager_;
   /// Stores references to URIs stored by the GCS for runtime envs.
   std::unique_ptr<ray::RuntimeEnvManager> runtime_env_manager_;
   /// Global KV storage handler.

--- a/src/ray/gcs/gcs_server/test/export_api/gcs_actor_manager_export_event_test.cc
+++ b/src/ray/gcs/gcs_server/test/export_api/gcs_actor_manager_export_event_test.cc
@@ -153,7 +153,7 @@ class GcsActorManagerTest : public ::testing::Test {
     gcs_publisher_ = std::make_unique<gcs::GcsPublisher>(std::move(publisher));
     gcs_table_storage_ = std::make_unique<gcs::InMemoryGcsTableStorage>();
     kv_ = std::make_unique<gcs::MockInternalKVInterface>();
-    function_manager_ = std::make_unique<gcs::GcsFunctionManager>(*kv_, io_service_);
+    function_manager_ = std::make_unique<gcs::GCSFunctionManager>(*kv_, io_service_);
     auto actor_scheduler = std::make_unique<MockActorScheduler>();
     mock_actor_scheduler_ = actor_scheduler.get();
     worker_client_pool_ = std::make_unique<rpc::CoreWorkerClientPool>(
@@ -256,7 +256,7 @@ class GcsActorManagerTest : public ::testing::Test {
   std::unique_ptr<ray::RuntimeEnvManager> runtime_env_mgr_;
   const std::chrono::milliseconds timeout_ms_{2000};
   absl::Mutex mutex_;
-  std::unique_ptr<gcs::GcsFunctionManager> function_manager_;
+  std::unique_ptr<gcs::GCSFunctionManager> function_manager_;
   std::unique_ptr<gcs::MockInternalKVInterface> kv_;
   std::shared_ptr<PeriodicalRunner> periodical_runner_;
   std::string log_dir_;

--- a/src/ray/gcs/gcs_server/test/export_api/gcs_job_manager_export_event_test.cc
+++ b/src/ray/gcs/gcs_server/test/export_api/gcs_job_manager_export_event_test.cc
@@ -53,7 +53,7 @@ class GcsJobManagerTest : public ::testing::Test {
     gcs_table_storage_ = std::make_shared<gcs::GcsTableStorage>(store_client_);
     kv_ = std::make_unique<gcs::MockInternalKVInterface>();
     fake_kv_ = std::make_unique<gcs::FakeInternalKVInterface>();
-    function_manager_ = std::make_unique<gcs::GcsFunctionManager>(*kv_, io_service_);
+    function_manager_ = std::make_unique<gcs::GCSFunctionManager>(*kv_, io_service_);
 
     // Mock client factory which abuses the "address" argument to return a
     // CoreWorkerClient whose number of running tasks equal to the address port. This is
@@ -78,7 +78,7 @@ class GcsJobManagerTest : public ::testing::Test {
   std::shared_ptr<gcs::StoreClient> store_client_;
   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
   std::shared_ptr<gcs::GcsPublisher> gcs_publisher_;
-  std::unique_ptr<gcs::GcsFunctionManager> function_manager_;
+  std::unique_ptr<gcs::GCSFunctionManager> function_manager_;
   std::unique_ptr<gcs::MockInternalKVInterface> kv_;
   std::unique_ptr<gcs::FakeInternalKVInterface> fake_kv_;
   std::unique_ptr<rpc::CoreWorkerClientPool> worker_client_pool_;

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -153,7 +153,7 @@ class GcsActorManagerTest : public ::testing::Test {
     store_client_ = std::make_shared<gcs::InMemoryStoreClient>();
     gcs_table_storage_ = std::make_unique<gcs::InMemoryGcsTableStorage>();
     kv_ = std::make_unique<gcs::MockInternalKVInterface>();
-    function_manager_ = std::make_unique<gcs::GcsFunctionManager>(*kv_, io_service_);
+    function_manager_ = std::make_unique<gcs::GCSFunctionManager>(*kv_, io_service_);
     auto scheduler = std::make_unique<MockActorScheduler>();
     mock_actor_scheduler_ = scheduler.get();
     worker_client_pool_ = std::make_unique<rpc::CoreWorkerClientPool>(
@@ -341,7 +341,7 @@ class GcsActorManagerTest : public ::testing::Test {
   std::unique_ptr<ray::RuntimeEnvManager> runtime_env_mgr_;
   const std::chrono::milliseconds timeout_ms_{2000};
   absl::Mutex mutex_;
-  std::unique_ptr<gcs::GcsFunctionManager> function_manager_;
+  std::unique_ptr<gcs::GCSFunctionManager> function_manager_;
   std::unique_ptr<gcs::MockInternalKVInterface> kv_;
   std::shared_ptr<PeriodicalRunner> periodical_runner_;
 };

--- a/src/ray/gcs/gcs_server/test/gcs_autoscaler_state_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_autoscaler_state_manager_test.cc
@@ -63,7 +63,7 @@ class GcsAutoscalerStateManagerTest : public ::testing::Test {
   std::unique_ptr<MockGcsActorManager> gcs_actor_manager_;
   std::unique_ptr<GcsAutoscalerStateManager> gcs_autoscaler_state_manager_;
   std::shared_ptr<MockGcsPlacementGroupManager> gcs_placement_group_manager_;
-  std::unique_ptr<GcsFunctionManager> function_manager_;
+  std::unique_ptr<GCSFunctionManager> function_manager_;
   std::unique_ptr<RuntimeEnvManager> runtime_env_manager_;
   std::unique_ptr<GcsInternalKVManager> kv_manager_;
   std::unique_ptr<rpc::CoreWorkerClientPool> worker_client_pool_;
@@ -79,7 +79,7 @@ class GcsAutoscalerStateManagerTest : public ::testing::Test {
         kRayletConfig,
         io_service_);
     function_manager_ =
-        std::make_unique<GcsFunctionManager>(kv_manager_->GetInstance(), io_service_);
+        std::make_unique<GCSFunctionManager>(kv_manager_->GetInstance(), io_service_);
     runtime_env_manager_ = std::make_unique<RuntimeEnvManager>(
         [](const std::string &, std::function<void(bool)>) {});
     worker_client_pool_ =

--- a/src/ray/gcs/gcs_server/test/gcs_job_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_job_manager_test.cc
@@ -50,7 +50,7 @@ class GcsJobManagerTest : public ::testing::Test {
     gcs_table_storage_ = std::make_shared<gcs::GcsTableStorage>(store_client_);
     kv_ = std::make_unique<gcs::MockInternalKVInterface>();
     fake_kv_ = std::make_unique<gcs::FakeInternalKVInterface>();
-    function_manager_ = std::make_unique<gcs::GcsFunctionManager>(*kv_, io_service_);
+    function_manager_ = std::make_unique<gcs::GCSFunctionManager>(*kv_, io_service_);
 
     // Mock client pool which abuses the "address" argument to return a
     // CoreWorkerClient whose number of running tasks equal to the address port. This is
@@ -80,7 +80,7 @@ class GcsJobManagerTest : public ::testing::Test {
   std::shared_ptr<gcs::StoreClient> store_client_;
   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
   std::shared_ptr<gcs::GcsPublisher> gcs_publisher_;
-  std::unique_ptr<gcs::GcsFunctionManager> function_manager_;
+  std::unique_ptr<gcs::GCSFunctionManager> function_manager_;
   std::unique_ptr<gcs::MockInternalKVInterface> kv_;
   std::unique_ptr<gcs::FakeInternalKVInterface> fake_kv_;
   std::unique_ptr<rpc::CoreWorkerClientPool> worker_client_pool_;


### PR DESCRIPTION
## Why are these changes needed?

Followup to https://github.com/ray-project/ray/pull/53951#pullrequestreview-2943651683

- Rename `GcsFunctionManager` to `GCSFunctionManager`
- Use fakes instead of mocks in `gcs_function_manager_test.cc`
