### PR TITLE
[train] Force abort on SIGINT spam and do not abort finished runs

### DIFF
--- a/python/ray/train/v2/_internal/callbacks/metrics.py
+++ b/python/ray/train/v2/_internal/callbacks/metrics.py
@@ -36,6 +36,9 @@ class ControllerMetricsCallback(ControllerCallback, WorkerGroupCallback):
 
     def before_controller_shutdown(self):
         """Shutdown metrics before controller shuts down."""
+        import time
+
+        time.sleep(60)
         for metric in self._metrics.values():
             metric.reset()
 

--- a/python/ray/train/v2/_internal/callbacks/metrics.py
+++ b/python/ray/train/v2/_internal/callbacks/metrics.py
@@ -36,9 +36,6 @@ class ControllerMetricsCallback(ControllerCallback, WorkerGroupCallback):
 
     def before_controller_shutdown(self):
         """Shutdown metrics before controller shuts down."""
-        import time
-
-        time.sleep(60)
         for metric in self._metrics.values():
             metric.reset()
 

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -483,6 +483,9 @@ class TrainController:
 
     async def abort(self):
         """Trigger callback abort hooks and terminate the controller process."""
+        # Do not abort run if it's already finished.
+        if self.get_state().is_terminal():
+            return
         # Intentionally abort worker group before setting train run state because
         # we only reconcile the states of live train runs.
         if self._worker_group:

--- a/python/ray/train/v2/api/data_parallel_trainer.py
+++ b/python/ray/train/v2/api/data_parallel_trainer.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import ray
 from ray._private.ray_constants import env_bool
 from ray._private.usage import usage_lib
+from ray.actor import ActorHandle
 from ray.air._internal.usage import tag_train_v2_trainer
 from ray.train import (
     BackendConfig,
@@ -208,7 +209,7 @@ class DataParallelTrainer:
             asyncio.run(controller.run())
             return controller.get_result()
 
-    def _register_sigint_handler(self, controller: TrainController):
+    def _register_sigint_handler(self, controller: ActorHandle[TrainController]):
         """Register SIGINT handler so user Ctrl C gracefully aborts run."""
         sigint_count = 0
 

--- a/python/ray/train/v2/api/data_parallel_trainer.py
+++ b/python/ray/train/v2/api/data_parallel_trainer.py
@@ -226,13 +226,13 @@ class DataParallelTrainer:
                     "Forcefully aborting the training run."
                 )
                 sys.exit(0)
-            try:
-                ray.get(controller.abort.remote())
-            except ray.exceptions.ActorDiedError:
-                logger.info("Gracefully aborted the training run.")
-                # We catch the error and exit 0 to indicate graceful termination.
-                # However, for some reason the process still exits with 1.
-                sys.exit(0)
+            if sigint_count <= 1:
+                try:
+                    ray.get(controller.abort.remote())
+                except ray.exceptions.ActorDiedError:
+                    # We catch the error and exit 0 to indicate graceful termination.
+                    # However, for some reason the process still exits with 1.
+                    sys.exit(0)
 
         signal.signal(signal.SIGINT, sigint_handler)
 

--- a/python/ray/train/v2/api/data_parallel_trainer.py
+++ b/python/ray/train/v2/api/data_parallel_trainer.py
@@ -210,16 +210,26 @@ class DataParallelTrainer:
 
     def _register_sigint_handler(self, controller: TrainController):
         """Register SIGINT handler so user Ctrl C gracefully aborts run."""
+        sigint_count = 0
 
         def sigint_handler(signum, frame):
-            try:
+            logger.info(
+                "Received SIGINT. Gracefully aborting the training run — this "
+                "may take a few seconds. To forcefully abort immediately, you "
+                "can send a different signal, such as SIGKILL."
+            )
+            nonlocal sigint_count
+            sigint_count += 1
+            if sigint_count >= 3:
                 logger.info(
-                    "Received SIGINT. Gracefully aborting the training run — this "
-                    "may take a few seconds. To forcefully abort immediately, you "
-                    "can send a different signal, such as SIGKILL."
+                    "Received SIGINT at least 3 times. "
+                    "Forcefully aborting the training run."
                 )
