### PR TITLE
Add label selector observability to placement group tables and actor and task detail pages

### DIFF
--- a/python/ray/dashboard/client/src/components/PlacementGroupTable.component.test.tsx
+++ b/python/ray/dashboard/client/src/components/PlacementGroupTable.component.test.tsx
@@ -1,0 +1,390 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { PlacementGroup, PlacementGroupState } from "../type/placementGroup";
+import { TEST_APP_WRAPPER } from "../util/test-utils";
+import PlacementGroupTable from "./PlacementGroupTable";
+
+const MOCK_PLACEMENT_GROUPS: PlacementGroup[] = [
+  {
+    placement_group_id: "pg-123456789",
+    name: "MyPlacementGroup1",
+    creator_job_id: "job-987654321",
+    state: PlacementGroupState.CREATED,
+    stats: {
+      scheduling_state: "SUCCESS",
+    },
+    bundles: [
+      {
+        bundle_id: "bundle-1",
+        node_id: "node-1",
+        unit_resources: {
+          cpu: 4,
+          memory: 8192,
+        },
+        label_selector: {
+          "test-label-key": "test-label-value",
+        },
+      },
+      {
+        bundle_id: "bundle-2",
+        node_id: null,
+        unit_resources: {
+          cpu: 2,
+          memory: 4096,
+        },
+        label_selector: null,
+      },
+    ],
+  },
+  {
+    placement_group_id: "pg-987654321",
+    name: "MyPlacementGroup2",
+    creator_job_id: "job-123456789",
+    state: PlacementGroupState.PENDING,
+    stats: {
+      scheduling_state: "PENDING",
+    },
+    bundles: [
+      {
+        bundle_id: "bundle-3",
+        node_id: "node-2",
+        unit_resources: {
+          cpu: 8,
+          memory: 16384,
+          gpu: 1,
+        },
+        label_selector: {
+          "gpu-required": "true",
+        },
+      },
+    ],
+  },
+  {
+    placement_group_id: "pg-555666777",
+    name: "MyPlacementGroup3",
+    creator_job_id: "job-987654321",
+    state: PlacementGroupState.REMOVED,
+    stats: null,
+    bundles: [
+      {
+        bundle_id: "bundle-4",
+        node_id: null,
+        unit_resources: {},
+        label_selector: {},
+      },
+    ],
+  },
+];
+
+// These tests are slow because they involve a lot of interactivity.
+// Clicking various buttons and waiting for the table to update.
+// So we increase the timeout to 40 seconds.
+jest.setTimeout(40000);
+
+describe("PlacementGroupTable", () => {
+  it("renders a table of placement groups with all columns", () => {
+    render(<PlacementGroupTable placementGroups={MOCK_PLACEMENT_GROUPS} />, {
+      wrapper: TEST_APP_WRAPPER,
+    });
+
+    // Check that all column headers are present
+    const idHeaders = screen.getAllByText("ID");
+    expect(idHeaders.length).toBeGreaterThan(0);
+
+    const nameHeaders = screen.getAllByText("Name");
+    expect(nameHeaders.length).toBeGreaterThan(0);
+
+    const jobIdHeaders = screen.getAllByText("Job Id");
+    expect(jobIdHeaders.length).toBeGreaterThan(0);
+
+    const stateHeaders = screen.getAllByText("State");
+    expect(stateHeaders.length).toBeGreaterThan(0);
+
+    const reservedResourcesHeaders = screen.getAllByText("Reserved Resources");
+    expect(reservedResourcesHeaders.length).toBeGreaterThan(0);
+
+    const labelSelectorHeaders = screen.getAllByText("Label Selector");
+    expect(labelSelectorHeaders.length).toBeGreaterThan(0);
+
+    const schedulingDetailHeaders = screen.getAllByText("Scheduling Detail");
+    expect(schedulingDetailHeaders.length).toBeGreaterThan(0);
+
+    // Check that placement group data is displayed
+    expect(screen.getByText("pg-123456789")).toBeInTheDocument();
+    expect(screen.getByText("MyPlacementGroup1")).toBeInTheDocument();
+    const jobIdElements = screen.getAllByText("job-987654321");
+    expect(jobIdElements.length).toBeGreaterThan(0);
+    expect(screen.getByText("SUCCESS")).toBeInTheDocument();
+  });
+
+  it("renders placement groups filtered by placement group ID", async () => {
+    const user = userEvent.setup();
+    render(<PlacementGroupTable placementGroups={MOCK_PLACEMENT_GROUPS} />, {
+      wrapper: TEST_APP_WRAPPER,
+    });
+
+    // Get the input directly by its label
+    const input = screen.getByLabelText("Placement group ID");
+
+    // Filter by placement group ID
+    await user.type(input, "pg-123456789");
+
+    // Wait for the filter to be applied
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Check that only the filtered placement group is shown
+    const pg123Elements = screen.getAllByText("pg-123456789");
+    expect(pg123Elements.length).toBeGreaterThan(0);
+
+    // Check that other placement groups are not shown
+    expect(screen.queryByText("pg-987654321")).not.toBeInTheDocument();
+    expect(screen.queryByText("pg-555666777")).not.toBeInTheDocument();
+  });
+
+  it("renders placement groups filtered by state", async () => {
+    const user = userEvent.setup();
+    render(<PlacementGroupTable placementGroups={MOCK_PLACEMENT_GROUPS} />, {
+      wrapper: TEST_APP_WRAPPER,
+    });
+
+    // Get the input directly by its label
+    const input = screen.getByLabelText("State");
+
+    // Filter by state
+    await user.type(input, "CREATED");
+
+    // Wait for the filter to be applied
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Check that only the filtered placement group is shown
+    expect(screen.queryByText("pg-123456789")).toBeInTheDocument();
+    expect(screen.queryByText("pg-987654321")).not.toBeInTheDocument();
+    expect(screen.queryByText("pg-555666777")).not.toBeInTheDocument();
+  });
+
+  it("renders placement groups filtered by job ID", async () => {
+    const user = userEvent.setup();
+    render(<PlacementGroupTable placementGroups={MOCK_PLACEMENT_GROUPS} />, {
+      wrapper: TEST_APP_WRAPPER,
+    });
+
+    // Get the input directly by its label
+    const input = screen.getByLabelText("Job Id");
+
+    // Filter by job ID
+    await user.type(input, "job-987654321");
+
+    // Wait for the filter to be applied
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Check that only the filtered placement groups are shown
+    expect(screen.queryByText("pg-123456789")).toBeInTheDocument();
+    expect(screen.queryByText("pg-987654321")).not.toBeInTheDocument();
+    expect(screen.queryByText("pg-555666777")).toBeInTheDocument();
+  });
+
+  it("renders placement groups filtered by name", async () => {
+    const user = userEvent.setup();
+    render(<PlacementGroupTable placementGroups={MOCK_PLACEMENT_GROUPS} />, {
+      wrapper: TEST_APP_WRAPPER,
+    });
+
+    // Get the input directly by its label
+    const input = screen.getByLabelText("Name");
+
+    // Filter by name
+    await user.type(input, "MyPlacementGroup1");
+
+    // Wait for the filter to be applied
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Check that only the filtered placement group is shown
+    const nameElements = screen.getAllByText("MyPlacementGroup1");
+    expect(nameElements.length).toBeGreaterThan(0);
+
+    // Check that other placement groups are not shown
+    expect(screen.queryByText("MyPlacementGroup2")).not.toBeInTheDocument();
+    expect(screen.queryByText("MyPlacementGroup3")).not.toBeInTheDocument();
+  });
+
+  it("renders placement groups with pagination", async () => {
+    const user = userEvent.setup();
+    render(<PlacementGroupTable placementGroups={MOCK_PLACEMENT_GROUPS} />, {
+      wrapper: TEST_APP_WRAPPER,
+    });
+
+    // Check that pagination controls are present
+    expect(screen.getByRole("navigation")).toBeInTheDocument();
+
+    // Change page size
+    const pageSizeInput = screen.getByLabelText("Page Size");
+    await user.clear(pageSizeInput);
+    await user.type(pageSizeInput, "2");
+
+    // Verify pagination works
+    expect(screen.getByText("pg-123456789")).toBeInTheDocument();
+    expect(screen.getByText("pg-987654321")).toBeInTheDocument();
+    expect(screen.queryByText("pg-555666777")).not.toBeInTheDocument();
+  });
+
+  it("renders placement groups with job ID prop", () => {
+    render(
+      <PlacementGroupTable
+        placementGroups={MOCK_PLACEMENT_GROUPS}
+        jobId="job-987654321"
+      />,
+      {
+        wrapper: TEST_APP_WRAPPER,
+      },
+    );
+
+    // Check that the job ID filter is pre-populated
+    const jobIdFilter = screen.getByLabelText("Job Id");
+    expect(jobIdFilter).toHaveValue("job-987654321");
+  });
+
+  it("renders placement groups with empty bundles", () => {
+    const placementGroupsWithEmptyBundles = [
+      {
+        ...MOCK_PLACEMENT_GROUPS[0],
+        bundles: [],
+      },
+    ];
+
+    render(
+      <PlacementGroupTable placementGroups={placementGroupsWithEmptyBundles} />,
+      {
+        wrapper: TEST_APP_WRAPPER,
+      },
+    );
+
+    // Check that empty bundles are handled gracefully
+    expect(screen.getByText("pg-123456789")).toBeInTheDocument();
+    // Check that empty resources are handled - might be rendered as "{}" or not at all
+    const emptyResourceElements = screen.getAllByText("{}");
+    expect(emptyResourceElements.length).toBeGreaterThan(0);
+  });
+
+  it("renders placement groups with null stats", () => {
+    const placementGroupsWithNullStats = [
+      {
+        ...MOCK_PLACEMENT_GROUPS[0],
+        stats: null,
+      },
+    ];
+
+    render(
+      <PlacementGroupTable placementGroups={placementGroupsWithNullStats} />,
+      {
+        wrapper: TEST_APP_WRAPPER,
+      },
+    );
+
+    // Check that null stats are handled gracefully
+    expect(screen.getByText("pg-123456789")).toBeInTheDocument();
+    expect(screen.getByText("-")).toBeInTheDocument(); // Null scheduling detail
+  });
+
+  it("renders placement groups with empty name", () => {
+    const placementGroupsWithEmptyName = [
+      {
+        ...MOCK_PLACEMENT_GROUPS[0],
+        name: "",
+      },
+    ];
+
+    render(
+      <PlacementGroupTable placementGroups={placementGroupsWithEmptyName} />,
+      {
+        wrapper: TEST_APP_WRAPPER,
+      },
+    );
+
+    // Check that empty names are handled gracefully
+    expect(screen.getByText("pg-123456789")).toBeInTheDocument();
+    expect(screen.getByText("-")).toBeInTheDocument(); // Empty name
+  });
+
+  it("renders state counter for placement groups", () => {
+    render(<PlacementGroupTable placementGroups={MOCK_PLACEMENT_GROUPS} />, {
+      wrapper: TEST_APP_WRAPPER,
+    });
+
+    // Check that state counter is present by looking for the total count
+    expect(screen.getByText(/x 3/)).toBeInTheDocument(); // Total count of 3 placement groups
+  });
+
+  it("renders resource requirements as JSON dialog", () => {
+    render(<PlacementGroupTable placementGroups={MOCK_PLACEMENT_GROUPS} />, {
+      wrapper: TEST_APP_WRAPPER,
+    });
+
+    // Check that resource requirements are rendered as dialog buttons
+    // Look for the button text or check that the table cell contains resource data
+    const resourceCells = screen.getAllByText(/cpu|memory|gpu/i);
+    expect(resourceCells.length).toBeGreaterThan(0);
+  });
+
+  it("renders label selector as JSON dialog", () => {
+    render(<PlacementGroupTable placementGroups={MOCK_PLACEMENT_GROUPS} />, {
+      wrapper: TEST_APP_WRAPPER,
+    });
+
+    // Check that label selector is rendered as dialog buttons
+    // Look for the button text or check that the table cell contains label data
+    const labelCells = screen.getAllByText(/test-label-key|gpu-required/i);
+    expect(labelCells.length).toBeGreaterThan(0);
+  });
+
+  it("handles placement groups with different states", () => {
+    render(<PlacementGroupTable placementGroups={MOCK_PLACEMENT_GROUPS} />, {
+      wrapper: TEST_APP_WRAPPER,
+    });
+
+    // Check that different states are displayed by looking for the placement group rows
+    expect(screen.getByText("pg-123456789")).toBeInTheDocument();
+    expect(screen.getByText("pg-987654321")).toBeInTheDocument();
+    expect(screen.getByText("pg-555666777")).toBeInTheDocument();
+
+    // Check that the table contains the expected states (using getAllByText to handle multiple instances)
+    const createdElements = screen.getAllByText("CREATED");
+    const pendingElements = screen.getAllByText("PENDING");
+    const removedElements = screen.getAllByText("REMOVED");
+
+    expect(createdElements.length).toBeGreaterThan(0);
+    expect(pendingElements.length).toBeGreaterThan(0);
+    expect(removedElements.length).toBeGreaterThan(0);
+  });
+
+  it("renders empty table when no placement groups provided", () => {
+    render(<PlacementGroupTable placementGroups={[]} />, {
+      wrapper: TEST_APP_WRAPPER,
+    });
+
+    // Check that column headers are still present by looking for table headers specifically
+    const tableHeaders = screen.getAllByText("ID");
+    expect(tableHeaders.length).toBeGreaterThan(0);
+
+    const nameHeaders = screen.getAllByText("Name");
+    expect(nameHeaders.length).toBeGreaterThan(0);
+
+    const jobIdHeaders = screen.getAllByText("Job Id");
+    expect(jobIdHeaders.length).toBeGreaterThan(0);
+
+    const stateHeaders = screen.getAllByText("State");
+    expect(stateHeaders.length).toBeGreaterThan(0);
+
+    const reservedResourcesHeaders = screen.getAllByText("Reserved Resources");
+    expect(reservedResourcesHeaders.length).toBeGreaterThan(0);
+
+    const labelSelectorHeaders = screen.getAllByText("Label Selector");
+    expect(labelSelectorHeaders.length).toBeGreaterThan(0);
+
+    const schedulingDetailHeaders = screen.getAllByText("Scheduling Detail");
+    expect(schedulingDetailHeaders.length).toBeGreaterThan(0);
+
+    // Check that no data rows are present
+    expect(screen.queryByText("pg-123456789")).not.toBeInTheDocument();
+  });
+});

