### PR TITLE
[core] Deflake `test_hybrid_policy_threshold`

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -376,6 +376,7 @@ steps:
     tags:
       - python
       - flaky
+      - skip-on-premerge
     instance_type: large
     soft_fail: true
     commands:

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -376,7 +376,6 @@ steps:
     tags:
       - python
       - flaky
-      - skip-on-premerge
     instance_type: large
     soft_fail: true
     commands:

--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -87,6 +87,8 @@ def test_hybrid_policy_threshold(ray_start_cluster):
 
     # Add the `memory` resource because the CPU will be released when the task is
     # blocked calling `ray.get()`.
+    # NOTE(edoakes): this needs to be `memory`, not a custom resource.
+    # See: https://github.com/ray-project/ray/pull/54271.
     @ray.remote(num_cpus=1, memory=1)
     def get_node_id() -> str:
         ray.get(block_driver.release.remote())

--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -73,10 +73,12 @@ def test_hybrid_policy_threshold(ray_start_cluster):
         cluster.add_node(
             num_cpus=NUM_CPUS_PER_NODE,
             resources={"custom": NUM_CPUS_PER_NODE},
-			_system_config={
-				"scheduler_top_k_absolute": 1,
-				"scheduler_top_k_fraction": 0,
-			} if i == 0 else None,
+            _system_config={
+                "scheduler_top_k_absolute": 1,
+                "scheduler_top_k_fraction": 0,
+            }
+            if i == 0
+            else None,
         )
 
     cluster.wait_for_nodes()

--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -69,7 +69,7 @@ def test_hybrid_policy_threshold(ray_start_cluster):
     NUM_CPUS_PER_NODE = 4
     # The default hybrid policy packs nodes up to 50% capacity before spreading.
     PER_NODE_HYBRID_THRESHOLD = int(NUM_CPUS_PER_NODE / 2)
-    for i in range(NUM_NODES):
+    for _ in range(NUM_NODES):
         cluster.add_node(
             num_cpus=NUM_CPUS_PER_NODE,
             memory=NUM_CPUS_PER_NODE,

--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -85,7 +85,7 @@ def test_hybrid_policy_threshold(ray_start_cluster):
     # until all are running.
     block_driver = Semaphore.remote(0)
 
-    # Add the custom resource because the CPU will be released when the task is
+    # Add the `memory` resource because the CPU will be released when the task is
     # blocked calling `ray.get()`.
     @ray.remote(num_cpus=1, memory=1)
     def get_node_id() -> str:

--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -72,13 +72,7 @@ def test_hybrid_policy_threshold(ray_start_cluster):
     for i in range(NUM_NODES):
         cluster.add_node(
             num_cpus=NUM_CPUS_PER_NODE,
-            resources={"custom": NUM_CPUS_PER_NODE},
-            _system_config={
-                "scheduler_top_k_absolute": 1,
-                "scheduler_top_k_fraction": 0,
-            }
-            if i == 0
-            else None,
+            memory=NUM_CPUS_PER_NODE,
         )
 
     cluster.wait_for_nodes()
@@ -93,7 +87,7 @@ def test_hybrid_policy_threshold(ray_start_cluster):
 
     # Add the custom resource because the CPU will be released when the task is
     # blocked calling `ray.get()`.
-    @ray.remote(num_cpus=1, resources={"custom": 1})
+    @ray.remote(num_cpus=1, memory=1)
     def get_node_id() -> str:
         ray.get(block_driver.release.remote())
         ray.get(block_task.acquire.remote())

--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -69,10 +69,14 @@ def test_hybrid_policy_threshold(ray_start_cluster):
     NUM_CPUS_PER_NODE = 4
     # The default hybrid policy packs nodes up to 50% capacity before spreading.
     PER_NODE_HYBRID_THRESHOLD = int(NUM_CPUS_PER_NODE / 2)
-    for _ in range(NUM_NODES):
+    for i in range(NUM_NODES):
         cluster.add_node(
             num_cpus=NUM_CPUS_PER_NODE,
             resources={"custom": NUM_CPUS_PER_NODE},
+			_system_config={
+				"scheduler_top_k_absolute": 1,
+				"scheduler_top_k_fraction": 0,
+			} if i == 0 else None,
         )
 
     cluster.wait_for_nodes()
@@ -93,20 +97,13 @@ def test_hybrid_policy_threshold(ray_start_cluster):
         ray.get(block_task.acquire.remote())
         return ray.get_runtime_context().get_node_id()
 
-    # First Ensure both nodes are schedulable.
-    refs = [get_node_id.remote() for _ in range(int(NUM_NODES * NUM_CPUS_PER_NODE))]
-    ray.get([block_driver.acquire.remote() for _ in refs], timeout=20)
-    ray.get([block_task.release.remote() for _ in refs], timeout=20)
-    nodes = ray.get(refs, timeout=20)
-    assert len(set(nodes)) == 2, nodes
-
     # Submit 1 * PER_NODE_HYBRID_THRESHOLD tasks.
     # They should all be packed on the local node.
     refs = [get_node_id.remote() for _ in range(PER_NODE_HYBRID_THRESHOLD)]
     ray.get([block_driver.acquire.remote() for _ in refs], timeout=20)
     ray.get([block_task.release.remote() for _ in refs], timeout=20)
     nodes = ray.get(refs, timeout=20)
-    assert len(set(nodes)) == 1, nodes
+    assert len(set(nodes)) == 1
 
     # Submit 2 * PER_NODE_HYBRID_THRESHOLD tasks.
     # The first PER_NODE_HYBRID_THRESHOLD tasks should be packed on the local node, then

--- a/python/ray/util/client/__init__.py
+++ b/python/ray/util/client/__init__.py
@@ -14,7 +14,6 @@ from ray.util.annotations import DeveloperAPI
 from ray._private.utils import check_version_info
 
 
-# XXX: force tests
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Somehow changing from using the `memory` resource to using the custom resource caused this test to become very flaky on Ray Client. I have no idea why 🫠

My guess is that we don't consider custom resource utilization when making decisions for the default "hybrid" policy. This doesn't explain at all why the test is only flaky for the Ray Client condition. Could be a timing issue where non-Ray Client runs faster and therefore the CPUs are not released before the scheduling decisions are made.

Need to do some digging.