### PR TITLE
Revert "[core][refactor] move NodeManager::KillWorker to WorkerInterface::KillAsync for better testability (#54068)"

### DIFF
--- a/src/mock/ray/raylet/worker.h
+++ b/src/mock/ray/raylet/worker.h
@@ -20,10 +20,6 @@ class MockWorkerInterface : public WorkerInterface {
   MOCK_METHOD(rpc::WorkerType, GetWorkerType, (), (const, override));
   MOCK_METHOD(void, MarkDead, (), (override));
   MOCK_METHOD(bool, IsDead, (), (const, override));
-  MOCK_METHOD(void,
-              KillAsync,
-              (instrumented_io_context & io_service, bool force),
-              (override));
   MOCK_METHOD(void, MarkBlocked, (), (override));
   MOCK_METHOD(void, MarkUnblocked, (), (override));
   MOCK_METHOD(bool, IsBlocked, (), (const, override));

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -382,6 +382,31 @@ ray::Status NodeManager::RegisterGcs() {
   return ray::Status::OK();
 }
 
+void NodeManager::KillWorker(std::shared_ptr<WorkerInterface> worker, bool force) {
+  if (force) {
+    worker->GetProcess().Kill();
+    return;
+  }
+#ifdef _WIN32
+// TODO(mehrdadn): implement graceful process termination mechanism
+#else
+  // If we're just cleaning up a single worker, allow it some time to clean
+  // up its state before force killing. The client socket will be closed
+  // and the worker struct will be freed after the timeout.
+  kill(worker->GetProcess().GetId(), SIGTERM);
+#endif
+
+  auto retry_timer = std::make_shared<boost::asio::deadline_timer>(io_service_);
+  auto retry_duration = boost::posix_time::milliseconds(
+      RayConfig::instance().kill_worker_timeout_milliseconds());
+  retry_timer->expires_from_now(retry_duration);
+  retry_timer->async_wait([retry_timer, worker](const boost::system::error_code &error) {
+    RAY_LOG(DEBUG) << "Send SIGKILL to worker, pid=" << worker->GetProcess().GetId();
+    // Force kill worker
+    worker->GetProcess().Kill();
+  });
+}
+
 void NodeManager::DestroyWorker(std::shared_ptr<WorkerInterface> worker,
                                 rpc::WorkerExitType disconnect_type,
                                 const std::string &disconnect_detail,
@@ -392,7 +417,7 @@ void NodeManager::DestroyWorker(std::shared_ptr<WorkerInterface> worker,
   DisconnectClient(
       worker->Connection(), /*graceful=*/false, disconnect_type, disconnect_detail);
   worker->MarkDead();
-  worker->KillAsync(io_service_, force);
+  KillWorker(worker, force);
   if (disconnect_type == rpc::WorkerExitType::SYSTEM_ERROR) {
     number_workers_killed_++;
   } else if (disconnect_type == rpc::WorkerExitType::NODE_OUT_OF_MEMORY) {
@@ -436,7 +461,7 @@ void NodeManager::HandleJobFinished(const JobID &job_id, const JobTableData &job
                   << "Failed to send exit request to worker "
                   << ": " << status.ToString() << ". Killing it using SIGKILL instead.";
               // Just kill-9 as a last resort.
-              worker->KillAsync(io_service_, /* force */ true);
+              KillWorker(worker, /* force */ true);
             }
           });
     }
@@ -446,7 +471,7 @@ void NodeManager::HandleJobFinished(const JobID &job_id, const JobTableData &job
 
 // TODO(edoakes): the connection management and logic to destroy a worker should live
 // inside of the WorkerPool. We also need to unify the destruction paths between
-// DestroyWorker, and DisconnectWorker.
+// DestroyWorker, DisconnectWorker, and KillWorker.
 void NodeManager::CheckForUnexpectedWorkerDisconnects() {
   std::vector<std::shared_ptr<ClientConnection>> all_connections;
   std::vector<std::shared_ptr<WorkerInterface>> all_workers =
@@ -844,7 +869,7 @@ void NodeManager::NodeRemoved(const NodeID &node_id) {
     // worker.
     RAY_LOG(INFO).WithField(worker->WorkerId()).WithField(owner_node_id)
         << "The leased worker is killed because the owner node died.";
-    worker->KillAsync(io_service_);
+    KillWorker(worker);
   }
 
   // Below, when we remove node_id from all of these data structures, we could
@@ -887,7 +912,7 @@ void NodeManager::HandleUnexpectedWorkerFailure(const WorkerID &worker_id) {
     RAY_LOG(INFO) << "The leased worker " << worker->WorkerId()
                   << " is killed because the owner process " << owner_worker_id
                   << " died.";
-    worker->KillAsync(io_service_);
+    KillWorker(worker);
   }
 }
 

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -411,6 +411,18 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   /// \param worker Shared ptr to the worker, or nullptr if lost.
   void HandleDirectCallTaskUnblocked(const std::shared_ptr<WorkerInterface> &worker);
 
+  /// Kill a worker.
+  ///
+  /// This shouldn't be directly used to kill a worker. If you use this API
+  /// the worker's crash cause is not correctly recorded (it will be either SIGTERM
+  /// or an unexpected failure). Use `DestroyWorker` instead.
+  ///
+  /// \param worker The worker to kill.
+  /// \param force true to kill immediately, false to give time for the worker to
+  /// clean up and exit gracefully.
+  /// \return Void.
+  void KillWorker(std::shared_ptr<WorkerInterface> worker, bool force = false);
+
   /// Destroy a worker.
   /// We will disconnect the worker connection first and then kill the worker.
   ///

--- a/src/ray/raylet/test/node_manager_test.cc
+++ b/src/ray/raylet/test/node_manager_test.cc
@@ -386,7 +386,8 @@ class NodeManagerTest : public ::testing::Test {
           return std::make_shared<rpc::MockCoreWorkerClientInterface>();
         }) {
     RayConfig::instance().initialize(R"({
-      "raylet_liveness_self_check_interval_ms": 100
+      "raylet_liveness_self_check_interval_ms": 100,
+      "kill_worker_timeout_milliseconds": 10
     })");
 
     NodeManagerConfig node_manager_config{};
@@ -621,8 +622,13 @@ TEST_F(NodeManagerTest, TestDetachedWorkerIsKilledByFailedWorker) {
         promise.set_value(status);
       });
 
