### PR TITLE
[core] Skip `test_owner_assign_inner_object` on Windows

### DIFF
--- a/python/ray/tests/test_object_assign_owner.py
+++ b/python/ray/tests/test_object_assign_owner.py
@@ -157,10 +157,8 @@ def test_multiple_objects(ray_start_cluster):
     assert ray.get(owner.remote_get_object_refs.remote(borrower), timeout=60)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows.")
 def test_owner_assign_inner_object(shutdown_only):
-
-    ray.init()
-
     @ray.remote
     class Owner:
         def warmup(self):


### PR DESCRIPTION
Test is flaky on Windows. `_owner=` arg is experimental and will be deprecated/removed soon, no need to spend time debugging this on Windows.

Closes https://github.com/ray-project/ray/issues/54333