### PR TITLE
[data/preprocessors] Improve execution perf for One Hot encoding

### DIFF
--- a/python/ray/data/preprocessors/encoder.py
+++ b/python/ray/data/preprocessors/encoder.py
@@ -271,6 +271,8 @@ class OneHotEncoder(Preprocessor):
 
         # Compute new one-hot encoded columns
         for column, output_column in zip(self.columns, self.output_columns):
+            if _is_series_composed_of_lists(df[column]):
+                df[column] = df[column].map(tuple)
             codes, uniques = df[column].factorize()
             ohe = np.eye(len(uniques), dtype=int)[codes]  # (n_rows, n_cats)
             df[output_column] = ohe.tolist()  # vector per row


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Avoid creating dummy columns, just transform using `numpy` vectorized operations to construct the final vector.


Benchmark:
```
#!/usr/bin/env python3
"""
benchmark_onehot.py

The script creates a synthetic DataFrame, builds the same stats_
dict both paths need, then measures execution speed and peak
memory for each transform.

Usage
-----
    python -m memory_profiler benchmark_onehot.py
    python -m memory_profiler benchmark_onehot.py --rows 2_000_000 --categories 20
"""

import argparse
import gc
import timeit
from collections import Counter
from typing import Dict, List

import numpy as np
import pandas as pd
import polars as pl
from memory_profiler import memory_usage


# -----------------------------------------------------------------------------
# Helpers (tiny re-implementations pulled from the Ray preprocessors codebase)
# -----------------------------------------------------------------------------
def _is_series_composed_of_lists(series: pd.Series) -> bool:
    first_not_none = next((e for e in series if e is not None), None)
    return (
        pd.api.types.is_object_dtype(series.dtype)
        and isinstance(first_not_none, (list, np.ndarray))
    )


def compute_unique_value_indices(df: pd.DataFrame, columns: List[str]) -> Dict[str, Dict]:
    """Mimic _get_unique_value_indices but on an in-memory DataFrame."""
    out = {}
    for col in columns:
        uniques = sorted(df[col].map(tuple).unique()) if _is_series_composed_of_lists(df[col]) else sorted(df[col].unique())
        out[f"unique_values({col})"] = {v: i for i, v in enumerate(uniques)}
    return out


# -----------------------------------------------------------------------------
# 1) Original Pandas transform (condensed from OneHotEncoder._transform_pandas)
# -----------------------------------------------------------------------------
def transform_pandas(df: pd.DataFrame, *, columns: List[str], output_columns: List[str], stats: Dict):
    for column, output_column in zip(columns, output_columns):
        col_values = stats[f"unique_values({column})"]

        if _is_series_composed_of_lists(df[column]):
            df[column] = df[column].map(tuple)

        # add dummy columns
        for v in col_values:
            df[f"{column}_{v}"] = (df[column] == v).astype("int8")

        # pack into single list column
        value_cols = [f"{column}_{v}" for v in col_values]
        df.loc[:, output_column] = pd.Series(list(df[value_cols].to_numpy()), index=df.index)

        # drop dummies
        df = df.drop(columns=value_cols)

    # print(f"PANDAS ONLY------------------:\n {df}\n--------------")
    # print(f"\n------------WORSE----------\n")
    # print(df)
    return df


# -----------------------------------------------------------------------------
# 2) Fully vectorised Numpy vectorized transform
#    (matches the version delivered earlier: no Python loops over categories)
# -----------------------------------------------------------------------------
def transform_numpy(df: pd.DataFrame, *, columns, output_columns, dtype: np.dtype = np.uint8):
    for col, output_col in zip(columns, output_columns):
        codes, uniques = df[col].factorize()
        ohe = np.eye(len(uniques), dtype=dtype)[codes]  # (n_rows, n_cats)
        df[f"{output_col}"] = ohe.tolist()              # vector per row                     # (n_rows, total_dims)
    return df


# -----------------------------------------------------------------------------
# Benchmark harness
# -----------------------------------------------------------------------------
def bench(rows: int, categories: int):
    rng = np.random.default_rng(0)

    df_raw = pd.DataFrame(
        {
            "color": rng.integers(0, categories, size=rows).astype(str),
        }
    )

    columns = ["color"]
    output_columns = ["color_encoded"]
    stats = compute_unique_value_indices(df_raw, columns)

    # ------------------------------------------------------------------
    def run_pandas():
        _ = transform_pandas(
            df_raw.copy(deep=False),
            columns=columns,
            output_columns=output_columns,
            stats=stats,
        )

    def run_numpy():
        _ = transform_numpy(
            df_raw.copy(deep=False),
            columns=columns,
            output_columns=output_columns,
        )

    # speed (best of 5 single-shot runs)
    pandas_t = min(timeit.repeat(run_pandas, number=1, repeat=5))
    numpy_t = min(timeit.repeat(run_numpy, number=1, repeat=5))

    # memory (peak RSS for a single run)
    # FIX: Removed the unnecessary max() call.
    # memory_usage with max_usage=True already returns the single max value.
    pandas_m = memory_usage(run_pandas, max_usage=True, retval=False)
    numpy_m = memory_usage(run_numpy, max_usage=True, retval=False)

    print(f"Pandas  : {pandas_t:>6.3f} s   |  peak RSS {pandas_m:>8.1f} MiB")
    print(f"Numpy  : {numpy_t:>6.3f} s    |  peak RSS {numpy_m:>8.1f} MiB")


# -----------------------------------------------------------------------------
# CLI
# -----------------------------------------------------------------------------
if __name__ == "__main__":
    parser = argparse.ArgumentParser(description="Benchmark Pandas vs Numpy one-hot transform.")
    parser.add_argument("--rows", type=int, default=1_000_000, help="Number of rows in synthetic DataFrame.")
    parser.add_argument("--categories", type=int, default=10, help="Uniqueness of category column.")
    args = parser.parse_args()

    # light GC to reduce noise
    gc.collect()
    bench(args.rows, args.categories)

```

Results: 
python -m memory_profiler benchmark_onehot.py --rows 2_000_000 --categories 20
Pandas  :  3.411 s   |  peak RSS    607.8 MiB
Numpy  :  0.971 s    |  peak RSS    825.0 MiB

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
