### PR TITLE
[core] Deflake `test_ray_init`

### DIFF
--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -1,3 +1,4 @@
+from concurrent.futures import ThreadPoolExecutor
 import json
 import os
 import sys
@@ -5,6 +6,7 @@ import unittest.mock
 import signal
 import subprocess
 import tempfile
+import threading
 from pathlib import Path
 
 import grpc
@@ -94,31 +96,36 @@ def test_ray_init_existing_instance(call_ray_start, address):
     reason="Flaky when run on windows CI",
 )
 def test_ray_init_existing_instance_via_blocked_ray_start():
-    blocked = subprocess.Popen(
-        ["ray", "start", "--head", "--block", "--num-cpus", "1999"]
+    """Run a blocked ray start command and check that ray.init() connects to it."""
+    blocked_start_cmd = subprocess.Popen(
+        ["ray", "start", "--head", "--block", "--num-cpus", "1999"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
 
-    def _connect_to_existing_instance():
-        while True:
-            try:
-                # Make sure ray.init can connect to the existing cluster.
-                ray.init()
-                if ray.cluster_resources().get("CPU", 0) == 1999:
-                    return True
-                else:
-                    return False
-            except Exception:
-                return False
-            finally:
-                ray.shutdown()
+    def _wait_for_startup_msg():
+        for line in blocked_start_cmd.stdout:
+            l = line.decode("utf-8")
+            print(l)
+            if "Ray runtime started." in l:
+                return
 
     try:
-        wait_for_condition(
-            _connect_to_existing_instance, timeout=30, retry_interval_ms=1000
-        )
+        # Wait for the blocked start command's output to indicate that the local Ray
+        # instance has been started successfully. This is done in a background thread
+        # because there is no direct way to read the process' stdout with a timeout.
+        tp = ThreadPoolExecutor(max_workers=1)
+        fut = tp.submit(_wait_for_startup_msg)
+        fut.result(timeout=5)
+
+        # Make sure ray.init can connect to the existing cluster.
+        ray.init()
+        assert ray.cluster_resources().get("CPU", 0) == 1999
     finally:
-        blocked.terminate()
-        blocked.wait()
+        ray.shutdown()
+        blocked_start_cmd.terminate()
+        blocked_start_cmd.wait()
+        tp.shutdown()
         subprocess.check_output("ray stop --force", shell=True)
 
 

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -116,7 +116,8 @@ def test_ray_init_existing_instance_via_blocked_ray_start():
         fut = tp.submit(_wait_for_startup_msg)
         fut.result(timeout=5)
 
-        # Make sure ray.init can connect to the existing cluster.
+        # Verify that `ray.init()` connects to the existing cluster
+        # (verified by checking the resources specified to the `ray start` command).
         ray.init()
         assert ray.cluster_resources().get("CPU", 0) == 1999
     finally:

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -6,14 +6,12 @@ import unittest.mock
 import signal
 import subprocess
 import tempfile
-import threading
 from pathlib import Path
 
 import grpc
 import pytest
 
 import ray
-from ray._common.test_utils import wait_for_condition
 import ray._private.services
 import ray._private.utils as utils
 from ray.client_builder import ClientContext


### PR DESCRIPTION
Instead of repeatedly trying to call `ray.init` and waiting for one to connect to the running instance, I've modified the test to wait until that instance is ready, then assert that it connects to the running instance.