### PR TITLE
[train][checkpoint] Populate checkpoint from before_init_train_context instead of workergroupcontext

### DIFF
--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -146,13 +146,17 @@ class TrainController:
         ]
         # Group callbacks that will be propagated to the worker group,
         # train worker and the train context.
-        self._worker_group_callbacks_to_propagate = [report_handler] + [
-            c
-            for c in self._callbacks
-            if isinstance(
-                c, (WorkerGroupCallback, WorkerCallback, TrainContextCallback)
-            )
-        ]
+        self._worker_group_callbacks_to_propagate = (
+            [report_handler]
+            + [
+                c
+                for c in self._callbacks
+                if isinstance(
+                    c, (WorkerGroupCallback, WorkerCallback, TrainContextCallback)
+                )
+            ]
+            + [self._checkpoint_manager]
+        )
 
         self._health_check_interval_s = float(
             os.getenv(HEALTH_CHECK_INTERVAL_S_ENV_VAR, DEFAULT_HEALTH_CHECK_INTERVAL_S)
@@ -268,27 +272,14 @@ class TrainController:
         Returns:
             True if the worker group was successfully started, False otherwise.
         """
-
-        # If there's a latest checkpoint that's been committed,
-        # use it to restore the worker group.
-        latest_checkpoint_result = self._checkpoint_manager.latest_checkpoint_result
-        latest_checkpoint = (
-            latest_checkpoint_result.checkpoint if latest_checkpoint_result else None
-        )
         placement_strategy = self._scaling_policy.scaling_config.placement_strategy
-
         worker_group_context = WorkerGroupContext(
             run_attempt_id=self._get_run_attempt_id(),
             train_fn_ref=self._train_fn_ref,
             num_workers=num_workers,
             resources_per_worker=resources_per_worker,
             placement_strategy=placement_strategy,
-            checkpoint=latest_checkpoint,
         )
-
-        # Start the worker group with the latest checkpoint if there is one.
-        # Otherwise, start the worker group with the checkpoint set by controller.
-        # Finally, if there is no checkpoint, start the worker group with None.
         try:
             self._worker_group = self.worker_group_cls.create(
                 train_run_context=self._train_run_context,

--- a/python/ray/train/v2/_internal/execution/worker_group/worker_group.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/worker_group.py
@@ -10,7 +10,6 @@ from ray._private.ray_constants import env_float
 from ray.actor import ActorHandle
 from ray.exceptions import GetTimeoutError, RayActorError
 from ray.runtime_env import RuntimeEnv
-from ray.train import Checkpoint
 from ray.train.v2._internal.constants import (
     DEFAULT_REPORT_BARRIER_TIMEOUT_S,
     DEFAULT_REPORT_BARRIER_WARN_INTERVAL_S,
@@ -88,7 +87,6 @@ class WorkerGroupContext:
         num_workers: The number of workers in the worker group.
         resources_per_worker: The resources per worker.
         placement_strategy: Strategy for placing workers.
-        checkpoint: Optional checkpoint to restore from.
     """
 
     run_attempt_id: str
@@ -96,10 +94,6 @@ class WorkerGroupContext:
     num_workers: int
     resources_per_worker: Dict[str, float]
     placement_strategy: str = "PACK"
-    # TODO: Remove checkpoint from WorkerGroupContext
-    # and move it to CheckpointManager. Populate TrainContext
-    # similar to how the dataset shards are passed to the workers.
-    checkpoint: Optional[Checkpoint] = None
 
 
 class WorkerGroup:
@@ -290,9 +284,7 @@ class WorkerGroup:
             # To prevent the driver from crashing, catch all `RayActorError`s and
             # raise a specially handled error to the controller.
             try:
-                train_context_args = {
-                    "checkpoint": [worker_group_context.checkpoint] * len(workers)
-                }
+                train_context_args = {}
                 for callable in self._callbacks:
                     args = callable.before_init_train_context(workers)
                     for arg, arg_values in args.items():


### PR DESCRIPTION
# Summary

This PR cleans up technical debt by implementing a TODO in the codebase. The TODO was essentially to populate all Train Context args with `before_init_train_context` methods.

# Testing

I ran [this example](https://docs.ray.io/en/latest/train/user-guides/checkpoints.html#restore-training-state-from-a-checkpoint) in an Anyscale Workspace which produced these logs: https://gist.github.com/TimothySeah/4d84e6548f565f9746d41d444df9cb00. This shows that checkpoint restoration still works. 