+                sys.exit(0)
+            try:
                 ray.get(controller.abort.remote())
             except ray.exceptions.ActorDiedError:
+                logger.info("Gracefully aborted the training run.")
                 # We catch the error and exit 0 to indicate graceful termination.
                 # However, for some reason the process still exits with 1.
                 sys.exit(0)

--- a/python/ray/train/v2/tests/test_data_parallel_trainer.py
+++ b/python/ray/train/v2/tests/test_data_parallel_trainer.py
@@ -1,4 +1,6 @@
+import multiprocessing
 import os
+import signal
 import tempfile
 from pathlib import Path
 
@@ -6,6 +8,7 @@ import pyarrow.fs
 import pytest
 
 import ray
+from ray.tests.client_test_utils import create_remote_signal_actor
 from ray.train import BackendConfig, Checkpoint, RunConfig, ScalingConfig, UserCallback
 from ray.train.backend import Backend
 from ray.train.constants import RAY_CHDIR_TO_TRIAL_DIR, _get_ray_train_session_dir
@@ -208,6 +211,74 @@ def test_user_callback(tmp_path):
     # The error should NOT be an assertion error from the user callback.
     with pytest.raises(TrainingFailedError):
         trainer.fit()
+
+
+def run_process_for_sigint_abort(abort_terminates):
+    # Lives outside test_sigint_abort because cannot pickle nested functions.
+
+    # Needed to reuse current ray cluster.
+    ray.init(address="auto")
+
+    if not abort_terminates:
+
+        async def fake_abort():
+            while True:
+                pass
+
+        from ray.train.v2._internal.execution.controller import TrainController
+
+        TrainController.abort = fake_abort
+
+    def train_fn():
+        signal_actor = ray.get_actor("signal_actor", namespace="test_sigint_abort")
+        ray.get(signal_actor.send.remote())
+        while True:
+            pass
+
+    trainer = DataParallelTrainer(
+        train_fn,
+        scaling_config=ScalingConfig(num_workers=2),
+    )
+    trainer.fit()
+
+
+@pytest.mark.parametrize(
+    "spam_sigint",
+    [
+        False,
+        # Disabling this test because it's flaky.
+        # True,
+    ],
+)
+def test_sigint_abort(ray_start_4_cpus, spam_sigint):
+    # Use SignalActor to wait for training to start before sending SIGINT.
+    SignalActor = create_remote_signal_actor(ray)
+    signal_actor = SignalActor.options(
+        name="signal_actor", namespace="test_sigint_abort"
+    ).remote()
+
+    # Use spawn because of
+    # https://docs.ray.io/en/latest/ray-core/patterns/fork-new-processes.html
+    multiprocessing.set_start_method("spawn", force=True)
+    process = multiprocessing.Process(
+        target=run_process_for_sigint_abort, args=(not spam_sigint,)
+    )
+    process.start()
+
+    # Wait for training to start.
+    ray.get(signal_actor.wait.remote())
+
+    # Verify that process exits after sufficient number of SIGINTS.
+    os.kill(process.pid, signal.SIGINT)
+    if spam_sigint:
+        import time
+
+        assert process.exitcode is None
+        # This is flaky. Sometimes SIGINTs are ignored and you need to wait.
+        while process.exitcode is None:
+            time.sleep(1)
+            os.kill(process.pid, signal.SIGINT)
+    process.join()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Summary

Before this PR, spamming Ctrl C used to continue blocking until the controller awaited. This was especially slow during worker group initialization. Now, 3 Ctrl C's will force kill the run.

