### PR TITLE
[Core] Fix test_aggregator_agent Failing Test on MacOS

### DIFF
--- a/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
@@ -2,7 +2,6 @@ import sys
 import json
 import time
 import base64
-from datetime import datetime, timezone
 
 import pytest
 from google.protobuf.timestamp_pb2 import Timestamp
@@ -33,12 +32,6 @@ from ray.core.generated.common_pb2 import TaskAttempt
 @pytest.fixture(scope="session")
 def httpserver_listen_address():
     return ("127.0.0.1", 12345)
-
-
-def _format_timestamp_ns(ts_ns: int) -> str:
-    sec, ns = divmod(ts_ns, 10**9)
-    dt = datetime.fromtimestamp(sec, tz=timezone.utc)
-    return f"{dt:%Y-%m-%dT%H:%M:%S}.{ns:09d}Z"
 
 
 def get_event_aggregator_grpc_stub(webui_url, gcs_address, head_node_id):
@@ -110,7 +103,7 @@ def test_aggregator_agent_receive_publish_events_normally(
     assert req_json[0]["eventType"] == "TASK_DEFINITION_EVENT"
     assert req_json[0]["severity"] == "INFO"
     assert req_json[0]["message"] == "hello"
-    assert req_json[0]["timestamp"] == _format_timestamp_ns(test_time)
+    assert req_json[0]["timestamp"] == "2025-06-30T16:50:30.130457542Z"
 
 
 @pytest.mark.parametrize(

--- a/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
@@ -73,8 +73,8 @@ def test_aggregator_agent_receive_publish_events_normally(
 
     httpserver.expect_request("/", method="POST").respond_with_data("", status=200)
 
-    now = time.time_ns()
-    seconds, nanos = divmod(now, 10**9)
+    test_time = 1751302230130457542
+    seconds, nanos = divmod(test_time, 10**9)
     timestamp = Timestamp(seconds=seconds, nanos=nanos)
 
     request = AddEventRequest(
@@ -110,7 +110,7 @@ def test_aggregator_agent_receive_publish_events_normally(
     assert req_json[0]["eventType"] == "TASK_DEFINITION_EVENT"
     assert req_json[0]["severity"] == "INFO"
     assert req_json[0]["message"] == "hello"
-    assert req_json[0]["timestamp"] == _format_timestamp_ns(now)
+    assert req_json[0]["timestamp"] == _format_timestamp_ns(test_time)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

The PR fixed the failing `test_aggregator_agent` test on MacOS. 

The test failing on macOS because macOS only provides microseconds level time precision instead of nanoseconds. So in the test,  the timestamp in `google.proto.Timestamp` will be converted to a microseconds level time string which fails the assertion that is asking for a nano second precision. 

The fix is to use an existing timestamp instead of getting the time from the test to make the testing behavior consistent across platforms. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

fixes #54191

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