-  // Prepare a mock worker and check if it is not killed later.
+  // Prepare a mock worker with a real process so that we can check if the process is
+  // alive later.
   const auto worker = std::make_shared<MockWorker>(WorkerID::FromRandom(), 10);
+  auto [proc, spawn_error] =
+      Process::Spawn(std::vector<std::string>{"sleep", "1000"}, true);
+  EXPECT_FALSE(spawn_error);
+  worker->SetProcess(proc);
   // Complete the RequestWorkerLease rpc with the mock worker.
   pop_worker_callback(worker, PopWorkerStatus::OK, "");
   EXPECT_TRUE(promise.get_future().get().ok());
@@ -633,9 +639,13 @@ TEST_F(NodeManagerTest, TestDetachedWorkerIsKilledByFailedWorker) {
   rpc::WorkerDeltaData delta_data;
   delta_data.set_worker_id(owner_worker_id.Binary());
   publish_worker_failure_callback(std::move(delta_data));
-  // The worker should still be alive because it should not be killed by
+  // Wait for more than kill_worker_timeout_milliseconds.
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  // The process should still be alive because it should not be killed by
   // publish_worker_failure_callback.
-  EXPECT_FALSE(worker->IsKilled());
+  EXPECT_TRUE(proc.IsAlive());
+  // clean up.
+  proc.Kill();
 }
 
 TEST_F(NodeManagerTest, TestDetachedWorkerIsKilledByFailedNode) {
@@ -702,8 +712,13 @@ TEST_F(NodeManagerTest, TestDetachedWorkerIsKilledByFailedNode) {
         promise.set_value(status);
       });
 
-  // Prepare a mock worker and check if it is not killed later.
+  // Prepare a mock worker with a real process so that we can check if the process is
+  // alive later.
   const auto worker = std::make_shared<MockWorker>(WorkerID::FromRandom(), 10);
+  auto [proc, spawn_error] =
+      Process::Spawn(std::vector<std::string>{"sleep", "1000"}, true);
+  EXPECT_FALSE(spawn_error);
+  worker->SetProcess(proc);
   // Complete the RequestWorkerLease rpc with the mock worker.
   pop_worker_callback(worker, PopWorkerStatus::OK, "");
   EXPECT_TRUE(promise.get_future().get().ok());
@@ -714,9 +729,13 @@ TEST_F(NodeManagerTest, TestDetachedWorkerIsKilledByFailedNode) {
   GcsNodeInfo node_info;
   node_info.set_state(GcsNodeInfo::DEAD);
   publish_node_change_callback(owner_node_id, std::move(node_info));
-  // The worker should still be alive because it should not be killed by
+  // Wait for more than kill_worker_timeout_milliseconds.
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  // The process should still be alive because it should not be killed by
   // publish_node_change_callback.
-  EXPECT_FALSE(worker->IsKilled());
+  EXPECT_TRUE(proc.IsAlive());
+  // clean up.
+  proc.Kill();
 }
 
 TEST_F(NodeManagerTest, TestPinningAnObjectPendingDeletionFails) {

--- a/src/ray/raylet/test/util.h
+++ b/src/ray/raylet/test/util.h
@@ -87,10 +87,6 @@ class MockWorker : public WorkerInterface {
     RAY_CHECK(false) << "Method unused";
     return false;
   }
-  void KillAsync(instrumented_io_context &io_service, bool force) override {
-    killed_.store(true);
-  }
-  bool IsKilled() const { return killed_.load(); }
   void MarkBlocked() override { blocked_ = true; }
   void MarkUnblocked() override { blocked_ = false; }
   bool IsBlocked() const override { return blocked_; }
@@ -203,7 +199,6 @@ class MockWorker : public WorkerInterface {
   JobID job_id_;
   ActorID root_detached_actor_id_;
   Process proc_;
-  std::atomic<bool> killed_ = false;
 };
 
 }  // namespace raylet

