### PR TITLE
[data] split dask and modin tests

### DIFF
--- a/python/ray/data/BUILD
+++ b/python/ray/data/BUILD
@@ -464,10 +464,25 @@ py_test(
 )
 
 py_test(
-    name = "test_ecosystem",
+    name = "test_ecosystem_modin",
     size = "small",
-    srcs = ["tests/test_ecosystem.py"],
+    srcs = ["tests/test_ecosystem_modin.py"],
     tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
+    name = "test_ecosystem_dask",
+    size = "small",
+    srcs = ["tests/test_ecosystem_dask.py"],
+    tags = [
+        "dask",
         "exclusive",
         "team:data",
     ],

--- a/python/ray/data/tests/test_ecosystem_dask.py
+++ b/python/ray/data/tests/test_ecosystem_dask.py
@@ -149,33 +149,5 @@ def test_to_dask_tensor_column_cast_arrow(ray_start_regular_shared):
         ctx.enable_tensor_extension_casting = original
 
 
-def test_from_modin(ray_start_regular_shared):
-    import modin.pandas as mopd
-
-    df = pd.DataFrame(
-        {"one": list(range(100)), "two": list(range(100))},
-    )
-    modf = mopd.DataFrame(df)
-    ds = ray.data.from_modin(modf)
-    dfds = ds.to_pandas()
-    assert df.equals(dfds)
-
-
-def test_to_modin(ray_start_regular_shared):
-    # create two modin dataframes
-    # one directly from a pandas dataframe, and
-    # another from ray.dataset created from the original pandas dataframe
-    #
-    import modin.pandas as mopd
-
-    df = pd.DataFrame(
-        {"one": list(range(100)), "two": list(range(100))},
-    )
-    modf1 = mopd.DataFrame(df)
-    ds = ray.data.from_pandas([df])
-    modf2 = ds.to_modin()
-    assert modf1.equals(modf2)
-
-
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/tests/test_ecosystem_modin.py
+++ b/python/ray/data/tests/test_ecosystem_modin.py
@@ -1,0 +1,40 @@
+import sys
+
+import pandas as pd
+import pytest
+
+import ray
+from ray.data.tests.conftest import *  # noqa
+from ray.tests.conftest import *  # noqa
+
+
+def test_from_modin(ray_start_regular_shared):
+    import modin.pandas as mopd
+
+    df = pd.DataFrame(
+        {"one": list(range(100)), "two": list(range(100))},
+    )
+    modf = mopd.DataFrame(df)
+    ds = ray.data.from_modin(modf)
+    dfds = ds.to_pandas()
+    assert df.equals(dfds)
+
+
+def test_to_modin(ray_start_regular_shared):
+    # create two modin dataframes
+    # one directly from a pandas dataframe, and
+    # another from ray.dataset created from the original pandas dataframe
+    #
+    import modin.pandas as mopd
+
+    df = pd.DataFrame(
+        {"one": list(range(100)), "two": list(range(100))},
+    )
+    modf1 = mopd.DataFrame(df)
+    ds = ray.data.from_pandas([df])
+    modf2 = ds.to_modin()
+    assert modf1.equals(modf2)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
as dask tests will require running on python 3.12+ after upgrade; modin does not

also adds `dask` tag, for running on a separate test job in the future.