### PR TITLE
[llm.data] Fix AttributeError for the shallow copy of data batch transfer

### DIFF
--- a/python/ray/llm/_internal/batch/stages/base.py
+++ b/python/ray/llm/_internal/batch/stages/base.py
@@ -1,4 +1,5 @@
 """The base class for all stages."""
+import copy
 import logging
 from typing import Any, AsyncIterator, Callable, Dict, List, Optional, Type
 
@@ -163,7 +164,7 @@ class StatefulStageUDF:
         # Collect all outputs first, then return them in the original order
         # This is a requirement set by https://github.com/ray-project/ray/pull/54190/
         not_outputed_rows = set(range(len(inputs)))
-        async for output in self.udf(inputs):
+        async for output in self.udf(copy.deepcopy(inputs)):
             if self.IDX_IN_BATCH_COLUMN not in output:
                 raise ValueError(
                     "The output of the UDF must contain the column "


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Based on the architecture of ray.llm.batch, I want to construct udf_stage and udf_processor. However, when I used the 
```python
SimplestStageUDF(StatefulStageUDF):
        async def udf(self, rows: List[Dict[str, Any]]) -> AsyncIterator[Dict[str, Any]]:
                for item in rows:
                    yield item
```
for full-link testing, I found that `stage.__call__` would report `AttributeError: 'dict' object has no attribute '__idx_in_batch'` at line `inputs[idx_in_batch].pop(self.IDX_IN_BATCH_COLUMN)`. Obviously, this is because the input is a shallow copy during data transmission. Of course, deep copying in SimplestStageUDF can also solve this problem, but I still think it is more reasonable for the copy operation to be performed by the data sender.

## Related issue number

https://github.com/ray-project/ray/issues/54420

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- [ ] 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(
