### PR TITLE
[data.llm] Make ray the distributed backend for vLLM stage

### DIFF
--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -649,9 +649,13 @@ class vLLMEngineStage(StatefulStage):
         pp_size = engine_kwargs.get("pipeline_parallel_size", 1)
         num_bundles_per_replica = tp_size * pp_size
 
-        # Use the MP backend by default.
-        engine_kwargs.setdefault("distributed_executor_backend", "mp")
-        executor_backend = engine_kwargs.get("distributed_executor_backend")
+        # Use the Ray backend by default.
+        executor_backend = engine_kwargs.get("distributed_executor_backend", "ray")
+        if executor_backend and executor_backend != "ray":
+            raise ValueError(
+                "Distributed executor backend must be ray when using Ray Data, but got %s"
+                % executor_backend
+            )
 
         # When Ray is used in the vLLM engine, we set num_devices to 0 so that
         # Ray Data won't reserve GPUs in advance. Instead, we specify scheduling

--- a/release/llm_tests/batch/llm_1xl4.yaml
+++ b/release/llm_tests/batch/llm_1xl4.yaml
@@ -1,0 +1,15 @@
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west-2
+
+head_node_type:
+    name: head_node
+    instance_type: m5.2xlarge
+    resources:
+      cpu: 0
+
+worker_node_types:
+    - name: worker_node
+      instance_type: g6.2xlarge
+      min_workers: 0
+      max_workers: 1
+      use_spot: false

--- a/release/llm_tests/batch/test_batch_vllm_single_gpu.py
+++ b/release/llm_tests/batch/test_batch_vllm_single_gpu.py
@@ -1,0 +1,49 @@
+import sys
+import logging
+
+import pytest
+
+import ray
+from ray.data.llm import build_llm_processor, vLLMEngineProcessorConfig
+
+logger = logging.getLogger(__name__)
+
+
+def test_run_processor_in_loop():
+    """Test running a processor in a loop."""
+
+    for _ in range(2):
+        processor_config = vLLMEngineProcessorConfig(
+            model_source="unsloth/Llama-3.2-1B-Instruct",
+            engine_kwargs=dict(
+                enforce_eager=True,
+            ),
+        )
+
+        ds = ray.data.range(10)
+        ds = ds.map(lambda x: {"id": x["id"], "val": x["id"] + 5})
+
+        processor = build_llm_processor(
+            processor_config,
+            preprocess=lambda row: dict(
+                messages=[
+                    {"role": "system", "content": "You are a calculator"},
+                    {"role": "user", "content": f"{row['id']} ** 3 = ?"},
+                ],
+                sampling_params=dict(
+                    max_tokens=10,
+                ),
+            ),
+            postprocess=lambda row: {
+                "resp": row["generated_text"],
+            },
+        )
+        ds = processor(ds)
+        ds = ds.materialize()
+        outs = ds.take_all()
+        assert len(outs) == 10
+        assert all("resp" in out for out in outs)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4374,6 +4374,26 @@
     script: >
       pytest -sv test_batch_vllm.py
 
+- name: llm_batch_vllm_single_gpu
+  frequency: nightly
+  python: "3.11"
+  group: llm-batch
+  team: llm
+  working_dir: llm_tests/batch
+
+  cluster:
+    byod:
+      type: llm-cu128
+    cluster_compute: llm_1xl4.yaml
+    # NOTE: Important for getting the correct secrets
+    cloud_id: cld_wy5a6nhazplvu32526ams61d98
+    project_id: prj_lhlrf1u5yv8qz9qg3xzw8fkiiq
+
+  run:
+    timeout: 3600
+    script: >
+      pytest -sv test_batch_vllm_single_gpu.py
+
 - name: llm_batch_sglang_llama
   frequency: nightly
   python: "3.11"


### PR DESCRIPTION
If we do not use ray distributed backend, then finishing the processor pipeling / ctrl + c ing on the running pipeline leads into zombie nvidia gpu processes which makes running consecutive pipelines not possible. 


TODO:
 - [x] Add a release test that runs two pipelines in a for loop on a single GPU machine. https://buildkite.com/ray-project/release/builds/47648