### PR TITLE
[data] allow custom batcher for dataset iteration

### DIFF
--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Iterator, List, Optional, Tuple
 
 import ray
 from ray.actor import ActorHandle
-from ray.data._internal.batcher import Batcher, ShufflingBatcher
+from ray.data._internal.batcher import BatcherInterface
 from ray.data._internal.block_batching.interfaces import (
     Batch,
     BlockPrefetcher,
@@ -72,12 +72,9 @@ def resolve_block_refs(
 
 def blocks_to_batches(
     block_iter: Iterator[Block],
+    batcher: BatcherInterface,
     stats: Optional[DatasetStats] = None,
-    batch_size: Optional[int] = None,
     drop_last: bool = False,
-    shuffle_buffer_min_size: Optional[int] = None,
-    shuffle_seed: Optional[int] = None,
-    ensure_copy: bool = False,
 ) -> Iterator[Batch]:
     """Given an iterator over blocks, returns an iterator over blocks
     of the appropriate bacth size.
@@ -101,14 +98,6 @@ def blocks_to_batches(
     Returns:
         An iterator over blocks of the given size that are potentially shuffled.
     """
-    if shuffle_buffer_min_size is not None:
-        batcher = ShufflingBatcher(
-            batch_size=batch_size,
-            shuffle_buffer_min_size=shuffle_buffer_min_size,
-            shuffle_seed=shuffle_seed,
-        )
-    else:
-        batcher = Batcher(batch_size=batch_size, ensure_copy=ensure_copy)
 
     def get_iter_next_batch_s_timer():
         return stats.iter_next_batch_s.timer() if stats else nullcontext()

--- a/python/ray/data/tests/block_batching/test_util.py
+++ b/python/ray/data/tests/block_batching/test_util.py
@@ -10,6 +10,7 @@ import pyarrow as pa
 import pytest
 
 import ray
+from ray.data._internal.batcher import create_batcher
 from ray.data._internal.block_batching.interfaces import Batch
 from ray.data._internal.block_batching.util import (
     _calculate_ref_hits,
@@ -44,7 +45,11 @@ def test_blocks_to_batches(block_size, drop_last):
 
     batch_size = 3
     batch_iter = list(
-        blocks_to_batches(block_iter, batch_size=batch_size, drop_last=drop_last)
+        blocks_to_batches(
+            block_iter,
+            batcher=create_batcher(batch_size=batch_size),
+            drop_last=drop_last,
+        )
     )
 
     if drop_last:


### PR DESCRIPTION
## Why are these changes needed?

Exposing the BatcherInterface allows user to customize the batcher in iter_torch_batches. This is helpful for the cases when global shuffle is too heavy but the local shuffle is not good enough..

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Maybe? #54197

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
