### PR TITLE
[data] Remove asserts that test internal `ds._block_num_rows()`

### DIFF
--- a/python/ray/data/tests/test_repartition_e2e.py
+++ b/python/ray/data/tests/test_repartition_e2e.py
@@ -16,21 +16,19 @@ def test_repartition_shuffle(
     ds = ray.data.range(20, override_num_blocks=10)
     assert ds._plan.initial_num_blocks() == 10
     assert ds.sum() == 190
-    assert ds._block_num_rows() == [2] * 10
 
     ds2 = ds.repartition(5, shuffle=True)
     assert ds2._plan.initial_num_blocks() == 5
     assert ds2.sum() == 190
-    assert ds2._block_num_rows() == [10, 10, 0, 0, 0]
 
     ds3 = ds2.repartition(20, shuffle=True)
     assert ds3._plan.initial_num_blocks() == 20
     assert ds3.sum() == 190
-    assert ds3._block_num_rows() == [2] * 10 + [0] * 10
 
     large = ray.data.range(10000, override_num_blocks=10)
     large = large.repartition(20, shuffle=True)
-    assert large._block_num_rows() == [500] * 20
+    assert large._plan.initial_num_blocks() == 20
+    assert large.sum() == 49995000
 
 
 def test_key_based_repartition_shuffle(
@@ -107,21 +105,19 @@ def test_repartition_shuffle_arrow(
     ds = ray.data.range(20, override_num_blocks=10)
     assert ds._plan.initial_num_blocks() == 10
     assert ds.count() == 20
-    assert ds._block_num_rows() == [2] * 10
 
     ds2 = ds.repartition(5, shuffle=True)
     assert ds2._plan.initial_num_blocks() == 5
     assert ds2.count() == 20
-    assert ds2._block_num_rows() == [10, 10, 0, 0, 0]
 
     ds3 = ds2.repartition(20, shuffle=True)
     assert ds3._plan.initial_num_blocks() == 20
     assert ds3.count() == 20
-    assert ds3._block_num_rows() == [2] * 10 + [0] * 10
 
     large = ray.data.range(10000, override_num_blocks=10)
     large = large.repartition(20, shuffle=True)
-    assert large._block_num_rows() == [500] * 20
+    assert large._plan.initial_num_blocks() == 20
+    assert large.count() == 10000
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why are these changes needed?
We don't need to assert that the repartition behavior structures block / rows in an exact way.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
