### PR TITLE
[core][autoscaler] fix: enable cloud_instance_id reusing in autoscaler v2

### DIFF
--- a/python/ray/autoscaler/v2/instance_manager/instance_manager.py
+++ b/python/ray/autoscaler/v2/instance_manager/instance_manager.py
@@ -198,6 +198,7 @@ class InstanceManager:
             instance.cloud_instance_id = update.cloud_instance_id
             instance.node_kind = update.node_kind
             instance.instance_type = update.instance_type
+            instance.node_id = update.ray_node_id
         elif update.new_instance_status == Instance.RAY_RUNNING:
             assert update.ray_node_id, "RAY_RUNNING update must have ray_node_id"
             instance.node_id = update.ray_node_id

--- a/python/ray/autoscaler/v2/instance_manager/node_provider.py
+++ b/python/ray/autoscaler/v2/instance_manager/node_provider.py
@@ -487,6 +487,9 @@ class NodeProviderAdapter(ICloudInstanceProvider):
             )
             logger.info("Launched {} nodes of type {}.".format(count, node_type))
         except Exception as e:
+            logger.info(
+                "Failed to launch {} nodes of type {}: {}".format(count, node_type, e)
+            )
             error = LaunchNodeError(node_type, count, request_id, int(time.time_ns()))
             error.__cause__ = e
             self._errors_queue.put(error)

--- a/python/ray/autoscaler/v2/instance_manager/reconciler.py
+++ b/python/ray/autoscaler/v2/instance_manager/reconciler.py
@@ -108,6 +108,7 @@ class Reconciler:
         autoscaling_state.last_seen_cluster_resource_state_version = (
             ray_cluster_resource_state.cluster_resource_state_version
         )
