### PR TITLE
[core] Deflake `test_scheduling.py` in client mode

### DIFF
--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -390,6 +390,8 @@ def test_locality_aware_leasing_cached_objects(ray_start_cluster):
 
 def test_locality_aware_leasing_borrowed_objects(ray_start_cluster):
     """Test that a task runs where its dependencies are located for borrowed objects."""
+    is_ray_client_test = ray._private.client_mode_hook.is_client_mode_enabled
+
     # This test ensures that a task will run where its task dependencies are
     # located, even when those objects are borrowed.
     cluster = ray_start_cluster
@@ -411,6 +413,9 @@ def test_locality_aware_leasing_borrowed_objects(ray_start_cluster):
     @ray.remote(num_cpus=0)
     def borrower(o: List[ray.ObjectRef]) -> str:
         obj_ref = o[0]
+        if is_ray_client_test:
+            ray.wait([obj_ref], fetch_local=False)
+
         return ray.get(get_node_id.remote(obj_ref))
 
     # The result of worker_node_ref will be pinned on the worker node.
@@ -422,7 +427,11 @@ def test_locality_aware_leasing_borrowed_objects(ray_start_cluster):
 
     # Ensure the owner has object info prior to scheduling the task so the object info
     # will be inlined to the borrower.
-    ray.wait([worker_node_ref], fetch_local=False)
+    # NOTE(edoakes): Ray Client does not respect `fetch_local=False`, so this pulls the
+    # object to the head node. We instead test a slightly weaker condition by moving the
+    # `ray.wait` call to resolve the location inside of the borrower task (see above).
+    if not is_ray_client_test:
+        ray.wait([worker_node_ref], fetch_local=False)
 
     # Run a borrower task on the head node. From within the borrower task, we launch
     # another task. That inner task should run on the worker node based on locality.


### PR DESCRIPTION
`test_locality_aware_borrowed_objects` is flaking in postmerge: https://buildkite.com/ray-project/postmerge/builds/11069#0197aaa0-d2d1-4a49-b505-8af58a44a57b/6-143

After some local testing/digging, I found that this is caused by the fact that `fetch_local=False` is not respected for Ray Client, meaning that the object was available on both the head and worker nodes. I modified the test under Ray Client conditions to instead call `ray.wait` to resolve object locations inside of the borrower task.