### PR TITLE
[core] let's break things

### DIFF
--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -974,6 +974,7 @@ bool TaskManager::RetryTaskIfPossible(const TaskID &task_id,
   {
     absl::MutexLock lock(&mu_);
     auto it = submissible_tasks_.find(task_id);
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
     RAY_CHECK(it != submissible_tasks_.end())
         << "Tried to retry task that was not pending " << task_id;
     RAY_CHECK(it->second.IsPending())


### PR DESCRIPTION
Insert a random sleep before the RAY_CHECK to increase the chance of triggering potential method interleavings before the check in out unittest. Let's see what breaks.

Test:
- CI