### PR TITLE
[data] adapt dask on ray to the new dask task class 

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -181,9 +181,9 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker --
         python/ray/util/dask/... core
         --install-mask all-ray-libraries
-        --build-name datalbuild
+        --build-name databuild-py3.12
     depends_on:
-      - datalbuild
+      - databuild-multipy
       - forge
 
   - label: ":ray: core: modin tests"

--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -152,9 +152,9 @@ steps:
     instance_type: medium
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/data/... data
-        --build-name datalbuild
+        --build-name databuild-py3.12
         --only-tags dask
-    depends_on: datalbuild
+    depends_on: databuild-multipy
 
   - label: ":database: data: TFRecords (tfx-bsl) tests"
     tags:
@@ -193,10 +193,10 @@ steps:
     instance_type: medium
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //doc/... data
-        --build-name datalbuild
+        --build-name databuild-py3.12
         --only-tags dask
         --parallelism-per-worker 2
-    depends_on: datalbuild
+    depends_on: databuild-multipy
 
   - label: ":database: data: doc gpu tests"
     tags:

--- a/doc/source/ray-more-libs/doc_code/dask_on_ray_persist_example.py
+++ b/doc/source/ray-more-libs/doc_code/dask_on_ray_persist_example.py
@@ -12,10 +12,12 @@ ray.init()
 enable_dask_on_ray()
 
 d_arr = da.ones(100)
-print(dask.base.collections_to_dsk([d_arr]))
-# {('ones-c345e6f8436ff9bcd68ddf25287d27f3',
-#   0): (functools.partial(<function _broadcast_trick_inner at 0x7f27f1a71f80>,
-#   dtype=dtype('float64')), (5,))}
+
+# Print the internal Dask graph. Replace this with `print(dask.base.collections_to_dsk([d_arr]))` when dask>=2024.11.0,<2025.4.0.
+print(dask.base.collections_to_expr([d_arr]).dask)
+# {('ones_like-5902a58f37d3b639948dee893f5c4f4a', 0):
+# <Task ('ones_like-5902a58f37d3b639948dee893f5c4f4a', 0)
+# ones_like(...)>}
 
 # This submits all underlying Ray tasks to the cluster and returns
 # a Dask array with the Ray futures inlined.
@@ -23,9 +25,10 @@ d_arr_p = d_arr.persist()
 
 # Notice that the Ray ObjectRef is inlined. The dask.ones() task has
 # been submitted to and is running on the Ray cluster.
-dask.base.collections_to_dsk([d_arr_p])
-# {('ones-c345e6f8436ff9bcd68ddf25287d27f3',
-#   0): ObjectRef(8b4e50dc1ddac855ffffffffffffffffffffffff0100000001000000)}
+# Replace this in a similar way when dask>=2024.11.0,<2025.4.0.
+print(dask.base.collections_to_expr([d_arr_p]).dask)
+# {('ones_like-5902a58f37d3b639948dee893f5c4f4a', 0):
+# DataNode(ObjectRef(2c329aa28fcae64affffffffffffffffffffffff2c00000001000000))}
 
 # Future computations on this persisted Dask Array will be fast since we
 # already started computing d_arr_p in the background.

--- a/python/ray/data/tests/test_ecosystem_dask.py
+++ b/python/ray/data/tests/test_ecosystem_dask.py
@@ -54,6 +54,12 @@ def test_to_dask_simple(ray_start_regular_shared):
 
 @pytest.mark.parametrize("ds_format", ["pandas", "arrow"])
 def test_to_dask(ray_start_regular_shared, ds_format):
+    # Since 2023.7.1, Dask DataFrame automatically converts text data using object data types to string[pyarrow]
+    # For the purpose of this test, we need to disable this behavior.
+    import dask
+
+    dask.config.set({"dataframe.convert-string": False})
+
     from ray.util.dask import ray_dask_get
 
     df1 = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})

--- a/python/ray/util/dask/__init__.py
+++ b/python/ray/util/dask/__init__.py
@@ -1,4 +1,16 @@
 import dask
