### PR TITLE
[data] dask: mark all dask-on-ray tests as manual

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2954,7 +2954,7 @@
   group: core-daily-test
   working_dir: nightly_tests
 
-  frequency: nightly
+  frequency: manual # was nightly
   team: core
   # https://github.com/ray-project/ray/issues/39165
   stable: false
@@ -2983,7 +2983,7 @@
   group: core-daily-test
   working_dir: nightly_tests
 
-  frequency: nightly
+  frequency: manual # was nightly
   team: data
 
   cluster:
@@ -3310,7 +3310,7 @@
   group: core-daily-test
   working_dir: nightly_tests
 
-  frequency: nightly-3x
+  frequency: manual # was nightly-3x
   team: core
 
   cluster:
@@ -3844,7 +3844,7 @@
   group: data-tests
   working_dir: nightly_tests
 
-  frequency: nightly
+  frequency: manual # was nightly
   team: data
 
   cluster:
@@ -3873,7 +3873,7 @@
   group: data-tests
   working_dir: nightly_tests
 
-  frequency: nightly
+  frequency: manual # was nightly
   team: data
 
   cluster:


### PR DESCRIPTION
have to run on python 3.12, and not sure what changes are required to make them passing
