### PR TITLE
[train][doc] ray.train.report api docs should mention optional checkpoint_dir_name

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -2128,10 +2128,6 @@ python/ray/train/v2/api/context.py
     DOC201: Method `TrainContext.get_local_world_size` does not have a return section in docstring
     DOC201: Method `TrainContext.get_node_rank` does not have a return section in docstring
 --------------------
-python/ray/train/v2/api/train_fn_utils.py
-    DOC101: Function `report`: Docstring contains fewer arguments than in function signature.
-    DOC103: Function `report`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [checkpoint_dir_name: Optional[str]].
---------------------
 python/ray/train/v2/lightgbm/lightgbm_trainer.py
     DOC101: Method `LightGBMTrainer.__init__`: Docstring contains fewer arguments than in function signature.
     DOC103: Method `LightGBMTrainer.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [label_column: Optional[str], num_boost_round: Optional[int], params: Optional[Dict[str, Any]]].

--- a/python/ray/train/v2/api/train_fn_utils.py
+++ b/python/ray/train/v2/api/train_fn_utils.py
@@ -81,10 +81,11 @@ def report(
     Args:
         metrics: The metrics you want to report.
         checkpoint: The optional checkpoint you want to report.
-        checkpoint_dir_name: Custom name for the checkpoint directory. If not provided, a unique directory
-    name will be automatically generated. If provided, it must be unique
-    across all checkpoints to avoid naming collisions. Consider including identifiers
-    such as the epoch or batch index in the name.
+        checkpoint_dir_name: Custom name for the checkpoint directory.
+            If not provided, a unique directory name will be automatically generated.
+            If provided, it must be unique across all checkpoints per worker to avoid
+            naming collisions. Consider including identifiers such as the epoch or batch
+            index in the name.
     """
 
     get_train_context().report(

--- a/python/ray/train/v2/api/train_fn_utils.py
+++ b/python/ray/train/v2/api/train_fn_utils.py
@@ -81,9 +81,10 @@ def report(
     Args:
         metrics: The metrics you want to report.
         checkpoint: The optional checkpoint you want to report.
-        checkpoint_dir_name: The optional directory to store the checkpoint.
-            If not set, the checkpoint will be stored in the default storage path.
-            If set, make sure this value is unique for each iteration.
+        checkpoint_dir_name: Custom name for the checkpoint directory. If not provided, a unique directory
+    name will be automatically generated. If provided, it must be unique
+    across all checkpoints to avoid naming collisions. Consider including identifiers
+    such as the epoch or batch index in the name.
     """
 
     get_train_context().report(

--- a/python/ray/train/v2/api/train_fn_utils.py
+++ b/python/ray/train/v2/api/train_fn_utils.py
@@ -81,6 +81,9 @@ def report(
     Args:
         metrics: The metrics you want to report.
         checkpoint: The optional checkpoint you want to report.
+        checkpoint_dir_name: The optional directory to store the checkpoint.
+            If not set, the checkpoint will be stored in the default storage path.
+            If set, make sure this value is unique for each iteration.
     """
 
     get_train_context().report(


### PR DESCRIPTION
Note: I manually modified `ci/lint/pydoclint-baseline.txt` because otherwise the `pydoclint` hook would delete the entire file. 