### PR TITLE
[core][autoscaler] make the autoscaler v2 work with the cluster launcher

### DIFF
--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -57,6 +57,7 @@ from ray.autoscaler._private.util import (
     hash_runtime_conf,
     prepare_config,
     validate_config,
+    with_envs,
 )
 from ray.autoscaler.node_provider import NodeProvider
 from ray.autoscaler.tags import (
@@ -820,6 +821,16 @@ def get_or_create_head_node(
 
         if not no_restart:
             warn_about_bad_start_command(ray_start_commands, no_monitor_on_head)
+
+        if os.getenv("RAY_enable_autoscaler_v2", "0") == "1":
+            ray_start_commands = with_envs(
+                ray_start_commands,
+                {
+                    "RAY_enable_autoscaler_v2": "1",
+                    "RAY_CLOUD_INSTANCE_ID": head_node,
+                    "RAY_NODE_TYPE_NAME": head_node_type,
+                },
+            )
 
         updater = NodeUpdaterThread(
             node_id=head_node,

--- a/python/ray/autoscaler/v2/autoscaler.py
+++ b/python/ray/autoscaler/v2/autoscaler.py
@@ -25,16 +25,21 @@ from ray.autoscaler.v2.instance_manager.node_provider import (
     ICloudInstanceProvider,
     NodeProviderAdapter,
 )
+from ray.autoscaler.v2.instance_manager.ray_installer import RayInstaller
 from ray.autoscaler.v2.instance_manager.reconciler import Reconciler
 from ray.autoscaler.v2.instance_manager.storage import InMemoryStorage
 from ray.autoscaler.v2.instance_manager.subscribers.cloud_instance_updater import (
     CloudInstanceUpdater,
 )
 from ray.autoscaler.v2.instance_manager.subscribers.ray_stopper import RayStopper
+from ray.autoscaler.v2.instance_manager.subscribers.threaded_ray_installer import (
+    ThreadedRayInstaller,
+)
 from ray.autoscaler.v2.metrics_reporter import AutoscalerMetricsReporter
 from ray.autoscaler.v2.scheduler import ResourceDemandScheduler
 from ray.autoscaler.v2.sdk import get_cluster_resource_state
 from ray.core.generated.autoscaler_pb2 import AutoscalingState
+from urllib.parse import urlsplit
 
 logger = logging.getLogger(__name__)
 
@@ -133,16 +138,21 @@ class Autoscaler:
         subscribers.append(
             RayStopper(gcs_client=gcs_client, error_queue=self._ray_stop_errors_queue)
         )
-        if not config.disable_node_updaters():
-            # Supporting ray installer is only needed for providers that doesn't
-            # install or manage ray (e.g. AWS, GCP). These providers will be
-            # supported in the future.
-            raise NotImplementedError(
-                "RayInstaller is not supported yet in current "
-                "release of the Autoscaler V2. Therefore, providers "
-                "that update nodes (with `disable_node_updaters` set to True) "
-                "are not supported yet. Only KubeRay is supported for now which sets "
-                "disable_node_updaters to True in provider's config."
+        if not config.disable_node_updaters() and isinstance(
+            cloud_provider, NodeProviderAdapter
+        ):
+            head_node_ip = urlsplit("//" + self._gcs_client.address).hostname
+            assert head_node_ip is not None, "Invalid GCS address format"
+            subscribers.append(
+                ThreadedRayInstaller(
+                    head_node_ip=head_node_ip,
+                    instance_storage=instance_storage,
+                    ray_installer=RayInstaller(
+                        provider=cloud_provider.v1_provider,
+                        config=config,
+                    ),
+                    error_queue=self._ray_install_errors_queue,
+                )
             )
 
         self._instance_manager = InstanceManager(

--- a/python/ray/autoscaler/v2/autoscaler.py
+++ b/python/ray/autoscaler/v2/autoscaler.py
@@ -152,6 +152,12 @@ class Autoscaler:
                         config=config,
                     ),
                     error_queue=self._ray_install_errors_queue,
+                    # TODO(rueian): Rewrite the ThreadedRayInstaller and its underlying
+                    # NodeUpdater and CommandRunner to use the asyncio, so that we don't
+                    # need to use so many threads. We use so many threads now because
+                    # they are blocking and letting the new cloud machines to wait for
+                    # previous machines to finish installing Ray is quite inefficient.
+                    max_concurrent_installs=config.get_max_num_worker_nodes() or 50,
                 )
             )
 

--- a/python/ray/autoscaler/v2/instance_manager/config.py
+++ b/python/ray/autoscaler/v2/instance_manager/config.py
@@ -174,12 +174,12 @@ class AutoscalingConfig:
         validate_config(self._configs)
         if skip_content_hash:
             return
-        self.calculate_hashes()
+        self._calculate_hashes()
         self._sync_continuously = self._configs.get(
             "generate_file_mounts_contents_hash", True
         )
 
-    def calculate_hashes(self) -> None:
+    def _calculate_hashes(self) -> None:
         logger.info("Calculating hashes for file mounts and ray commands.")
         self._runtime_hash, self._file_mounts_contents_hash = hash_runtime_conf(
             self._configs.get("file_mounts", {}),
@@ -435,10 +435,14 @@ class AutoscalingConfig:
 
     @property
     def runtime_hash(self) -> str:
+        if not hasattr(self, "_runtime_hash"):
+            self._calculate_hashes()
         return self._runtime_hash
 
     @property
     def file_mounts_contents_hash(self) -> str:
+        if not hasattr(self, "_file_mounts_contents_hash"):
+            self._calculate_hashes()
         return self._file_mounts_contents_hash
 
 

--- a/python/ray/autoscaler/v2/instance_manager/config.py
+++ b/python/ray/autoscaler/v2/instance_manager/config.py
@@ -174,12 +174,12 @@ class AutoscalingConfig:
         validate_config(self._configs)
         if skip_content_hash:
             return
-        self._calculate_hashes()
+        self.calculate_hashes()
         self._sync_continuously = self._configs.get(
             "generate_file_mounts_contents_hash", True
         )
 
-    def _calculate_hashes(self) -> None:
+    def calculate_hashes(self) -> None:
         logger.info("Calculating hashes for file mounts and ray commands.")
         self._runtime_hash, self._file_mounts_contents_hash = hash_runtime_conf(
             self._configs.get("file_mounts", {}),
@@ -388,7 +388,7 @@ class AutoscalingConfig:
 
     def disable_node_updaters(self) -> bool:
         provider_config = self._configs.get("provider", {})
-        return provider_config.get(DISABLE_NODE_UPDATERS_KEY, True)
+        return provider_config.get(DISABLE_NODE_UPDATERS_KEY, False)
 
     def get_idle_timeout_s(self) -> Optional[float]:
         """

--- a/python/ray/autoscaler/v2/instance_manager/node_provider.py
+++ b/python/ray/autoscaler/v2/instance_manager/node_provider.py
@@ -341,6 +341,10 @@ class NodeProviderAdapter(ICloudInstanceProvider):
         # temporarily.
         self._errors_queue = Queue()
 
+    @property
+    def v1_provider(self) -> NodeProviderV1:
+        return self._v1_provider
+
     def get_non_terminated(self) -> Dict[CloudInstanceId, CloudInstance]:
         nodes = {}
 

--- a/python/ray/autoscaler/v2/instance_manager/ray_installer.py
+++ b/python/ray/autoscaler/v2/instance_manager/ray_installer.py
@@ -1,22 +1,17 @@
-import dataclasses
 import logging
 import subprocess
 
-from ray.autoscaler._private.updater import NodeUpdater
+from ray.autoscaler._private.updater import (
+    NodeUpdater,
+    TAG_RAY_NODE_STATUS,
+    STATUS_UP_TO_DATE,
+)
 from ray.autoscaler._private.util import with_envs, with_head_node_ip
 from ray.autoscaler.node_provider import NodeProvider as NodeProviderV1
 from ray.autoscaler.v2.instance_manager.config import AutoscalingConfig
 from ray.core.generated.instance_manager_pb2 import Instance
 
 logger = logging.getLogger(__name__)
-
-
-@dataclasses.dataclass(frozen=True)
-class RayInstallError:
-    # Instance manager's instance id.
-    im_instance_id: str
-    # Error details.
-    details: str
 
 
 class RayInstaller(object):
@@ -34,12 +29,13 @@ class RayInstaller(object):
         self._config = config
         self._process_runner = process_runner
 
-    def install_ray(self, instance: Instance, head_node_ip: str) -> bool:
+    def install_ray(self, instance: Instance, head_node_ip: str) -> None:
         """
         Install ray on the target instance synchronously.
         TODO:(rickyx): This runs in another thread, and errors are silently
         ignored. We should propagate the error to the main thread.
         """
+        self._config.calculate_hashes()
         setup_commands = self._config.get_worker_setup_commands(instance.instance_type)
         ray_start_commands = self._config.get_worker_start_ray_commands()
         docker_config = self._config.get_docker_config(instance.instance_type)
@@ -52,7 +48,7 @@ class RayInstaller(object):
             instance.instance_type
         )
         updater = NodeUpdater(
-            node_id=instance.instance_id,
+            node_id=instance.cloud_instance_id,
             provider_config=self._config.get_config("provider"),
             provider=self._provider,
             auth_config=self._config.get_config("auth"),
@@ -72,7 +68,7 @@ class RayInstaller(object):
                 ray_start_commands,
                 {
                     "RAY_HEAD_IP": head_node_ip,
-                    "RAY_CLOUD_INSTANCE_ID": instance.instance_id,
+                    "RAY_CLOUD_INSTANCE_ID": instance.cloud_instance_id,
                     "RAY_NODE_TYPE_NAME": instance.instance_type,
                     "RAY_CLOUD_INSTANCE_TYPE_NAME": provider_instance_type_name,
                 },
@@ -91,9 +87,11 @@ class RayInstaller(object):
             node_labels=self._config.get_node_labels(instance.instance_type),
             process_runner=self._process_runner,
         )
-        try:
-            updater.run()
-        except Exception:
-            # Errors has already been handled.
-            return False
-        return True
+        updater.run()
+        # check if the updater was successful by checking the node tags
+        # since the updater could hide exceptions and just set the status tag
+        tags = self._provider.node_tags(instance.cloud_instance_id)
+        if tags.get(TAG_RAY_NODE_STATUS) != STATUS_UP_TO_DATE:
+            raise Exception(
+                f"Ray installation failed with unexpected status: {tags.get(TAG_RAY_NODE_STATUS)}"
+            )

--- a/python/ray/autoscaler/v2/instance_manager/ray_installer.py
+++ b/python/ray/autoscaler/v2/instance_manager/ray_installer.py
@@ -35,7 +35,6 @@ class RayInstaller(object):
         TODO:(rickyx): This runs in another thread, and errors are silently
         ignored. We should propagate the error to the main thread.
         """
-        self._config.calculate_hashes()
         setup_commands = self._config.get_worker_setup_commands(instance.instance_type)
         ray_start_commands = self._config.get_worker_start_ray_commands()
         docker_config = self._config.get_docker_config(instance.instance_type)

--- a/python/ray/autoscaler/v2/instance_manager/reconciler.py
+++ b/python/ray/autoscaler/v2/instance_manager/reconciler.py
@@ -21,7 +21,9 @@ from ray.autoscaler.v2.instance_manager.node_provider import (
     LaunchNodeError,
     TerminateNodeError,
 )
-from ray.autoscaler.v2.instance_manager.ray_installer import RayInstallError
+from ray.autoscaler.v2.instance_manager.subscribers.threaded_ray_installer import (
+    RayInstallError,
+)
 from ray.autoscaler.v2.instance_manager.subscribers.ray_stopper import RayStopError
 from ray.autoscaler.v2.metrics_reporter import AutoscalerMetricsReporter
 from ray.autoscaler.v2.scheduler import IResourceScheduler, SchedulingRequest

--- a/python/ray/autoscaler/v2/instance_manager/subscribers/threaded_ray_installer.py
+++ b/python/ray/autoscaler/v2/instance_manager/subscribers/threaded_ray_installer.py
@@ -1,16 +1,30 @@
+import dataclasses
 import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import List
+from queue import Queue
 
 from ray.autoscaler.v2.instance_manager.instance_manager import (
     InstanceUpdatedSubscriber,
 )
 from ray.autoscaler.v2.instance_manager.instance_storage import InstanceStorage
 from ray.autoscaler.v2.instance_manager.ray_installer import RayInstaller
-from ray.core.generated.instance_manager_pb2 import Instance, InstanceUpdateEvent
+from ray.core.generated.instance_manager_pb2 import (
+    NodeKind,
+    Instance,
+    InstanceUpdateEvent,
+)
 
 logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(frozen=True)
+class RayInstallError:
+    # Instance manager's instance id.
+    im_instance_id: str
+    # Error details.
+    details: str
 
 
 class ThreadedRayInstaller(InstanceUpdatedSubscriber):
@@ -21,6 +35,7 @@ class ThreadedRayInstaller(InstanceUpdatedSubscriber):
         head_node_ip: str,
         instance_storage: InstanceStorage,
         ray_installer: RayInstaller,
+        error_queue: Queue,
         max_install_attempts: int = 3,
         install_retry_interval: int = 10,
         max_concurrent_installs: int = 50,
@@ -31,65 +46,50 @@ class ThreadedRayInstaller(InstanceUpdatedSubscriber):
         self._max_concurrent_installs = max_concurrent_installs
         self._max_install_attempts = max_install_attempts
         self._install_retry_interval = install_retry_interval
+        self._error_queue = error_queue
         self._ray_installation_executor = ThreadPoolExecutor(
             max_workers=self._max_concurrent_installs
         )
 
     def notify(self, events: List[InstanceUpdateEvent]) -> None:
         for event in events:
-            if event.new_instance_status == Instance.ALLOCATED:
+            if event.new_instance_status == Instance.RAY_INSTALLING:
                 self._install_ray_on_new_nodes(event.instance_id)
 
     def _install_ray_on_new_nodes(self, instance_id: str) -> None:
         allocated_instance, _ = self._instance_storage.get_instances(
             instance_ids={instance_id},
-            status_filter={Instance.ALLOCATED},
+            status_filter={Instance.RAY_INSTALLING},
         )
         for instance in allocated_instance.values():
+            assert instance.node_kind == NodeKind.WORKER
             self._ray_installation_executor.submit(
                 self._install_ray_on_single_node, instance
             )
 
     def _install_ray_on_single_node(self, instance: Instance) -> None:
-        assert instance.status == Instance.ALLOCATED
-        success, version = self._instance_storage.upsert_instance(
-            instance, expected_instance_version=instance.version
-        )
-        if not success:
-            logger.warning(
-                f"Failed to update instance {instance.instance_id} to RAY_INSTALLING"
-            )
-            # Do not need to handle failures, it will be covered by
-            # garbage collection.
-            return
+        assert instance.status == Instance.RAY_INSTALLING
 
         # install with exponential backoff
-        installed = False
         backoff_factor = 1
+        last_exception = None
         for _ in range(self._max_install_attempts):
-            installed = self._ray_installer.install_ray(instance, self._head_node_ip)
-            if installed:
-                break
+            try:
+                self._ray_installer.install_ray(instance, self._head_node_ip)
+                return
+            except Exception as e:
+                logger.info(
+                    f"Ray installation failed on instance {instance.cloud_instance_id}: {e}"
+                )
+                last_exception = e
+
             logger.warning("Failed to install ray, retrying...")
             time.sleep(self._install_retry_interval * backoff_factor)
             backoff_factor *= 2
 
-        if not installed:
-            instance.status = Instance.RAY_INSTALL_FAILED
-            success, version = self._instance_storage.upsert_instance(
-                instance,
-                expected_instance_version=version,
+        self._error_queue.put_nowait(
+            RayInstallError(
+                im_instance_id=instance.instance_id,
+                details=str(last_exception),
             )
-        else:
-            instance.status = Instance.RAY_RUNNING
-            success, version = self._instance_storage.upsert_instance(
-                instance,
-                expected_instance_version=version,
-            )
-        if not success:
-            logger.warning(
-                f"Failed to update instance {instance.instance_id} to {instance.status}"
-            )
-            # Do not need to handle failures, it will be covered by
-            # garbage collection.
-            return
+        )

--- a/python/ray/autoscaler/v2/tests/test_reconciler.py
+++ b/python/ray/autoscaler/v2/tests/test_reconciler.py
@@ -18,10 +18,12 @@ from ray.autoscaler.v2.instance_manager.node_provider import (  # noqa
     LaunchNodeError,
     TerminateNodeError,
 )
-from ray.autoscaler.v2.instance_manager.ray_installer import RayInstallError
 from ray.autoscaler.v2.instance_manager.reconciler import Reconciler, logger
 from ray.autoscaler.v2.instance_manager.storage import InMemoryStorage
 from ray.autoscaler.v2.instance_manager.subscribers.ray_stopper import RayStopError
+from ray.autoscaler.v2.instance_manager.subscribers.threaded_ray_installer import (
+    RayInstallError,
+)
 from ray.autoscaler.v2.scheduler import IResourceScheduler, SchedulingReply
 from ray.autoscaler.v2.tests.util import MockSubscriber, create_instance
 from ray.core.generated.autoscaler_pb2 import (


### PR DESCRIPTION
## Why are these changes needed?

This PR wires up the `NodeProviderAdapter` and `ThreadedRayInstaller` to make autoscaler v2 work with the cluster launcher.

An autoscaler v2 enabled cluster can be launched by the following command:

```sh
RAY_enable_autoscaler_v2=1 ray up aws.yaml -y
```

and this `aws.yaml`:

```yaml
cluster_name: default
max_workers: 2
upscaling_speed: 1.0
docker:
    image: "rayproject/ray:nightly-py312"
    container_name: "ray_container"
    pull_before_run: True
    run_options:
        - --ulimit nofile=65536:65536
idle_timeout_minutes: 5
provider:
    type: aws
    region: us-west-2
    availability_zone: us-west-2a,us-west-2b
    cache_stopped_nodes: True
auth:
    ssh_user: ubuntu
available_node_types:
    ray.head.default:
        resources: {}
        node_config:
            InstanceType: m5.large
            ImageId: ami-0387d929287ab193e
            BlockDeviceMappings:
                - DeviceName: /dev/sda1
                  Ebs:
                      VolumeSize: 140
                      VolumeType: gp3
    ray.worker.default:
        min_workers: 1
        max_workers: 2
        resources: {}
        node_config:
            InstanceType: m5.large
            ImageId: ami-0387d929287ab193e
            InstanceMarketOptions:
                MarketType: spot
head_node_type: ray.head.default

file_mounts: {
    "/home/ray/anaconda3/lib/python3.12/site-packages/ray/autoscaler/v2": "python/ray/autoscaler/v2",
}

cluster_synced_files: []
file_mounts_sync_continuously: False
rsync_exclude:
    - "**/.git"
    - "**/.git/**"
rsync_filter:
    - ".gitignore"
initialization_commands: []
setup_commands: []
head_setup_commands: []
worker_setup_commands: []
head_start_ray_commands:
    - ray stop
    - ray start --head --port=6379 --object-manager-port=8076 --autoscaling-config=~/ray_bootstrap_config.yaml --dashboard-host=0.0.0.0
worker_start_ray_commands:
    - ray stop
    - ray start --address=$RAY_HEAD_IP:6379 --object-manager-port=8076
```

The equivalent setup for gcp is also tested.

Note that the `image: "rayproject/ray:nightly-py312"` and `file_mounts` are **required**, and the `python/ray/autoscaler/v2` local path should point to this PR since we need to patch the autoscaler in the docker image.


## Summary of Changes

* Make `ray up` accept the `RAY_enable_autoscaler_v2` env.
* Enable the `ThreadedRayInstaller` in the autoscaler v2 if the node provider is a `NodeProviderAdapter`.
* Fix the `ThreadedRayInstaller` for not conflict with the autoscaler v2.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
