### PR TITLE
add memory buffer logger to serve

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -465,7 +465,7 @@ RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD = (
 
 # The default buffer size for request path logs. Setting to 1 will ensure
 # logs are flushed to file handler immediately, otherwise it will be buffered
-# and flushed to file handler when the buffer is full or when there is an log
+# and flushed to file handler when the buffer is full or when there is a log
 # line with level ERROR.
 RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE = int(
     os.environ.get("RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE", "1")

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -462,3 +462,11 @@ REQUEST_ROUTING_STATS_METHOD = "record_routing_stats"
 RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD = (
     os.environ.get("RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD", "1") == "1"
 )
+
+# The default buffer size for request path logs. Setting to 1 will ensure
+# logs are flushed to file handler immediately, otherwise it will be buffered
+# and flushed to file handler when the buffer is full or when there is an log
+# line with level ERROR.
+RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE = int(
+    os.environ.get("RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE", "1")
+)

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -1149,8 +1149,8 @@ class ServeController:
         """Get the logging configuration (for testing purposes)."""
         log_file_path = None
         for handler in logger.handlers:
-            if isinstance(handler, logging.handlers.RotatingFileHandler):
-                log_file_path = handler.baseFilename
+            if isinstance(handler, logging.handlers.MemoryHandler):
+                log_file_path = handler.target.baseFilename
         return self.global_logging_config, log_file_path
 
     def _get_target_capacity_direction(self) -> Optional[TargetCapacityDirection]:

--- a/python/ray/serve/_private/http_util.py
+++ b/python/ray/serve/_private/http_util.py
@@ -562,7 +562,7 @@ class ASGIAppReplicaWrapper:
 
         # Use uvicorn's lifespan handling code to properly deal with
         # startup and shutdown event.
-        # if log_config is not None, uvicorn will use the default logger.
+        # If log_config is not None, uvicorn will use the default logger.
         # and that interferes with our logging setup.
         self._serve_asgi_lifespan = LifespanOn(
             Config(

--- a/python/ray/serve/_private/http_util.py
+++ b/python/ray/serve/_private/http_util.py
@@ -562,7 +562,17 @@ class ASGIAppReplicaWrapper:
 
         # Use uvicorn's lifespan handling code to properly deal with
         # startup and shutdown event.
-        self._serve_asgi_lifespan = LifespanOn(Config(self._asgi_app, lifespan="on"))
+        # if log_config is not None, uvicorn will use the default logger.
+        # and that interferes with our logging setup.
+        self._serve_asgi_lifespan = LifespanOn(
+            Config(
+                self._asgi_app,
+                lifespan="on",
+                log_level=None,
+                log_config=None,
+                access_log=False,
+            )
+        )
 
         # Replace uvicorn logger with our own.
         self._serve_asgi_lifespan.logger = logger
@@ -722,7 +732,8 @@ async def start_asgi_http_server(
             loop=event_loop,
             lifespan="off",
             access_log=False,
-            log_level="warning",
+            log_level=None,
+            log_config=None,
         )
     )
 

--- a/python/ray/serve/_private/logging_utils.py
+++ b/python/ray/serve/_private/logging_utils.py
@@ -115,6 +115,7 @@ class ServeFormatter(TextFormatter):
     """Serve Logging Formatter
 
     The formatter will generate the log format on the fly based on the field of record.
+    Optimized to pre-compute format strings and formatters for better performance.
     """
 
     COMPONENT_LOG_FMT = f"%({SERVE_LOG_LEVEL_NAME})s %({SERVE_LOG_TIME})s {{{SERVE_LOG_COMPONENT}}} {{{SERVE_LOG_COMPONENT_ID}}} "  # noqa:E501
@@ -133,6 +134,24 @@ class ServeFormatter(TextFormatter):
             component_name=component_name, component_id=component_id
         )
 
+        # Pre-compute format strings and formatters for performance
+        self._precompute_formatters()
+
+    def _precompute_formatters(self):
+        """Pre-compute common format strings and their formatters."""
+        # Base format without request ID
+        base_attrs = [f"%({k})s" for k in self.additional_log_standard_attrs]
+        base_attrs.append(SERVE_LOG_RECORD_FORMAT[SERVE_LOG_MESSAGE])
+        self.base_format = self.component_log_fmt + " ".join(base_attrs)
+        self.base_formatter = logging.Formatter(self.base_format)
+
+        # Format with request ID
+        request_attrs = [SERVE_LOG_RECORD_FORMAT[SERVE_LOG_REQUEST_ID]]
+        request_attrs.extend([f"%({k})s" for k in self.additional_log_standard_attrs])
+        request_attrs.append(SERVE_LOG_RECORD_FORMAT[SERVE_LOG_MESSAGE])
+        self.request_format = self.component_log_fmt + " ".join(request_attrs)
+        self.request_formatter = logging.Formatter(self.request_format)
+
     def format(self, record: logging.LogRecord) -> str:
         """Format the log record into the format string.
 
@@ -141,20 +160,11 @@ class ServeFormatter(TextFormatter):
             Returns:
                 The formatted log record in string format.
         """
-        record_format = self.component_log_fmt
-        record_formats_attrs = []
+        # Use pre-computed formatters for better performance
         if SERVE_LOG_REQUEST_ID in record.__dict__:
-            record_formats_attrs.append(SERVE_LOG_RECORD_FORMAT[SERVE_LOG_REQUEST_ID])
-        record_formats_attrs.extend(
-            [f"%({k})s" for k in self.additional_log_standard_attrs]
-        )
-        record_formats_attrs.append(SERVE_LOG_RECORD_FORMAT[SERVE_LOG_MESSAGE])
-        record_format += " ".join(record_formats_attrs)
-        # create a formatter using the format string
-        formatter = logging.Formatter(record_format)
-
-        # format the log record using the formatter
-        return formatter.format(record)
+            return self.request_formatter.format(record)
+        else:
+            return self.base_formatter.format(record)
 
 
 def access_log_msg(*, method: str, route: str, status: str, latency_ms: float):
@@ -284,6 +294,7 @@ def configure_component_logger(
     max_bytes: Optional[int] = None,
     backup_count: Optional[int] = None,
     stream_handler_only: bool = False,
+    buffer_size: int = 1,
 ):
     """Configure a logger to be used by a Serve component.
 
@@ -373,7 +384,17 @@ def configure_component_logger(
         sys.stdout = StreamToLogger(logger, logging.INFO, sys.stdout)
         sys.stderr = StreamToLogger(logger, logging.INFO, sys.stderr)
 
-    logger.addHandler(file_handler)
+    # Create a memory handler that buffers log records and flushes to file handler
+    # Buffer capacity: buffer_size records
+    # Flush triggers: buffer full, ERROR messages, or explicit flush
+    memory_handler = logging.handlers.MemoryHandler(
+        capacity=buffer_size,
+        target=file_handler,
+        flushLevel=logging.ERROR,  # Auto-flush on ERROR/CRITICAL
+    )
+
+    # Add the memory handler instead of the file handler directly
+    logger.addHandler(memory_handler)
 
 
 def configure_default_serve_logger():

--- a/python/ray/serve/_private/logging_utils.py
+++ b/python/ray/serve/_private/logging_utils.py
@@ -200,8 +200,8 @@ def get_component_logger_file_path() -> Optional[str]:
     """
     logger = logging.getLogger(SERVE_LOGGER_NAME)
     for handler in logger.handlers:
-        if isinstance(handler, logging.handlers.RotatingFileHandler):
-            absolute_path = handler.baseFilename
+        if isinstance(handler, logging.handlers.MemoryHandler):
+            absolute_path = handler.target.baseFilename
             ray_logs_dir = ray._private.worker._global_node.get_logs_dir_path()
             if absolute_path.startswith(ray_logs_dir):
                 return absolute_path[len(ray_logs_dir) :]

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -29,6 +29,7 @@ from ray.serve._private.constants import (
     PROXY_MIN_DRAINING_PERIOD_S,
     RAY_SERVE_ENABLE_PROXY_GC_OPTIMIZATIONS,
     RAY_SERVE_PROXY_GC_THRESHOLD,
+    RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE,
     RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S,
     REQUEST_LATENCY_BUCKETS_MS,
     SERVE_CONTROLLER_NAME,
@@ -1056,6 +1057,7 @@ class ProxyActor:
             component_name="proxy",
             component_id=node_ip_address,
             logging_config=logging_config,
+            buffer_size=RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE,
         )
 
         startup_msg = f"Proxy starting on node {self._node_id} (HTTP port: {self._http_options.port}"

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -1146,8 +1146,8 @@ class ProxyActor:
         """Get the logging configuration (for testing purposes)."""
         log_file_path = None
         for handler in logger.handlers:
-            if isinstance(handler, logging.handlers.RotatingFileHandler):
-                log_file_path = handler.baseFilename
+            if isinstance(handler, logging.handlers.MemoryHandler):
+                log_file_path = handler.target.baseFilename
         return log_file_path
 
     def _dump_ingress_replicas_for_testing(self, route: str) -> Set[ReplicaID]:

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -53,6 +53,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE,
     RAY_SERVE_METRICS_EXPORT_INTERVAL_MS,
     RAY_SERVE_REPLICA_AUTOSCALING_METRIC_RECORD_PERIOD_S,
+    RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE,
     RAY_SERVE_RUN_SYNC_IN_THREADPOOL,
     RAY_SERVE_RUN_SYNC_IN_THREADPOOL_WARNING,
     RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD,
@@ -444,6 +445,7 @@ class ReplicaBase(ABC):
             component_name=self._component_name,
             component_id=self._component_id,
             logging_config=logging_config,
+            buffer_size=RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE,
         )
         configure_component_memory_profiler(
             component_type=ServeComponentType.REPLICA,

--- a/python/ray/serve/tests/test_config_files/logging_config_test.py
+++ b/python/ray/serve/tests/test_config_files/logging_config_test.py
@@ -14,7 +14,7 @@ class Model:
         logger.debug("this_is_debug_info")
         logger.info("this_is_access_log", extra={"serve_access_log": True})
 
-        log_file = logger.handlers[1].baseFilename
+        log_file = logger.handlers[1].target.baseFilename
 
         return {
             "log_file": log_file,
@@ -33,7 +33,7 @@ class Router:
         logger.debug("this_is_debug_info_from_router")
         log_info = await self.handle.remote()
         if len(logger.handlers) == 2:
-            log_info["router_log_file"] = logger.handlers[1].baseFilename
+            log_info["router_log_file"] = logger.handlers[1].target.baseFilename
         else:
             log_info["router_log_file"] = None
         log_info["router_log_level"] = logger.level
@@ -55,7 +55,7 @@ model = Router.bind(Model.bind())
 class ModelWithConfig:
     def __call__(self):
         logger.debug("this_is_debug_info")
-        log_file = logger.handlers[1].baseFilename
+        log_file = logger.handlers[1].target.baseFilename
         return {"log_file": log_file}
 
 

--- a/python/ray/serve/tests/test_logging.py
+++ b/python/ray/serve/tests/test_logging.py
@@ -834,11 +834,11 @@ def test_configure_component_logger_with_log_encoding_env_text(log_encoding):
         )
 
         for handler in logger.handlers:
-            if isinstance(handler, logging.handlers.RotatingFileHandler):
+            if isinstance(handler, logging.handlers.MemoryHandler):
                 if expected_encoding == EncodingType.JSON:
-                    assert isinstance(handler.formatter, JSONFormatter)
+                    assert isinstance(handler.target.formatter, JSONFormatter)
                 else:
-                    assert isinstance(handler.formatter, ServeFormatter)
+                    assert isinstance(handler.target.formatter, ServeFormatter)
 
         # Clean up logger handlers
         logger.handlers.clear()

--- a/python/ray/serve/tests/test_logging.py
+++ b/python/ray/serve/tests/test_logging.py
@@ -88,9 +88,11 @@ def test_log_rotation_config(monkeypatch, ray_shutdown):
             handlers = logger.handlers
             res = {}
             for handler in handlers:
-                if isinstance(handler, logging.handlers.RotatingFileHandler):
-                    res["max_bytes"] = handler.maxBytes
-                    res["backup_count"] = handler.backupCount
+                if isinstance(handler, logging.handlers.MemoryHandler):
+                    target = handler.target
+                    assert isinstance(target, logging.handlers.RotatingFileHandler)
+                    res["max_bytes"] = target.maxBytes
+                    res["backup_count"] = target.backupCount
             return res
 
     handle = serve.run(Handle.bind())
@@ -139,6 +141,7 @@ def test_http_access_log(serve_instance):
             fail: bool = False,
         ):
             s = f.getvalue()
+            print(s)
             return all(
                 [
                     name in s,


### PR DESCRIPTION
The following benchmarks are computed with
```
Concurrency Level:      100
Complete requests:      2000
```
`ab -n 2000 -c 100 "http://127.0.0.1:8000/"`

Using this PR
```
Requests per second:    192.09 [#/sec] (mean)
Time per request:       520.581 [ms] (mean)
log buffer size: 		1

Requests per second:    196.65 [#/sec] (mean)
Time per request:       508.507 [ms] (mean)
log buffer size: 		10

Requests per second:    200.41 [#/sec] (mean)
Time per request:       498.987 [ms] (mean)
log buffer size: 		100

Requests per second:    218.11 [#/sec] (mean)
Time per request:       458.476 [ms] (mean)
log buffer size: 		1000
```

From master
```
Requests per second:    189.75 [#/sec] (mean)
Time per request:       527.014 [ms] (mean)
```

Repro script used for benchmark
```
from ray import serve
import asyncio
import logging
from fastapi import FastAPI

logger = logging.getLogger(__name__)


@serve.deployment(max_ongoing_requests=1000)
class ChildDeployment:
    
    async def __call__(self):
        return "Hello, world!"


def get_app():
    app = FastAPI()
    @app.get("/")
    async def f():
        handle = serve.get_deployment_handle("ChildDeployment")
        return await handle.remote()

    return app

@serve.deployment(max_ongoing_requests=1000)
@serve.ingress(get_app)
class MyDeployment:
    def __init__(self, child):
        self.child = child


app = MyDeployment.bind(ChildDeployment.bind())
```

Machine type: m6a.2xlarge