### PR TITLE
Updated stalebot to add bounced label and exempt labels

### DIFF
--- a/.github/workflows/stale_pull_request.yaml
+++ b/.github/workflows/stale_pull_request.yaml
@@ -69,7 +69,7 @@ jobs:
           # Remove stale label from PRs on update (default is true)
           remove-pr-stale-when-updated: true
 
-          #Add bounced label. Whenever a PR is marked as 'bounced' it will not be marked stale again.
+          # Add bounced label. Whenever a PR is marked as 'bounced' it will not be marked stale again.
           labels-to-add-when-unstale: bounced
 
           ascending: true

--- a/.github/workflows/stale_pull_request.yaml
+++ b/.github/workflows/stale_pull_request.yaml
@@ -56,7 +56,8 @@ jobs:
           # Pull Requests with these labels will never be considered stale
           exempt-pr-labels: >
             weekly-release-blocker,
-            release-blocker
+            release-blocker,
+            bounced
 
           # Set to true to ignore PRs in a milestone (defaults to false)
           exempt-all-pr-milestones: true
@@ -67,5 +68,8 @@ jobs:
 
           # Remove stale label from PRs on update (default is true)
           remove-pr-stale-when-updated: true
+
+          #Add bounced label. Whenever a PR is marked as 'bounced' it will not be marked stale again.
+          labels-to-add-when-unstale: bounced
 
           ascending: true


### PR DESCRIPTION
## Why are these changes needed?
We've had some stalebot conflicts where PRs are being marked stale repeatedly. This is so that if a PR is marked "unstale", it will add a `bounced` label. If a PR has this label, it will never be marked stale again. 

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
