### PR TITLE
[data.llm] Decouple max_tasks_in_flight from max_concurrent_batches

### DIFF
--- a/python/ray/llm/_internal/batch/processor/base.py
+++ b/python/ray/llm/_internal/batch/processor/base.py
@@ -52,7 +52,9 @@ class ProcessorConfig(BaseModelExtended):
 
     experimental: Dict[str, Any] = Field(
         default_factory=dict,
-        description="[Experimental] Experimental configurations.",
+        description="[Experimental] Experimental configurations."
+        "Supported keys:\n"
+        "`max_tasks_in_flight_per_actor`: The maximum number of tasks in flight per actor. Default to 4.",
     )
 
     class Config:

--- a/python/ray/llm/_internal/batch/processor/base.py
+++ b/python/ray/llm/_internal/batch/processor/base.py
@@ -50,6 +50,11 @@ class ProcessorConfig(BaseModelExtended):
         description="The number of workers for data parallelism. Default to 1.",
     )
 
+    experimental: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="[Experimental] Experimental configurations.",
+    )
+
     class Config:
         validate_assignment = True
         arbitrary_types_allowed = True

--- a/python/ray/llm/_internal/batch/processor/sglang_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/sglang_engine_proc.py
@@ -125,8 +125,8 @@ def build_sglang_engine_processor(
                 compute=ray.data.ActorPoolStrategy(
                     min_size=config.concurrency,
                     max_size=config.concurrency,
-                    max_tasks_in_flight_per_actor=max(
-                        config.max_concurrent_batches, DEFAULT_MAX_TASKS_IN_FLIGHT
+                    max_tasks_in_flight_per_actor=config.experimental.get(
+                        "max_tasks_in_flight_per_actor", DEFAULT_MAX_TASKS_IN_FLIGHT
                     ),
                 ),
                 # The number of running batches "per actor" in Ray Core level.

--- a/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
@@ -161,8 +161,8 @@ def build_vllm_engine_processor(
                     # concurrency, start all instances without auto-scaling.
                     min_size=config.concurrency,
                     max_size=config.concurrency,
-                    max_tasks_in_flight_per_actor=max(
-                        config.max_concurrent_batches, DEFAULT_MAX_TASKS_IN_FLIGHT
+                    max_tasks_in_flight_per_actor=config.experimental.get(
+                        "max_tasks_in_flight_per_actor", DEFAULT_MAX_TASKS_IN_FLIGHT
                     ),
                 ),
                 # The number of running batches "per actor" in Ray Core level.

--- a/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
+++ b/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
@@ -4,8 +4,6 @@ from typing import Any, AsyncIterator, Dict, List, Type
 import pydantic
 import pytest
 
-
-
 import ray
 from ray.llm._internal.batch.processor import vLLMEngineProcessorConfig
 from ray.llm._internal.batch.processor.base import (
@@ -202,7 +200,6 @@ class TestProcessorConfig:
             model_source="unsloth/Llama-3.2-1B-Instruct",
         )
         assert config.concurrency == 1
-        
 
 
 if __name__ == "__main__":

--- a/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
+++ b/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
@@ -4,6 +4,8 @@ from typing import Any, AsyncIterator, Dict, List, Type
 import pydantic
 import pytest
 
+
+
 import ray
 from ray.llm._internal.batch.processor import vLLMEngineProcessorConfig
 from ray.llm._internal.batch.processor.base import (
@@ -200,6 +202,7 @@ class TestProcessorConfig:
             model_source="unsloth/Llama-3.2-1B-Instruct",
         )
         assert config.concurrency == 1
+        
 
 
 if __name__ == "__main__":

--- a/python/ray/llm/tests/batch/gpu/processor/test_sglang_engine_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_sglang_engine_proc.py
@@ -1,6 +1,7 @@
 """This test suite does not need sglang to be installed."""
 import sys
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 import ray
@@ -71,36 +72,46 @@ def test_sglang_engine_processor(gpu_type, model_llama_3_2_216M):
 
 
 class TestSGLangEngineProcessorConfig:
-
-    @pytest.mark.parametrize("experimental_config", [
-        {"max_tasks_in_flight_per_actor": 10},
-        {},
-    ])
-    def test_experimental_max_tasks_in_flight_per_actor_usage(self, experimental_config):
+    @pytest.mark.parametrize(
+        "experimental_config",
+        [
+            {"max_tasks_in_flight_per_actor": 10},
+            {},
+        ],
+    )
+    def test_experimental_max_tasks_in_flight_per_actor_usage(
+        self, experimental_config
+    ):
         """Tests that max_tasks_in_flight_per_actor is set properly in the ActorPoolStrategy."""
-        
-        from ray.llm._internal.batch.processor.sglang_engine_proc import (
-            build_sglang_engine_processor,
-            SGLangEngineProcessorConfig,
-        )
+
         from ray.llm._internal.batch.processor.base import DEFAULT_MAX_TASKS_IN_FLIGHT
-        
-        with patch('ray.data.ActorPoolStrategy') as mock_actor_pool:
+        from ray.llm._internal.batch.processor.sglang_engine_proc import (
+            SGLangEngineProcessorConfig,
+            build_sglang_engine_processor,
+        )
+
+        with patch("ray.data.ActorPoolStrategy") as mock_actor_pool:
             mock_actor_pool.return_value = MagicMock()
-            
+
             config = SGLangEngineProcessorConfig(
                 model_source="unsloth/Llama-3.2-1B-Instruct",
                 experimental=experimental_config,
             )
             build_sglang_engine_processor(config)
-            
+
             mock_actor_pool.assert_called()
             call_kwargs = mock_actor_pool.call_args[1]
             if experimental_config:
-                assert call_kwargs['max_tasks_in_flight_per_actor'] == experimental_config['max_tasks_in_flight_per_actor']
+                assert (
+                    call_kwargs["max_tasks_in_flight_per_actor"]
+                    == experimental_config["max_tasks_in_flight_per_actor"]
+                )
             else:
-                assert call_kwargs['max_tasks_in_flight_per_actor'] == DEFAULT_MAX_TASKS_IN_FLIGHT
-        
+                assert (
+                    call_kwargs["max_tasks_in_flight_per_actor"]
+                    == DEFAULT_MAX_TASKS_IN_FLIGHT
+                )
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/llm/tests/batch/gpu/processor/test_vllm_engine_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_vllm_engine_proc.py
@@ -1,6 +1,7 @@
 import sys
 
 import pytest
+from unittest.mock import patch, MagicMock
 
 import ray
 from ray.llm._internal.batch.processor import ProcessorBuilder
@@ -241,6 +242,38 @@ def test_vision_model(gpu_type, model_smolvlm_256m):
     assert len(outs) == 60
     assert all("resp" in out for out in outs)
 
+
+class TestVLLMEngineProcessorConfig:
+
+    @pytest.mark.parametrize("experimental_config", [
+        {"max_tasks_in_flight_per_actor": 10},
+        {},
+    ])
+    def test_experimental_max_tasks_in_flight_per_actor_usage(self, experimental_config):
+        """Tests that max_tasks_in_flight_per_actor is set properly in the ActorPoolStrategy."""
+        
+        from ray.llm._internal.batch.processor.vllm_engine_proc import (
+            build_vllm_engine_processor,
+            vLLMEngineProcessorConfig,
+        )
+        from ray.llm._internal.batch.processor.base import DEFAULT_MAX_TASKS_IN_FLIGHT
+        
+        with patch('ray.data.ActorPoolStrategy') as mock_actor_pool:
+            mock_actor_pool.return_value = MagicMock()
+            
+            config = vLLMEngineProcessorConfig(
+                model_source="unsloth/Llama-3.2-1B-Instruct",
+                experimental=experimental_config,
+            )
+            build_vllm_engine_processor(config)
+            
+            mock_actor_pool.assert_called()
+            call_kwargs = mock_actor_pool.call_args[1]
+            if experimental_config:
+                assert call_kwargs['max_tasks_in_flight_per_actor'] == experimental_config['max_tasks_in_flight_per_actor']
+            else:
+                assert call_kwargs['max_tasks_in_flight_per_actor'] == DEFAULT_MAX_TASKS_IN_FLIGHT
+        
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
In ray data llm, we have historically coupled number of max_tasks_per_actor_in_flight and max_concurrency in map batches. They are not necessarily coupled: `max_tasks_per_actor_in_flight` determines the number of blocks to process in parallel by spawning N tasks from each actor. `max_concurrent_batches` in an async udf controls the number of async tasks to run on the same thread of the ray task overlapping multiple batches within a block. 