### PR TITLE
[ci] fix mac ci by pinning cython version

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -231,12 +231,17 @@ install_ray() {
   (
     cd "${WORKSPACE_DIR}"/python
     build_dashboard_front_end
-    keep_alive pip install -v -e .
+
+    # This is required so that pip does not pick up a cython version that is
+    # too high that can break CI, especially on MacOS.
+    pip install -q cython==3.0.12
+
+    pip install -v -e . -c requirements_compiled.txt
   )
   (
     # For runtime_env tests, wheels are needed
     cd "${WORKSPACE_DIR}"
-    keep_alive pip wheel -e python -w .whl
+    pip wheel -e python -w .whl
   )
 }
 

--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -198,7 +198,6 @@ download_mnist() {
 }
 
 retry_pip_install() {
-  local pip_command=$1
   local status="0"
   local errmsg=""
 
@@ -206,7 +205,7 @@ retry_pip_install() {
   # that break the entire CI job: Simply retry installation in this case
   # after n seconds.
   for _ in {1..3}; do
-    errmsg=$(eval "${pip_command}" 2>&1) && break
+    errmsg="$("$@" 2>&1)" && break
     status=$errmsg && echo "'pip install ...' failed, will retry after n seconds!" && sleep 30
   done
   if [[ "$status" != "0" ]]; then
@@ -317,7 +316,8 @@ install_pip_packages() {
     fi
   fi
 
-  retry_pip_install "CC=gcc pip install -Ur ${WORKSPACE_DIR}/python/requirements.txt"
+  # TODO(ray-ci): pin the dependencies.
+  CC=gcc retry_pip_install pip install -Ur "${WORKSPACE_DIR}/python/requirements.txt"
 
   # Install deeplearning libraries (Torch + TensorFlow)
   if [[ -n "${TORCH_VERSION-}" || "${DL-}" == "1" || "${RLLIB_TESTING-}" == 1 || "${TRAIN_TESTING-}" == 1 || "${TUNE_TESTING-}" == 1 || "${DOC_TESTING-}" == 1 ]]; then

--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -71,7 +71,7 @@ for ((i=0; i<${#PY_MMS[@]}; ++i)); do
     # Setuptools on CentOS is too old to install arrow 0.9.0, therefore we upgrade.
     # TODO: Unpin after https://github.com/pypa/setuptools/issues/2849 is fixed.
     $PIP_CMD install --upgrade setuptools==69.5.1
-    $PIP_CMD install -q cython==0.29.37
+    $PIP_CMD install -q cython==3.0.12
     # Install wheel to avoid the error "invalid command 'bdist_wheel'".
     $PIP_CMD install -q wheel
     # Set the commit SHA in _version.py.


### PR DESCRIPTION
this pins cython version to 3.0.12 for all macos
execution paths that requires building the wheel.

without the pinning, pip might pick 3.1.2, which does
not work properly the mac CI fleet. the root cause is
that we are still using setup.py with `setup_requires`,
which is deprecated.

also pins dependencies to `requirements_compiled.txt` file when possible.