### PR TITLE
[core] Task receiver cleanup

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -418,27 +418,6 @@ CoreWorker::CoreWorker(CoreWorkerOptions options, const WorkerID &worker_id)
   task_event_buffer_ = std::make_unique<worker::TaskEventBufferImpl>(
       std::make_shared<gcs::GcsClient>(options_.gcs_options));
 
-  // Initialize task receivers.
-  if (options_.worker_type == WorkerType::WORKER || options_.is_local_mode) {
-    RAY_CHECK(options_.task_execution_callback != nullptr);
-    auto execute_task = std::bind(&CoreWorker::ExecuteTask,
-                                  this,
-                                  std::placeholders::_1,
-                                  std::placeholders::_2,
-                                  std::placeholders::_3,
-                                  std::placeholders::_4,
-                                  std::placeholders::_5,
-                                  std::placeholders::_6,
-                                  std::placeholders::_7,
-                                  std::placeholders::_8);
-    task_receiver_ = std::make_unique<TaskReceiver>(
-        task_execution_service_,
-        *task_event_buffer_,
-        execute_task,
-        options_.initialize_thread_callback,
-        [this] { return local_raylet_client_->ActorCreationTaskDone(); });
-  }
-
   // Initialize raylet client.
   // NOTE(edoakes): the core_worker_server_ must be running before registering with
   // the raylet, as the raylet will start sending some RPC messages immediately.
@@ -520,6 +499,29 @@ CoreWorker::CoreWorker(CoreWorkerOptions options, const WorkerID &worker_id)
   local_raylet_client_ = std::make_shared<raylet::RayletClient>(
       std::move(raylet_conn), std::move(grpc_client), GetWorkerID());
   connected_ = true;
+
+  // Initialize task receivers.
+  if (options_.worker_type == WorkerType::WORKER || options_.is_local_mode) {
+    RAY_CHECK(options_.task_execution_callback != nullptr);
+    auto execute_task = std::bind(&CoreWorker::ExecuteTask,
+                                  this,
+                                  std::placeholders::_1,
+                                  std::placeholders::_2,
+                                  std::placeholders::_3,
+                                  std::placeholders::_4,
+                                  std::placeholders::_5,
+                                  std::placeholders::_6,
+                                  std::placeholders::_7,
+                                  std::placeholders::_8);
+    task_argument_waiter_ = std::make_unique<DependencyWaiterImpl>(*local_raylet_client_);
+    task_receiver_ = std::make_unique<TaskReceiver>(
+        task_execution_service_,
+        *task_event_buffer_,
+        execute_task,
+        *task_argument_waiter_,
+        options_.initialize_thread_callback,
+        [this] { return local_raylet_client_->ActorCreationTaskDone(); });
+  }
 
   // Start RPC server after all the task receivers are properly initialized and we have
   // our assigned port from the raylet.
@@ -850,13 +852,6 @@ CoreWorker::CoreWorker(CoreWorkerOptions options, const WorkerID &worker_id)
                                        std::move(report_locality_data_callback),
                                        core_worker_client_pool_,
                                        rpc_address_);
-
-  // Unfortunately the raylet client has to be constructed after the receivers.
-  if (task_receiver_ != nullptr) {
-    task_argument_waiter_ = std::make_unique<DependencyWaiterImpl>(*local_raylet_client_);
-    task_receiver_->Init(
-        core_worker_client_pool_, rpc_address_, task_argument_waiter_.get());
-  }
 
   actor_manager_ = std::make_unique<ActorManager>(
       gcs_client_, *actor_task_submitter_, *reference_counter_);

--- a/src/ray/core_worker/transport/task_receiver.h
+++ b/src/ray/core_worker/transport/task_receiver.h
@@ -42,7 +42,6 @@
 #include "ray/core_worker/transport/out_of_order_actor_scheduling_queue.h"
 #include "ray/core_worker/transport/thread_pool.h"
 #include "ray/rpc/grpc_server.h"
