### PR TITLE
[core] Add timeouts to `test_scheduling.py::test_hybrid_policy`

### DIFF
--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -94,26 +94,18 @@ def test_hybrid_policy(ray_start_cluster):
 
     # Submit 1 * PER_NODE_HYBRID_THRESHOLD tasks.
     # They should all be packed on the local node.
-    print("[1.0] Submitting batch of tasks.")
     refs = [get_node_id.remote() for _ in range(PER_NODE_HYBRID_THRESHOLD)]
-    print("[1.1] Acquire block_driver semaphore.")
     ray.get([block_driver.acquire.remote() for _ in refs], timeout=20)
-    print("[1.2] Release block_task semaphore.")
     ray.get([block_task.release.remote() for _ in refs], timeout=20)
-    print("[1.3] Get refs.")
     nodes = ray.get(refs, timeout=20)
     assert len(set(nodes)) == 1
 
     # Submit 2 * PER_NODE_HYBRID_THRESHOLD tasks.
     # The first PER_NODE_HYBRID_THRESHOLD tasks should be packed on the local node, then
     # the second PER_NODE_HYBRID_THRESHOLD tasks should be packed on the remote node.
-    print("[2.0] Submitting batch of tasks.")
     refs = [get_node_id.remote() for _ in range(int(PER_NODE_HYBRID_THRESHOLD * 2))]
-    print("[2.1] Acquire block_driver semaphore.")
     ray.get([block_driver.acquire.remote() for _ in refs], timeout=20)
-    print("[2.2] Release block_task semaphore.")
     ray.get([block_task.release.remote() for _ in refs], timeout=20)
-    print("[2.3] Get refs.")
     counter = collections.Counter(ray.get(refs, timeout=20))
     assert all(v == PER_NODE_HYBRID_THRESHOLD for v in counter.values()), counter
 
@@ -121,13 +113,9 @@ def test_hybrid_policy(ray_start_cluster):
     # Once all nodes are past the hybrid threshold we round robin.
     # TODO(wuisawesome): Ideally we could schedule less than 20 nodes here, but the
     # policy is imperfect if a resource report interrupts the process.
-    print("[3.0] Submitting batch of tasks.")
     refs = [get_node_id.remote() for _ in range(int(NUM_CPUS_PER_NODE * NUM_NODES))]
-    print("[3.1] Acquire block_driver semaphore.")
     ray.get([block_driver.acquire.remote() for _ in refs], timeout=20)
-    print("[3.2] Release block_task semaphore.")
     ray.get([block_task.release.remote() for _ in refs], timeout=20)
-    print("[3.3] Get refs.")
     counter = collections.Counter(ray.get(refs, timeout=20))
     assert all(v == NUM_CPUS_PER_NODE for v in counter.values()), counter
 

--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -403,7 +403,6 @@ def test_locality_aware_leasing_cached_objects(ray_start_cluster):
 def test_locality_aware_leasing_borrowed_objects(ray_start_cluster):
     """Test that a task runs where its dependencies are located for borrowed objects."""
     is_ray_client_test = ray._private.client_mode_hook.is_client_mode_enabled
-    print("CLIENT?", is_ray_client_test)
 
     # This test ensures that a task will run where its task dependencies are
     # located, even when those objects are borrowed.

--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -96,16 +96,24 @@ def test_hybrid_policy(ray_start_cluster):
         return ray._private.worker.global_worker.current_node_id
 
     # Below the hybrid threshold we pack on the local node first.
+    print("[1.0] Submitting batch of tasks.")
     refs = [get_node.remote() for _ in range(5)]
+    print("[1.1] Acquire block_driver semaphore.")
     ray.get([block_driver.acquire.remote() for _ in refs])
+    print("[1.2] Release block_task semaphore.")
     ray.get([block_task.release.remote() for _ in refs])
+    print("[1.3] Get refs.")
     nodes = ray.get(refs)
     assert len(set(nodes)) == 1
 
     # We pack the second node to the hybrid threshold.
+    print("[2.0] Submitting batch of tasks.")
     refs = [get_node.remote() for _ in range(10)]
+    print("[2.1] Acquire block_driver semaphore.")
     ray.get([block_driver.acquire.remote() for _ in refs])
+    print("[2.2] Release block_task semaphore.")
     ray.get([block_task.release.remote() for _ in refs])
+    print("[2.3] Get refs.")
     nodes = ray.get(refs)
     counter = collections.Counter(nodes)
     for node_id in counter:
@@ -115,9 +123,13 @@ def test_hybrid_policy(ray_start_cluster):
     # Once all nodes are past the hybrid threshold we round robin.
     # TODO (Alex): Ideally we could schedule less than 20 nodes here, but the
     # policy is imperfect if a resource report interrupts the process.
+    print("[3.0] Submitting batch of tasks.")
     refs = [get_node.remote() for _ in range(20)]
+    print("[3.1] Acquire block_driver semaphore.")
     ray.get([block_driver.acquire.remote() for _ in refs])
+    print("[3.2] Release block_task semaphore.")
     ray.get([block_task.release.remote() for _ in refs])
+    print("[3.3] Get refs.")
     nodes = ray.get(refs)
     counter = collections.Counter(nodes)
     for node_id in counter:
@@ -391,6 +403,7 @@ def test_locality_aware_leasing_cached_objects(ray_start_cluster):
 def test_locality_aware_leasing_borrowed_objects(ray_start_cluster):
     """Test that a task runs where its dependencies are located for borrowed objects."""
     is_ray_client_test = ray._private.client_mode_hook.is_client_mode_enabled
+    print("CLIENT?", is_ray_client_test)
 
     # This test ensures that a task will run where its task dependencies are
     # located, even when those objects are borrowed.

--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -69,7 +69,8 @@ def test_hybrid_policy(ray_start_cluster):
     NUM_CPUS_PER_NODE = 10
     for _ in range(NUM_NODES):
         cluster.add_node(
-            num_cpus=NUM_CPUS_PER_NODE, resources={"custom": NUM_CPUS_PER_NODE},
+            num_cpus=NUM_CPUS_PER_NODE,
+            resources={"custom": NUM_CPUS_PER_NODE},
         )
 
     cluster.wait_for_nodes()


### PR DESCRIPTION
This test sometimes hangs/times out in CI: https://buildkite.com/ray-project/postmerge/builds/11135#0197b3db-8451-4e3c-b30f-a298e408b251/177-3110

Added timeouts to the `ray.get` calls as well so the test won't hang for as long and we will know when it hangs.

I've also made the test less stressful by reducing the number of CPUs per node from 10 -> 4.