### PR TITLE
[data.llm][Bugfix] Fix doc to only support int `concurrency`

### DIFF
--- a/python/ray/llm/_internal/batch/processor/base.py
+++ b/python/ray/llm/_internal/batch/processor/base.py
@@ -1,6 +1,6 @@
 import logging
 from collections import OrderedDict
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Type
 
 from pydantic import Field
 

--- a/python/ray/llm/_internal/batch/processor/base.py
+++ b/python/ray/llm/_internal/batch/processor/base.py
@@ -45,11 +45,9 @@ class ProcessorConfig(BaseModelExtended):
         description="The accelerator type used by the LLM stage in a processor. "
         "Default to None, meaning that only the CPU will be used.",
     )
-    concurrency: Optional[Union[int, Tuple[int, int]]] = Field(
+    concurrency: Optional[int] = Field(
         default=1,
-        description="The number of workers for data parallelism. Default to 1."
-        "If ``concurrency`` is a tuple ``(m, n)``, Ray will use an autoscaling actor pool from"
-        " ``m`` to ``n`` workers.",
+        description="The number of workers for data parallelism. Default to 1.",
     )
 
     class Config:

--- a/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
@@ -90,12 +90,10 @@ def build_vllm_engine_processor(
     if isinstance(config.concurrency, int):
         # For CPU-only stages, we leverage auto-scaling to recycle resources.
         processor_concurrency = (1, config.concurrency)
-    elif isinstance(config.concurrency, tuple):
-        processor_concurrency = config.concurrency
     else:
         raise ValueError(
-            "``concurrency`` is expected to be set as an integer or a "
-            f"tuple of integers, but got: {config.concurrency}."
+            "``concurrency`` is expected to be set as an integer,"
+            f" but got: {config.concurrency}."
         )
 
     if config.has_image:
@@ -161,12 +159,8 @@ def build_vllm_engine_processor(
                 compute=ray.data.ActorPoolStrategy(
                     # vLLM start up time is significant, so if user give fixed
                     # concurrency, start all instances without auto-scaling.
-                    min_size=(
-                        config.concurrency
-                        if isinstance(config.concurrency, int)
-                        else processor_concurrency[0]
-                    ),
-                    max_size=processor_concurrency[1],
+                    min_size=config.concurrency,
+                    max_size=config.concurrency,
                     max_tasks_in_flight_per_actor=max(
                         config.max_concurrent_batches, DEFAULT_MAX_TASKS_IN_FLIGHT
                     ),

--- a/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
@@ -161,9 +161,11 @@ def build_vllm_engine_processor(
                 compute=ray.data.ActorPoolStrategy(
                     # vLLM start up time is significant, so if user give fixed
                     # concurrency, start all instances without auto-scaling.
-                    min_size=config.concurrency
-                    if isinstance(config.concurrency, int)
-                    else processor_concurrency[0],
+                    min_size=(
+                        config.concurrency
+                        if isinstance(config.concurrency, int)
+                        else processor_concurrency[0]
+                    ),
                     max_size=processor_concurrency[1],
                     max_tasks_in_flight_per_actor=max(
                         config.max_concurrent_batches, DEFAULT_MAX_TASKS_IN_FLIGHT

--- a/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
+++ b/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
@@ -10,6 +10,7 @@ from ray.llm._internal.batch.processor.base import (
     ProcessorConfig,
 )
 from ray.llm._internal.batch.stages.base import StatefulStage, StatefulStageUDF
+from ray.llm._internal.batch.processor import vLLMEngineProcessorConfig
 
 
 def test_empty_processor():
@@ -184,6 +185,17 @@ def test_builder():
     assert (
         processor.get_stage_by_name("DummyStage").map_batches_kwargs["concurrency"] == 2
     )
+
+
+class TestProcessorConfig:
+    def test_valid_concurrency(self):
+
+        with pytest.raises(ValueError, match="expected to be set as an integer"):
+            config = vLLMEngineProcessorConfig(
+                concurrency=(1, 2),
+            )
+        config = vLLMEngineProcessorConfig()
+        assert config.concurrency == 1
 
 
 if __name__ == "__main__":

--- a/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
+++ b/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
@@ -4,13 +4,13 @@ from typing import Any, AsyncIterator, Dict, List, Type
 import pytest
 
 import ray
+from ray.llm._internal.batch.processor import vLLMEngineProcessorConfig
 from ray.llm._internal.batch.processor.base import (
     Processor,
     ProcessorBuilder,
     ProcessorConfig,
 )
 from ray.llm._internal.batch.stages.base import StatefulStage, StatefulStageUDF
-from ray.llm._internal.batch.processor import vLLMEngineProcessorConfig
 
 
 def test_empty_processor():

--- a/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
+++ b/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
@@ -193,9 +193,12 @@ class TestProcessorConfig:
 
         with pytest.raises(pydantic.ValidationError, match="should be a valid integer"):
             config = vLLMEngineProcessorConfig(
+                model_source="unsloth/Llama-3.2-1B-Instruct",
                 concurrency=(1, 2),
             )
-        config = vLLMEngineProcessorConfig()
+        config = vLLMEngineProcessorConfig(
+            model_source="unsloth/Llama-3.2-1B-Instruct",
+        )
         assert config.concurrency == 1
 
 

--- a/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
+++ b/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
@@ -1,6 +1,7 @@
 import sys
 from typing import Any, AsyncIterator, Dict, List, Type
 
+import pydantic
 import pytest
 
 import ray
@@ -190,7 +191,7 @@ def test_builder():
 class TestProcessorConfig:
     def test_valid_concurrency(self):
 
-        with pytest.raises(ValueError, match="expected to be set as an integer"):
+        with pytest.raises(pydantic.ValidationError, match="should be a valid integer"):
             config = vLLMEngineProcessorConfig(
                 concurrency=(1, 2),
             )

--- a/release/llm_tests/batch/test_batch_vllm.py
+++ b/release/llm_tests/batch/test_batch_vllm.py
@@ -58,7 +58,7 @@ def test_chat_template_with_vllm():
     "tp_size,pp_size,concurrency",
     [
         (2, 1, 2),  # TP=2, concurrency=2
-        (1, 2, (1, 2)),  # PP=2, concurrency=2
+        (1, 2, 2),  # PP=2, concurrency=2
     ],
 )
 def test_vllm_llama_parallel(tp_size, pp_size, concurrency):

--- a/release/llm_tests/batch/test_batch_vllm.py
+++ b/release/llm_tests/batch/test_batch_vllm.py
@@ -58,7 +58,7 @@ def test_chat_template_with_vllm():
     "tp_size,pp_size,concurrency",
     [
         (2, 1, 2),  # TP=2, concurrency=2
-        (1, 2, 2),  # PP=2, concurrency=2
+        (1, 2, (1, 2)),  # PP=2, concurrency=2
     ],
 )
 def test_vllm_llama_parallel(tp_size, pp_size, concurrency):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR removes tuple `concurrency` support from [API doc](https://github.com/ray-project/ray/blob/79a1dad74bf3d841525f11672906611c8a56f1bb/python/ray/llm/_internal/batch/processor/base.py#L48) 

Closes https://anyscale1.atlassian.net/browse/CI-1155
## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
