### PR TITLE
[data] Use `write_dataset` for partitioning & writing to file instead of custom implementation

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -122,17 +122,17 @@ class ParquetDatasink(_FileDatasink):
         # keep the rest for ParquetWriter()
         row_group_size = write_kwargs.pop("row_group_size", None)
 
-        for table in tables:
-            pq.write_to_dataset(
-                table,
-                root_path=path,
-                max_rows_per_group=row_group_size,
-                filesystem=self.filesystem,
-                basename_template=filename,
-                schema=output_schema,
-                use_legacy_dataset=False,
-                **write_kwargs,
-            )
+        table = concat(tables, promote_types=False)
+        pq.write_to_dataset(
+            table,
+            root_path=path,
+            max_rows_per_group=row_group_size,
+            filesystem=self.filesystem,
+            basename_template=filename,
+            schema=output_schema,
+            use_legacy_dataset=False,
+            **write_kwargs,
+        )
 
     def _write_partition_files(
         self,

--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -128,7 +128,7 @@ class ParquetDatasink(_FileDatasink):
             root_path=path,
             max_rows_per_group=row_group_size,
             filesystem=self.filesystem,
-            basename_template=filename,
+            basename_template=filename + "-{i}.parquet",
             schema=output_schema,
             use_legacy_dataset=False,
             **write_kwargs,
@@ -149,7 +149,7 @@ class ParquetDatasink(_FileDatasink):
             root_path=self.path,
             partition_cols=self.partition_cols,
             schema=output_schema,
-            basename_template=filename,
+            basename_template=filename + "-{i}.parquet",
             use_legacy_dataset=False,
             **write_kwargs,
         )

--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -141,9 +141,8 @@ class ParquetDatasink(_FileDatasink):
         # Check if write_uuid is present in filename, add if missing
         if write_uuid not in filename and self.mode == SaveMode.APPEND:
             raise ValueError(
-                f"Write UUID '{write_uuid}' not found in filename '{filename}'. "
-                f"Please modify your FileNameProvider implementation to include the write_uuid in the filename. "
-                f"Adding UUID as suffix to ensure uniqueness across write operations."
+                f"Write UUID '{write_uuid}' missing from filename template '{filename}'. This could result in files being overwritten."
+                f"Modify your FileNameProvider implementation to include the `write_uuid` into the filename template or change your write mode to SaveMode.OVERWRITE. "
             )
         # Check if filename is already templatized
         if "{i}" in filename:

--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -16,6 +16,14 @@ if TYPE_CHECKING:
 WRITE_FILE_MAX_ATTEMPTS = 10
 WRITE_FILE_RETRY_MAX_BACKOFF_SECONDS = 32
 
+# Map SaveMode to existing_data_behavior
+EXISTING_DATA_BEHAVIOR_MAP = {
+    SaveMode.APPEND: "overwrite_or_ignore",
+    SaveMode.OVERWRITE: "delete_matching",
+    SaveMode.IGNORE: "overwrite_or_ignore",
+    SaveMode.ERROR: "error",
+}
+
 logger = logging.getLogger(__name__)
 
 
@@ -117,14 +125,7 @@ class ParquetDatasink(_FileDatasink):
 
         row_group_size = write_kwargs.pop("row_group_size", None)
 
