### PR TITLE
[core][GPU Objects] Disable tensordict tests in macos ci

### DIFF
--- a/python/ray/tests/test_gpu_objects_gloo.py
+++ b/python/ray/tests/test_gpu_objects_gloo.py
@@ -205,7 +205,7 @@ def test_fetch_gpu_object_to_driver(ray_start_regular):
 
 @pytest.mark.skipif(
     not support_tensordict,
-    reason="tensordict is not supported",
+    reason="tensordict is not supported on this platform",
 )
 def test_invalid_tensor_transport(ray_start_regular):
     with pytest.raises(ValueError, match="Invalid tensor transport"):
@@ -219,7 +219,7 @@ def test_invalid_tensor_transport(ray_start_regular):
 
 @pytest.mark.skipif(
     not support_tensordict,
-    reason="tensordict is not supported",
+    reason="tensordict is not supported on this platform",
 )
 def test_tensordict_transfer(ray_start_regular):
     world_size = 2
@@ -240,7 +240,7 @@ def test_tensordict_transfer(ray_start_regular):
 
 @pytest.mark.skipif(
     not support_tensordict,
-    reason="tensordict is not supported",
+    reason="tensordict is not supported on this platform",
 )
 def test_nested_tensordict(ray_start_regular):
     world_size = 2
@@ -265,7 +265,7 @@ def test_nested_tensordict(ray_start_regular):
 
 @pytest.mark.skipif(
     not support_tensordict,
-    reason="tensordict is not supported",
+    reason="tensordict is not supported on this platform",
 )
 def test_tensor_extracted_from_tensordict_in_gpu_object_store(ray_start_regular):
     actor = GPUTestActor.remote()

--- a/python/ray/tests/test_gpu_objects_gloo.py
+++ b/python/ray/tests/test_gpu_objects_gloo.py
@@ -5,12 +5,9 @@ import pytest
 import ray
 from ray.experimental.collective import create_collective_group
 from ray._private.custom_types import TensorTransportEnum
-import platform
 
-# tensordict is not supported on macos x86_64
-support_tensordict = sys.platform != "darwin" or (
-    sys.platform == "darwin" and platform.machine() == "arm64"
-)
+# tensordict is not supported on macos ci, so we skip the tests
+support_tensordict = sys.platform != "darwin"
 
 if support_tensordict:
     from tensordict import TensorDict

--- a/python/ray/tests/test_gpu_objects_gloo.py
+++ b/python/ray/tests/test_gpu_objects_gloo.py
@@ -2,10 +2,18 @@ import sys
 import random
 import torch
 import pytest
-from tensordict import TensorDict
 import ray
 from ray.experimental.collective import create_collective_group
 from ray._private.custom_types import TensorTransportEnum
+import platform
+
+# tensordict is not supported on macos x86_64
+support_tensordict = sys.platform != "darwin" or (
+    sys.platform == "darwin" and platform.machine() == "arm64"
+)
+
+if support_tensordict:
+    from tensordict import TensorDict
 
 
 @ray.remote
@@ -17,7 +25,7 @@ class GPUTestActor:
     def double(self, data):
         if isinstance(data, list):
             return [self.double(d) for d in data]
-        if isinstance(data, TensorDict):
+        if support_tensordict and isinstance(data, TensorDict):
             return data.apply(lambda x: x * 2)
         return data * 2
 
@@ -107,12 +115,16 @@ def test_multiple_tensors(ray_start_regular):
 
     tensor1 = torch.randn((1,))
     tensor2 = torch.randn((2,))
-    td1 = TensorDict(
-        {"action1": torch.randn((2,)), "reward1": torch.randn((2,))}, batch_size=[2]
-    )
-    td2 = TensorDict(
-        {"action2": torch.randn((2,)), "reward2": torch.randn((2,))}, batch_size=[2]
-    )
+    if support_tensordict:
+        td1 = TensorDict(
+            {"action1": torch.randn((2,)), "reward1": torch.randn((2,))}, batch_size=[2]
+        )
+        td2 = TensorDict(
+            {"action2": torch.randn((2,)), "reward2": torch.randn((2,))}, batch_size=[2]
+        )
+    else:
+        td1 = 0
+        td2 = 0
     cpu_data = random.randint(0, 100)
     data = [tensor1, tensor2, cpu_data, td1, td2]
 
@@ -124,10 +136,11 @@ def test_multiple_tensors(ray_start_regular):
     assert result[0] == pytest.approx(tensor1 * 2)
     assert result[1] == pytest.approx(tensor2 * 2)
     assert result[2] == cpu_data * 2
