### PR TITLE
[serve] deflake test_deployment_scheduler_with_comp_sched

### DIFF
--- a/python/ray/serve/_private/deployment_scheduler.py
+++ b/python/ray/serve/_private/deployment_scheduler.py
@@ -56,7 +56,8 @@ class Resources(dict):
 
     def can_fit(self, other):
         keys = set(self.keys()) | set(other.keys())
-        return all(self.get(k) >= other.get(k) for k in keys)
+        # We add a small epsilon to avoid floating point precision issues.
+        return all(self.get(k) + 1e-9 >= other.get(k) for k in keys)
 
     def __eq__(self, other):
         keys = set(self.keys()) | set(other.keys())

--- a/python/ray/serve/_private/deployment_scheduler.py
+++ b/python/ray/serve/_private/deployment_scheduler.py
@@ -41,6 +41,7 @@ class SpreadDeploymentSchedulingPolicy:
 class Resources(dict):
     # Custom resource priority from environment variable
     CUSTOM_PRIORITY: List[str] = RAY_SERVE_HIGH_PRIORITY_CUSTOM_RESOURCES
+    EPSILON = 1e-9
 
     def get(self, key: str):
         val = super().get(key)
@@ -57,7 +58,7 @@ class Resources(dict):
     def can_fit(self, other):
         keys = set(self.keys()) | set(other.keys())
         # We add a small epsilon to avoid floating point precision issues.
-        return all(self.get(k) + 1e-9 >= other.get(k) for k in keys)
+        return all(self.get(k) + self.EPSILON >= other.get(k) for k in keys)
 
     def __eq__(self, other):
         keys = set(self.keys()) | set(other.keys())

--- a/python/ray/serve/tests/test_deployment_scheduler.py
+++ b/python/ray/serve/tests/test_deployment_scheduler.py
@@ -207,7 +207,7 @@ class TestCompactScheduling:
     @pytest.mark.parametrize(
         "app_resources,expected_worker_nodes",
         [
-            # [2, 5, 3, 3, 7, 2, 6, 2] -> 3 nodes
+            # [2, 5, 3, 3, 7, 6, 4] -> 3 nodes
             ({5: 1, 3: 2, 7: 1, 2: 1, 6: 1, 4: 1}, 3),
             # [1, 7, 7, 3, 2] -> 2 nodes
             ({1: 1, 7: 2, 3: 1, 2: 1}, 2),

--- a/python/ray/serve/tests/test_deployment_scheduler.py
+++ b/python/ray/serve/tests/test_deployment_scheduler.py
@@ -15,8 +15,6 @@ from ray.serve._private.deployment_scheduler import (
 )
 from ray.serve._private.test_utils import check_apps_running, get_node_id
 from ray.serve._private.utils import get_head_node_id
-from ray.serve.context import _get_global_client
-from ray.serve.schema import ServeDeploySchema
 from ray.tests.conftest import *  # noqa
 
 
@@ -210,7 +208,7 @@ class TestCompactScheduling:
         "app_resources,expected_worker_nodes",
         [
             # [2, 5, 3, 3, 7, 2, 6, 2] -> 3 nodes
-            ({5: 1, 3: 2, 7: 1, 2: 3, 6: 1}, 3),
+            ({5: 1, 3: 2, 7: 1, 2: 1, 6: 1, 4: 1}, 3),
             # [1, 7, 7, 3, 2] -> 2 nodes
             ({1: 1, 7: 2, 3: 1, 2: 1}, 2),
             # [7, 3, 2, 7, 7, 2] -> 3 nodes
@@ -221,37 +219,39 @@ class TestCompactScheduling:
         self, ray_cluster, use_pg, app_resources, expected_worker_nodes
     ):
         for _ in range(expected_worker_nodes):
-            ray_cluster.add_node(num_cpus=10)
+            ray_cluster.add_node(num_cpus=1)
         ray_cluster.wait_for_nodes()
         ray.init(address=ray_cluster.address)
 
         serve.start()
-        client = _get_global_client()
 
-        applications = []
+        @serve.deployment
+        def A():
+            return ray.get_runtime_context().get_node_id()
+
+        @serve.deployment(ray_actor_options={"num_cpus": 0})
+        class Ingress:
+            def __init__(self, *handles):
+                self.handles = handles
+
+            def __call__(self):
+                pass
+
+        deployments = []
         for n, count in app_resources.items():
-            name = n
             num_cpus = 0.1 * n
-            app = {
-                "name": f"app{name}",
-                "import_path": "ray.serve.tests.test_deployment_scheduler.app_A",
-                "route_prefix": f"/app{name}",
-                "deployments": [
-                    {
-                        "name": "A",
-                        "num_replicas": count,
-                        "ray_actor_options": {"num_cpus": 0 if use_pg else num_cpus},
-                    }
-                ],
-            }
-            if use_pg:
-                app["deployments"][0]["placement_group_bundles"] = [{"CPU": num_cpus}]
-                app["deployments"][0]["placement_group_strategy"] = "STRICT_PACK"
+            deployments.append(
+                A.options(
+                    name=f"A{n}",
+                    num_replicas=count,
+                    ray_actor_options={"num_cpus": 0 if use_pg else num_cpus},
+                    placement_group_bundles=[{"CPU": num_cpus}] if use_pg else None,
+                    placement_group_strategy="STRICT_PACK" if use_pg else None,
+                ).bind()
+            )
 
-            applications.append(app)
-
-        client.deploy_apps(ServeDeploySchema(**{"applications": applications}))
-        wait_for_condition(check_apps_running, apps=[f"app{n}" for n in app_resources])
+        serve.run(Ingress.bind(*deployments))
+        wait_for_condition(check_apps_running, apps=["default"])
         print("Test passed!")
 
     @pytest.mark.parametrize("use_pg", [True, False])


### PR DESCRIPTION
Deflake `test_deployment_scheduler_with_comp_sched`.
Example failures:
https://buildkite.com/ray-project/postmerge/builds/11299#0197e67f-226c-4c40-accc-76584a3f07b3/177-1986
https://buildkite.com/ray-project/postmerge/builds/11286#0197e5a4-f838-4779-8883-1731ed77b2a8/177-1501
https://buildkite.com/ray-project/postmerge/builds/11286#0197e5f0-bf4b-45dc-8cb7-a30db3eeb4bc/177-1949

Cause for flakiness:
- In order to deploy replica actors with non-uniform resource requirements, we used multiple applications. However this causes the controller to launch a separate task for each application to import + build the app, which takes time and sometimes causes the wait_for_condition to time out waiting for all applications to reach RUNNING.
  - Fixed by deploying a single application with multiple deployments instead of multiple applications with 1 deployment-per-application.

Other issues found while debugging the test:
- The test was not really functional because the resource requirements was off by a factor of 10.
  - Fixed by setting num available cpus on each node to 1 instead of 10.
- Comparisons between resource objects suffer from floating precision issues.
  - Fixed by adding an epsilon when doing comparisons.