### PR TITLE
[core] Atomic num_tasks_submitted

### DIFF
--- a/src/ray/core_worker/transport/normal_task_submitter.cc
+++ b/src/ray/core_worker/transport/normal_task_submitter.cc
@@ -28,7 +28,7 @@ namespace core {
 Status NormalTaskSubmitter::SubmitTask(TaskSpecification task_spec) {
   RAY_CHECK(task_spec.IsNormalTask());
   RAY_LOG(DEBUG) << "Submit task " << task_spec.TaskId();
-  num_tasks_submitted_++;
+  num_tasks_submitted_.fetch_add(1, std::memory_order_relaxed);
 
   resolver_.ResolveDependencies(task_spec, [this, task_spec](Status status) mutable {
     // NOTE: task_spec here is capture copied (from a stack variable) and also
@@ -43,47 +43,45 @@ Status NormalTaskSubmitter::SubmitTask(TaskSpecification task_spec) {
     }
     RAY_LOG(DEBUG) << "Task dependencies resolved " << task_spec.TaskId();
 
-    {
-      absl::MutexLock lock(&mu_);
-      auto task_iter = cancelled_tasks_.find(task_spec.TaskId());
-      if (task_iter != cancelled_tasks_.end()) {
-        cancelled_tasks_.erase(task_iter);
-        return;
-      }
+    absl::MutexLock lock(&mu_);
+    auto task_iter = cancelled_tasks_.find(task_spec.TaskId());
+    if (task_iter != cancelled_tasks_.end()) {
+      cancelled_tasks_.erase(task_iter);
+      return;
+    }
 
-      task_spec.GetMutableMessage().set_dependency_resolution_timestamp_ms(
-          current_sys_time_ms());
-      // Note that the dependencies in the task spec are mutated to only contain
-      // plasma dependencies after ResolveDependencies finishes.
-      const SchedulingKey scheduling_key(
-          task_spec.GetSchedulingClass(),
-          task_spec.GetDependencyIds(),
-          task_spec.IsActorCreationTask() ? task_spec.ActorCreationId() : ActorID::Nil(),
-          task_spec.GetRuntimeEnvHash());
-      auto &scheduling_key_entry = scheduling_key_entries_[scheduling_key];
-      scheduling_key_entry.task_queue.push_back(task_spec);
-      scheduling_key_entry.resource_spec = std::move(task_spec);
+    task_spec.GetMutableMessage().set_dependency_resolution_timestamp_ms(
+        current_sys_time_ms());
+    // Note that the dependencies in the task spec are mutated to only contain
+    // plasma dependencies after ResolveDependencies finishes.
+    const SchedulingKey scheduling_key(
+        task_spec.GetSchedulingClass(),
+        task_spec.GetDependencyIds(),
+        task_spec.IsActorCreationTask() ? task_spec.ActorCreationId() : ActorID::Nil(),
+        task_spec.GetRuntimeEnvHash());
+    auto &scheduling_key_entry = scheduling_key_entries_[scheduling_key];
+    scheduling_key_entry.task_queue.push_back(task_spec);
+    scheduling_key_entry.resource_spec = std::move(task_spec);
 
-      if (!scheduling_key_entry.AllWorkersBusy()) {
-        // There are idle workers, so we don't need more
-        // workers.
-        for (const auto &active_worker_addr : scheduling_key_entry.active_workers) {
-          auto iter = worker_to_lease_entry_.find(active_worker_addr);
-          RAY_CHECK(iter != worker_to_lease_entry_.end());
-          auto &lease_entry = iter->second;
-          if (!lease_entry.is_busy) {
-            OnWorkerIdle(active_worker_addr,
-                         scheduling_key,
-                         /*was_error*/ false,
-                         /*error_detail*/ "",
-                         /*worker_exiting*/ false,
-                         lease_entry.assigned_resources);
-            break;
-          }
+    if (!scheduling_key_entry.AllWorkersBusy()) {
+      // There are idle workers, so we don't need more
+      // workers.
+      for (const auto &active_worker_addr : scheduling_key_entry.active_workers) {
+        auto iter = worker_to_lease_entry_.find(active_worker_addr);
+        RAY_CHECK(iter != worker_to_lease_entry_.end());
+        auto &lease_entry = iter->second;
+        if (!lease_entry.is_busy) {
+          OnWorkerIdle(active_worker_addr,
+                       scheduling_key,
+                       /*was_error*/ false,
+                       /*error_detail*/ "",
+                       /*worker_exiting*/ false,
+                       lease_entry.assigned_resources);
+          break;
         }
       }
-      RequestNewWorkerIfNeeded(scheduling_key);
     }
+    RequestNewWorkerIfNeeded(scheduling_key);
   });
   return Status::OK();
 }

--- a/src/ray/core_worker/transport/normal_task_submitter.h
+++ b/src/ray/core_worker/transport/normal_task_submitter.h
@@ -134,7 +134,9 @@ class NormalTaskSubmitter {
     return scheduling_key_entries_.empty();
   }
 
-  int64_t GetNumTasksSubmitted() const { return num_tasks_submitted_; }
+  int64_t GetNumTasksSubmitted() const {
+    return num_tasks_submitted_.load(std::memory_order_relaxed);
+  }
 
   int64_t GetNumLeasesRequested() {
     absl::MutexLock lock(&mu_);
@@ -376,7 +378,7 @@ class NormalTaskSubmitter {
   // Retries cancelation requests if they were not successful.
   std::optional<boost::asio::steady_timer> cancel_retry_timer_;
 
-  int64_t num_tasks_submitted_ = 0;
+  std::atomic<int64_t> num_tasks_submitted_ = 0;
   int64_t num_leases_requested_ ABSL_GUARDED_BY(mu_) = 0;
 };
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
`num_tasks_submitted` is subject to data races because it SubmitTask could be called from the core worker's io_service thread or the user's Python thread. It's also possible for SubmitTask or GetNumTasksSubmitted from multiple user Python threads since we release the gil before calling into them.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