+from packaging.version import Version
+
+# Version(dask.__version__) becomes "0" during doc builds.
+if Version(dask.__version__) != Version("0") and Version(dask.__version__) < Version(
+    "2024.11.0"
+):
+    # Dask on Ray doesn't work if Dask version is less than 2024.11.0.
+    raise ImportError(
+        "Dask on Ray requires Dask version 2024.11.0 or later. "
+        "Please upgrade your Dask installation."
+    )
+
 from .scheduler import (
     ray_dask_get,
     ray_dask_get_sync,

--- a/python/ray/util/dask/common.py
+++ b/python/ray/util/dask/common.py
@@ -5,7 +5,7 @@ import uuid
 
 import ray
 
-from dask.base import quote
+from dask.core import quote
 from dask.core import get as get_sync
 from dask.utils import apply
 

--- a/python/ray/util/dask/optimizations.py
+++ b/python/ray/util/dask/optimizations.py
@@ -1,21 +1,27 @@
-import operator
 import warnings
 
 import dask
 from dask import core
-from dask.core import istask
 from dask.dataframe.core import _concat
-from dask.dataframe.optimize import optimize
-from dask.dataframe.shuffle import shuffle_group
 from dask.highlevelgraph import HighLevelGraph
 
 from .scheduler import MultipleReturnFunc, multiple_return_get
 
 try:
     from dask.dataframe.shuffle import SimpleShuffleLayer
+    from dask.dataframe.optimize import optimize
+    from dask.dataframe.shuffle import shuffle_group
 except ImportError:
     # SimpleShuffleLayer doesn't exist in this version of Dask.
+    # This is the case for dask>=2025.1.0.
     SimpleShuffleLayer = None
+try:
+    import dask_expr  # noqa: F401
+
+    SimpleShuffleLayer = None
+except ImportError:
+    pass
+
 
 if SimpleShuffleLayer is not None:
 
@@ -137,31 +143,8 @@ else:
     def dataframe_optimize(dsk, keys, **kwargs):
         warnings.warn(
             "Custom dataframe shuffle optimization only works on "
-            "dask>=2020.12.0, you are on version "
-            f"{dask.__version__}, please upgrade Dask."
-            "Falling back to default dataframe optimizer."
+            "dask>=2024.11.0,<2025.1.0, you are on version "
+            f"{dask.__version__}."
+            "Doing no additional optimization aside from the default one."
         )
-        return optimize(dsk, keys, **kwargs)
-
-
-# Stale approaches below.
-
-
-def fuse_splits_into_multiple_return(dsk, keys):
-    if not isinstance(dsk, HighLevelGraph):
-        dsk = HighLevelGraph.from_collections(id(dsk), dsk, dependencies=())
-    else:
-        dsk = dsk.copy()
-    dependencies = dsk.dependencies.copy()
-    for k, v in dsk.items():
-        if istask(v) and v[0] == shuffle_group:
-            task_deps = dependencies[k]
-            # Only rewrite shuffle group split if all downstream dependencies
-            # are splits.
-            if all(
-                istask(dsk[dep]) and dsk[dep][0] == operator.getitem
-                for dep in task_deps
-            ):
-                for dep in task_deps:
-                    # Rewrite split
-                    pass
+        return None

--- a/python/ray/util/dask/scheduler.py
+++ b/python/ray/util/dask/scheduler.py
@@ -1,15 +1,26 @@
+import warnings
+
 import atexit
 import threading
 import time
 from collections import defaultdict
 from collections import OrderedDict
+from collections.abc import Mapping
 from dataclasses import dataclass
 from multiprocessing.pool import ThreadPool
 from pprint import pprint
 from typing import Optional
 
 import dask
-from dask.core import istask, ishashable, _execute_task
+from dask.core import istask, ishashable
+
+try:
+    from dask._task_spec import Task, Alias, DataNode, TaskRef, convert_legacy_graph
+except ImportError:
+    warnings.warn(
+        "Dask on Ray is available only on dask>=2024.11.0, "
+        f"you are on version {dask.__version__}."
+    )
 from dask.system import CPU_COUNT
 from dask.threaded import pack_exception, _thread_get_id
 
@@ -147,13 +158,18 @@ def ray_dask_get(dsk, keys, **kwargs):
     if "resources" in kwargs:
         raise ValueError(TOP_LEVEL_RESOURCES_ERR_MSG)
     ray_remote_args = kwargs.pop("ray_remote_args", {})
-    try:
-        annotations = dask.config.get("annotations")
-    except KeyError:
-        annotations = {}
+    annotations = dask.get_annotations()
     if "resources" in annotations:
         raise ValueError(TOP_LEVEL_RESOURCES_ERR_MSG)
 
+    # Take out the dask graph if it is an Expr for dask>=2025.4.0.
+    if not isinstance(dsk, Mapping):
+        if hasattr(dsk, "_optimized_dsk"):
+            # For Expr with this property
+            dsk = dsk._optimized_dsk
+        else:
+            # For any other Expr
+            dsk = dsk.__dask_graph__()
     scoped_ray_remote_args = _build_key_scoped_ray_remote_args(
         dsk, annotations, ray_remote_args
     )
@@ -168,6 +184,8 @@ def ray_dask_get(dsk, keys, **kwargs):
             ray_postsubmit_all_cbs,
             ray_finish_cbs,
         ) = unpack_ray_callbacks(ray_callbacks)
