### PR TITLE
[Doc][KubeRay] Kuberay gcs ft takes yaml file with version 1.4.0

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-ft.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-ft.md
@@ -49,7 +49,7 @@ Follow [this document](kuberay-operator-deploy) to install the latest stable Kub
 ### Step 3: Install a RayCluster with GCS FT enabled
 
 ```sh
-curl -LO https://raw.githubusercontent.com/ray-project/kuberay/master/ray-operator/config/samples/ray-cluster.external-redis.yaml
+curl -LO https://raw.githubusercontent.com/ray-project/kuberay/v1.4.0/ray-operator/config/samples/ray-cluster.external-redis.yaml
 kubectl apply -f ray-cluster.external-redis.yaml
 ```
 
@@ -110,7 +110,7 @@ The `ray-example` ConfigMap houses two Python scripts: `detached_actor.py` and `
 ### Step 5: Create a detached actor
 
 ```sh
-# Step 4.1: Create a detached actor with the name, `counter_actor`.
+# Step 5.1: Create a detached actor with the name, `counter_actor`.
 export HEAD_POD=$(kubectl get pods --selector=ray.io/node-type=head -o custom-columns=POD:metadata.name --no-headers)
 kubectl exec -it $HEAD_POD -- python3 /home/ray/samples/detached_actor.py
 
@@ -118,7 +118,7 @@ kubectl exec -it $HEAD_POD -- python3 /home/ray/samples/detached_actor.py
 # 2025-04-18 02:51:25,361	INFO worker.py:1654 -- Connecting to existing Ray cluster at address: 10.244.0.8:6379...
 # 2025-04-18 02:51:25,557	INFO worker.py:1832 -- Connected to Ray cluster. View the dashboard at 10.244.0.8:8265 
 
-# Step 4.2: Increment the counter.
+# Step 5.2: Increment the counter.
 kubectl exec -it $HEAD_POD -- python3 /home/ray/samples/increment_counter.py
 
 # 2025-04-18 02:51:29,069	INFO worker.py:1514 -- Using address 127.0.0.1:6379 set in the environment variable RAY_ADDRESS


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
The yaml in Kuberay gcs fault tolerance guide takes the yaml file from master. This PR changes to version 1.4.0.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
