### PR TITLE
[ci] stop using get.docker.com

### DIFF
--- a/ci/docker/base.gpu.Dockerfile
+++ b/ci/docker/base.gpu.Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.3-labs
 ARG BASE_IMAGE=nvidia/cuda:12.1.1-cudnn8-devel-ubuntu20.04
 FROM $BASE_IMAGE
 
@@ -23,19 +24,35 @@ ENV BUILDKITE_PULL_REQUEST_BASE_BRANCH=${BUILDKITE_PULL_REQUEST_BASE_BRANCH}
 ENV TRAVIS_COMMIT=${BUILDKITE_COMMIT}
 ENV BUILDKITE_BAZEL_CACHE_URL=${REMOTE_CACHE_URL}
 
-RUN apt-get update -qq && apt-get upgrade -qq
-RUN apt-get install -y -qq \
+RUN <<EOF
+#!/bin/bash
+
+set -euo pipefail
+
+apt-get update -qq && apt-get upgrade -qq
+apt-get install -y -qq \
     curl python-is-python3 git build-essential \
     sudo unzip unrar apt-utils dialog tzdata wget rsync \
     language-pack-en tmux cmake gdb vim htop \
     libgtk2.0-dev zlib1g-dev libgl1-mesa-dev \
     clang-format-12 jq \
     clang-tidy-12 clang-12
-RUN ln -s /usr/bin/clang-format-12 /usr/bin/clang-format && \
-    ln -s /usr/bin/clang-tidy-12 /usr/bin/clang-tidy && \
-    ln -s /usr/bin/clang-12 /usr/bin/clang
+ln -s /usr/bin/clang-format-12 /usr/bin/clang-format
+ln -s /usr/bin/clang-tidy-12 /usr/bin/clang-tidy
+ln -s /usr/bin/clang-12 /usr/bin/clang
 
-RUN curl -o- https://get.docker.com | sh -s -- --version 27.2
+# Install docker CLI
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
+  tee /etc/apt/sources.list.d/docker.list > /dev/null
+apt-get update
+apt-get install -y docker-ce-cli
+
+EOF
 
 # System conf for tests
 RUN locale -a

--- a/ci/docker/base.test.Dockerfile
+++ b/ci/docker/base.test.Dockerfile
@@ -20,6 +20,8 @@ ENV BUILDKITE_BAZEL_CACHE_URL=${BUILDKITE_BAZEL_CACHE_URL}
 RUN <<EOF
 #!/bin/bash
 
+set -euo pipefail
+
 apt-get update -qq && apt-get upgrade -qq
 apt-get install -y -qq \
     curl python-is-python3 git build-essential \
@@ -34,9 +36,18 @@ ln -s /usr/bin/clang-format-12 /usr/bin/clang-format
 ln -s /usr/bin/clang-tidy-12 /usr/bin/clang-tidy
 ln -s /usr/bin/clang-12 /usr/bin/clang
 
-EOF
+# Install docker CLI
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
+  tee /etc/apt/sources.list.d/docker.list > /dev/null
+apt-get update
+apt-get install -y docker-ce-cli
 
-RUN curl -o- https://get.docker.com | sh -s -- --version 27.2
+EOF
 
 # System conf for tests
 RUN locale -a


### PR DESCRIPTION
use the official ppa instead.

get.docker.sh script stops working on ubuntu20.04 any more
