### PR TITLE
[core] Revert test changes to `test_hybrid_policy`

### DIFF
--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -62,19 +62,22 @@ def test_load_balancing(ray_start_cluster):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Times out on Windows")
-def test_hybrid_policy_threshold(ray_start_cluster):
+def test_hybrid_policy(ray_start_cluster):
     cluster = ray_start_cluster
 
-    NUM_NODES = 2
-    NUM_CPUS_PER_NODE = 4
-    # The default hybrid policy packs nodes up to 50% capacity before spreading.
-    PER_NODE_HYBRID_THRESHOLD = int(NUM_CPUS_PER_NODE / 2)
-    for _ in range(NUM_NODES):
-        cluster.add_node(
-            num_cpus=NUM_CPUS_PER_NODE,
-            resources={"custom": NUM_CPUS_PER_NODE},
-        )
-
+    num_cpus = 10
+    cluster.add_node(
+        num_cpus=num_cpus,
+        memory=num_cpus,
+        _system_config={
+            "scheduler_top_k_absolute": 1,
+            "scheduler_top_k_fraction": 0,
+        },
+    )
+    cluster.add_node(
+        num_cpus=num_cpus,
+        memory=num_cpus,
+    )
     cluster.wait_for_nodes()
     ray.init(address=cluster.address)
 
@@ -85,30 +88,41 @@ def test_hybrid_policy_threshold(ray_start_cluster):
     # until all are running.
     block_driver = Semaphore.remote(0)
 
-    # Add the custom resource because the CPU will be released when the task is
-    # blocked calling `ray.get()`.
-    @ray.remote(num_cpus=1, resources={"custom": 1})
-    def get_node_id() -> str:
+    # Add the memory resource because the cpu will be released in the ray.get
+    @ray.remote(num_cpus=1, memory=1)
+    def get_node():
         ray.get(block_driver.release.remote())
         ray.get(block_task.acquire.remote())
-        return ray.get_runtime_context().get_node_id()
+        return ray._private.worker.global_worker.current_node_id
 
-    # Submit 1 * PER_NODE_HYBRID_THRESHOLD tasks.
-    # They should all be packed on the local node.
-    refs = [get_node_id.remote() for _ in range(PER_NODE_HYBRID_THRESHOLD)]
-    ray.get([block_driver.acquire.remote() for _ in refs], timeout=20)
-    ray.get([block_task.release.remote() for _ in refs], timeout=20)
-    nodes = ray.get(refs, timeout=20)
+    # Below the hybrid threshold we pack on the local node first.
+    refs = [get_node.remote() for _ in range(5)]
+    ray.get([block_driver.acquire.remote() for _ in refs])
+    ray.get([block_task.release.remote() for _ in refs])
+    nodes = ray.get(refs)
     assert len(set(nodes)) == 1
 
-    # Submit 2 * PER_NODE_HYBRID_THRESHOLD tasks.
-    # The first PER_NODE_HYBRID_THRESHOLD tasks should be packed on the local node, then
-    # the second PER_NODE_HYBRID_THRESHOLD tasks should be packed on the remote node.
-    refs = [get_node_id.remote() for _ in range(int(PER_NODE_HYBRID_THRESHOLD * 2))]
-    ray.get([block_driver.acquire.remote() for _ in refs], timeout=20)
-    ray.get([block_task.release.remote() for _ in refs], timeout=20)
-    counter = collections.Counter(ray.get(refs, timeout=20))
-    assert all(v == PER_NODE_HYBRID_THRESHOLD for v in counter.values()), counter
+    # We pack the second node to the hybrid threshold.
+    refs = [get_node.remote() for _ in range(10)]
+    ray.get([block_driver.acquire.remote() for _ in refs])
+    ray.get([block_task.release.remote() for _ in refs])
+    nodes = ray.get(refs)
+    counter = collections.Counter(nodes)
+    for node_id in counter:
+        print(f"{node_id}: {counter[node_id]}")
+        assert counter[node_id] == 5
+
+    # Once all nodes are past the hybrid threshold we round robin.
+    # TODO (Alex): Ideally we could schedule less than 20 nodes here, but the
+    # policy is imperfect if a resource report interrupts the process.
+    refs = [get_node.remote() for _ in range(20)]
+    ray.get([block_driver.acquire.remote() for _ in refs])
+    ray.get([block_task.release.remote() for _ in refs])
+    nodes = ray.get(refs)
+    counter = collections.Counter(nodes)
+    for node_id in counter:
+        print(f"{node_id}: {counter[node_id]}")
+        assert counter[node_id] == 10, counter
 
 
 def test_legacy_spillback_distribution(ray_start_cluster):

--- a/python/ray/tests/test_scheduling.py
+++ b/python/ray/tests/test_scheduling.py
@@ -96,14 +96,14 @@ def test_hybrid_policy(ray_start_cluster):
         return ray.get_runtime_context().get_node_id()
 
     # Below the hybrid threshold we pack on the local node first.
-    refs = [get_node.remote() for _ in range(5)]
+    refs = [get_node_id.remote() for _ in range(5)]
     ray.get([block_driver.acquire.remote() for _ in refs], timeout=20)
     ray.get([block_task.release.remote() for _ in refs], timeout=20)
     nodes = ray.get(refs, timeout=20)
     assert len(set(nodes)) == 1
 
     # We pack the second node to the hybrid threshold.
-    refs = [get_node.remote() for _ in range(10)]
+    refs = [get_node_id.remote() for _ in range(10)]
     ray.get([block_driver.acquire.remote() for _ in refs], timeout=20)
     ray.get([block_task.release.remote() for _ in refs], timeout=20)
     nodes = ray.get(refs, timeout=20)
@@ -115,7 +115,7 @@ def test_hybrid_policy(ray_start_cluster):
     # Once all nodes are past the hybrid threshold we round robin.
     # TODO (Alex): Ideally we could schedule less than 20 nodes here, but the
     # policy is imperfect if a resource report interrupts the process.
-    refs = [get_node.remote() for _ in range(20)]
+    refs = [get_node_id.remote() for _ in range(20)]
     ray.get([block_driver.acquire.remote() for _ in refs], timeout=20)
     ray.get([block_task.release.remote() for _ in refs], timeout=20)
     nodes = ray.get(refs, timeout=20)

--- a/python/ray/util/client/__init__.py
+++ b/python/ray/util/client/__init__.py
@@ -14,7 +14,6 @@ from ray.util.annotations import DeveloperAPI
 from ray._private.utils import check_version_info
 
 
-# XXX: force tests
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Reverts the changes from https://github.com/ray-project/ray/pull/54176 except for the timeouts.

Somehow that PR made the test more flaky, and after spending my morning debugging I have no clue why 😞.