--- a/src/ray/raylet/worker.cc
+++ b/src/ray/raylet/worker.cc
@@ -49,7 +49,6 @@ Worker::Worker(const JobID &job_id,
       runtime_env_hash_(runtime_env_hash),
       bundle_id_(std::make_pair(PlacementGroupID::Nil(), -1)),
       dead_(false),
-      killing_(false),
       blocked_(false),
       client_call_manager_(client_call_manager) {}
 
@@ -58,43 +57,6 @@ rpc::WorkerType Worker::GetWorkerType() const { return worker_type_; }
 void Worker::MarkDead() { dead_ = true; }
 
 bool Worker::IsDead() const { return dead_; }
-
-void Worker::KillAsync(instrumented_io_context &io_service, bool force) {
-  if (killing_.exchange(true)) {  // TODO(rueian): could we just reuse the dead_ flag?
-    return;  // This is not the first time calling KillAsync, do nothing.
-  }
-  const auto worker = shared_from_this();
-  if (force) {
-    worker->GetProcess().Kill();
-    return;
-  }
-#ifdef _WIN32
-  // TODO(mehrdadn): implement graceful process termination mechanism
-#else
-  // Attempt to gracefully shutdown the worker before force killing it.
-  kill(worker->GetProcess().GetId(), SIGTERM);
-#endif
-
-  auto retry_timer = std::make_shared<boost::asio::deadline_timer>(io_service);
-  auto timeout = RayConfig::instance().kill_worker_timeout_milliseconds();
-  auto retry_duration = boost::posix_time::milliseconds(timeout);
-  retry_timer->expires_from_now(retry_duration);
-  retry_timer->async_wait(
-      [timeout, retry_timer, worker](const boost::system::error_code &error) {
-#ifdef _WIN32
-#else
-        if (worker->GetProcess().IsAlive()) {
-          RAY_LOG(INFO) << "Worker with PID=" << worker->GetProcess().GetId()
-                        << " did not exit after " << timeout
-                        << "ms, force killing with SIGKILL.";
-        } else {
-          return;
-        }
-#endif
-        // Force kill worker
-        worker->GetProcess().Kill();
-      });
-}
 
 void Worker::MarkBlocked() { blocked_ = true; }
 

--- a/src/ray/raylet/worker.h
+++ b/src/ray/raylet/worker.h
@@ -46,7 +46,6 @@ class WorkerInterface {
   virtual rpc::WorkerType GetWorkerType() const = 0;
   virtual void MarkDead() = 0;
   virtual bool IsDead() const = 0;
-  virtual void KillAsync(instrumented_io_context &io_service, bool force = false) = 0;
   virtual void MarkBlocked() = 0;
   virtual void MarkUnblocked() = 0;
   virtual bool IsBlocked() const = 0;
@@ -137,7 +136,7 @@ class WorkerInterface {
 /// Worker class encapsulates the implementation details of a worker. A worker
 /// is the execution container around a unit of Ray work, such as a task or an
 /// actor. Ray units of work execute in the context of a Worker.
-class Worker : public std::enable_shared_from_this<Worker>, public WorkerInterface {
+class Worker : public WorkerInterface {
  public:
   /// A constructor that initializes a worker object.
   /// NOTE: You MUST manually set the worker process.
@@ -155,12 +154,6 @@ class Worker : public std::enable_shared_from_this<Worker>, public WorkerInterfa
   rpc::WorkerType GetWorkerType() const;
   void MarkDead();
   bool IsDead() const;
-  /// Kill the worker process. This is idempotent.
-  /// \param io_service for scheduling the graceful period timer.
-  /// \param force true to kill immediately, false to give time for the worker to clean up
-  /// and exit gracefully.
-  /// \return Void.
-  void KillAsync(instrumented_io_context &io_service, bool force = false);
   void MarkBlocked();
   void MarkUnblocked();
   bool IsBlocked() const;
@@ -304,8 +297,6 @@ class Worker : public std::enable_shared_from_this<Worker>, public WorkerInterfa
   BundleID bundle_id_;
   /// Whether the worker is dead.
   bool dead_;
-  /// Whether the worker is killed by the Kill method.
-  std::atomic<bool> killing_;
   /// Whether the worker is blocked. Workers become blocked in a `ray.get`, if
   /// they require a data dependency while executing a task.
   bool blocked_;


### PR DESCRIPTION

This reverts commit 4d9b32346bcbc4f551c4b232c8adceac6f1479b9.

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
