### PR TITLE
[core] Manually run io service in actor manager tests to simulate different orderings

### DIFF
--- a/src/ray/common/test_util.h
+++ b/src/ray/common/test_util.h
@@ -146,23 +146,4 @@ SaveArgToUniquePtrAction<k, T> SaveArgToUniquePtr(std::unique_ptr<T> *ptr) {
   return {ptr};
 }
 
-template <typename Lambda>
-auto SyncPostAndWait(instrumented_io_context &io_context,
-                     const std::string &name,
-                     Lambda f) {
-  using ReturnType = std::invoke_result_t<Lambda>;
-  std::promise<ReturnType> promise;
-  io_context.post(
-      [&]() {
-        if constexpr (std::is_void_v<ReturnType>) {
-          f();
-          promise.set_value();
-        } else {
-          promise.set_value(f());
-        }
-      },
-      name);
-  return promise.get_future().get();
-}
-
 }  // namespace ray

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -91,21 +91,9 @@ class MockWorkerClient : public rpc::CoreWorkerClientInterface {
     if (callbacks_.size() == 0) {
       return false;
     }
-
-    // The created_actors_ of gcs actor manager will be modified in io_service thread.
-    // In order to avoid multithreading reading and writing created_actors_, we also
-    // send the `WaitForActorRefDeleted` callback operation to io_service thread.
-    std::promise<bool> promise;
-    io_service_.post(
-        [this, status, &promise]() {
-          auto callback = callbacks_.front();
-          auto reply = rpc::WaitForActorRefDeletedReply();
-          callback(status, std::move(reply));
-          promise.set_value(false);
-        },
-        "test");
-    promise.get_future().get();
-
+    auto callback = callbacks_.front();
+    auto reply = rpc::WaitForActorRefDeletedReply();
+    callback(status, std::move(reply));
     callbacks_.pop_front();
     return true;
   }
@@ -115,10 +103,6 @@ class MockWorkerClient : public rpc::CoreWorkerClientInterface {
   instrumented_io_context &io_service_;
 };
 
-// Note: there are a lot of SyncPostAndWait calls in this test. This is because certain
-// GcsActorManager methods require to be called on the main io_context. We can't simply
-// put the whole test body in a SyncPostAndWait because that would deadlock (we need to
-// debug why).
 class GcsActorManagerTest : public ::testing::Test {
  public:
   GcsActorManagerTest() : periodical_runner_(PeriodicalRunner::Create(io_service_)) {
@@ -128,14 +112,6 @@ class GcsActorManagerTest : public ::testing::Test {
   "maximum_gcs_destroyed_actor_cached_count": 10
 }
   )");
-    std::promise<bool> promise;
-    thread_io_service_.reset(new std::thread([this, &promise] {
-      boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work(
-          io_service_.get_executor());
-      promise.set_value(true);
-      io_service_.run();
-    }));
-    promise.get_future().get();
     worker_client_ = std::make_shared<MockWorkerClient>(io_service_);
     runtime_env_mgr_ =
         std::make_unique<ray::RuntimeEnvManager>([](auto, auto f) { f(true); });
@@ -174,35 +150,7 @@ class GcsActorManagerTest : public ::testing::Test {
     }
   }
 
