### PR TITLE
[core] fix get_max_resources_from_cluster_config

### DIFF
--- a/python/ray/_private/state.py
+++ b/python/ray/_private/state.py
@@ -886,14 +886,10 @@ class GlobalState:
             # Return CPU/GPU/TPU as None when no config is available
             return {key: None for key in all_resource_keys}
 
-        # Only include additional resource types if there are actual node group configs
-        # If no node groups exist, resources from max_resources aren't actually available
         if config.node_group_configs:
-            # Check resources in node group configs
             for node_group_config in config.node_group_configs:
                 all_resource_keys.update(node_group_config.resources.keys())
 
-        # Calculate max value for each resource key
         return {
             key: self._calculate_max_resource_from_cluster_config(key)
             for key in all_resource_keys

--- a/python/ray/tests/test_global_state.py
+++ b/python/ray/tests/test_global_state.py
@@ -741,11 +741,12 @@ def test_get_max_cpus_from_cluster_config(
             ),
             {
                 "CPU": 90,
+                "GPU": 4,
                 "memory": 500,
             },  # 50 + (10*4), 500 + 0
         ),
         (
-            "should return None for resources with 0 count or 0 resources",
+            "should return 0 for resources with 0 count or 0 resources",
             autoscaler_pb2.ClusterConfig(
                 node_group_configs=[
                     autoscaler_pb2.NodeGroupConfig(
@@ -762,11 +763,12 @@ def test_get_max_cpus_from_cluster_config(
             ),
             {
                 "CPU": 0,
+                "GPU": 2,
                 "memory": 0,
-            },  # CPU is None due to max_count=0, memory has valid count
+            },  # CPU is None due to max_count=0, GPU has valid count
         ),
         (
-            "should discover all resource types including custom ones, always including CPU/GPU/TPU",
+            "should discover all resource types including custom ones",
             autoscaler_pb2.ClusterConfig(
                 max_resources={"TPU": 16, "special_resource": 100},
                 node_group_configs=[
@@ -790,7 +792,6 @@ def test_get_max_cpus_from_cluster_config(
             {
                 "CPU": 160,  # (32*2) + (96*1)
                 "GPU": 16,  # (8*2) + 0
-                "TPU": 0,  # Always included but not in node_group_configs
                 "memory": 4000,  # (1000*2) + (2000*1)
                 "custom_accelerator": 8,  # (4*2) + 0
                 "disk": 500,  # 0 + (500*1)

--- a/python/ray/tests/test_global_state.py
+++ b/python/ray/tests/test_global_state.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import time
-from typing import Optional
+from typing import Optional, Dict
 
 import pytest
 
@@ -645,6 +645,194 @@ def test_get_max_cpus_from_cluster_config(
     gcs_client.report_cluster_config(cluster_config.SerializeToString())
     max_resources = ray._private.state.state.get_max_resources_from_cluster_config()
     assert (max_resources and max_resources["CPU"]) == num_cpu, description
+
+
+@pytest.mark.parametrize(
+    "description, cluster_config, expected_resources",
+    [
+        (
+            "should return CPU/GPU/TPU as None since empty config is provided",
+            autoscaler_pb2.ClusterConfig(),
+            {"CPU": None, "GPU": None, "TPU": None},
+        ),
+        (
+            "should return CPU/GPU/TPU as None since no node_group_config is provided",
+            autoscaler_pb2.ClusterConfig(
+                max_resources={"CPU": 100, "memory": 1000},
+            ),
+            {
+                "CPU": None,
+                "GPU": None,
+                "TPU": None,
+            },
+        ),
+        (
+            "should return CPU/GPU/TPU plus resources from node_group_configs",
+            autoscaler_pb2.ClusterConfig(
+                node_group_configs=[
+                    autoscaler_pb2.NodeGroupConfig(
+                        name="m5.large",
+                        resources={"CPU": 50, "memory": 500},
+                        max_count=1,
+                    )
+                ],
+            ),
+            {"CPU": 50, "GPU": None, "TPU": None, "memory": 500},
+        ),
+        (
+            "should return resources from both node_group_configs and max_resources",
+            autoscaler_pb2.ClusterConfig(
+                max_resources={"GPU": 8},
+                node_group_configs=[
+                    autoscaler_pb2.NodeGroupConfig(
+                        name="m5.large",
+                        resources={"CPU": 50, "memory": 500},
+                        max_count=1,
+                    )
+                ],
+            ),
+            {
+                "CPU": 50,
+                "GPU": None,
+                "TPU": None,
+                "memory": 500,
+            },  # GPU and TPU are None because not in node_group_configs
+        ),
+        (
+            "should return limited by max_resources when node_group total exceeds it",
+            autoscaler_pb2.ClusterConfig(
+                max_resources={"CPU": 30, "memory": 200},
+                node_group_configs=[
+                    autoscaler_pb2.NodeGroupConfig(
+                        name="m5.large",
+                        resources={"CPU": 50, "memory": 500},
+                        max_count=1,
+                    )
+                ],
+            ),
+            {"CPU": 30, "GPU": None, "TPU": None, "memory": 200},
+        ),
+        (
+            "should return sys.maxsize when max_count=-1",
+            autoscaler_pb2.ClusterConfig(
+                node_group_configs=[
+                    autoscaler_pb2.NodeGroupConfig(
+                        name="m5.large",
+                        resources={"CPU": 50, "custom_resource": 10},
+                        max_count=-1,
+                    )
+                ],
+            ),
+            {
+                "CPU": sys.maxsize,
+                "GPU": None,
+                "TPU": None,
+                "custom_resource": sys.maxsize,
+            },
+        ),
+        (
+            "should sum across multiple node_group_configs",
+            autoscaler_pb2.ClusterConfig(
+                node_group_configs=[
+                    autoscaler_pb2.NodeGroupConfig(
+                        name="m5.large",
+                        resources={"CPU": 50, "memory": 500},
+                        max_count=1,
+                    ),
+                    autoscaler_pb2.NodeGroupConfig(
+                        name="m5.small",
+                        resources={"CPU": 10, "GPU": 1},
+                        max_count=4,
+                    ),
+                ],
+            ),
+            {
+                "CPU": 90,
+                "GPU": 4,
+                "TPU": None,
+                "memory": 500,
+            },  # 50 + (10*4), 0 + (1*4), None, 500 + 0
+        ),
+        (
+            "should return None for resources with 0 count or 0 resources",
+            autoscaler_pb2.ClusterConfig(
+                node_group_configs=[
+                    autoscaler_pb2.NodeGroupConfig(
+                        name="m5.large",
+                        resources={"CPU": 50, "memory": 0},
+                        max_count=0,  # This makes all resources None
+                    ),
+                    autoscaler_pb2.NodeGroupConfig(
+                        name="m5.small",
+                        resources={"GPU": 1},
+                        max_count=2,
+                    ),
+                ],
+            ),
+            {
+                "CPU": None,
+                "GPU": 2,
+                "TPU": None,
+                "memory": None,
+            },  # CPU is None due to max_count=0, GPU has valid count
+        ),
+        (
+            "should discover all resource types including custom ones, always including CPU/GPU/TPU",
+            autoscaler_pb2.ClusterConfig(
+                max_resources={"TPU": 16, "special_resource": 100},
+                node_group_configs=[
+                    autoscaler_pb2.NodeGroupConfig(
+                        name="gpu-node",
+                        resources={
+                            "CPU": 32,
+                            "GPU": 8,
+                            "memory": 1000,
+                            "custom_accelerator": 4,
+                        },
+                        max_count=2,
+                    ),
+                    autoscaler_pb2.NodeGroupConfig(
+                        name="cpu-node",
+                        resources={"CPU": 96, "memory": 2000, "disk": 500},
+                        max_count=1,
+                    ),
+                ],
+            ),
+            {
+                "CPU": 160,  # (32*2) + (96*1)
+                "GPU": 16,  # (8*2) + 0
+                "TPU": None,  # Always included but not in node_group_configs
+                "memory": 4000,  # (1000*2) + (2000*1)
+                "custom_accelerator": 8,  # (4*2) + 0
+                "disk": 500,  # 0 + (500*1)
+            },
+        ),
+    ],
+)
+def test_get_max_resources_from_cluster_config(
+    shutdown_only,
+    description: str,
+    cluster_config: autoscaler_pb2.ClusterConfig,
+    expected_resources: Dict[str, Optional[int]],
+):
+    """Test get_max_resources_from_cluster_config method.
+
+    This test verifies that the method correctly:
+    1. Always includes CPU/GPU/TPU in the results
+    2. Discovers additional resource types from node_group_configs and max_resources
+    3. Calculates maximum values for each resource type
+    4. Handles edge cases like empty configs, zero counts, unlimited resources
+    5. Supports resource types beyond CPU/GPU/TPU
+    """
+    ray.init(num_cpus=1)
+    gcs_client = GcsClient(address=ray.get_runtime_context().gcs_address)
+
+    gcs_client.report_cluster_config(cluster_config.SerializeToString())
+    max_resources = ray._private.state.state.get_max_resources_from_cluster_config()
+
+    assert (
+        max_resources == expected_resources
+    ), f"{description}\nExpected: {expected_resources}\nActual: {max_resources}"
 
 
 def test_get_draining_nodes(ray_start_cluster):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

`get_max_resources_from_cluster_config` is only returning `CPU`, `GPU`, and `TPU`. But users might need to check other available resources, like `memory`.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
