### PR TITLE
Fix `test_runtime_env_container`

### DIFF
--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -9,7 +9,6 @@ from copy import copy, deepcopy
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import grpc
-import httpx
 import requests
 from starlette.requests import Request
 
@@ -423,18 +422,6 @@ def check_telemetry(
     print(report["extra_usage_tags"])
     assert tag.get_value_from_report(report) == expected
     return True
-
-
-CONNECTION_ERROR_MSG = "connection error"
-
-
-def ping_endpoint(endpoint: str, params: str = ""):
-    endpoint = endpoint.lstrip("/")
-
-    try:
-        return httpx.get(f"http://localhost:8000/{endpoint}{params}").text
-    except httpx.HTTPError:
-        return CONNECTION_ERROR_MSG
 
 
 def ping_grpc_list_applications(channel, app_names, test_draining=False):

--- a/python/ray/serve/tests/test_cli_2.py
+++ b/python/ray/serve/tests/test_cli_2.py
@@ -17,7 +17,6 @@ from ray import serve
 from ray._common.test_utils import wait_for_condition
 from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME, SERVE_NAMESPACE
 from ray.serve._private.test_utils import (
-    ping_endpoint,
     ping_fruit_stand,
     ping_grpc_another_method,
     ping_grpc_call_method,
@@ -30,6 +29,15 @@ from ray.serve.generated import serve_pb2, serve_pb2_grpc
 from ray.util.state import list_actors
 
 CONNECTION_ERROR_MSG = "connection error"
+
+
+def ping_endpoint(endpoint: str, params: str = ""):
+    endpoint = endpoint.lstrip("/")
+
+    try:
+        return httpx.get(f"http://localhost:8000/{endpoint}{params}").text
+    except httpx.HTTPError:
+        return CONNECTION_ERROR_MSG
 
 
 def check_app_status(app_name: str, expected_status: str):

--- a/python/ray/serve/tests/test_cli_3.py
+++ b/python/ray/serve/tests/test_cli_3.py
@@ -13,7 +13,6 @@ from ray import serve
 from ray._common.pydantic_compat import BaseModel
 from ray._common.test_utils import wait_for_condition
 from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
-from ray.serve._private.test_utils import ping_endpoint
 from ray.serve.handle import DeploymentHandle
 from ray.serve.tests.common.remote_uris import (
     TEST_DAG_PINNED_URI,
@@ -21,6 +20,15 @@ from ray.serve.tests.common.remote_uris import (
 )
 
 CONNECTION_ERROR_MSG = "connection error"
+
+
+def ping_endpoint(endpoint: str, params: str = ""):
+    endpoint = endpoint.lstrip("/")
+
+    try:
+        return httpx.get(f"http://localhost:8000/{endpoint}{params}").text
+    except httpx.HTTPError:
+        return CONNECTION_ERROR_MSG
 
 
 def check_app_status(app_name: str, expected_status: str):


### PR DESCRIPTION
Move `httpx` out of `test_utils` because for some reason it is not available in the image used for `test_runtime_env_container.