### PR TITLE
[serve] Remove hardcoded urls from serve microbenchmarks

### DIFF
--- a/release/serve_tests/workloads/microbenchmarks.py
+++ b/release/serve_tests/workloads/microbenchmarks.py
@@ -19,6 +19,7 @@ import pandas as pd
 import requests
 from typing import Dict, List, Optional
 
+from python.ray.serve._private.common import RequestProtocol
 from ray import serve
 from ray.serve._private.benchmarks.common import (
     Benchmarker,
@@ -31,6 +32,7 @@ from ray.serve._private.benchmarks.common import (
     run_throughput_benchmark,
     Streamer,
 )
+from ray.serve._private.test_utils import get_application_url
 from ray.serve.generated import serve_pb2, serve_pb2_grpc
 from ray.serve.config import gRPCOptions
 from ray.serve.handle import DeploymentHandle
@@ -136,8 +138,9 @@ async def _main(
                 (payload_10mb, "http_10mb"),
             ]:
                 serve.run(Noop.bind())
+                url = get_application_url()
                 latencies = await run_latency_benchmark(
-                    lambda: requests.get("http://localhost:8000", data=payload),
+                    lambda: requests.get(url, data=payload),
                     num_requests=NUM_REQUESTS,
                 )
                 perf_metrics.extend(convert_latencies_to_perf_metrics(name, latencies))
@@ -146,8 +149,9 @@ async def _main(
         if run_throughput:
             # Microbenchmark: HTTP throughput
             serve.run(Noop.bind())
+            url = get_application_url()
             mean, std, _ = await run_throughput_benchmark(
-                fn=partial(do_single_http_batch, batch_size=BATCH_SIZE),
+                fn=partial(do_single_http_batch, batch_size=BATCH_SIZE, url=url),
                 multiplier=BATCH_SIZE,
                 num_trials=NUM_TRIALS,
                 trial_runtime=TRIAL_RUNTIME_S,
@@ -157,8 +161,9 @@ async def _main(
 
             # Microbenchmark: HTTP throughput at max_ongoing_requests=100
             serve.run(Noop.options(max_ongoing_requests=100).bind())
+            url = get_application_url()
             mean, std, _ = await run_throughput_benchmark(
-                fn=partial(do_single_http_batch, batch_size=BATCH_SIZE),
+                fn=partial(do_single_http_batch, batch_size=BATCH_SIZE, url=url),
                 multiplier=BATCH_SIZE,
                 num_trials=NUM_TRIALS,
                 trial_runtime=TRIAL_RUNTIME_S,
@@ -178,6 +183,7 @@ async def _main(
                     inter_token_delay_ms=10,
                 )
             )
+            url = get_application_url()
             # In each trial, complete only one batch of requests. Each
             # batch should take 10+ seconds to complete (because we are
             # streaming 1000 tokens per request with a 10ms inter token
@@ -189,6 +195,7 @@ async def _main(
                     do_single_http_batch,
                     batch_size=STREAMING_HTTP_BATCH_SIZE,
                     stream=True,
+                    url=url,
                 ),
                 multiplier=STREAMING_HTTP_BATCH_SIZE * STREAMING_TOKENS_PER_REQUEST,
                 num_trials=STREAMING_NUM_TRIALS,
@@ -214,11 +221,13 @@ async def _main(
                     )
                 )
             )
+            url = get_application_url()
             mean, std, latencies = await run_throughput_benchmark(
                 fn=partial(
                     do_single_http_batch,
                     batch_size=STREAMING_BATCH_SIZE,
                     stream=True,
+                    url=url,
                 ),
                 multiplier=STREAMING_BATCH_SIZE * STREAMING_TOKENS_PER_REQUEST,
                 num_trials=STREAMING_NUM_TRIALS,
@@ -246,8 +255,6 @@ async def _main(
             ],
         )
         if run_latency:
-            channel = grpc.insecure_channel("localhost:9000")
-            stub = serve_pb2_grpc.RayServeBenchmarkServiceStub(channel)
             grpc_payload_noop = serve_pb2.StringData(data="")
             grpc_payload_1mb = serve_pb2.StringData(data=payload_1mb)
             grpc_payload_10mb = serve_pb2.StringData(data=payload_10mb)
@@ -259,6 +266,9 @@ async def _main(
             ]:
                 serve.start(grpc_options=serve_grpc_options)
                 serve.run(GrpcDeployment.bind())
+                target = get_application_url(protocol=RequestProtocol.GRPC)
+                channel = grpc.insecure_channel(target)
+                stub = serve_pb2_grpc.RayServeBenchmarkServiceStub(channel)
                 latencies: pd.Series = await run_latency_benchmark(
                     lambda: stub.call_with_string(payload),
                     num_requests=NUM_REQUESTS,
@@ -270,8 +280,9 @@ async def _main(
             # Microbenchmark: GRPC throughput
             serve.start(grpc_options=serve_grpc_options)
             serve.run(GrpcDeployment.bind())
+            target = get_application_url(protocol=RequestProtocol.GRPC)
             mean, std, _ = await run_throughput_benchmark(
-                fn=partial(do_single_grpc_batch, batch_size=BATCH_SIZE),
+                fn=partial(do_single_grpc_batch, batch_size=BATCH_SIZE, target=target),
                 multiplier=BATCH_SIZE,
                 num_trials=NUM_TRIALS,
                 trial_runtime=TRIAL_RUNTIME_S,
@@ -282,8 +293,9 @@ async def _main(
             # Microbenchmark: GRPC throughput at max_ongoing_requests = 100
             serve.start(grpc_options=serve_grpc_options)
             serve.run(GrpcDeployment.options(max_ongoing_requests=100).bind())
+            target = get_application_url(protocol=RequestProtocol.GRPC)
             mean, std, _ = await run_throughput_benchmark(
-                fn=partial(do_single_grpc_batch, batch_size=BATCH_SIZE),
+                fn=partial(do_single_grpc_batch, batch_size=BATCH_SIZE, target=target),
                 multiplier=BATCH_SIZE,
                 num_trials=NUM_TRIALS,
                 trial_runtime=TRIAL_RUNTIME_S,

--- a/release/serve_tests/workloads/microbenchmarks.py
+++ b/release/serve_tests/workloads/microbenchmarks.py
@@ -13,7 +13,6 @@ import click
 from functools import partial
 import json
 import logging
-import os
 
 import grpc
 import pandas as pd

--- a/release/serve_tests/workloads/microbenchmarks.py
+++ b/release/serve_tests/workloads/microbenchmarks.py
@@ -140,7 +140,7 @@ async def _main(
             ]:
                 serve.start(http_options=http_options)
                 serve.run(Noop.bind())
-                url = get_application_url()
+                url = f"{get_application_url()}/"
                 latencies = await run_latency_benchmark(
                     lambda: requests.get(url, data=payload),
                     num_requests=NUM_REQUESTS,
@@ -152,7 +152,7 @@ async def _main(
             # Microbenchmark: HTTP throughput
             serve.start(http_options=http_options)
             serve.run(Noop.bind())
-            url = get_application_url()
+            url = f"{get_application_url()}/"
             mean, std, _ = await run_throughput_benchmark(
                 fn=partial(do_single_http_batch, batch_size=BATCH_SIZE, url=url),
                 multiplier=BATCH_SIZE,
@@ -165,7 +165,7 @@ async def _main(
             # Microbenchmark: HTTP throughput at max_ongoing_requests=100
             serve.start(http_options=http_options)
             serve.run(Noop.options(max_ongoing_requests=100).bind())
-            url = get_application_url()
+            url = f"{get_application_url()}/"
             mean, std, _ = await run_throughput_benchmark(
                 fn=partial(do_single_http_batch, batch_size=BATCH_SIZE, url=url),
                 multiplier=BATCH_SIZE,
@@ -188,7 +188,7 @@ async def _main(
                     inter_token_delay_ms=10,
                 )
             )
-            url = get_application_url()
+            url = f"{get_application_url()}/"
             # In each trial, complete only one batch of requests. Each
             # batch should take 10+ seconds to complete (because we are
             # streaming 1000 tokens per request with a 10ms inter token
@@ -227,7 +227,7 @@ async def _main(
                     )
                 )
             )
-            url = get_application_url()
+            url = f"{get_application_url()}/"
             mean, std, latencies = await run_throughput_benchmark(
                 fn=partial(
                     do_single_http_batch,

--- a/release/serve_tests/workloads/microbenchmarks.py
+++ b/release/serve_tests/workloads/microbenchmarks.py
@@ -19,7 +19,6 @@ import pandas as pd
 import requests
 from typing import Dict, List, Optional
 
-from python.ray.serve._private.common import RequestProtocol
 from ray import serve
 from ray.serve._private.benchmarks.common import (
     Benchmarker,
@@ -32,6 +31,7 @@ from ray.serve._private.benchmarks.common import (
     run_throughput_benchmark,
     Streamer,
 )
+from ray.serve._private.common import RequestProtocol
 from ray.serve._private.test_utils import get_application_url
 from ray.serve.generated import serve_pb2, serve_pb2_grpc
 from ray.serve.config import gRPCOptions


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
We should migrate things to use `get_application_url` to get the target url.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
