### PR TITLE
[core][autoscaler] fix: use RAY_UP_enable_autoscaler_v2 instead of RAY_enable_autoscaler_v2 for ray up

### DIFF
--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -822,7 +822,10 @@ def get_or_create_head_node(
         if not no_restart:
             warn_about_bad_start_command(ray_start_commands, no_monitor_on_head)
 
-        if os.getenv("RAY_enable_autoscaler_v2", "0") == "1":
+        # Use RAY_UP_enable_autoscaler_v2 instead of RAY_enable_autoscaler_v2
+        # to avoid accidentally enabling autoscaler v2 for ray up
+        # due to env inheritance.
+        if os.getenv("RAY_UP_enable_autoscaler_v2", "0") == "1":
             ray_start_commands = with_envs(
                 ray_start_commands,
                 {


### PR DESCRIPTION
## Why are these changes needed?

Use a different env var for ray up to enable autoscaler v2 to avoid accidentally enabling v2 due to env inheritance.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