--- a/python/ray/dashboard/client/src/components/PlacementGroupTable.component.test.tsx
+++ b/python/ray/dashboard/client/src/components/PlacementGroupTable.component.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { PlacementGroup, PlacementGroupState } from "../type/placementGroup";
@@ -261,8 +261,8 @@ describe("PlacementGroupTable", () => {
 
     // Check that empty bundles are handled gracefully
     expect(screen.getByText("pg-123456789")).toBeInTheDocument();
-    // Check that empty resources are handled - might be rendered as "{}" or not at all
-    const emptyResourceElements = screen.getAllByText("{}");
+    // Check that empty resources are handled - might be rendered as "[]" or not at all
+    const emptyResourceElements = screen.getAllByText("[]");
     expect(emptyResourceElements.length).toBeGreaterThan(0);
   });
 

--- a/python/ray/dashboard/client/src/components/PlacementGroupTable.tsx
+++ b/python/ray/dashboard/client/src/components/PlacementGroupTable.tsx
@@ -15,11 +15,11 @@ import {
 import Autocomplete from "@mui/material/Autocomplete";
 import Pagination from "@mui/material/Pagination";
 import React, { useState } from "react";
+import { CodeDialogButtonWithPreview } from "../common/CodeDialogButton";
 import rowStyles from "../common/RowStyles";
 import { sliceToPage } from "../common/util";
 import { Bundle, PlacementGroup } from "../type/placementGroup";
 import { useFilter } from "../util/hook";
-import OverflowCollapsibleCell from "./OverflowCollapsibleCell";
 import StateCounter from "./StatesCounter";
 import { StatusChip } from "./StatusChip";
 
@@ -30,12 +30,39 @@ const BundleResourceRequirements = ({
   sx?: SxProps<Theme>;
 }) => {
   const resources = bundles.map(({ unit_resources }) => unit_resources);
-  const resourceString =
-    resources.length === 0
-      ? "-"
-      : resources.map((resource) => JSON.stringify(resource)).join(", ");
+  return (
+    <React.Fragment>
+      {Object.entries(resources).length > 0 ? (
+        <CodeDialogButtonWithPreview
+          title="Required resources"
+          code={JSON.stringify(resources, undefined, 2)}
+        />
+      ) : (
+        "{}"
+      )}
+    </React.Fragment>
+  );
+};
 
-  return <OverflowCollapsibleCell text={resourceString} maxWidth={300} />;
+const LabelSelector = ({
+  bundles,
+}: {
+  bundles: Bundle[];
+  sx?: SxProps<Theme>;
+}) => {
+  const labelSelector = bundles.map(({ label_selector }) => label_selector);
+  return (
+    <React.Fragment>
+      {Object.entries(labelSelector).length > 0 ? (
+        <CodeDialogButtonWithPreview
+          title="Label selector"
+          code={JSON.stringify(labelSelector, undefined, 2)}
+        />
+      ) : (
+        "{}"
+      )}
+    </React.Fragment>
+  );
 };
 
 const PlacementGroupTable = ({
@@ -61,6 +88,7 @@ const PlacementGroupTable = ({
     { label: "Job Id" },
     { label: "State" },
     { label: "Reserved Resources" },
+    { label: "Label Selector" },
     { label: "Scheduling Detail" },
   ];
 
@@ -179,6 +207,9 @@ const PlacementGroupTable = ({
                   </TableCell>
                   <TableCell align="center">
                     <BundleResourceRequirements bundles={bundles} />
+                  </TableCell>
+                  <TableCell align="center">
+                    <LabelSelector bundles={bundles} />
                   </TableCell>
                   <TableCell align="center">
                     {stats ? stats.scheduling_state : "-"}

--- a/python/ray/dashboard/client/src/components/PlacementGroupTable.tsx
+++ b/python/ray/dashboard/client/src/components/PlacementGroupTable.tsx
@@ -38,7 +38,7 @@ const BundleResourceRequirements = ({
           code={JSON.stringify(resources, undefined, 2)}
         />
       ) : (
-        "{}"
+        "[]"
       )}
     </React.Fragment>
   );
@@ -59,7 +59,7 @@ const LabelSelector = ({
           code={JSON.stringify(labelSelector, undefined, 2)}
         />
       ) : (
-        "{}"
+        "[]"
       )}
     </React.Fragment>
   );

--- a/python/ray/dashboard/client/src/pages/actor/ActorDetail.tsx
+++ b/python/ray/dashboard/client/src/pages/actor/ActorDetail.tsx
@@ -1,7 +1,10 @@
 import { Box } from "@mui/material";
 import React from "react";
 import { Outlet } from "react-router-dom";
-import { CodeDialogButton } from "../../common/CodeDialogButton";
+import {
+  CodeDialogButton,
+  CodeDialogButtonWithPreview,
+} from "../../common/CodeDialogButton";
 import { CollapsibleSection } from "../../common/CollapsibleSection";
 import { DurationText } from "../../common/DurationText";
 import { formatDateFromTimeMs } from "../../common/formatUtils";
@@ -217,6 +220,47 @@ const ActorDetailPage = () => {
                     'Call site not recorded. To enable, set environment variable "RAY_record_task_actor_creation_sites" to "true".'
                   }
                 />
+              </Box>
+            ),
+          },
+          {
+            label: "Required Resources",
+            content: (
+              <Box display="inline-block">
+                {Object.entries(actorDetail.requiredResources || {}).length >
+                0 ? (
+                  <CodeDialogButtonWithPreview
+                    sx={{ maxWidth: 200 }}
+                    title="Required resources"
+                    code={JSON.stringify(
+                      actorDetail.requiredResources,
+                      undefined,
+                      2,
+                    )}
+                  />
+                ) : (
+                  "{}"
+                )}
+              </Box>
+            ),
+          },
+          {
+            label: "Label Selector",
+            content: (
+              <Box display="inline-block">
+                {Object.entries(actorDetail.labelSelector || {}).length > 0 ? (
+                  <CodeDialogButtonWithPreview
+                    sx={{ maxWidth: 200 }}
+                    title="Label selector"
+                    code={JSON.stringify(
+                      actorDetail.labelSelector,
+                      undefined,
+                      2,
+                    )}
+                  />
+                ) : (
+                  "{}"
+                )}
               </Box>
             ),
           },

--- a/python/ray/dashboard/client/src/pages/task/TaskPage.tsx
+++ b/python/ray/dashboard/client/src/pages/task/TaskPage.tsx
@@ -90,6 +90,7 @@ const TaskPageContents = ({
     func_or_class_name,
     name,
     call_site,
+    label_selector,
   } = task;
   const isTaskActive = task.state === "RUNNING" && task.worker_id;
 
@@ -194,6 +195,21 @@ const TaskPageContents = ({
                   value: "{}",
                 }
               ),
+          },
+          {
+            label: "Label Selector",
+            content: (
+              <Box display="inline-block">
+                {Object.entries(label_selector || {}).length > 0 ? (
+                  <CodeDialogButtonWithPreview
+                    title="Label selector"
+                    code={JSON.stringify(label_selector, undefined, 2)}
+                  />
+                ) : (
+                  "{}"
+                )}
+              </Box>
+            ),
           },
           {
             label: "Started at",

--- a/python/ray/dashboard/client/src/type/placementGroup.ts
+++ b/python/ray/dashboard/client/src/type/placementGroup.ts
@@ -12,6 +12,9 @@ export type Bundle = {
   unit_resources: {
     [key: string]: number;
   };
+  label_selector?: {
+    [key: string]: string;
+  } | null;
 };
 
 export type PlacementGroup = {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Follow-up to https://github.com/ray-project/ray/pull/53423

Missed a few places in the UI.
Also updates placement group tables to use the same code preview component as the actor and tasks tables.

Placement group table
![Screenshot 2025-07-02 at 4 00 53 PM](https://github.com/user-attachments/assets/8de97470-abda-4680-b2fb-a4f90add0063)
![Screenshot 2025-07-02 at 4 00 56 PM](https://github.com/user-attachments/assets/a3c37e6f-c9db-4b37-b873-a5fbbd3012d7)

Actor detail
![Screenshot 2025-07-02 at 4 01 05 PM](https://github.com/user-attachments/assets/839cdaea-b441-4380-9c77-4ccb4ebfe563)

Task detail
![Screenshot 2025-07-02 at 4 01 19 PM](https://github.com/user-attachments/assets/aa12461c-a192-4114-a7fd-824613b9c6e6)


<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
