### PR TITLE
[Data] Fixing `sort_benchmark` to avoid offsets overflows with Pyarrow

### DIFF
--- a/release/nightly_tests/dataset/sort_benchmark.py
+++ b/release/nightly_tests/dataset/sort_benchmark.py
@@ -37,11 +37,13 @@ class RandomIntRowDatasource(Datasource):
         row = np.random.bytes(row_size_bytes)
 
         schema = pyarrow.schema(
-            pyarrow.field("c_0", pyarrow.int64()),
-            # NOTE: We use fixed-size binary type to avoid Arrow (list) offsets
-            #       overflows when using non-fixed-size data-types (like string,
-            #       binary, list, etc) whose size exceeds int32 limit (of 2^31-1)
-            pyarrow.field("c_1", pyarrow.binary(row_size_bytes)),
+            [
+                pyarrow.field("c_0", pyarrow.int64()),
+                # NOTE: We use fixed-size binary type to avoid Arrow (list) offsets
+                #       overflows when using non-fixed-size data-types (like string,
+                #       binary, list, etc) whose size exceeds int32 limit (of 2^31-1)
+                pyarrow.field("c_1", pyarrow.binary(row_size_bytes)),
+            ]
         )
 
         def make_block(count: int) -> Block:

--- a/release/nightly_tests/dataset/sort_benchmark.py
+++ b/release/nightly_tests/dataset/sort_benchmark.py
@@ -36,7 +36,15 @@ class RandomIntRowDatasource(Datasource):
         block_size = max(1, n // parallelism)
         row = np.random.bytes(row_size_bytes)
 
-        def make_block(count: int, row_size_bytes: int) -> Block:
+        schema = pyarrow.schema(
+            pyarrow.field("c_0", pyarrow.int64()),
+            # NOTE: We use fixed-size binary type to avoid Arrow (list) offsets
+            #       overflows when using non-fixed-size data-types (like string,
+            #       binary, list, etc) whose size exceeds int32 limit (of 2^31-1)
+            pyarrow.field("c_1", pyarrow.binary(row_size_bytes)),
+        )
+
+        def make_block(count: int) -> Block:
             return pyarrow.Table.from_arrays(
                 [
                     np.random.randint(
@@ -44,15 +52,8 @@ class RandomIntRowDatasource(Datasource):
                     ),
                     [row for _ in range(count)],
                 ],
-                names=["c_0", "c_1"],
+                schema=schema,
             )
-
-        schema = pyarrow.Table.from_pydict(
-            {
-                "c_0": [0],
-                "c_1": [row],
-            }
-        ).schema
 
         i = 0
         while i < n:
@@ -65,8 +66,8 @@ class RandomIntRowDatasource(Datasource):
             )
             read_tasks.append(
                 ReadTask(
-                    lambda count=count, row_size_bytes=row_size_bytes: [
-                        make_block(count, row_size_bytes)
+                    lambda count=count: [
+                        make_block(count)
                     ],
                     meta,
                     schema=schema,

--- a/release/nightly_tests/dataset/sort_benchmark.py
+++ b/release/nightly_tests/dataset/sort_benchmark.py
@@ -66,9 +66,7 @@ class RandomIntRowDatasource(Datasource):
             )
             read_tasks.append(
                 ReadTask(
-                    lambda count=count: [
-                        make_block(count)
-                    ],
+                    lambda count=count: [make_block(count)],
                     meta,
                     schema=schema,
                 )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Addresses https://github.com/ray-project/ray/issues/53546

Currently, we're using unbounded size data type (binary) that internally utilizes int32 offsets to index individual elements. Using int32 offsets imposes a max limit on the cumulative size of the column being 2^31-1 bytes, which this tests consistently violates.

This change addresses that by replacing arbitrary length `binary` type with fixed-size `binary` type that doesn't use int32 offsets (instead just relying on int64 element counter) 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
