### PR TITLE
[core] fix checking for uv existence during ray_runtime setup

### DIFF
--- a/python/ray/_private/runtime_env/uv.py
+++ b/python/ray/_private/runtime_env/uv.py
@@ -151,7 +151,7 @@ class UvProcessor:
         requirements_file = dependency_utils.get_requirements_file(path, uv_packages)
 
         # Check existence for `uv` and see if we could skip `uv` installation.
-        uv_exists = await self._check_uv_existence(python, cwd, pip_env, logger)
+        uv_exists = await self._check_uv_existence(path, cwd, pip_env, logger)
 
         # Install uv, which acts as the default package manager.
         if (not uv_exists) or (self._uv_config.get("uv_version", None) is not None):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Without this fix, Ray cannot install packages when installed in a virtual environment that is created via `uv` in a "default way" (i.e.`uv venv`).

The `_install_uv_packages()` function incorrectly uses the path to the Python executable rather than the virtual environment path when calling `_check_uv_existence()`. In turn, `_check_uv_existence()` always returns `False`, even if `uv` is actually installed.

Additionally, when `uv` is either missing or a specific version is requested, Ray attempts to install it using `python -m pip`. However, in a standard `uv` virtual environment, the `pip` module is not available, causing this command to raise an exception.


## Related issue number

Closes #54134 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
