### PR TITLE
[core] Fix flaky `test_state_api`

### DIFF
--- a/python/ray/dashboard/http_server_agent.py
+++ b/python/ray/dashboard/http_server_agent.py
@@ -65,9 +65,9 @@ class HttpServerAgent:
                     )
                     await asyncio.sleep(delay)
                 else:
-                    logger.error(
+                    logger.exception(
                         f"Agent port #{self.listen_port} failed to bind after "
-                        f"{max_retries + 1} attempts. Last error: {e}"
+                        f"{max_retries + 1} attempts."
                     )
                     break
 

--- a/python/ray/dashboard/http_server_agent.py
+++ b/python/ray/dashboard/http_server_agent.py
@@ -1,4 +1,7 @@
+import asyncio
 import logging
+import random
+from typing import List, Optional
 
 from packaging.version import Version
 
@@ -11,7 +14,7 @@ routes = dashboard_optional_utils.DashboardAgentRouteTable
 
 
 class HttpServerAgent:
-    def __init__(self, ip, listen_port):
+    def __init__(self, ip: str, listen_port: int) -> None:
         self.ip = ip
         self.listen_port = listen_port
         self.http_host = None
@@ -19,7 +22,59 @@ class HttpServerAgent:
         self.http_session = None
         self.runner = None
 
-    async def start(self, modules):
+    async def _start_site_with_retry(
+        self, max_retries: int = 5, base_delay: float = 0.1
+    ) -> aiohttp.web.TCPSite:
+        """Start the TCP site with retry logic and exponential backoff.
+
+        Args:
+            max_retries: Maximum number of retry attempts
+            base_delay: Base delay in seconds for exponential backoff
+
+        Returns:
+            The started site object
+
+        Raises:
+            OSError: If all retry attempts fail
+        """
+        last_exception: Optional[OSError] = None
+
+        for attempt in range(max_retries + 1):  # +1 for initial attempt
+            try:
+                site = aiohttp.web.TCPSite(
+                    self.runner,
+                    "127.0.0.1" if self.ip == "127.0.0.1" else "0.0.0.0",
+                    self.listen_port,
+                )
+                await site.start()
+                if attempt > 0:
+                    logger.info(
+                        f"Successfully started agent on port {self.listen_port} "
+                        f"after {attempt} retry attempts"
+                    )
+                return site
+
+            except OSError as e:
+                last_exception = e
+                if attempt < max_retries:
+                    # Calculate exponential backoff with jitter
+                    delay = base_delay * (2**attempt) + random.uniform(0, 0.1)
+                    logger.warning(
+                        f"Failed to bind to port {self.listen_port} (attempt {attempt + 1}/"
+                        f"{max_retries + 1}). Retrying in {delay:.2f}s. Error: {e}"
+                    )
+                    await asyncio.sleep(delay)
+                else:
+                    logger.error(
+                        f"Agent port #{self.listen_port} failed to bind after "
+                        f"{max_retries + 1} attempts. Last error: {e}"
+                    )
+                    break
+
+        # If we get here, all retries failed
+        raise last_exception
+
+    async def start(self, modules: List) -> None:
         # Create a http session for all modules.
         # aiohttp<4.0.0 uses a 'loop' variable, aiohttp>=4.0.0 doesn't anymore
         if Version(aiohttp.__version__) < Version("4.0.0"):
@@ -52,20 +107,10 @@ class HttpServerAgent:
 
         self.runner = aiohttp.web.AppRunner(app)
         await self.runner.setup()
-        try:
-            site = aiohttp.web.TCPSite(
-                self.runner,
-                "127.0.0.1" if self.ip == "127.0.0.1" else "0.0.0.0",
-                self.listen_port,
-            )
-            await site.start()
-        except OSError as e:
-            logger.error(
-                f"Agent port #{self.listen_port} already in use. "
-                "Failed to start agent. "
-                f"Ensure port #{self.listen_port} is available, and then try again."
-            )
-            raise e
+
+        # Start the site with retry logic
+        site = await self._start_site_with_retry()
+
         self.http_host, self.http_port, *_ = site._server.sockets[0].getsockname()
         logger.info(
             "Dashboard agent http address: %s:%s", self.http_host, self.http_port
@@ -77,7 +122,7 @@ class HttpServerAgent:
             logger.info(r)
         logger.info("Registered %s routes.", len(dump_routes))
 
-    async def cleanup(self):
+    async def cleanup(self) -> None:
         # Wait for finish signal.
         await self.runner.cleanup()
         await self.http_session.close()


### PR DESCRIPTION
## Why are these changes needed?

Concurrent tests running dashboard agents sometimes fail because the agent fails to bind port (OSError). This PR adds:
- Retry logic with exponential backoff
- Only retries on OSError

## Related issue number

Closes #54001 