### PR TITLE
Run Docker builds as non-root user with scoped root access via `sudo`

### DIFF
--- a/ci/build/build-manylinux-forge.sh
+++ b/ci/build/build-manylinux-forge.sh
@@ -9,15 +9,15 @@ if [[ ! -e /usr/bin/nproc ]]; then
 fi
 
 # Install ray cpp dependencies.
-yum -y install unzip zip sudo openssl xz
+sudo yum -y install unzip zip sudo openssl xz
 if [[ "${HOSTTYPE-}" == "x86_64" ]]; then
-  yum -y install libasan-4.8.5-44.el7.x86_64 libubsan-7.3.1-5.10.el7.x86_64 \
+  sudo yum -y install libasan-4.8.5-44.el7.x86_64 libubsan-7.3.1-5.10.el7.x86_64 \
     devtoolset-8-libasan-devel.x86_64
 fi
 
 # Install ray java dependencies.
 if [[ "${RAY_INSTALL_JAVA}" == "1" ]]; then
-  yum -y install java-1.8.0-openjdk java-1.8.0-openjdk-devel maven
+  sudo yum -y install java-1.8.0-openjdk java-1.8.0-openjdk-devel maven
   java -version
   JAVA_BIN="$(readlink -f "$(command -v java)")"
   echo "java_bin path ${JAVA_BIN}"
@@ -34,7 +34,8 @@ nvm use "$NODE_VERSION"
 
 # Install bazel
 npm install -g @bazel/bazelisk
-ln -sf "$(which bazelisk)" /usr/local/bin/bazel
+mkdir -p "$HOME"/bin
+ln -sf "$(which bazelisk)" "$HOME"/bin/bazel
 
 {
   echo "build --config=ci"
@@ -42,4 +43,4 @@ ln -sf "$(which bazelisk)" /usr/local/bin/bazel
   if [[ "${BUILDKITE_BAZEL_CACHE_URL:-}" != "" ]]; then
     echo "build:ci --remote_cache=${BUILDKITE_BAZEL_CACHE_URL:-}"
   fi
-} > ~/.bazelrc
+} > "$HOME"/.bazelrc

--- a/ci/build/build-manylinux-wheel.sh
+++ b/ci/build/build-manylinux-wheel.sh
@@ -20,6 +20,8 @@ fi
 # When building the wheel, we always set RAY_INSTALL_JAVA=0 because we
 # have already built the Java code above.
 
+export BAZEL_PATH="$HOME"/bin/bazel
+
 # build ray wheel
 PATH="/opt/python/${PYTHON}/bin:$PATH" RAY_INSTALL_JAVA=0 \
 "/opt/python/${PYTHON}/bin/python" -m pip wheel -q -w dist . --no-deps

--- a/ci/docker/manylinux.Dockerfile
+++ b/ci/docker/manylinux.Dockerfile
@@ -9,6 +9,8 @@ ENV BUILD_JAR=1
 ENV RAY_INSTALL_JAVA=1
 ENV BUILDKITE_BAZEL_CACHE_URL=$BUILDKITE_BAZEL_CACHE_URL
 
+RUN yum -y install sudo
+
 COPY ci/build/build-manylinux-forge.sh /tmp/build-manylinux-forge.sh
 
 RUN ./tmp/build-manylinux-forge.sh

--- a/python/README-building-wheels.md
+++ b/python/README-building-wheels.md
@@ -10,9 +10,12 @@ Inside the root directory (i.e., one level above this python directory), run
 
 ```
 docker run -ti --rm \
+    -e HOST_UID=$(id -u) \
+    -e HOST_GID=$(id -g) \
     -e BUILDKITE_COMMIT="$(git rev-parse HEAD)" \
     -e BUILD_ONE_PYTHON_ONLY=py39 \
     -w /ray -v "$(pwd)":/ray \
+    -e HOME=/tmp \
     quay.io/pypa/manylinux2014_x86_64:2024-07-02-9ac04ee \
     /ray/python/build-wheel-manylinux2014.sh
 ```


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

This PR introduces a clean way to run Ray’s manylinux wheel builds **as a non-root user**, while allowing scoped `sudo` access where needed.

---

 ✅ **Key Changes:**

1. **Created a new helper script** that:
   - Creates a `builduser` with UID/GID matching the host
   - Grants it **NOPASSWD `sudo` access** (minimal and controlled)
   - Runs the final Docker command **fully as non-root user**

2. **Modified scripts** to:
   - Use `sudo` only where root access is necessary (e.g., installing tools, etc.)
   - Set a `BAZEL_PATH` env var override to ensure correct Bazel version is picked (esp. when symlinked under `/tmp/bin`)
   - Ensure generated artifacts (e.g., `.whl` files) are owned by the non-root user

3. **Improved portability**:
   - Output files now match the host user’s UID/GID
   - Avoids permission issues in CI or local development where Docker runs non-root

---

📌 **Motivation**

The current setup runs the build as root, which causes:

- **Generated files (e.g., wheels) are owned by root**, so contributors can't easily modify or remove them locally
- Host-side file ownership issues in shared dev environments
- Fragile behavior in CI/dev environments where users don’t have root access

This PR solves that while keeping root usage minimal and scoped.  
Now all output files are owned by the non-root user, making them **easily editable, deletable, and shareable** without special privileges.

Take a look at the ownership details after I called my bash script, `build-docker-linux-x86_64.sh`,

```bash
(ray-dev) czgdp1807@ray-linux-1:~/Anyscale/ray$ ls -l python/ray/dashboard/client
total 844
-rw-rw-r--   1 czgdp1807 czgdp1807   2336 Jun 18 13:44 README.rst
drwxr-xr-x   4 czgdp1807 czgdp1807   4096 Jul  2 16:07 build
drwxr-xr-x 875 czgdp1807 czgdp1807  36864 Jul  2 16:05 node_modules
-rw-rw-r--   1 czgdp1807 czgdp1807 798628 Jun 18 13:44 package-lock.json
-rw-rw-r--   1 czgdp1807 czgdp1807   3818 Jun 18 13:44 package.json
drwxrwxr-x   3 czgdp1807 czgdp1807   4096 Jun 18 13:44 public
drwxrwxr-x   8 czgdp1807 czgdp1807   4096 Jun 18 13:44 src
-rw-rw-r--   1 czgdp1807 czgdp1807    531 Jun 18 13:44 tsconfig.json
(ray-dev) czgdp1807@ray-linux-1:~/Anyscale/ray$ ls -l python/requirements_compiled.txt
-rw-rw-r-- 1 czgdp1807 czgdp1807 59892 Jul  1 17:07 python/requirements_compiled.txt
```

Everything owned by current user i.e., `czgdp1807`.

---

@aslonnie suggested that this approach needs to be integrated at the following places,

https://github.com/ray-project/ray/blob/fbe43f27f350f1e90eaa2a54a1d52eeda35c8d22/ci/ray_ci/builder_container.py#L61

and 

https://github.com/ray-project/ray/blob/fbe43f27f350f1e90eaa2a54a1d52eeda35c8d22/ci/ray_ci/container.py#L78C18-L78C33

So I will work on it in this PR itself. Meanwhile feel free to drop any suggestions/feedbacks.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
