### PR TITLE
[Data] Avoid OOMs with `read_json(..., lines=True)`

### DIFF
--- a/python/ray/data/_internal/datasource/json_datasource.py
+++ b/python/ray/data/_internal/datasource/json_datasource.py
@@ -1,9 +1,11 @@
 import logging
 from io import BytesIO
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+
+import pandas as pd
 
 from ray.air.util.tensor_extensions.arrow import pyarrow_table_from_pydict
-from ray.data.block import DataBatch
+from ray.data._internal.pandas_block import PandasBlockAccessor
 from ray.data.context import DataContext
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
 
@@ -12,34 +14,33 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+JSON_FILE_EXTENSIONS = [
+    "json",
+    "jsonl",
+    # gzip-compressed files
+    "json.gz",
+    "jsonl.gz",
+    # Brotli-compressed fi;es
+    "json.br",
+    "jsonl.br",
+    # Zstandard-compressed files
+    "json.zst",
+    "jsonl.zst",
+    # lz4-compressed files
+    "json.lz4",
+    "jsonl.lz4",
+]
+
 # TODO(rliaw): Arbitrarily chosen. Make this configurable
-_JSONL_ROWS_PER_CHUNK = 10000
+_DEFAULT_JSONL_ROWS_PER_CHUNK = 10000
 
 
-class JSONDatasource(FileBasedDatasource):
+class ArrowJSONDatasource(FileBasedDatasource):
     """JSON datasource, for reading and writing JSON and JSONL files."""