-        # Map SaveMode to existing_data_behavior
-        existing_data_behavior_map = {
-            SaveMode.APPEND: "overwrite_or_ignore",
-            SaveMode.OVERWRITE: "delete_matching",
-            SaveMode.IGNORE: "overwrite_or_ignore",
-            SaveMode.ERROR: "error",
-        }
-        existing_data_behavior = existing_data_behavior_map.get(
+        existing_data_behavior = EXISTING_DATA_BEHAVIOR_MAP.get(
             self.mode, "overwrite_or_ignore"
         )
 

--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -168,6 +168,7 @@ class ParquetDatasink(_FileDatasink):
             # Use pathlib.Path to properly handle filenames with dots
             filename_path = Path(filename)
             stem = filename_path.stem  # filename without extension
+            assert "." not in stem, "Filename should not contain a dot"
             suffix = filename_path.suffix  # extension including the dot
             basename_template = f"{stem}-{{i}}{suffix}"
         return basename_template

--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -63,17 +63,6 @@ class ParquetDatasink(_FileDatasink):
         self.min_rows_per_file = min_rows_per_file
         self.partition_cols = partition_cols
 
-        if self.open_stream_args is not None:
-            intersecting_keys = UNSUPPORTED_OPEN_STREAM_ARGS.intersection(
-                set(self.open_stream_args.keys())
-            )
-            if intersecting_keys:
-                logger.warning(
-                    "open_stream_args contains unsupported arguments: %s. These arguments "
-                    "are not supported by ParquetDatasink. They will be ignored.",
-                    intersecting_keys,
-                )
-
         super().__init__(
             path,
             filesystem=filesystem,
@@ -178,8 +167,19 @@ class ParquetDatasink(_FileDatasink):
             suffix = filename_path.suffix  # extension including the dot
             basename_template = f"{stem}-{{i}}{suffix}"
 
-        if "compression" in self.open_stream_args:
-            write_kwargs["compression"] = self.open_stream_args["compression"]
+        if self.open_stream_args is not None:
+            intersecting_keys = UNSUPPORTED_OPEN_STREAM_ARGS.intersection(
+                set(self.open_stream_args.keys())
+            )
+            if intersecting_keys:
+                logger.warning(
+                    "open_stream_args contains unsupported arguments: %s. These arguments "
+                    "are not supported by ParquetDatasink. They will be ignored.",
+                    intersecting_keys,
+                )
+
+            if "compression" in self.open_stream_args:
+                write_kwargs["compression"] = self.open_stream_args["compression"]
 
         ds.write_dataset(
             data=tables,

--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -160,9 +160,9 @@ class ParquetDatasink(_FileDatasink):
         else:
             # Has extension but not templatized, add template while preserving extension
             logger.warning(
-                "FilenameProvider have to providing proper filename base template including '{{i}}' "
+                "FilenameProvider have to provide proper filename template including '{{i}}' "
                 "macro to ensure unique filenames when writing multiple files. Appending '{{i}}' "
-                "macros to the end of the file. For more details on the expected filename template checkout "
+                "macro to the end of the file. For more details on the expected filename template checkout "
                 "PyArrow's `write_to_dataset` API"
             )
             # Use pathlib.Path to properly handle filenames with dots

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3390,7 +3390,7 @@ class Dataset:
                 opening the file to write to.
             filename_provider: A :class:`~ray.data.datasource.FilenameProvider`
                 implementation. Use this parameter to customize what your filenames
-                look like.
+                look like. The following convention is used: ```{filename}-{i}.parquet```
             arrow_parquet_args_fn: Callable that returns a dictionary of write
                 arguments that are provided to `pyarrow.parquet.ParquetWriter() <https:/\
                     /arrow.apache.org/docs/python/generated/\

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3390,7 +3390,10 @@ class Dataset:
                 opening the file to write to.
             filename_provider: A :class:`~ray.data.datasource.FilenameProvider`
                 implementation. Use this parameter to customize what your filenames
-                look like. The following convention is used: ```{filename}-{i}.parquet```
+                look like. The filename is expected to be templatized with `{i}`
+                to ensure unique filenames when writing multiple files. If it's not
+                templatized, Ray Data will add `{i}` to the filename to ensure
+                compatibility with the pyarrow `write_dataset <https://arrow.apache.org/docs/python/generated/pyarrow.parquet.write_dataset.html>`_.
             arrow_parquet_args_fn: Callable that returns a dictionary of write
                 arguments that are provided to `pyarrow.parquet.ParquetWriter() <https:/\
                     /arrow.apache.org/docs/python/generated/\

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -1020,6 +1020,93 @@ def test_parquet_write_append_save_mode(ray_start_regular_shared, local_path):
         assert count_of_files == 2
 
 
+@pytest.mark.parametrize(
+    "filename_template,should_raise_error",
+    [
+        # Case 1: No UUID, no extension - should raise error in append mode
+        ("myfile", True),
+        # Case 2: No UUID, has extension - should raise error in append mode
+        ("myfile.parquet", True),
+        # Case 3: No UUID, different extension - should raise error in append mode
+        ("myfile.txt", True),
+        # Case 4: Already has UUID - should not raise error
+        ("myfile_{write_uuid}", False),
+        # Case 5: Already has UUID with extension - should not raise error
+        ("myfile_{write_uuid}.parquet", False),
+        # Case 6: Templated filename without UUID - should raise error in append mode
+        ("myfile-{i}", True),
+        # Case 7: Templated filename with extension but no UUID - should raise error in append mode
+        ("myfile-{i}.parquet", True),
+        # Case 8: Templated filename with UUID already present - should not raise error
+        ("myfile_{write_uuid}-{i}.parquet", False),
+    ],
+    ids=[
+        "no_uuid_no_ext",
+        "no_uuid_with_parquet_ext",
+        "no_uuid_with_other_ext",
+        "has_uuid_no_ext",
+        "has_uuid_with_ext",
+        "templated_no_uuid_no_ext",
+        "templated_no_uuid_with_ext",
+        "templated_has_uuid",
+    ],
+)
+def test_parquet_write_uuid_handling_with_custom_filename_provider(
+    ray_start_regular_shared, tmp_path, filename_template, should_raise_error
+):
+    """Test that write_parquet correctly handles UUID validation in filenames when using custom filename providers in append mode."""
+    import re
+
+    from ray.data.datasource.filename_provider import FilenameProvider
+
+    class CustomFilenameProvider(FilenameProvider):
+        def __init__(self, filename_template, should_include_uuid):
+            self.filename_template = filename_template
+            self.should_include_uuid = should_include_uuid
+
+        def get_filename_for_block(self, block, write_uuid, task_index, block_index):
+            if self.should_include_uuid:
+                # Replace {write_uuid} placeholder with actual write_uuid
+                return self.filename_template.format(write_uuid=write_uuid, i="{i}")
+            else:
+                # Don't include UUID - this simulates the problematic case
+                return self.filename_template
+
+    # Create a simple dataset
+    ds = ray.data.range(10).repartition(1)
+
+    # Create custom filename provider
+    custom_provider = CustomFilenameProvider(filename_template, not should_raise_error)
+
+    if should_raise_error:
+        # Should raise ValueError when UUID is missing in append mode
+        with pytest.raises(
+            ValueError,
+            match=r"Write UUID.*not found in filename.*Please modify your FileNameProvider implementation",
+        ):
+            ds.write_parquet(tmp_path, filename_provider=custom_provider, mode="append")
+    else:
+        # Should succeed when UUID is present
+        ds.write_parquet(tmp_path, filename_provider=custom_provider, mode="append")
+
+        # Check that files were created
+        written_files = os.listdir(tmp_path)
+        assert len(written_files) == 1
+
+        written_file = written_files[0]
+
+        # Verify UUID is present in filename (should be the actual write_uuid)
+        uuid_pattern = r"[a-f0-9]{32}"  # 32 hex characters (UUID without dashes)
+        assert re.search(
+            uuid_pattern, written_file
+        ), f"File '{written_file}' should contain UUID"
+
+        # Verify the content is correct by reading back
+        ds_read = ray.data.read_parquet(tmp_path)
+        assert ds_read.count() == 10
+        assert sorted([row["id"] for row in ds_read.take_all()]) == list(range(10))
+
+
 def test_parquet_write_overwrite_save_mode(ray_start_regular_shared, local_path):
     data_path = local_path
     path = os.path.join(data_path, "test_parquet_dir")
@@ -1562,39 +1649,6 @@ def test_parquet_row_group_size_002(ray_start_regular_shared, tmp_path):
             use_legacy_dataset=False,
         )
     assert ds.fragments[0].num_row_groups == 10
-
-
-def test_parquet_write_with_custom_filename_provider(
-    ray_start_regular_shared, tmp_path
-):
-    """Test write_parquet with a custom filename provider and assert on output file names."""
-    from ray.data.datasource.filename_provider import FilenameProvider
-
-    class CustomFilenameProvider(FilenameProvider):
-        def get_filename_for_block(self, block, write_uuid, task_index, block_index):
-            return f"custom_file_{task_index}_{block_index}.parquet"
-
-    # Create a dataset with multiple blocks
-    ds = ray.data.range(100).repartition(3)
-
-    # Write with custom filename provider
-    custom_provider = CustomFilenameProvider()
-    ds.write_parquet(tmp_path, filename_provider=custom_provider)
-
-    # Check that files exist with expected names
-    written_files = sorted(os.listdir(tmp_path))
-    expected_files = [
-        "custom_file_0_0-0.parquet",
-        "custom_file_1_0-0.parquet",
-        "custom_file_2_0-0.parquet",
-    ]
-
-    assert written_files == expected_files
-
-    # Verify the content is correct by reading back
-    ds_read = ray.data.read_parquet(tmp_path)
-    assert ds_read.count() == 100
-    assert sorted([row["id"] for row in ds_read.take_all()]) == list(range(100))
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -1080,9 +1080,10 @@ def test_parquet_write_uuid_handling_with_custom_filename_provider(
 
     if should_raise_error:
         # Should raise ValueError when UUID is missing in append mode
+        # Updated regex to match the actual error message
         with pytest.raises(
             ValueError,
-            match=r"Write UUID.*not found in filename.*Please modify your FileNameProvider implementation",
+            match=r"Write UUID.*missing from filename template.*This could result in files being overwritten.*Modify your FileNameProvider implementation",
         ):
             ds.write_parquet(tmp_path, filename_provider=custom_provider, mode="append")
     else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Use native pyarrow implementation for writing parquet files.
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