-    assert result[3]["action1"] == pytest.approx(td1["action1"] * 2)
-    assert result[3]["reward1"] == pytest.approx(td1["reward1"] * 2)
-    assert result[4]["action2"] == pytest.approx(td2["action2"] * 2)
-    assert result[4]["reward2"] == pytest.approx(td2["reward2"] * 2)
+    if support_tensordict:
+        assert result[3]["action1"] == pytest.approx(td1["action1"] * 2)
+        assert result[3]["reward1"] == pytest.approx(td1["reward1"] * 2)
+        assert result[4]["action2"] == pytest.approx(td2["action2"] * 2)
+        assert result[4]["reward2"] == pytest.approx(td2["reward2"] * 2)
 
 
 def test_trigger_out_of_band_tensor_transfer(ray_start_regular):
@@ -190,6 +203,10 @@ def test_fetch_gpu_object_to_driver(ray_start_regular):
     assert result[2] == 7
 
 
+@pytest.mark.skipif(
+    not support_tensordict,
+    reason="tensordict is not supported",
+)
 def test_invalid_tensor_transport(ray_start_regular):
     with pytest.raises(ValueError, match="Invalid tensor transport"):
 
@@ -200,6 +217,10 @@ def test_invalid_tensor_transport(ray_start_regular):
                 return data
 
 
+@pytest.mark.skipif(
+    not support_tensordict,
+    reason="tensordict is not supported",
+)
 def test_tensordict_transfer(ray_start_regular):
     world_size = 2
     actors = [GPUTestActor.remote() for _ in range(world_size)]
@@ -217,6 +238,10 @@ def test_tensordict_transfer(ray_start_regular):
     assert td_result["reward"] == pytest.approx(td["reward"] * 2)
 
 
+@pytest.mark.skipif(
+    not support_tensordict,
+    reason="tensordict is not supported",
+)
 def test_nested_tensordict(ray_start_regular):
     world_size = 2
     actors = [GPUTestActor.remote() for _ in range(world_size)]
@@ -238,6 +263,10 @@ def test_nested_tensordict(ray_start_regular):
     assert torch.equal(ret_val_src["test"], outer_td["test"] * 2)
 
 
+@pytest.mark.skipif(
+    not support_tensordict,
+    reason="tensordict is not supported",
+)
 def test_tensor_extracted_from_tensordict_in_gpu_object_store(ray_start_regular):
     actor = GPUTestActor.remote()
     create_collective_group([actor], backend="torch_gloo")

--- a/python/requirements/test-requirements.txt
+++ b/python/requirements/test-requirements.txt
@@ -111,7 +111,7 @@ threadpoolctl==3.1.0
 numexpr==2.8.4
 
 # For test_gpu_objects_gloo.py
-tensordict==0.8.3 ; sys_platform != "darwin" or (sys_platform == "darwin" and platform_machine == "arm64")
+tensordict==0.8.3 ; sys_platform != "darwin"
 
 # For `serve run --reload` CLI.
 watchfiles==0.19.0

--- a/python/requirements/test-requirements.txt
+++ b/python/requirements/test-requirements.txt
@@ -111,7 +111,7 @@ threadpoolctl==3.1.0
 numexpr==2.8.4
 
 # For test_gpu_objects_gloo.py
-tensordict==0.8.3
+tensordict==0.8.3 ; sys_platform != "darwin" or (sys_platform == "darwin" and platform_machine == "arm64")
 
 # For `serve run --reload` CLI.
 watchfiles==0.19.0

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -2183,7 +2183,7 @@ tensorboardx==2.6.2.2
     #   -r python/requirements.txt
     #   -r python/requirements/test-requirements.txt
     #   pytorch-lightning
-tensordict==0.8.3 ; sys_platform != "darwin" or (sys_platform == "darwin" and platform_machine == "arm64")
+tensordict==0.8.3 ; sys_platform != "darwin"
     # via -r python/requirements/test-requirements.txt
 tensorflow==2.15.1 ; python_version < "3.12" and (sys_platform != "darwin" or platform_machine != "arm64")
     # via -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -2183,7 +2183,7 @@ tensorboardx==2.6.2.2
     #   -r python/requirements.txt
     #   -r python/requirements/test-requirements.txt
     #   pytorch-lightning
-tensordict==0.8.3
+tensordict==0.8.3 ; sys_platform != "darwin" or (sys_platform == "darwin" and platform_machine == "arm64")
     # via -r python/requirements/test-requirements.txt
 tensorflow==2.15.1 ; python_version < "3.12" and (sys_platform != "darwin" or platform_machine != "arm64")
     # via -r python/requirements/ml/dl-cpu-requirements.txt


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Since macos ci has issues on installing tensordict (https://buildkite.com/ray-project/postmerge-macos/builds/6542#0197e577-80b5-4f34-8cf4-a1d56b06c5c6), this PR aims to disable these tensordict tests on macos ci.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
