### PR TITLE
[core] Deflake `test_reconstruction_suppression`

### DIFF
--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -207,7 +207,7 @@ def test_actor_restart_multiple_callers(ray_start_cluster):
         max_restarts=1,
         # Retry transient ActorUnavailableErrors.
         max_task_retries=-1,
-        # Schedule the counter on actor_worker_node.
+        # Schedule the actor on actor_worker_node.
         resources={"actor": 1},
     )
     class A:

--- a/python/ray/tests/test_actor_advanced.py
+++ b/python/ray/tests/test_actor_advanced.py
@@ -195,7 +195,7 @@ def test_actor_fail_during_constructor_restart(ray_start_cluster_head):
 
 def test_actor_restart_multiple_callers(ray_start_cluster):
     cluster = ray_start_cluster
-    head_node = cluster.add_node(num_cpus=4)
+    _ = cluster.add_node(num_cpus=4)
     ray.init(address=cluster.address)
 
     _ = cluster.add_node(num_cpus=4)


### PR DESCRIPTION
This test flakes in CI due to transient `ActorUnavailableError` (expected): https://buildkite.com/ray-project/postmerge/builds/11276#0197d8fa-8bfe-4d64-9422-be76cffedc02/177-1290

Reworked the test to:

- improve the name
- retry the `ActorUnavailableError`
- make the behavior deterministic
- reduce the number of excess nodes.