### PR TITLE
disable uvicorn message logger middleware

### DIFF
--- a/python/ray/serve/_private/http_util.py
+++ b/python/ray/serve/_private/http_util.py
@@ -718,6 +718,11 @@ async def start_asgi_http_server(
             f"Failed to bind to address '{http_options.host}:{http_options.port}'."
         ) from e
 
+    # Even though we set log_level=None, uvicorn adds MessageLoggerMiddleware
+    # if log level for uvicorn.error is not set. And MessageLoggerMiddleware
+    # of no use to us.
+    logging.getLogger("uvicorn.error").level = logging.CRITICAL
+
     # NOTE: We have to use lower level uvicorn Config and Server
     # class because we want to run the server as a coroutine. The only
     # alternative is to call uvicorn.run which is blocking.

--- a/python/ray/serve/_private/http_util.py
+++ b/python/ray/serve/_private/http_util.py
@@ -720,7 +720,7 @@ async def start_asgi_http_server(
 
     # Even though we set log_level=None, uvicorn adds MessageLoggerMiddleware
     # if log level for uvicorn.error is not set. And MessageLoggerMiddleware
-    # of no use to us.
+    # has no use to us.
     logging.getLogger("uvicorn.error").level = logging.CRITICAL
 
     # NOTE: We have to use lower level uvicorn Config and Server


### PR DESCRIPTION
with message logger middleware
```
Requests per second:    387.81 [#/sec] (mean)
Time per request:       257.855 [ms] (mean)
```

without message logger middleware
```
Requests per second:    400.14 [#/sec] (mean)
Time per request:       249.915 [ms] (mean)
```

repro script
```python
from ray import serve
import asyncio
import logging
from fastapi import FastAPI

logger = logging.getLogger(__name__)

@serve.deployment(max_ongoing_requests=1000)
class MyDeployment:

    def __call__(self):
        return "Hello, world!"


app = MyDeployment.bind()
```

machine `m6a.2xlarge`
load test command `ab -n 2000 -c 100 "http://127.0.0.1:8000/"`


same result using locust
<img width="1502" alt="image" src="https://github.com/user-attachments/assets/4c096454-f40d-40cf-bbac-c752657990ff" />
