### PR TITLE
[core][tune] fix RayTaskError (de)serialization logic

### DIFF
--- a/python/ray/exceptions.py
+++ b/python/ray/exceptions.py
@@ -168,10 +168,10 @@ class RayTaskError(RayError):
         class cls(RayTaskError, cause_cls):
             def __init__(self, cause):
                 self.cause = cause
-                # BaseException implements a __reduce__ method that returns
-                # a tuple with the type and the value of self.args.
-                # https://stackoverflow.com/a/49715949/2213289
                 self.args = (cause,)
+
+            def __reduce__(self):
+                return (cls, self.args)
 
             def __getattr__(self, name):
                 return getattr(self.cause, name)
@@ -196,10 +196,10 @@ class RayTaskError(RayError):
 
             def __init__(self, cause):
                 self.cause = cause
-                # BaseException implements a __reduce__ method that returns
-                # a tuple with the type and the value of self.args.
-                # https://stackoverflow.com/a/49715949/2213289
                 self.args = (cause,)
+
+            def __reduce__(self):
+                return (cls, self.args)
 
             def __getattr__(self, name):
                 return getattr(self.cause, name)


### PR DESCRIPTION
## Summary
Fixes a (de)serialization issue in `RayTaskError` that happens when the original cause has its own `__reduce__` method defined.

```
TypeError: RayTaskError._make_normal_dual_exception_instance.<locals>.cls.__init__() takes 2 positional arguments but 3 were given
```

Closes #54379.

## Details

The existing implementation relies on the definition of `BaseException.__reduce__`:
```
# BaseException implements a __reduce__ method that returns
# a tuple with the type and the value of self.args.
# https://stackoverflow.com/a/49715949/2213289
```

However, since it's also subclassing the `cause_cls`, if `__reduce__` is also defined there then that will override the original definition from `BaseException`. 

This surfaced in #54379 because Ray Train V2 implements exception classes with custom `__reduce__` definitions (e.g. `TrainingFailedError`).

The fix is to explicitly define `__reduce__`. Also removed the comment since it's no longer an assumption that's needed to understand the logic.

## Testing

Added tests in Core and Tune.