### PR TITLE
[Core] Fix the issue where multiple multithreaded calls to ray.get may cause hanging.

### DIFF
--- a/python/ray/tests/test_threaded_actor.py
+++ b/python/ray/tests/test_threaded_actor.py
@@ -291,6 +291,48 @@ def test_threaded_actor_integration_test_stress(
         ), "Resource deadlock warning shouldn't be printed, but it did."
 
 
+@pytest.mark.parametrize(
+    "ray_start_cluster_head",
+    [
+        test_utils.generate_system_config_map(
+            # 6MB, It is just large enough to accommodate one chunk, which 
+            # is also intended to ensure that the push object process is sufficiently slow.
+            object_manager_max_bytes_in_flight=6 * 1024 ** 2,
+        )
+    ],
+    indirect=True,
+)
+def test_ray_actor_get_in_multiple_threads(ray_start_cluster_head):
+    """
+    Used for testing the execution of ray.get in a multi-threading environment.
+    """
+    cluster = ray_start_cluster_head
+
+    # It needs to be large enough to ensure that this get operation 
+    # takes a sufficiently long time. and make sure this object in head.
+    large_object_ref = ray.put(b"0" * 2 * 1024 ** 3)
+
+    worker = cluster.add_node(resources={"worker": 1}, num_cpus=1)
+
+    @ray.remote(resources={"worker": 0.1})
+    class Actor:
+        def run(self, refs):
+            ref_largs = refs[0]
+            # put into worker plasma. Ensure that each get returns immediately. 
+            # Before this fix, this get would repeatedly clear the pull progress.
+            ref_small = ray.put("1")
+            def get_small():
+                while True:
+                    ray.get(ref_small)
+                    import time
+                    time.sleep(0.1)
+            t = threading.Thread(target=get_small, daemon=True)
+            t.start()
+            ray.get(ref_largs)
+    actor = Actor.remote()
+    ray.get(actor.run.remote([large_object_ref]), timeout=30)
+    
+
 if __name__ == "__main__":
 
     # Test suite is timing out. Disable on windows for now.

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.cc
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.cc
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <condition_variable>
+#include <limits>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -378,7 +379,9 @@ Status CoreWorkerMemoryStore::GetImpl(const std::vector<ObjectID> &object_ids,
   }
 
   if (should_notify_raylet) {
-    RAY_CHECK_OK(raylet_ipc_client_->NotifyDirectCallTaskUnblocked());
+    /// No get request needs to be canceled.
+    RAY_CHECK_OK(raylet_ipc_client_->NotifyDirectCallTaskUnblocked(
+        /*get_request_id=*/std::numeric_limits<uint64_t>::max()));
   }
 
   {

--- a/src/ray/core_worker/store_provider/plasma_store_provider.cc
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.cc
@@ -182,9 +182,11 @@ Status CoreWorkerPlasmaStoreProvider::PullObjectsAndGetFromPlasmaStore(
     const std::vector<ObjectID> &batch_ids,
     int64_t timeout_ms,
     absl::flat_hash_map<ObjectID, std::shared_ptr<RayObject>> *results,
-    bool *got_exception) {
+    bool *got_exception,
+    uint64_t *request_id) {
   const auto owner_addresses = reference_counter_.GetOwnerAddresses(batch_ids);
-  RAY_RETURN_NOT_OK(raylet_ipc_client_->AsyncGetObjects(batch_ids, owner_addresses));
+  RAY_RETURN_NOT_OK(
+      raylet_ipc_client_->AsyncGetObjects(batch_ids, owner_addresses, request_id));
 
   std::vector<plasma::ObjectBuffer> plasma_results;
   RAY_RETURN_NOT_OK(store_client_->Get(batch_ids, timeout_ms, &plasma_results));
@@ -258,17 +260,18 @@ Status CoreWorkerPlasmaStoreProvider::GetExperimentalMutableObject(
 
 Status UnblockIfNeeded(
     const std::shared_ptr<ipc::RayletIpcClientInterface> &raylet_client,
-    const WorkerContext &ctx) {
+    const WorkerContext &ctx,
+    const uint64_t get_request_id) {
   if (ctx.CurrentTaskIsDirectCall()) {
     // NOTE: for direct call actors, we still need to issue an unblock IPC to release
     // get subscriptions, even if the worker isn't blocked.
     if (ctx.ShouldReleaseResourcesOnBlockingCalls() || ctx.CurrentActorIsDirectCall()) {
-      return raylet_client->NotifyDirectCallTaskUnblocked();
+      return raylet_client->NotifyDirectCallTaskUnblocked(get_request_id);
     } else {
       return Status::OK();  // We don't need to release resources.
     }
   } else {
-    return raylet_client->CancelGetRequest();
+    return raylet_client->CancelGetRequest(get_request_id);
   }
 }
 
@@ -285,6 +288,7 @@ Status CoreWorkerPlasmaStoreProvider::Get(
   // Send initial requests to pull all objects in parallel.
   std::vector<ObjectID> id_vector(object_ids.begin(), object_ids.end());
   int64_t total_size = static_cast<int64_t>(object_ids.size());
+  uint64_t request_id = 0;
   for (int64_t start = 0; start < total_size; start += batch_size) {
     batch_ids.clear();
     for (int64_t i = start; i < batch_size && i < total_size; i++) {
@@ -296,13 +300,14 @@ Status CoreWorkerPlasmaStoreProvider::Get(
                                          /*timeout_ms=*/0,
                                          // Mutable objects must be local before ray.get.
                                          results,
-                                         got_exception));
+                                         got_exception,
+                                         &request_id));
   }
 
   // If all objects were fetched already, return. Note that we always need to
   // call UnblockIfNeeded() to cancel the get request.
   if (remaining.empty() || *got_exception) {
-    return UnblockIfNeeded(raylet_ipc_client_, ctx);
+    return UnblockIfNeeded(raylet_ipc_client_, ctx, request_id);
   }
 
   // If not all objects were successfully fetched, repeatedly call FetchOrReconstruct
@@ -332,7 +337,7 @@ Status CoreWorkerPlasmaStoreProvider::Get(
 
     size_t previous_size = remaining.size();
     RAY_RETURN_NOT_OK(PullObjectsAndGetFromPlasmaStore(
-        remaining, batch_ids, batch_timeout, results, got_exception));
+        remaining, batch_ids, batch_timeout, results, got_exception, &request_id));
     should_break = timed_out || *got_exception;
 
     if ((previous_size - remaining.size()) < batch_ids.size()) {
@@ -342,7 +347,7 @@ Status CoreWorkerPlasmaStoreProvider::Get(
       Status status = check_signals_();
       if (!status.ok()) {
         // TODO(edoakes): in this case which status should we return?
-        RAY_RETURN_NOT_OK(UnblockIfNeeded(raylet_ipc_client_, ctx));
+        RAY_RETURN_NOT_OK(UnblockIfNeeded(raylet_ipc_client_, ctx, request_id));
         return status;
       }
     }
@@ -357,13 +362,13 @@ Status CoreWorkerPlasmaStoreProvider::Get(
   }
 
   if (!remaining.empty() && timed_out) {
-    RAY_RETURN_NOT_OK(UnblockIfNeeded(raylet_ipc_client_, ctx));
+    RAY_RETURN_NOT_OK(UnblockIfNeeded(raylet_ipc_client_, ctx, request_id));
     return Status::TimedOut("Get timed out: some object(s) not ready.");
   }
 
   // Notify unblocked because we blocked when calling FetchOrReconstruct with
   // fetch_only=false.
-  return UnblockIfNeeded(raylet_ipc_client_, ctx);
+  return UnblockIfNeeded(raylet_ipc_client_, ctx, request_id);
 }
 
 Status CoreWorkerPlasmaStoreProvider::Contains(const ObjectID &object_id,
@@ -406,7 +411,9 @@ Status CoreWorkerPlasmaStoreProvider::Wait(
     ready->insert(entry);
   }
   if (ctx.CurrentTaskIsDirectCall() && ctx.ShouldReleaseResourcesOnBlockingCalls()) {
-    RAY_RETURN_NOT_OK(raylet_ipc_client_->NotifyDirectCallTaskUnblocked());
+    /// No get request needs to be canceled.
+    RAY_RETURN_NOT_OK(raylet_ipc_client_->NotifyDirectCallTaskUnblocked(
+        /*get_request_id=*/std::numeric_limits<uint64_t>::max()));
   }
   return Status::OK();
 }

--- a/src/ray/core_worker/store_provider/plasma_store_provider.h
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.h
@@ -216,13 +216,15 @@ class CoreWorkerPlasmaStoreProvider {
   /// map.
   /// \param[out] got_exception Set to true if any of the fetched objects contained an
   /// exception.
+  /// \param[in/out] The current get request ID.
   /// \return Status.
   Status PullObjectsAndGetFromPlasmaStore(
       absl::flat_hash_set<ObjectID> &remaining,
       const std::vector<ObjectID> &batch_ids,
       int64_t timeout_ms,
       absl::flat_hash_map<ObjectID, std::shared_ptr<RayObject>> *results,
-      bool *got_exception);
+      bool *got_exception,
+      uint64_t *request_id);
 
   /// Print a warning if we've attempted the fetch for too long and some
   /// objects are still unavailable.

--- a/src/ray/flatbuffers/node_manager.fbs
+++ b/src/ray/flatbuffers/node_manager.fbs
@@ -41,6 +41,9 @@ enum MessageType:int {
   // Request the Raylet to pull a set of objects to the local node.
   // a raylet.
   AsyncGetObjectsRequest,
+  // The response message to AsyncGetObjects; replies with the new get request
+  // id.
+  AsyncGetObjectsReply,
   // Cancel outstanding get requests from the worker.
   CancelGetRequest,
   // Notify the current worker is blocked. This is only used by direct task calls;
@@ -133,15 +136,26 @@ table AsyncGetObjectsRequest {
   // Object IDs that we want the Raylet to pull locally.
   object_ids: [string];
   owner_addresses: [Address];
+  // The current get request ID.
+  request_id: ulong;
+}
+
+table AsyncGetObjectsReply {
+  // After update get request, get new request id.
+  new_request_id: ulong;
 }
 
 table CancelGetRequest {
+  // The ID of the get request that needs to be canceled.
+  request_id: ulong;
 }
 
 table NotifyDirectCallTaskBlocked {
 }
 
 table NotifyDirectCallTaskUnblocked {
+  // The ID of the get request that needs to be canceled.
+  get_request_id: ulong;
 }
 
 table WaitRequest {

--- a/src/ray/ipc/fake_raylet_ipc_client.h
+++ b/src/ray/ipc/fake_raylet_ipc_client.h
@@ -50,7 +50,8 @@ class FakeRayletIpcClient : public RayletIpcClientInterface {
   ray::Status ActorCreationTaskDone() override { return Status::OK(); }
 
   ray::Status AsyncGetObjects(const std::vector<ObjectID> &object_ids,
-                              const std::vector<rpc::Address> &owner_addresses) override {
+                              const std::vector<rpc::Address> &owner_addresses,
+                              uint64_t *request_id) override {
     return Status::OK();
   }
 
@@ -62,11 +63,15 @@ class FakeRayletIpcClient : public RayletIpcClientInterface {
     return absl::flat_hash_set<ObjectID>();
   }
 
-  ray::Status CancelGetRequest() override { return Status::OK(); }
+  ray::Status CancelGetRequest(const uint64_t get_request_id) override {
+    return Status::OK();
+  }
 
   ray::Status NotifyDirectCallTaskBlocked() override { return Status::OK(); }
 
-  ray::Status NotifyDirectCallTaskUnblocked() override { return Status::OK(); }
+  ray::Status NotifyDirectCallTaskUnblocked(const uint64_t get_request_id) override {
+    return Status::OK();
+  }
 
   ray::Status WaitForActorCallArgs(const std::vector<rpc::ObjectReference> &references,
                                    int64_t tag) override {

--- a/src/ray/ipc/raylet_ipc_client.h
+++ b/src/ray/ipc/raylet_ipc_client.h
@@ -73,7 +73,8 @@ class RayletIpcClient : public RayletIpcClientInterface {
   ray::Status ActorCreationTaskDone() override;
 
   ray::Status AsyncGetObjects(const std::vector<ObjectID> &object_ids,
-                              const std::vector<rpc::Address> &owner_addresses) override;
+                              const std::vector<rpc::Address> &owner_addresses,
+                              uint64_t *request_id) override;
 
   ray::StatusOr<absl::flat_hash_set<ObjectID>> Wait(
       const std::vector<ObjectID> &object_ids,
@@ -81,11 +82,11 @@ class RayletIpcClient : public RayletIpcClientInterface {
       int num_returns,
       int64_t timeout_milliseconds) override;
 
-  ray::Status CancelGetRequest() override;
+  ray::Status CancelGetRequest(const uint64_t get_request_id) override;
 
   ray::Status NotifyDirectCallTaskBlocked() override;
 
-  ray::Status NotifyDirectCallTaskUnblocked() override;
+  ray::Status NotifyDirectCallTaskUnblocked(const uint64_t get_request_id) override;
 
   ray::Status WaitForActorCallArgs(const std::vector<rpc::ObjectReference> &references,
                                    int64_t tag) override;

--- a/src/ray/ipc/raylet_ipc_client_interface.h
+++ b/src/ray/ipc/raylet_ipc_client_interface.h
@@ -105,10 +105,11 @@ class RayletIpcClientInterface {
   ///
   /// \param object_ids The IDs of the objects to pull.
   /// \param owner_addresses The owner addresses of the objects.
+  /// \param request_id The current get request ID.
   /// \return ray::Status.
-  virtual ray::Status AsyncGetObjects(
-      const std::vector<ObjectID> &object_ids,
-      const std::vector<rpc::Address> &owner_addresses) = 0;
+  virtual ray::Status AsyncGetObjects(const std::vector<ObjectID> &object_ids,
+                                      const std::vector<rpc::Address> &owner_addresses,
+                                      uint64_t *request_id) = 0;
 
   /// Wait for the given objects until timeout expires or num_return objects are
   /// found.
@@ -129,8 +130,9 @@ class RayletIpcClientInterface {
 
   /// Tell the Raylet to cancel the get request from this worker.
   ///
+  /// \param get_request_id The ID of the get request that needs to be canceled.
   /// \return ray::Status.
-  virtual ray::Status CancelGetRequest() = 0;
+  virtual ray::Status CancelGetRequest(const uint64_t get_request_id) = 0;
 
   /// Notify the raylet that this client is blocked. This is only used for direct task
   /// calls. Note that ordering of this with respect to Unblock calls is important.
@@ -141,8 +143,9 @@ class RayletIpcClientInterface {
   /// Notify the raylet that this client is unblocked. This is only used for direct task
   /// calls. Note that ordering of this with respect to Block calls is important.
   ///
+  /// \param get_request_id The ID of the get request that needs to be canceled.
   /// \return ray::Status.
-  virtual ray::Status NotifyDirectCallTaskUnblocked() = 0;
+  virtual ray::Status NotifyDirectCallTaskUnblocked(const uint64_t get_request_id) = 0;
 
   /// Wait for the given objects asynchronously.
   ///

--- a/src/ray/raylet/dependency_manager.cc
+++ b/src/ray/raylet/dependency_manager.cc
@@ -146,10 +146,11 @@ void DependencyManager::StartOrUpdateGetRequest(
       object_manager_.CancelPull(*request_id);
     }
 
-    if (*request_id != new_request_id) {
-      get_requests_[worker_id][new_request_id] = get_request;
-      get_requests_[worker_id].erase(*request_id);
-    }
+    // new_request_id and *request_id should not be equal. We leave a RAY_CHECK here to
+    // prevent subsequent modifications from making them equal.
+    RAY_CHECK(*request_id != new_request_id);
+    get_requests_[worker_id][new_request_id] = get_request;
+    get_requests_[worker_id].erase(*request_id);
 
     *request_id = new_request_id;
     RAY_LOG(DEBUG) << "Started pull for get request from worker " << worker_id

--- a/src/ray/raylet/dependency_manager.cc
+++ b/src/ray/raylet/dependency_manager.cc
@@ -116,8 +116,9 @@ void DependencyManager::StartOrUpdateGetRequest(
     const WorkerID &worker_id,
     const std::vector<rpc::ObjectReference> &required_objects,
     uint64_t *request_id) {
-  RAY_LOG(DEBUG) << "Starting get request for worker " << worker_id;
-  auto &get_request = get_requests_[worker_id][*request_id];
+  RAY_LOG(DEBUG) << "Starting get request for worker " << worker_id
+                 << ", request id: " << *request_id;
+  auto get_request = get_requests_[worker_id][*request_id];
   bool modified = false;
   for (const auto &ref : required_objects) {
     const auto obj_id = ObjectRefToId(ref);
@@ -149,7 +150,7 @@ void DependencyManager::StartOrUpdateGetRequest(
     // new_request_id and *request_id should not be equal. We leave a RAY_CHECK here to
     // prevent subsequent modifications from making them equal.
     RAY_CHECK(*request_id != new_request_id);
-    get_requests_[worker_id][new_request_id] = get_request;
+    get_requests_[worker_id][new_request_id] = std::move(get_request);
     get_requests_[worker_id].erase(*request_id);
 
     *request_id = new_request_id;

--- a/src/ray/raylet/dependency_manager.h
+++ b/src/ray/raylet/dependency_manager.h
@@ -297,10 +297,10 @@ class DependencyManager : public TaskDependencyManagerInterface {
   /// dependencies are all local or not.
   absl::flat_hash_map<TaskID, std::unique_ptr<TaskDependencies>> queued_task_requests_;
 
-  /// A map from worker ID to the set of objects that the worker called
-  /// `ray.get` on and a pull request ID for these objects. The pull request ID
-  /// should be used to cancel the pull request in the object manager once the
-  /// worker cancels the `ray.get` request.
+  /// A map from worker ID to the multiple sets of objects that the worker multiple called
+  /// ray.get on, and the corresponding pull request ID for each set. The pull request ID
+  /// should be used to cancel the pull request in the object manager once the worker
+  /// cancels the `ray.get` request.
   absl::flat_hash_map<WorkerID,
                       absl::flat_hash_map<uint64_t, absl::flat_hash_set<ObjectID>>>
       get_requests_;

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -377,16 +377,22 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   /// \param client The client that is requesting the objects.
   /// \param object_refs The objects that are requested.
   /// \param is_get_request If this is a get request, else it's a wait request.
+  /// \param get_request_id The ID of get request.
   void AsyncGetOrWait(const std::shared_ptr<ClientConnection> &client,
                       const std::vector<rpc::ObjectReference> &object_refs,
-                      bool is_get_request);
+                      bool is_get_request,
+                      uint64_t *get_request_id = nullptr);
 
   /// Cancel all ongoing get requests from the client.
   ///
   /// This does *not* cancel ongoing wait requests.
   ///
   /// \param client The client whose get requests will be canceled.
-  void CancelGetRequest(const std::shared_ptr<ClientConnection> &client);
+  /// \param get_request_ids The IDs of the get requests that needs to be canceled.
+  /// std:: means cancel all get request which come from worker.
+  void CancelGetRequest(
+      const std::shared_ptr<ClientConnection> &client,
+      std::optional<absl::flat_hash_set<uint64_t>> get_request_ids = std::nullopt);
 
   /// Handle a task that is blocked. Note that this callback may
   /// arrive after the worker lease has been returned to the node manager.
@@ -399,7 +405,11 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   /// However, it is guaranteed to arrive after DirectCallTaskBlocked.
   ///
   /// \param worker Shared ptr to the worker, or nullptr if lost.
-  void HandleDirectCallTaskUnblocked(const std::shared_ptr<WorkerInterface> &worker);
+  /// \param get_request_ids The IDs of the get requests that needs to be canceled.
+  /// std:: means cancel all get request which come from worker.
+  void HandleDirectCallTaskUnblocked(
+      const std::shared_ptr<WorkerInterface> &worker,
+      std::optional<absl::flat_hash_set<uint64_t>> get_request_ids = std::nullopt);
 
   /// Destroy a worker.
   /// We will disconnect the worker connection first and then kill the worker.

--- a/src/ray/raylet/tests/dependency_manager_test.cc
+++ b/src/ray/raylet/tests/dependency_manager_test.cc
@@ -233,6 +233,7 @@ TEST_F(DependencyManagerTest, TestGet) {
   WorkerID worker_id = WorkerID::FromRandom();
   int num_arguments = 3;
   std::vector<ObjectID> arguments;
+  uint64_t request_id = 0;
   for (int i = 0; i < num_arguments; i++) {
     // Add the new argument to the list of dependencies to subscribe to.
     ObjectID argument_id = ObjectID::FromRandom();
@@ -241,7 +242,8 @@ TEST_F(DependencyManagerTest, TestGet) {
     // duplicates of previous subscription calls. Each argument should only be
     // requested from the node manager once.
     auto prev_pull_reqs = object_manager_mock_.active_get_requests;
-    dependency_manager_.StartOrUpdateGetRequest(worker_id, ObjectIdsToRefs(arguments));
+    dependency_manager_.StartOrUpdateGetRequest(
+        worker_id, ObjectIdsToRefs(arguments), &request_id);
     // Previous pull request for this get should be canceled upon each new
     // bundle.
     ASSERT_EQ(object_manager_mock_.active_get_requests.size(), 1);
@@ -250,7 +252,8 @@ TEST_F(DependencyManagerTest, TestGet) {
 
   // Nothing happens if the same bundle is requested.
   auto prev_pull_reqs = object_manager_mock_.active_get_requests;
-  dependency_manager_.StartOrUpdateGetRequest(worker_id, ObjectIdsToRefs(arguments));
+  dependency_manager_.StartOrUpdateGetRequest(
+      worker_id, ObjectIdsToRefs(arguments), &request_id);
   ASSERT_EQ(object_manager_mock_.active_get_requests, prev_pull_reqs);
 
   // Cancel the pull request once the worker cancels the `ray.get`.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

In the current implementation, a worker process corresponds to only one get request ID. When any thread in the worker completes its get operation, it clears the progress of all get requests in the entire worker. This can easily lead to traffic waste in a multi-threaded environment and may even cause the following job models to hang:
- Thread A: Calls ray.get on a very large object, which usually takes more than 10 seconds.
- Thread B: Periodically calls ray.get on a very small object, which typically completes within 1 second. When this get operation completes, it clears the progress of Thread A’s ray.get request, effectively causing Thread A to hang.

## Related issue number

Closes #54007

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
