### PR TITLE
[train] Make worker group start and poll async

### DIFF
--- a/python/ray/train/v2/tests/test_controller.py
+++ b/python/ray/train/v2/tests/test_controller.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, create_autospec
+from unittest.mock import create_autospec
 
 import pytest
 
@@ -93,7 +93,7 @@ async def test_resize():
     assert isinstance(controller.get_state(), SchedulingState)
     assert controller.get_worker_group() is None
 
-    await controller._run_control_loop_iteration()
+    await controller._run_control_loop_iteration()  # modoru: wrong cu worker group real
     assert isinstance(controller.get_state(), RunningState)
 
     worker_group = controller.get_worker_group()
@@ -236,7 +236,7 @@ async def test_poll_frequency(monkeypatch):
         failure_policy=None,
     )
     # Mock worker group to avoid actual polling
-    controller._worker_group = MagicMock()
+    controller._worker_group = create_autospec(DummyWorkerGroup, instance=True)
 
     num_polls = 5
     for _ in range(num_polls):

--- a/python/ray/train/v2/tests/util.py
+++ b/python/ray/train/v2/tests/util.py
@@ -39,12 +39,12 @@ class DummyWorkerGroup(WorkerGroup):
         self._worker_group_state = None
         self._worker_statuses = {}
 
-    def poll_status(self, *args, **kwargs) -> WorkerGroupPollStatus:
+    async def poll_status(self, *args, **kwargs) -> WorkerGroupPollStatus:
         return WorkerGroupPollStatus(
             worker_statuses=self._worker_statuses,
         )
 
-    def _start(self):
+    async def _start(self):
         num_workers = self._num_workers
         if self._start_failure:
             raise self._start_failure


### PR DESCRIPTION
# Summary

Before this PR, worker group `start` and `poll` were using blocking `ray.get` and `ray.wait` calls. This meant if you aborted (https://github.com/ray-project/ray/pull/53600) a ray train run that was starting (this can take many seconds) or polling (this takes under a second) a worker group, you would need to wait until the start or poll finished before the abort actually started. Now that we are using `asyncio`, we can abort in the middle of these operations.

# Implementation Notes

Note that the ray train controller still isn't fully async e.g. framework-specific `on_start` methods like https://github.com/ray-project/ray/blob/master/python/ray/train/torch/config.py#L167 are still blocking. I can make the remaining operations async in a future PR. 

# Testing

NOT FULLY WORKING: got some exceptions: https://gist.github.com/TimothySeah/34e5ac5eec4619b413582d29ad804163


Closing this for now since it's difficult to fix the case below. Basically the issue is that if we abort while awaiting on pg.ready (https://github.com/ray-project/ray/blob/master/python/ray/train/v2/_internal/execution/worker_group/worker_group.py#L259), that happens
* after before_worker_group_start (https://github.com/ray-project/ray/blob/master/python/ray/train/v2/_internal/execution/worker_group/worker_group.py#L240), which creates the train run attempt and sets it to pending
* before creating the worker group (https://github.com/ray-project/ray/blob/master/python/ray/train/v2/_internal/execution/controller/controller.py#L293), whose existence the controller checks before aborting

This is more trouble than it's worth to fix because we need to clean up an in progress placement group. 

![Screenshot 2025-06-27 at 1 21 41 PM](https://github.com/user-attachments/assets/5c1e825f-e51d-4e14-9fa4-0a740131eed0)
