### PR TITLE
[Serve.llm] Add a doc snippet to inform users about existing diffs between vllm serve and ray serve llm.

### DIFF
--- a/doc/source/serve/llm/serving-llms.rst
+++ b/doc/source/serve/llm/serving-llms.rst
@@ -911,7 +911,7 @@ An example config is shown below:
 There are some differences between how `vllm serve` cli works and how ray serve llm works. How do I work around that?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-We have openned an issue to track and fix this: https://github.com/ray-project/ray/issues/53533. Please add comments to this issue thread if you are facing problems that fall under this category. We have identified the following example issues so far: 
+We have opened an issue to track and fix this: https://github.com/ray-project/ray/issues/53533. Please add comments to this issue thread if you are facing problems that fall under this category. We have identified the following example issues so far: 
 
 - Tool calling is not supported in the same way it is supported in vllm serve cli. This is due to the extra logical pieces of code that map cli args to extra layers in the api server critical path. 
 

--- a/doc/source/serve/llm/serving-llms.rst
+++ b/doc/source/serve/llm/serving-llms.rst
@@ -921,13 +921,6 @@ We have openned an issue to track and fix this: https://github.com/ray-project/r
 
 
 
-.. code-block:: python
-
-    from ray.serve.llm import LLMServer
-
-    class MyLLMServer(LLMServer):
-
-
 Usage Data Collection
 --------------------------
 We collect usage data to improve Ray Serve LLM.

--- a/doc/source/serve/llm/serving-llms.rst
+++ b/doc/source/serve/llm/serving-llms.rst
@@ -908,16 +908,16 @@ An example config is shown below:
       route_prefix: "/"
 
 
-There are some differences between how `vllm serve` cli works and how ray serve llm works. How do I work around that?
+There are some differences between `vllm serve` cli and Ray Serve LLM endpoint behavior. How do I work around that?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 We have opened an issue to track and fix this: https://github.com/ray-project/ray/issues/53533. Please add comments to this issue thread if you are facing problems that fall under this category. We have identified the following example issues so far: 
 
-- Tool calling is not supported in the same way it is supported in vllm serve cli. This is due to the extra logical pieces of code that map cli args to extra layers in the api server critical path. 
+- Tool calling is not supported in the same way it is supported in `vllm serve` CLI. This is due to the extra logical pieces of code that map CLI args to extra layers in the API server critical path. 
 
-- vLLM has a different critical path for dealing with tokenizer of mistral models. This logic is not coppied over to ray serve llm, because we want to find a more maintainable solution.
+- vLLM has a different critical path for dealing with the tokenizer of Mistral models. This logic has not been copied over to Ray Serve LLM, because we want to find a more maintainable solution.
 
-- Some sampling parameters like `max_completion_tokens` are not supported in the same way it is supported in vllm serve cli.
+- Some sampling parameters, like `max_completion_tokens`, are supported differently in Ray Serve LLM and `vllm serve` CLI.
 
 
 

--- a/doc/source/serve/llm/serving-llms.rst
+++ b/doc/source/serve/llm/serving-llms.rst
@@ -907,6 +907,27 @@ An example config is shown below:
       name: llm_app
       route_prefix: "/"
 
+
+There are some differences between how `vllm serve` cli works and how ray serve llm works. How do I work around that?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+We have openned an issue to track and fix this: https://github.com/ray-project/ray/issues/53533. Please add comments to this issue thread if you are facing problems that fall under this category. We have identified the following example issues so far: 
+
+- Tool calling is not supported in the same way it is supported in vllm serve cli. This is due to the extra logical pieces of code that map cli args to extra layers in the api server critical path. 
+
+- vLLM has a different critical path for dealing with tokenizer of mistral models. This logic is not coppied over to ray serve llm, because we want to find a more maintainable solution.
+
+- Some sampling parameters like `max_completion_tokens` are not supported in the same way it is supported in vllm serve cli.
+
+
+
+.. code-block:: python
+
+    from ray.serve.llm import LLMServer
+
+    class MyLLMServer(LLMServer):
+
+
 Usage Data Collection
 --------------------------
 We collect usage data to improve Ray Serve LLM.


### PR DESCRIPTION
This issue is getting referenced a lot. So I thought maybe we should add it explicitly to our docs, until we fix this issue elegantly which could take some time. https://github.com/ray-project/ray/issues/53533