### PR TITLE
[core] Always access task finisher from submitters without mutex

### DIFF
--- a/src/ray/core_worker/transport/actor_task_submitter.cc
+++ b/src/ray/core_worker/transport/actor_task_submitter.cc
@@ -101,11 +101,11 @@ Status ActorTaskSubmitter::SubmitActorCreationTask(TaskSpecification task_spec) 
     // outside of this closure).
     const auto actor_id = task_spec.ActorCreationId();
     const auto task_id = task_spec.TaskId();
-    task_finisher_.MarkDependenciesResolved(task_id);
+    TaskFinisher().MarkDependenciesResolved(task_id);
     if (!status.ok()) {
       RAY_LOG(WARNING).WithField(actor_id).WithField(task_id)
           << "Resolving actor creation task dependencies failed " << status;
-      RAY_UNUSED(task_finisher_.FailOrRetryPendingTask(
+      RAY_UNUSED(TaskFinisher().FailOrRetryPendingTask(
           task_id, rpc::ErrorType::DEPENDENCY_RESOLUTION_FAILED, &status));
       return;
     }
@@ -133,7 +133,7 @@ Status ActorTaskSubmitter::SubmitActorCreationTask(TaskSpecification task_spec) 
             }
             // NOTE: When actor creation task failed we will not retry the creation
             // task so just marking the task fails.
-            task_finisher_.CompletePendingTask(
+            TaskFinisher().CompletePendingTask(
                 task_id,
                 push_task_reply,
                 reply.actor_address(),
@@ -144,7 +144,7 @@ Status ActorTaskSubmitter::SubmitActorCreationTask(TaskSpecification task_spec) 
             if (status.IsSchedulingCancelled()) {
               RAY_LOG(DEBUG).WithField(actor_id).WithField(task_id)
                   << "Actor creation cancelled";
-              task_finisher_.MarkTaskCanceled(task_id);
+              TaskFinisher().MarkTaskCanceled(task_id);
               if (reply.has_death_cause()) {
                 ray_error_info.mutable_actor_died_error()->CopyFrom(reply.death_cause());
               }
@@ -155,7 +155,7 @@ Status ActorTaskSubmitter::SubmitActorCreationTask(TaskSpecification task_spec) 
             // Actor creation task retry happens in GCS
             // and transient rpc errors are retried in gcs client
             // so we don't need to retry here.
-            RAY_UNUSED(task_finisher_.FailPendingTask(
+            RAY_UNUSED(TaskFinisher().FailPendingTask(
                 task_id,
                 rpc::ErrorType::ACTOR_CREATION_FAILED,
                 &status,
@@ -204,7 +204,7 @@ Status ActorTaskSubmitter::SubmitTask(TaskSpecification task_spec) {
           auto task_id = task_spec.TaskId();
           resolver_.ResolveDependencies(
               task_spec, [this, send_pos, actor_id, task_id](Status status) {
-                task_finisher_.MarkDependenciesResolved(task_id);
+                TaskFinisher().MarkDependenciesResolved(task_id);
                 auto fail_or_retry_task = TaskID::Nil();
                 {
                   absl::MutexLock lock(&mu_);
@@ -226,15 +226,15 @@ Status ActorTaskSubmitter::SubmitTask(TaskSpecification task_spec) {
                 }
 
                 if (!fail_or_retry_task.IsNil()) {
-                  GetTaskFinisherWithoutMu().FailOrRetryPendingTask(
+                  TaskFinisher().FailOrRetryPendingTask(
                       task_id, rpc::ErrorType::DEPENDENCY_RESOLUTION_FAILED, &status);
                 }
               });
         },
         "ActorTaskSubmitter::SubmitTask");
   } else {
-    // Do not hold the lock while calling into task_finisher_.
-    task_finisher_.MarkTaskCanceled(task_id);
+    // Do not hold the lock while calling into TaskFinisher().
+    TaskFinisher().MarkTaskCanceled(task_id);
     rpc::ErrorType error_type;
     rpc::RayErrorInfo error_info;
     {
@@ -251,12 +251,12 @@ Status ActorTaskSubmitter::SubmitTask(TaskSpecification task_spec) {
         error_info.has_actor_died_error() &&
         error_info.actor_died_error().has_oom_context() &&
         error_info.actor_died_error().oom_context().fail_immediately();
-    GetTaskFinisherWithoutMu().FailOrRetryPendingTask(task_id,
-                                                      error_type,
-                                                      &status,
-                                                      &error_info,
-                                                      /*mark_task_object_failed*/ true,
-                                                      fail_immediately);
+    TaskFinisher().FailOrRetryPendingTask(task_id,
+                                          error_type,
+                                          &status,
+                                          &error_info,
+                                          /*mark_task_object_failed*/ true,
+                                          fail_immediately);
   }
 
   // If the task submission subsequently fails, then the client will receive
@@ -274,7 +274,7 @@ void ActorTaskSubmitter::FailInflightTasksOnRestart(
     const absl::flat_hash_map<TaskAttempt, rpc::ClientCallback<rpc::PushTaskReply>>
         &inflight_task_callbacks) {
   // NOTE(kfstorm): We invoke the callbacks with a bad status to act like there's a
-  // network issue. We don't call `task_finisher_.FailOrRetryPendingTask` directly because
+  // network issue. We don't call `TaskFinisher().FailOrRetryPendingTask` directly because
   // there's much more work to do in the callback.
   auto status = Status::IOError("The actor was restarted");
   for (const auto &[_, callback] : inflight_task_callbacks) {
@@ -442,7 +442,7 @@ void ActorTaskSubmitter::DisconnectActor(const ActorID &actor_id,
     for (auto &task_id : task_ids_to_fail) {
       // No need to increment the number of completed tasks since the actor is
       // dead.
-      task_finisher_.MarkTaskCanceled(task_id);
+      TaskFinisher().MarkTaskCanceled(task_id);
       // This task may have been waiting for dependency resolution, so cancel
       // this first.
       resolver_.CancelDependencyResolution(task_id);
@@ -450,18 +450,18 @@ void ActorTaskSubmitter::DisconnectActor(const ActorID &actor_id,
           error_info.has_actor_died_error() &&
           error_info.actor_died_error().has_oom_context() &&
           error_info.actor_died_error().oom_context().fail_immediately();
-      GetTaskFinisherWithoutMu().FailOrRetryPendingTask(task_id,
-                                                        error_type,
-                                                        &status,
-                                                        &error_info,
-                                                        /*mark_task_object_failed*/ true,
-                                                        fail_immediatedly);
+      TaskFinisher().FailOrRetryPendingTask(task_id,
+                                            error_type,
+                                            &status,
+                                            &error_info,
+                                            /*mark_task_object_failed*/ true,
+                                            fail_immediatedly);
     }
     if (!wait_for_death_info_tasks.empty()) {
       RAY_LOG(DEBUG).WithField(actor_id) << "Failing tasks waiting for death info, size="
                                          << wait_for_death_info_tasks.size();
       for (auto &task : wait_for_death_info_tasks) {
-        GetTaskFinisherWithoutMu().FailPendingTask(
+        TaskFinisher().FailPendingTask(
             task->task_spec.TaskId(), error_type, &task->status, &error_info);
       }
     }
@@ -489,7 +489,7 @@ void ActorTaskSubmitter::FailTaskWithError(const PendingTaskWaitingForDeathInfo 
     error_info.set_error_type(rpc::ErrorType::ACTOR_DIED);
     error_info.set_error_message("Actor died by preemption.");
   }
-  GetTaskFinisherWithoutMu().FailPendingTask(
+  TaskFinisher().FailPendingTask(
       task.task_spec.TaskId(), error_info.error_type(), &task.status, &error_info);
 }
 
@@ -621,7 +621,7 @@ void ActorTaskSubmitter::PushActorTask(ClientQueue &queue,
         reply_callback(status, std::move(reply));
       };
 
-  task_finisher_.MarkTaskWaitingForExecution(task_id,
+  TaskFinisher().MarkTaskWaitingForExecution(task_id,
                                              NodeID::FromBinary(addr.raylet_id()),
                                              WorkerID::FromBinary(addr.worker_id()));
   queue.rpc_client->PushActorTask(
@@ -649,7 +649,7 @@ void ActorTaskSubmitter::HandlePushTaskReply(const Status &status,
     }
   }
   if (resubmit_generator) {
-    GetTaskFinisherWithoutMu().MarkGeneratorFailedAndResubmit(task_id);
+    TaskFinisher().MarkGeneratorFailedAndResubmit(task_id);
     return;
   }
 
@@ -660,7 +660,7 @@ void ActorTaskSubmitter::HandlePushTaskReply(const Status &status,
   if (status.ok() && !is_retryable_exception) {
     // status.ok() means the worker completed the reply, either succeeded or with a
     // retryable failure (e.g. user exceptions). We complete only on non-retryable case.
-    task_finisher_.CompletePendingTask(
+    TaskFinisher().CompletePendingTask(
         task_id, reply, addr, reply.is_application_error());
   } else if (status.IsSchedulingCancelled()) {
     std::ostringstream stream;
@@ -671,10 +671,10 @@ void ActorTaskSubmitter::HandlePushTaskReply(const Status &status,
     rpc::RayErrorInfo error_info;
     error_info.set_error_message(msg);
     error_info.set_error_type(rpc::ErrorType::TASK_CANCELLED);
-    GetTaskFinisherWithoutMu().FailPendingTask(task_spec.TaskId(),
-                                               rpc::ErrorType::TASK_CANCELLED,
-                                               /*status*/ nullptr,
-                                               &error_info);
+    TaskFinisher().FailPendingTask(task_spec.TaskId(),
+                                   rpc::ErrorType::TASK_CANCELLED,
+                                   /*status*/ nullptr,
+                                   &error_info);
   } else {
     bool is_actor_dead = false;
     bool fail_immediately = false;
@@ -720,20 +720,20 @@ void ActorTaskSubmitter::HandlePushTaskReply(const Status &status,
     // this first.
     resolver_.CancelDependencyResolution(task_id);
 
-    will_retry = GetTaskFinisherWithoutMu().FailOrRetryPendingTask(
-        task_id,
-        error_info.error_type(),
-        &status,
-        &error_info,
-        /*mark_task_object_failed*/ is_actor_dead,
-        fail_immediately);
+    will_retry =
+        TaskFinisher().FailOrRetryPendingTask(task_id,
+                                              error_info.error_type(),
+                                              &status,
+                                              &error_info,
+                                              /*mark_task_object_failed*/ is_actor_dead,
+                                              fail_immediately);
     if (!is_actor_dead && !will_retry) {
       // Ran out of retries, last failure = either user exception or actor death.
       if (status.ok()) {
         // last failure = user exception, just complete it with failure.
         RAY_CHECK(reply.is_retryable_error());
 
-        GetTaskFinisherWithoutMu().CompletePendingTask(
+        TaskFinisher().CompletePendingTask(
             task_id, reply, addr, reply.is_application_error());
 
       } else if (RayConfig::instance().timeout_ms_task_wait_for_death_info() != 0) {
@@ -762,7 +762,7 @@ void ActorTaskSubmitter::HandlePushTaskReply(const Status &status,
           auto queue_pair = client_queues_.find(actor_id);
           RAY_CHECK(queue_pair != client_queues_.end());
         }
-        GetTaskFinisherWithoutMu().FailPendingTask(
+        TaskFinisher().FailPendingTask(
             task_spec.TaskId(), error_info.error_type(), &status, &error_info);
       }
     }
@@ -872,10 +872,10 @@ Status ActorTaskSubmitter::CancelTask(TaskSpecification task_spec, bool recursiv
   const auto &task_id = task_spec.TaskId();
   auto send_pos = task_spec.SequenceNumber();
 
-  // Shouldn't hold a lock while accessing task_finisher_.
+  // Shouldn't hold a lock while accessing TaskFinisher().
   // Task is already canceled or finished.
-  if (!GetTaskFinisherWithoutMu().MarkTaskCanceled(task_id) ||
-      !GetTaskFinisherWithoutMu().IsTaskPending(task_id)) {
+  if (!TaskFinisher().MarkTaskCanceled(task_id) ||
+      !TaskFinisher().IsTaskPending(task_id)) {
     RAY_LOG(DEBUG).WithField(task_id) << "Task is already finished or canceled";
     return Status::OK();
   }
@@ -919,7 +919,7 @@ Status ActorTaskSubmitter::CancelTask(TaskSpecification task_spec, bool recursiv
            << " before it executes.";
     error_info.set_error_message(stream.str());
     error_info.set_error_type(rpc::ErrorType::TASK_CANCELLED);
-    GetTaskFinisherWithoutMu().FailOrRetryPendingTask(
+    TaskFinisher().FailOrRetryPendingTask(
         task_id, rpc::ErrorType::TASK_CANCELLED, /*status*/ nullptr, &error_info);
     return Status::OK();
   }
@@ -957,7 +957,7 @@ Status ActorTaskSubmitter::CancelTask(TaskSpecification task_spec, bool recursiv
 
                          // Keep retrying every 2 seconds until a task is officially
                          // finished.
-                         if (!GetTaskFinisherWithoutMu().GetTaskSpec(task_id)) {
+                         if (!TaskFinisher().GetTaskSpec(task_id)) {
                            // Task is already finished.
                            RAY_LOG(DEBUG).WithField(task_spec.TaskId())
                                << "Task is finished. Stop a cancel request.";

--- a/src/ray/core_worker/transport/actor_task_submitter.h
+++ b/src/ray/core_worker/transport/actor_task_submitter.h
@@ -272,12 +272,9 @@ class ActorTaskSubmitter : public ActorTaskSubmitterInterface {
           status(std::move(status)),
           timeout_error_info(std::move(timeout_error_info)) {}
   };
+
   /// A helper function to get task finisher without holding mu_
-  /// We should use this function when access
-  /// - FailOrRetryPendingTask
-  /// - FailPendingTask
-  TaskFinisherInterface &GetTaskFinisherWithoutMu() {
-    mu_.AssertNotHeld();
+  TaskFinisherInterface &TaskFinisher() ABSL_LOCKS_EXCLUDED(mu_) {
     return task_finisher_;
   }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