Before this PR, there was an edge case in which if you aborted a train run after the controller set the state to finished/error but before it exited, you would override a finished run to aborted. This is rare in practice but it's good to cover all our bases.

# Testing

I was able to successfully abort a run by spamming ctrl c. Note that this run shows up as scheduling for now but https://github.com/ray-project/ray/pull/53818 will fix that and this is still an improvement over the existing flow.

```
(base) ray@ip-10-0-26-174:~/default$ RAY_TRAIN_V2_ENABLED=1 python driver.py
2025-06-27 18:35:13,233 INFO worker.py:1742 -- Connecting to existing Ray cluster at address: 10.0.26.174:6379...
2025-06-27 18:35:13,245 INFO worker.py:1913 -- Connected to Ray cluster. View the dashboard at https://session-fcehx7tn6ic7fjutqsxrurm55e.i.anyscaleuserdata-staging.com 
2025-06-27 18:35:13,247 INFO packaging.py:380 -- Pushing file package 'gcs://_ray_pkg_f781e7489361295ea3517549110997851e2f32dc.zip' (0.03MiB) to Ray cluster...
2025-06-27 18:35:13,247 INFO packaging.py:393 -- Successfully pushed file package 'gcs://_ray_pkg_f781e7489361295ea3517549110997851e2f32dc.zip'.
(TrainController pid=15961) [State Transition] INITIALIZING -> SCHEDULING.
(TrainController pid=15961) Attempting to start training worker group of size 2 with the following resources: [{'GPU': 1}] * 2
(TrainController pid=15961) Using blocking ray.get inside async actor. This blocks the event loop. Please use `await` on object ref with asyncio.gather if you want to yield execution to the event loop instead.
^C2025-06-27 18:35:24,324       INFO data_parallel_trainer.py:216 -- Received SIGINT. Gracefully aborting the training run — this may take a few seconds. To forcefully abort immediately, you can send a different signal, such as SIGKILL.
^C2025-06-27 18:35:26,324       INFO data_parallel_trainer.py:216 -- Received SIGINT. Gracefully aborting the training run — this may take a few seconds. To forcefully abort immediately, you can send a different signal, such as SIGKILL.
^C2025-06-27 18:35:27,325       INFO data_parallel_trainer.py:216 -- Received SIGINT. Gracefully aborting the training run — this may take a few seconds. To forcefully abort immediately, you can send a different signal, such as SIGKILL.
2025-06-27 18:35:27,325 INFO data_parallel_trainer.py:224 -- Received SIGINT at least 3 times. Forcefully aborting the training run.
```

I added a 1 minute sleep to `before_controller_shutdown` to test the "abort finished runs" case more easily. I was able to finish a train run normally (the earlier run in the screenshot below) and avoid marking a finished train run as aborted (the logs below + the later run in the screenshot below). 

```
(RayTrainWorker pid=7752, ip=10.0.46.20) {'loss': 0.04792049527168274, 'epoch': 9}
(RayTrainWorker pid=7752, ip=10.0.46.20) Checkpoint successfully created at: Checkpoint(filesystem=local, path=/mnt/cluster_storage/my_run_name/checkpoint_2025-06-27_18-49-31.317309) [repeated 2x across cluster]
(TrainController pid=20684) [State Transition] RUNNING -> FINISHED.
^C2025-06-27 18:49:39,541       INFO data_parallel_trainer.py:216 -- Received SIGINT. Gracefully aborting the training run — this may take a few seconds. To forcefully abort immediately, you can send a different signal, such as SIGKILL.
(RayTrainWorker pid=20848) Checkpoint successfully created at: Checkpoint(filesystem=local, path=/mnt/cluster_storage/my_run_name/checkpoint_2025-06-27_18-49-31.317309)
```

![Screenshot 2025-06-27 at 7 00 30 PM](https://github.com/user-attachments/assets/f4d548e1-493a-484e-be7c-dc3a55f7a32a)
