### PR TITLE
[data] Add timeout for `test_arrow_block_scaling.py`

### DIFF
--- a/python/ray/data/tests/test_arrow_block_scaling.py
+++ b/python/ray/data/tests/test_arrow_block_scaling.py
@@ -52,6 +52,7 @@ def parquet_dataset_single_column_gt_2gb():
         "map_batches",
     ],
 )
+@pytest.mark.timeout(300)
 def test_arrow_batch_gt_2gb(
     ray_start_regular,
     parquet_dataset_single_column_gt_2gb,


### PR DESCRIPTION
## Why are these changes needed?
The latest test splitting did not fully mitigate the failures, attempting to increase the timeout from 180s to 300s to decrease failures.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
