### PR TITLE
[train][tune] add support for dynamically loading callbacks by environement variables

### DIFF
--- a/python/ray/train/constants.py
+++ b/python/ray/train/constants.py
@@ -112,6 +112,9 @@ RAY_TRAIN_COUNT_PREEMPTION_AS_FAILURE = "RAY_TRAIN_COUNT_PREEMPTION_AS_FAILURE"
 # Defaults to 0
 RAY_TRAIN_ENABLE_STATE_TRACKING = "RAY_TRAIN_ENABLE_STATE_TRACKING"
 
+# Environment variable for Train execution callbacks
+RAY_TRAIN_CALLBACKS_ENV_VAR = "RAY_TRAIN_CALLBACKS"
+
 
 # NOTE: When adding a new environment variable, please track it in this list.
 TRAIN_ENV_VARS = {
@@ -123,6 +126,7 @@ TRAIN_ENV_VARS = {
     RAY_CHDIR_TO_TRIAL_DIR,
     RAY_TRAIN_COUNT_PREEMPTION_AS_FAILURE,
     RAY_TRAIN_ENABLE_STATE_TRACKING,
+    RAY_TRAIN_CALLBACKS_ENV_VAR,
 }
 
 # Key for AIR Checkpoint metadata in TrainingResult metadata

--- a/python/ray/train/constants.py
+++ b/python/ray/train/constants.py
@@ -112,9 +112,6 @@ RAY_TRAIN_COUNT_PREEMPTION_AS_FAILURE = "RAY_TRAIN_COUNT_PREEMPTION_AS_FAILURE"
 # Defaults to 0
 RAY_TRAIN_ENABLE_STATE_TRACKING = "RAY_TRAIN_ENABLE_STATE_TRACKING"
 
-# Environment variable for Train execution callbacks
-RAY_TRAIN_CALLBACKS_ENV_VAR = "RAY_TRAIN_CALLBACKS"
-
 
 # NOTE: When adding a new environment variable, please track it in this list.
 TRAIN_ENV_VARS = {
@@ -126,7 +123,6 @@ TRAIN_ENV_VARS = {
     RAY_CHDIR_TO_TRIAL_DIR,
     RAY_TRAIN_COUNT_PREEMPTION_AS_FAILURE,
     RAY_TRAIN_ENABLE_STATE_TRACKING,
-    RAY_TRAIN_CALLBACKS_ENV_VAR,
 }
 
 # Key for AIR Checkpoint metadata in TrainingResult metadata

--- a/python/ray/train/v2/BUILD
+++ b/python/ray/train/v2/BUILD
@@ -86,6 +86,22 @@ py_test(
 )
 
 py_test(
+    name = "test_env_callbacks",
+    size = "small",
+    srcs = ["tests/test_env_callbacks.py"],
+    env = {"RAY_TRAIN_V2_ENABLED": "1"},
+    tags = [
+        "exclusive",
+        "team:ml",
+        "train_v2",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_failure_policy",
     size = "small",
     srcs = ["tests/test_failure_policy.py"],

--- a/python/ray/train/v2/_internal/callbacks/env_callback.py
+++ b/python/ray/train/v2/_internal/callbacks/env_callback.py
@@ -2,7 +2,7 @@ import importlib
 import os
 from typing import List
 
-from ray.train.constants import RAY_TRAIN_CALLBACKS_ENV_VAR
+from ray.train.v2._internal.constants import RAY_TRAIN_CALLBACKS_ENV_VAR
 from ray.train.v2._internal.execution.callback import RayTrainCallback
 
 
@@ -26,9 +26,14 @@ def _initialize_env_callbacks() -> List[RayTrainCallback]:
             module_path, class_name = callback_path.rsplit(".", 1)
             module = importlib.import_module(module_path)
             callback_cls = getattr(module, class_name)
+            if not issubclass(callback_cls, RayTrainCallback):
+                raise ValueError(
+                    f"Callback class '{callback_path}' must be a subclass of "
+                    f"RayTrainCallback, got {type(callback_cls).__name__}"
+                )
             callback = callback_cls()
             callbacks.append(callback)
         except (ImportError, AttributeError, ValueError) as e:
-            raise ValueError(f"Failed to import callback from '{callback_path}': {e}")
+            raise ValueError(f"Failed to import callback from '{callback_path}'") from e
 
     return callbacks

--- a/python/ray/train/v2/_internal/callbacks/env_callback.py
+++ b/python/ray/train/v2/_internal/callbacks/env_callback.py
@@ -1,0 +1,34 @@
+import importlib
+import os
+from typing import List
+
+from ray.train.constants import RAY_TRAIN_CALLBACKS_ENV_VAR
+from ray.train.v2._internal.execution.callback import RayTrainCallback
+
+
+def _initialize_env_callbacks() -> List[RayTrainCallback]:
+    """Initialize callbacks from environment variable.
+
+    Returns:
+        List of callbacks initialized from environment variable.
+    """
+    callbacks = []
+    callbacks_str = os.environ.get(RAY_TRAIN_CALLBACKS_ENV_VAR, "")
+    if not callbacks_str:
+        return callbacks
+
+    for callback_path in callbacks_str.split(","):
+        callback_path = callback_path.strip()
+        if not callback_path:
+            continue
+
+        try:
+            module_path, class_name = callback_path.rsplit(".", 1)
+            module = importlib.import_module(module_path)
+            callback_cls = getattr(module, class_name)
+            callback = callback_cls()
+            callbacks.append(callback)
+        except (ImportError, AttributeError, ValueError) as e:
+            raise ValueError(f"Failed to import callback from '{callback_path}': {e}")
+
+    return callbacks

--- a/python/ray/train/v2/_internal/callbacks/env_callback.py
+++ b/python/ray/train/v2/_internal/callbacks/env_callback.py
@@ -27,13 +27,13 @@ def _initialize_env_callbacks() -> List[RayTrainCallback]:
             module = importlib.import_module(module_path)
             callback_cls = getattr(module, class_name)
             if not issubclass(callback_cls, RayTrainCallback):
-                raise ValueError(
+                raise TypeError(
                     f"Callback class '{callback_path}' must be a subclass of "
                     f"RayTrainCallback, got {type(callback_cls).__name__}"
                 )
             callback = callback_cls()
             callbacks.append(callback)
-        except (ImportError, AttributeError, ValueError) as e:
+        except (ImportError, AttributeError, ValueError, TypeError) as e:
             raise ValueError(f"Failed to import callback from '{callback_path}'") from e
 
     return callbacks

--- a/python/ray/train/v2/_internal/constants.py
+++ b/python/ray/train/v2/_internal/constants.py
@@ -59,6 +59,9 @@ ENABLE_WORKER_STRUCTURED_LOGGING_ENV_VAR = "RAY_TRAIN_ENABLE_WORKER_STRUCTURED_L
 DEFAULT_ENABLE_CONTROLLER_LOGGING = "1"
 DEFAULT_ENABLE_WORKER_LOGGING = "1"
 
+# Environment variable for Train execution callbacks
+RAY_TRAIN_CALLBACKS_ENV_VAR = "RAY_TRAIN_CALLBACKS"
+
 # Environment variables to propagate from the driver to the controller,
 # and then from the controller to the workers.
 ENV_VARS_TO_PROPAGATE = {

--- a/python/ray/train/v2/tests/test_env_callbacks.py
+++ b/python/ray/train/v2/tests/test_env_callbacks.py
@@ -1,0 +1,79 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ray.train.v2._internal.callbacks.env_callback import _initialize_env_callbacks
+
+
+def _create_mock_callback_setup():
+    """Helper to create mock callback setup."""
+    mock_callback = MagicMock()
+    mock_module = MagicMock()
+    mock_module.MockCallback = MagicMock(return_value=mock_callback)
+    return mock_callback, mock_module
+
+
+@patch("importlib.import_module")
+@patch.dict(os.environ, {"RAY_TRAIN_CALLBACKS": "my.module.TestCallback"})
+def test_env_callbacks_loaded(mock_import):
+    """Test loading execution callbacks from environment variable."""
+    mock_callback, mock_module = _create_mock_callback_setup()
+    mock_module.TestCallback = MagicMock(return_value=mock_callback)
+    mock_import.return_value = mock_module
+
+    callbacks = _initialize_env_callbacks()
+
+    mock_import.assert_called_once_with("my.module")
+    assert len([c for c in callbacks if c is mock_callback]) == 1
+
+
+@patch("importlib.import_module")
+@patch.dict(os.environ, {"RAY_TRAIN_CALLBACKS": "module1.Callback1,module2.Callback2"})
+def test_multiple_env_callbacks(mock_import):
+    """Test loading multiple callbacks from environment variable."""
+    mock_callback1, mock_module1 = _create_mock_callback_setup()
+    mock_callback2, mock_module2 = _create_mock_callback_setup()
+    mock_module1.Callback1 = MagicMock(return_value=mock_callback1)
+    mock_module2.Callback2 = MagicMock(return_value=mock_callback2)
+
+    def side_effect(name):
+        return {"module1": mock_module1, "module2": mock_module2}[name]
+
+    mock_import.side_effect = side_effect
+
+    callbacks = _initialize_env_callbacks()
+
+    assert len([c for c in callbacks if c is mock_callback1]) == 1
+    assert len([c for c in callbacks if c is mock_callback2]) == 1
+
+
+@patch.dict(os.environ, {"RAY_TRAIN_CALLBACKS": "invalid_module"})
+def test_invalid_callback_path():
+    """Test handling of invalid callback paths in environment variable."""
+    with pytest.raises(ValueError):
+        _initialize_env_callbacks()
+
+
+@patch("importlib.import_module")
+@patch.dict(os.environ, {"RAY_TRAIN_CALLBACKS": "nonexistent.module.TestCallback"})
+def test_import_error_handling(mock_import):
+    """Test handling of import errors when loading callbacks."""
+    mock_import.side_effect = ImportError("No module named 'nonexistent'")
+    with pytest.raises(ValueError):
+        _initialize_env_callbacks()
+
+
+def test_no_env_variable():
+    """Test that no callbacks are loaded when environment variable is not set."""
+    if "RAY_TRAIN_CALLBACKS" in os.environ:
+        del os.environ["RAY_TRAIN_CALLBACKS"]
+
+    callbacks = _initialize_env_callbacks()
+    assert len(callbacks) == 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/train/v2/tests/test_env_callbacks.py
+++ b/python/ray/train/v2/tests/test_env_callbacks.py
@@ -51,7 +51,7 @@ def test_env_callbacks_loading(mock_import, env_value, expected_callback_count):
     "env_value,original_error_type",
     [
         ("invalid_module", ValueError),
-        ("module.Class", ValueError),
+        ("module.Class", TypeError),
         ("module.NonExistentClass", AttributeError),
     ],
 )

--- a/python/ray/train/v2/tests/test_env_callbacks.py
+++ b/python/ray/train/v2/tests/test_env_callbacks.py
@@ -4,70 +4,100 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ray.train.v2._internal.callbacks.env_callback import _initialize_env_callbacks
+from ray.train.v2._internal.constants import RAY_TRAIN_CALLBACKS_ENV_VAR
+from ray.train.v2._internal.execution.callback import RayTrainCallback
 
 
-def _create_mock_callback_setup():
-    """Helper to create mock callback setup."""
-    mock_callback = MagicMock()
-    mock_module = MagicMock()
-    mock_module.MockCallback = MagicMock(return_value=mock_callback)
-    return mock_callback, mock_module
+class MockCallback(RayTrainCallback):
+    pass
 
 
+@pytest.mark.parametrize(
+    "env_value,expected_callback_count",
+    [
+        ("my.module.Callback1", 1),
+        ("module1.Callback1,module2.Callback2", 2),
+        ("", 0),
+        ("   ", 0),
+        ("module.Callback1, ,module.Callback2", 2),
+    ],
+)
 @patch("importlib.import_module")
-@patch.dict(os.environ, {"RAY_TRAIN_CALLBACKS": "my.module.TestCallback"})
-def test_env_callbacks_loaded(mock_import):
-    """Test loading execution callbacks from environment variable."""
-    mock_callback, mock_module = _create_mock_callback_setup()
-    mock_module.TestCallback = MagicMock(return_value=mock_callback)
-    mock_import.return_value = mock_module
+def test_env_callbacks_loading(mock_import, env_value, expected_callback_count):
+    """Test loading execution callbacks from environment variable with various inputs."""
+    if env_value:
+        with patch.dict(os.environ, {RAY_TRAIN_CALLBACKS_ENV_VAR: env_value}):
 
-    callbacks = _initialize_env_callbacks()
+            mock_module = MagicMock()
+            mock_module.Callback1 = MockCallback
+            mock_module.Callback2 = MockCallback
+            mock_import.return_value = mock_module
 
-    mock_import.assert_called_once_with("my.module")
-    assert len([c for c in callbacks if c is mock_callback]) == 1
+            callbacks = _initialize_env_callbacks()
+
+            assert len(callbacks) == expected_callback_count
+            for callback in callbacks:
+                assert isinstance(callback, RayTrainCallback)
+
+    else:
+        with patch.dict(
+            os.environ, {RAY_TRAIN_CALLBACKS_ENV_VAR: env_value}, clear=True
+        ):
+            callbacks = _initialize_env_callbacks()
+            assert len(callbacks) == 0
 
 
+@pytest.mark.parametrize(
+    "env_value,original_error_type",
+    [
+        ("invalid_module", ValueError),
+        ("module.Class", ValueError),
+        ("module.NonExistentClass", AttributeError),
+    ],
+)
 @patch("importlib.import_module")
-@patch.dict(os.environ, {"RAY_TRAIN_CALLBACKS": "module1.Callback1,module2.Callback2"})
-def test_multiple_env_callbacks(mock_import):
-    """Test loading multiple callbacks from environment variable."""
-    mock_callback1, mock_module1 = _create_mock_callback_setup()
-    mock_callback2, mock_module2 = _create_mock_callback_setup()
-    mock_module1.Callback1 = MagicMock(return_value=mock_callback1)
-    mock_module2.Callback2 = MagicMock(return_value=mock_callback2)
+def test_callback_loading_errors(mock_import, env_value, original_error_type):
+    """Test handling of various error conditions when loading callbacks."""
+    with patch.dict(os.environ, {RAY_TRAIN_CALLBACKS_ENV_VAR: env_value}):
+        if "invalid_module" in env_value:
+            pass
+        elif "NonExistentClass" in env_value:
+            mock_module = MagicMock()
+            del mock_module.NonExistentClass
+            mock_import.return_value = mock_module
+        else:
+            mock_module = MagicMock()
 
-    def side_effect(name):
-        return {"module1": mock_module1, "module2": mock_module2}[name]
+            class RegularClass:
+                pass
 
-    mock_import.side_effect = side_effect
+            mock_module.Class = RegularClass
+            mock_import.return_value = mock_module
 
-    callbacks = _initialize_env_callbacks()
+        with pytest.raises(
+            ValueError, match=f"Failed to import callback from '{env_value}'"
+        ) as exc_info:
+            _initialize_env_callbacks()
 
-    assert len([c for c in callbacks if c is mock_callback1]) == 1
-    assert len([c for c in callbacks if c is mock_callback2]) == 1
-
-
-@patch.dict(os.environ, {"RAY_TRAIN_CALLBACKS": "invalid_module"})
-def test_invalid_callback_path():
-    """Test handling of invalid callback paths in environment variable."""
-    with pytest.raises(ValueError):
-        _initialize_env_callbacks()
+        assert isinstance(exc_info.value.__cause__, original_error_type)
 
 
-@patch("importlib.import_module")
-@patch.dict(os.environ, {"RAY_TRAIN_CALLBACKS": "nonexistent.module.TestCallback"})
-def test_import_error_handling(mock_import):
+def test_import_error_handling():
     """Test handling of import errors when loading callbacks."""
-    mock_import.side_effect = ImportError("No module named 'nonexistent'")
-    with pytest.raises(ValueError):
-        _initialize_env_callbacks()
+    with patch.dict(
+        os.environ, {RAY_TRAIN_CALLBACKS_ENV_VAR: "nonexistent.module.TestCallback"}
+    ):
+        with pytest.raises(
+            ValueError,
+            match="Failed to import callback from 'nonexistent.module.TestCallback'",
+        ):
+            _initialize_env_callbacks()
 
 
 def test_no_env_variable():
     """Test that no callbacks are loaded when environment variable is not set."""
-    if "RAY_TRAIN_CALLBACKS" in os.environ:
-        del os.environ["RAY_TRAIN_CALLBACKS"]
+    if RAY_TRAIN_CALLBACKS_ENV_VAR in os.environ:
+        del os.environ[RAY_TRAIN_CALLBACKS_ENV_VAR]
 
     callbacks = _initialize_env_callbacks()
     assert len(callbacks) == 0

--- a/python/ray/tune/BUILD
+++ b/python/ray/tune/BUILD
@@ -152,6 +152,17 @@ py_test(
 )
 
 py_test(
+    name = "test_env_callbacks",
+    size = "small",
+    srcs = ["tests/test_env_callbacks.py"],
+    tags = [
+        "exclusive",
+        "team:ml",
+    ],
+    deps = [":tune_lib"],
+)
+
+py_test(
     name = "test_experiment",
     size = "small",
     srcs = ["tests/test_experiment.py"],

--- a/python/ray/tune/constants.py
+++ b/python/ray/tune/constants.py
@@ -2,6 +2,9 @@
 #               Environment Variables
 # ==================================================
 
+# Environment variable for Tune execution callbacks
+RAY_TUNE_CALLBACKS_ENV_VAR = "RAY_TUNE_CALLBACKS"
+
 # NOTE: When adding a new environment variable, please track it in this list.
 TUNE_ENV_VARS = {
     "RAY_AIR_LOCAL_CACHE_DIR",
@@ -29,4 +32,5 @@ TUNE_ENV_VARS = {
     "TUNE_WARN_EXCESSIVE_EXPERIMENT_CHECKPOINT_SYNC_THRESHOLD_S",
     "TUNE_STATE_REFRESH_PERIOD",
     "TUNE_RESTORE_RETRY_NUM",
+    RAY_TUNE_CALLBACKS_ENV_VAR,
 }

--- a/python/ray/tune/tests/test_env_callbacks.py
+++ b/python/ray/tune/tests/test_env_callbacks.py
@@ -48,7 +48,7 @@ def test_env_callbacks_loading(mock_import, env_value, expected_callback_count):
     "env_value,original_error_type",
     [
         ("invalid_module", ValueError),
-        ("module.Class", ValueError),
+        ("module.Class", TypeError),
         ("module.NonExistentClass", AttributeError),
     ],
 )

--- a/python/ray/tune/tests/test_env_callbacks.py
+++ b/python/ray/tune/tests/test_env_callbacks.py
@@ -1,0 +1,79 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ray.tune.utils.callback import _initialize_env_callbacks
+
+
+def _create_mock_callback_setup():
+    """Helper to create mock callback setup."""
+    mock_callback = MagicMock()
+    mock_module = MagicMock()
+    mock_module.MockCallback = MagicMock(return_value=mock_callback)
+    return mock_callback, mock_module
+
+
+@patch("importlib.import_module")
+@patch.dict(os.environ, {"RAY_TUNE_CALLBACKS": "my.module.TestCallback"})
+def test_env_callbacks_loaded(mock_import):
+    """Test loading execution callbacks from environment variable."""
+    mock_callback, mock_module = _create_mock_callback_setup()
+    mock_module.TestCallback = MagicMock(return_value=mock_callback)
+    mock_import.return_value = mock_module
+
+    callbacks = _initialize_env_callbacks()
+
+    mock_import.assert_called_once_with("my.module")
+    assert len([c for c in callbacks if c is mock_callback]) == 1
+
+
+@patch("importlib.import_module")
+@patch.dict(os.environ, {"RAY_TUNE_CALLBACKS": "module1.Callback1,module2.Callback2"})
+def test_multiple_env_callbacks(mock_import):
+    """Test loading multiple callbacks from environment variable."""
+    mock_callback1, mock_module1 = _create_mock_callback_setup()
+    mock_callback2, mock_module2 = _create_mock_callback_setup()
+    mock_module1.Callback1 = MagicMock(return_value=mock_callback1)
+    mock_module2.Callback2 = MagicMock(return_value=mock_callback2)
+
+    def side_effect(name):
+        return {"module1": mock_module1, "module2": mock_module2}[name]
+
+    mock_import.side_effect = side_effect
+
+    callbacks = _initialize_env_callbacks()
+
+    assert len([c for c in callbacks if c is mock_callback1]) == 1
+    assert len([c for c in callbacks if c is mock_callback2]) == 1
+
+
+@patch.dict(os.environ, {"RAY_TUNE_CALLBACKS": "invalid_module"})
+def test_invalid_callback_path():
+    """Test handling of invalid callback paths in environment variable."""
+    with pytest.raises(ValueError):
+        _initialize_env_callbacks()
+
+
+@patch("importlib.import_module")
+@patch.dict(os.environ, {"RAY_TUNE_CALLBACKS": "nonexistent.module.TestCallback"})
+def test_import_error_handling(mock_import):
+    """Test handling of import errors when loading callbacks."""
+    mock_import.side_effect = ImportError("No module named 'nonexistent'")
+    with pytest.raises(ValueError):
+        _initialize_env_callbacks()
+
+
+def test_no_env_variable():
+    """Test that no callbacks are loaded when environment variable is not set."""
+    if "RAY_TUNE_CALLBACKS" in os.environ:
+        del os.environ["RAY_TUNE_CALLBACKS"]
+
+    callbacks = _initialize_env_callbacks()
+    assert len(callbacks) == 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tune/utils/callback.py
+++ b/python/ray/tune/utils/callback.py
@@ -1,8 +1,10 @@
+import importlib
 import logging
 import os
 from typing import TYPE_CHECKING, Collection, List, Optional, Type, Union
 
 from ray.tune.callback import Callback, CallbackList
+from ray.tune.constants import RAY_TUNE_CALLBACKS_ENV_VAR
 from ray.tune.logger import (
     CSVLogger,
     CSVLoggerCallback,
@@ -68,6 +70,11 @@ def _create_default_callbacks(
 
     """
     callbacks = callbacks or []
+
+    # Initialize callbacks from environment variable
+    env_callbacks = _initialize_env_callbacks()
+    callbacks.extend(env_callbacks)
+
     has_csv_logger = False
     has_json_logger = False
     has_tbx_logger = False
@@ -139,5 +146,33 @@ def _create_default_callbacks(
                     "installed. Please make sure you have the latest version "
                     "of TensorboardX installed: `pip install -U tensorboardx`"
                 )
+
+    return callbacks
+
+
+def _initialize_env_callbacks() -> List[Callback]:
+    """Initialize callbacks from environment variable.
+
+    Returns:
+        List of callbacks initialized from environment variable.
+    """
+    callbacks = []
+    callbacks_str = os.environ.get(RAY_TUNE_CALLBACKS_ENV_VAR, "")
+    if not callbacks_str:
+        return callbacks
+
+    for callback_path in callbacks_str.split(","):
+        callback_path = callback_path.strip()
+        if not callback_path:
+            continue
+
+        try:
+            module_path, class_name = callback_path.rsplit(".", 1)
+            module = importlib.import_module(module_path)
+            callback_cls = getattr(module, class_name)
+            callback = callback_cls()
+            callbacks.append(callback)
+        except (ImportError, AttributeError, ValueError) as e:
+            raise ValueError(f"Failed to import callback from '{callback_path}': {e}")
 
     return callbacks

--- a/python/ray/tune/utils/callback.py
+++ b/python/ray/tune/utils/callback.py
@@ -170,9 +170,14 @@ def _initialize_env_callbacks() -> List[Callback]:
             module_path, class_name = callback_path.rsplit(".", 1)
             module = importlib.import_module(module_path)
             callback_cls = getattr(module, class_name)
+            if not issubclass(callback_cls, Callback):
+                raise ValueError(
+                    f"Callback class '{callback_path}' must be a subclass of "
+                    f"Callback, got {type(callback_cls).__name__}"
+                )
             callback = callback_cls()
             callbacks.append(callback)
         except (ImportError, AttributeError, ValueError) as e:
-            raise ValueError(f"Failed to import callback from '{callback_path}': {e}")
+            raise ValueError(f"Failed to import callback from '{callback_path}'") from e
 
     return callbacks

--- a/python/ray/tune/utils/callback.py
+++ b/python/ray/tune/utils/callback.py
@@ -171,13 +171,13 @@ def _initialize_env_callbacks() -> List[Callback]:
             module = importlib.import_module(module_path)
             callback_cls = getattr(module, class_name)
             if not issubclass(callback_cls, Callback):
-                raise ValueError(
+                raise TypeError(
                     f"Callback class '{callback_path}' must be a subclass of "
                     f"Callback, got {type(callback_cls).__name__}"
                 )
             callback = callback_cls()
             callbacks.append(callback)
-        except (ImportError, AttributeError, ValueError) as e:
+        except (ImportError, AttributeError, ValueError, TypeError) as e:
             raise ValueError(f"Failed to import callback from '{callback_path}'") from e
 
     return callbacks


### PR DESCRIPTION
This PR adds support for loading callbacks via environment variables in both Ray Train and Ray Tune. This enables users to configure callbacks without modifying their training/tuning code, making it easier to add monitoring, logging, or other custom behaviors across different execution environments.

## Changes

### Ray Train Changes

- **New Environment Variable**: Added `RAY_TRAIN_CALLBACKS` environment variable to `ray.train.constants`
- **New Module**: Created `ray.train.v2._internal.callbacks.env_callback` with `_initialize_env_callbacks()` function
- **Integration**: Modified `DataParallelTrainer._create_default_callbacks()` to load environment callbacks
- **Tests**: Added comprehensive test suite in `test_env_callbacks.py`

### Ray Tune Changes

- **New Environment Variable**: Added `RAY_TUNE_CALLBACKS` environment variable to `ray.tune.constants`
- **Integration**: Modified `_create_default_callbacks()` in `ray.tune.utils.callback` to load environment callbacks
- **Tests**: Added comprehensive test suite in `test_env_callbacks.py`

## Usage

### Single Callback
```bash
export RAY_TRAIN_CALLBACKS="my_module.MyCallback"
export RAY_TUNE_CALLBACKS="my_module.MyCallback"
```

### Multiple Callbacks
```bash
export RAY_TRAIN_CALLBACKS="module1.Callback1,module2.Callback2"
export RAY_TUNE_CALLBACKS="module1.Callback1,module2.Callback2"
```

## Example

```python

import os   
from ray.train.v2._internal.execution.callback import ControllerCallback
from ray import tune
from ray.tune.callback import Callback
from ray.train.v2.api.data_parallel_trainer import DataParallelTrainer


# Custom callback for Ray Tune
class TuneCallback(Callback):
    def setup(self, *args, **kwargs):
        print("[TUNE] setup")
    
    def on_experiment_end(self, *args, **kwargs):
        print("[TUNE] end")


class TrainCallback(ControllerCallback):

    def after_controller_start(self, *args, **kwargs):
        print("[TRAIN] start")

    def after_controller_finish(self, *args, **kwargs):
        print("[TRAIN] end")


def tune_example():
    os.environ["RAY_TUNE_CALLBACKS"] = "example_env_callbacks.TuneCallback"
    
    def train_fn(config):
        ...
    
    tuner = tune.Tuner(
        train_fn,
        run_config=tune.RunConfig(
            verbose=0,
        )
    )
    tuner.fit()


def train_example():
    os.environ["RAY_TRAIN_CALLBACKS"] = "example_env_callbacks.TrainCallback"
    
    def train_fn():
        ...
    
    trainer = DataParallelTrainer(
        train_loop_per_worker=train_fn
    )
    trainer.fit()


if __name__ == "__main__":

    print("=== Ray Train Example ===")
    train_example()

    import time
    time.sleep(2)

    print("=== Ray Tune Example ===")   
    tune_example()

    print("=== Environment Variables ===")
    print(f"RAY_TRAIN_CALLBACKS: {os.environ.get('RAY_TRAIN_CALLBACKS', 'Not set')}") 
    print(f"RAY_TUNE_CALLBACKS: {os.environ.get('RAY_TUNE_CALLBACKS', 'Not set')}")
```

```
RAY_TRAIN_V2_ENABLED=1 python example_env_callbacks.py
```

```
=== Ray Train Example ===
2025-06-30 17:29:30,308 INFO worker.py:1742 -- Connecting to existing Ray cluster at address: 127.0.0.1:6379...
2025-06-30 17:29:30,314 INFO worker.py:1913 -- Connected to Ray cluster. View the dashboard at 127.0.0.1:8265 
(TrainController pid=4786) [TRAIN] start
(TrainController pid=4786) Attempting to start training worker group of size 1 with the following resources: [{'CPU': 1}] * 1
(TrainController pid=4786) Using blocking ray.get inside async actor. This blocks the event loop. Please use `await` on object ref with asyncio.gather if you want to yield execution to the event loop instead.
(TrainController pid=4786) [TRAIN] end
(TrainController pid=4786) Started training worker group of size 1: 
(TrainController pid=4786) - (ip=127.0.0.1, pid=4792) world_rank=0, local_rank=0, node_rank=0
=== Ray Tune Example ===
[TUNE] setup
╭─────────────────────────────────────────────────────────────────╮
│ Configuration for experiment     train_fn_2025-06-30_17-29-34   │
├─────────────────────────────────────────────────────────────────┤
│ Search algorithm                 BasicVariantGenerator          │
│ Scheduler                        FIFOScheduler                  │
│ Number of trials                 1                              │
╰─────────────────────────────────────────────────────────────────╯

View detailed results here: /Users/matt/ray_results/train_fn_2025-06-30_17-29-34
To visualize your results with TensorBoard, run: `tensorboard --logdir /tmp/ray/session_2025-06-30_17-28-57_825888_4641/artifacts/2025-06-30_17-29-34/train_fn_2025-06-30_17-29-34/driver_artifacts`
2025-06-30 17:29:36,263 INFO tune.py:1009 -- Wrote the latest version of all result files and experiment state to '/Users/matt/ray_results/train_fn_2025-06-30_17-29-34' in 0.0040s.
[TUNE] end

=== Environment Variables ===
RAY_TRAIN_CALLBACKS: example_env_callbacks.TrainCallback
RAY_TUNE_CALLBACKS: example_env_callbacks.TuneCallback
```
