### PR TITLE
[core] Remove `ray.wait` for `test_locality_aware_leasing_borrowed_objects`

### DIFF
--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -428,12 +428,8 @@ def test_locality_aware_leasing_borrowed_objects(ray_start_cluster):
         ),
     ).remote()
 
-    # Ensure the owner has object info prior to scheduling the task so the object info
-    # will be inlined to the borrower.
-    ray.wait([worker_node_ref], fetch_local=False)
-
     # Run a borrower task on the head node. From within the borrower task, we launch
-    # another task. That inner task should run on the worker node based on locality.
+    # another task. The inner task should run on the worker node based on locality.
     assert (
         ray.get(
             borrower.options(

--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -388,14 +388,6 @@ def test_locality_aware_leasing_cached_objects(ray_start_cluster):
     assert ray.get(h.remote(f_obj1, f_obj2)) == worker2.unique_id
 
 
-@pytest.mark.skipif(
-    ray._private.client_mode_hook.is_client_mode_enabled,
-    reason=(
-        "fetch_local=False is not supported for Ray Client, which is needed to write "
-        "the tests in a deterministic way. "
-        "See https://github.com/ray-project/ray/issues/52401."
-    ),
-)
 def test_locality_aware_leasing_borrowed_objects(ray_start_cluster):
     """Test that a task runs where its dependencies are located for borrowed objects."""
     # This test ensures that a task will run where its task dependencies are


### PR DESCRIPTION
The `ray.wait` calls are unnecessary because the borrower will resolve the object location from the owner prior to submitting the task.