### PR TITLE
[serve] deflake test_multiplex

### DIFF
--- a/python/ray/serve/tests/test_multiplex.py
+++ b/python/ray/serve/tests/test_multiplex.py
@@ -535,8 +535,9 @@ def test_replica_upgrade_to_cleanup_resource(serve_instance):
             self.model_id = model_id
             self.record_handle = record_handle
 
-        def __del__(self):
-            self.record_handle.add.remote(self.model_id)
+        async def __del__(self):
+            await asyncio.sleep(10)
+            await self.record_handle.add.remote(self.model_id)
 
         def __eq__(self, model):
             return model.model_id == self.model_id

--- a/python/ray/serve/tests/test_multiplex.py
+++ b/python/ray/serve/tests/test_multiplex.py
@@ -536,7 +536,6 @@ def test_replica_upgrade_to_cleanup_resource(serve_instance):
             self.record_handle = record_handle
 
         async def __del__(self):
-            await asyncio.sleep(10)
             await self.record_handle.add.remote(self.model_id)
 
         def __eq__(self, model):


### PR DESCRIPTION
## Why are these changes needed?

Deflake `test_multiplex`.
https://buildkite.com/ray-project/postmerge/builds/11232#0197cd9b-97d6-4c15-9d3e-8740c601ecef/177-1298

Waiting for the `record_handle.add.remote` call to go through in `__del__`.