### PR TITLE
[core] Fix sanitizers for actor manager test

### DIFF
--- a/src/ray/gcs/gcs_server/test/BUILD.bazel
+++ b/src/ray/gcs/gcs_server/test/BUILD.bazel
@@ -225,7 +225,6 @@ ray_cc_test(
         "gcs_actor_manager_test.cc",
     ],
     tags = [
-        "no_tsan",
         "team:core",
     ],
     deps = [

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -1347,6 +1347,7 @@ TEST_F(GcsActorManagerTest, TestKillActorWhenActorIsCreating) {
       &reply,
       /*send_reply_callback*/
       [](Status status, std::function<void()> success, std::function<void()> failure) {});
+  io_service_.run_one();
 
   // Make sure the `KillActor` rpc is send.
   ASSERT_EQ(worker_client_->killed_actors_.size(), 1);
@@ -1475,6 +1476,8 @@ TEST_F(GcsActorManagerTest, TestRestartPermanentlyDeadActorForLineageReconstruct
       actor->GetActorID(),
       /*num_restarts_due_to_lineage_reconstruction=*/0);
   ASSERT_EQ(reply.status().code(), static_cast<int>(StatusCode::Invalid));
+  io_service_.run_one();
+  io_service_.run_one();
 }
 
 TEST_F(GcsActorManagerTest, TestIdempotencyOfRestartActorForLineageReconstruction) {
@@ -1606,6 +1609,7 @@ TEST_F(GcsActorManagerTest, TestDestroyActorWhenActorIsCreating) {
       &reply,
       /*send_reply_callback*/
       [](Status status, std::function<void()> success, std::function<void()> failure) {});
+  io_service_.run_one();
   io_service_.run_one();
 
   // Make sure the `KillActor` rpc is send.

--- a/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/gcs_server/test/gcs_actor_manager_test.cc
@@ -192,19 +192,6 @@ class GcsActorManagerTest : public ::testing::Test {
     gcs_actor_manager_->OnNodeDead(node_info, "127.0.0.1");
   }
 
-  rpc::RestartActorForLineageReconstructionReply RestartActorForLineageReconstruction(
-      const ActorID &actor_id, size_t num_restarts_due_to_lineage_reconstruction) {
-    rpc::RestartActorForLineageReconstructionRequest request;
-    request.set_actor_id(actor_id.Binary());
-    request.set_num_restarts_due_to_lineage_reconstruction(
-        num_restarts_due_to_lineage_reconstruction);
-    rpc::RestartActorForLineageReconstructionReply reply;
-    gcs_actor_manager_->HandleRestartActorForLineageReconstruction(
-        request, &reply, [](auto status, auto success_callback, auto failure_callback) {
-        });
-    return reply;
-  }
-
   void ReportActorOutOfScope(const ActorID &actor_id,
                              size_t num_restarts_due_to_lineage_reconstrcution) {
     rpc::ReportActorOutOfScopeRequest request;
@@ -1412,8 +1399,14 @@ TEST_F(GcsActorManagerTest, TestRestartActorForLineageReconstruction) {
   ASSERT_EQ(actor->GetState(), rpc::ActorTableData::DEAD);
 
   // Restart the actor due to linage reconstruction.
-  RestartActorForLineageReconstruction(actor->GetActorID(),
-                                       /*num_restarts_due_to_lineage_reconstruction=*/1);
+  rpc::RestartActorForLineageReconstructionRequest request;
+  request.set_actor_id(actor->GetActorID().Binary());
+  request.set_num_restarts_due_to_lineage_reconstruction(
+      /*num_restarts_due_to_lineage_reconstruction=*/1);
+  rpc::RestartActorForLineageReconstructionReply reply;
+  gcs_actor_manager_->HandleRestartActorForLineageReconstruction(
+      request, &reply, [](auto, auto, auto) {});
+  io_service_.run_one();
   ASSERT_EQ(actor->GetState(), rpc::ActorTableData::RESTARTING);
 
   // Add node and check that the actor is restarted.
@@ -1424,7 +1417,6 @@ TEST_F(GcsActorManagerTest, TestRestartActorForLineageReconstruction) {
   address.set_raylet_id(node_id3.Binary());
   actor->UpdateAddress(address);
   gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
-  io_service_.run_one();
   io_service_.run_one();
   ASSERT_EQ(created_actors.size(), 1);
   ASSERT_EQ(actor->GetState(), rpc::ActorTableData::ALIVE);
@@ -1467,17 +1459,26 @@ TEST_F(GcsActorManagerTest, TestRestartPermanentlyDeadActorForLineageReconstruct
   ASSERT_EQ(actor->GetState(), rpc::ActorTableData::DEAD);
 
   // Restart on an invalid or permanently dead actor should fail.
-  auto reply = RestartActorForLineageReconstruction(
-      ActorID::Of(actor->GetActorID().JobId(), RandomTaskId(), 0),
+  rpc::RestartActorForLineageReconstructionRequest request;
+  request.set_actor_id(
+      ActorID::Of(actor->GetActorID().JobId(), RandomTaskId(), 0).Binary());
+  request.set_num_restarts_due_to_lineage_reconstruction(
       /*num_restarts_due_to_lineage_reconstruction=*/0);
+  rpc::RestartActorForLineageReconstructionReply reply;
+  gcs_actor_manager_->HandleRestartActorForLineageReconstruction(
+      request, &reply, [](auto, auto, auto) {});
+  io_service_.run_one();
+  io_service_.run_one();
   ASSERT_EQ(reply.status().code(), static_cast<int>(StatusCode::Invalid));
 
-  reply = RestartActorForLineageReconstruction(
-      actor->GetActorID(),
+  rpc::RestartActorForLineageReconstructionRequest request2;
+  request2.set_actor_id(actor->GetActorID().Binary());
+  request2.set_num_restarts_due_to_lineage_reconstruction(
       /*num_restarts_due_to_lineage_reconstruction=*/0);
-  ASSERT_EQ(reply.status().code(), static_cast<int>(StatusCode::Invalid));
-  io_service_.run_one();
-  io_service_.run_one();
+  rpc::RestartActorForLineageReconstructionReply reply2;
+  gcs_actor_manager_->HandleRestartActorForLineageReconstruction(
+      request2, &reply2, [](auto, auto, auto) {});
+  ASSERT_EQ(reply2.status().code(), static_cast<int>(StatusCode::Invalid));
 }
 
 TEST_F(GcsActorManagerTest, TestIdempotencyOfRestartActorForLineageReconstruction) {
@@ -1560,10 +1561,13 @@ TEST_F(GcsActorManagerTest, TestIdempotencyOfRestartActorForLineageReconstructio
   // reply is lost and the caller resends the same request. The second
   // RestartActorForLineageReconstruction rpc should be directly replied without
   // triggering another restart of the actor.
-  auto reply = RestartActorForLineageReconstruction(
-      actor->GetActorID(),
-      /*num_restarts_due_to_lineage_reconstruction=*/1);
-  ASSERT_EQ(reply.status().code(), static_cast<int>(StatusCode::OK));
+  rpc::RestartActorForLineageReconstructionRequest request3;
+  request3.set_actor_id(actor->GetActorID().Binary());
+  request3.set_num_restarts_due_to_lineage_reconstruction(1);
+  rpc::RestartActorForLineageReconstructionReply reply3;
+  gcs_actor_manager_->HandleRestartActorForLineageReconstruction(
+      request3, &reply3, [](auto, auto, auto) {});
+  ASSERT_EQ(reply3.status().code(), static_cast<int>(StatusCode::OK));
   // Make sure the actor is not restarted again.
   ASSERT_EQ(actor->GetState(), rpc::ActorTableData::ALIVE);
   ASSERT_EQ(actor->GetActorTableData().num_restarts(), 1);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Fixes UBSAN failure on actor manager tests after #54203 

Inlining the `RestartActorForLineageReconstruction` because before the reply that was passed in would go out of scope, and then the io service would run the callback. Also moving some of the io service runs around to be in more logical places.

Also removed the no_tsan tag. After the previous pr everything is running on one thread as it is in reality so the test actually passes with tsan.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
