### PR TITLE
[wheel] mac: upgrade arm64 wheel to macos 12

### DIFF
--- a/ci/ray_ci/automation/ray_wheels_lib.py
+++ b/ci/ray_ci/automation/ray_wheels_lib.py
@@ -17,7 +17,7 @@ ALL_PLATFORMS = [
     "manylinux2014_x86_64",
     "manylinux2014_aarch64",
     "macosx_12_0_x86_64",
-    "macosx_11_0_arm64",
+    "macosx_12_0_arm64",
     "win_amd64",
 ]
 RAY_TYPES = ["ray", "ray_cpp"]

--- a/ci/ray_ci/automation/test_pypi_lib.py
+++ b/ci/ray_ci/automation/test_pypi_lib.py
@@ -58,8 +58,8 @@ def test_get_pypi_token_fail(mock_boto3_client):
 def test_upload_wheels_to_pypi(mock_subprocess, mock_get_pypi_url, mock_get_pypi_token):
     pypi_env = "test"
     wheels = [
-        "ray_cpp-2.9.3-cp310-cp310-macosx_11_0_arm64.whl",
-        "ray_cpp-2.9.3-cp311-cp311-macosx_11_0_arm64.whl",
+        "ray_cpp-2.9.3-cp310-cp310-macosx_12_0_arm64.whl",
+        "ray_cpp-2.9.3-cp311-cp311-macosx_12_0_arm64.whl",
     ]
     mock_get_pypi_token.return_value = "test_token"
     mock_get_pypi_url.return_value = "test_pypi_url"
@@ -97,8 +97,8 @@ def test_upload_wheels_to_pypi_fail_twine_upload(
 ):
     pypi_env = "test"
     wheels = [
-        "ray_cpp-2.9.3-cp310-cp310-macosx_11_0_arm64.whl",
-        "ray_cpp-2.9.3-cp311-cp311-macosx_11_0_arm64.whl",
+        "ray_cpp-2.9.3-cp310-cp310-macosx_12_0_arm64.whl",
+        "ray_cpp-2.9.3-cp311-cp311-macosx_12_0_arm64.whl",
     ]
     mock_get_pypi_token.return_value = "test_token"
     mock_get_pypi_url.return_value = "test_pypi_url"
@@ -117,8 +117,8 @@ def test_upload_wheels_to_pypi_fail_twine_upload(
 def test_upload_wheels_to_pypi_fail_get_pypi(mock_get_pypi_url, mock_get_pypi_token):
     pypi_env = "test"
     wheels = [
-        "ray_cpp-2.9.3-cp310-cp310-macosx_11_0_arm64.whl",
-        "ray_cpp-2.9.3-cp311-cp311-macosx_11_0_arm64.whl",
+        "ray_cpp-2.9.3-cp310-cp310-macosx_12_0_arm64.whl",
+        "ray_cpp-2.9.3-cp311-cp311-macosx_12_0_arm64.whl",
     ]
     mock_get_pypi_token.side_effect = ValueError("Invalid pypi_env: test")
     mock_get_pypi_url.side_effect = ValueError("Invalid pypi_env: test")

--- a/ci/ray_ci/automation/test_ray_wheels_lib.py
+++ b/ci/ray_ci/automation/test_ray_wheels_lib.py
@@ -21,7 +21,7 @@ SAMPLE_WHEELS = [
     "ray-1.0.0-cp39-cp39-manylinux2014_x86_64",
     "ray-1.0.0-cp39-cp39-manylinux2014_aarch64",
     "ray-1.0.0-cp39-cp39-macosx_12_0_x86_64",
-    "ray-1.0.0-cp39-cp39-macosx_11_0_arm64",
+    "ray-1.0.0-cp39-cp39-macosx_12_0_arm64",
     "ray-1.0.0-cp39-cp39-win_amd64",
 ]
 
@@ -58,7 +58,7 @@ def test_check_downloaded_wheels():
             "ray-1.0.0-cp39-cp39-manylinux2014_x86_64",
             "ray-1.0.0-cp39-cp39-manylinux2014_aarch64",
             "ray-1.0.0-cp39-cp39-macosx_12_0_x86_64",
-            "ray-1.0.0-cp39-cp39-macosx_11_0_arm64",
+            "ray-1.0.0-cp39-cp39-macosx_12_0_arm64",
             "ray-1.0.0-cp39-cp39-win_amd64",
         ]
 
@@ -75,7 +75,7 @@ def test_check_downloaded_wheels_fail():
             "ray-1.0.0-cp39-cp39-manylinux2014_x86_64",
             "ray-1.0.0-cp39-cp39-manylinux2014_aarch64",
             "ray-1.0.0-cp39-cp39-macosx_12_0_x86_64",
