### PR TITLE
Updated stalebot to run every 12 hours.

### DIFF
--- a/.github/workflows/stale_pull_request.yaml
+++ b/.github/workflows/stale_pull_request.yaml
@@ -2,8 +2,8 @@ name: Mark and Close Stale Pull Requests
 
 on:
   schedule:
-    # Runs daily at midnight UTC.
-    - cron: '0 0 * * *'
+    # Runs twice a day at 15 minutes past midnight and noon UTC
+    - cron: '15 */12 * * *'
 
 jobs:
   stale:


### PR DESCRIPTION
## Why are these changes needed?
Currently, our stalebot runs once a day at midnight UTC. Occasionally, we do hit our 500 operation limit, and it takes sometimes up to 24 hours for a stale label to be removed after activity. This means not all of our PRs are processed properly.

This PR aims to fix that by:
- Running every 12 hours to improve responsiveness.
- Running at XX:15 past the hour to reduce the XX:00 bottleneck (sometimes it takes a while for the bot to run - not a huge issue but wanted to make it nicer)
- Have 1000 operations a day on the bot to fully process all the open PRs.

After this change, it should be fairly robust for the foreseeable future. :) 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
