### PR TITLE
[Minor][Fix][Core/Test] Fix test_actor_restart_on_node_failure wrong test logic without waiting

### DIFF
--- a/python/ray/tests/test_actor_failures.py
+++ b/python/ray/tests/test_actor_failures.py
@@ -367,24 +367,34 @@ def test_actor_restart_on_node_failure(ray_start_cluster):
     cluster.wait_for_nodes()
     ray.init(address=cluster.address)
 
+    # Node to place the signal actor.
+    cluster.add_node(num_cpus=1, resources={"signal": 1})
     # Node to place the actor.
-    actor_node = cluster.add_node(num_cpus=1)
+    actor_node = cluster.add_node(num_cpus=1, resources={"actor": 1})
     cluster.wait_for_nodes()
 
     @ray.remote(num_cpus=1, max_restarts=1, max_task_retries=-1)
     class RestartableActor:
         """An actor that will be reconstructed at most once."""
 
+        def __init__(self, signal):
+            self._signal = signal
+
         def echo(self, value):
-            time.sleep(0.1)
+            if value >= 50:
+                ray.get(self._signal.wait.remote())
             return value
 
-    actor = RestartableActor.options(lifetime="detached").remote()
+    signal = SignalActor.options(resources={"signal": 1}).remote()
+    actor = RestartableActor.options(
+        lifetime="detached", resources={"actor": 1}
+    ).remote(signal)
     ray.get(actor.__ray_ready__.remote())
     results = [actor.echo.remote(i) for i in range(100)]
     # Kill actor node, while the above task is still being executed.
     cluster.remove_node(actor_node)
-    cluster.add_node(num_cpus=1)
+    ray.get(signal.send.remote())
+    cluster.add_node(num_cpus=1, resources={"actor": 1})
     cluster.wait_for_nodes()
     # All tasks should be executed successfully.
     results = ray.get(results)

--- a/python/ray/tests/test_actor_failures.py
+++ b/python/ray/tests/test_actor_failures.py
@@ -376,6 +376,7 @@ def test_actor_restart_on_node_failure(ray_start_cluster):
         """An actor that will be reconstructed at most once."""
 
         def echo(self, value):
+            time.sleep(0.1)
             return value
 
     actor = RestartableActor.options(lifetime="detached").remote()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

The comment here says "kill node while tasks are still running":

https://github.com/ray-project/ray/blob/d949d69ebcd90a6890892909aade7b1e076dcbfc/python/ray/tests/test_actor_failures.py#L384

However, the execution time of the `echo` task is very short, so the test doesn't reliably verify what it intends to. Specifically, if we set `@ray.remote(num_cpus=1, max_restarts=0, max_task_retries=0)` here:

https://github.com/ray-project/ray/blob/d949d69ebcd90a6890892909aade7b1e076dcbfc/python/ray/tests/test_actor_failures.py#L374

The test should always fail, since both restarts and task retries are disabled. But without a sleep in the `echo` function, the test sometimes passes by chance.

To fix this, I made half of the tasks block until receiving a signal from `SignalActor`.

Added one more node dedicated for the `SignalActor` so that the node where the `SignalActor` is located won't be removed during the test.

## Related issue number

<!-- For example: "Closes #1234" -->
N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
