### PR TITLE
Add n to tqdm

### DIFF
--- a/python/ray/experimental/tqdm_ray.py
+++ b/python/ray/experimental/tqdm_ray.py
@@ -127,6 +127,11 @@ class tqdm:
     def total(self, total: int):
         self._total = total
 
+    @property
+    def n(self) -> int:
+        """The current iteration count."""
+        return self._x
+
     def _dump_state(self, force_flush=False) -> None:
         now = time.time()
         if not force_flush and now - self._last_flush_time < self._flush_interval_s:


### PR DESCRIPTION
## Why are these changes needed?

The current tqdm version of ray differs from the normal `tqdm.tqdm`.

This PR adds a simple property to allow access to `n` just like in the normal class.

## Related issue number

NA

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] This PR is not tested 
