### PR TITLE
[core] improve wait_for_condition

### DIFF
--- a/python/ray/_common/test_utils.py
+++ b/python/ray/_common/test_utils.py
@@ -97,10 +97,10 @@ def wait_for_condition(
     last_ex = None
     while time.time() - start <= timeout:
         try:
-            if condition_predictor(**kwargs):
-                return
-        except Exception:
-            if raise_exceptions:
+            assert condition_predictor(**kwargs)
+            return
+        except (AssertionError, Exception) as e:
+            if raise_exceptions and not isinstance(e, AssertionError):
                 raise
             last_ex = ray._private.utils.format_error_message(traceback.format_exc())
         time.sleep(retry_interval_ms / 1000.0)

--- a/python/ray/_private/test_utils.py
+++ b/python/ray/_private/test_utils.py
@@ -578,46 +578,6 @@ def kill_actor_and_wait_for_failure(actor, timeout=10, retry_interval_ms=100):
     raise RuntimeError("It took too much time to kill an actor: {}".format(actor_id))
 
 
-def wait_for_assertion(
-    assertion_predictor: Callable,
-    timeout: int = 10,
-    retry_interval_ms: int = 100,
-    raise_exceptions: bool = False,
-    **kwargs: Any,
-):
-    """Wait until an assertion is met or time out with an exception.
-
-    Args:
-        assertion_predictor: A function that predicts the assertion.
-        timeout: Maximum timeout in seconds.
-        retry_interval_ms: Retry interval in milliseconds.
-        raise_exceptions: If true, exceptions that occur while executing
-            assertion_predictor won't be caught and instead will be raised.
-        **kwargs: Arguments to pass to the condition_predictor.
-
-    Raises:
-        RuntimeError: If the assertion is not met before the timeout expires.
-    """
-
-    def _assertion_to_condition():
-        try:
-            assertion_predictor(**kwargs)
-            return True
-        except AssertionError:
-            return False
-
-    try:
-        wait_for_condition(
-            _assertion_to_condition,
-            timeout=timeout,
-            retry_interval_ms=retry_interval_ms,
-            raise_exceptions=raise_exceptions,
-            **kwargs,
-        )
-    except RuntimeError:
-        assertion_predictor(**kwargs)  # Should fail assert
-
-
 @dataclass
 class MetricSamplePattern:
     name: Optional[str] = None

--- a/python/ray/tests/test_aggregated_prometheus_metrics.py
+++ b/python/ray/tests/test_aggregated_prometheus_metrics.py
@@ -7,10 +7,8 @@ import os
 import pytest
 
 import ray
-from ray._private.test_utils import (
-    fetch_prometheus_metrics,
-    wait_for_assertion,
-)
+from ray._private.test_utils import fetch_prometheus_metrics
+from ray._common.test_utils import wait_for_condition
 from ray._private.metrics_agent import WORKER_ID_TAG_KEY
 
 
@@ -79,7 +77,7 @@ def test_cardinality_levels(_setup_cluster_for_test, cardinality_level):
     TEST_TIMEOUT_S = 30
     prom_addresses = _setup_cluster_for_test
 
-    def _validate():
+    def _validate() -> bool:
         metric_samples = fetch_prometheus_metrics(prom_addresses)
         for metric in _TO_TEST_METRICS:
             samples = metric_samples.get(metric)
@@ -88,19 +86,15 @@ def test_cardinality_levels(_setup_cluster_for_test, cardinality_level):
                 if cardinality_level == "recommended":
                     # If the cardinality level is recommended, the WorkerId tag should
                     # be removed
-                    assert (
-                        sample.labels.get(WORKER_ID_TAG_KEY) is None
-                    ), f"Sample {sample} contains WorkerId tag"
+                    return sample.labels.get(WORKER_ID_TAG_KEY) is None
                 elif cardinality_level == "legacy":
                     # If the cardinality level is legacy, the WorkerId tag should be
                     # present
-                    assert (
-                        sample.labels.get(WORKER_ID_TAG_KEY) is not None
-                    ), f"Sample {sample} does not contain WorkerId tag"
+                    return sample.labels.get(WORKER_ID_TAG_KEY) is not None
                 else:
                     raise ValueError(f"Unknown cardinality level: {cardinality_level}")
 
-    wait_for_assertion(
+    wait_for_condition(
         _validate,
         timeout=TEST_TIMEOUT_S,
         retry_interval_ms=1000,  # Yield resource for other processes


### PR DESCRIPTION
`wait_for_condition` is a commonly used assertion check in Ray core tests. However, when it fails, it often doesn't include useful runtime information such as the stack trace or heap values making debugging more difficult. This PR updates the logic so that failures always produce an assertion-style stack trace, making them behave more like standard unittest assertion failures.

Test:
- CI
- Intentionally fail a test; test that the condition fails with a useful stack trace: https://github.com/ray-project/ray/pull/54014