-#include "ray/rpc/worker/core_worker_client.h"
 
 namespace ray {
 namespace core {
@@ -65,20 +64,17 @@ class TaskReceiver {
   TaskReceiver(instrumented_io_context &task_execution_service,
                worker::TaskEventBuffer &task_event_buffer,
                TaskHandler task_handler,
+               DependencyWaiter &dependency_waiter,
                std::function<std::function<void()>()> initialize_thread_callback,
-               const OnActorCreationTaskDone &actor_creation_task_done)
+               OnActorCreationTaskDone actor_creation_task_done)
       : task_handler_(std::move(task_handler)),
         task_execution_service_(task_execution_service),
         task_event_buffer_(task_event_buffer),
+        waiter_(dependency_waiter),
         initialize_thread_callback_(std::move(initialize_thread_callback)),
-        actor_creation_task_done_(actor_creation_task_done),
+        actor_creation_task_done_(std::move(actor_creation_task_done)),
         pool_manager_(std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>()),
         fiber_state_manager_(nullptr) {}
-
-  /// Initialize this receiver. This must be called prior to use.
-  void Init(std::shared_ptr<rpc::CoreWorkerClientPool>,
-            rpc::Address rpc_address,
-            DependencyWaiter *dependency_waiter);
 
   /// Handle a `PushTask` request. If it's an actor request, this function will enqueue
   /// the task and then start scheduling the requests to begin the execution. If it's a
@@ -117,50 +113,56 @@ class TaskReceiver {
   /// This should be called once for the actor creation task.
   void SetupActor(bool is_asyncio, int fiber_max_concurrency, bool execute_out_of_order);
 
- protected:
-  /// Cache the concurrency groups of actors.
-  // TODO(ryw): remove the ActorID key since we only ever handle 1 actor.
-  absl::flat_hash_map<ActorID, std::vector<ConcurrencyGroup>> concurrency_groups_cache_;
-
- private:
   /// The callback function to process a task.
   TaskHandler task_handler_;
+
   /// The event loop for running tasks on.
   instrumented_io_context &task_execution_service_;
+
   worker::TaskEventBuffer &task_event_buffer_;
+
+  /// Shared waiter for dependencies required by incoming tasks.
+  DependencyWaiter &waiter_;
+
   /// The language-specific callback function that initializes threads.
   std::function<std::function<void()>()> initialize_thread_callback_;
+
   /// The callback function to be invoked when finishing a task.
   OnActorCreationTaskDone actor_creation_task_done_;
-  /// Shared pool for producing new core worker clients.
-  std::shared_ptr<rpc::CoreWorkerClientPool> client_pool_;
-  /// Address of our RPC server.
-  rpc::Address rpc_address_;
-  /// Shared waiter for dependencies required by incoming tasks.
-  DependencyWaiter *waiter_ = nullptr;
+
   /// Queue of pending requests per actor handle.
   /// TODO(ekl) GC these queues once the handle is no longer active.
   absl::flat_hash_map<WorkerID, std::unique_ptr<SchedulingQueue>>
       actor_scheduling_queues_;
+
   // Queue of pending normal (non-actor) tasks.
   std::unique_ptr<SchedulingQueue> normal_scheduling_queue_ =
       std::make_unique<NormalSchedulingQueue>();
+
   /// The max number of concurrent calls to allow for fiber mode.
   /// 0 indicates that the value is not set yet.
   int fiber_max_concurrency_ = 0;
+
   /// If concurrent calls are allowed, holds the pools for executing these tasks.
   std::shared_ptr<ConcurrencyGroupManager<BoundedExecutor>> pool_manager_;
+
   /// If async calls are allowed, holds the fibers for executing async tasks.
   /// Only populated if this actor is async.
   std::shared_ptr<ConcurrencyGroupManager<FiberState>> fiber_state_manager_;
+
   /// Whether this actor use asyncio for concurrency.
   bool is_asyncio_ = false;
+
   /// Whether this actor executes tasks out of order with respect to client submission
   /// order.
   bool execute_out_of_order_ = false;
+
   /// The repr name of the actor instance for an anonymous actor.
   /// This is only available after the actor creation task.
   std::string actor_repr_name_;
+
+  /// Cache the concurrency groups of this worker's actor.
+  std::vector<ConcurrencyGroup> concurrency_groups_cache_;
 };
 
 }  // namespace core


### PR DESCRIPTION
## Why are these changes needed?
Cleaning up the task receiver, the changes are:
1. It held its own rpc address and worker client pool. Both of these were unused.
2. It had a separate init function outside of the constructor. The only leftover use after 1 was to pass in the waiter. Moving initialization a couple lines down means we can just pass it in the constructor and kill the Init.
3. It had a map of actor -> concurrency groups. An executing worker can only belong to one actor for its lifetime, so there's no use of this. It can just be a vector of concurrency groups.
4. The tests relied on access to the private member concurrency_groups_cache, it doesn't need this after 3.
5. Removed recomputation of concurrency groups when creating fiber/pool managers and having it just use the cached list.