### PR TITLE
[deps] core: drop opencensus-proto test dep

### DIFF
--- a/python/requirements/test-requirements.txt
+++ b/python/requirements/test-requirements.txt
@@ -38,7 +38,6 @@ numba==0.59.1
 openpyxl==3.0.10
 opentelemetry-api
 opentelemetry-sdk
-opencensus-proto==0.1.0
 pexpect==4.8.0
 Pillow==10.3.0; platform_system != "Windows"
 proxy.py==2.4.3

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -677,7 +677,6 @@ grpcio==1.66.2 ; sys_platform != "darwin"
     #   grpcio-status
     #   grpcio-tools
     #   mlagents-envs
-    #   opencensus-proto
     #   tensorboard
     #   tensorflow
 grpcio-status==1.48.2
@@ -1295,8 +1294,6 @@ opencensus==0.11.3
     # via -r python/requirements.txt
 opencensus-context==0.1.3
     # via opencensus
-opencensus-proto==0.1.0
-    # via -r python/requirements/test-requirements.txt
 opencv-python-headless==4.9.0.80
     # via -r python/requirements/ml/rllib-test-requirements.txt
 openpyxl==3.0.10


### PR DESCRIPTION
avoid unnecessary test dependency; instead, check the protobuf footprint of `ray.init()` by directly querying the default descriptor pool

getting ready to upgrade into protobuf4

