### PR TITLE
[data] fix lint error in conftest.py

### DIFF
--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -23,7 +23,7 @@ from ray.data.tests.mock_server import *  # noqa
 
 # Trigger pytest hook to automatically zip test cluster logs to archive dir on failure
 from ray.tests.conftest import *  # noqa
-from ray.tests.conftest import _ray_start  # noqa,
+from ray.tests.conftest import _ray_start
 from ray.util.debug import reset_log_once
 
 


### PR DESCRIPTION
Not sure why it wasn't caught in the original PR. 

```
warning: Invalid `# noqa` directive on python/ray/data/tests/conftest.py:26: expected `:` followed by a comma-separated list of codes (e.g., `# noqa: F401, F841`).
```