### PR TITLE
fix test_request_timeout timeout mismatch issue

### DIFF
--- a/python/ray/serve/tests/test_request_timeout.py
+++ b/python/ray/serve/tests/test_request_timeout.py
@@ -20,7 +20,9 @@ from ray.util.state import list_tasks
 
 @ray.remote
 def do_request():
-    return httpx.get("http://localhost:8000")
+    # Set a timeout to 10 because some test use RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S = 5
+    # and httpx default timeout is 5 seconds.
+    return httpx.get("http://localhost:8000", timeout=10)
 
 
 @pytest.fixture
@@ -225,7 +227,7 @@ def test_streaming_request_already_sent_and_timed_out(ray_instance, shutdown_ser
         timeout=10,
     )
 
-    with httpx.stream("GET", "http://localhost:8000") as r:
+    with httpx.stream("GET", "http://localhost:8000", timeout=10) as r:
         iterator = r.iter_text()
 
         # The first chunk should be received successfully.


### PR DESCRIPTION
tests passes locally, ran windows test in CI and that passes