### PR TITLE
[Serve] Make replica scheduler backoff configurable #52871

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -432,6 +432,10 @@ RAY_SERVE_METRICS_EXPORT_INTERVAL_MS = int(
     os.environ.get("RAY_SERVE_METRICS_EXPORT_INTERVAL_MS", "100")
 )
 
+# The default sequence of backoff timeouts to use when all replicas' queues are
+# full. The last item in the list is the max timeout and will be used repeatedly.
+DEFAULT_REQUEST_ROUTER_BACKOFF_SEQUENCE_S = [0.025, 0.05, 0.1, 0.2]
+
 # The default request router class to use if none is specified.
 DEFAULT_REQUEST_ROUTER_PATH = (
     "ray.serve._private.request_router:PowerOfTwoChoicesRequestRouter"

--- a/python/ray/serve/tests/unit/test_pow_2_request_router.py
+++ b/python/ray/serve/tests/unit/test_pow_2_request_router.py
@@ -149,10 +149,10 @@ def pow_2_router(request) -> PowerOfTwoChoicesRequestRouter:
                 "use_replica_queue_len_cache", False
             ),
             get_curr_time_s=TIMER.time,
-        )
-        request_router.backoff_sequence_s = request.param.get(
-            "backoff_sequence_s",
-            [0, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001],
+            backoff_sequence_s=request.param.get(
+                "backoff_sequence_s",
+                [0, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001],
+            ),
         )
         return request_router
 


### PR DESCRIPTION
## Why are these changes needed?

* Moves backoff_sequence_s to constructor arg so it can be configured by custom implementations of RequestRouter
* Reduces backoff sequence length and maximum as requested

## Related issue number

Closes #52871

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