-
-    _FILE_EXTENSIONS = [
-        "json",
-        "jsonl",
-        # gzip-compressed files
-        "json.gz",
-        "jsonl.gz",
-        # Brotli-compressed fi;es
-        "json.br",
-        "jsonl.br",
-        # Zstandard-compressed files
-        "json.zst",
-        "jsonl.zst",
-        # lz4-compressed files
-        "json.lz4",
-        "jsonl.lz4",
-    ]
 
     def __init__(
         self,
         paths: Union[str, List[str]],
-        is_jsonl: bool = False,
         *,
         arrow_json_args: Optional[Dict[str, Any]] = None,
         **file_based_datasource_kwargs,
@@ -48,38 +49,20 @@ class JSONDatasource(FileBasedDatasource):
 
         super().__init__(paths, **file_based_datasource_kwargs)
 
-        self.is_jsonl = is_jsonl
-
         if arrow_json_args is None:
             arrow_json_args = {}
+
         self.read_options = arrow_json_args.pop(
             "read_options", json.ReadOptions(use_threads=False)
         )
         self.arrow_json_args = arrow_json_args
-
-    def _read_jsonlines_pandas(
-        self, buffer: "pyarrow.lib.Buffer"
-    ) -> Iterable[DataBatch]:
-        """Read JSONL files with pandas."""
-        import pandas as pd
-
-        reader = pd.read_json(
-            BytesIO(buffer),
-            chunksize=_JSONL_ROWS_PER_CHUNK,
-            lines=True,
-        )
-        for df in reader:
-            # Note: PandasBlockAccessor doesn't support RangeIndex, so we need to convert
-            # to string.
-            if isinstance(df.columns, pd.RangeIndex):
-                df.columns = df.columns.astype(str)
-            yield df
 
     def _read_with_pyarrow_read_json(self, buffer: "pyarrow.lib.Buffer"):
         """Read with PyArrow JSON reader, trying to auto-increase the
         read block size in the case of the read object
         straddling block boundaries."""
         import pyarrow as pa
+        import pyarrow.json as pajson
 
         # When reading large files, the default block size configured in PyArrow can be
         # too small, resulting in the following error: `pyarrow.lib.ArrowInvalid:
@@ -101,7 +84,7 @@ class JSONDatasource(FileBasedDatasource):
         max_block_size = DataContext.get_current().target_max_block_size
         while True:
             try:
-                yield pa.json.read_json(
+                yield pajson.read_json(
                     BytesIO(buffer),
                     read_options=self.read_options,
                     **self.arrow_json_args,
@@ -166,16 +149,68 @@ class JSONDatasource(FileBasedDatasource):
 
         buffer: pa.lib.Buffer = f.read_buffer()
 
-        if self.is_jsonl:
-            yield from self._read_jsonlines_pandas(buffer)
-        else:
-            try:
-                yield from self._read_with_pyarrow_read_json(buffer)
-            except pa.ArrowInvalid as e:
-                # If read with PyArrow fails, try falling back to native json.load().
-                logger.warning(
-                    f"Error reading with pyarrow.json.read_json(). "
-                    f"Falling back to native json.load(), which may be slower. "
-                    f"PyArrow error was:\n{e}"
-                )
-                yield from self._read_with_python_json(buffer)
+        try:
+            yield from self._read_with_pyarrow_read_json(buffer)
+        except pa.ArrowInvalid as e:
+            # If read with PyArrow fails, try falling back to native json.load().
+            logger.warning(
+                f"Error reading with pyarrow.json.read_json(). "
+                f"Falling back to native json.load(), which may be slower. "
+                f"PyArrow error was:\n{e}"
+            )
+            yield from self._read_with_python_json(buffer)
+
+
+class PandasJSONDatasource(FileBasedDatasource):
+    def __init__(
+        self,
+        paths: Union[str, List[str]],
+        target_output_size_bytes: int,
+        **file_based_datasource_kwargs,
+    ):
+        super().__init__(paths, **file_based_datasource_kwargs)
+
+        self._target_output_size_bytes = target_output_size_bytes
+
+    def _read_stream(self, f: "pyarrow.NativeFile", path: str):
+        chunksize = self._estimate_chunksize(f)
+        with pd.read_json(f, chunksize=chunksize, lines=True) as reader:
+            for df in reader:
+                yield _cast_range_index_to_string(df)
+
+    def _estimate_chunksize(self, f: "pyarrow.NativeFile") -> int:
+        assert f.tell() == 0, "File pointer must be at the beginning"
+
+        with pd.read_json(f, chunksize=1, lines=True) as reader:
+            df = _cast_range_index_to_string(next(reader))
+
+        block_accessor = PandasBlockAccessor.for_block(df)
+        if block_accessor.num_rows() == 0:
+            return 1
+
+        bytes_per_row = block_accessor.size_bytes() / block_accessor.num_rows()
+        chunksize = max(round(self._target_output_size_bytes / bytes_per_row), 1)
+
+        # Reset file pointer to the beginning.
+        f.seek(0)
+
+        return chunksize
+
+    def _open_input_source(
+        self,
+        filesystem: "pyarrow.fs.FileSystem",
+        path: str,
+        **open_args,
+    ) -> "pyarrow.NativeFile":
+        # Use seekable file to ensure we can correctly sample the first row.
+        file = filesystem.open_input_file(path, **open_args)
+        assert file.seekable(), "File must be seekable"
+        return file
+
+
+def _cast_range_index_to_string(df: pd.DataFrame):
+    # NOTE: PandasBlockAccessor doesn't support RangeIndex, so we need to convert
+    # to string.
+    if isinstance(df.columns, pd.RangeIndex):
+        df.columns = df.columns.astype(str)
+    return df

--- a/python/ray/data/_internal/datasource/json_datasource.py
+++ b/python/ray/data/_internal/datasource/json_datasource.py
@@ -31,9 +31,6 @@ JSON_FILE_EXTENSIONS = [
     "jsonl.lz4",
 ]
 
-# TODO(rliaw): Arbitrarily chosen. Make this configurable
-_DEFAULT_JSONL_ROWS_PER_CHUNK = 10000
-
 
 class ArrowJSONDatasource(FileBasedDatasource):
     """JSON datasource, for reading and writing JSON and JSONL files."""

--- a/python/ray/data/tests/test_json.py
+++ b/python/ray/data/tests/test_json.py
@@ -6,12 +6,15 @@ from functools import partial
 
 import pandas as pd
 import pyarrow as pa
+import pyarrow.fs as fs
 import pyarrow.json as pajson
 import pytest
 from pytest_lazy_fixtures import lf as lazy_fixture
 
 import ray
 from ray.data import Schema
+from ray.data._internal.datasource.json_datasource import PandasJSONDatasource
+from ray.data._internal.pandas_block import PandasBlockBuilder
 from ray.data._internal.util import rows_same
 from ray.data.block import BlockAccessor
 from ray.data.datasource import (
@@ -671,6 +674,60 @@ def test_json_with_http_path_parallelization(ray_start_regular_shared, httpserve
     assert sorted(actual_rows, key=lambda row: row["id"]) == sorted(
         expected_rows, key=lambda row: row["id"]
     )
+
+
+class TestPandasJSONDatasource:
+    @pytest.mark.parametrize(
+        "data",
+        [{"a": []}, {"a": [1]}, {"a": [1, 2, 3]}],
+        ids=["empty", "single", "multiple"],
+    )
+    def test_read_stream(self, data, tmp_path):
+        # Setup test file.
+        df = pd.DataFrame(data)
+        path = os.path.join(tmp_path, "test.json")
+        df.to_json(path, orient="records", lines=True)
+
+        # Setup datasource.
+        local_filesystem = fs.LocalFileSystem()
+        source = PandasJSONDatasource(
+            path, target_output_size_bytes=1, filesystem=local_filesystem
+        )
+
+        # Read stream.
+        block_builder = PandasBlockBuilder()
+        with source._open_input_source(local_filesystem, path) as f:
+            for block in source._read_stream(f, path):
+                block_builder.add_block(block)
+        block = block_builder.build()
+
+        # Verify.
+        assert rows_same(block, df)
+
+    def test_read_stream_with_target_output_size_bytes(self, tmp_path):
+        # Setup test file. It contains 16 lines, each line is 8 MiB.
+        df = pd.DataFrame({"data": ["a" * 8] * 16})
+        path = os.path.join(tmp_path, "test.json")
+        df.to_json(path, orient="records", lines=True)
+
+        # Setup datasource. It should read 32 MiB (4 lines) per output.
+        local_filesystem = fs.LocalFileSystem()
+        source = PandasJSONDatasource(
+            path,
+            target_output_size_bytes=32 * 1024 * 1024,
+            filesystem=local_filesystem,
+        )
+
+        # Read stream.
+        block_builder = PandasBlockBuilder()
+        with source._open_input_source(local_filesystem, path) as f:
+            for block in source._read_stream(f, path):
+                assert len(block) == 4
+                block_builder.add_block(block)
+        block = block_builder.build()
+
+        # Verify.
+        assert rows_same(block, df)
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_json.py
+++ b/python/ray/data/tests/test_json.py
@@ -706,7 +706,7 @@ class TestPandasJSONDatasource:
 
     def test_read_stream_with_target_output_size_bytes(self, tmp_path):
         # Setup test file. It contains 16 lines, each line is 8 MiB.
-        df = pd.DataFrame({"data": ["a" * 8] * 16})
+        df = pd.DataFrame({"data": ["a" * 8 * 1024 * 1024] * 16})
         path = os.path.join(tmp_path, "test.json")
         df.to_json(path, orient="records", lines=True)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

`read_json(..., lines=True)` uses pandas to read batches of data. The issue is that the batch size is always set to 10000 rows per batch, and this can cause OOMs if each line is large (e.g., a line might contain bytes for a 8 MiB image).

To avoid OOMs, this PR updates the implementation to sample a row and infer the appropriate batch size.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
