### PR TITLE
[core][refactor/02] encapsulate cancelation state within task manager

### DIFF
--- a/src/mock/ray/core_worker/task_manager.h
+++ b/src/mock/ray/core_worker/task_manager.h
@@ -47,7 +47,7 @@ class MockTaskFinisherInterface : public TaskFinisherInterface {
               (const std::vector<ObjectID> &inlined_dependency_ids,
                const std::vector<ObjectID> &contained_ids),
               (override));
-  MOCK_METHOD(bool, MarkTaskCanceled, (const TaskID &task_id), (override));
+  MOCK_METHOD(void, MarkTaskCanceled, (const TaskID &task_id), (override));
   MOCK_METHOD(std::optional<TaskSpecification>,
               GetTaskSpec,
               (const TaskID &task_id),

--- a/src/mock/ray/core_worker/task_manager.h
+++ b/src/mock/ray/core_worker/task_manager.h
@@ -62,6 +62,7 @@ class MockTaskFinisherInterface : public TaskFinisherInterface {
               (const TaskID &task_id, const NodeID &node_id, const WorkerID &worker_id),
               (override));
   MOCK_METHOD(bool, IsTaskPending, (const TaskID &task_id), (const, override));
+  MOCK_METHOD(bool, IsTaskCanceled, (const TaskID &task_id), (const, override));
   MOCK_METHOD(void, MarkGeneratorFailedAndResubmit, (const TaskID &task_id), (override));
 };
 

