### PR TITLE
[core][refactor/01] remove MarkTaskCanceled as a condition check

### DIFF
--- a/src/mock/ray/core_worker/task_manager.h
+++ b/src/mock/ray/core_worker/task_manager.h
@@ -47,7 +47,7 @@ class MockTaskFinisherInterface : public TaskFinisherInterface {
               (const std::vector<ObjectID> &inlined_dependency_ids,
                const std::vector<ObjectID> &contained_ids),
               (override));
-  MOCK_METHOD(bool, MarkTaskCanceled, (const TaskID &task_id), (override));
+  MOCK_METHOD(void, MarkTaskCanceled, (const TaskID &task_id), (override));
   MOCK_METHOD(std::optional<TaskSpecification>,
               GetTaskSpec,
               (const TaskID &task_id),

--- a/src/ray/core_worker/task_finisher.h
+++ b/src/ray/core_worker/task_finisher.h
@@ -62,7 +62,7 @@ class TaskFinisherInterface {
 
   virtual void MarkDependenciesResolved(const TaskID &task_id) = 0;
 
-  virtual bool MarkTaskCanceled(const TaskID &task_id) = 0;
+  virtual void MarkTaskCanceled(const TaskID &task_id) = 0;
 
   virtual std::optional<TaskSpecification> GetTaskSpec(const TaskID &task_id) const = 0;
 

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -1350,8 +1350,8 @@ int64_t TaskManager::RemoveLineageReference(const ObjectID &object_id,
   return total_lineage_footprint_bytes_ - total_lineage_footprint_bytes_prev;
 }
 
-bool TaskManager::MarkTaskCanceled(const TaskID &task_id) {
-  // Mark the task for cancellation. This will prevent the task from being retried.
+void TaskManager::MarkTaskCanceled(const TaskID &task_id) {
+  // Mark the task for cancelation. This will prevent the task from being retried.
   ObjectID generator_id = TaskGeneratorId(task_id);
   if (!generator_id.IsNil()) {
     // Pass -1 because the task has been canceled, so we should just end the
@@ -1369,7 +1369,6 @@ bool TaskManager::MarkTaskCanceled(const TaskID &task_id) {
     it->second.num_oom_retries_left = 0;
     it->second.is_canceled = true;
   }
-  return it != submissible_tasks_.end();
 }
 
 absl::flat_hash_set<ObjectID> TaskManager::GetTaskReturnObjectsToStoreInPlasma(

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -507,11 +507,10 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
   void OnTaskDependenciesInlined(const std::vector<ObjectID> &inlined_dependency_ids,
                                  const std::vector<ObjectID> &contained_ids) override;
 
-  /// Set number of retries to zero for a task that is being canceled.
+  /// Set the task state to be canceled. Set the number of retries to zero.
   ///
   /// \param[in] task_id to cancel.
-  /// \return Whether the task was pending and was marked for cancellation.
-  bool MarkTaskCanceled(const TaskID &task_id) override;
+  void MarkTaskCanceled(const TaskID &task_id) override;
 
   /// Return the spec for a pending task.
   std::optional<TaskSpecification> GetTaskSpec(const TaskID &task_id) const override;

--- a/src/ray/core_worker/test/dependency_resolver_test.cc
+++ b/src/ray/core_worker/test/dependency_resolver_test.cc
@@ -109,7 +109,7 @@ class MockTaskFinisher : public TaskFinisherInterface {
     num_contained_ids += contained_ids.size();
   }
 
-  bool MarkTaskCanceled(const TaskID &task_id) override { return true; }
+  void MarkTaskCanceled(const TaskID &task_id) override {}
 
   std::optional<TaskSpecification> GetTaskSpec(const TaskID &task_id) const override {
     TaskSpecification task = BuildEmptyTaskSpec();

--- a/src/ray/core_worker/test/normal_task_submitter_test.cc
+++ b/src/ray/core_worker/test/normal_task_submitter_test.cc
@@ -188,7 +188,7 @@ class MockTaskFinisher : public TaskFinisherInterface {
     num_contained_ids += contained_ids.size();
   }
 
-  bool MarkTaskCanceled(const TaskID &task_id) override { return true; }
+  void MarkTaskCanceled(const TaskID &task_id) override {}
 
   std::optional<TaskSpecification> GetTaskSpec(const TaskID &task_id) const override {
     TaskSpecification task = BuildEmptyTaskSpec();

--- a/src/ray/core_worker/transport/actor_task_submitter.cc
+++ b/src/ray/core_worker/transport/actor_task_submitter.cc
@@ -874,8 +874,8 @@ Status ActorTaskSubmitter::CancelTask(TaskSpecification task_spec, bool recursiv
 
   // Shouldn't hold a lock while accessing task_finisher_.
   // Task is already canceled or finished.
-  if (!GetTaskFinisherWithoutMu().MarkTaskCanceled(task_id) ||
-      !GetTaskFinisherWithoutMu().IsTaskPending(task_id)) {
+  GetTaskFinisherWithoutMu().MarkTaskCanceled(task_id);
+  if (!GetTaskFinisherWithoutMu().IsTaskPending(task_id)) {
     RAY_LOG(DEBUG).WithField(task_id) << "Task is already finished or canceled";
     return Status::OK();
   }


### PR DESCRIPTION
Currently, `MarkTaskCanceled` is used both to check a condition and to modify state. Refactor it to be purely a state-modifying function. It is only used as a condition in two places, both of which already include `IsTaskPending`, which can serve as a suitable replacement. `MarkTaskCanceled` can be safely removed from those condition checks.

Purely a refactoring, no logical changes.

Test:
- CI