-  virtual ~GcsActorManagerTest() {
-    io_service_.stop();
-    thread_io_service_->join();
-  }
-
-  void WaitActorCreated(const ActorID &actor_id) {
-    auto condition = [this, actor_id]() {
-      // The created_actors_ of gcs actor manager will be modified in io_service thread.
-      // In order to avoid multithreading reading and writing created_actors_, we also
-      // send the read operation to io_service thread.
-      std::promise<bool> promise;
-      io_service_.post(
-          [this, actor_id, &promise]() {
-            const auto &created_actors = gcs_actor_manager_->GetCreatedActors();
-            for (auto &node_iter : created_actors) {
-              for (auto &actor_iter : node_iter.second) {
-                if (actor_iter.second == actor_id) {
-                  promise.set_value(true);
-                  return;
-                }
-              }
-            }
-            promise.set_value(false);
-          },
-          "test");
-      return promise.get_future().get();
-    };
-    EXPECT_TRUE(WaitForCondition(condition, timeout_ms_.count()));
-  }
+  virtual ~GcsActorManagerTest() { io_service_.stop(); }
 
   rpc::Address RandomAddress() const {
     rpc::Address address;
@@ -219,43 +167,30 @@ class GcsActorManagerTest : public ::testing::Test {
       bool detached = false,
       const std::string &name = "",
       const std::string &ray_namespace = "test") {
-    std::promise<std::shared_ptr<gcs::GcsActor>> promise;
+    // The tests queue up operations and sometimes don't execute them through the
+    // io_context themselves. This is a hack, and future tests shouldn't use this
+    // RegisterActor function.
+    while (io_service_.poll_one()) {
+      std::cout << "io_service_.poll_one()" << std::endl;
+      continue;
+    }
     auto request = Mocker::GenRegisterActorRequest(
         job_id, max_restarts, detached, name, ray_namespace);
-    // `DestroyActor` triggers some asynchronous operations.
-    // If we register an actor after destroying an actor, it may result in multithreading
-    // reading and writing the same variable. In order to avoid the problem of
-    // multithreading, we put `RegisterActor` to io_service thread.
-    io_service_.post(
-        [this, request, &promise]() {
-          auto status = gcs_actor_manager_->RegisterActor(
-              request,
-              [&promise](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {
-                promise.set_value(std::move(actor));
-              });
-          if (!status.ok()) {
-            promise.set_value(nullptr);
-          }
-        },
-        "test");
-    return promise.get_future().get();
+    std::shared_ptr<gcs::GcsActor> actor_out;
+    auto status = gcs_actor_manager_->RegisterActor(
+        request,
+        [&actor_out](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {
+          actor_out = std::move(actor);
+        });
+    io_service_.run_one();
+    io_service_.run_one();
+    return actor_out;
   }
 
   void OnNodeDead(const NodeID &node_id) {
-    std::promise<bool> promise;
-    // `OnNodeDead` triggers some asynchronous operations. If we call `OnNodeDead` 2
-    // times in succession, the second call may result in multithreading reading and
-    // writing the same variable. In order to avoid the problem of multithreading, we put
-    // `OnNodeDead` to io_service thread.
     auto node_info = std::make_shared<rpc::GcsNodeInfo>();
     node_info->set_node_id(node_id.Binary());
-    io_service_.post(
-        [this, node_info, &promise]() {
-          gcs_actor_manager_->OnNodeDead(node_info, "127.0.0.1");
-          promise.set_value(true);
-        },
-        "test");
-    promise.get_future().get();
+    gcs_actor_manager_->OnNodeDead(node_info, "127.0.0.1");
   }
 
   rpc::RestartActorForLineageReconstructionReply RestartActorForLineageReconstruction(
@@ -265,18 +200,9 @@ class GcsActorManagerTest : public ::testing::Test {
     request.set_num_restarts_due_to_lineage_reconstruction(
         num_restarts_due_to_lineage_reconstruction);
     rpc::RestartActorForLineageReconstructionReply reply;
-    std::promise<bool> promise;
-    io_service_.post(
-        [this, &request, &reply, &promise]() {
-          gcs_actor_manager_->HandleRestartActorForLineageReconstruction(
-              request,
-              &reply,
-              [&promise](Status status,
-                         std::function<void()> success,
-                         std::function<void()> failure) { promise.set_value(true); });
-        },
-        "test");
-    promise.get_future().get();
+    gcs_actor_manager_->HandleRestartActorForLineageReconstruction(
+        request, &reply, [](auto status, auto success_callback, auto failure_callback) {
+        });
     return reply;
   }
 
@@ -287,48 +213,13 @@ class GcsActorManagerTest : public ::testing::Test {
     request.set_num_restarts_due_to_lineage_reconstruction(
         num_restarts_due_to_lineage_reconstrcution);
     rpc::ReportActorOutOfScopeReply reply;
-    std::promise<bool> promise;
-    io_service_.post(
-        [this, &request, &reply, &promise]() {
-          gcs_actor_manager_->HandleReportActorOutOfScope(
-              request,
-              &reply,
-              [&promise](Status status,
-                         std::function<void()> success,
-                         std::function<void()> failure) { promise.set_value(true); });
-        },
-        "test");
-    promise.get_future().get();
-  }
-
-  std::shared_ptr<gcs::GcsActor> CreateActorAndWaitTilAlive(const JobID &job_id) {
-    auto registered_actor = RegisterActor(job_id);
-    rpc::CreateActorRequest create_actor_request;
-    create_actor_request.mutable_task_spec()->CopyFrom(
-        registered_actor->GetCreationTaskSpecification().GetMessage());
-    std::vector<std::shared_ptr<gcs::GcsActor>> finished_actors;
-    Status status = gcs_actor_manager_->CreateActor(
-        create_actor_request,
-        [&finished_actors](const std::shared_ptr<gcs::GcsActor> &actor,
-                           const rpc::PushTaskReply &reply,
-                           const Status &status) {
-          finished_actors.emplace_back(actor);
+    gcs_actor_manager_->HandleReportActorOutOfScope(
+        request, &reply, [](auto status, auto success_callback, auto failure_callback) {
         });
-
-    auto actor = mock_actor_scheduler_->actors.back();
-    mock_actor_scheduler_->actors.pop_back();
-
-    // Check that the actor is in state `ALIVE`.
-    actor->UpdateAddress(RandomAddress());
-    gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
-    WaitActorCreated(actor->GetActorID());
-    RAY_CHECK_EQ(gcs_actor_manager_->CountFor(rpc::ActorTableData::ALIVE, ""), 1);
-    RAY_CHECK_EQ(actor->GetState(), rpc::ActorTableData::ALIVE);
-    return actor;
+    io_service_.run_one();
   }
 
   instrumented_io_context io_service_;
-  std::unique_ptr<std::thread> thread_io_service_;
   std::shared_ptr<gcs::StoreClient> store_client_;
   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
   // Actor scheduler's ownership lies in actor manager.
@@ -373,7 +264,7 @@ TEST_F(GcsActorManagerTest, TestBasic) {
   // Check that the actor is in state `ALIVE`.
   actor->UpdateAddress(RandomAddress());
   gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
-  WaitActorCreated(actor->GetActorID());
+  io_service_.run_one();
   ASSERT_EQ(finished_actors.size(), 1);
   RAY_CHECK_EQ(gcs_actor_manager_->CountFor(rpc::ActorTableData::ALIVE, ""), 1);
 
@@ -412,7 +303,7 @@ TEST_F(GcsActorManagerTest, TestDeadCount) {
     // Check that the actor is in state `ALIVE`.
     actor->UpdateAddress(RandomAddress());
     gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
-    WaitActorCreated(actor->GetActorID());
+    io_service_.run_one();
     // Actor is killed.
     ASSERT_TRUE(worker_client_->Reply());
     ASSERT_EQ(actor->GetState(), rpc::ActorTableData::DEAD);
@@ -439,12 +330,11 @@ TEST_F(GcsActorManagerTest, TestSchedulingFailed) {
   auto actor = mock_actor_scheduler_->actors.back();
   mock_actor_scheduler_->actors.clear();
 
-  SyncPostAndWait(io_service_, "TestSchedulingFailed", [&]() {
-    gcs_actor_manager_->OnActorSchedulingFailed(
-        actor,
-        rpc::RequestWorkerLeaseReply::SCHEDULING_CANCELLED_RUNTIME_ENV_SETUP_FAILED,
-        "");
-  });
+  gcs_actor_manager_->OnActorSchedulingFailed(
+      actor,
+      rpc::RequestWorkerLeaseReply::SCHEDULING_CANCELLED_RUNTIME_ENV_SETUP_FAILED,
+      "");
+  io_service_.run_one();
   ASSERT_EQ(mock_actor_scheduler_->actors.size(), 0);
 }
 
@@ -473,7 +363,7 @@ TEST_F(GcsActorManagerTest, TestWorkerFailure) {
   auto worker_id = WorkerID::FromBinary(address.worker_id());
   actor->UpdateAddress(address);
   gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
-  WaitActorCreated(actor->GetActorID());
+  io_service_.run_one();
   ASSERT_EQ(finished_actors.size(), 1);
 
   // Killing another worker does not affect this actor.
@@ -518,7 +408,7 @@ TEST_F(GcsActorManagerTest, TestNodeFailure) {
   auto address = RandomAddress();
   actor->UpdateAddress(address);
   gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
-  WaitActorCreated(actor->GetActorID());
+  io_service_.run_one();
   ASSERT_EQ(finished_actors.size(), 1);
 
   // Killing another node does not affect this actor.
@@ -569,7 +459,7 @@ TEST_F(GcsActorManagerTest, TestActorReconstruction) {
   auto node_id = NodeID::FromBinary(address.raylet_id());
   actor->UpdateAddress(address);
   gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
-  WaitActorCreated(actor->GetActorID());
+  io_service_.run_one();
   ASSERT_EQ(finished_actors.size(), 1);
 
   // Remove worker and then check that the actor is being restarted.
@@ -585,7 +475,8 @@ TEST_F(GcsActorManagerTest, TestActorReconstruction) {
   address.set_raylet_id(node_id2.Binary());
   actor->UpdateAddress(address);
   gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
-  WaitActorCreated(actor->GetActorID());
+  io_service_.run_one();
+  io_service_.run_one();
   ASSERT_EQ(finished_actors.size(), 1);
   ASSERT_EQ(actor->GetState(), rpc::ActorTableData::ALIVE);
   ASSERT_EQ(actor->GetNodeID(), node_id2);
@@ -636,7 +527,7 @@ TEST_F(GcsActorManagerTest, TestActorRestartWhenOwnerDead) {
   auto node_id = NodeID::FromBinary(address.raylet_id());
   actor->UpdateAddress(address);
   gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
-  WaitActorCreated(actor->GetActorID());
+  io_service_.run_one();
   ASSERT_EQ(finished_actors.size(), 1);
 
   // Remove the owner's node.
@@ -684,7 +575,7 @@ TEST_F(GcsActorManagerTest, TestDetachedActorRestartWhenCreatorDead) {
   // Check that the actor is in state `ALIVE`.
   actor->UpdateAddress(RandomAddress());
   gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
-  WaitActorCreated(actor->GetActorID());
+  io_service_.run_one();
   ASSERT_EQ(finished_actors.size(), 1);
 
   // Remove the owner's node.
@@ -705,10 +596,9 @@ TEST_F(GcsActorManagerTest, TestActorWithEmptyName) {
                                                   /*detached=*/true,
                                                   /*name=*/"");
 
-  Status status = SyncPostAndWait(io_service_, "TestActorWithEmptyName", [&]() {
-    return gcs_actor_manager_->RegisterActor(
-        request1, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
-  });
+  Status status = gcs_actor_manager_->RegisterActor(
+      request1, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
+  io_service_.run_one();
 
   // Ensure successful registration.
   ASSERT_TRUE(status.ok());
@@ -721,10 +611,9 @@ TEST_F(GcsActorManagerTest, TestActorWithEmptyName) {
                                                   /*max_restarts=*/0,
                                                   /*detached=*/true,
                                                   /*name=*/"");
-  status = SyncPostAndWait(io_service_, "TestActorWithEmptyName", [&]() {
-    return gcs_actor_manager_->RegisterActor(
-        request2, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
-  });
+  status = gcs_actor_manager_->RegisterActor(
+      request2, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
+  io_service_.run_one();
   // Ensure successful registration.
   ASSERT_TRUE(status.ok());
 }
@@ -738,10 +627,9 @@ TEST_F(GcsActorManagerTest, TestNamedActors) {
                                                   /*detached=*/true,
                                                   /*name=*/"actor1",
                                                   /*ray_namesapce=*/"test_named_actor");
-  Status status = SyncPostAndWait(io_service_, "TestNamedActors", [&]() {
-    return gcs_actor_manager_->RegisterActor(
-        request1, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
-  });
+  Status status = gcs_actor_manager_->RegisterActor(
+      request1, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
+  io_service_.run_one();
   ASSERT_TRUE(status.ok());
   ASSERT_EQ(gcs_actor_manager_->GetActorIDByName("actor1", "test_named_actor").Binary(),
             request1.task_spec().actor_creation_task_spec().actor_id());
@@ -751,10 +639,9 @@ TEST_F(GcsActorManagerTest, TestNamedActors) {
                                                   /*detached=*/true,
                                                   /*name=*/"actor2",
                                                   /*ray_namesapce=*/"test_named_actor");
-  status = SyncPostAndWait(io_service_, "TestNamedActors", [&]() {
-    return gcs_actor_manager_->RegisterActor(
-        request2, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
-  });
+  status = gcs_actor_manager_->RegisterActor(
+      request2, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
+  io_service_.run_one();
   ASSERT_TRUE(status.ok());
   ASSERT_EQ(gcs_actor_manager_->GetActorIDByName("actor2", "test_named_actor").Binary(),
             request2.task_spec().actor_creation_task_spec().actor_id());
@@ -769,10 +656,9 @@ TEST_F(GcsActorManagerTest, TestNamedActors) {
                                                   /*detached=*/true,
                                                   /*name=*/"actor2",
                                                   /*ray_namesapce=*/"test_named_actor");
-  status = SyncPostAndWait(io_service_, "TestNamedActors", [&]() {
-    return gcs_actor_manager_->RegisterActor(
-        request3, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
-  });
+  status = gcs_actor_manager_->RegisterActor(
+      request3, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
+  io_service_.run_one();
   ASSERT_TRUE(status.IsAlreadyExists());
   ASSERT_EQ(gcs_actor_manager_->GetActorIDByName("actor2", "test_named_actor").Binary(),
             request2.task_spec().actor_creation_task_spec().actor_id());
@@ -783,10 +669,9 @@ TEST_F(GcsActorManagerTest, TestNamedActors) {
                                                   /*detached=*/true,
                                                   /*name=*/"actor2",
                                                   /*ray_namesapce=*/"test_named_actor");
-  status = SyncPostAndWait(io_service_, "TestNamedActors", [&]() {
-    return gcs_actor_manager_->RegisterActor(
-        request4, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
-  });
+  status = gcs_actor_manager_->RegisterActor(
+      request4, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
+  io_service_.run_one();
   ASSERT_TRUE(status.IsAlreadyExists());
   ASSERT_EQ(gcs_actor_manager_->GetActorIDByName("actor2", "test_named_actor").Binary(),
             request2.task_spec().actor_creation_task_spec().actor_id());
@@ -821,7 +706,7 @@ TEST_F(GcsActorManagerTest, TestNamedActorDeletionWorkerFailure) {
   auto worker_id = WorkerID::FromBinary(address.worker_id());
   actor->UpdateAddress(address);
   gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
-  WaitActorCreated(actor->GetActorID());
+  io_service_.run_one();
 
   // Remove worker and then check that the actor is dead.
   gcs_actor_manager_->OnWorkerDead(node_id, worker_id);
@@ -878,7 +763,7 @@ TEST_F(GcsActorManagerTest, TestNamedActorDeletionNodeFailure) {
   auto node_id = NodeID::FromBinary(address.raylet_id());
   actor->UpdateAddress(address);
   gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
-  WaitActorCreated(actor->GetActorID());
+  io_service_.run_one();
 
   // Remove node and then check that the actor is dead.
   EXPECT_CALL(*mock_actor_scheduler_, CancelOnNode(node_id));
@@ -937,7 +822,7 @@ TEST_F(GcsActorManagerTest, TestNamedActorDeletionNotHappendWhenReconstructed) {
   auto worker_id = WorkerID::FromBinary(address.worker_id());
   actor->UpdateAddress(address);
   gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
-  WaitActorCreated(actor->GetActorID());
+  io_service_.run_one();
 
   // Remove worker and then check that the actor is dead. The actor should be
   // reconstructed.
@@ -952,10 +837,9 @@ TEST_F(GcsActorManagerTest, TestNamedActorDeletionNotHappendWhenReconstructed) {
                                                   /*max_restarts=*/0,
                                                   /*detached=*/true,
                                                   /*name=*/"actor");
-  status = SyncPostAndWait(io_service_, "TestNamedActors", [&]() {
-    return gcs_actor_manager_->RegisterActor(
-        request2, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
-  });
+  status = gcs_actor_manager_->RegisterActor(
+      request2, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
+  io_service_.run_one();
   ASSERT_TRUE(status.IsAlreadyExists());
   ASSERT_EQ(gcs_actor_manager_->GetActorIDByName("actor", "test").Binary(),
             request1.task_spec().actor_creation_task_spec().actor_id());
@@ -1028,9 +912,8 @@ TEST_F(GcsActorManagerTest, TestRaceConditionCancelLease) {
   const auto &task_id = TaskID::FromBinary(
       registered_actor->GetCreationTaskSpecification().GetMessage().task_id());
   EXPECT_CALL(*mock_actor_scheduler_, CancelOnLeasing(node_id, actor_id, task_id));
-  SyncPostAndWait(io_service_, "TestRaceConditionCancelLease", [&]() {
-    gcs_actor_manager_->OnWorkerDead(owner_node_id, owner_worker_id);
-  });
+  gcs_actor_manager_->OnWorkerDead(owner_node_id, owner_worker_id);
+  io_service_.run_one();
   ASSERT_TRUE(actor->GetActorTableData().death_cause().has_actor_died_error_context());
   ASSERT_TRUE(absl::StrContains(
       actor->GetActorTableData().death_cause().actor_died_error_context().error_message(),
@@ -1065,7 +948,7 @@ TEST_F(GcsActorManagerTest, TestRegisterActor) {
 
   actor->UpdateAddress(RandomAddress());
   gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
-  WaitActorCreated(actor->GetActorID());
+  io_service_.run_one();
   ASSERT_EQ(actor->GetState(), rpc::ActorTableData::ALIVE);
 }
 
@@ -1075,9 +958,8 @@ TEST_F(GcsActorManagerTest, TestOwnerWorkerDieBeforeActorDependenciesResolved) {
   const auto &owner_address = registered_actor->GetOwnerAddress();
   auto node_id = NodeID::FromBinary(owner_address.raylet_id());
   auto worker_id = WorkerID::FromBinary(owner_address.worker_id());
-  SyncPostAndWait(io_service_,
-                  "TestOwnerWorkerDieBeforeActorDependenciesResolved",
-                  [&]() { gcs_actor_manager_->OnWorkerDead(node_id, worker_id); });
+  gcs_actor_manager_->OnWorkerDead(node_id, worker_id);
+  io_service_.run_one();
   ASSERT_EQ(registered_actor->GetState(), rpc::ActorTableData::DEAD);
   ASSERT_TRUE(
       registered_actor->GetActorTableData().death_cause().has_actor_died_error_context());
@@ -1090,11 +972,10 @@ TEST_F(GcsActorManagerTest, TestOwnerWorkerDieBeforeActorDependenciesResolved) {
   // Make sure the actor gets cleaned up.
   const auto &registered_actors = gcs_actor_manager_->GetRegisteredActors();
   ASSERT_FALSE(registered_actors.count(registered_actor->GetActorID()));
-  SyncPostAndWait(
-      io_service_, "TestOwnerWorkerDieBeforeActorDependenciesResolved", [&]() {
-        const auto &callbacks = gcs_actor_manager_->GetActorRegisterCallbacks();
-        ASSERT_FALSE(callbacks.count(registered_actor->GetActorID()));
-      });
+
+  const auto &callbacks = gcs_actor_manager_->GetActorRegisterCallbacks();
+  ASSERT_FALSE(callbacks.count(registered_actor->GetActorID()));
+  io_service_.run_one();
 }
 
 TEST_F(GcsActorManagerTest, TestOwnerWorkerDieBeforeDetachedActorDependenciesResolved) {
@@ -1103,9 +984,8 @@ TEST_F(GcsActorManagerTest, TestOwnerWorkerDieBeforeDetachedActorDependenciesRes
   const auto &owner_address = registered_actor->GetOwnerAddress();
   auto node_id = NodeID::FromBinary(owner_address.raylet_id());
   auto worker_id = WorkerID::FromBinary(owner_address.worker_id());
-  SyncPostAndWait(io_service_,
-                  "TestOwnerWorkerDieBeforeDetachedActorDependenciesResolved",
-                  [&]() { gcs_actor_manager_->OnWorkerDead(node_id, worker_id); });
+  gcs_actor_manager_->OnWorkerDead(node_id, worker_id);
+  io_service_.run_one();
   ASSERT_EQ(registered_actor->GetState(), rpc::ActorTableData::DEAD);
   ASSERT_TRUE(
       registered_actor->GetActorTableData().death_cause().has_actor_died_error_context());
@@ -1118,11 +998,9 @@ TEST_F(GcsActorManagerTest, TestOwnerWorkerDieBeforeDetachedActorDependenciesRes
   // Make sure the actor gets cleaned up.
   const auto &registered_actors = gcs_actor_manager_->GetRegisteredActors();
   ASSERT_FALSE(registered_actors.count(registered_actor->GetActorID()));
-  SyncPostAndWait(
-      io_service_, "TestOwnerWorkerDieBeforeDetachedActorDependenciesResolved", [&]() {
-        const auto &callbacks = gcs_actor_manager_->GetActorRegisterCallbacks();
-        ASSERT_FALSE(callbacks.count(registered_actor->GetActorID()));
-      });
+  const auto &callbacks = gcs_actor_manager_->GetActorRegisterCallbacks();
+  ASSERT_FALSE(callbacks.count(registered_actor->GetActorID()));
+  io_service_.run_one();
 }
 
 TEST_F(GcsActorManagerTest, TestOwnerNodeDieBeforeActorDependenciesResolved) {
@@ -1143,10 +1021,8 @@ TEST_F(GcsActorManagerTest, TestOwnerNodeDieBeforeActorDependenciesResolved) {
   // Make sure the actor gets cleaned up.
   const auto &registered_actors = gcs_actor_manager_->GetRegisteredActors();
   ASSERT_FALSE(registered_actors.count(registered_actor->GetActorID()));
-  SyncPostAndWait(io_service_, "TestOwnerNodeDieBeforeActorDependenciesResolved", [&]() {
-    const auto &callbacks = gcs_actor_manager_->GetActorRegisterCallbacks();
-    ASSERT_FALSE(callbacks.count(registered_actor->GetActorID()));
-  });
+  const auto &callbacks = gcs_actor_manager_->GetActorRegisterCallbacks();
+  ASSERT_FALSE(callbacks.count(registered_actor->GetActorID()));
 }
 
 TEST_F(GcsActorManagerTest, TestOwnerNodeDieBeforeDetachedActorDependenciesResolved) {
@@ -1167,11 +1043,8 @@ TEST_F(GcsActorManagerTest, TestOwnerNodeDieBeforeDetachedActorDependenciesResol
   // Make sure the actor gets cleaned up.
   const auto &registered_actors = gcs_actor_manager_->GetRegisteredActors();
   ASSERT_FALSE(registered_actors.count(registered_actor->GetActorID()));
-  SyncPostAndWait(
-      io_service_, "TestOwnerNodeDieBeforeDetachedActorDependenciesResolved", [&]() {
-        const auto &callbacks = gcs_actor_manager_->GetActorRegisterCallbacks();
-        ASSERT_FALSE(callbacks.count(registered_actor->GetActorID()));
-      });
+  const auto &callbacks = gcs_actor_manager_->GetActorRegisterCallbacks();
+  ASSERT_FALSE(callbacks.count(registered_actor->GetActorID()));
 }
 
 TEST_F(GcsActorManagerTest, TestOwnerAndChildDiedAtTheSameTimeRaceCondition) {
@@ -1196,7 +1069,7 @@ TEST_F(GcsActorManagerTest, TestOwnerAndChildDiedAtTheSameTimeRaceCondition) {
   auto address = RandomAddress();
   actor->UpdateAddress(address);
   gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
-  WaitActorCreated(actor->GetActorID());
+  io_service_.run_one();
   ASSERT_EQ(finished_actors.size(), 1);
 
   const auto owner_node_id = actor->GetOwnerNodeID();
@@ -1205,12 +1078,11 @@ TEST_F(GcsActorManagerTest, TestOwnerAndChildDiedAtTheSameTimeRaceCondition) {
   const auto child_worker_id = actor->GetWorkerID();
   const auto actor_id = actor->GetActorID();
   // Make worker & owner fail at the same time, but owner's failure comes first.
-  SyncPostAndWait(io_service_, "TestOwnerAndChildDiedAtTheSameTimeRaceCondition", [&]() {
-    gcs_actor_manager_->OnWorkerDead(owner_node_id, owner_worker_id);
-    EXPECT_CALL(*mock_actor_scheduler_, CancelOnWorker(child_node_id, child_worker_id))
-        .WillOnce(Return(actor_id));
-    gcs_actor_manager_->OnWorkerDead(child_node_id, child_worker_id);
-  });
+  gcs_actor_manager_->OnWorkerDead(owner_node_id, owner_worker_id);
+  EXPECT_CALL(*mock_actor_scheduler_, CancelOnWorker(child_node_id, child_worker_id))
+      .WillOnce(Return(actor_id));
+  gcs_actor_manager_->OnWorkerDead(child_node_id, child_worker_id);
+  io_service_.run_one();
 }
 
 TEST_F(GcsActorManagerTest, TestRayNamespace) {
@@ -1224,44 +1096,41 @@ TEST_F(GcsActorManagerTest, TestRayNamespace) {
                                                   /*max_restarts=*/0,
                                                   /*detached=*/true,
                                                   /*name=*/"actor");
-  SyncPostAndWait(io_service_, "TestRayNamespace", [&]() {
-    Status status = gcs_actor_manager_->RegisterActor(
-        request1, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
-    ASSERT_TRUE(status.ok());
-    ASSERT_EQ(gcs_actor_manager_->GetActorIDByName("actor", "test").Binary(),
-              request1.task_spec().actor_creation_task_spec().actor_id());
-  });
+  Status status = gcs_actor_manager_->RegisterActor(
+      request1, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
+  ASSERT_TRUE(status.ok());
+  ASSERT_EQ(gcs_actor_manager_->GetActorIDByName("actor", "test").Binary(),
+            request1.task_spec().actor_creation_task_spec().actor_id());
+  io_service_.run_one();
 
   auto request2 = Mocker::GenRegisterActorRequest(job_id_2,
                                                   /*max_restarts=*/0,
                                                   /*detached=*/true,
                                                   /*name=*/"actor",
                                                   second_namespace);
-  SyncPostAndWait(io_service_, "TestRayNamespace", [&]() {
-    // Create a second actor of the same name. Its job id belongs to a different
-    // namespace though.
-    Status status = gcs_actor_manager_->RegisterActor(
-        request2, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
-    ASSERT_TRUE(status.ok());
-    ASSERT_EQ(gcs_actor_manager_->GetActorIDByName("actor", second_namespace).Binary(),
-              request2.task_spec().actor_creation_task_spec().actor_id());
-    // The actors may have the same name, but their ids are different.
-    ASSERT_NE(gcs_actor_manager_->GetActorIDByName("actor", second_namespace).Binary(),
-              request1.task_spec().actor_creation_task_spec().actor_id());
-  });
+  // Create a second actor of the same name. Its job id belongs to a different
+  // namespace though.
+  status = gcs_actor_manager_->RegisterActor(
+      request2, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
+  ASSERT_TRUE(status.ok());
+  ASSERT_EQ(gcs_actor_manager_->GetActorIDByName("actor", second_namespace).Binary(),
+            request2.task_spec().actor_creation_task_spec().actor_id());
+  // The actors may have the same name, but their ids are different.
+  ASSERT_NE(gcs_actor_manager_->GetActorIDByName("actor", second_namespace).Binary(),
+            request1.task_spec().actor_creation_task_spec().actor_id());
+  io_service_.run_one();
 
   auto request3 = Mocker::GenRegisterActorRequest(job_id_3,
                                                   /*max_restarts=*/0,
                                                   /*detached=*/true,
                                                   /*name=*/"actor",
                                                   /*ray_namespace=*/"test");
-  SyncPostAndWait(io_service_, "TestRayNamespace", [&]() {
-    Status status = gcs_actor_manager_->RegisterActor(
-        request3, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
-    ASSERT_TRUE(status.IsAlreadyExists());
-    ASSERT_EQ(gcs_actor_manager_->GetActorIDByName("actor", "test").Binary(),
-              request1.task_spec().actor_creation_task_spec().actor_id());
-  });
+  status = gcs_actor_manager_->RegisterActor(
+      request3, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
+  ASSERT_TRUE(status.IsAlreadyExists());
+  ASSERT_EQ(gcs_actor_manager_->GetActorIDByName("actor", "test").Binary(),
+            request1.task_spec().actor_creation_task_spec().actor_id());
+  io_service_.run_one();
 }
 
 TEST_F(GcsActorManagerTest, TestReuseActorNameInNamespace) {
@@ -1273,44 +1142,60 @@ TEST_F(GcsActorManagerTest, TestReuseActorNameInNamespace) {
       Mocker::GenRegisterActorRequest(job_id_1, 0, true, actor_name, ray_namespace);
   auto actor_id_1 =
       ActorID::FromBinary(request_1.task_spec().actor_creation_task_spec().actor_id());
-  SyncPostAndWait(io_service_, "TestReuseActorNameInNamespace", [&]() {
-    Status status = gcs_actor_manager_->RegisterActor(
-        request_1,
-        [](const std::shared_ptr<gcs::GcsActor> &actor, const Status &status) {});
-    ASSERT_TRUE(status.ok());
-    ASSERT_EQ(gcs_actor_manager_->GetActorIDByName(actor_name, ray_namespace).Binary(),
-              actor_id_1.Binary());
-  });
+  Status status = gcs_actor_manager_->RegisterActor(
+      request_1,
+      [](const std::shared_ptr<gcs::GcsActor> &actor, const Status &status) {});
+  ASSERT_TRUE(status.ok());
+  ASSERT_EQ(gcs_actor_manager_->GetActorIDByName(actor_name, ray_namespace).Binary(),
+            actor_id_1.Binary());
+  io_service_.run_one();
 
-  SyncPostAndWait(io_service_, "TestReuseActorNameInNamespace", [&]() {
-    auto owner_address = request_1.task_spec().caller_address();
-    auto node_info = std::make_shared<rpc::GcsNodeInfo>();
-    node_info->set_node_id(owner_address.raylet_id());
-    gcs_actor_manager_->OnNodeDead(node_info, "");
-    ASSERT_EQ(gcs_actor_manager_->GetActorIDByName(actor_name, ray_namespace).Binary(),
-              ActorID::Nil().Binary());
-  });
+  auto owner_address = request_1.task_spec().caller_address();
+  auto node_info = std::make_shared<rpc::GcsNodeInfo>();
+  node_info->set_node_id(owner_address.raylet_id());
+  gcs_actor_manager_->OnNodeDead(node_info, "");
+  ASSERT_EQ(gcs_actor_manager_->GetActorIDByName(actor_name, ray_namespace).Binary(),
+            ActorID::Nil().Binary());
+  io_service_.run_one();
 
-  SyncPostAndWait(io_service_, "TestReuseActorNameInNamespace", [&]() {
-    auto job_id_2 = JobID::FromInt(2);
-    auto request_2 =
-        Mocker::GenRegisterActorRequest(job_id_2, 0, true, actor_name, ray_namespace);
-    auto actor_id_2 =
-        ActorID::FromBinary(request_2.task_spec().actor_creation_task_spec().actor_id());
-    auto status = gcs_actor_manager_->RegisterActor(
-        request_2,
-        [](const std::shared_ptr<gcs::GcsActor> &actor, const Status &status) {});
-    ASSERT_TRUE(status.ok());
-    ASSERT_EQ(gcs_actor_manager_->GetActorIDByName(actor_name, ray_namespace).Binary(),
-              actor_id_2.Binary());
-  });
+  auto job_id_2 = JobID::FromInt(2);
+  auto request_2 =
+      Mocker::GenRegisterActorRequest(job_id_2, 0, true, actor_name, ray_namespace);
+  auto actor_id_2 =
+      ActorID::FromBinary(request_2.task_spec().actor_creation_task_spec().actor_id());
+  status = gcs_actor_manager_->RegisterActor(
+      request_2,
+      [](const std::shared_ptr<gcs::GcsActor> &actor, const Status &status) {});
+  ASSERT_TRUE(status.ok());
+  ASSERT_EQ(gcs_actor_manager_->GetActorIDByName(actor_name, ray_namespace).Binary(),
+            actor_id_2.Binary());
+  io_service_.run_one();
 }
 
 TEST_F(GcsActorManagerTest, TestGetAllActorInfoFilters) {
   google::protobuf::Arena arena;
   // The target filter actor.
   auto job_id = JobID::FromInt(1);
-  auto actor = CreateActorAndWaitTilAlive(job_id);
+  auto registered_actor = RegisterActor(job_id);
+  rpc::CreateActorRequest create_actor_request;
+  create_actor_request.mutable_task_spec()->CopyFrom(
+      registered_actor->GetCreationTaskSpecification().GetMessage());
+  std::vector<std::shared_ptr<gcs::GcsActor>> finished_actors;
+  Status status = gcs_actor_manager_->CreateActor(
+      create_actor_request,
+      [&finished_actors](const std::shared_ptr<gcs::GcsActor> &actor,
+                         const rpc::PushTaskReply &reply,
+                         const Status &status) { finished_actors.emplace_back(actor); });
+
+  auto actor = mock_actor_scheduler_->actors.back();
+  mock_actor_scheduler_->actors.pop_back();
+
+  // Check that the actor is in state `ALIVE`.
+  actor->UpdateAddress(RandomAddress());
+  gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
+  io_service_.run_one();
+  ASSERT_EQ(gcs_actor_manager_->CountFor(rpc::ActorTableData::ALIVE, ""), 1);
+  ASSERT_EQ(actor->GetState(), rpc::ActorTableData::ALIVE);
 
   // Just register some other actors.
   auto job_id_other = JobID::FromInt(2);
@@ -1319,11 +1204,10 @@ TEST_F(GcsActorManagerTest, TestGetAllActorInfoFilters) {
     auto request1 = Mocker::GenRegisterActorRequest(job_id_other,
                                                     /*max_restarts=*/0,
                                                     /*detached=*/false);
-    SyncPostAndWait(io_service_, "TestGetAllActorInfoFilters", [&]() {
-      Status status = gcs_actor_manager_->RegisterActor(
-          request1, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
-      ASSERT_TRUE(status.ok());
-    });
+    Status status = gcs_actor_manager_->RegisterActor(
+        request1, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
+    ASSERT_TRUE(status.ok());
+    io_service_.run_one();
   }
 
   auto callback =
@@ -1398,11 +1282,10 @@ TEST_F(GcsActorManagerTest, TestGetAllActorInfoLimit) {
     auto request1 = Mocker::GenRegisterActorRequest(job_id_1,
                                                     /*max_restarts=*/0,
                                                     /*detached=*/false);
-    SyncPostAndWait(io_service_, "TestGetAllActorInfoLimit", [&]() {
-      Status status = gcs_actor_manager_->RegisterActor(
-          request1, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
-      ASSERT_TRUE(status.ok());
-    });
+    Status status = gcs_actor_manager_->RegisterActor(
+        request1, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
+    ASSERT_TRUE(status.ok());
+    io_service_.run_one();
   }
 
   {
@@ -1425,6 +1308,7 @@ TEST_F(GcsActorManagerTest, TestGetAllActorInfoLimit) {
 }
 
 namespace gcs {
+
 TEST_F(GcsActorManagerTest, TestKillActorWhenActorIsCreating) {
   auto job_id = JobID::FromInt(1);
   auto registered_actor = RegisterActor(job_id, /*max_restarts*/ -1);
@@ -1497,7 +1381,7 @@ TEST_F(GcsActorManagerTest, TestRestartActorForLineageReconstruction) {
   auto node_id = NodeID::FromBinary(address.raylet_id());
   actor->UpdateAddress(address);
   gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
-  WaitActorCreated(actor->GetActorID());
+  io_service_.run_one();
   ASSERT_EQ(created_actors.size(), 1);
   ASSERT_EQ(actor->GetState(), rpc::ActorTableData::ALIVE);
 
@@ -1514,7 +1398,8 @@ TEST_F(GcsActorManagerTest, TestRestartActorForLineageReconstruction) {
   address.set_raylet_id(node_id2.Binary());
   actor->UpdateAddress(address);
   gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
-  WaitActorCreated(actor->GetActorID());
+  io_service_.run_one();
+  io_service_.run_one();
   ASSERT_EQ(created_actors.size(), 1);
   ASSERT_EQ(actor->GetState(), rpc::ActorTableData::ALIVE);
   ASSERT_EQ(actor->GetNodeID(), node_id2);
@@ -1539,7 +1424,8 @@ TEST_F(GcsActorManagerTest, TestRestartActorForLineageReconstruction) {
   address.set_raylet_id(node_id3.Binary());
   actor->UpdateAddress(address);
   gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
-  WaitActorCreated(actor->GetActorID());
+  io_service_.run_one();
+  io_service_.run_one();
   ASSERT_EQ(created_actors.size(), 1);
   ASSERT_EQ(actor->GetState(), rpc::ActorTableData::ALIVE);
   ASSERT_EQ(actor->GetNodeID(), node_id3);
@@ -1570,7 +1456,7 @@ TEST_F(GcsActorManagerTest, TestRestartPermanentlyDeadActorForLineageReconstruct
   auto address = RandomAddress();
   actor->UpdateAddress(address);
   gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
-  WaitActorCreated(actor->GetActorID());
+  io_service_.run_one();
   ASSERT_EQ(created_actors.size(), 1);
   ASSERT_EQ(actor->GetState(), rpc::ActorTableData::ALIVE);
 
@@ -1615,7 +1501,7 @@ TEST_F(GcsActorManagerTest, TestIdempotencyOfRestartActorForLineageReconstructio
   auto address = RandomAddress();
   actor->UpdateAddress(address);
   gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
-  WaitActorCreated(actor->GetActorID());
+  io_service_.run_one();
   ASSERT_EQ(created_actors.size(), 1);
 
   // The actor is out of scope and dead.
@@ -1633,32 +1519,22 @@ TEST_F(GcsActorManagerTest, TestIdempotencyOfRestartActorForLineageReconstructio
   request.set_num_restarts_due_to_lineage_reconstruction(1);
   rpc::RestartActorForLineageReconstructionReply reply1;
   rpc::RestartActorForLineageReconstructionReply reply2;
-  std::promise<bool> promise1;
-  std::promise<bool> promise2;
-  io_service_.post(
-      [this, &request, &reply1, &reply2, &promise1, &promise2]() {
-        gcs_actor_manager_->HandleRestartActorForLineageReconstruction(
-            request,
-            &reply1,
-            [&reply1, &promise1](Status status,
-                                 std::function<void()> success,
-                                 std::function<void()> failure) {
-              ASSERT_EQ(reply1.status().code(), static_cast<int>(StatusCode::OK));
-              promise1.set_value(true);
-            });
-        gcs_actor_manager_->HandleRestartActorForLineageReconstruction(
-            request,
-            &reply2,
-            [&reply2, &promise2](Status status,
-                                 std::function<void()> success,
-                                 std::function<void()> failure) {
-              ASSERT_EQ(reply2.status().code(), static_cast<int>(StatusCode::OK));
-              promise2.set_value(true);
-            });
-      },
-      "test");
-  promise1.get_future().get();
-  promise2.get_future().get();
+
+  gcs_actor_manager_->HandleRestartActorForLineageReconstruction(
+      request,
+      &reply1,
+      [&reply1](
+          Status status, std::function<void()> success, std::function<void()> failure) {
+        ASSERT_EQ(reply1.status().code(), static_cast<int>(StatusCode::OK));
+      });
+  gcs_actor_manager_->HandleRestartActorForLineageReconstruction(
+      request,
+      &reply2,
+      [&reply2](
+          Status status, std::function<void()> success, std::function<void()> failure) {
+        ASSERT_EQ(reply2.status().code(), static_cast<int>(StatusCode::OK));
+      });
+  io_service_.run_one();
   ASSERT_EQ(actor->GetState(), rpc::ActorTableData::RESTARTING);
 
   // Add node and check that the actor is restarted.
@@ -1669,7 +1545,7 @@ TEST_F(GcsActorManagerTest, TestIdempotencyOfRestartActorForLineageReconstructio
   address.set_raylet_id(node_id.Binary());
   actor->UpdateAddress(address);
   gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
-  WaitActorCreated(actor->GetActorID());
+  io_service_.run_one();
   ASSERT_EQ(created_actors.size(), 1);
   ASSERT_EQ(actor->GetState(), rpc::ActorTableData::ALIVE);
   ASSERT_EQ(actor->GetNodeID(), node_id);
@@ -1726,14 +1602,12 @@ TEST_F(GcsActorManagerTest, TestDestroyActorWhenActorIsCreating) {
   request.set_force_kill(true);
   // Set the `no_restart` flag to true so that the actor will be destoryed.
   request.set_no_restart(true);
-  SyncPostAndWait(io_service_, "TestDestroyActorWhenActorIsCreating", [&]() {
-    gcs_actor_manager_->HandleKillActorViaGcs(
-        request,
-        &reply,
-        /*send_reply_callback*/
-        [](Status status, std::function<void()> success, std::function<void()> failure) {
-        });
-  });
+  gcs_actor_manager_->HandleKillActorViaGcs(
+      request,
+      &reply,
+      /*send_reply_callback*/
+      [](Status status, std::function<void()> success, std::function<void()> failure) {});
+  io_service_.run_one();
 
   // Make sure the `KillActor` rpc is send.
   ASSERT_EQ(worker_client_->killed_actors_.size(), 1);
@@ -1744,4 +1618,5 @@ TEST_F(GcsActorManagerTest, TestDestroyActorWhenActorIsCreating) {
 }
 
 }  // namespace gcs
+
 }  // namespace ray

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -171,7 +171,6 @@ class GcsActorManagerTest : public ::testing::Test {
     // io_context themselves. This is a hack, and future tests shouldn't use this
     // RegisterActor function.
     while (io_service_.poll_one()) {
-      std::cout << "io_service_.poll_one()" << std::endl;
       continue;
     }
     auto request = Mocker::GenRegisterActorRequest(
@@ -626,7 +625,7 @@ TEST_F(GcsActorManagerTest, TestNamedActors) {
                                                   /*max_restarts=*/0,
                                                   /*detached=*/true,
                                                   /*name=*/"actor1",
-                                                  /*ray_namesapce=*/"test_named_actor");
+                                                  /*ray_namespace=*/"test_named_actor");
   Status status = gcs_actor_manager_->RegisterActor(
       request1, [](std::shared_ptr<gcs::GcsActor> actor, const Status &status) {});
   io_service_.run_one();


### PR DESCRIPTION
## Why are these changes needed?
Currently the actor manager tests run the io service on its own thread. This is not good for a number of reasons.
1. Impossible to simulate different ordering of callbacks and actor manager function calls, e.g. call RegisterActor -> Destroy Actor -> RegisterActor callback after kv persist.
2. Makes tests less deterministic because the callbacks could run whenever.
3. Different from the actual gcs actor manager threading model where there is only one thread where everything runs.
4. Introduces race conditions in tests that don't actually exist in the source code.

This fixes it by manually running the io service inside the tests / helper functions on the test's main thread. This way you can control when callbacks run to simulate the different ways the code could actually run. This also aligns it with how the gcs actually runs the actor manager functions and callbacks.

This is also needed to write unit tests for https://github.com/ray-project/ray/pull/53634.