+        # Make sure the graph is in the new format
+        dsk = convert_legacy_graph(dsk)
         # NOTE: We hijack Dask's `get_async` function, injecting a different
         # task executor.
         object_refs = get_async(
@@ -362,13 +380,23 @@ def _rayify_task(
                 if alternate_return is not None:
                     return alternate_return
 
-        func, args = task[0], task[1:]
-        if func is multiple_return_get:
-            return _execute_task(task, deps)
+        if isinstance(task, Alias):
+            target = task.target
+            if isinstance(target, TaskRef):
+                # for 2024.12.0
+                return deps[target.key]
+            else:
+                # for 2024.12.1+
+                return deps[target]
+        elif isinstance(task, Task):
+            func = task.func
+        else:
+            raise ValueError("Invalid task type: %s" % type(task))
+
         # If the function's arguments contain nested object references, we must
         # unpack said object references into a flat set of arguments so that
         # Ray properly tracks the object dependencies between Ray tasks.
-        arg_object_refs, repack = unpack_object_refs(args, deps)
+        arg_object_refs, repack = unpack_object_refs(deps)
         # Submit the task using a wrapper function.
         object_refs = dask_task_wrapper.options(
             name=f"dask:{key!s}",
@@ -377,7 +405,7 @@ def _rayify_task(
             ),
             **ray_remote_args,
         ).remote(
-            func,
+            task,
             repack,
             key,
             ray_pretask_cbs,
@@ -399,23 +427,23 @@ def _rayify_task(
 
 
 @ray.remote
-def dask_task_wrapper(func, repack, key, ray_pretask_cbs, ray_posttask_cbs, *args):
+def dask_task_wrapper(
+    task, repack, key, ray_pretask_cbs, ray_posttask_cbs, *arg_object_refs
+):
     """
     A Ray remote function acting as a Dask task wrapper. This function will
-    repackage the given flat `args` into its original data structures using
-    `repack`, execute any Dask subtasks within the repackaged arguments
-    (inlined by Dask's optimization pass), and then pass the concrete task
-    arguments to the provide Dask task function, `func`.
+    repackage the given `arg_object_refs` into its original `deps` using
+    `repack`, and then pass it to the provided Dask Task object , `task`.
 
     Args:
-        func: The Dask task function to execute.
+        task: The Dask Task class object to execute.
         repack: A function that repackages the provided args into
             the original (possibly nested) Python objects.
         key: The Dask key for this task.
         ray_pretask_cbs: Pre-task execution callbacks.
         ray_posttask_cbs: Post-task execution callback.
-        *args (ObjectRef): Ray object references representing the Dask task's
-            arguments.
+        *arg_object_refs (ObjectRef): Ray object references representing the dependencies'
+            results.
 
     Returns:
         The output of the Dask task. In the context of Ray, a
@@ -424,13 +452,31 @@ def dask_task_wrapper(func, repack, key, ray_pretask_cbs, ray_posttask_cbs, *arg
     """
     if ray_pretask_cbs is not None:
         pre_states = [
-            cb(key, args) if cb is not None else None for cb in ray_pretask_cbs
+            cb(key, arg_object_refs) if cb is not None else None
+            for cb in ray_pretask_cbs
         ]
-    repacked_args, repacked_deps = repack(args)
-    # Recursively execute Dask-inlined tasks.
-    actual_args = [_execute_task(a, repacked_deps) for a in repacked_args]
-    # Execute the actual underlying Dask task.
-    result = func(*actual_args)
+    (repacked_deps,) = repack(arg_object_refs)
+    # De-reference the potentially nested arguments recursively.
+    def _dereference_args(x):
+        if isinstance(x, Task):
+            x.args = _dereference_args(x.args)
+            return x
+        elif isinstance(x, Mapping):
+            return {k: _dereference_args(v) for k, v in x.items()}
+        elif isinstance(x, tuple):
+            return tuple(_dereference_args(x) for x in x)
+        elif isinstance(x, ray.ObjectRef):
+            return ray.get(x)
+        elif isinstance(x, DataNode):
+            if isinstance(x.value, ray.ObjectRef):
+                value = ray.get(x.value)
+                return DataNode(key=x.key, value=value)
+            return x
+        else:
+            return x
+
+    task = _dereference_args(task)
+    result = task(repacked_deps)
 
     if ray_posttask_cbs is not None:
         for cb, pre_state in zip(ray_posttask_cbs, pre_states):
@@ -548,6 +594,8 @@ def ray_dask_get_sync(dsk, keys, **kwargs):
             ray_postsubmit_all_cbs,
             ray_finish_cbs,
         ) = unpack_ray_callbacks(ray_callbacks)
+        # Make sure the graph is in the new format
+        dsk = convert_legacy_graph(dsk)
         # NOTE: We hijack Dask's `get_async` function, injecting a different
         # task executor.
         object_refs = get_async(

--- a/python/ray/util/dask/scheduler_utils.py
+++ b/python/ray/util/dask/scheduler_utils.py
@@ -4,11 +4,21 @@ The following is adapted from Dask release 2021.03.1:
 """
 
 import os
+import warnings
 from queue import Queue, Empty
 
+import dask
 from dask import config
+
+try:
+    from dask._task_spec import DataNode, DependenciesMapping
+except ImportError:
+    warnings.warn(
+        "Dask on Ray is available only on dask>=2024.11.0, "
+        f"you are on version {dask.__version__}."
+    )
 from dask.callbacks import local_callbacks, unpack_callbacks
-from dask.core import _execute_task, flatten, get_dependencies, has_tasks, reverse_dict
+from dask.core import flatten, get_dependencies, reverse_dict
 from dask.order import order
 
 if os.name == "nt":
@@ -56,17 +66,18 @@ def start_state_from_dask(dsk, cache=None, sortkey=None):
         cache = config.get("cache", None)
     if cache is None:
         cache = dict()
+
     data_keys = set()
     for k, v in dsk.items():
-        if not has_tasks(dsk, v):
-            cache[k] = v
+        if isinstance(v, DataNode):
+            cache[k] = v()
             data_keys.add(k)
 
     dsk2 = dsk.copy()
     dsk2.update(cache)
 
-    dependencies = {k: get_dependencies(dsk2, k) for k in dsk}
-    waiting = {k: v.copy() for k, v in dependencies.items() if k not in data_keys}
+    dependencies = DependenciesMapping(dsk)
+    waiting = {k: set(v) for k, v in dependencies.items() if k not in data_keys}
 
     dependents = reverse_dict(dependencies)
     for a in cache:
@@ -102,7 +113,7 @@ def execute_task(key, task_info, dumps, loads, get_id, pack_exception):
     """
     try:
         task, data = loads(task_info)
-        result = _execute_task(task, data)
+        result = task(data)
         id = get_id()
         result = dumps((result, id))
         failed = False
@@ -220,7 +231,7 @@ def get_async(
     callbacks=None,
     dumps=identity,
     loads=identity,
-    **kwargs
+    **kwargs,
 ):
     """Asynchronous get function
     This is a general version of various asynchronous schedulers for dask.  It
@@ -339,7 +350,7 @@ def get_async(
                             for dep in get_dependencies(dsk, key)
                         }
                         task = dsk[key]
-                        _execute_task(task, data)  # Re-execute locally
+                        task(data)  # Re-execute locally
                     else:
                         raise_exception(exc, tb)
                 res, worker_id = loads(res_info)

--- a/python/ray/util/dask/tests/test_dask_callback.py
+++ b/python/ray/util/dask/tests/test_dask_callback.py
@@ -8,10 +8,6 @@ import ray
 from ray.tests.conftest import *  # noqa: F403, F401
 from ray.util.dask import ray_dask_get, RayDaskCallback
 
-pytestmark = pytest.mark.skipif(
-    sys.version_info >= (3, 12), reason="Skip dask tests for Python version 3.12+"
-)
-
 
 @dask.delayed
 def add(x, y):

--- a/python/ray/util/dask/tests/test_dask_optimization.py
+++ b/python/ray/util/dask/tests/test_dask_optimization.py
@@ -2,21 +2,33 @@ import sys
 
 import dask
 import dask.dataframe as dd
-from dask.dataframe.shuffle import SimpleShuffleLayer
 from unittest import mock
 import numpy as np
 import pandas as pd
 import pytest
+from packaging.version import Version
 
 from ray.tests.conftest import *  # noqa
 from ray.util.dask import dataframe_optimize
-from ray.util.dask.optimizations import (
-    rewrite_simple_shuffle_layer,
-    MultipleReturnSimpleShuffleLayer,
-)
+
+try:
+    import dask_expr  # noqa: F401
+
+    DASK_EXPR_INSTALLED = True
+except ImportError:
+    DASK_EXPR_INSTALLED = False
+    pass
+
+if Version(dask.__version__) < Version("2025.1") and not DASK_EXPR_INSTALLED:
+    from dask.dataframe.shuffle import SimpleShuffleLayer
+    from ray.util.dask.optimizations import (
+        rewrite_simple_shuffle_layer,
+        MultipleReturnSimpleShuffleLayer,
+    )
 
 pytestmark = pytest.mark.skipif(
-    sys.version_info >= (3, 12), reason="Skip dask tests for Python version 3.12+"
+    Version(dask.__version__) >= Version("2025.1") or DASK_EXPR_INSTALLED,
+    reason="Skip dask tests for Dask 2025.1+",
 )
 
 

--- a/python/ray/util/dask/tests/test_dask_scheduler.py
+++ b/python/ray/util/dask/tests/test_dask_scheduler.py
@@ -13,10 +13,6 @@ from ray.util.client.common import ClientObjectRef
 from ray.util.dask import disable_dask_on_ray, enable_dask_on_ray, ray_dask_get
 from ray.util.dask.callbacks import ProgressBarCallback
 
-pytestmark = pytest.mark.skipif(
-    sys.version_info >= (3, 12), reason="Skip dask tests for Python version 3.12+"
-)
-
 
 @pytest.fixture
 def ray_enable_dask_on_ray():
@@ -90,10 +86,10 @@ def test_sort_with_progress_bar(ray_start_regular_shared):
     sorted_without_pb = None
     with ProgressBarCallback():
         sorted_with_pb = df.set_index(
-            ["age"], shuffle="tasks", max_branch=npartitions
+            ["age"], shuffle_method="tasks", max_branch=npartitions
         ).compute(scheduler=ray_dask_get, _ray_enable_progress_bar=True)
     sorted_without_pb = df.set_index(
-        ["age"], shuffle="tasks", max_branch=npartitions
+        ["age"], shuffle_method="tasks", max_branch=npartitions
     ).compute(scheduler=ray_dask_get)
     assert sorted_with_pb.equals(sorted_without_pb)
 

--- a/python/requirements/ml/data-requirements.txt
+++ b/python/requirements/ml/data-requirements.txt
@@ -2,13 +2,14 @@
 # https://github.com/ray-project/ray/pull/29448#discussion_r1006256498
 
 getdaft==0.4.3
-dask[complete]==2022.10.2; python_version < '3.12'
-distributed==2022.10.2; python_version < '3.12'
-dask[complete]==2024.6.0; python_version >= '3.12'
-distributed==2024.6.0; python_version >= '3.12'
+dask[complete]==2023.6.1; python_version < '3.12'
+distributed==2023.6.1; python_version < '3.12'
+dask[complete]==2025.5.0; python_version >= '3.12'
+distributed==2025.5.0; python_version >= '3.12'
 aioboto3==11.2.0
 crc32c==2.3
 flask_cors
+bokeh==2.4.3; python_version < '3.12'
 modin==0.22.2; python_version < '3.12'
 pandas==1.5.3; python_version < '3.12'
 modin==0.31.0; python_version >= '3.12'

--- a/python/requirements/test-requirements.txt
+++ b/python/requirements/test-requirements.txt
@@ -12,7 +12,10 @@ msrestazure==0.6.4
 beautifulsoup4==4.11.1
 boto3==1.26.76
 # Todo: investigate if we can get rid of this and exchange for ray.cloudpickle
-cloudpickle==2.2.0
+cloudpickle==2.2.0 ; python_version < "3.12"
+cloudpickle==3.0.0 ; python_version >= "3.12"
+tornado==6.1 ; python_version < "3.12"
+tornado==6.2.0 ; python_version >= "3.12"
 cython==0.29.37
 fastapi>=0.115.12
 feather-format==0.4.1

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -201,8 +201,10 @@ black==22.10.0
     # via -r python/requirements/lint-requirements.txt
 bleach==6.1.0
     # via nbconvert
-bokeh==2.4.3
-    # via dask
+bokeh==2.4.3 ; python_version < "3.12"
+    # via
+    #   -r python/requirements/ml/data-requirements.txt
+    #   dask
 boltons==21.0.0
     # via
     #   face
@@ -294,7 +296,7 @@ click-option-group==0.5.6
     # via semgrep
 clickhouse-connect==0.8.10
     # via -r python/requirements/ml/data-test-requirements.txt
-cloudpickle==2.2.0
+cloudpickle==2.2.0 ; python_version < "3.12"
     # via
     #   -r python/requirements/test-requirements.txt
     #   dask
@@ -372,7 +374,7 @@ cython==0.29.37
     # via
     #   -r python/requirements/test-requirements.txt
     #   gpy
-dask==2022.10.2 ; python_version < "3.12"
+dask==2023.6.1 ; python_version < "3.12"
     # via
     #   -r python/requirements/ml/data-requirements.txt
     #   distributed
@@ -383,7 +385,6 @@ datasets==2.19.1
     #   -r python/requirements/ml/data-test-requirements.txt
     #   -r python/requirements/ml/train-requirements.txt
     #   evaluate
-    #   mosaicml
 debugpy==1.8.0
     # via ipykernel
 decorator==5.1.1
@@ -418,7 +419,7 @@ dill==0.3.7
     #   multiprocess
 distlib==0.3.7
     # via virtualenv
-distributed==2022.10.2 ; python_version < "3.12"
+distributed==2023.6.1 ; python_version < "3.12"
     # via
     #   -r python/requirements/ml/data-requirements.txt
     #   dask
@@ -568,7 +569,7 @@ fugue-sql-antlr==0.2.0
     # via fugue
 future==1.0.0
     # via -r python/requirements/ml/tune-requirements.txt
-gast==0.4.0
+gast==0.6.0
     # via
     #   tensorflow
     #   tensorflow-probability
@@ -783,6 +784,7 @@ imagesize==1.4.1
 importlib-metadata==6.11.0
     # via
     #   -r python/requirements/test-requirements.txt
+    #   dask
     #   jupyter-cache
     #   mlflow-skinny
     #   myst-nb
@@ -968,7 +970,7 @@ lazy-loader==0.4
     # via scikit-image
 lazy-object-proxy==1.9.0
     # via openapi-spec-validator
-libclang==16.0.6
+libclang==18.1.1
     # via tensorflow
 lightgbm==4.6.0
     # via -r python/requirements/ml/core-requirements.txt
@@ -998,6 +1000,7 @@ lz4==4.3.3
     # via
     #   -r python/requirements.txt
     #   clickhouse-connect
+    #   dask
 mako==1.3.0
     # via alembic
 markdown==3.5.1
@@ -1035,8 +1038,6 @@ mdit-py-plugins==0.3.5
     #   myst-parser
 mdurl==0.1.2
     # via markdown-it-py
-medpy==0.4.0
-    # via mosaicml
 memray==1.10.0 ; platform_system != "Windows" and sys_platform != "darwin" and platform_machine != "aarch64"
     # via
     #   -r python/requirements.txt
@@ -1059,15 +1060,13 @@ mmh3==4.1.0
     # via pyiceberg
 modin==0.22.2 ; python_version < "3.12"
     # via -r python/requirements/ml/data-requirements.txt
-monai==1.3.2
-    # via mosaicml
 monotonic==1.6
     # via
     #   gsutil
     #   segment-analytics-python
-more-itertools==10.1.0
+more-itertools==10.7.0
     # via configspace
-mosaicml==0.2.4 ; python_version < "3.12"
+mosaicml==0.3.1 ; python_version < "3.12"
     # via -r python/requirements/ml/train-test-requirements.txt
 moto==4.2.12
     # via -r python/requirements/test-requirements.txt
@@ -1224,13 +1223,11 @@ numpy==1.26.4
     #   labmaze
     #   lightgbm
     #   matplotlib
-    #   medpy
     #   minigrid
     #   ml-dtypes
     #   mlagents-envs
     #   mlflow
     #   modin
-    #   monai
     #   moviepy
     #   msgpack-numpy
     #   mujoco
@@ -1578,6 +1575,7 @@ py4j==0.10.9.7
 pyarrow==14.0.2
     # via
     #   -r python/requirements.txt
+    #   dask
     #   datasets
     #   delta-sharing
     #   deltalake
@@ -1718,7 +1716,7 @@ pytest-asyncio==0.17.2
     #   pytest-aiohttp
 pytest-docker-tools==3.1.3
     # via -r python/requirements/test-requirements.txt
-pytest-fixture-config==1.7.0
+pytest-fixture-config==1.8.0
     # via pytest-virtualenv
 pytest-forked==1.4.0
     # via -r python/requirements/test-requirements.txt
@@ -1909,7 +1907,7 @@ responses==0.13.4
     # via
     #   -r python/requirements/ml/data-requirements.txt
     #   moto
-restrictedpython==7.1
+restrictedpython==8.0
     # via aim
 retry-decorator==1.1.1
     # via
@@ -1970,7 +1968,6 @@ scikit-learn==1.3.2
     #   bayesian-optimization
     #   gpytorch
     #   mlflow
-    #   mosaicml
     #   pymars
     #   torch-geometric
 scipy==1.11.4
@@ -1986,7 +1983,6 @@ scipy==1.11.4
     #   hyperopt
     #   lightgbm
     #   linear-operator
-    #   medpy
     #   mlflow
     #   open-spiel
     #   paramz
@@ -2032,8 +2028,6 @@ shimmy==2.0.0
     # via -r python/requirements/ml/rllib-test-requirements.txt
 shortuuid==1.0.1
     # via -r python/requirements/ml/tune-test-requirements.txt
-simpleitk==2.3.1
-    # via medpy
 simplejson==3.19.2
     # via comet-ml
 six==1.16.0
@@ -2253,7 +2247,6 @@ torch==2.3.0
     #   deepspeed
     #   fairscale
     #   linear-operator
-    #   monai
     #   mosaicml
     #   pyro-ppl
     #   pytorch-lightning
@@ -2267,7 +2260,7 @@ torch-cluster==1.6.3
     # via -r python/requirements/ml/dl-cpu-requirements.txt
 torch-geometric==2.5.3
     # via -r python/requirements/ml/dl-cpu-requirements.txt
-torch-optimizer==0.3.0
+torch-optimizer==0.1.0
     # via mosaicml
 torch-scatter==2.1.2
     # via -r python/requirements/ml/dl-cpu-requirements.txt
@@ -2287,8 +2280,9 @@ torchvision==0.18.0
     #   -r python/requirements/ml/dl-cpu-requirements.txt
     #   mosaicml
     #   timm
-tornado==6.1
+tornado==6.1 ; python_version < "3.12"
     # via
+    #   -r python/requirements/test-requirements.txt
     #   bokeh
     #   distributed
     #   ipykernel
@@ -2342,9 +2336,7 @@ traitlets==5.14.3
     #   nbformat
     #   notebook
 transformers==4.36.2
-    # via
-    #   -r python/requirements/ml/core-requirements.txt
-    #   mosaicml
+    # via -r python/requirements/ml/core-requirements.txt
 triad==0.9.8
     # via
     #   adagio
@@ -2431,7 +2423,7 @@ uvicorn==0.22.0
     #   aim
     #   gradio
     #   mlflow-skinny
-uvloop==0.19.0
+uvloop==0.21.0
     # via pymars
     # via
     #   nsx-policy-python-sdk


### PR DESCRIPTION
"Dask on Ray" (DoR) is broken in dask==2024.11.0 or later as reported in https://github.com/ray-project/ray/issues/48689 because Dask removed a private function in https://github.com/dask/dask/pull/11378 that DoR has been relying on. Not only https://github.com/dask/dask/pull/11378, Dask has migrated their task data structure to a new format (the high-level motivation is described in https://github.com/dask/dask/issues/9969). Since this migration spans across a series of PRs between 2024.11.0 and 2025.1.0, it's not realistic to copy what's been removed and paste them in Ray.

This PR adapts Dask on Ray to the change to keep its functionality.
The current PR as of 7c9def3 is compatible only with `dask>=2024.11.0,<2025.1.0` because Dask made another major change in 2025.1.0, breaking the shuffle optimization introduced in https://github.com/ray-project/ray/pull/13951.
I can make further changes in this PR if we want to support `dask>=2025.1.0` and drop support `dask<2025.1.0`. Supporting both would technically be possible but that would make codebase complicated. Let me know how Ray would like to approach this.
