### PR TITLE
[serve] update `test_request_timeout`

### DIFF
--- a/python/ray/serve/tests/test_request_timeout.py
+++ b/python/ray/serve/tests/test_request_timeout.py
@@ -115,7 +115,7 @@ class HangsOnFirstRequest:
 hangs_on_first_request_app = HangsOnFirstRequest.bind()
 
 
-def test_with_rest_api(ray_instance):
+def test_with_rest_api(ray_instance, shutdown_serve):
     """Verify the REST API can configure the request timeout."""
     config = {
         "proxy_location": "EveryNode",

--- a/python/ray/serve/tests/test_request_timeout.py
+++ b/python/ray/serve/tests/test_request_timeout.py
@@ -13,7 +13,10 @@ import ray
 from ray import serve
 from ray._common.test_utils import SignalActor, wait_for_condition
 from ray.dashboard.modules.serve.sdk import ServeSubmissionClient
-from ray.serve._private.test_utils import send_signal_on_cancellation
+from ray.serve._private.test_utils import (
+    get_application_url,
+    send_signal_on_cancellation,
+)
 from ray.serve.schema import ApplicationStatus, ServeInstanceDetails
 from ray.util.state import list_tasks
 
@@ -22,7 +25,7 @@ from ray.util.state import list_tasks
 def do_request():
     # Set a timeout to 10 because some test use RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S = 5
     # and httpx default timeout is 5 seconds.
-    return httpx.get("http://localhost:8000", timeout=10)
+    return httpx.get(get_application_url(use_localhost=True), timeout=10)
 
 
 @pytest.fixture
@@ -32,11 +35,7 @@ def shutdown_serve():
 
 
 @pytest.mark.parametrize(
-    "ray_instance",
-    [
-        {"RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S": "5"},
-    ],
-    indirect=True,
+    "ray_instance", [{"RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S": "5"}], indirect=True
 )
 def test_normal_operation(ray_instance, shutdown_serve):
     """
@@ -56,11 +55,7 @@ def test_normal_operation(ray_instance, shutdown_serve):
 
 
 @pytest.mark.parametrize(
-    "ray_instance",
-    [
-        {"RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S": "0.1"},
-    ],
-    indirect=True,
+    "ray_instance", [{"RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S": "0.1"}], indirect=True
 )
 def test_request_hangs_in_execution(ray_instance, shutdown_serve):
     """
@@ -96,7 +91,7 @@ def test_request_hangs_in_execution(ray_instance, shutdown_serve):
 
     serve.run(HangsOnFirstRequest.bind())
 
-    response = httpx.get("http://localhost:8000")
+    response = httpx.get(get_application_url(use_localhost=True))
     assert response.status_code == 408
 
     ray.get(signal_actor.send.remote())
@@ -120,7 +115,7 @@ class HangsOnFirstRequest:
 hangs_on_first_request_app = HangsOnFirstRequest.bind()
 
 
-def test_with_rest_api(ray_start_stop):
+def test_with_rest_api(ray_instance):
     """Verify the REST API can configure the request timeout."""
     config = {
         "proxy_location": "EveryNode",
@@ -149,21 +144,17 @@ def test_with_rest_api(ray_start_stop):
     wait_for_condition(application_running, timeout=15)
     print("Application has started running. Testing requests...")
 
-    response = httpx.get("http://localhost:8000")
+    response = httpx.get(get_application_url(app_name="app", use_localhost=True))
     assert response.status_code == 408
 
-    response = httpx.get("http://localhost:8000")
+    response = httpx.get(get_application_url(app_name="app", use_localhost=True))
     assert response.status_code == 200
     print("Requests succeeded! Deleting application.")
     ServeSubmissionClient("http://localhost:8265").delete_applications()
 
 
 @pytest.mark.parametrize(
-    "ray_instance",
-    [
-        {"RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S": "0.5"},
-    ],
-    indirect=True,
+    "ray_instance", [{"RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S": "0.5"}], indirect=True
 )
 def test_request_hangs_in_assignment(ray_instance, shutdown_serve):
     """
@@ -195,11 +186,7 @@ def test_request_hangs_in_assignment(ray_instance, shutdown_serve):
 
 
 @pytest.mark.parametrize(
-    "ray_instance",
-    [
-        {"RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S": "5"},
-    ],
-    indirect=True,
+    "ray_instance", [{"RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S": "5"}], indirect=True
 )
 def test_streaming_request_already_sent_and_timed_out(ray_instance, shutdown_serve):
     """
@@ -221,13 +208,15 @@ def test_streaming_request_already_sent_and_timed_out(ray_instance, shutdown_ser
 
     serve.run(BlockOnSecondChunk.bind())
 
-    # Wait for the server to start by doing health check.
-    wait_for_condition(
-        lambda: httpx.get("http://localhost:8000/-/healthz").status_code == 200,
-        timeout=10,
-    )
+    def health_check():
+        response = httpx.get(f"{get_application_url(use_localhost=True)}/-/healthz")
+        assert response.status_code == 200
+        return True
 
-    with httpx.stream("GET", "http://localhost:8000", timeout=10) as r:
+    # Wait for the server to start by doing health check.
+    wait_for_condition(health_check, timeout=10)
+
+    with httpx.stream("GET", get_application_url(use_localhost=True), timeout=10) as r:
         iterator = r.iter_text()
 
         # The first chunk should be received successfully.
@@ -246,7 +235,7 @@ def test_streaming_request_already_sent_and_timed_out(ray_instance, shutdown_ser
         {
             "RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S": "0.5",
             "RAY_SERVE_ENABLE_TASK_EVENTS": "1",
-        },
+        }
     ],
     indirect=True,
 )
@@ -286,13 +275,7 @@ def test_request_timeout_does_not_leak_tasks(ray_instance, shutdown_serve):
 
 
 @pytest.mark.parametrize(
-    "ray_instance",
-    [
-        {
-            "RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S": "0.5",
-        },
-    ],
-    indirect=True,
+    "ray_instance", [{"RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S": "0.5"}], indirect=True
 )
 @pytest.mark.parametrize("use_fastapi", [False, True])
 def test_cancel_on_http_timeout_during_execution(
@@ -337,19 +320,13 @@ def test_cancel_on_http_timeout_during_execution(
     serve.run(Ingress.bind(inner.bind()))
 
     # Request should time out, causing the handler and handle call to be cancelled.
-    assert httpx.get("http://localhost:8000").status_code == 408
+    assert httpx.get(get_application_url(use_localhost=True)).status_code == 408
     ray.get(inner_signal_actor.wait.remote())
     ray.get(outer_signal_actor.wait.remote())
 
 
 @pytest.mark.parametrize(
-    "ray_instance",
-    [
-        {
-            "RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S": "0.5",
-        },
-    ],
-    indirect=True,
+    "ray_instance", [{"RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S": "0.5"}], indirect=True
 )
 def test_cancel_on_http_timeout_during_assignment(ray_instance, shutdown_serve):
     """Test the client disconnecting while the proxy is assigning the request."""
@@ -374,7 +351,7 @@ def test_cancel_on_http_timeout_during_assignment(ray_instance, shutdown_serve):
     wait_for_condition(lambda: ray.get(signal_actor.cur_num_waiters.remote()) == 1)
 
     # Request should time out, causing the handler and handle call to be cancelled.
-    assert httpx.get("http://localhost:8000").status_code == 408
+    assert httpx.get(get_application_url(use_localhost=True)).status_code == 408
 
     # Now signal the initial request to finish and check that the request sent via HTTP
     # never reaches the replica.
@@ -385,13 +362,7 @@ def test_cancel_on_http_timeout_during_assignment(ray_instance, shutdown_serve):
 
 
 @pytest.mark.parametrize(
-    "ray_instance",
-    [
-        {
-            "RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S": "0.5",
-        },
-    ],
-    indirect=True,
+    "ray_instance", [{"RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S": "0.5"}], indirect=True
 )
 def test_timeout_error_in_child_deployment_of_fastapi(ray_instance, shutdown_serve):
     """Test that timeout error in child deployment returns 408 with FastAPI ingress."""
@@ -416,7 +387,7 @@ def test_timeout_error_in_child_deployment_of_fastapi(ray_instance, shutdown_ser
 
     serve.run(Parent.bind(Child.bind()))
 
-    r = httpx.get("http://localhost:8000/")
+    r = httpx.get(get_application_url(use_localhost=True))
     assert r.status_code == 408
 
     ray.get(signal.send.remote())


### PR DESCRIPTION
Update `test_request_timeout` to use test_utils.get_application_url