### PR TITLE
[serve] optimize code when user code is on same event loop

### DIFF
--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -71,8 +71,8 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/... //python/ray/tests/...  serve
         --except-tags post_wheel_build,gpu,ha_integration
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
-        --build-name servepydantic1build --test-env=EXPECTED_PYTHON_VERSION=3.9 --test-env=EXPECTED_PYDANTIC_VERSION=1.10.12
-    depends_on: servepydantic1build
+        --build-name servesamethreadbuild --test-env=EXPECTED_PYTHON_VERSION=3.9 --test-env=RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD=0
+    depends_on: "servebuild"
 
   - label: ":ray-serve: serve: python {{matrix.python}} tests ({{matrix.worker_id}})"
     if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -71,7 +71,7 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/... //python/ray/tests/...  serve
         --except-tags post_wheel_build,gpu,ha_integration
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
-        --build-name servesamethreadbuild --test-env=EXPECTED_PYTHON_VERSION=3.9 --test-env=RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD=0
+        --build-name servebuild --test-env=EXPECTED_PYTHON_VERSION=3.9 --test-env=RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD=0
     depends_on: "servebuild"
 
   - label: ":ray-serve: serve: python {{matrix.python}} tests ({{matrix.worker_id}})"

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -60,6 +60,20 @@ steps:
         --build-name servepydantic1build --test-env=EXPECTED_PYTHON_VERSION=3.9 --test-env=EXPECTED_PYDANTIC_VERSION=1.10.12
     depends_on: servepydantic1build
 
+  - label: ":ray-serve: serve: same event loop tests"
+    parallelism: 2
+    tags:
+      - serve
+      - python
+    instance_type: large
+    soft_fail: true
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/... //python/ray/tests/...  serve
+        --except-tags post_wheel_build,gpu,ha_integration
+        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
+        --build-name servepydantic1build --test-env=EXPECTED_PYTHON_VERSION=3.9 --test-env=EXPECTED_PYDANTIC_VERSION=1.10.12
+    depends_on: servepydantic1build
+
   - label: ":ray-serve: serve: python {{matrix.python}} tests ({{matrix.worker_id}})"
     if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
     tags:

--- a/python/ray/serve/_private/local_testing_mode.py
+++ b/python/ray/serve/_private/local_testing_mode.py
@@ -312,7 +312,7 @@ class LocalRouter(Router):
                 request_meta,
                 request_args,
                 request_kwargs,
-                enq=generator_result_callback,
+                enqueue=generator_result_callback,
             )
         else:
             fut = self._user_callable_wrapper.call_user_method(

--- a/python/ray/serve/_private/local_testing_mode.py
+++ b/python/ray/serve/_private/local_testing_mode.py
@@ -312,7 +312,7 @@ class LocalRouter(Router):
                 request_meta,
                 request_args,
                 request_kwargs,
-                generator_result_callback=generator_result_callback,
+                enq=generator_result_callback,
             )
         else:
             fut = self._user_callable_wrapper.call_user_method(

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1783,6 +1783,8 @@ class UserCallableWrapper:
 
         async def _call_generator_async() -> AsyncGenerator[Any, None]:
             gen = callable(*request_args, **request_kwargs)
+            if inspect.iscoroutine(gen):
+                gen = await gen
 
             if inspect.isgenerator(gen):
                 for result in gen:

--- a/python/ray/serve/tests/test_regression.py
+++ b/python/ray/serve/tests/test_regression.py
@@ -245,7 +245,7 @@ def test_uvicorn_duplicate_headers(serve_instance):
 
 
 @pytest.mark.skipif(
-    RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD,
+    not RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD,
     reason="Health check will block if user code is running in the main event loop",
 )
 def test_healthcheck_timeout(serve_instance):

--- a/python/ray/serve/tests/test_regression.py
+++ b/python/ray/serve/tests/test_regression.py
@@ -11,6 +11,7 @@ from fastapi.responses import JSONResponse
 import ray
 from ray import serve
 from ray._common.test_utils import SignalActor
+from ray.serve._private.constants import RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD
 from ray.serve.context import _get_global_client
 from ray.serve.handle import DeploymentHandle
 
@@ -243,6 +244,10 @@ def test_uvicorn_duplicate_headers(serve_instance):
     assert resp.headers["content-length"] == "9"
 
 
+@pytest.mark.skipif(
+    RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD,
+    reason="Health check will block if user code is running in the main event loop",
+)
 def test_healthcheck_timeout(serve_instance):
     # https://github.com/ray-project/ray/issues/24554
 


### PR DESCRIPTION
## Why are these changes needed?

Previously we had a lot of code to deal with the user code being run on a separate event loop, e.g. thread-safe message queues. If we assume the user code is now being run on the same event loop, we can make the code path simpler and more performant.