### PR TITLE
[doc] fix broken links in the vllm guide

### DIFF
--- a/doc/source/cluster/kubernetes/examples/vllm-rayservice.md
+++ b/doc/source/cluster/kubernetes/examples/vllm-rayservice.md
@@ -44,10 +44,10 @@ This guide references this secret as an environment variable in the RayCluster u
 
 Create a RayService custom resource:
 ```
-kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/master/ray-operator/config/samples/vllm/ray-service.vllm.yaml
+kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/v1.3.2/ray-operator/config/samples/vllm/ray-service.vllm.yaml
 ```
 
-This step configures RayService to deploy a Ray Serve app, running vLLM as the serving engine for the Llama 3 8B Instruct model. You can find the code for this example [on GitHub](https://github.com/ray-project/kuberay/blob/master/ray-operator/config/samples/vllm/serve.py).
+This step configures RayService to deploy a Ray Serve app, running vLLM as the serving engine for the Llama 3 8B Instruct model. You can find the code for this example [on GitHub](https://github.com/ray-project/kuberay/blob/v1.3.2/ray-operator/config/samples/vllm/serve.py).
 You can inspect the Serve Config for more details about the Serve deployment:
 ```yaml
   serveConfigV2: |
@@ -62,7 +62,7 @@ You can inspect the Serve Config for more details about the Serve deployment:
           num_cpus: 8
           # NOTE: num_gpus is set automatically based on TENSOR_PARALLELISM
       runtime_env:
-        working_dir: "https://github.com/ray-project/kuberay/archive/master.zip"
+        working_dir: "https://github.com/ray-project/kuberay/archive/v1.3.2.zip"
         pip: ["vllm==0.5.4"]
         env_vars:
           MODEL_ID: "meta-llama/Meta-Llama-3-8B-Instruct"


### PR DESCRIPTION
## Why are these changes needed?

Those links in the guide have been deleted from the KubeRay repository. This [vllm-rayservice.md](https://github.com/ray-project/ray/compare/releases/2.47.1...rueian:ray:2.47.1-fix-vllm-md?expand=1#diff-9519bc2bf201581ab0711d01434ec078fb5e3fcbbd06353b4cb312f6ffb30837) guide is already deleted from the master branch of the Ray repository actually. However, it is still listed in the default `latest` documentation.

This PR corrects those links by specifying an old KubeRay repository version.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
