### PR TITLE
reduce number of loops over request headers from 2 to 1

### DIFF
--- a/python/ray/serve/_private/http_util.py
+++ b/python/ray/serve/_private/http_util.py
@@ -668,9 +668,9 @@ class RequestIdMiddleware:
         async def send_with_request_id(message: Message):
             if message["type"] == "http.response.start":
                 headers = MutableHeaders(scope=message)
-                headers.append(SERVE_HTTP_REQUEST_ID_HEADER, request_id)
+                headers.append("X-Request-ID", request_id)
             if message["type"] == "websocket.accept":
-                message[SERVE_HTTP_REQUEST_ID_HEADER] = request_id
+                message["X-Request-ID"] = request_id
             await send(message)
 
         await self._app(scope, receive, send_with_request_id)

--- a/python/ray/serve/_private/http_util.py
+++ b/python/ray/serve/_private/http_util.py
@@ -662,8 +662,6 @@ class RequestIdMiddleware:
         if request_id is None:
             request_id = generate_request_id()
             headers.append(SERVE_HTTP_REQUEST_ID_HEADER, request_id)
-        else:
-            request_id = headers[SERVE_HTTP_REQUEST_ID_HEADER]
 
         async def send_with_request_id(message: Message):
             if message["type"] == "http.response.start":


### PR DESCRIPTION
`__getitem__` on headers is a O(n) operation. Optimize the code to cut out the extra loop.