### PR TITLE
[serve] configure http options in controller

### DIFF
--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -36,6 +36,10 @@ from ray.serve._private.default_impl import create_cluster_node_info_cache
 from ray.serve._private.deployment_info import DeploymentInfo
 from ray.serve._private.deployment_state import DeploymentStateManager
 from ray.serve._private.endpoint_state import EndpointState
+from ray.serve._private.http_util import (
+    configure_http_options_with_defaults,
+    set_proxy_default_grpc_options,
+)
 from ray.serve._private.logging_utils import (
     configure_component_cpu_profiler,
     configure_component_logger,
@@ -156,13 +160,16 @@ class ServeController:
         self.cluster_node_info_cache = create_cluster_node_info_cache(self.gcs_client)
         self.cluster_node_info_cache.update()
 
+        # Configure proxy default HTTP and gRPC options.
         self.proxy_state_manager = ProxyStateManager(
-            http_options=http_options,
+            http_options=configure_http_options_with_defaults(http_options),
             head_node_id=self._controller_node_id,
             cluster_node_info_cache=self.cluster_node_info_cache,
             logging_config=self.global_logging_config,
-            grpc_options=grpc_options,
+            grpc_options=set_proxy_default_grpc_options(grpc_options),
         )
+        # We modify the HTTP and gRPC options above, so delete them to avoid
+        del http_options, grpc_options
 
         self.endpoint_state = EndpointState(self.kv_store, self.long_poll_host)
 

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -36,9 +36,9 @@ from ray.serve._private.default_impl import create_cluster_node_info_cache
 from ray.serve._private.deployment_info import DeploymentInfo
 from ray.serve._private.deployment_state import DeploymentStateManager
 from ray.serve._private.endpoint_state import EndpointState
+from ray.serve._private.grpc_util import set_proxy_default_grpc_options
 from ray.serve._private.http_util import (
     configure_http_options_with_defaults,
-    set_proxy_default_grpc_options,
 )
 from ray.serve._private.logging_utils import (
     configure_component_cpu_profiler,

--- a/python/ray/serve/_private/http_util.py
+++ b/python/ray/serve/_private/http_util.py
@@ -46,7 +46,7 @@ from ray.serve._private.utils import (
     generate_request_id,
     serve_encoders,
 )
-from ray.serve.config import HTTPOptions
+from ray.serve.config import HTTPOptions, gRPCOptions
 from ray.serve.exceptions import (
     BackPressureError,
     DeploymentUnavailableError,
@@ -797,6 +797,16 @@ def send_http_response_on_exception(
         status.message,
         status_code=status.code,
     )
+
+
+def set_proxy_default_grpc_options(grpc_options) -> gRPCOptions:
+    grpc_options = deepcopy(grpc_options) or gRPCOptions()
+
+    grpc_options.request_timeout_s = (
+        grpc_options.request_timeout_s or RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S
+    )
+
+    return grpc_options
 
 
 def configure_http_options_with_defaults(http_options: HTTPOptions) -> HTTPOptions:

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -44,6 +44,7 @@ from ray.serve._private.grpc_util import (
 )
 from ray.serve._private.http_util import (
     MessageQueue,
+    configure_http_middlewares,
     convert_object_to_asgi_messages,
     get_http_response_status,
     receive_http_body,
@@ -1009,8 +1010,8 @@ class ProxyActor:
     def __init__(
         self,
         http_options: HTTPOptions,
+        grpc_options: gRPCOptions,
         *,
-        grpc_options: Optional[gRPCOptions] = None,
         node_id: NodeId,
         node_ip_address: str,
         logging_config: LoggingConfig,
@@ -1018,9 +1019,8 @@ class ProxyActor:
     ):  # noqa: F821
         self._node_id = node_id
         self._node_ip_address = node_ip_address
-        self._http_options = http_options
+        self._http_options = configure_http_middlewares(http_options)
         self._grpc_options = grpc_options
-
         grpc_enabled = is_grpc_enabled(self._grpc_options)
 
         event_loop = get_or_create_event_loop()

--- a/python/ray/serve/tests/test_callback.py
+++ b/python/ray/serve/tests/test_callback.py
@@ -14,7 +14,7 @@ from ray._common.test_utils import wait_for_condition
 from ray.exceptions import RayActorError
 from ray.serve._private.test_utils import get_application_url
 from ray.serve._private.utils import call_function_from_import_path
-from ray.serve.config import HTTPOptions
+from ray.serve.config import HTTPOptions, gRPCOptions
 from ray.serve.context import _get_global_client
 from ray.serve.schema import LoggingConfig, ProxyStatus, ServeInstanceDetails
 
@@ -170,6 +170,7 @@ def test_callback_fail(ray_instance):
     actor_def = ray.serve._private.proxy.ProxyActor
     handle = actor_def.remote(
         http_options=HTTPOptions(host="http_proxy", root_path="/", port=123),
+        grpc_options=gRPCOptions(),
         node_ip_address="127.0.0.1",
         node_id="123",
         logging_config=LoggingConfig(),
@@ -182,6 +183,7 @@ def test_callback_fail(ray_instance):
     actor_def = ray.actor._make_actor(serve_controller, {})
     handle = actor_def.remote(
         http_options=HTTPOptions(),
+        grpc_options=gRPCOptions(),
         global_logging_config=LoggingConfig(),
     )
     with pytest.raises(RayActorError, match="cannot be imported"):
@@ -203,6 +205,7 @@ def test_http_proxy_return_aribitary_objects(ray_instance):
     actor_def = ray.serve._private.proxy.ProxyActor
     handle = actor_def.remote(
         http_options=HTTPOptions(host="http_proxy", root_path="/", port=123),
+        grpc_options=gRPCOptions(),
         node_ip_address="127.0.0.1",
         node_id="123",
         logging_config=LoggingConfig(),

--- a/python/ray/serve/tests/unit/test_http_util.py
+++ b/python/ray/serve/tests/unit/test_http_util.py
@@ -13,6 +13,7 @@ from ray.serve import HTTPOptions
 from ray.serve._private.http_util import (
     ASGIReceiveProxy,
     MessageQueue,
+    configure_http_middlewares,
     configure_http_options_with_defaults,
 )
 
@@ -359,7 +360,7 @@ class TestConfigureHttpOptionsWithDefaults:
         ]  # Return list of wrapped middleware
 
         # Act
-        result = configure_http_options_with_defaults(base_http_options)
+        result = configure_http_middlewares(base_http_options)
 
         # Assert
         mock_call_function.assert_called_once_with(


### PR DESCRIPTION
We set a bunch of defaults for http and grpc options in the proxy, but we should set them in the controller.