### PR TITLE
increase timeout for wait condition

### DIFF
--- a/python/ray/serve/tests/test_logging.py
+++ b/python/ray/serve/tests/test_logging.py
@@ -417,7 +417,7 @@ def test_http_access_log_in_logs_file(serve_instance, log_format):
         line_checker, captured_lines = create_line_checker(
             log_file_path, start_position
         )
-        wait_for_condition(line_checker, retry_interval_ms=1000)
+        wait_for_condition(line_checker, retry_interval_ms=1000, timeout=25)
         new_log_lines = captured_lines["lines"]
 
         # Step 4: Verify HTTP response matches new log lines

--- a/python/ray/serve/tests/test_logging.py
+++ b/python/ray/serve/tests/test_logging.py
@@ -646,18 +646,11 @@ def test_context_information_in_logging(serve_and_ray_shutdown, json_log_format)
 
         def check_log():
             logs_content = f.getvalue()
-
-            all_conditions_true = True
             for expected_log_info in expected_log_infos:
-                if expected_log_info not in logs_content:
-                    all_conditions_true = False
-                    break
+                assert expected_log_info in logs_content
             for regex in user_log_regexes:
-                if re.findall(regex, logs_content) == []:
-                    all_conditions_true = False
-                    break
-
-            return all_conditions_true
+                assert re.findall(regex, logs_content) != []
+            return True
 
         # Check stream log
         wait_for_condition(

--- a/python/ray/serve/tests/test_logging.py
+++ b/python/ray/serve/tests/test_logging.py
@@ -646,11 +646,8 @@ def test_context_information_in_logging(serve_and_ray_shutdown, json_log_format)
 
         def check_log():
             logs_content = ""
-            for _ in range(20):
-                time.sleep(0.1)
-                logs_content = f.getvalue()
-                if logs_content:
-                    break
+            time.sleep(10)
+            logs_content = f.getvalue()
             for expected_log_info in expected_log_infos:
                 assert expected_log_info in logs_content
             for regex in user_log_regexes:


### PR DESCRIPTION
- increase timeout for wait condition so that logs can get populate properly
- wait for 10 seconds instead of 2 seconds in the `test_context_information_in_logging` test, also, earlier we were breaking the loop as soon as we find anything, breaking that pattern now. Now we will wait for 10 seconds, and get all the content to check against the expected info