### PR TITLE
[Data] Remove warning if filename doesn't contain template

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -158,12 +158,6 @@ class ParquetDatasink(_FileDatasink):
             basename_template = f"{filename}-{{i}}.{FILE_FORMAT}"
         else:
             # Has extension but not templatized, add template while preserving extension
-            logger.warning(
-                "FilenameProvider have to provide proper filename template including '{{i}}' "
-                "macro to ensure unique filenames when writing multiple files. Appending '{{i}}' "
-                "macro to the end of the file. For more details on the expected filename template checkout "
-                "PyArrow's `write_to_dataset` API"
-            )
             # Use pathlib.Path to properly handle filenames with dots
             filename_path = Path(filename)
             stem = filename_path.stem  # filename without extension


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

If you use the built-in `FilenameProvider` implementation, `write_parquet` emits a warning like this:
```
(Write pid=3693, ip=10.0.62.18) FilenameProvider have to provide proper filename template including '{{i}}' macro to ensure unique filenames when writing multiple files. Appending '{{i}}' macro to the end of the file. For more details on the expected filename template checkout PyArrow's `write_to_dataset` API [repeated 45x across cluster]                                             
```

Getting warnings with defaults isn't great UX, so this PR removes the warning.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
