### PR TITLE
Fixes default_dqn_torch_rl_module assuming the device is 'cpu'

### DIFF
--- a/rllib/algorithms/dqn/torch/default_dqn_torch_rl_module.py
+++ b/rllib/algorithms/dqn/torch/default_dqn_torch_rl_module.py
@@ -93,7 +93,7 @@ class DefaultDQNTorchRLModule(TorchRLModule, DefaultDQNRLModule):
             dim=1,
         )
 
-        if not random_actions.device == exploit_actions.device:
+        if random_actions.device != exploit_actions.device:
             raise RuntimeError(
                 f"Device mismatch: random_actions is on {random_actions.device}, "
                 f"but exploit_actions is on {exploit_actions.device}."

--- a/rllib/algorithms/dqn/torch/default_dqn_torch_rl_module.py
+++ b/rllib/algorithms/dqn/torch/default_dqn_torch_rl_module.py
@@ -93,8 +93,14 @@ class DefaultDQNTorchRLModule(TorchRLModule, DefaultDQNRLModule):
             dim=1,
         )
 
+        if not random_actions.device == exploit_actions.device:
+            raise RuntimeError(
+                f"Device mismatch: random_actions is on {random_actions.device}, "
+                f"but exploit_actions is on {exploit_actions.device}."
+            )
+
         actions = torch.where(
-            torch.rand((B,)) < epsilon,
+            torch.rand((B,)).to(exploit_actions.device) < epsilon,
             random_actions,
             exploit_actions,
         )


### PR DESCRIPTION
Previously, this code would produce 'RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!' when the module was being run on GPU.

## Why are these changes needed?

They're breaking the DQN algorithm when using the GPU to run inference.

## Related issue number

N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
