### PR TITLE
Remove `botocore` dependency in Ray Serve LLM

### DIFF
--- a/python/ray/llm/_internal/serve/observability/usage_telemetry/usage.py
+++ b/python/ray/llm/_internal/serve/observability/usage_telemetry/usage.py
@@ -1,9 +1,6 @@
 from enum import Enum
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Sequence
 
-# TODO (genesu): remove dependency on botocore
-from botocore.exceptions import ClientError
-
 import ray
 from ray import serve
 from ray._private.usage.usage_lib import (
@@ -254,19 +251,12 @@ def push_telemetry_report_for_all_models(
         )
         initial_num_lora_adapters = 0
         if use_lora:
-            # This try-except block is used to handle the case where the Lora model IDs
-            # cannot be fetched. In such cases, the telemetry report will be pushed with
-            # 0 initial Lora adapters.
-            try:
-                lora_model_ids = get_lora_model_func(
-                    dynamic_lora_loading_path=model.lora_config.dynamic_lora_loading_path,
-                    base_model_id=model.model_id,
-                )
-                initial_num_lora_adapters = len(lora_model_ids)
-            except ClientError as e:
-                logger.error(
-                    f"Failed to get Lora model IDs for model {model.model_id}: {e}"
-                )
+            lora_model_ids = get_lora_model_func(
+                dynamic_lora_loading_path=model.lora_config.dynamic_lora_loading_path,
+                base_model_id=model.model_id,
+            )
+            initial_num_lora_adapters = len(lora_model_ids)
+
         use_autoscaling = model.deployment_config.get("autoscaling_config") is not None
         num_replicas, min_replicas, max_replicas = 1, 1, 1
         if use_autoscaling:

--- a/python/ray/llm/tests/common/utils/test_cloud_utils.py
+++ b/python/ray/llm/tests/common/utils/test_cloud_utils.py
@@ -361,6 +361,19 @@ class TestCloudFileSystem:
         folders = CloudFileSystem.list_subfolders("gs://bucket/parent")
         assert sorted(folders) == ["dir1", "dir2"]
 
+    @patch("ray.llm._internal.common.utils.cloud_utils.CloudFileSystem.get_fs_and_path")
+    def test_list_subfolders_exception_handling(self, mock_get_fs_and_path):
+        """Test that list_subfolders returns empty list when get_fs_and_path raises exception."""
+        # Make get_fs_and_path raise an exception
+        mock_get_fs_and_path.side_effect = ValueError("Example exception")
+
+        # Test that list_subfolders handles the exception gracefully
+        folders = CloudFileSystem.list_subfolders("gs://bucket/parent")
+        assert folders == []
+
+        # Verify get_fs_and_path was called
+        mock_get_fs_and_path.assert_called_once_with("gs://bucket/parent/")
+
     @patch("pyarrow.fs.S3FileSystem")
     def test_download_files(self, mock_s3fs):
         """Test downloading files from cloud storage."""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Superfluous `botocore` dependency; the default value for `get_lora_model_func`, `get_lora_model_ids`, swallows all exceptions and returns an empty list. I.e., `ClientError` is never seen.

## Related issue number

Closes #53052

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
