### PR TITLE
Fix timeout multiplier issue in GetApiOptions #54153

### DIFF
--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -3803,38 +3803,38 @@ def test_hang_driver_has_no_is_running_task(monkeypatch, ray_start_cluster):
 
 def test_get_actor_timeout_multiplier(shutdown_only):
     """Test that GetApiOptions applies the same timeout multiplier as ListApiOptions.
-    
+
     This test reproduces the issue where get_actor with timeout=1 fails even though
     the actual operation takes less than 1 second, because GetApiOptions doesn't
     apply the 0.8 server timeout multiplier that ListApiOptions uses.
     """
     from ray.util.state.common import GetApiOptions, ListApiOptions
-    
+
     ray.init()
-    
+
     @ray.remote
     class TestActor:
         def ready(self):
             pass
-    
+
     actor = TestActor.remote()
     ray.get(actor.ready.remote())
-    
+
     # Test that both options classes apply the same timeout multiplier
     test_timeout = 1
     get_options = GetApiOptions(timeout=test_timeout)
     list_options = ListApiOptions(timeout=test_timeout)
-    
+
     # After __post_init__, both should have the same effective timeout
     assert get_options.timeout == list_options.timeout, (
         f"GetApiOptions timeout ({get_options.timeout}) should match "
         f"ListApiOptions timeout ({list_options.timeout}) after applying multiplier"
     )
-    
+
     # Test that get_actor works with a 1-second timeout
     actors = list_actors()
     actor_id = actors[0]["actor_id"]
-    
+
     # This should work without timeout issues
     result = get_actor(actor_id, timeout=1)
     assert result is not None

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -111,6 +111,7 @@ from ray.util.state.common import (
     WorkerState,
     StateSchema,
     state_column,
+    GetApiOptions,
 )
 from ray.dashboard.utils import ray_address_to_api_server_url
 from ray.util.state.exception import DataSourceUnavailable, RayStateApiException
@@ -3798,6 +3799,46 @@ def test_hang_driver_has_no_is_running_task(monkeypatch, ray_start_cluster):
     all_job_info = client.get_all_job_info()
     assert list(all_job_info.keys()) == [my_job_id]
     assert not all_job_info[my_job_id].HasField("is_running_tasks")
+
+
+def test_get_actor_timeout_multiplier(shutdown_only):
+    """Test that GetApiOptions applies the same timeout multiplier as ListApiOptions.
+    
+    This test reproduces the issue where get_actor with timeout=1 fails even though
+    the actual operation takes less than 1 second, because GetApiOptions doesn't
+    apply the 0.8 server timeout multiplier that ListApiOptions uses.
+    """
+    from ray.util.state.common import GetApiOptions, ListApiOptions
+    
+    ray.init()
+    
+    @ray.remote
+    class TestActor:
+        def ready(self):
+            pass
+    
+    actor = TestActor.remote()
+    ray.get(actor.ready.remote())
+    
+    # Test that both options classes apply the same timeout multiplier
+    test_timeout = 1
+    get_options = GetApiOptions(timeout=test_timeout)
+    list_options = ListApiOptions(timeout=test_timeout)
+    
+    # After __post_init__, both should have the same effective timeout
+    assert get_options.timeout == list_options.timeout, (
+        f"GetApiOptions timeout ({get_options.timeout}) should match "
+        f"ListApiOptions timeout ({list_options.timeout}) after applying multiplier"
+    )
+    
+    # Test that get_actor works with a 1-second timeout
+    actors = list_actors()
+    actor_id = actors[0]["actor_id"]
+    
+    # This should work without timeout issues
+    result = get_actor(actor_id, timeout=1)
+    assert result is not None
+    assert result["actor_id"] == actor_id
 
 
 if __name__ == "__main__":

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -197,6 +197,18 @@ class ListApiOptions:
 class GetApiOptions:
     # Timeout for the HTTP request
     timeout: int = DEFAULT_RPC_TIMEOUT
+    # When the request is processed on the server side,
+    # we should apply multiplier so that server side can finish
+    # processing a request within timeout. Otherwise,
+    # timeout will always lead Http timeout.
+    server_timeout_multiplier: float = 0.8
+
+    def __post_init__(self):
+        # To return the data to users, when there's a partial failure
+        # we need to have a timeout that's smaller than the users' timeout.
+        # 80% is configured arbitrarily.
+        self.timeout = int(self.timeout * self.server_timeout_multiplier)
+        assert self.timeout != 0, "0 second timeout is not supported."
 
 
 @dataclass(init=not IS_PYDANTIC_2)

--- a/python/ray/util/state/common.py
+++ b/python/ray/util/state/common.py
@@ -207,7 +207,7 @@ class GetApiOptions:
         # To return the data to users, when there's a partial failure
         # we need to have a timeout that's smaller than the users' timeout.
         # 80% is configured arbitrarily.
-        self.timeout = int(self.timeout * self.server_timeout_multiplier)
+        self.timeout = int(self.timeout * self.server_timeout_multiplier) or (1 if self.timeout * self.server_timeout_multiplier > 0 else 0)
         assert self.timeout != 0, "0 second timeout is not supported."
 
 


### PR DESCRIPTION
## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. (N/A - no new APIs added)
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(