### PR TITLE
[Data] Fix the issue where data files written by different tasks have the same file name when using Iceberg sink. 

### DIFF
--- a/python/ray/data/tests/test_iceberg.py
+++ b/python/ray/data/tests/test_iceberg.py
@@ -258,6 +258,37 @@ def test_write_basic():
     assert orig_table_p.equals(table_p)
 
 
+@pytest.mark.skipif(
+    get_pyarrow_version() < parse_version("14.0.0"),
+    reason="PyIceberg 0.7.0 fails on pyarrow <= 14.0.0",
+)
+def test_write_with_multi_task():
+
+    sql_catalog = pyi_catalog.load_catalog(**_CATALOG_KWARGS)
+    table = sql_catalog.load_table(f"{_DB_NAME}.{_TABLE_NAME}")
+    table.delete()
+
+    ds = ray.data.from_arrow(create_pa_table())
+    ds.repartition(num_blocks=2).write_iceberg(
+        table_identifier=f"{_DB_NAME}.{_TABLE_NAME}",
+        catalog_kwargs=_CATALOG_KWARGS.copy(),
+    )
+
+    # Read the raw table from PyIceberg after writing
+    table = sql_catalog.load_table(f"{_DB_NAME}.{_TABLE_NAME}")
+    orig_table_p = (
+        table.scan()
+        .to_pandas()
+        .sort_values(["col_a", "col_b", "col_c"])
+        .reset_index(drop=True)
+    )
+
+    table_p = (
+        ds.to_pandas().sort_values(["col_a", "col_b", "col_c"]).reset_index(drop=True)
+    )
+    assert orig_table_p.equals(table_p)
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

When using write_iceberg, different write tasks use the same filename, resulting in the datafile being overwritten and incorrect data being written.

## Related issue number
 (#52967)
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
