### PR TITLE
[core][test] fix data races in NodeManagerTest

### DIFF
--- a/src/ray/raylet/test/node_manager_test.cc
+++ b/src/ray/raylet/test/node_manager_test.cc
@@ -523,7 +523,8 @@ TEST_F(NodeManagerTest, TestDetachedWorkerIsKilledByFailedWorker) {
   worker->SetProcess(proc);
   // Complete the RequestWorkerLease rpc with the mock worker.
   pop_worker_callback_promise.get_future().wait();
-  pop_worker_callback(worker, PopWorkerStatus::OK, "");
+  io_service_.dispatch([&] { pop_worker_callback(worker, PopWorkerStatus::OK, ""); },
+                       "pop_worker_callback");
 
   // Wait for the client thead to complete. This waits for the RequestWorkerLease call
   // and publish_worker_failure_callback to finish.
@@ -629,7 +630,8 @@ TEST_F(NodeManagerTest, TestDetachedWorkerIsKilledByFailedNode) {
   worker->SetProcess(proc);
   // Complete the RequestWorkerLease rpc with the mock worker.
   pop_worker_callback_promise.get_future().wait();
-  pop_worker_callback(worker, PopWorkerStatus::OK, "");
+  io_service_.dispatch([&] { pop_worker_callback(worker, PopWorkerStatus::OK, ""); },
+                       "pop_worker_callback");
 
   // Wait for the client thead to complete. This waits for the RequestWorkerLease call
   // and publish_worker_failure_callback to finish.

--- a/src/ray/raylet/test/node_manager_test.cc
+++ b/src/ray/raylet/test/node_manager_test.cc
@@ -524,7 +524,7 @@ TEST_F(NodeManagerTest, TestDetachedWorkerIsKilledByFailedWorker) {
   // Complete the RequestWorkerLease rpc with the mock worker.
   pop_worker_callback_promise.get_future().wait();
   io_service_.post([&] { pop_worker_callback(worker, PopWorkerStatus::OK, ""); },
-                       "pop_worker_callback");
+                   "pop_worker_callback");
 
   // Wait for the client thead to complete. This waits for the RequestWorkerLease call
   // and publish_worker_failure_callback to finish.
@@ -631,7 +631,7 @@ TEST_F(NodeManagerTest, TestDetachedWorkerIsKilledByFailedNode) {
   // Complete the RequestWorkerLease rpc with the mock worker.
   pop_worker_callback_promise.get_future().wait();
   io_service_.post([&] { pop_worker_callback(worker, PopWorkerStatus::OK, ""); },
-                       "pop_worker_callback");
+                   "pop_worker_callback");
 
   // Wait for the client thead to complete. This waits for the RequestWorkerLease call
   // and publish_worker_failure_callback to finish.

--- a/src/ray/raylet/test/node_manager_test.cc
+++ b/src/ray/raylet/test/node_manager_test.cc
@@ -523,7 +523,7 @@ TEST_F(NodeManagerTest, TestDetachedWorkerIsKilledByFailedWorker) {
   worker->SetProcess(proc);
   // Complete the RequestWorkerLease rpc with the mock worker.
   pop_worker_callback_promise.get_future().wait();
-  io_service_.dispatch([&] { pop_worker_callback(worker, PopWorkerStatus::OK, ""); },
+  io_service_.post([&] { pop_worker_callback(worker, PopWorkerStatus::OK, ""); },
                        "pop_worker_callback");
 
   // Wait for the client thead to complete. This waits for the RequestWorkerLease call
@@ -630,7 +630,7 @@ TEST_F(NodeManagerTest, TestDetachedWorkerIsKilledByFailedNode) {
   worker->SetProcess(proc);
   // Complete the RequestWorkerLease rpc with the mock worker.
   pop_worker_callback_promise.get_future().wait();
-  io_service_.dispatch([&] { pop_worker_callback(worker, PopWorkerStatus::OK, ""); },
+  io_service_.post([&] { pop_worker_callback(worker, PopWorkerStatus::OK, ""); },
                        "pop_worker_callback");
 
   // Wait for the client thead to complete. This waits for the RequestWorkerLease call


### PR DESCRIPTION
## Why are these changes needed?

Since https://github.com/ray-project/ray/commit/45e369ad4d8baad1db1adac5feb6e2ea57a0d458, TSAN check fails with the following:

```
[2025-06-25T05:31:21Z] WARNING: ThreadSanitizer: data race (pid=953)
[2025-06-25T05:31:21Z]   Write of size 8 at 0x7b18000035f0 by main thread:
[2025-06-25T05:31:21Z]     #0 std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > >::erase(std::__1::__deque_iterator<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::shared_ptr<ray::raylet::internal::Work> const*, std::__1::shared_ptr<ray::raylet::internal::Work> const&, std::__1::shared_ptr<ray::raylet::internal::Work> const* const*, long, 256l>) /opt/llvm/bin/../include/c++/v1/deque:2877:9 (liblibraylet_Ulib.so+0x20f5ce)
[2025-06-25T05:31:21Z]     #1 ray::raylet::LocalTaskManager::PoppedWorkerHandler(std::__1::shared_ptr<ray::raylet::WorkerInterface>, ray::raylet::PopWorkerStatus, ray::TaskID const&, int, std::__1::shared_ptr<ray::raylet::internal::Work> const&, bool, ray::rpc::Address const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)::$_2::operator()(std::__1::shared_ptr<ray::raylet::internal::Work> const&, int const&) const /proc/self/cwd/src/ray/raylet/local_task_manager.cc:568:24 (liblibraylet_Ulib.so+0x2130b4)
[2025-06-25T05:31:21Z]     #2 ray::raylet::LocalTaskManager::PoppedWorkerHandler(std::__1::shared_ptr<ray::raylet::WorkerInterface>, ray::raylet::PopWorkerStatus, ray::TaskID const&, int, std::__1::shared_ptr<ray::raylet::internal::Work> const&, bool, ray::rpc::Address const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /proc/self/cwd/src/ray/raylet/local_task_manager.cc:647:5 (liblibraylet_Ulib.so+0x212471)
[2025-06-25T05:31:21Z]     #3 ray::raylet::LocalTaskManager::DispatchScheduledTasksToWorkers()::$_1::operator()(std::__1::shared_ptr<ray::raylet::WorkerInterface>, ray::raylet::PopWorkerStatus, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) const /proc/self/cwd/src/ray/raylet/local_task_manager.cc:382:22 (liblibraylet_Ulib.so+0x222f1b)
[2025-06-25T05:31:21Z]     #4 decltype(std::__1::forward<ray::raylet::LocalTaskManager::DispatchScheduledTasksToWorkers()::$_1&>(fp)(std::__1::forward<std::__1::shared_ptr<ray::raylet::WorkerInterface> const&>(fp0), std::__1::forward<ray::raylet::PopWorkerStatus>(fp0), std::__1::forward<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>(fp0))) std::__1::__invoke<ray::raylet::LocalTaskManager::DispatchScheduledTasksToWorkers()::$_1&, std::__1::shared_ptr<ray::raylet::WorkerInterface> const&, ray::raylet::PopWorkerStatus, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>(ray::raylet::LocalTaskManager::DispatchScheduledTasksToWorkers()::$_1&, std::__1::shared_ptr<ray::raylet::WorkerInterface> const&, ray::raylet::PopWorkerStatus&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /opt/llvm/bin/../include/c++/v1/type_traits:3694:1 (liblibraylet_Ulib.so+0x222f1b)
[2025-06-25T05:31:21Z]     #5 bool std::__1::__invoke_void_return_wrapper<bool, false>::__call<ray::raylet::LocalTaskManager::DispatchScheduledTasksToWorkers()::$_1&, std::__1::shared_ptr<ray::raylet::WorkerInterface> const&, ray::raylet::PopWorkerStatus, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>(ray::raylet::LocalTaskManager::DispatchScheduledTasksToWorkers()::$_1&, std::__1::shared_ptr<ray::raylet::WorkerInterface> const&, ray::raylet::PopWorkerStatus&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /opt/llvm/bin/../include/c++/v1/__functional_base:317:16 (liblibraylet_Ulib.so+0x222f1b)
[2025-06-25T05:31:21Z]     #6 std::__1::__function::__alloc_func<ray::raylet::LocalTaskManager::DispatchScheduledTasksToWorkers()::$_1, std::__1::allocator<ray::raylet::LocalTaskManager::DispatchScheduledTasksToWorkers()::$_1>, bool (std::__1::shared_ptr<ray::raylet::WorkerInterface> const&, ray::raylet::PopWorkerStatus, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)>::operator()(std::__1::shared_ptr<ray::raylet::WorkerInterface> const&, ray::raylet::PopWorkerStatus&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /opt/llvm/bin/../include/c++/v1/functional:1558:16 (liblibraylet_Ulib.so+0x222f1b)
[2025-06-25T05:31:21Z]     #7 std::__1::__function::__func<ray::raylet::LocalTaskManager::DispatchScheduledTasksToWorkers()::$_1, std::__1::allocator<ray::raylet::LocalTaskManager::DispatchScheduledTasksToWorkers()::$_1>, bool (std::__1::shared_ptr<ray::raylet::WorkerInterface> const&, ray::raylet::PopWorkerStatus, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)>::operator()(std::__1::shared_ptr<ray::raylet::WorkerInterface> const&, ray::raylet::PopWorkerStatus&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /opt/llvm/bin/../include/c++/v1/functional:1732:12 (liblibraylet_Ulib.so+0x222f1b)
[2025-06-25T05:31:21Z]     #8 std::__1::__function::__value_func<bool (std::__1::shared_ptr<ray::raylet::WorkerInterface> const&, ray::raylet::PopWorkerStatus, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)>::operator()(std::__1::shared_ptr<ray::raylet::WorkerInterface> const&, ray::raylet::PopWorkerStatus&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) const /opt/llvm/bin/../include/c++/v1/functional:1885:16 (node_manager_test+0x1da9ed)
[2025-06-25T05:31:21Z]     #9 std::__1::function<bool (std::__1::shared_ptr<ray::raylet::WorkerInterface> const&, ray::raylet::PopWorkerStatus, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)>::operator()(std::__1::shared_ptr<ray::raylet::WorkerInterface> const&, ray::raylet::PopWorkerStatus, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) const /opt/llvm/bin/../include/c++/v1/functional:2560:12 (node_manager_test+0x1da9ed)
[2025-06-25T05:31:21Z]     #10 ray::raylet::NodeManagerTest_TestDetachedWorkerIsKilledByFailedWorker_Test::TestBody() /proc/self/cwd/src/ray/raylet/test/node_manager_test.cc:526:3 (node_manager_test+0x1da9ed)
[2025-06-25T05:31:21Z]     #11 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:2612:10 (libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so+0xd4a1f)
[2025-06-25T05:31:21Z]     #12 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:2648:14 (libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so+0xd4a1f)
[2025-06-25T05:31:21Z]     #13 testing::Test::Run() /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:2687:5 (libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so+0xd4901)
[2025-06-25T05:31:21Z]     #14 testing::TestInfo::Run() /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:2836:11 (libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so+0xd63c8)
[2025-06-25T05:31:21Z]     #15 testing::TestSuite::Run() /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:3015:30 (libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so+0xd79e4)
[2025-06-25T05:31:21Z]     #16 testing::internal::UnitTestImpl::RunAllTests() /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:5920:44 (libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so+0xecc44)
[2025-06-25T05:31:21Z]     #17 bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:2612:10 (libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so+0xec05f)
[2025-06-25T05:31:21Z]     #18 bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:2648:14 (libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so+0xec05f)
[2025-06-25T05:31:21Z]     #19 testing::UnitTest::Run() /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:5484:10 (libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so+0xebe4c)
[2025-06-25T05:31:21Z]     #20 RUN_ALL_TESTS() /proc/self/cwd/external/com_google_googletest/googletest/include/gtest/gtest.h:2317:73 (node_manager_test+0x1e18ce)
[2025-06-25T05:31:21Z]     #21 main /proc/self/cwd/src/ray/raylet/test/node_manager_test.cc:652:10 (node_manager_test+0x1e18ce)
[2025-06-25T05:31:21Z]
[2025-06-25T05:31:21Z]   Previous read of size 8 at 0x7b18000035f0 by thread T28:
[2025-06-25T05:31:21Z]     #0 std::__1::__deque_base<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > >::end() /opt/llvm/bin/../include/c++/v1/deque:1158:21 (liblibraylet_Ulib.so+0x20cc0b)
[2025-06-25T05:31:21Z]     #1 std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > >::end() /opt/llvm/bin/../include/c++/v1/deque:1361:60 (liblibraylet_Ulib.so+0x20cc0b)
[2025-06-25T05:31:21Z]     #2 ray::raylet::LocalTaskManager::DispatchScheduledTasksToWorkers() /proc/self/cwd/src/ray/raylet/local_task_manager.cc:250:75 (liblibraylet_Ulib.so+0x20cc0b)
[2025-06-25T05:31:21Z]     #3 ray::raylet::LocalTaskManager::ScheduleAndDispatchTasks() /proc/self/cwd/src/ray/raylet/local_task_manager.cc:110:3 (liblibraylet_Ulib.so+0x20bd09)
[2025-06-25T05:31:21Z]     #4 ray::raylet::ClusterTaskManager::ScheduleAndDispatchTasks() /proc/self/cwd/src/ray/raylet/scheduling/cluster_task_manager.cc:297:23 (libsrc_Sray_Sraylet_Sscheduling_Slibcluster_Utask_Umanager.so+0x76eaa)
[2025-06-25T05:31:21Z]     #5 ray::raylet::ClusterTaskManager::QueueAndScheduleTask(ray::RayTask, bool, bool, ray::rpc::RequestWorkerLeaseReply*, std::__1::function<void (ray::Status, std::__1::function<void ()>, std::__1::function<void ()>)>) /proc/self/cwd/src/ray/raylet/scheduling/cluster_task_manager.cc:72:3 (libsrc_Sray_Sraylet_Sscheduling_Slibcluster_Utask_Umanager.so+0x746e9)
[2025-06-25T05:31:21Z]     #6 ray::raylet::NodeManager::HandleRequestWorkerLease(ray::rpc::RequestWorkerLeaseRequest, ray::rpc::RequestWorkerLeaseReply*, std::__1::function<void (ray::Status, std::__1::function<void ()>, std::__1::function<void ()>)>) /proc/self/cwd/src/ray/raylet/node_manager.cc:1844:26 (liblibraylet_Ulib.so+0x24c8d0)
[2025-06-25T05:31:21Z]     #7 ray::rpc::ServerCallImpl<ray::rpc::NodeManagerServiceHandler, ray::rpc::RequestWorkerLeaseRequest, ray::rpc::RequestWorkerLeaseReply, (ray::rpc::AuthType)0>::HandleRequestImpl(bool) /proc/self/cwd/bazel-out/k8-opt/bin/_virtual_includes/rpc_server_call/ray/rpc/server_call.h:279:7 (liblibraylet_Ulib.so+0x28fa87)
[2025-06-25T05:31:21Z]     #8 ray::rpc::ServerCallImpl<ray::rpc::NodeManagerServiceHandler, ray::rpc::RequestWorkerLeaseRequest, ray::rpc::RequestWorkerLeaseReply, (ray::rpc::AuthType)0>::HandleRequest()::'lambda'()::operator()() const /proc/self/cwd/bazel-out/k8-opt/bin/_virtual_includes/rpc_server_call/ray/rpc/server_call.h:240:47 (liblibraylet_Ulib.so+0x28f814)
[2025-06-25T05:31:21Z]     #9 decltype(std::__1::forward<ray::rpc::NodeManagerServiceHandler>(fp)(std::__1::forward<ray::rpc::RequestWorkerLeaseRequest>(fp0)...)) std::__1::__invoke<ray::rpc::ServerCallImpl<ray::rpc::NodeManagerServiceHandler, ray::rpc::RequestWorkerLeaseRequest, ray::rpc::RequestWorkerLeaseReply, (ray::rpc::AuthType)0>::HandleRequest()::'lambda'()&>(ray::rpc::NodeManagerServiceHandler&&, ray::rpc::RequestWorkerLeaseRequest&&...) /opt/llvm/bin/../include/c++/v1/type_traits:3694:1 (liblibraylet_Ulib.so+0x28f814)
[2025-06-25T05:31:21Z]     #10 void std::__1::__invoke_void_return_wrapper<void, true>::__call<ray::rpc::ServerCallImpl<ray::rpc::NodeManagerServiceHandler, ray::rpc::RequestWorkerLeaseRequest, ray::rpc::RequestWorkerLeaseReply, (ray::rpc::AuthType)0>::HandleRequest()::'lambda'()&>(ray::rpc::NodeManagerServiceHandler&&...) /opt/llvm/bin/../include/c++/v1/__functional_base:348:9 (liblibraylet_Ulib.so+0x28f814)
[2025-06-25T05:31:21Z]     #11 std::__1::__function::__alloc_func<ray::rpc::ServerCallImpl<ray::rpc::NodeManagerServiceHandler, ray::rpc::RequestWorkerLeaseRequest, ray::rpc::RequestWorkerLeaseReply, (ray::rpc::AuthType)0>::HandleRequest()::'lambda'(), std::__1::allocator<ray::rpc::ServerCallImpl<ray::rpc::NodeManagerServiceHandler, ray::rpc::RequestWorkerLeaseRequest, ray::rpc::RequestWorkerLeaseReply, (ray::rpc::AuthType)0>::HandleRequest()::'lambda'()>, void ()>::operator()() /opt/llvm/bin/../include/c++/v1/functional:1558:16 (liblibraylet_Ulib.so+0x28f814)
[2025-06-25T05:31:21Z]     #12 std::__1::__function::__func<ray::rpc::ServerCallImpl<ray::rpc::NodeManagerServiceHandler, ray::rpc::RequestWorkerLeaseRequest, ray::rpc::RequestWorkerLeaseReply, (ray::rpc::AuthType)0>::HandleRequest()::'lambda'(), std::__1::allocator<ray::rpc::ServerCallImpl<ray::rpc::NodeManagerServiceHandler, ray::rpc::RequestWorkerLeaseRequest, ray::rpc::RequestWorkerLeaseReply, (ray::rpc::AuthType)0>::HandleRequest()::'lambda'()>, void ()>::operator()() /opt/llvm/bin/../include/c++/v1/functional:1732:12 (liblibraylet_Ulib.so+0x28f814)
[2025-06-25T05:31:21Z]     #13 std::__1::__function::__value_func<void ()>::operator()() const /opt/llvm/bin/../include/c++/v1/functional:1885:16 (libsrc_Sray_Scommon_Slibevent_Ustats.so+0x6a751)
[2025-06-25T05:31:21Z]     #14 std::__1::function<void ()>::operator()() const /opt/llvm/bin/../include/c++/v1/functional:2560:12 (libsrc_Sray_Scommon_Slibevent_Ustats.so+0x6a751)
[2025-06-25T05:31:21Z]     #15 EventTracker::RecordExecution(std::__1::function<void ()> const&, std::__1::shared_ptr<StatsHandle>) /proc/self/cwd/src/ray/common/event_stats.cc:113:3 (libsrc_Sray_Scommon_Slibevent_Ustats.so+0x6a751)
[2025-06-25T05:31:21Z]     #16 instrumented_io_context::post(std::__1::function<void ()>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, long)::$_0::operator()() /proc/self/cwd/src/ray/common/asio/instrumented_io_context.cc:99:7 (libsrc_Sray_Scommon_Slibasio.so+0x9627c)
[2025-06-25T05:31:21Z]     #17 decltype(std::__1::forward<instrumented_io_context::post(std::__1::function<void ()>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, long)::$_0&>(fp)()) std::__1::__invoke<instrumented_io_context::post(std::__1::function<void ()>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, long)::$_0&>(instrumented_io_context::post(std::__1::function<void ()>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, long)::$_0&) /opt/llvm/bin/../include/c++/v1/type_traits:3694:1 (libsrc_Sray_Scommon_Slibasio.so+0x9627c)
[2025-06-25T05:31:21Z]     #18 void std::__1::__invoke_void_return_wrapper<void, true>::__call<instrumented_io_context::post(std::__1::function<void ()>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, long)::$_0&>(instrumented_io_context::post(std::__1::function<void ()>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, long)::$_0&) /opt/llvm/bin/../include/c++/v1/__functional_base:348:9 (libsrc_Sray_Scommon_Slibasio.so+0x9627c)
[2025-06-25T05:31:21Z]     #19 std::__1::__function::__alloc_func<instrumented_io_context::post(std::__1::function<void ()>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, long)::$_0, std::__1::allocator<instrumented_io_context::post(std::__1::function<void ()>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, long)::$_0>, void ()>::operator()() /opt/llvm/bin/../include/c++/v1/functional:1558:16 (libsrc_Sray_Scommon_Slibasio.so+0x9627c)
[2025-06-25T05:31:21Z]     #20 std::__1::__function::__func<instrumented_io_context::post(std::__1::function<void ()>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, long)::$_0, std::__1::allocator<instrumented_io_context::post(std::__1::function<void ()>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, long)::$_0>, void ()>::operator()() /opt/llvm/bin/../include/c++/v1/functional:1732:12 (libsrc_Sray_Scommon_Slibasio.so+0x9627c)
[2025-06-25T05:31:21Z]     #21 std::__1::__function::__value_func<void ()>::operator()() const /opt/llvm/bin/../include/c++/v1/functional:1885:16 (libsrc_Sray_Scommon_Slibasio.so+0x9506e)
[2025-06-25T05:31:21Z]     #22 std::__1::function<void ()>::operator()() const /opt/llvm/bin/../include/c++/v1/functional:2560:12 (libsrc_Sray_Scommon_Slibasio.so+0x9506e)
[2025-06-25T05:31:21Z]     #23 boost::asio::detail::binder0<std::__1::function<void ()> >::operator()() /proc/self/cwd/external/boost/boost/asio/detail/bind_handler.hpp:60:5 (libsrc_Sray_Scommon_Slibasio.so+0x9506e)
[2025-06-25T05:31:21Z]     #24 void boost::asio::asio_handler_invoke<boost::asio::detail::binder0<std::__1::function<void ()> > >(boost::asio::detail::binder0<std::__1::function<void ()> >&, ...) /proc/self/cwd/external/boost/boost/asio/handler_invoke_hook.hpp:88:3 (libsrc_Sray_Scommon_Slibasio.so+0x9506e)
[2025-06-25T05:31:21Z]     #25 void boost_asio_handler_invoke_helpers::invoke<boost::asio::detail::binder0<std::__1::function<void ()> >, std::__1::function<void ()> >(boost::asio::detail::binder0<std::__1::function<void ()> >&, std::__1::function<void ()>&) /proc/self/cwd/external/boost/boost/asio/detail/handler_invoke_helpers.hpp:54:3 (libsrc_Sray_Scommon_Slibasio.so+0x9506e)
[2025-06-25T05:31:21Z]     #26 void boost::asio::detail::asio_handler_invoke<boost::asio::detail::binder0<std::__1::function<void ()> >, std::__1::function<void ()> >(boost::asio::detail::binder0<std::__1::function<void ()> >&, boost::asio::detail::binder0<std::__1::function<void ()> >*) /proc/self/cwd/external/boost/boost/asio/detail/bind_handler.hpp:111:3 (libsrc_Sray_Scommon_Slibasio.so+0x9506e)
[2025-06-25T05:31:21Z]     #27 void boost_asio_handler_invoke_helpers::invoke<boost::asio::detail::binder0<std::__1::function<void ()> >, boost::asio::detail::binder0<std::__1::function<void ()> > >(boost::asio::detail::binder0<std::__1::function<void ()> >&, boost::asio::detail::binder0<std::__1::function<void ()> >&) /proc/self/cwd/external/boost/boost/asio/detail/handler_invoke_helpers.hpp:54:3 (libsrc_Sray_Scommon_Slibasio.so+0x9506e)
[2025-06-25T05:31:21Z]     #28 boost::asio::detail::executor_op<boost::asio::detail::binder0<std::__1::function<void ()> >, std::__1::allocator<void>, boost::asio::detail::scheduler_operation>::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long) /proc/self/cwd/external/boost/boost/asio/detail/executor_op.hpp:70:7 (libsrc_Sray_Scommon_Slibasio.so+0x9506e)
[2025-06-25T05:31:21Z]     #29 boost::asio::detail::scheduler_operation::complete(void*, boost::system::error_code const&, unsigned long) /proc/self/cwd/external/boost/boost/asio/detail/scheduler_operation.hpp:40:5 (libexternal_Sboost_Slibasio.so+0xa9840)
[2025-06-25T05:31:21Z]     #30 boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&) /proc/self/cwd/external/boost/boost/asio/detail/impl/scheduler.ipp:492:12 (libexternal_Sboost_Slibasio.so+0xa9840)
[2025-06-25T05:31:21Z]     #31 boost::asio::detail::scheduler::run(boost::system::error_code&) /proc/self/cwd/external/boost/boost/asio/detail/impl/scheduler.ipp:210:10 (libexternal_Sboost_Slibasio.so+0x96501)
[2025-06-25T05:31:21Z]     #32 boost::asio::io_context::run() /proc/self/cwd/external/boost/boost/asio/impl/io_context.ipp:63:24 (libexternal_Sboost_Slibasio.so+0x9638e)
[2025-06-25T05:31:21Z]     #33 ray::raylet::NodeManagerTest_TestDetachedWorkerIsKilledByFailedWorker_Test::TestBody()::$_7::operator()() const /proc/self/cwd/src/ray/raylet/test/node_manager_test.cc:481:17 (node_manager_test+0x463844)
[2025-06-25T05:31:21Z]     #34 decltype(std::__1::forward<ray::raylet::NodeManagerTest_TestDetachedWorkerIsKilledByFailedWorker_Test::TestBody()::$_7>(fp)()) std::__1::__invoke<ray::raylet::NodeManagerTest_TestDetachedWorkerIsKilledByFailedWorker_Test::TestBody()::$_7>(ray::raylet::NodeManagerTest_TestDetachedWorkerIsKilledByFailedWorker_Test::TestBody()::$_7&&) /opt/llvm/bin/../include/c++/v1/type_traits:3694:1 (node_manager_test+0x463844)
[2025-06-25T05:31:21Z]     #35 void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, ray::raylet::NodeManagerTest_TestDetachedWorkerIsKilledByFailedWorker_Test::TestBody()::$_7>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, ray::raylet::NodeManagerTest_TestDetachedWorkerIsKilledByFailedWorker_Test::TestBody()::$_7>&, std::__1::__tuple_indices<>) /opt/llvm/bin/../include/c++/v1/thread:280:5 (node_manager_test+0x463844)
[2025-06-25T05:31:21Z]     #36 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, ray::raylet::NodeManagerTest_TestDetachedWorkerIsKilledByFailedWorker_Test::TestBody()::$_7> >(void*) /opt/llvm/bin/../include/c++/v1/thread:291:5 (node_manager_test+0x463844)
[2025-06-25T05:31:21Z]
[2025-06-25T05:31:21Z]   Location is heap block of size 88 at 0x7b18000035a0 allocated by thread T28:
[2025-06-25T05:31:21Z]     #0 malloc /tmp/llvm/utils/release/final/llvm-project/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:651:5 (node_manager_test+0x154dab)
[2025-06-25T05:31:21Z]     #1 operator new(unsigned long) <null> (liblibraylet_Ulib.so+0x3cb284)
[2025-06-25T05:31:21Z]     #2 absl::lts_20230802::container_internal::raw_hash_set<absl::lts_20230802::container_internal::FlatHashMapPolicy<int, std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > > >, absl::lts_20230802::hash_internal::Hash<int>, std::__1::equal_to<int>, std::__1::allocator<std::__1::pair<int const, std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > > > > >::initialize_slots() /proc/self/cwd/external/com_google_absl/absl/container/internal/raw_hash_set.h:2505:5 (liblibraylet_Ulib.so+0x21deea)
[2025-06-25T05:31:21Z]     #3 absl::lts_20230802::container_internal::raw_hash_set<absl::lts_20230802::container_internal::FlatHashMapPolicy<int, std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > > >, absl::lts_20230802::hash_internal::Hash<int>, std::__1::equal_to<int>, std::__1::allocator<std::__1::pair<int const, std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > > > > >::resize(unsigned long) /proc/self/cwd/external/com_google_absl/absl/container/internal/raw_hash_set.h:2515:5 (liblibraylet_Ulib.so+0x21deea)
[2025-06-25T05:31:21Z]     #4 absl::lts_20230802::container_internal::raw_hash_set<absl::lts_20230802::container_internal::FlatHashMapPolicy<int, std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > > >, absl::lts_20230802::hash_internal::Hash<int>, std::__1::equal_to<int>, std::__1::allocator<std::__1::pair<int const, std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > > > > >::rehash_and_grow_if_necessary() /proc/self/cwd/external/com_google_absl/absl/container/internal/raw_hash_set.h:2603:7 (liblibraylet_Ulib.so+0x21ddca)
[2025-06-25T05:31:21Z]     #5 absl::lts_20230802::container_internal::raw_hash_set<absl::lts_20230802::container_internal::FlatHashMapPolicy<int, std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > > >, absl::lts_20230802::hash_internal::Hash<int>, std::__1::equal_to<int>, std::__1::allocator<std::__1::pair<int const, std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > > > > >::prepare_insert(unsigned long) /proc/self/cwd/external/com_google_absl/absl/container/internal/raw_hash_set.h:2678:7 (liblibraylet_Ulib.so+0x21ddca)
[2025-06-25T05:31:21Z]     #6 std::__1::pair<unsigned long, bool> absl::lts_20230802::container_internal::raw_hash_set<absl::lts_20230802::container_internal::FlatHashMapPolicy<int, std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > > >, absl::lts_20230802::hash_internal::Hash<int>, std::__1::equal_to<int>, std::__1::allocator<std::__1::pair<int const, std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > > > > >::find_or_prepare_insert<int>(int const&) /proc/self/cwd/external/com_google_absl/absl/container/internal/raw_hash_set.h:2659:13 (liblibraylet_Ulib.so+0x20b968)
[2025-06-25T05:31:21Z]     #7 std::__1::pair<absl::lts_20230802::container_internal::raw_hash_set<absl::lts_20230802::container_internal::FlatHashMapPolicy<int, std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > > >, absl::lts_20230802::hash_internal::Hash<int>, std::__1::equal_to<int>, std::__1::allocator<std::__1::pair<int const, std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > > > > >::iterator, bool> absl::lts_20230802::container_internal::raw_hash_map<absl::lts_20230802::container_internal::FlatHashMapPolicy<int, std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > > >, absl::lts_20230802::hash_internal::Hash<int>, std::__1::equal_to<int>, std::__1::allocator<std::__1::pair<int const, std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > > > > >::try_emplace_impl<int const&>(int const&) /proc/self/cwd/external/com_google_absl/absl/container/internal/raw_hash_map.h:202:22 (liblibraylet_Ulib.so+0x20b968)
[2025-06-25T05:31:21Z]     #8 std::__1::pair<absl::lts_20230802::container_internal::raw_hash_set<absl::lts_20230802::container_internal::FlatHashMapPolicy<int, std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > > >, absl::lts_20230802::hash_internal::Hash<int>, std::__1::equal_to<int>, std::__1::allocator<std::__1::pair<int const, std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > > > > >::iterator, bool> absl::lts_20230802::container_internal::raw_hash_map<absl::lts_20230802::container_internal::FlatHashMapPolicy<int, std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > > >, absl::lts_20230802::hash_internal::Hash<int>, std::__1::equal_to<int>, std::__1::allocator<std::__1::pair<int const, std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > > > > >::try_emplace<int, 0>(int const&) /proc/self/cwd/external/com_google_absl/absl/container/internal/raw_hash_map.h:139:12 (liblibraylet_Ulib.so+0x20b968)
[2025-06-25T05:31:21Z]     #9 decltype(absl::lts_20230802::container_internal::FlatHashMapPolicy<int, std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > > >::value(std::__1::pair<int const, std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > > >* std::__1::addressof<std::__1::pair<int const, std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > > > >(std::__1::pair<int const, std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > > >&)(decltype(std::__1::__declval<std::__1::pair<int const, std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > > > >(0)) std::__1::declval<std::__1::pair<int const, std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > > >&>()()))) absl::lts_20230802::container_internal::raw_hash_map<absl::lts_20230802::container_internal::FlatHashMapPolicy<int, std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > > >, absl::lts_20230802::hash_internal::Hash<int>, std::__1::equal_to<int>, std::__1::allocator<std::__1::pair<int const, std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > > > > >::operator[]<int, absl::lts_20230802::container_internal::FlatHashMapPolicy<int, std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > > > >(int const&) /proc/self/cwd/external/com_google_absl/absl/container/internal/raw_hash_map.h:184:28 (liblibraylet_Ulib.so+0x20b968)
[2025-06-25T05:31:21Z]     #10 ray::raylet::LocalTaskManager::WaitForTaskArgsRequests(std::__1::shared_ptr<ray::raylet::internal::Work>) /proc/self/cwd/src/ray/raylet/local_task_manager.cc:105:5 (liblibraylet_Ulib.so+0x20b968)
[2025-06-25T05:31:21Z]     #11 ray::raylet::LocalTaskManager::QueueAndScheduleTask(std::__1::shared_ptr<ray::raylet::internal::Work>) /proc/self/cwd/src/ray/raylet/local_task_manager.cc:79:3 (liblibraylet_Ulib.so+0x20ab3b)
[2025-06-25T05:31:21Z]     #12 ray::raylet::ClusterTaskManager::ScheduleOnNode(ray::NodeID const&, std::__1::shared_ptr<ray::raylet::internal::Work> const&) /proc/self/cwd/src/ray/raylet/scheduling/cluster_task_manager.cc:425:25 (libsrc_Sray_Sraylet_Sscheduling_Slibcluster_Utask_Umanager.so+0x7884a)
[2025-06-25T05:31:21Z]     #13 ray::raylet::ClusterTaskManager::ScheduleAndDispatchTasks() /proc/self/cwd/src/ray/raylet/scheduling/cluster_task_manager.cc:262:7 (libsrc_Sray_Sraylet_Sscheduling_Slibcluster_Utask_Umanager.so+0x7638b)
[2025-06-25T05:31:21Z]     #14 ray::raylet::ClusterTaskManager::QueueAndScheduleTask(ray::RayTask, bool, bool, ray::rpc::RequestWorkerLeaseReply*, std::__1::function<void (ray::Status, std::__1::function<void ()>, std::__1::function<void ()>)>) /proc/self/cwd/src/ray/raylet/scheduling/cluster_task_manager.cc:72:3 (libsrc_Sray_Sraylet_Sscheduling_Slibcluster_Utask_Umanager.so+0x746e9)
[2025-06-25T05:31:21Z]     #15 ray::raylet::NodeManager::HandleRequestWorkerLease(ray::rpc::RequestWorkerLeaseRequest, ray::rpc::RequestWorkerLeaseReply*, std::__1::function<void (ray::Status, std::__1::function<void ()>, std::__1::function<void ()>)>) /proc/self/cwd/src/ray/raylet/node_manager.cc:1844:26 (liblibraylet_Ulib.so+0x24c8d0)
[2025-06-25T05:31:21Z]     #16 ray::rpc::ServerCallImpl<ray::rpc::NodeManagerServiceHandler, ray::rpc::RequestWorkerLeaseRequest, ray::rpc::RequestWorkerLeaseReply, (ray::rpc::AuthType)0>::HandleRequestImpl(bool) /proc/self/cwd/bazel-out/k8-opt/bin/_virtual_includes/rpc_server_call/ray/rpc/server_call.h:279:7 (liblibraylet_Ulib.so+0x28fa87)
[2025-06-25T05:31:21Z]     #17 ray::rpc::ServerCallImpl<ray::rpc::NodeManagerServiceHandler, ray::rpc::RequestWorkerLeaseRequest, ray::rpc::RequestWorkerLeaseReply, (ray::rpc::AuthType)0>::HandleRequest()::'lambda'()::operator()() const /proc/self/cwd/bazel-out/k8-opt/bin/_virtual_includes/rpc_server_call/ray/rpc/server_call.h:240:47 (liblibraylet_Ulib.so+0x28f814)
[2025-06-25T05:31:21Z]     #18 decltype(std::__1::forward<ray::rpc::NodeManagerServiceHandler>(fp)(std::__1::forward<ray::rpc::RequestWorkerLeaseRequest>(fp0)...)) std::__1::__invoke<ray::rpc::ServerCallImpl<ray::rpc::NodeManagerServiceHandler, ray::rpc::RequestWorkerLeaseRequest, ray::rpc::RequestWorkerLeaseReply, (ray::rpc::AuthType)0>::HandleRequest()::'lambda'()&>(ray::rpc::NodeManagerServiceHandler&&, ray::rpc::RequestWorkerLeaseRequest&&...) /opt/llvm/bin/../include/c++/v1/type_traits:3694:1 (liblibraylet_Ulib.so+0x28f814)
[2025-06-25T05:31:21Z]     #19 void std::__1::__invoke_void_return_wrapper<void, true>::__call<ray::rpc::ServerCallImpl<ray::rpc::NodeManagerServiceHandler, ray::rpc::RequestWorkerLeaseRequest, ray::rpc::RequestWorkerLeaseReply, (ray::rpc::AuthType)0>::HandleRequest()::'lambda'()&>(ray::rpc::NodeManagerServiceHandler&&...) /opt/llvm/bin/../include/c++/v1/__functional_base:348:9 (liblibraylet_Ulib.so+0x28f814)
[2025-06-25T05:31:21Z]     #20 std::__1::__function::__alloc_func<ray::rpc::ServerCallImpl<ray::rpc::NodeManagerServiceHandler, ray::rpc::RequestWorkerLeaseRequest, ray::rpc::RequestWorkerLeaseReply, (ray::rpc::AuthType)0>::HandleRequest()::'lambda'(), std::__1::allocator<ray::rpc::ServerCallImpl<ray::rpc::NodeManagerServiceHandler, ray::rpc::RequestWorkerLeaseRequest, ray::rpc::RequestWorkerLeaseReply, (ray::rpc::AuthType)0>::HandleRequest()::'lambda'()>, void ()>::operator()() /opt/llvm/bin/../include/c++/v1/functional:1558:16 (liblibraylet_Ulib.so+0x28f814)
[2025-06-25T05:31:21Z]     #21 std::__1::__function::__func<ray::rpc::ServerCallImpl<ray::rpc::NodeManagerServiceHandler, ray::rpc::RequestWorkerLeaseRequest, ray::rpc::RequestWorkerLeaseReply, (ray::rpc::AuthType)0>::HandleRequest()::'lambda'(), std::__1::allocator<ray::rpc::ServerCallImpl<ray::rpc::NodeManagerServiceHandler, ray::rpc::RequestWorkerLeaseRequest, ray::rpc::RequestWorkerLeaseReply, (ray::rpc::AuthType)0>::HandleRequest()::'lambda'()>, void ()>::operator()() /opt/llvm/bin/../include/c++/v1/functional:1732:12 (liblibraylet_Ulib.so+0x28f814)
[2025-06-25T05:31:21Z]     #22 std::__1::__function::__value_func<void ()>::operator()() const /opt/llvm/bin/../include/c++/v1/functional:1885:16 (libsrc_Sray_Scommon_Slibevent_Ustats.so+0x6a751)
[2025-06-25T05:31:21Z]     #23 std::__1::function<void ()>::operator()() const /opt/llvm/bin/../include/c++/v1/functional:2560:12 (libsrc_Sray_Scommon_Slibevent_Ustats.so+0x6a751)
[2025-06-25T05:31:21Z]     #24 EventTracker::RecordExecution(std::__1::function<void ()> const&, std::__1::shared_ptr<StatsHandle>) /proc/self/cwd/src/ray/common/event_stats.cc:113:3 (libsrc_Sray_Scommon_Slibevent_Ustats.so+0x6a751)
[2025-06-25T05:31:21Z]     #25 instrumented_io_context::post(std::__1::function<void ()>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, long)::$_0::operator()() /proc/self/cwd/src/ray/common/asio/instrumented_io_context.cc:99:7 (libsrc_Sray_Scommon_Slibasio.so+0x9627c)
[2025-06-25T05:31:21Z]     #26 decltype(std::__1::forward<instrumented_io_context::post(std::__1::function<void ()>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, long)::$_0&>(fp)()) std::__1::__invoke<instrumented_io_context::post(std::__1::function<void ()>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, long)::$_0&>(instrumented_io_context::post(std::__1::function<void ()>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, long)::$_0&) /opt/llvm/bin/../include/c++/v1/type_traits:3694:1 (libsrc_Sray_Scommon_Slibasio.so+0x9627c)
[2025-06-25T05:31:21Z]     #27 void std::__1::__invoke_void_return_wrapper<void, true>::__call<instrumented_io_context::post(std::__1::function<void ()>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, long)::$_0&>(instrumented_io_context::post(std::__1::function<void ()>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, long)::$_0&) /opt/llvm/bin/../include/c++/v1/__functional_base:348:9 (libsrc_Sray_Scommon_Slibasio.so+0x9627c)
[2025-06-25T05:31:21Z]     #28 std::__1::__function::__alloc_func<instrumented_io_context::post(std::__1::function<void ()>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, long)::$_0, std::__1::allocator<instrumented_io_context::post(std::__1::function<void ()>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, long)::$_0>, void ()>::operator()() /opt/llvm/bin/../include/c++/v1/functional:1558:16 (libsrc_Sray_Scommon_Slibasio.so+0x9627c)
[2025-06-25T05:31:21Z]     #29 std::__1::__function::__func<instrumented_io_context::post(std::__1::function<void ()>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, long)::$_0, std::__1::allocator<instrumented_io_context::post(std::__1::function<void ()>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, long)::$_0>, void ()>::operator()() /opt/llvm/bin/../include/c++/v1/functional:1732:12 (libsrc_Sray_Scommon_Slibasio.so+0x9627c)
[2025-06-25T05:31:21Z]     #30 std::__1::__function::__value_func<void ()>::operator()() const /opt/llvm/bin/../include/c++/v1/functional:1885:16 (libsrc_Sray_Scommon_Slibasio.so+0x9506e)
[2025-06-25T05:31:21Z]     #31 std::__1::function<void ()>::operator()() const /opt/llvm/bin/../include/c++/v1/functional:2560:12 (libsrc_Sray_Scommon_Slibasio.so+0x9506e)
[2025-06-25T05:31:21Z]     #32 boost::asio::detail::binder0<std::__1::function<void ()> >::operator()() /proc/self/cwd/external/boost/boost/asio/detail/bind_handler.hpp:60:5 (libsrc_Sray_Scommon_Slibasio.so+0x9506e)
[2025-06-25T05:31:21Z]     #33 void boost::asio::asio_handler_invoke<boost::asio::detail::binder0<std::__1::function<void ()> > >(boost::asio::detail::binder0<std::__1::function<void ()> >&, ...) /proc/self/cwd/external/boost/boost/asio/handler_invoke_hook.hpp:88:3 (libsrc_Sray_Scommon_Slibasio.so+0x9506e)
[2025-06-25T05:31:21Z]     #34 void boost_asio_handler_invoke_helpers::invoke<boost::asio::detail::binder0<std::__1::function<void ()> >, std::__1::function<void ()> >(boost::asio::detail::binder0<std::__1::function<void ()> >&, std::__1::function<void ()>&) /proc/self/cwd/external/boost/boost/asio/detail/handler_invoke_helpers.hpp:54:3 (libsrc_Sray_Scommon_Slibasio.so+0x9506e)
[2025-06-25T05:31:21Z]     #35 void boost::asio::detail::asio_handler_invoke<boost::asio::detail::binder0<std::__1::function<void ()> >, std::__1::function<void ()> >(boost::asio::detail::binder0<std::__1::function<void ()> >&, boost::asio::detail::binder0<std::__1::function<void ()> >*) /proc/self/cwd/external/boost/boost/asio/detail/bind_handler.hpp:111:3 (libsrc_Sray_Scommon_Slibasio.so+0x9506e)
[2025-06-25T05:31:21Z]     #36 void boost_asio_handler_invoke_helpers::invoke<boost::asio::detail::binder0<std::__1::function<void ()> >, boost::asio::detail::binder0<std::__1::function<void ()> > >(boost::asio::detail::binder0<std::__1::function<void ()> >&, boost::asio::detail::binder0<std::__1::function<void ()> >&) /proc/self/cwd/external/boost/boost/asio/detail/handler_invoke_helpers.hpp:54:3 (libsrc_Sray_Scommon_Slibasio.so+0x9506e)
[2025-06-25T05:31:21Z]     #37 boost::asio::detail::executor_op<boost::asio::detail::binder0<std::__1::function<void ()> >, std::__1::allocator<void>, boost::asio::detail::scheduler_operation>::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long) /proc/self/cwd/external/boost/boost/asio/detail/executor_op.hpp:70:7 (libsrc_Sray_Scommon_Slibasio.so+0x9506e)
[2025-06-25T05:31:21Z]     #38 boost::asio::detail::scheduler_operation::complete(void*, boost::system::error_code const&, unsigned long) /proc/self/cwd/external/boost/boost/asio/detail/scheduler_operation.hpp:40:5 (libexternal_Sboost_Slibasio.so+0xa9840)
[2025-06-25T05:31:21Z]     #39 boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&) /proc/self/cwd/external/boost/boost/asio/detail/impl/scheduler.ipp:492:12 (libexternal_Sboost_Slibasio.so+0xa9840)
[2025-06-25T05:31:21Z]     #40 boost::asio::detail::scheduler::run(boost::system::error_code&) /proc/self/cwd/external/boost/boost/asio/detail/impl/scheduler.ipp:210:10 (libexternal_Sboost_Slibasio.so+0x96501)
[2025-06-25T05:31:21Z]     #41 boost::asio::io_context::run() /proc/self/cwd/external/boost/boost/asio/impl/io_context.ipp:63:24 (libexternal_Sboost_Slibasio.so+0x9638e)
[2025-06-25T05:31:21Z]     #42 ray::raylet::NodeManagerTest_TestDetachedWorkerIsKilledByFailedWorker_Test::TestBody()::$_7::operator()() const /proc/self/cwd/src/ray/raylet/test/node_manager_test.cc:481:17 (node_manager_test+0x463844)
[2025-06-25T05:31:21Z]     #43 decltype(std::__1::forward<ray::raylet::NodeManagerTest_TestDetachedWorkerIsKilledByFailedWorker_Test::TestBody()::$_7>(fp)()) std::__1::__invoke<ray::raylet::NodeManagerTest_TestDetachedWorkerIsKilledByFailedWorker_Test::TestBody()::$_7>(ray::raylet::NodeManagerTest_TestDetachedWorkerIsKilledByFailedWorker_Test::TestBody()::$_7&&) /opt/llvm/bin/../include/c++/v1/type_traits:3694:1 (node_manager_test+0x463844)
[2025-06-25T05:31:21Z]     #44 void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, ray::raylet::NodeManagerTest_TestDetachedWorkerIsKilledByFailedWorker_Test::TestBody()::$_7>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, ray::raylet::NodeManagerTest_TestDetachedWorkerIsKilledByFailedWorker_Test::TestBody()::$_7>&, std::__1::__tuple_indices<>) /opt/llvm/bin/../include/c++/v1/thread:280:5 (node_manager_test+0x463844)
[2025-06-25T05:31:21Z]     #45 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, ray::raylet::NodeManagerTest_TestDetachedWorkerIsKilledByFailedWorker_Test::TestBody()::$_7> >(void*) /opt/llvm/bin/../include/c++/v1/thread:291:5 (node_manager_test+0x463844)
[2025-06-25T05:31:21Z]
[2025-06-25T05:31:21Z]   Thread T28 (tid=987, running) created by main thread at:
[2025-06-25T05:31:21Z]     #0 pthread_create /tmp/llvm/utils/release/final/llvm-project/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:965:3 (node_manager_test+0x15659b)
[2025-06-25T05:31:21Z]     #1 std::__1::__libcpp_thread_create(unsigned long*, void* (*)(void*), void*) /opt/llvm/bin/../include/c++/v1/__threading_support:509:10 (node_manager_test+0x1da502)
[2025-06-25T05:31:21Z]     #2 std::__1::thread::thread<ray::raylet::NodeManagerTest_TestDetachedWorkerIsKilledByFailedWorker_Test::TestBody()::$_7, void>(ray::raylet::NodeManagerTest_TestDetachedWorkerIsKilledByFailedWorker_Test::TestBody()::$_7&&) /opt/llvm/bin/../include/c++/v1/thread:307:16 (node_manager_test+0x1da502)
[2025-06-25T05:31:21Z]     #3 ray::raylet::NodeManagerTest_TestDetachedWorkerIsKilledByFailedWorker_Test::TestBody() /proc/self/cwd/src/ray/raylet/test/node_manager_test.cc:478:15 (node_manager_test+0x1da502)
[2025-06-25T05:31:21Z]     #4 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:2612:10 (libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so+0xd4a1f)
[2025-06-25T05:31:21Z]     #5 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:2648:14 (libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so+0xd4a1f)
[2025-06-25T05:31:21Z]     #6 testing::Test::Run() /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:2687:5 (libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so+0xd4901)
[2025-06-25T05:31:21Z]     #7 testing::TestInfo::Run() /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:2836:11 (libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so+0xd63c8)
[2025-06-25T05:31:21Z]     #8 testing::TestSuite::Run() /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:3015:30 (libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so+0xd79e4)
[2025-06-25T05:31:21Z]     #9 testing::internal::UnitTestImpl::RunAllTests() /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:5920:44 (libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so+0xecc44)
[2025-06-25T05:31:21Z]     #10 bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:2612:10 (libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so+0xec05f)
[2025-06-25T05:31:21Z]     #11 bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:2648:14 (libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so+0xec05f)
[2025-06-25T05:31:21Z]     #12 testing::UnitTest::Run() /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:5484:10 (libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so+0xebe4c)
[2025-06-25T05:31:21Z]     #13 RUN_ALL_TESTS() /proc/self/cwd/external/com_google_googletest/googletest/include/gtest/gtest.h:2317:73 (node_manager_test+0x1e18ce)
[2025-06-25T05:31:21Z]     #14 main /proc/self/cwd/src/ray/raylet/test/node_manager_test.cc:652:10 (node_manager_test+0x1e18ce)
[2025-06-25T05:31:21Z]
[2025-06-25T05:31:21Z] SUMMARY: ThreadSanitizer: data race /opt/llvm/bin/../include/c++/v1/deque:2877:9 in std::__1::deque<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::allocator<std::__1::shared_ptr<ray::raylet::internal::Work> > >::erase(std::__1::__deque_iterator<std::__1::shared_ptr<ray::raylet::internal::Work>, std::__1::shared_ptr<ray::raylet::internal::Work> const*, std::__1::shared_ptr<ray::raylet::internal::Work> const&, std::__1::shared_ptr<ray::raylet::internal::Work> const* const*, long, 256l>)
```

That's because calling the `pop_worker_callback` on the main test thread is wrong. It should be run on the same raylet io thread. This PR dispatches the invocation to the io_service_ to resolve the failure.

## Related issue number

fixes https://github.com/ray-project/ray/issues/54096

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
