### PR TITLE
remove final references to plasma_event_handler

### DIFF
--- a/python/ray/_raylet.pxd
+++ b/python/ray/_raylet.pxd
@@ -126,7 +126,6 @@ cdef class CoreWorker:
         c_bool is_driver
         object async_thread
         object async_event_loop
-        object plasma_event_handler
         object job_config
         object current_runtime_env
         c_bool is_local_mode

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -3173,9 +3173,6 @@ cdef class CoreWorker:
     def set_actor_repr_name(self, repr_name):
         CCoreWorkerProcess.GetCoreWorker().SetActorReprName(repr_name)
 
-    def get_plasma_event_handler(self):
-        return self.plasma_event_handler
-
     def get_objects(self, object_refs, int64_t timeout_ms=-1):
         cdef:
             c_vector[shared_ptr[CRayObject]] results


### PR DESCRIPTION
Removes CoreWorker's plasma_event_handler and get_plasma_event_handler().

Seems like this is a vestigial property - not referenced anywhere else in the codebase. Seems like its functionality was moved into the C++ classes which actually interface with the plasma store? If anyone has wisdom/remembers why this is here/if this is still necessary, please speak out.

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related PR
It looks like this is a leftover missed by
https://github.com/ray-project/ray/pull/9228#issue-648593084

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [/] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [/] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
