### PR TITLE
[Test][KubeRay] Update KubeRay version to v1.4.0 for autoscaler tests

### DIFF
--- a/ci/k8s/run-operator-tests.sh
+++ b/ci/k8s/run-operator-tests.sh
@@ -17,6 +17,7 @@ kind load docker-image ray-ci:kuberay-test
 # python python/ray/tests/kuberay/setup/setup_kuberay.py
 
 bash python/ray/autoscaler/kuberay/init-config.sh
+kubectl create namespace kuberay-system
 kubectl create -k python/ray/autoscaler/kuberay/config/default
 
 echo "--- Test ray cluster creation"
@@ -28,7 +29,7 @@ echo "--- Wait until all pods of test cluster are deleted"
 kubectl get pods -o custom-columns=POD:metadata.name --no-headers
 
 for i in {1..120}; do
-    if [[ "$(kubectl get pods -o custom-columns=POD:metadata.name --no-headers | grep -vc kuberay-operator)" == "0" ]]; then
+    if [[ "$(kubectl get pods -o custom-columns=POD:metadata.name --no-headers | wc -l)" == "0" ]]; then
         break
     fi
     if [[ $i == 120 ]]; then

--- a/ci/k8s/run-operator-tests.sh
+++ b/ci/k8s/run-operator-tests.sh
@@ -28,7 +28,7 @@ echo "--- Wait until all pods of test cluster are deleted"
 kubectl get pods -o custom-columns=POD:metadata.name --no-headers
 
 for i in {1..120}; do
-    if [[ "$(kubectl get pods -o custom-columns=POD:metadata.name --no-headers | wc -l)" == "0" ]]; then
+    if [[ "$(kubectl get pods -o custom-columns=POD:metadata.name --no-headers | grep -vc kuberay-operator)" == "0" ]]; then
         break
     fi
     if [[ $i == 120 ]]; then

--- a/python/ray/autoscaler/kuberay/init-config.sh
+++ b/python/ray/autoscaler/kuberay/init-config.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 
 # Clone pinned KubeRay commit to temporary directory, copy the CRD definitions
 # into the autoscaler folder.
-KUBERAY_BRANCH="v1.2.2"
-OPERATOR_TAG="v1.2.2"
+KUBERAY_BRANCH="v1.4.0"
+OPERATOR_TAG="v1.4.0"
 
 # Requires Kustomize
 if ! command -v kustomize &> /dev/null

--- a/python/ray/autoscaler/kuberay/init-config.sh
+++ b/python/ray/autoscaler/kuberay/init-config.sh
@@ -24,6 +24,7 @@ DIR=$(mktemp -d -t "kuberay-XXXXXX")
     (
         cd kuberay/ray-operator/config/default
         kustomize edit set image kuberay/operator=quay.io/kuberay/operator:"$OPERATOR_TAG"
+        kustomize edit set namespace kuberay-system
     )
     cp -r kuberay/ray-operator/config "$SCRIPT_DIR/"
 )

--- a/python/ray/tests/kuberay/test_files/ray-cluster.autoscaler-template.yaml
+++ b/python/ray/tests/kuberay/test_files/ray-cluster.autoscaler-template.yaml
@@ -9,7 +9,7 @@ metadata:
   name: raycluster-autoscaler
 spec:
   # The version of Ray you are using. Make sure all Ray containers are running this version of Ray.
-  rayVersion: '2.7.0'
+  rayVersion: '2.46.0'
   # If `enableInTreeAutoscaling` is true, the Autoscaler sidecar will be added to the Ray head pod.
   # Ray Autoscaler integration is Beta with KubeRay >= 0.3.0 and Ray >= 2.0.0.
   enableInTreeAutoscaling: true
@@ -30,7 +30,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.7.0
+          image: rayproject/ray:2.46.0
           ports:
           - containerPort: 6379
             name: gcs
@@ -60,7 +60,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.7.0
+          image: rayproject/ray:2.46.0
           lifecycle:
             preStop:
               exec:

--- a/python/ray/tests/kuberay/test_files/ray-cluster.autoscaler-v2-template.yaml
+++ b/python/ray/tests/kuberay/test_files/ray-cluster.autoscaler-v2-template.yaml
@@ -7,14 +7,14 @@ metadata:
   name: raycluster-autoscaler
 spec:
   # The version of Ray you are using. Make sure all Ray containers are running this version of Ray.
-  rayVersion: '2.7.0'
+  rayVersion: '2.46.0'
   # If `enableInTreeAutoscaling` is true, the Autoscaler sidecar will be added to the Ray head pod.
   # Ray Autoscaler integration is Beta with KubeRay >= 0.3.0 and Ray >= 2.0.0.
   enableInTreeAutoscaling: true
   autoscalerOptions:
     # Use version: v2 instead of env var RAY_enable_autoscaler_v2 and restartPolicy: Never below if
     # you're using KubeRay >= 1.4.0.
-    # version: v2
+    version: v2
     upscalingMode: Default
     idleTimeoutSeconds: 60
     imagePullPolicy: IfNotPresent
@@ -31,7 +31,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.7.0
+          image: rayproject/ray:2.46.0
           ports:
           - containerPort: 6379
             name: gcs
@@ -51,9 +51,6 @@ spec:
             requests:
               cpu: "500m"
               memory: "2G"
-          env:
-            - name: RAY_enable_autoscaler_v2 # Pass env var for the autoscaler v2.
-              value: "1"
         restartPolicy: Never # No restart to avoid reuse of pod for different ray nodes.
   workerGroupSpecs:
   - replicas: 1
@@ -65,7 +62,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.7.0
+          image: rayproject/ray:2.46.0
           lifecycle:
             preStop:
               exec:

--- a/release/k8s_tests/run_gcs_ft_on_k8s.py
+++ b/release/k8s_tests/run_gcs_ft_on_k8s.py
@@ -51,7 +51,7 @@ def generate_cluster_variable():
 
 def check_kuberay_installed():
     # Make sure the ray namespace exists
-    KUBERAY_VERSION = "v1.2.2"
+    KUBERAY_VERSION = "v1.4.0"
     uri = (
         "github.com/ray-project/kuberay/manifests"
         f"/base?ref={KUBERAY_VERSION}&timeout=90s"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Part of KubeRay release process.

- KubeRay version updated to v1.4.0.
- Ray version updated to 2.46.0.
- Update autoscaler v2 yaml template to use new `autoscalerOptions.version = v2` instead of setting the `RAY_enable_autoscaler_v2` environment variable.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
