### PR TITLE
[train] Add support for loading Ray Train callbacks from environment variable

### DIFF
--- a/python/ray/train/constants.py
+++ b/python/ray/train/constants.py
@@ -112,6 +112,13 @@ RAY_TRAIN_COUNT_PREEMPTION_AS_FAILURE = "RAY_TRAIN_COUNT_PREEMPTION_AS_FAILURE"
 # Defaults to 0
 RAY_TRAIN_ENABLE_STATE_TRACKING = "RAY_TRAIN_ENABLE_STATE_TRACKING"
 
+# Environment variable to specify a comma-separated list of callback classes
+# to be used in the training run. Each class should be specified as
+# "module.ClassName". The classes will be instantiated and added to the
+# training run context.
+# This is used to allow users to specify custom callbacks for training runs
+# via environment variables without passing them directly in the `RunConfig`.
+RAY_TRAIN_CALLBACKS_ENV_VAR = "RAY_TRAIN_CALLBACKS"
 
 # NOTE: When adding a new environment variable, please track it in this list.
 TRAIN_ENV_VARS = {
@@ -123,6 +130,7 @@ TRAIN_ENV_VARS = {
     RAY_CHDIR_TO_TRIAL_DIR,
     RAY_TRAIN_COUNT_PREEMPTION_AS_FAILURE,
     RAY_TRAIN_ENABLE_STATE_TRACKING,
+    RAY_TRAIN_CALLBACKS_ENV_VAR,
 }
 
 # Key for AIR Checkpoint metadata in TrainingResult metadata

--- a/python/ray/train/v2/tests/conftest.py
+++ b/python/ray/train/v2/tests/conftest.py
@@ -3,6 +3,7 @@ import logging
 import pytest
 
 import ray
+from ray.tests.conftest import propagate_logs  # noqa
 
 
 @pytest.fixture()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Similarly to https://github.com/ray-project/ray/pull/51449 for Ray Data Execution Callbacks - this change adds support for loading Ray Train (v2) Callbacks from an environment variable. Users can now specify a comma-separated list of callback instances, which will be dynamically imported and added to DataParallelTrainers.

This allows for easy instrumentation and monitoring of Ray Train executions without modifying application code, which is useful for debugging and observability in production environments.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
