### PR TITLE
[serve] Remove usage of `internal_api.memory_summary()`

### DIFF
--- a/python/ray/serve/tests/test_advanced.py
+++ b/python/ray/serve/tests/test_advanced.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+import sys
 
 import httpx
 import pytest
@@ -10,6 +11,7 @@ from ray import serve
 from ray._common.test_utils import SignalActor
 from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
 from ray.serve.handle import DeploymentHandle
+from ray.util.state import list_objects
 
 
 def test_serve_forceful_shutdown(serve_instance):
@@ -110,9 +112,20 @@ def test_passing_object_ref_to_deployment_not_pinned_to_memory(serve_instance):
     See: https://github.com/ray-project/ray/issues/43248
     """
 
+    def _obj_ref_exists_in_state(obj_ref_hex: str) -> bool:
+        return (
+            len(
+                list_objects(
+                    filters=[("object_id", "=", obj_ref_hex)],
+                    raise_on_missing_output=False,
+                )
+            )
+            > 0
+        )
+
     @serve.deployment
     class Dep1:
-        def multiple_by_two(self, length: int):
+        def multiply_by_two(self, length: int):
             return length * 2
 
     @serve.deployment
@@ -121,31 +134,27 @@ def test_passing_object_ref_to_deployment_not_pinned_to_memory(serve_instance):
             self.dep1: DeploymentHandle = dep1
 
         async def __call__(self, http_request: Request) -> str:
-            _length = int(http_request.query_params.get("length"))
-            length_ref = ray.put(_length)
-            obj_ref_hex = length_ref.hex()
+            length = int(http_request.query_params.get("length"))
+            length_ref = ray.put(length)
 
-            # Object ref should be in the memory for downstream deployment to access.
-            assert obj_ref_hex in ray._private.internal_api.memory_summary()
+            # Sanity check that the ObjectRef exists in the state API.
+            assert _obj_ref_exists_in_state(length_ref.hex())
             return {
-                "result": await self.dep1.multiple_by_two.remote(length_ref),
-                "length": _length,
-                "obj_ref_hex": obj_ref_hex,
+                "length": length,
+                "result": await self.dep1.multiply_by_two.remote(length_ref),
+                "length_ref_hex": length_ref.hex(),
             }
 
-    app = Gateway.bind(Dep1.bind())
-    serve.run(target=app)
+    serve.run(Gateway.bind(Dep1.bind()))
 
     length = 10
     response = httpx.get(f"http://localhost:8000?length={length}").json()
-    assert response["result"] == length * 2
     assert response["length"] == length
+    assert response["result"] == length * 2
 
     # Ensure the object ref is not in the memory anymore.
-    assert response["obj_ref_hex"] not in ray._private.internal_api.memory_summary()
+    assert not _obj_ref_exists_in_state(response["length_ref_hex"])
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/test_advanced.py
+++ b/python/ray/serve/tests/test_advanced.py
@@ -1,6 +1,6 @@
 import asyncio
-import time
 import sys
+import time
 
 import httpx
 import pytest

--- a/python/ray/serve/tests/test_advanced.py
+++ b/python/ray/serve/tests/test_advanced.py
@@ -112,7 +112,7 @@ def test_passing_object_ref_to_deployment_not_pinned_to_memory(serve_instance):
     See: https://github.com/ray-project/ray/issues/43248
     """
 
-    def _obj_ref_exists_in_state(obj_ref_hex: str) -> bool:
+    def _obj_ref_exists_in_state_api(obj_ref_hex: str) -> bool:
         return (
             len(
                 list_objects(
@@ -138,7 +138,7 @@ def test_passing_object_ref_to_deployment_not_pinned_to_memory(serve_instance):
             length_ref = ray.put(length)
 
             # Sanity check that the ObjectRef exists in the state API.
-            assert _obj_ref_exists_in_state(length_ref.hex())
+            assert _obj_ref_exists_in_state_api(length_ref.hex())
             return {
                 "length": length,
                 "result": await self.dep1.multiply_by_two.remote(length_ref),
@@ -153,7 +153,7 @@ def test_passing_object_ref_to_deployment_not_pinned_to_memory(serve_instance):
     assert response["result"] == length * 2
 
     # Ensure the object ref is not in the memory anymore.
-    assert not _obj_ref_exists_in_state(response["length_ref_hex"])
+    assert not _obj_ref_exists_in_state_api(response["length_ref_hex"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replace with usage of the `list_objects` public state API.