### PR TITLE
[core] Deflake `test_actor_scheduling_not_block_with_placement_group`

### DIFF
--- a/python/ray/tests/test_placement_group_3.py
+++ b/python/ray/tests/test_placement_group_3.py
@@ -490,8 +490,8 @@ def test_incremental_pg_and_actor_scheduling(ray_start_cluster):
     # as their required resources become available.
     for i in range(5):
         cluster.add_node(num_cpus=1)
-        wait_for_condition(lambda: check_num_refs_ready(pg_refs, i+1), timeout=30)
-        wait_for_condition(lambda: check_num_refs_ready(actor_refs, i+1), timeout=30)
+        wait_for_condition(lambda: check_num_refs_ready(pg_refs, i + 1), timeout=30)
+        wait_for_condition(lambda: check_num_refs_ready(actor_refs, i + 1), timeout=30)
 
 
 def test_placement_group_gpu_unique_assigned(ray_start_cluster):

--- a/python/ray/tests/test_placement_group_3.py
+++ b/python/ray/tests/test_placement_group_3.py
@@ -1,10 +1,12 @@
 import os
 import sys
 import time
+from typing import List
 
 import pytest
 
 import ray
+from ray import ObjectRef
 from ray._common.test_utils import wait_for_condition
 import ray._private.gcs_utils as gcs_utils
 import ray.cluster_utils
@@ -447,17 +449,14 @@ def test_placement_group_gpu_assigned(ray_start_cluster):
     assert len(gpu_ids_res) == 2
 
 
-@pytest.mark.repeat(3)
-def test_actor_scheduling_not_block_with_placement_group(ray_start_cluster):
-    """Tests the scheduling of lots of actors will not be blocked
-    when using placement groups.
+def test_incremental_pg_and_actor_scheduling(ray_start_cluster):
+    """Tests that actors in pending PGs are scheduled as resources become available.
 
     For more detailed information please refer to:
     https://github.com/ray-project/ray/issues/15801.
     """
-
     cluster = ray_start_cluster
-    cluster.add_node(num_cpus=1)
+    cluster.add_node(num_cpus=0)
     ray.init(address=cluster.address)
 
     @ray.remote(num_cpus=1)
@@ -465,44 +464,34 @@ def test_actor_scheduling_not_block_with_placement_group(ray_start_cluster):
         def ready(self):
             pass
 
-    actor_num = 1000
-    pgs = [ray.util.placement_group([{"CPU": 1}]) for _ in range(actor_num)]
+    # Schedule a large number of placement groups and actors that should be placed in
+    # those groups. Initially, none are schedulable.
+    pgs = [ray.util.placement_group([{"CPU": 1}]) for _ in range(1000)]
+    pg_refs = [pg.ready() for pg in pgs]
     actors = [
         A.options(
             scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
         ).remote()
         for pg in pgs
     ]
-    refs = [actor.ready.remote() for actor in actors]
+    actor_refs = [actor.ready.remote() for actor in actors]
 
-    expected_created_num = 1
+    ready_pgs, _ = ray.wait(pg_refs, timeout=0.1)
+    assert len(ready_pgs) == 0
+    ready_actors, _ = ray.wait(actor_refs, timeout=0.1)
+    assert len(ready_actors) == 0
 
-    def is_actor_created_number_correct():
-        ready, not_ready = ray.wait(refs, num_returns=len(refs), timeout=1)
-        return len(ready) == expected_created_num
+    def check_num_refs_ready(refs: List[ObjectRef], expected: int) -> bool:
+        ready, _ = ray.wait(refs, num_returns=expected, timeout=1)
+        return len(ready) == expected
 
-    def is_pg_created_number_correct():
-        created_pgs = [
-            pg
-            for _, pg in ray.util.placement_group_table().items()
-            if pg["state"] == "CREATED"
-        ]
-        return len(created_pgs) == expected_created_num
-
-    wait_for_condition(is_pg_created_number_correct, timeout=3)
-    wait_for_condition(is_actor_created_number_correct, timeout=30, retry_interval_ms=0)
-
-    # NOTE: we don't need to test all the actors create successfully.
-    for _ in range(20):
-        expected_created_num += 1
+    # Iteratively add nodes to the cluster so that some of the placement groups (and
+    # therefore actors) can be scheduled. Verify that the PGs and actors are scheduled
+    # as their required resources become available.
+    for i in range(5):
         cluster.add_node(num_cpus=1)
-
-        wait_for_condition(is_pg_created_number_correct, timeout=10)
-        # Make sure the node add event will cause a waiting actor
-        # to create successfully in time.
-        wait_for_condition(
-            is_actor_created_number_correct, timeout=30, retry_interval_ms=0
-        )
+        wait_for_condition(lambda: check_num_refs_ready(pg_refs, i+1), timeout=30)
+        wait_for_condition(lambda: check_num_refs_ready(actor_refs, i+1), timeout=30)
 
 
 def test_placement_group_gpu_unique_assigned(ray_start_cluster):

--- a/python/ray/tests/test_placement_group_3.py
+++ b/python/ray/tests/test_placement_group_3.py
@@ -487,7 +487,7 @@ def test_incremental_pg_and_actor_scheduling(ray_start_cluster):
 
     # Iteratively add nodes to the cluster so that some of the placement groups (and
     # therefore actors) can be scheduled. Verify that the PGs and actors are scheduled
-    # as their required resources become available.
+    # incrementally as their required resources become available.
     for i in range(5):
         cluster.add_node(num_cpus=1)
         wait_for_condition(lambda: check_num_refs_ready(pg_refs, i + 1), timeout=30)


### PR DESCRIPTION
This test was flaking in CI due to a timeout: https://buildkite.com/ray-project/postmerge/builds/11274#0197d7e7-a9ec-43fa-9b29-8561fbb34ec0/177-1584

As it was written, it was creating a 20 node cluster, which is far too stressful to be in CI. I've reduced the stressfulness of the workload to hopefully deflake, along with some other cleanup:

- Improved the test name and header comment.
- Removed the unnecessary `repeat(3)` that was burning CI time.
- Used `pg.wait()` to unify the checks for actor and PG readiness.
- Removed the captured nonlocal variable check.