### PR TITLE
[wheel] remove pyarrow <18 restriction

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -23,10 +23,7 @@ grpcio == 1.54.2; sys_platform == "darwin"
 grpcio >= 1.54.2; sys_platform != "darwin"
 numpy>=1.20
 
-# pyarrow 18 causes macos build failures.
-# See https://github.com/ray-project/ray/pull/48300
 pyarrow >= 9.0.0
-pyarrow <18; sys_platform == "darwin" and platform_machine == "x86_64"
 
 # ray[all]
 smart_open

--- a/python/setup.py
+++ b/python/setup.py
@@ -220,7 +220,6 @@ if setup_spec.type == SetupType.RAY:
     numpy_dep = "numpy >= 1.20"
     pyarrow_deps = [
         "pyarrow >= 9.0.0",
-        "pyarrow <18; sys_platform == 'darwin' and platform_machine == 'x86_64'",
     ]
     pydantic_dep = "pydantic!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,<3"
     setup_spec.extras = {


### PR DESCRIPTION
the restriction should be on installation time rather than inside the wheel. this extra constraint sometimes can unnecessarily mislead depedency manager's resolution algorithms
