### PR TITLE
[serve] Fix `test_deploy` on windows

### DIFF
--- a/python/ray/serve/tests/test_deploy.py
+++ b/python/ray/serve/tests/test_deploy.py
@@ -716,9 +716,10 @@ def test_deploy_multiple_apps_batched(serve_instance):
     assert serve.get_app_handle("a").remote().result() == "a"
     assert serve.get_app_handle("b").remote().result() == "b"
 
-    url = get_application_url("HTTP", use_localhost=True)
-    assert httpx.get(f"{url}/a").text == "a"
-    assert httpx.get(f"{url}/b").text == "b"
+    urla = get_application_url("HTTP", app_name="a", use_localhost=True)
+    urlb = get_application_url("HTTP", app_name="b", use_localhost=True)
+    assert httpx.get(urla).text == "a"
+    assert httpx.get(urlb).text == "b"
 
 
 def test_redeploy_multiple_apps_batched(serve_instance):

--- a/python/ray/serve/tests/test_deploy.py
+++ b/python/ray/serve/tests/test_deploy.py
@@ -716,7 +716,7 @@ def test_deploy_multiple_apps_batched(serve_instance):
     assert serve.get_app_handle("a").remote().result() == "a"
     assert serve.get_app_handle("b").remote().result() == "b"
 
-    url = get_application_url("HTTP")
+    url = get_application_url("HTTP", use_localhost=True)
     assert httpx.get(f"{url}/a").text == "a"
     assert httpx.get(f"{url}/b").text == "b"
 


### PR DESCRIPTION
Use localhost when sending the http request in `test_deploy.py::test_deploy_multiple_apps_batched`