+
         Reconciler._sync_from(
             instance_manager=instance_manager,
             ray_nodes=ray_cluster_resource_state.node_states,
@@ -322,7 +323,11 @@ class Reconciler:
             instances_with_launch_requests.append(instance)
 
         assigned_cloud_instance_ids: Set[CloudInstanceId] = {
-            instance.cloud_instance_id for instance in im_instances
+            instance.cloud_instance_id
+            for instance in im_instances
+            if instance.cloud_instance_id
+            and instance.status
+            not in [IMInstance.TERMINATED, IMInstance.ALLOCATION_FAILED]
         }
         launch_errors: Dict[str, LaunchNodeError] = {
             error.request_id: error
@@ -654,48 +659,60 @@ class Reconciler:
         updates = {}
 
         im_instances_by_cloud_instance_id = {
-            i.cloud_instance_id: i for i in instances if i.cloud_instance_id
+            instance.cloud_instance_id: instance
+            for instance in instances
+            if instance.cloud_instance_id
+            and instance.status
+            not in [IMInstance.TERMINATED, IMInstance.ALLOCATION_FAILED]
         }
-        ray_nodes_by_cloud_instance_id = {}
-        for n in ray_nodes:
-            if n.instance_id:
-                ray_nodes_by_cloud_instance_id[n.instance_id] = n
+        im_instances_by_ray_node_id = {
+            instance.node_id: instance for instance in instances if instance.node_id
+        }
+
+        for ray_node in ray_nodes:
+            im_instance = None
+            ray_node_id = binary_to_hex(ray_node.node_id)
+            if ray_node_id in im_instances_by_ray_node_id:
+                im_instance = im_instances_by_ray_node_id[ray_node_id]
             else:
                 if autoscaling_config.provider == Provider.READ_ONLY:
                     # We will use the node id as the cloud instance id for read-only
                     # provider.
-                    ray_nodes_by_cloud_instance_id[binary_to_hex(n.node_id)] = n
+                    im_instance = im_instances_by_cloud_instance_id[ray_node_id]
+                elif ray_node.instance_id:
+                    im_instance = im_instances_by_cloud_instance_id[
+                        ray_node.instance_id
+                    ]
                 else:
                     # This should only happen to a ray node that's not managed by us.
                     logger.warning(
-                        f"Ray node {binary_to_hex(n.node_id)} has no instance id. "
+                        f"Ray node {ray_node_id} has no instance id. "
                         "This only happens to a ray node not managed by autoscaler. "
                         "If not, please file a bug at "
                         "https://github.com/ray-project/ray"
                     )
+                    continue
 
-        for cloud_instance_id, ray_node in ray_nodes_by_cloud_instance_id.items():
-            assert cloud_instance_id in im_instances_by_cloud_instance_id, (
-                f"Ray node {binary_to_hex(ray_node.node_id)} has no matching "
-                f"instance with cloud instance id={cloud_instance_id}. We should "
+            assert im_instance is not None, (
+                f"Ray node {ray_node_id} has no matching "
+                f"instance with cloud instance id={ray_node.instance_id}. We should "
                 "not see a ray node with cloud instance id not found in IM since "
                 "we have reconciled all cloud instances, and ray nodes by now."
             )
 
-            im_instance = im_instances_by_cloud_instance_id[cloud_instance_id]
             reconciled_im_status = Reconciler._reconciled_im_status_from_ray_status(
                 ray_node.status, im_instance.status
             )
 
             if reconciled_im_status != im_instance.status:
-                updates[im_instance.instance_id] = IMInstanceUpdateEvent(
+                updates[ray_node_id] = IMInstanceUpdateEvent(
                     instance_id=im_instance.instance_id,
                     new_instance_status=reconciled_im_status,
                     details=(
-                        f"ray node {binary_to_hex(ray_node.node_id)} is "
+                        f"ray node {ray_node_id} is "
                         f"{NodeStatus.Name(ray_node.status)}"
                     ),
-                    ray_node_id=binary_to_hex(ray_node.node_id),
+                    ray_node_id=ray_node_id,
                 )
 
         Reconciler._update_instance_manager(instance_manager, version, updates)
@@ -1462,11 +1479,11 @@ class Reconciler:
                 the cloud provider.
             ray_nodes: The ray cluster's states of ray nodes.
         """
-        Reconciler._handle_extra_cloud_instances_from_cloud_provider(
-            instance_manager, non_terminated_cloud_instances
-        )
         Reconciler._handle_extra_cloud_instances_from_ray_nodes(
             instance_manager, ray_nodes
+        )
+        Reconciler._handle_extra_cloud_instances_from_cloud_provider(
+            instance_manager, non_terminated_cloud_instances
         )
 
     @staticmethod
@@ -1491,6 +1508,8 @@ class Reconciler:
             instance.cloud_instance_id
             for instance in instances
             if instance.cloud_instance_id
+            and instance.status
+            not in [IMInstance.TERMINATED, IMInstance.ALLOCATION_FAILED]
         }
 
         # Find the extra cloud instances that are not managed by the instance manager.
@@ -1531,10 +1550,20 @@ class Reconciler:
             instance.cloud_instance_id
             for instance in instances
             if instance.cloud_instance_id
+            and not instance.node_id
+            and instance.status
+            not in [IMInstance.TERMINATED, IMInstance.ALLOCATION_FAILED]
+        }
+        ray_node_ids_managed_by_im = {
+            instance.node_id for instance in instances if instance.node_id
         }
 
         for ray_node in ray_nodes:
             if not ray_node.instance_id:
+                continue
+
+            ray_node_id = binary_to_hex(ray_node.node_id)
+            if ray_node_id in ray_node_ids_managed_by_im:
                 continue
 
             cloud_instance_id = ray_node.instance_id
@@ -1542,15 +1571,16 @@ class Reconciler:
                 continue
 
             is_head = is_head_node(ray_node)
-            updates[cloud_instance_id] = IMInstanceUpdateEvent(
+            updates[ray_node_id] = IMInstanceUpdateEvent(
                 instance_id=InstanceUtil.random_instance_id(),  # Assign a new id.
                 cloud_instance_id=cloud_instance_id,
                 new_instance_status=IMInstance.ALLOCATED,
                 node_kind=NodeKind.HEAD if is_head else NodeKind.WORKER,
+                ray_node_id=ray_node_id,
                 instance_type=ray_node.ray_node_type_name,
                 details=(
                     "allocated unmanaged worker cloud instance from ray node: "
-                    f"{binary_to_hex(ray_node.node_id)}"
+                    f"{ray_node_id}"
                 ),
                 upsert=True,
             )

--- a/python/ray/autoscaler/v2/tests/test_reconciler.py
+++ b/python/ray/autoscaler/v2/tests/test_reconciler.py
@@ -391,6 +391,9 @@ class TestReconciler:
             NodeState(node_id=b"r-1", status=NodeStatus.RUNNING, instance_id="c-1"),
         ]
         im_instances = [
+            create_instance(
+                "i-0", status=Instance.TERMINATED, cloud_instance_id="c-1"
+            ),  # this should not be matched.
             create_instance("i-1", status=Instance.ALLOCATED, cloud_instance_id="c-1"),
         ]
         cloud_instances = {
@@ -409,7 +412,8 @@ class TestReconciler:
         )
 
         instances, _ = instance_storage.get_instances()
-        assert len(instances) == 1
+        assert len(instances) == 2
+        assert instances["i-0"].status == Instance.TERMINATED
         assert instances["i-1"].status == Instance.RAY_RUNNING
         assert instances["i-1"].node_id == binary_to_hex(b"r-1")
 
@@ -596,10 +600,16 @@ class TestReconciler:
 
         im_instances = [
             create_instance(
-                "i-1", status=Instance.RAY_RUNNING, cloud_instance_id="c-1"
+                "i-1",
+                status=Instance.RAY_RUNNING,
+                cloud_instance_id="c-1",
+                ray_node_id=binary_to_hex(b"r-1"),
             ),  # To be reconciled.
             create_instance(
-                "i-2", status=Instance.RAY_RUNNING, cloud_instance_id="c-2"
+                "i-2",
+                status=Instance.RAY_RUNNING,
+                cloud_instance_id="c-2",
+                ray_node_id=binary_to_hex(b"r-2"),
             ),  # To be reconciled.
         ]
         TestReconciler._add_instances(instance_storage, im_instances)
@@ -1475,6 +1485,190 @@ class TestReconciler:
         assert len(instances) == 3
         statuses = {instance.status for instance in instances.values()}
         assert statuses == {Instance.RAY_RUNNING, Instance.ALLOCATED}
+
+    @staticmethod
+    def test_cloud_instance_reboot(setup):
+        """
+        Test that the case of booting up a previous stopped cloud instance.
+        """
+        instance_manager, instance_storage, subscriber = setup
+
+        im_instances = [
+            create_instance(
+                "i-1",
+                status=Instance.TERMINATED,
+                cloud_instance_id="c-1",
+                ray_node_id=binary_to_hex(b"r-1"),
+            ),
+        ]
+        TestReconciler._add_instances(instance_storage, im_instances)
+
+        ray_nodes = [
+            NodeState(
+                node_id=b"r-1",
+                status=NodeStatus.DEAD,
+                instance_id="c-1",
+                ray_node_type_name="type-1",
+            ),
+        ]
+
+        cloud_instances = {
+            "c-1": CloudInstance("c-1", "type-1", True, NodeKind.WORKER),
+        }
+
+        subscriber.clear()
+        Reconciler.reconcile(
+            instance_manager,
+            scheduler=MockScheduler(),
+            cloud_provider=MagicMock(),
+            ray_cluster_resource_state=ClusterResourceState(node_states=ray_nodes),
+            non_terminated_cloud_instances=cloud_instances,
+            cloud_provider_errors=[],
+            ray_install_errors=[],
+            autoscaling_config=MockAutoscalingConfig(),
+        )
+        events = subscriber.events
+        for e in events:
+            assert e.new_instance_status == Instance.ALLOCATED
+            assert e.cloud_instance_id == "c-1"
+
+        instances, _ = instance_storage.get_instances()
+        assert len(instances) == 2
+        statuses = {instance.status for instance in instances.values()}
+        assert statuses == {Instance.ALLOCATED, Instance.TERMINATED}
+
+    @staticmethod
+    def test_ray_node_restarted_on_the_same_cloud_instance(setup):
+        """
+        Test that the case of reusing cloud instances.
+        """
+        instance_manager, instance_storage, subscriber = setup
+
+        im_instances = [
+            create_instance(
+                "i-1",
+                status=Instance.RAY_RUNNING,
+                cloud_instance_id="c-1",
+                ray_node_id=binary_to_hex(b"r-1"),
+            ),
+        ]
+        TestReconciler._add_instances(instance_storage, im_instances)
+
+        ray_nodes = [
+            NodeState(
+                node_id=b"r-2",
+                status=NodeStatus.IDLE,
+                instance_id="c-1",
+                ray_node_type_name="type-1",
+            ),
+            NodeState(
+                node_id=b"r-1",
+                status=NodeStatus.DEAD,
+                instance_id="c-1",
+                ray_node_type_name="type-1",
+            ),
+        ]
+
+        cloud_instances = {
+            "c-1": CloudInstance("c-1", "type-1", True, NodeKind.WORKER),
+        }
+
+        subscriber.clear()
+        Reconciler.reconcile(
+            instance_manager,
+            scheduler=MockScheduler(),
+            cloud_provider=MagicMock(),
+            ray_cluster_resource_state=ClusterResourceState(node_states=ray_nodes),
+            non_terminated_cloud_instances=cloud_instances,
+            cloud_provider_errors=[],
+            ray_install_errors=[],
+            autoscaling_config=MockAutoscalingConfig(),
+        )
+        events = subscriber.events
+        assert len(events) == 4
+        assert events[0].new_instance_status == Instance.ALLOCATED
+        assert events[0].cloud_instance_id == "c-1"
+        assert events[0].ray_node_id == binary_to_hex(b"r-2")
+
+        assert events[1].new_instance_status == Instance.RAY_RUNNING
+        assert events[1].instance_id == events[0].instance_id
+        assert events[1].ray_node_id == binary_to_hex(b"r-2")
+
+        assert events[2].new_instance_status == Instance.RAY_STOPPED
+        assert events[2].instance_id == "i-1"
+        assert events[2].ray_node_id == binary_to_hex(b"r-1")
+        assert events[3].new_instance_status == Instance.TERMINATING
+        assert events[3].instance_id == "i-1"
+
+        instances, _ = instance_storage.get_instances()
+        assert len(instances) == 2
+        statuses = {instance.status for instance in instances.values()}
+        assert statuses == {Instance.RAY_RUNNING, Instance.TERMINATING}
+
+    @staticmethod
+    def test_ray_head_restarted_on_the_same_cloud_instance(setup):
+        """
+        Test that the case of restarting Head node with GCS FT.
+        """
+        instance_manager, instance_storage, subscriber = setup
+
+        ray_nodes = [
+            NodeState(
+                node_id=b"r-2",
+                status=NodeStatus.IDLE,
+                instance_id="c-1",
+                ray_node_type_name="type-1",
+            ),
+            NodeState(
+                node_id=b"r-1",
+                status=NodeStatus.DEAD,
+                instance_id="c-1",
+                ray_node_type_name="type-1",
+            ),
+        ]
+
+        cloud_instances = {
+            "c-1": CloudInstance("c-1", "type-1", True, NodeKind.HEAD),
+        }
+
+        subscriber.clear()
+        Reconciler.reconcile(
+            instance_manager,
+            scheduler=MockScheduler(),
+            cloud_provider=MagicMock(),
+            ray_cluster_resource_state=ClusterResourceState(node_states=ray_nodes),
+            non_terminated_cloud_instances=cloud_instances,
+            cloud_provider_errors=[],
+            ray_install_errors=[],
+            autoscaling_config=MockAutoscalingConfig(),
+        )
+        events = subscriber.events
+        assert len(events) == 5
+        assert events[0].new_instance_status == Instance.ALLOCATED
+        assert events[0].cloud_instance_id == "c-1"
+        assert events[0].ray_node_id == binary_to_hex(b"r-2")
+
+        assert events[1].new_instance_status == Instance.ALLOCATED
+        assert events[1].cloud_instance_id == "c-1"
+        assert events[1].ray_node_id == binary_to_hex(b"r-1")
+
+        assert events[1].instance_id != events[0].instance_id
+
+        assert events[2].new_instance_status == Instance.RAY_RUNNING
+        assert events[2].instance_id == events[0].instance_id
+        assert events[2].ray_node_id == binary_to_hex(b"r-2")
+
+        assert events[3].new_instance_status == Instance.RAY_STOPPED
+        assert events[3].instance_id == events[1].instance_id
+        assert events[3].ray_node_id == binary_to_hex(b"r-1")
+
+        assert events[4].new_instance_status == Instance.TERMINATING
+        assert events[4].instance_id == events[1].instance_id
+
+        instances, _ = instance_storage.get_instances()
+        assert len(instances) == 2
+        statuses = {instance.status for instance in instances.values()}
+        assert statuses == {Instance.RAY_RUNNING, Instance.TERMINATING}
 
     @staticmethod
     def test_reconcile_max_worker_nodes_limit_triggers_termination(setup):


### PR DESCRIPTION
## Why are these changes needed?

When a Head node restarted with GCS FT enabled, the `ClusterResourceState` response contains old `DEAD` entries for the Head node. For example:

```
node_states {
  node_id: "\322\326p*\261\305\331\016\005^\364\235\266\314\023x\307Md^\262\212|\247<@\013\301"
  instance_id: "raycluster-external-redis-head"
  ray_node_type_name: "headgroup"
  node_state_version: 4
  status: IDLE
  node_ip_address: "10.244.0.29"
}
node_states {
  node_id: "\210\236\255\245k\350\341\3746\312|\362j\033\221\364T\277\331V\025!\223J\232\320\334N"
  instance_id: "raycluster-external-redis-head"
  ray_node_type_name: "headgroup"
  node_state_version: 4
  status: DEAD
  node_ip_address: "10.244.0.28"
}
```

Autoscaler v2 previously did not allow reusing `instance_id(cloud_instance_id)`. This PR makes it possible.


## Related issue number

fixes https://github.com/ray-project/ray/issues/54353

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
