### PR TITLE
[serve] support running user code on same event loop

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -456,7 +456,9 @@ DEFAULT_REQUEST_ROUTING_STATS_TIMEOUT_S = 30
 # Name of deployment request routing stats method implemented by user.
 REQUEST_ROUTING_STATS_METHOD = "record_routing_stats"
 
-# Feature flag to run user code in a separate event loop.
+# By default, we run user code in a separate event loop.
+# This flag can be set to 0 to run user code in the same event loop as the
+# replica's main event loop.
 RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD = (
     os.environ.get("RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD", "1") == "1"
 )

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -455,3 +455,8 @@ DEFAULT_REQUEST_ROUTING_STATS_TIMEOUT_S = 30
 
 # Name of deployment request routing stats method implemented by user.
 REQUEST_ROUTING_STATS_METHOD = "record_routing_stats"
+
+# Feature flag to run user code in a separate event loop.
+RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD = (
+    os.environ.get("RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD", "0") == "1"
+)

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -458,5 +458,5 @@ REQUEST_ROUTING_STATS_METHOD = "record_routing_stats"
 
 # Feature flag to run user code in a separate event loop.
 RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD = (
-    os.environ.get("RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD", "0") == "1"
+    os.environ.get("RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD", "1") == "1"
 )

--- a/python/ray/serve/_private/local_testing_mode.py
+++ b/python/ray/serve/_private/local_testing_mode.py
@@ -70,6 +70,7 @@ def make_local_deployment_handle(
         deployment.init_kwargs,
         deployment_id=deployment_id,
         run_sync_methods_in_threadpool=RAY_SERVE_RUN_SYNC_IN_THREADPOOL,
+        run_user_code_in_separate_thread=True,
         local_testing_mode=True,
     )
     try:

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -55,6 +55,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_REPLICA_AUTOSCALING_METRIC_RECORD_PERIOD_S,
     RAY_SERVE_RUN_SYNC_IN_THREADPOOL,
     RAY_SERVE_RUN_SYNC_IN_THREADPOOL_WARNING,
+    RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD,
     RECONFIGURE_METHOD,
     REQUEST_LATENCY_BUCKETS_MS,
     REQUEST_ROUTING_STATS_METHOD,
@@ -371,6 +372,7 @@ class ReplicaBase(ABC):
             init_kwargs,
             deployment_id=self._deployment_id,
             run_sync_methods_in_threadpool=RAY_SERVE_RUN_SYNC_IN_THREADPOOL,
+            run_user_code_in_separate_thread=RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD,
             local_testing_mode=False,
         )
         self._semaphore = Semaphore(lambda: self.max_ongoing_requests)
@@ -1169,6 +1171,7 @@ class UserCallableWrapper:
         *,
         deployment_id: DeploymentID,
         run_sync_methods_in_threadpool: bool,
+        run_user_code_in_separate_thread: bool,
         local_testing_mode: bool,
     ):
         if not (inspect.isfunction(deployment_def) or inspect.isclass(deployment_def)):
@@ -1185,27 +1188,37 @@ class UserCallableWrapper:
         self._local_testing_mode = local_testing_mode
         self._destructor_called = False
         self._run_sync_methods_in_threadpool = run_sync_methods_in_threadpool
+        self._run_user_code_in_separate_thread = run_user_code_in_separate_thread
         self._warned_about_sync_method_change = False
         self._cached_user_method_info: Dict[str, UserMethodInfo] = {}
 
         # Will be populated in `initialize_callable`.
         self._callable = None
 
-        # All interactions with user code run on this loop to avoid blocking the
-        # replica's main event loop.
-        self._user_code_event_loop: asyncio.AbstractEventLoop = asyncio.new_event_loop()
+        if self._run_user_code_in_separate_thread:
+            # All interactions with user code run on this loop to avoid blocking the
+            # replica's main event loop.
+            self._user_code_event_loop: asyncio.AbstractEventLoop = (
+                asyncio.new_event_loop()
+            )
 