--- a/src/ray/core_worker/task_finisher.h
+++ b/src/ray/core_worker/task_finisher.h
@@ -62,7 +62,7 @@ class TaskFinisherInterface {
 
   virtual void MarkDependenciesResolved(const TaskID &task_id) = 0;
 
-  virtual bool MarkTaskCanceled(const TaskID &task_id) = 0;
+  virtual void MarkTaskCanceled(const TaskID &task_id) = 0;
 
   virtual std::optional<TaskSpecification> GetTaskSpec(const TaskID &task_id) const = 0;
 

--- a/src/ray/core_worker/task_finisher.h
+++ b/src/ray/core_worker/task_finisher.h
@@ -68,6 +68,8 @@ class TaskFinisherInterface {
 
   virtual bool IsTaskPending(const TaskID &task_id) const = 0;
 
+  virtual bool IsTaskCanceled(const TaskID &task_id) const = 0;
+
   virtual void MarkGeneratorFailedAndResubmit(const TaskID &task_id) = 0;
 };
 

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -1350,8 +1350,8 @@ int64_t TaskManager::RemoveLineageReference(const ObjectID &object_id,
   return total_lineage_footprint_bytes_ - total_lineage_footprint_bytes_prev;
 }
 
-bool TaskManager::MarkTaskCanceled(const TaskID &task_id) {
-  // Mark the task for cancellation. This will prevent the task from being retried.
+void TaskManager::MarkTaskCanceled(const TaskID &task_id) {
+  // Mark the task for cancelation. This will prevent the task from being retried.
   ObjectID generator_id = TaskGeneratorId(task_id);
   if (!generator_id.IsNil()) {
     // Pass -1 because the task has been canceled, so we should just end the
@@ -1369,7 +1369,6 @@ bool TaskManager::MarkTaskCanceled(const TaskID &task_id) {
     it->second.num_oom_retries_left = 0;
     it->second.is_canceled = true;
   }
-  return it != submissible_tasks_.end();
 }
 
 absl::flat_hash_set<ObjectID> TaskManager::GetTaskReturnObjectsToStoreInPlasma(

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -494,7 +494,7 @@ bool TaskManager::IsTaskCanceled(const TaskID &task_id) const {
   const auto it = submissible_tasks_.find(task_id);
   if (it == submissible_tasks_.end()) {
     // If the task is no longer in the submissible tasks map, it has the same semantic
-    // as being cancelled (because it can never be submitted for execution again).
+    // as being canceled (because it can never be submitted for execution again).
     return true;
   }
   return it->second.is_canceled;

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -489,6 +489,17 @@ bool TaskManager::IsTaskPending(const TaskID &task_id) const {
   return it->second.IsPending();
 }
 
+bool TaskManager::IsTaskCanceled(const TaskID &task_id) const {
+  absl::MutexLock lock(&mu_);
+  const auto it = submissible_tasks_.find(task_id);
+  if (it == submissible_tasks_.end()) {
+    // If the task is no longer in the submissible tasks map, it has the same semantic
+    // as being cancelled (because it can never be submitted for execution again).
+    return true;
+  }
+  return it->second.is_canceled;
+}
+
 bool TaskManager::IsTaskWaitingForExecution(const TaskID &task_id) const {
   absl::MutexLock lock(&mu_);
   const auto it = submissible_tasks_.find(task_id);

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -507,11 +507,10 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
   void OnTaskDependenciesInlined(const std::vector<ObjectID> &inlined_dependency_ids,
                                  const std::vector<ObjectID> &contained_ids) override;
 
-  /// Set number of retries to zero for a task that is being canceled.
+  /// Set the task state to be canceled. Set the number of retries to zero.
   ///
   /// \param[in] task_id to cancel.
-  /// \return Whether the task was pending and was marked for cancellation.
-  bool MarkTaskCanceled(const TaskID &task_id) override;
+  void MarkTaskCanceled(const TaskID &task_id) override;
 
   /// Return the spec for a pending task.
   std::optional<TaskSpecification> GetTaskSpec(const TaskID &task_id) const override;

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -530,6 +530,12 @@ class TaskManager : public TaskFinisherInterface, public TaskResubmissionInterfa
   /// \return Whether the task is pending.
   bool IsTaskPending(const TaskID &task_id) const override;
 
+  /// Return whether the task is cancelled (can never be submitted for execution again).
+  ///
+  /// \param[in] task_id ID of the task to query.
+  /// \return Whether the task is cancelled.
+  bool IsTaskCanceled(const TaskID &task_id) const override;
+
   /// Return whether the task is scheduled adn waiting for execution.
   ///
   /// \param[in] task_id ID of the task to query.

--- a/src/ray/core_worker/test/dependency_resolver_test.cc
+++ b/src/ray/core_worker/test/dependency_resolver_test.cc
@@ -109,7 +109,7 @@ class MockTaskFinisher : public TaskFinisherInterface {
     num_contained_ids += contained_ids.size();
   }
 
-  bool MarkTaskCanceled(const TaskID &task_id) override { return true; }
+  void MarkTaskCanceled(const TaskID &task_id) override {}
 
   std::optional<TaskSpecification> GetTaskSpec(const TaskID &task_id) const override {
     TaskSpecification task = BuildEmptyTaskSpec();

--- a/src/ray/core_worker/test/dependency_resolver_test.cc
+++ b/src/ray/core_worker/test/dependency_resolver_test.cc
@@ -109,7 +109,9 @@ class MockTaskFinisher : public TaskFinisherInterface {
     num_contained_ids += contained_ids.size();
   }
 
-  void MarkTaskCanceled(const TaskID &task_id) override {}
+  void MarkTaskCanceled(const TaskID &task_id) override {
+    cancelled_tasks_.insert(task_id);
+  }
 
   std::optional<TaskSpecification> GetTaskSpec(const TaskID &task_id) const override {
     TaskSpecification task = BuildEmptyTaskSpec();
@@ -124,7 +126,9 @@ class MockTaskFinisher : public TaskFinisherInterface {
 
   bool IsTaskPending(const TaskID &task_id) const override { return true; }
 
-  bool IsTaskCanceled(const TaskID &task_id) const override { return false; }
+  bool IsTaskCanceled(const TaskID &task_id) const override {
+    return cancelled_tasks_.contains(task_id);
+  }
 
   void MarkGeneratorFailedAndResubmit(const TaskID &task_id) override {}
 
@@ -134,6 +138,9 @@ class MockTaskFinisher : public TaskFinisherInterface {
   int num_contained_ids = 0;
   int num_task_retries_attempted = 0;
   int num_fail_pending_task_calls = 0;
+
+ private:
+  absl::flat_hash_set<TaskID> cancelled_tasks_;
 };
 
 class MockActorCreator : public ActorCreatorInterface {

--- a/src/ray/core_worker/test/dependency_resolver_test.cc
+++ b/src/ray/core_worker/test/dependency_resolver_test.cc
@@ -124,6 +124,8 @@ class MockTaskFinisher : public TaskFinisherInterface {
 
   bool IsTaskPending(const TaskID &task_id) const override { return true; }
 
+  bool IsTaskCanceled(const TaskID &task_id) const override { return false; }
+
   void MarkGeneratorFailedAndResubmit(const TaskID &task_id) override {}
 
   int num_tasks_complete = 0;

--- a/src/ray/core_worker/test/normal_task_submitter_test.cc
+++ b/src/ray/core_worker/test/normal_task_submitter_test.cc
@@ -188,7 +188,7 @@ class MockTaskFinisher : public TaskFinisherInterface {
     num_contained_ids += contained_ids.size();
   }
 
-  bool MarkTaskCanceled(const TaskID &task_id) override { return true; }
+  void MarkTaskCanceled(const TaskID &task_id) override {}
 
   std::optional<TaskSpecification> GetTaskSpec(const TaskID &task_id) const override {
     TaskSpecification task = BuildEmptyTaskSpec();

--- a/src/ray/core_worker/test/normal_task_submitter_test.cc
+++ b/src/ray/core_worker/test/normal_task_submitter_test.cc
@@ -203,6 +203,8 @@ class MockTaskFinisher : public TaskFinisherInterface {
 
   bool IsTaskPending(const TaskID &task_id) const override { return true; }
 
+  bool IsTaskCanceled(const TaskID &task_id) const override { return false; }
+
   void MarkGeneratorFailedAndResubmit(const TaskID &task_id) override {
     num_generator_failed_and_resubmitted++;
   }

--- a/src/ray/core_worker/transport/actor_task_submitter.cc
+++ b/src/ray/core_worker/transport/actor_task_submitter.cc
@@ -874,8 +874,8 @@ Status ActorTaskSubmitter::CancelTask(TaskSpecification task_spec, bool recursiv
 
   // Shouldn't hold a lock while accessing task_finisher_.
   // Task is already canceled or finished.
-  if (!GetTaskFinisherWithoutMu().MarkTaskCanceled(task_id) ||
-      !GetTaskFinisherWithoutMu().IsTaskPending(task_id)) {
+  GetTaskFinisherWithoutMu().MarkTaskCanceled(task_id);
+  if (!GetTaskFinisherWithoutMu().IsTaskPending(task_id)) {
     RAY_LOG(DEBUG).WithField(task_id) << "Task is already finished or canceled";
     return Status::OK();
   }

--- a/src/ray/core_worker/transport/normal_task_submitter.h
+++ b/src/ray/core_worker/transport/normal_task_submitter.h
@@ -372,9 +372,6 @@ class NormalTaskSubmitter {
   absl::flat_hash_map<SchedulingKey, SchedulingKeyEntry> scheduling_key_entries_
       ABSL_GUARDED_BY(mu_);
 
-  // Tasks that were cancelled while being resolved.
-  absl::flat_hash_set<TaskID> cancelled_tasks_ ABSL_GUARDED_BY(mu_);
-
   // Keeps track of where currently executing tasks are being run.
   absl::flat_hash_map<TaskID, rpc::Address> executing_tasks_ ABSL_GUARDED_BY(mu_);
 


### PR DESCRIPTION
Currently, the task cancellation state is tracked separately across multiple classes, leading to duplicated logic and unclear component ownership. This PR centralizes the cancellation state within the `TaskManager` class, allowing other components—specifically `NormalTaskSubmitter` in this case—to rely on `TaskManager` for state management and avoid handling it independently.
- We can now delete the `canceled_tasks_` map in `NormalTaskSubmitter`

Moving toward clearer ownership and better encapsulation across components. `TaskManager` is the central place to track the state of a task — please share your thoughts.

Test:
- CI