### PR TITLE
[core] Remove `test_get_locations_timeout`

### DIFF
--- a/python/ray/tests/test_get_locations.py
+++ b/python/ray/tests/test_get_locations.py
@@ -19,13 +19,11 @@ def test_get_locations_empty_list(ray_start_regular):
     assert len(locations) == 0
 
 
-def test_get_locations_timeout(ray_start_regular):
+def test_get_locations_zero_timeout(ray_start_regular):
     sizes = [100, 1000]
     obj_refs = [ray.put(np.zeros(s, dtype=np.uint8)) for s in sizes]
-    ray.wait(obj_refs)
-    timeout_ms = 0
     with pytest.raises(ray.exceptions.GetTimeoutError):
-        ray.experimental.get_object_locations(obj_refs, timeout_ms)
+        ray.experimental.get_object_locations(obj_refs, timeout_ms=0)
 
 
 def test_get_locations(ray_start_regular):

--- a/python/ray/tests/test_get_locations.py
+++ b/python/ray/tests/test_get_locations.py
@@ -19,13 +19,6 @@ def test_get_locations_empty_list(ray_start_regular):
     assert len(locations) == 0
 
 
-def test_get_locations_zero_timeout(ray_start_regular):
-    sizes = [100, 1000]
-    obj_refs = [ray.put(np.zeros(s, dtype=np.uint8)) for s in sizes]
-    with pytest.raises(ray.exceptions.GetTimeoutError):
-        ray.experimental.get_object_locations(obj_refs, timeout_ms=0)
-
-
 def test_get_locations(ray_start_regular):
     node_id = ray.get_runtime_context().get_node_id()
     sizes = [100, 1000]


### PR DESCRIPTION
This test sometimes fails because the location info _is_ available: https://buildkite.com/ray-project/postmerge/builds/11255#0197d1e5-5ee0-4b16-b852-4ee17b39cc10

The entire implementation is problematic, and after data [migrates](https://github.com/ray-project/ray/pull/53942) to `get_local_object_locations`, `get_object_locations` will be deleted. So for now deleting the flaky test.