### PR TITLE
[core] Skip generator reconstruction test

### DIFF
--- a/python/ray/tests/test_streaming_generator_2.py
+++ b/python/ray/tests/test_streaming_generator_2.py
@@ -49,7 +49,7 @@ def assert_no_leak(filter_refs=None):
 
 
 @pytest.mark.skip(
-    reason="This test is flaky on darwin as of https://github.com/ray-project/ray/pull/53999. See "
+    reason="This test is flaky on darwin as of https://github.com/ray-project/ray/pull/53999. See https://github.com/ray-project/ray/pull/54320 for context on when to stop skipping."
 )
 def test_reconstruction(ray_start_cluster):
     cluster = ray_start_cluster

--- a/python/ray/tests/test_streaming_generator_2.py
+++ b/python/ray/tests/test_streaming_generator_2.py
@@ -49,7 +49,8 @@ def assert_no_leak(filter_refs=None):
 
 
 @pytest.mark.skip(
-    reason="This test is flaky on darwin as of https://github.com/ray-project/ray/pull/53999. See https://github.com/ray-project/ray/pull/54320 for context on when to stop skipping."
+    reason="This test is flaky on darwin as of https://github.com/ray-project/ray/pull/53999."
+    "See https://github.com/ray-project/ray/pull/54320 for context on when to stop skipping."
 )
 def test_reconstruction(ray_start_cluster):
     cluster = ray_start_cluster

--- a/python/ray/tests/test_streaming_generator_2.py
+++ b/python/ray/tests/test_streaming_generator_2.py
@@ -48,29 +48,23 @@ def assert_no_leak(filter_refs=None):
     wait_for_condition(check)
 
 
-@pytest.mark.parametrize("delay", [True])
-def test_reconstruction(monkeypatch, ray_start_cluster, delay):
-    with monkeypatch.context() as m:
-        if delay:
-            m.setenv(
-                "RAY_testing_asio_delay_us",
-                "CoreWorkerService.grpc_server."
-                "ReportGeneratorItemReturns=10000:1000000",
-            )
-        cluster = ray_start_cluster
-        # Head node with no resources.
-        cluster.add_node(
-            num_cpus=0,
-            _system_config=RECONSTRUCTION_CONFIG,
-            enable_object_reconstruction=True,
-        )
-        ray.init(address=cluster.address)
-        # Node to place the initial object.
-        node_to_kill = cluster.add_node(num_cpus=1, object_store_memory=10**8)
-        cluster.wait_for_nodes()
+@pytest.mark.skip(
+    reason="This test is flaky on darwin as of https://github.com/ray-project/ray/pull/53999. See "
+)
+def test_reconstruction(ray_start_cluster):
+    cluster = ray_start_cluster
+    # Head node with no resources.
+    cluster.add_node(
+        num_cpus=0,
+        _system_config=RECONSTRUCTION_CONFIG,
+    )
+    ray.init(address=cluster.address)
+    # Node to place the initial object.
+    node_to_kill = cluster.add_node(num_cpus=1, object_store_memory=10**8)
+    cluster.wait_for_nodes()
 
     @ray.remote(max_retries=2)
-    def dynamic_generator(num_returns):
+    def generator(num_returns):
         for i in range(num_returns):
             yield np.ones(1_000_000, dtype=np.int8) * i
 
@@ -79,7 +73,7 @@ def test_reconstruction(monkeypatch, ray_start_cluster, delay):
         return x[0]
 
     # Test recovery of all dynamic objects through re-execution.
-    gen = dynamic_generator.remote(10)
+    gen = generator.remote(10)
     refs = []
 
     for i in range(5):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
https://github.com/ray-project/ray/pull/53999 resulted in this test being flaky on mac. This test's purpose seems to be similar to https://github.com/ray-project/ray/blob/986115ce566fda437c5e3fcca3705c225b06f3b8/python/ray/tests/test_streaming_generator_4.py#L73 and was kind of trying to test a feature that didn't exist. But since it wasn't actually pausing the generator for backpressure, the generator would usually finish before the node removal actually happens. Now sometimes when the node removal happens before the generator finishes, we'll lose objects and go through the new path. We could also go through the new resubmission path multiple times for one node death because multiple objects from the same generator may be marked lost. Therefore, sometimes we run out of retries before getting to the third retry in the test and it fails with `ray.exceptions.RayTaskError(ObjectReconstructionFailedMaxAttemptsExceededError)`

The fix to make this not flaky would be to do the follow up listed in the previous pr.
> Currently, if multiple objects from the same generator are queued up to be recovered when the recovery periodical runner runs, we could resubmit for the first object and then once again queue up a resubmit for the second if argument resolution and sequence numbering lines up. Since this doesn't actually affect correctness and requires a bit of refactoring, it'll be in a follow-up PR.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
