### PR TITLE
[data.llm] Log engine stats after each batch task is done.

### DIFF
--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -475,7 +475,6 @@ class vLLMEngineStageUDF(StatefulStageUDF):
             model=self.model,
             model_source=model_source,
             idx_in_batch_column=self.IDX_IN_BATCH_COLUMN,
-            disable_log_stats=False,
             disable_log_requests=True,
             max_pending_requests=self.max_pending_requests,
             dynamic_lora_loading_path=dynamic_lora_loading_path,
@@ -566,6 +565,11 @@ class vLLMEngineStageUDF(StatefulStageUDF):
             len(batch),
             time_taken,
         )
+        
+        # Log engine stats after each batch is done conditioned on the flag 
+        # passed to the engine.
+        if not self.engine_kwargs.get("disable_log_stats", False):
+            await self.llm.engine.do_log_stats()  
 
     def __del__(self):
         if hasattr(self, "llm"):

--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -565,11 +565,11 @@ class vLLMEngineStageUDF(StatefulStageUDF):
             len(batch),
             time_taken,
         )
-        
-        # Log engine stats after each batch is done conditioned on the flag 
+
+        # Log engine stats after each batch is done conditioned on the flag
         # passed to the engine.
         if not self.engine_kwargs.get("disable_log_stats", False):
-            await self.llm.engine.do_log_stats()  
+            await self.llm.engine.do_log_stats()
 
     def __del__(self):
         if hasattr(self, "llm"):


### PR DESCRIPTION
This will be gated by engine_kwargs parameter `disable_log_stats`, so that users will get to turn it off.