### PR TITLE
[core][refactor/02] move TaskResubmissionInterface in a header file

### DIFF
--- a/src/ray/core_worker/BUILD.bazel
+++ b/src/ray/core_worker/BUILD.bazel
@@ -275,6 +275,17 @@ ray_cc_library(
 )
 
 ray_cc_library(
+    name = "task_resubmission",
+    hdrs = ["task_resubmission.h"],
+    deps = [
+        "//src/ray/common:id",
+        "//src/ray/protobuf:common_cc_proto",
+        "//src/ray/protobuf:worker_cc_proto",
+        "@com_google_absl//absl/types:optional",
+    ]
+)
+
+ray_cc_library(
     name = "task_manager",
     srcs = ["task_manager.cc"],
     hdrs = ["task_manager.h"],
@@ -283,6 +294,7 @@ ray_cc_library(
         ":memory_store",
         ":task_event_buffer",
         ":task_finisher",
+        ":task_resubmission",
         "//src/ray/gcs:gcs_pb_util",
         "//src/ray/common:id",
         "//src/ray/common:ray_object",

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -27,6 +27,7 @@
 #include "ray/core_worker/store_provider/memory_store/memory_store.h"
 #include "ray/core_worker/task_event_buffer.h"
 #include "ray/core_worker/task_finisher.h"
+#include "ray/core_worker/task_resubmission.h"
 #include "ray/stats/metric_defs.h"
 #include "ray/util/counter_map.h"
 #include "src/ray/protobuf/common.pb.h"
@@ -37,14 +38,6 @@ namespace ray {
 namespace core {
 
 class ActorManager;
-
-class TaskResubmissionInterface {
- public:
-  virtual std::optional<rpc::ErrorType> ResubmitTask(
-      const TaskID &task_id, std::vector<ObjectID> *task_deps) = 0;
-
-  virtual ~TaskResubmissionInterface() = default;
-};
 
 using TaskStatusCounter = CounterMap<std::tuple<std::string, rpc::TaskStatus, bool>>;
 using PutInLocalPlasmaCallback =

--- a/src/ray/core_worker/task_resubmission.h
+++ b/src/ray/core_worker/task_resubmission.h
@@ -1,0 +1,35 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <vector>
+
+#include "absl/types/optional.h"
+#include "ray/common/id.h"
+#include "src/ray/protobuf/core_worker.pb.h"
+
+namespace ray {
+namespace core {
+
+class TaskResubmissionInterface {
+ public:
+  virtual std::optional<rpc::ErrorType> ResubmitTask(
+      const TaskID &task_id, std::vector<ObjectID> *task_deps) = 0;
+
+  virtual ~TaskResubmissionInterface() = default;
+};
+
+}  // namespace core
+}  // namespace ray


### PR DESCRIPTION
This is part of my effort to clean up `TaskManager`, move its interface into its own header file to reduce the complexity of `task_manager.h`

Test:
- CI