### PR TITLE
[core][raycheck/01] Fix "it != submissible_tasks_.end()"

### DIFF
--- a/src/ray/core_worker/test/normal_task_submitter_test.cc
+++ b/src/ray/core_worker/test/normal_task_submitter_test.cc
@@ -152,15 +152,18 @@ class MockTaskManager : public MockTaskManagerInterface {
  public:
   MockTaskManager() {}
 
-  void CompletePendingTask(const TaskID &,
+  void CompletePendingTask(const TaskID &task_id,
                            const rpc::PushTaskReply &,
                            const rpc::Address &actor_addr,
                            bool is_application_error) override {
     num_tasks_complete++;
+    not_submissible_tasks_.insert(task_id);
   }
 
   bool RetryTaskIfPossible(const TaskID &task_id,
                            const rpc::RayErrorInfo &error_info) override {
+    RAY_CHECK(!not_submissible_tasks_.contains(task_id))
+        << "Tried to retry task that was not pending " << task_id;
     num_task_retries_attempted++;
     return false;
   }
@@ -171,6 +174,7 @@ class MockTaskManager : public MockTaskManagerInterface {
                        const rpc::RayErrorInfo *ray_error_info = nullptr) override {
     num_fail_pending_task_calls++;
     num_tasks_failed++;
+    not_submissible_tasks_.insert(task_id);
   }
 
   bool FailOrRetryPendingTask(const TaskID &task_id,
@@ -180,6 +184,10 @@ class MockTaskManager : public MockTaskManagerInterface {
                               bool mark_task_object_failed = true,
                               bool fail_immediately = false) override {
     num_tasks_failed++;
+    if (!fail_immediately) {
+      RetryTaskIfPossible(task_id,
+                          ray_error_info ? *ray_error_info : rpc::RayErrorInfo());
+    }
     return true;
   }
 
@@ -215,6 +223,9 @@ class MockTaskManager : public MockTaskManagerInterface {
   int num_task_retries_attempted = 0;
   int num_fail_pending_task_calls = 0;
   int num_generator_failed_and_resubmitted = 0;
+
+ private:
+  absl::flat_hash_set<TaskID> not_submissible_tasks_;
 };
 
 class MockRayletClient : public WorkerLeaseInterface {
@@ -241,9 +252,20 @@ class MockRayletClient : public WorkerLeaseInterface {
       const ray::rpc::ClientCallback<ray::rpc::GetTaskFailureCauseReply> &callback)
       override {
     std::lock_guard<std::mutex> lock(mu_);
-    ray::rpc::GetTaskFailureCauseReply reply;
-    callback(Status::OK(), std::move(reply));
+    get_task_failure_cause_callbacks.push_back(callback);
     num_get_task_failure_causes += 1;
+  }
+
+  bool ReplyGetTaskFailureCause() {
+    std::lock_guard<std::mutex> lock(mu_);
+    if (get_task_failure_cause_callbacks.size() == 0) {
+      return false;
+    }
+    auto callback = std::move(get_task_failure_cause_callbacks.front());
+    get_task_failure_cause_callbacks.pop_front();
+    rpc::GetTaskFailureCauseReply reply;
+    callback(Status::OK(), std::move(reply));
+    return true;
   }
 
   void ReportWorkerBacklog(
@@ -673,6 +695,7 @@ TEST(NormalTaskSubmitterTest, TestHandleTaskFailure) {
   ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1234, NodeID::Nil()));
   // Simulate a system failure, i.e., worker died unexpectedly.
   ASSERT_TRUE(worker_client->ReplyPushTask(Status::IOError("oops")));
+  ASSERT_TRUE(raylet_client->ReplyGetTaskFailureCause());
   ASSERT_EQ(worker_client->callbacks.size(), 0);
   ASSERT_EQ(raylet_client->num_workers_returned, 0);
   ASSERT_EQ(raylet_client->num_workers_disconnected, 1);
@@ -685,6 +708,48 @@ TEST(NormalTaskSubmitterTest, TestHandleTaskFailure) {
   // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
   // would otherwise cause a memory leak.
   ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
+}
+
+TEST(NormalTaskSubmitterTest, TestCancellationWhileHandlingTaskFailure) {
+  // This test is a regression test for a bug where a crash happens when
+  // the task cancellation races between ReplyPushTask and ReplyGetTaskFailureCause.
+  // For a python integration test, see
+  // https://github.com/ray-project/ray/blob/2b6807f4d9c4572e6309f57bc404aa641bc4b185/python/ray/tests/test_cancel.py#L35
+  rpc::Address address;
+  auto raylet_client = std::make_shared<MockRayletClient>();
+  auto worker_client = std::make_shared<MockWorkerClient>();
+  auto store = DefaultCoreWorkerMemoryStoreWithThread::CreateShared();
+  auto client_pool = std::make_shared<rpc::CoreWorkerClientPool>(
+      [&](const rpc::Address &addr) { return worker_client; });
+  auto task_manager = std::make_unique<MockTaskManager>();
+  auto actor_creator = std::make_shared<MockActorCreator>();
+  auto lease_policy = std::make_unique<MockLeasePolicy>();
+  NormalTaskSubmitter submitter(
+      address,
+      raylet_client,
+      client_pool,
+      nullptr,
+      std::move(lease_policy),
+      store,
+      *task_manager,
+      NodeID::Nil(),
+      WorkerType::WORKER,
+      kLongTimeout,
+      actor_creator,
+      JobID::Nil(),
+      kOneRateLimiter,
+      [](const ObjectID &object_id) { return rpc::TensorTransport::OBJECT_STORE; });
+
+  TaskSpecification task = BuildEmptyTaskSpec();
+  ASSERT_TRUE(submitter.SubmitTask(task).ok());
+  ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1234, NodeID::Nil()));
+  // Simulate a system failure, i.e., worker died unexpectedly so that
+  // GetTaskFailureCause is called.
+  ASSERT_TRUE(worker_client->ReplyPushTask(Status::IOError("oops")));
+  // Cancel the task while GetTaskFailureCause has not been completed.
+  ASSERT_TRUE(submitter.CancelTask(task, true, false).ok());
+  // Completing the GetTaskFailureCause call. Check that the reply runs without error.
+  ASSERT_TRUE(raylet_client->ReplyGetTaskFailureCause());
 }
 
 TEST(NormalTaskSubmitterTest, TestHandleUnschedulableTask) {
@@ -1549,6 +1614,7 @@ TEST(NormalTaskSubmitterTest, TestWorkerNotReusedOnError) {
 
   // Task 1 finishes with failure; the worker is returned.
   ASSERT_TRUE(worker_client->ReplyPushTask(Status::IOError("worker dead")));
+  ASSERT_TRUE(raylet_client->ReplyGetTaskFailureCause());
   ASSERT_EQ(worker_client->callbacks.size(), 0);
   ASSERT_EQ(raylet_client->num_workers_returned, 0);
   ASSERT_EQ(raylet_client->num_workers_disconnected, 1);
@@ -2064,6 +2130,7 @@ TEST(NormalTaskSubmitterTest, TestWorkerLeaseTimeout) {
   // Task 1 finishes with failure; the worker is returned due to the error even though
   // it hasn't timed out.
   ASSERT_TRUE(worker_client->ReplyPushTask(Status::IOError("worker dead")));
+  ASSERT_TRUE(raylet_client->ReplyGetTaskFailureCause());
   ASSERT_EQ(raylet_client->num_workers_returned, 0);
   ASSERT_EQ(raylet_client->num_workers_disconnected, 1);
 
@@ -2126,6 +2193,7 @@ TEST(NormalTaskSubmitterTest, TestKillExecutingTask) {
   ASSERT_TRUE(submitter.CancelTask(task, true, false).ok());
   ASSERT_EQ(worker_client->kill_requests.front().intended_task_id(), task.TaskIdBinary());
   ASSERT_TRUE(worker_client->ReplyPushTask(Status::IOError("workerdying"), true));
+  ASSERT_TRUE(raylet_client->ReplyGetTaskFailureCause());
   ASSERT_EQ(worker_client->callbacks.size(), 0);
   ASSERT_EQ(raylet_client->num_workers_returned, 0);
   ASSERT_EQ(raylet_client->num_workers_returned_exiting, 0);

--- a/src/ray/core_worker/transport/normal_task_submitter.cc
+++ b/src/ray/core_worker/transport/normal_task_submitter.cc
@@ -180,7 +180,7 @@ void NormalTaskSubmitter::OnWorkerIdle(
       task_spec.GetMutableMessage().set_lease_grant_timestamp_ms(current_sys_time_ms());
       task_spec.EmitTaskMetrics();
 
-      executing_tasks_.emplace(task_spec.TaskId(), addr);
+      pushed_to_worker_tasks_.emplace(task_spec.TaskId(), addr);
       PushNormalTask(
           addr, client, scheduling_key, std::move(task_spec), assigned_resources);
     }
@@ -580,7 +580,6 @@ void NormalTaskSubmitter::PushNormalTask(
                          << WorkerID::FromBinary(addr.worker_id()) << " of raylet "
                          << NodeID::FromBinary(addr.raylet_id());
           absl::MutexLock lock(&mu_);
-          executing_tasks_.erase(task_id);
 
           resubmit_generator = generators_to_resubmit_.erase(task_id) > 0;
 

--- a/src/ray/core_worker/transport/normal_task_submitter.cc
+++ b/src/ray/core_worker/transport/normal_task_submitter.cc
@@ -606,6 +606,8 @@ void NormalTaskSubmitter::PushNormalTask(
                                             addr,
                                             get_task_failure_cause_reply_status,
                                             get_task_failure_cause_reply);
+                  absl::MutexLock lock(&mu_);
+                  pushed_to_worker_tasks_.erase(task_id);
                 };
             auto &cur_lease_entry = worker_to_lease_entry_[addr];
             RAY_CHECK(cur_lease_entry.lease_client);
@@ -643,6 +645,8 @@ void NormalTaskSubmitter::PushNormalTask(
             task_manager_.CompletePendingTask(
                 task_id, reply, addr, reply.is_application_error());
           }
+          absl::MutexLock lock(&mu_);
+          pushed_to_worker_tasks_.erase(task_id);
         }
       });
 }
@@ -744,9 +748,9 @@ Status NormalTaskSubmitter::CancelTask(TaskSpecification task_spec,
     // This will get removed either when the RPC call to cancel is returned
     // or when all dependencies are resolved.
     RAY_CHECK(cancelled_tasks_.emplace(task_spec.TaskId()).second);
-    auto rpc_client = executing_tasks_.find(task_spec.TaskId());
+    auto rpc_client = pushed_to_worker_tasks_.find(task_spec.TaskId());
 
-    if (rpc_client == executing_tasks_.end()) {
+    if (rpc_client == pushed_to_worker_tasks_.end()) {
       // This case is reached for tasks that have unresolved dependencies.
       resolver_.CancelDependencyResolution(task_spec.TaskId());
       RAY_UNUSED(task_manager_.FailPendingTask(task_spec.TaskId(),

--- a/src/ray/core_worker/transport/normal_task_submitter.h
+++ b/src/ray/core_worker/transport/normal_task_submitter.h
@@ -375,8 +375,9 @@ class NormalTaskSubmitter {
   // Tasks that were cancelled while being resolved.
   absl::flat_hash_set<TaskID> cancelled_tasks_ ABSL_GUARDED_BY(mu_);
 
-  // Keeps track of where currently executing tasks are being run.
-  absl::flat_hash_map<TaskID, rpc::Address> executing_tasks_ ABSL_GUARDED_BY(mu_);
+  // Keeps track of the address of the worker that currently has a task being pushed to
+  // it. This include tasks that are still in the progress of post-pushing handling.
+  absl::flat_hash_map<TaskID, rpc::Address> pushed_to_worker_tasks_ ABSL_GUARDED_BY(mu_);
 
   // Generators that are currently running and need to be resubmitted.
   absl::flat_hash_set<TaskID> generators_to_resubmit_ ABSL_GUARDED_BY(mu_);


### PR DESCRIPTION
## Problems

This PR fixes the `RAY_CHECK failure:
it != submissible_tasks_.end() Tried to retry task that was not pending`.

This failure occurs when a task cancellation ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L702)) races with the callback from PushNormalTask ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L546)).

Currently, there's a map called `executing_tasks_` that is intended to prevent this race, but it fails to do so. The crash happens via the following sequence:
- The `PushNormalTask` callback removes the task ID from `executing_tasks_` ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L583)).
- This causes the task cancellation to enter the following condition ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L750)), which eventually invokes `TaskManager::FailPendingTask` ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L753)).
- `TaskManager` always removes the task from the `submissible_tasks_ `map when it ends a pending task’s lifecycle (via `FailPendingTask` and others).
- After that, the `PushNormalTask` callback invokes `HandleGetTaskFailureCause` ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L605)), which attempts to retrieve the task’s failure cause. This function asks `TaskManager` to retry the task ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L694)), but it fails because the task has already been removed from the `submissible_tasks_` map.

## Solutions

I believe the root cause is that `executing_tasks_` removes the task ID too early—before the callback completes—instead of at the end of the callback, which eventually causes the race between itself and task cancellation. This PR moves the logic for removing the task ID to the end of the PushNormalTask callback, consequently eliminating the race .

I discussed this offline with @dayshah. The original idea was to introduce a new map to resolve the issue, but I’m instead aiming to reuse or remove `executing_tasks_` to reduce overall complexity.

Another direction could be to fund a dedicated project to rethink task cancellation holistically, rather than continuing with these incremental fixes. Let's discuss.

## Test
- CI
- A test that crashes without this fix and passes with this fix
- Also update `normal_task_submitter_test` to represent its real implementation