-            "ray-1.0.0-cp39-cp39-macosx_11_0_arm64",
+            "ray-1.0.0-cp39-cp39-macosx_12_0_arm64",
             "ray-1.0.0-cp39-cp39-win_amd64",
         ]
 
@@ -94,7 +94,7 @@ def test_download_wheel_from_s3(mock_boto3_client):
             "releases/1.0.0/1234567/ray-1.0.0-cp39-cp39-manylinux2014_x86_64.whl",
             "releases/1.0.0/1234567/ray-1.0.0-cp39-cp39-manylinux2014_aarch64.whl",
             "releases/1.0.0/1234567/ray-1.0.0-cp39-cp39-macosx_12_0_x86_64.whl",
-            "releases/1.0.0/1234567/ray-1.0.0-cp39-cp39-macosx_11_0_arm64.whl",
+            "releases/1.0.0/1234567/ray-1.0.0-cp39-cp39-macosx_12_0_arm64.whl",
             "releases/1.0.0/1234567/ray-1.0.0-cp39-cp39-win_amd64.whl",
         ]
         for key in keys:

--- a/doc/source/ray-overview/installation.rst
+++ b/doc/source/ray-overview/installation.rst
@@ -163,11 +163,11 @@ You can install the nightly Ray wheels via the following links. These daily rele
 .. _`MacOS Python 3.12 (x86_64)`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp312-cp312-macosx_12_0_x86_64.whl
 .. _`MacOS Python 3.13 (x86_64)`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp313-cp313-macosx_12_0_x86_64.whl
 
-.. _`MacOS Python 3.9 (arm64)`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-macosx_11_0_arm64.whl
-.. _`MacOS Python 3.10 (arm64)`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp310-cp310-macosx_11_0_arm64.whl
-.. _`MacOS Python 3.11 (arm64)`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp311-cp311-macosx_11_0_arm64.whl
-.. _`MacOS Python 3.12 (arm64)`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp312-cp312-macosx_11_0_arm64.whl
-.. _`MacOS Python 3.13 (arm64)`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp313-cp313-macosx_11_0_arm64.whl
+.. _`MacOS Python 3.9 (arm64)`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-macosx_12_0_arm64.whl
+.. _`MacOS Python 3.10 (arm64)`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp310-cp310-macosx_12_0_arm64.whl
+.. _`MacOS Python 3.11 (arm64)`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp311-cp311-macosx_12_0_arm64.whl
+.. _`MacOS Python 3.12 (arm64)`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp312-cp312-macosx_12_0_arm64.whl
+.. _`MacOS Python 3.13 (arm64)`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp313-cp313-macosx_12_0_arm64.whl
 
 
 .. _`Windows Python 3.9`: https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-win_amd64.whl

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -916,9 +916,9 @@ def get_wheel_filename(
     architecture = architecture or platform.processor()
 
     if py_version_str in ["311", "310", "39", "38"] and architecture == "arm64":
-        darwin_os_string = "macosx_11_0_arm64"
+        darwin_os_string = "macosx_12_0_arm64"
     else:
-        darwin_os_string = "macosx_10_15_x86_64"
+        darwin_os_string = "macosx_12_0_x86_64"
 
     if architecture == "aarch64":
         linux_os_string = "manylinux2014_aarch64"

--- a/python/ray/tests/test_runtime_env_get_wheel_names.py
+++ b/python/ray/tests/test_runtime_env_get_wheel_names.py
@@ -34,7 +34,10 @@ def test_get_master_wheel_url():
     # This should be a commit for which wheels have already been built for
     # all platforms and python versions at
     # `s3://ray-wheels/master/<test_commit>/`.
-    test_commit = "593d04aba2726a0104280d1bdbc2779e3a8ba7d4"
+    #
+    # Link to commit:
+    # https://github.com/ray-project/ray/commit/263c7e1e66746c03f16e8ee20753d05a9936f6f0
+    test_commit = "263c7e1e66746c03f16e8ee20753d05a9936f6f0"
     for sys_platform in ["darwin", "linux", "win32"]:
         for py_version in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS:
             url = get_master_wheel_url(
@@ -48,7 +51,7 @@ def test_get_release_wheel_url():
     # This should be a commit for which wheels have already been built for
     # all platforms and python versions at
     # `s3://ray-wheels/releases/2.2.0/<commit>/`.
-    test_commits = {"2.31.0": "1240d3fc326517f9be28bb7897c1c88619f0d984"}
+    test_commits = {"2.47.1": "61d3f2f1aa33563faa398105f4abda88cb39440b"}
     for sys_platform in ["darwin", "linux", "win32"]:
         for py_version in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS:
             for version, commit in test_commits.items():


### PR DESCRIPTION
now wheels for both intel and apple silicon are on the same version

`ray[all]` does not work on arm64 macos 11 anyways, as `scipy` does not have the related wheels