-        def _run_user_code_event_loop():
-            # Required so that calls to get the current running event loop work
-            # properly in user code.
-            asyncio.set_event_loop(self._user_code_event_loop)
-            self._user_code_event_loop.run_forever()
+            def _run_user_code_event_loop():
+                # Required so that calls to get the current running event loop work
+                # properly in user code.
+                asyncio.set_event_loop(self._user_code_event_loop)
+                self._user_code_event_loop.run_forever()
 
-        self._user_code_event_loop_thread = threading.Thread(
-            daemon=True,
-            target=_run_user_code_event_loop,
-        )
-        self._user_code_event_loop_thread.start()
+            self._user_code_event_loop_thread = threading.Thread(
+                daemon=True,
+                target=_run_user_code_event_loop,
+            )
+            self._user_code_event_loop_thread.start()
+        else:
+            self._user_code_event_loop = asyncio.get_running_loop()
+
+    @property
+    def event_loop(self) -> asyncio.AbstractEventLoop:
+        return self._user_code_event_loop
 
     def _run_user_code(f: Callable) -> Callable:
         """Decorator to run a coroutine method on the user code event loop.
@@ -1220,11 +1233,14 @@ class UserCallableWrapper:
         @functools.wraps(f)
         def wrapper(self, *args, **kwargs) -> Any:
             coro = f(self, *args, **kwargs)
-            fut = asyncio.run_coroutine_threadsafe(coro, self._user_code_event_loop)
-            if self._local_testing_mode:
-                return fut
+            if self._run_user_code_in_separate_thread:
+                fut = asyncio.run_coroutine_threadsafe(coro, self._user_code_event_loop)
+                if self._local_testing_mode:
+                    return fut
 
-            return asyncio.wrap_future(fut)
+                return asyncio.wrap_future(fut)
+            else:
+                return asyncio.create_task(coro)
 
         return wrapper
 
@@ -1576,14 +1592,22 @@ class UserCallableWrapper:
         # `asyncio.Event`s are not thread safe, so `call_soon_threadsafe` must be
         # used to interact with the result queue from the user callable thread.
         system_event_loop = asyncio.get_running_loop()
-
-        async def enq(item: Any):
-            system_event_loop.call_soon_threadsafe(result_queue.put_nowait, item)
-
         user_method_info = self.get_user_method_info(request_metadata.call_method)
+
+        if self._run_user_code_in_separate_thread:
+
+            async def enq(item: Any):
+                system_event_loop.call_soon_threadsafe(result_queue.put_nowait, item)
+
+        else:
+
+            async def enq(item: Any):
+                result_queue.put_nowait(item)
+
         call_user_method_future = self._call_http_entrypoint(
             user_method_info, scope, receive, enq
         )
+
         first_message_peeked = False
         async for messages in result_queue.fetch_messages_from_queue(
             call_user_method_future

--- a/python/ray/serve/tests/unit/test_user_callable_wrapper.py
+++ b/python/ray/serve/tests/unit/test_user_callable_wrapper.py
@@ -176,9 +176,10 @@ async def test_basic_class_callable(
     # Call non-generator method with is_streaming.
     request_metadata = _make_request_metadata(is_streaming=True)
     with pytest.raises(TypeError, match="did not return a generator."):
-        await user_callable_wrapper._call_user_generator(
+        async for _ in user_callable_wrapper.call_user_generator(
             request_metadata, tuple(), dict()
-        )
+        ):
+            pass
 
     # Test calling default sync `__call__` method.
     request_metadata = _make_request_metadata()
@@ -207,9 +208,10 @@ async def test_basic_class_callable(
         call_method="call_async", is_streaming=True
     )
     with pytest.raises(TypeError, match="did not return a generator."):
-        await user_callable_wrapper._call_user_generator(
+        async for _ in user_callable_wrapper.call_user_generator(
             request_metadata, tuple(), dict()
-        )
+        ):
+            pass
 
     # Test calling `call_async` method.
     request_metadata = _make_request_metadata(call_method="call_async")
@@ -266,20 +268,21 @@ async def test_basic_class_callable_generators(
     request_metadata = _make_request_metadata(
         call_method="call_generator", is_streaming=True
     )
-    await user_callable_wrapper._call_user_generator(
-        request_metadata, (10,), dict(), generator_result_callback=result_list.append
-    )
+    async for result in user_callable_wrapper.call_user_generator(
+        request_metadata, (10,), dict()
+    ):
+        result_list.append(result)
     assert result_list == list(range(10))
     result_list.clear()
 
     # Call sync generator raising exception.
     with pytest.raises(RuntimeError, match="uh-oh"):
-        await user_callable_wrapper._call_user_generator(
+        async for result in user_callable_wrapper.call_user_generator(
             request_metadata,
             (10,),
             {"raise_exception": True},
-            generator_result_callback=result_list.append,
-        )
+        ):
+            result_list.append(result)
     assert result_list == [0]
     result_list.clear()
 
@@ -300,20 +303,21 @@ async def test_basic_class_callable_generators(
     request_metadata = _make_request_metadata(
         call_method="call_async_generator", is_streaming=True
     )
-    await user_callable_wrapper._call_user_generator(
-        request_metadata, (10,), dict(), generator_result_callback=result_list.append
-    )
+    async for result in user_callable_wrapper.call_user_generator(
+        request_metadata, (10,), dict()
+    ):
+        result_list.append(result)
     assert result_list == list(range(10))
     result_list.clear()
 
     # Call async generator raising exception.
     with pytest.raises(RuntimeError, match="uh-oh"):
-        await user_callable_wrapper._call_user_generator(
+        async for result in user_callable_wrapper.call_user_generator(
             request_metadata,
             (10,),
             {"raise_exception": True},
-            generator_result_callback=result_list.append,
-        )
+        ):
+            result_list.append(result)
     assert result_list == [0]
 
 
@@ -336,9 +340,10 @@ async def test_basic_function_callable(
     # Call non-generator function with is_streaming.
     request_metadata = _make_request_metadata(is_streaming=True)
     with pytest.raises(TypeError, match="did not return a generator."):
-        await user_callable_wrapper._call_user_generator(
+        async for _ in user_callable_wrapper.call_user_generator(
             request_metadata, tuple(), dict()
-        )
+        ):
+            pass
 
     request_metadata = _make_request_metadata()
     assert (
@@ -393,20 +398,21 @@ async def test_basic_function_callable_generators(
     request_metadata = _make_request_metadata(
         call_method="call_generator", is_streaming=True
     )
-    await user_callable_wrapper._call_user_generator(
-        request_metadata, (10,), dict(), generator_result_callback=result_list.append
-    )
+    async for result in user_callable_wrapper.call_user_generator(
+        request_metadata, (10,), dict()
+    ):
+        result_list.append(result)
     assert result_list == list(range(10))
     result_list.clear()
 
     # Call generator function raising exception.
     with pytest.raises(RuntimeError, match="uh-oh"):
-        await user_callable_wrapper._call_user_generator(
+        async for result in user_callable_wrapper.call_user_generator(
             request_metadata,
             (10,),
             {"raise_exception": True},
-            generator_result_callback=result_list.append,
-        )
+        ):
+            result_list.append(result)
     assert result_list == [0]
 
 
@@ -516,12 +522,12 @@ async def test_grpc_streaming_request(
     request_metadata = _make_request_metadata(
         call_method="stream", is_grpc_request=True, is_streaming=True
     )
-    await user_callable_wrapper._call_user_generator(
+    async for result in user_callable_wrapper.call_user_generator(
         request_metadata,
         (serve_pb2.UserDefinedResponse(greeting="world"),),
         dict(),
-        generator_result_callback=result_list.append,
-    )
+    ):
+        result_list.append(result)
 
     assert len(result_list) == 10
     for i, result in enumerate(result_list):

--- a/python/ray/serve/tests/unit/test_user_callable_wrapper.py
+++ b/python/ray/serve/tests/unit/test_user_callable_wrapper.py
@@ -164,7 +164,7 @@ async def test_calling_methods_before_initialize(
 @pytest.mark.parametrize("run_sync_methods_in_threadpool", [False, True])
 @pytest.mark.asyncio
 async def test_basic_class_callable(
-    run_sync_methods_in_threadpool: bool, run_user_code_in_separate_thread: bool
+    run_user_code_in_separate_thread: bool, run_sync_methods_in_threadpool: bool
 ):
     user_callable_wrapper = _make_user_callable_wrapper(
         run_sync_methods_in_threadpool=run_sync_methods_in_threadpool,

--- a/python/ray/serve/tests/unit/test_user_callable_wrapper.py
+++ b/python/ray/serve/tests/unit/test_user_callable_wrapper.py
@@ -93,6 +93,7 @@ def _make_user_callable_wrapper(
     init_args: Optional[Tuple[Any]] = None,
     init_kwargs: Optional[Dict[str, Any]] = None,
     run_sync_methods_in_threadpool: bool = False,
+    run_user_code_in_separate_thread: bool = True,
 ) -> UserCallableWrapper:
     return UserCallableWrapper(
         callable if callable is not None else BasicClass,
@@ -100,6 +101,7 @@ def _make_user_callable_wrapper(
         init_kwargs or dict(),
         deployment_id=DeploymentID(name="test_name"),
         run_sync_methods_in_threadpool=run_sync_methods_in_threadpool,
+        run_user_code_in_separate_thread=run_user_code_in_separate_thread,
         local_testing_mode=False,
     )
 
@@ -126,9 +128,12 @@ def _make_request_metadata(
     )
 
 
+@pytest.mark.parametrize("run_user_code_in_separate_thread", [False, True])
 @pytest.mark.asyncio
-async def test_calling_initialize_twice():
-    user_callable_wrapper = _make_user_callable_wrapper()
+async def test_calling_initialize_twice(run_user_code_in_separate_thread: bool):
+    user_callable_wrapper = _make_user_callable_wrapper(
+        run_user_code_in_separate_thread=run_user_code_in_separate_thread
+    )
 
     await user_callable_wrapper.initialize_callable()
     assert isinstance(user_callable_wrapper.user_callable, BasicClass)
@@ -136,9 +141,14 @@ async def test_calling_initialize_twice():
         await user_callable_wrapper.initialize_callable()
 
 
+@pytest.mark.parametrize("run_user_code_in_separate_thread", [False, True])
 @pytest.mark.asyncio
-async def test_calling_methods_before_initialize():
-    user_callable_wrapper = _make_user_callable_wrapper()
+async def test_calling_methods_before_initialize(
+    run_user_code_in_separate_thread: bool,
+):
+    user_callable_wrapper = _make_user_callable_wrapper(
+        run_user_code_in_separate_thread=run_user_code_in_separate_thread
+    )
 
     with pytest.raises(RuntimeError):
         await user_callable_wrapper.call_user_method(None, tuple(), dict())
@@ -150,11 +160,15 @@ async def test_calling_methods_before_initialize():
         await user_callable_wrapper.call_reconfigure(None)
 
 
+@pytest.mark.parametrize("run_user_code_in_separate_thread", [False, True])
 @pytest.mark.parametrize("run_sync_methods_in_threadpool", [False, True])
 @pytest.mark.asyncio
-async def test_basic_class_callable(run_sync_methods_in_threadpool: bool):
+async def test_basic_class_callable(
+    run_sync_methods_in_threadpool: bool, run_user_code_in_separate_thread: bool
+):
     user_callable_wrapper = _make_user_callable_wrapper(
-        run_sync_methods_in_threadpool=run_sync_methods_in_threadpool
+        run_sync_methods_in_threadpool=run_sync_methods_in_threadpool,
+        run_user_code_in_separate_thread=run_user_code_in_separate_thread,
     )
 
     await user_callable_wrapper.initialize_callable()
@@ -221,11 +235,15 @@ async def test_basic_class_callable(run_sync_methods_in_threadpool: bool):
         )
 
 
+@pytest.mark.parametrize("run_user_code_in_separate_thread", [False, True])
 @pytest.mark.parametrize("run_sync_methods_in_threadpool", [False, True])
 @pytest.mark.asyncio
-async def test_basic_class_callable_generators(run_sync_methods_in_threadpool: bool):
+async def test_basic_class_callable_generators(
+    run_sync_methods_in_threadpool: bool, run_user_code_in_separate_thread: bool
+):
     user_callable_wrapper = _make_user_callable_wrapper(
-        run_sync_methods_in_threadpool=run_sync_methods_in_threadpool
+        run_sync_methods_in_threadpool=run_sync_methods_in_threadpool,
+        run_user_code_in_separate_thread=run_user_code_in_separate_thread,
     )
     await user_callable_wrapper.initialize_callable()
 
@@ -299,14 +317,19 @@ async def test_basic_class_callable_generators(run_sync_methods_in_threadpool: b
     assert result_list == [0]
 
 
+@pytest.mark.parametrize("run_user_code_in_separate_thread", [False, True])
 @pytest.mark.parametrize("run_sync_methods_in_threadpool", [False, True])
 @pytest.mark.parametrize("fn", [basic_sync_function, basic_async_function])
 @pytest.mark.asyncio
 async def test_basic_function_callable(
-    fn: Callable, run_sync_methods_in_threadpool: bool
+    fn: Callable,
+    run_sync_methods_in_threadpool: bool,
+    run_user_code_in_separate_thread: bool,
 ):
     user_callable_wrapper = _make_user_callable_wrapper(
-        fn, run_sync_methods_in_threadpool=run_sync_methods_in_threadpool
+        fn,
+        run_sync_methods_in_threadpool=run_sync_methods_in_threadpool,
+        run_user_code_in_separate_thread=run_user_code_in_separate_thread,
     )
     await user_callable_wrapper.initialize_callable()
 
@@ -337,14 +360,19 @@ async def test_basic_function_callable(
         )
 
 
+@pytest.mark.parametrize("run_user_code_in_separate_thread", [False, True])
 @pytest.mark.parametrize("run_sync_methods_in_threadpool", [False, True])
 @pytest.mark.parametrize("fn", [basic_sync_generator, basic_async_generator])
 @pytest.mark.asyncio
 async def test_basic_function_callable_generators(
-    fn: Callable, run_sync_methods_in_threadpool: bool
+    fn: Callable,
+    run_sync_methods_in_threadpool: bool,
+    run_user_code_in_separate_thread: bool,
 ):
     user_callable_wrapper = _make_user_callable_wrapper(
-        fn, run_sync_methods_in_threadpool=run_sync_methods_in_threadpool
+        fn,
+        run_sync_methods_in_threadpool=run_sync_methods_in_threadpool,
+        run_user_code_in_separate_thread=run_user_code_in_separate_thread,
     )
     await user_callable_wrapper.initialize_callable()
 
@@ -382,75 +410,9 @@ async def test_basic_function_callable_generators(
     assert result_list == [0]
 
 
+@pytest.mark.parametrize("run_user_code_in_separate_thread", [False, True])
 @pytest.mark.asyncio
-@pytest.mark.parametrize("run_sync_methods_in_threadpool", [False, True])
-async def test_user_code_runs_on_separate_loop(run_sync_methods_in_threadpool: bool):
-    main_loop = asyncio.get_running_loop()
-
-    class GetLoop:
-        def __init__(self):
-            self._constructor_loop = asyncio.get_running_loop()
-
-        async def check_health(self):
-            check_health_loop = asyncio.get_running_loop()
-            assert (
-                check_health_loop == self._constructor_loop
-            ), "User constructor and health check should run on the same loop."
-            return check_health_loop
-
-        async def call_async(self) -> Optional[asyncio.AbstractEventLoop]:
-            user_method_loop = asyncio.get_running_loop()
-            assert (
-                user_method_loop == self._constructor_loop
-            ), "User constructor and other methods should run on the same loop."
-
-            return user_method_loop
-
-        def call_sync(self):
-            if run_sync_methods_in_threadpool:
-                with pytest.raises(RuntimeError, match="no running event loop"):
-                    asyncio.get_running_loop()
-
-                user_method_loop = None
-            else:
-                user_method_loop = asyncio.get_running_loop()
-                assert (
-                    user_method_loop == self._constructor_loop
-                ), "User constructor and other methods should run on the same loop."
-
-            return user_method_loop
-
-    user_callable_wrapper = _make_user_callable_wrapper(
-        GetLoop, run_sync_methods_in_threadpool=run_sync_methods_in_threadpool
-    )
-    await user_callable_wrapper.initialize_callable()
-
-    # Async methods should all run on the same loop.
-    request_metadata = _make_request_metadata(call_method="call_async")
-    user_code_loop = await user_callable_wrapper.call_user_method(
-        request_metadata, tuple(), dict()
-    )
-    assert isinstance(user_code_loop, asyncio.AbstractEventLoop)
-    assert user_code_loop != main_loop
-
-    # Sync methods should run on the same loop if run_sync_methods_in_threadpool is off,
-    # else run in no asyncio loop.
-    request_metadata = _make_request_metadata(call_method="call_sync")
-    user_code_loop = await user_callable_wrapper.call_user_method(
-        request_metadata, tuple(), dict()
-    )
-    if run_sync_methods_in_threadpool:
-        assert user_code_loop is None
-    else:
-        assert isinstance(user_code_loop, asyncio.AbstractEventLoop)
-        assert user_code_loop != main_loop
-
-    # `check_health` method asserts that it runs on the correct loop.
-    await user_callable_wrapper.call_user_health_check()
-
-
-@pytest.mark.asyncio
-async def test_callable_with_async_init():
+async def test_callable_with_async_init(run_user_code_in_separate_thread: bool):
     class AsyncInitializer:
         async def __init__(self, msg: str):
             await asyncio.sleep(0.001)
@@ -463,6 +425,7 @@ async def test_callable_with_async_init():
     user_callable_wrapper = _make_user_callable_wrapper(
         AsyncInitializer,
         init_args=(msg,),
+        run_user_code_in_separate_thread=run_user_code_in_separate_thread,
     )
     await user_callable_wrapper.initialize_callable()
     request_metadata = _make_request_metadata()
@@ -471,9 +434,12 @@ async def test_callable_with_async_init():
     ) == msg
 
 
+@pytest.mark.parametrize("run_user_code_in_separate_thread", [False, True])
 @pytest.mark.parametrize("async_del", [False, True])
 @pytest.mark.asyncio
-async def test_destructor_only_called_once(async_del: bool):
+async def test_destructor_only_called_once(
+    async_del: bool, run_user_code_in_separate_thread: bool
+):
     num_destructor_calls = 0
 
     if async_del:
@@ -492,6 +458,7 @@ async def test_destructor_only_called_once(async_del: bool):
 
     user_callable_wrapper = _make_user_callable_wrapper(
         DestroyerOfNothing,
+        run_user_code_in_separate_thread=run_user_code_in_separate_thread,
     )
     await user_callable_wrapper.initialize_callable()
 
@@ -499,41 +466,6 @@ async def test_destructor_only_called_once(async_del: bool):
     # run the `__del__` method.
     await asyncio.gather(*[user_callable_wrapper.call_destructor() for _ in range(100)])
     assert num_destructor_calls == 1
-
-
-@pytest.mark.asyncio
-async def test_no_user_health_check_not_blocked():
-    """
-    If there is no user-defined health check, it should not interact with the user code
-    event loop at all and therefore still return if the event loop is blocked.
-    """
-    sync_event = threading.Event()
-
-    class LoopBlocker:
-        async def __call__(self) -> str:
-            # Block the loop until the event is set.
-            sync_event.wait()
-            return "Sorry I got stuck!"
-
-    user_callable_wrapper = _make_user_callable_wrapper(
-        LoopBlocker,
-    )
-    await user_callable_wrapper.initialize_callable()
-    request_metadata = _make_request_metadata()
-    blocked_future = user_callable_wrapper.call_user_method(
-        request_metadata, tuple(), dict()
-    )
-    _, pending = await asyncio.wait([blocked_future], timeout=0.01)
-    assert len(pending) == 1
-
-    for _ in range(100):
-        # If this called something on the event loop, it'd be blocked.
-        # Instead, `user_callable_wrapper.call_user_health_check` returns None
-        # when there's no user health check configured.
-        assert user_callable_wrapper.call_user_health_check() is None
-
-    sync_event.set()
-    assert await blocked_future == "Sorry I got stuck!"
 
 
 class gRPCClass:
@@ -545,11 +477,16 @@ class gRPCClass:
             yield serve_pb2.UserDefinedResponse(greeting=f"Hello {msg.greeting} {i}!")
 
 
+@pytest.mark.parametrize("run_user_code_in_separate_thread", [False, True])
 @pytest.mark.parametrize("run_sync_methods_in_threadpool", [False, True])
 @pytest.mark.asyncio
-async def test_grpc_unary_request(run_sync_methods_in_threadpool: bool):
+async def test_grpc_unary_request(
+    run_sync_methods_in_threadpool: bool, run_user_code_in_separate_thread: bool
+):
     user_callable_wrapper = _make_user_callable_wrapper(
-        gRPCClass, run_sync_methods_in_threadpool=run_sync_methods_in_threadpool
+        gRPCClass,
+        run_sync_methods_in_threadpool=run_sync_methods_in_threadpool,
+        run_user_code_in_separate_thread=run_user_code_in_separate_thread,
     )
     await user_callable_wrapper.initialize_callable()
 
@@ -562,12 +499,17 @@ async def test_grpc_unary_request(run_sync_methods_in_threadpool: bool):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("run_user_code_in_separate_thread", [False, True])
 @pytest.mark.parametrize("run_sync_methods_in_threadpool", [False, True])
-async def test_grpc_streaming_request(run_sync_methods_in_threadpool: bool):
+async def test_grpc_streaming_request(
+    run_sync_methods_in_threadpool: bool, run_user_code_in_separate_thread: bool
+):
     user_callable_wrapper = _make_user_callable_wrapper(
-        gRPCClass, run_sync_methods_in_threadpool=run_sync_methods_in_threadpool
+        gRPCClass,
+        run_sync_methods_in_threadpool=run_sync_methods_in_threadpool,
+        run_user_code_in_separate_thread=run_user_code_in_separate_thread,
     )
-    user_callable_wrapper.initialize_callable()
+    await user_callable_wrapper.initialize_callable()
 
     result_list = []
 
@@ -604,10 +546,15 @@ class FastAPIRequestHandler:
         return PlainTextResponse(f"Hello {msg}!")
 
 
+@pytest.mark.parametrize("run_user_code_in_separate_thread", [False, True])
 @pytest.mark.parametrize("callable", [RawRequestHandler, FastAPIRequestHandler])
 @pytest.mark.asyncio
-async def test_http_handler(callable: Callable, monkeypatch):
-    user_callable_wrapper = _make_user_callable_wrapper(callable)
+async def test_http_handler(
+    callable: Callable, monkeypatch, run_user_code_in_separate_thread: bool
+):
+    user_callable_wrapper = _make_user_callable_wrapper(
+        callable, run_user_code_in_separate_thread=run_user_code_in_separate_thread
+    )
     await user_callable_wrapper.initialize_callable()
 
     @dataclass
@@ -666,6 +613,113 @@ async def test_http_handler(callable: Callable, monkeypatch):
         "type": "http.response.body",
         "body": b"Hello b'\"world\"'!",
     }
+
+
+class TestSeparateThread:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("run_sync_methods_in_threadpool", [False, True])
+    async def test_user_code_runs_on_separate_loop(
+        self, run_sync_methods_in_threadpool: bool
+    ):
+        main_loop = asyncio.get_running_loop()
+
+        class GetLoop:
+            def __init__(self):
+                self._constructor_loop = asyncio.get_running_loop()
+
+            async def check_health(self):
+                check_health_loop = asyncio.get_running_loop()
+                assert (
+                    check_health_loop == self._constructor_loop
+                ), "User constructor and health check should run on the same loop."
+                return check_health_loop
+
+            async def call_async(self) -> Optional[asyncio.AbstractEventLoop]:
+                user_method_loop = asyncio.get_running_loop()
+                assert (
+                    user_method_loop == self._constructor_loop
+                ), "User constructor and other methods should run on the same loop."
+
+                return user_method_loop
+
+            def call_sync(self):
+                if run_sync_methods_in_threadpool:
+                    with pytest.raises(RuntimeError, match="no running event loop"):
+                        asyncio.get_running_loop()
+
+                    user_method_loop = None
+                else:
+                    user_method_loop = asyncio.get_running_loop()
+                    assert (
+                        user_method_loop == self._constructor_loop
+                    ), "User constructor and other methods should run on the same loop."
+
+                return user_method_loop
+
+        user_callable_wrapper = _make_user_callable_wrapper(
+            GetLoop,
+            run_sync_methods_in_threadpool=run_sync_methods_in_threadpool,
+            run_user_code_in_separate_thread=True,
+        )
+        await user_callable_wrapper.initialize_callable()
+
+        # Async methods should all run on the same loop.
+        request_metadata = _make_request_metadata(call_method="call_async")
+        user_code_loop = await user_callable_wrapper.call_user_method(
+            request_metadata, tuple(), dict()
+        )
+        assert isinstance(user_code_loop, asyncio.AbstractEventLoop)
+        assert user_code_loop != main_loop
+
+        # Sync methods should run on the same loop if run_sync_methods_in_threadpool is off,
+        # else run in no asyncio loop.
+        request_metadata = _make_request_metadata(call_method="call_sync")
+        user_code_loop = await user_callable_wrapper.call_user_method(
+            request_metadata, tuple(), dict()
+        )
+        if run_sync_methods_in_threadpool:
+            assert user_code_loop is None
+        else:
+            assert isinstance(user_code_loop, asyncio.AbstractEventLoop)
+            assert user_code_loop != main_loop
+
+        # `check_health` method asserts that it runs on the correct loop.
+        await user_callable_wrapper.call_user_health_check()
+
+    @pytest.mark.asyncio
+    async def test_no_user_health_check_not_blocked(self):
+        """
+        If there is no user-defined health check, it should not interact with the user code
+        event loop at all and therefore still return if the event loop is blocked.
+        """
+        sync_event = threading.Event()
+
+        class LoopBlocker:
+            async def __call__(self) -> str:
+                # Block the loop until the event is set.
+                sync_event.wait()
+                return "Sorry I got stuck!"
+
+        user_callable_wrapper = _make_user_callable_wrapper(
+            LoopBlocker,
+            run_user_code_in_separate_thread=True,
+        )
+        await user_callable_wrapper.initialize_callable()
+        request_metadata = _make_request_metadata()
+        blocked_future = user_callable_wrapper.call_user_method(
+            request_metadata, tuple(), dict()
+        )
+        _, pending = await asyncio.wait([blocked_future], timeout=0.01)
+        assert len(pending) == 1
+
+        for _ in range(100):
+            # If this called something on the event loop, it'd be blocked.
+            # Instead, `user_callable_wrapper.call_user_health_check` returns None
+            # when there's no user health check configured.
+            assert user_callable_wrapper.call_user_health_check() is None
+
+        sync_event.set()
+        assert await blocked_future == "Sorry I got stuck!"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?

Currently we run all user code on a separate event loop (the user code event loop) to avoid the system event loop being blocked by user code. However if the user is confident that they are writing proper async python code, they can choose to bypass that and run user code on the same event loop. This will boost the performance since we avoid cross-thread communication.