### PR TITLE
[serve] Move logic into user callable wrapper

### DIFF
--- a/python/ray/serve/_private/http_util.py
+++ b/python/ray/serve/_private/http_util.py
@@ -295,9 +295,6 @@ class MessageQueue(Send):
                 # Exit once `call_fut` has finished. In this case, all
                 # messages must have already been sent.
                 if call_fut in done:
-                    if call_fut.result() is not None:
-                        yield call_fut.result()
-
                     break
 
             e = call_fut.exception()

--- a/python/ray/serve/_private/http_util.py
+++ b/python/ray/serve/_private/http_util.py
@@ -6,7 +6,17 @@ import pickle
 import socket
 from collections import deque
 from dataclasses import dataclass
-from typing import Any, Awaitable, Callable, List, Optional, Tuple, Type, Union
+from typing import (
+    Any,
+    AsyncGenerator,
+    Awaitable,
+    Callable,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 
 import starlette
 import uvicorn
@@ -253,6 +263,52 @@ class MessageQueue(Send):
             raise self._error
         elif len(self._message_queue) == 0 and self._closed:
             raise StopAsyncIteration
+
+    async def fetch_messages_from_queue(
+        self, call_fut: asyncio.Future
+    ) -> AsyncGenerator[List[Any], None]:
+        """Repeatedly consume messages from the queue and yield them.
+
+        This is used to fetch queue messages in the system event loop in
+        a thread-safe manner.
+
+        Args:
+            call_fut: The async Future pointing to the task from the user
+                code event loop that is pushing messages onto the queue.
+
+        Yields:
+            List[Any]: Messages from the queue.
+        """
+        # Repeatedly consume messages from the queue.
+        wait_for_msg_task = None
+        try:
+            while True:
+                wait_for_msg_task = asyncio.create_task(self.wait_for_message())
+                done, _ = await asyncio.wait(
+                    [call_fut, wait_for_msg_task], return_when=asyncio.FIRST_COMPLETED
+                )
+
+                messages = self.get_messages_nowait()
+                if messages:
+                    yield messages
+
+                # Exit once `call_fut` has finished. In this case, all
+                # messages must have already been sent.
+                if call_fut in done:
+                    if call_fut.result() is not None:
+                        yield call_fut.result()
+
+                    break
+
+            e = call_fut.exception()
+            if e is not None:
+                raise e from None
+        finally:
+            if not call_fut.done():
+                call_fut.cancel()
+
+            if wait_for_msg_task is not None and not wait_for_msg_task.done():
+                wait_for_msg_task.cancel()
 
 
 class ASGIReceiveProxy:

--- a/python/ray/serve/_private/local_testing_mode.py
+++ b/python/ray/serve/_private/local_testing_mode.py
@@ -299,8 +299,15 @@ class LocalRouter(Router):
             generator_result_callback = None
 
         # Conform to the router interface of returning a future to the ReplicaResult.
-        if request_meta.is_streaming:
-            fut = self._user_callable_wrapper.call_user_generator(
+        if request_meta.is_http_request:
+            fut = self._user_callable_wrapper._call_http_entrypoint(
+                request_meta,
+                request_args,
+                request_kwargs,
+                generator_result_callback=generator_result_callback,
+            )
+        elif request_meta.is_streaming:
+            fut = self._user_callable_wrapper._call_user_generator(
                 request_meta,
                 request_args,
                 request_kwargs,

--- a/python/ray/serve/tests/unit/test_user_callable_wrapper.py
+++ b/python/ray/serve/tests/unit/test_user_callable_wrapper.py
@@ -163,7 +163,7 @@ async def test_basic_class_callable(run_sync_methods_in_threadpool: bool):
     # Call non-generator method with is_streaming.
     request_metadata = _make_request_metadata(is_streaming=True)
     with pytest.raises(TypeError, match="did not return a generator."):
-        await user_callable_wrapper.call_user_generator(
+        await user_callable_wrapper._call_user_generator(
             request_metadata, tuple(), dict()
         )
 
@@ -194,7 +194,7 @@ async def test_basic_class_callable(run_sync_methods_in_threadpool: bool):
         call_method="call_async", is_streaming=True
     )
     with pytest.raises(TypeError, match="did not return a generator."):
-        await user_callable_wrapper.call_user_generator(
+        await user_callable_wrapper._call_user_generator(
             request_metadata, tuple(), dict()
         )
 
@@ -249,7 +249,7 @@ async def test_basic_class_callable_generators(run_sync_methods_in_threadpool: b
     request_metadata = _make_request_metadata(
         call_method="call_generator", is_streaming=True
     )
-    await user_callable_wrapper.call_user_generator(
+    await user_callable_wrapper._call_user_generator(
         request_metadata, (10,), dict(), generator_result_callback=result_list.append
     )
     assert result_list == list(range(10))
@@ -257,7 +257,7 @@ async def test_basic_class_callable_generators(run_sync_methods_in_threadpool: b
 
     # Call sync generator raising exception.
     with pytest.raises(RuntimeError, match="uh-oh"):
-        await user_callable_wrapper.call_user_generator(
+        await user_callable_wrapper._call_user_generator(
             request_metadata,
             (10,),
             {"raise_exception": True},
@@ -283,7 +283,7 @@ async def test_basic_class_callable_generators(run_sync_methods_in_threadpool: b
     request_metadata = _make_request_metadata(
         call_method="call_async_generator", is_streaming=True
     )
-    await user_callable_wrapper.call_user_generator(
+    await user_callable_wrapper._call_user_generator(
         request_metadata, (10,), dict(), generator_result_callback=result_list.append
     )
     assert result_list == list(range(10))
@@ -291,7 +291,7 @@ async def test_basic_class_callable_generators(run_sync_methods_in_threadpool: b
 
     # Call async generator raising exception.
     with pytest.raises(RuntimeError, match="uh-oh"):
-        await user_callable_wrapper.call_user_generator(
+        await user_callable_wrapper._call_user_generator(
             request_metadata,
             (10,),
             {"raise_exception": True},
@@ -314,7 +314,7 @@ async def test_basic_function_callable(
     # Call non-generator function with is_streaming.
     request_metadata = _make_request_metadata(is_streaming=True)
     with pytest.raises(TypeError, match="did not return a generator."):
-        await user_callable_wrapper.call_user_generator(
+        await user_callable_wrapper._call_user_generator(
             request_metadata, tuple(), dict()
         )
 
@@ -366,7 +366,7 @@ async def test_basic_function_callable_generators(
     request_metadata = _make_request_metadata(
         call_method="call_generator", is_streaming=True
     )
-    await user_callable_wrapper.call_user_generator(
+    await user_callable_wrapper._call_user_generator(
         request_metadata, (10,), dict(), generator_result_callback=result_list.append
     )
     assert result_list == list(range(10))
@@ -374,7 +374,7 @@ async def test_basic_function_callable_generators(
 
     # Call generator function raising exception.
     with pytest.raises(RuntimeError, match="uh-oh"):
-        await user_callable_wrapper.call_user_generator(
+        await user_callable_wrapper._call_user_generator(
             request_metadata,
             (10,),
             {"raise_exception": True},
@@ -578,7 +578,7 @@ async def test_grpc_streaming_request(run_sync_methods_in_threadpool: bool):
     request_metadata = _make_request_metadata(
         call_method="stream", is_grpc_request=True, is_streaming=True
     )
-    await user_callable_wrapper.call_user_generator(
+    await user_callable_wrapper._call_user_generator(
         request_metadata,
         (grpc_request,),
         dict(),
@@ -660,7 +660,7 @@ async def test_http_handler(callable: Callable, monkeypatch):
     result_list = []
 
     request_metadata = _make_request_metadata(is_http_request=True, is_streaming=True)
-    await user_callable_wrapper.call_http_entrypoint(
+    await user_callable_wrapper._call_http_entrypoint(
         request_metadata,
         (http_request,),
         dict(),


### PR DESCRIPTION
## Why are these changes needed?

Move logic in `_call_streaming` into `UserCallableWrapper` and `MessageQueue`.
Now all `handle_request_...` methods are calling into `UserCallableWrapper` directly, since logic for calling user methods is all living in `UserCallableWrapper`.