### PR TITLE
[Data] Mark `test_huggingface` as flaky

### DIFF
--- a/python/ray/data/BUILD
+++ b/python/ray/data/BUILD
@@ -849,6 +849,9 @@ py_test(
     tags = [
         "exclusive",
         "team:data",
+        # Many of the HuggingFace tests depend on HuggingFace's servers, which
+        # occasionally fail.
+        "flaky",
     ],
     deps = [
         ":conftest",

--- a/python/ray/data/tests/test_huggingface.py
+++ b/python/ray/data/tests/test_huggingface.py
@@ -1,3 +1,5 @@
+import sys
+
 import datasets
 import pyarrow
 import pytest
@@ -5,7 +7,9 @@ from packaging.version import Version
 
 import ray
 from ray.data.dataset import Dataset
-from ray.tests.conftest import *  # noqa
+from ray.data.tests.conftest import *  # noqa
+from ray.data.tests.test_util import _check_usage_record
+from ray.tests.conftest import *  # noqa  # noqa
 
 
 @pytest.fixture(scope="session")
@@ -86,6 +90,55 @@ def test_from_huggingface_dynamic_generated(ray_start_regular_shared):
     )
     ds = ray.data.from_huggingface(hfds)
     ds.take(1)
+
+
+def test_from_huggingface_e2e(ray_start_regular_shared_2_cpus):
+    import datasets
+
+    from ray.data.tests.test_huggingface import hfds_assert_equals
+
+    data = datasets.load_dataset("tweet_eval", "emotion")
+    assert isinstance(data, datasets.DatasetDict)
+    ray_datasets = {
+        "train": ray.data.from_huggingface(data["train"]),
+        "validation": ray.data.from_huggingface(data["validation"]),
+        "test": ray.data.from_huggingface(data["test"]),
+    }
+
+    for ds_key, ds in ray_datasets.items():
+        assert isinstance(ds, ray.data.Dataset)
+        # `ds.take_all()` triggers execution with new backend, which is
+        # needed for checking operator usage below.
+        assert len(ds.take_all()) > 0
+        # Check that metadata fetch is included in stats;
+        # the underlying implementation uses the `ReadParquet` operator
+        # as this is an un-transformed public dataset.
+        assert "ReadParquet" in ds.stats() or "FromArrow" in ds.stats()
+        assert (
+            ds._plan._logical_plan.dag.name == "ReadParquet"
+            or ds._plan._logical_plan.dag.name == "FromArrow"
+        )
+        # use sort by 'text' to match order of rows
+        hfds_assert_equals(data[ds_key], ds)
+        try:
+            _check_usage_record(["ReadParquet"])
+        except AssertionError:
+            _check_usage_record(["FromArrow"])
+
+    # test transformed public dataset for fallback behavior
+    base_hf_dataset = data["train"]
+    hf_dataset_split = base_hf_dataset.train_test_split(test_size=0.2)
+    ray_dataset_split_train = ray.data.from_huggingface(hf_dataset_split["train"])
+    assert isinstance(ray_dataset_split_train, ray.data.Dataset)
+    # `ds.take_all()` triggers execution with new backend, which is
+    # needed for checking operator usage below.
+    assert len(ray_dataset_split_train.take_all()) > 0
+    # Check that metadata fetch is included in stats;
+    # the underlying implementation uses the `FromArrow` operator.
+    assert "FromArrow" in ray_dataset_split_train.stats()
+    assert ray_dataset_split_train._plan._logical_plan.dag.name == "FromArrow"
+    assert ray_dataset_split_train.count() == hf_dataset_split["train"].num_rows
+    _check_usage_record(["FromArrow"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Many of the HuggingFace tests depend on HuggingFace's servers, which can occasional be unavailable. To avoid failing the entire job due to transient errors, this PR marks `test_huggingface` as flaky.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
