### PR TITLE
[serve] skip test_proxy_disconnect_metrics on windows

### DIFF
--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -549,6 +549,7 @@ def test_proxy_timeout_metrics(metrics_start_shutdown):
     assert num_errors[0]["application"] == "status_code_timeout"
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows")
 def test_proxy_disconnect_metrics(metrics_start_shutdown):
     """Test that disconnect metrics are reported correctly."""
 


### PR DESCRIPTION
Skip `test_proxy_disconnect_metrics` on windows because it is flaky.