### PR TITLE
[core][raycheck/01] Fix "it != submissible_tasks_.end()"

### DIFF
--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -1531,6 +1531,13 @@ void TaskManager::SetTaskStatus(
       << "Setting task status from " << task_entry.GetStatus() << " to " << status;
   task_entry.SetStatus(status);
 
+  if (task_entry.is_canceled) {
+    // If the task cancellation comes in anytime after the task error has been set,
+    // reset the error info to TASK_CANCELLED.
+    rpc::RayErrorInfo error_info;
+    error_info.set_error_type(rpc::ErrorType::TASK_CANCELLED);
+    state_update = worker::TaskStatusEvent::TaskStateUpdate(error_info);
+  }
   const int32_t attempt_number_to_record =
       attempt_number.value_or(task_entry.spec.AttemptNumber());
   const auto state_update_to_record =

--- a/src/ray/core_worker/test/normal_task_submitter_test.cc
+++ b/src/ray/core_worker/test/normal_task_submitter_test.cc
@@ -148,15 +148,18 @@ class MockTaskManager : public MockTaskManagerInterface {
  public:
   MockTaskManager() {}
 
-  void CompletePendingTask(const TaskID &,
+  void CompletePendingTask(const TaskID &task_id,
                            const rpc::PushTaskReply &,
                            const rpc::Address &actor_addr,
                            bool is_application_error) override {
     num_tasks_complete++;
+    not_submissible_tasks_.insert(task_id);
   }
 
   bool RetryTaskIfPossible(const TaskID &task_id,
                            const rpc::RayErrorInfo &error_info) override {
+    RAY_CHECK(!not_submissible_tasks_.contains(task_id))
+        << "Tried to retry task that was not pending " << task_id;
     num_task_retries_attempted++;
     return false;
   }
@@ -167,6 +170,7 @@ class MockTaskManager : public MockTaskManagerInterface {
                        const rpc::RayErrorInfo *ray_error_info = nullptr) override {
     num_fail_pending_task_calls++;
     num_tasks_failed++;
+    not_submissible_tasks_.insert(task_id);
   }
 
   bool FailOrRetryPendingTask(const TaskID &task_id,
@@ -176,6 +180,9 @@ class MockTaskManager : public MockTaskManagerInterface {
                               bool mark_task_object_failed = true,
                               bool fail_immediately = false) override {
     num_tasks_failed++;
+    if (!fail_immediately) {
+      RetryTaskIfPossible(task_id, *ray_error_info);
+    }
     return true;
   }
 
@@ -211,6 +218,9 @@ class MockTaskManager : public MockTaskManagerInterface {
   int num_task_retries_attempted = 0;
   int num_fail_pending_task_calls = 0;
   int num_generator_failed_and_resubmitted = 0;
+
+ private:
+  absl::flat_hash_set<TaskID> not_submissible_tasks_;
 };
 
 class MockRayletClient : public WorkerLeaseInterface {
@@ -237,9 +247,20 @@ class MockRayletClient : public WorkerLeaseInterface {
       const ray::rpc::ClientCallback<ray::rpc::GetTaskFailureCauseReply> &callback)
       override {
     std::lock_guard<std::mutex> lock(mu_);
-    ray::rpc::GetTaskFailureCauseReply reply;
-    callback(Status::OK(), std::move(reply));
+    get_task_failure_cause_callbacks.push_back(callback);
     num_get_task_failure_causes += 1;
+  }
+
+  bool ReplyGetTaskFailureCause() {
+    std::lock_guard<std::mutex> lock(mu_);
+    if (get_task_failure_cause_callbacks.size() == 0) {
+      return false;
+    }
+    auto callback = std::move(get_task_failure_cause_callbacks.front());
+    get_task_failure_cause_callbacks.pop_front();
+    rpc::GetTaskFailureCauseReply reply;
+    callback(Status::OK(), std::move(reply));
+    return true;
   }
 
   void ReportWorkerBacklog(
@@ -630,6 +651,7 @@ TEST_F(NormalTaskSubmitterTest, TestHandleTaskFailure) {
   ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1234, NodeID::Nil()));
   // Simulate a system failure, i.e., worker died unexpectedly.
   ASSERT_TRUE(worker_client->ReplyPushTask(Status::IOError("oops")));
+  ASSERT_TRUE(raylet_client->ReplyGetTaskFailureCause());
   ASSERT_EQ(worker_client->callbacks.size(), 0);
   ASSERT_EQ(raylet_client->num_workers_returned, 0);
   ASSERT_EQ(raylet_client->num_workers_disconnected, 1);
@@ -642,6 +664,48 @@ TEST_F(NormalTaskSubmitterTest, TestHandleTaskFailure) {
   // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
   // would otherwise cause a memory leak.
   ASSERT_TRUE(submitter.CheckNoSchedulingKeyEntriesPublic());
+}
+
+TEST_F(NormalTaskSubmitterTest, TestCancellationWhileHandlingTaskFailure) {
+  // This test is a regression test for a bug where a crash happens when
+  // the task cancellation races between ReplyPushTask and ReplyGetTaskFailureCause.
+  // For a python integration test, see
+  // https://github.com/ray-project/ray/blob/2b6807f4d9c4572e6309f57bc404aa641bc4b185/python/ray/tests/test_cancel.py#L35
+  rpc::Address address;
+  auto raylet_client = std::make_shared<MockRayletClient>();
+  auto worker_client = std::make_shared<MockWorkerClient>();
+  auto store = DefaultCoreWorkerMemoryStoreWithThread::CreateShared();
+  auto client_pool = std::make_shared<rpc::CoreWorkerClientPool>(
+      [&](const rpc::Address &addr) { return worker_client; });
+  auto task_manager = std::make_unique<MockTaskManager>();
+  auto actor_creator = std::make_shared<MockActorCreator>();
+  auto lease_policy = std::make_unique<MockLeasePolicy>();
+  NormalTaskSubmitter submitter(
+      address,
+      raylet_client,
+      client_pool,
+      nullptr,
+      std::move(lease_policy),
+      store,
+      *task_manager,
+      NodeID::Nil(),
+      WorkerType::WORKER,
+      kLongTimeout,
+      actor_creator,
+      JobID::Nil(),
+      kOneRateLimiter,
+      [](const ObjectID &object_id) { return rpc::TensorTransport::OBJECT_STORE; });
+
+  TaskSpecification task = BuildEmptyTaskSpec();
+  ASSERT_TRUE(submitter.SubmitTask(task).ok());
+  ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1234, NodeID::Nil()));
+  // Simulate a system failure, i.e., worker died unexpectedly so that
+  // GetTaskFailureCause is called.
+  ASSERT_TRUE(worker_client->ReplyPushTask(Status::IOError("oops")));
+  // Cancel the task while GetTaskFailureCause has not been completed.
+  ASSERT_TRUE(submitter.CancelTask(task, true, false).ok());
+  // Completing the GetTaskFailureCause call. Check that the reply runs without error.
+  ASSERT_TRUE(raylet_client->ReplyGetTaskFailureCause());
 }
 
 TEST_F(NormalTaskSubmitterTest, TestHandleUnschedulableTask) {
@@ -1225,6 +1289,7 @@ TEST_F(NormalTaskSubmitterTest, TestWorkerNotReusedOnError) {
 
   // Task 1 finishes with failure; the worker is returned.
   ASSERT_TRUE(worker_client->ReplyPushTask(Status::IOError("worker dead")));
+  ASSERT_TRUE(raylet_client->ReplyGetTaskFailureCause());
   ASSERT_EQ(worker_client->callbacks.size(), 0);
   ASSERT_EQ(raylet_client->num_workers_returned, 0);
   ASSERT_EQ(raylet_client->num_workers_disconnected, 1);
@@ -1646,6 +1711,7 @@ TEST_F(NormalTaskSubmitterTest, TestWorkerLeaseTimeout) {
   // Task 1 finishes with failure; the worker is returned due to the error even though
   // it hasn't timed out.
   ASSERT_TRUE(worker_client->ReplyPushTask(Status::IOError("worker dead")));
+  ASSERT_TRUE(raylet_client->ReplyGetTaskFailureCause());
   ASSERT_EQ(raylet_client->num_workers_returned, 0);
   ASSERT_EQ(raylet_client->num_workers_disconnected, 1);
 
@@ -1685,6 +1751,7 @@ TEST_F(NormalTaskSubmitterTest, TestKillExecutingTask) {
   ASSERT_TRUE(submitter.CancelTask(task, true, false).ok());
   ASSERT_EQ(worker_client->kill_requests.front().intended_task_id(), task.TaskIdBinary());
   ASSERT_TRUE(worker_client->ReplyPushTask(Status::IOError("workerdying"), true));
+  ASSERT_TRUE(raylet_client->ReplyGetTaskFailureCause());
   ASSERT_EQ(worker_client->callbacks.size(), 0);
   ASSERT_EQ(raylet_client->num_workers_returned, 0);
   ASSERT_EQ(raylet_client->num_workers_returned_exiting, 0);

--- a/src/ray/core_worker/transport/normal_task_submitter.cc
+++ b/src/ray/core_worker/transport/normal_task_submitter.cc
@@ -37,8 +37,12 @@ Status NormalTaskSubmitter::SubmitTask(TaskSpecification task_spec) {
     task_manager_.MarkDependenciesResolved(task_spec.TaskId());
     if (!status.ok()) {
       RAY_LOG(WARNING) << "Resolving task dependencies failed " << status.ToString();
-      RAY_UNUSED(task_manager_.FailOrRetryPendingTask(
-          task_spec.TaskId(), rpc::ErrorType::DEPENDENCY_RESOLUTION_FAILED, &status));
+      bool will_retry = task_manager_.FailOrRetryPendingTask(
+          task_spec.TaskId(), rpc::ErrorType::DEPENDENCY_RESOLUTION_FAILED, &status);
+      if (!will_retry) {
+        absl::MutexLock lock(&mu_);
+        cancelled_tasks_.erase(task_spec.TaskId());
+      }
       return;
     }
     RAY_LOG(DEBUG) << "Task dependencies resolved " << task_spec.TaskId();
@@ -595,19 +599,27 @@ void NormalTaskSubmitter::PushNormalTask(
           scheduling_key_entry.num_busy_workers--;
 
           if (!status.ok()) {
-            limbo_tasks_.insert(task_id);
+            failed_tasks_pending_failure_cause_.insert(task_id);
             RAY_LOG(DEBUG) << "Getting error from raylet for task " << task_id;
             const ray::rpc::ClientCallback<ray::rpc::GetTaskFailureCauseReply> callback =
                 [this, status, task_id, addr](
                     const Status &get_task_failure_cause_reply_status,
                     const rpc::GetTaskFailureCauseReply &get_task_failure_cause_reply) {
-                  HandleGetTaskFailureCause(status,
-                                            task_id,
-                                            addr,
-                                            get_task_failure_cause_reply_status,
-                                            get_task_failure_cause_reply);
+                  bool will_retry =
+                      HandleGetTaskFailureCause(status,
+                                                task_id,
+                                                addr,
+                                                get_task_failure_cause_reply_status,
+                                                get_task_failure_cause_reply);
                   absl::MutexLock lock(&mu_);
-                  limbo_tasks_.erase(task_id);
+                  if (!will_retry) {
+                    // Task submission and task cancellation are the only two other code
+                    // paths that clean up the cancelled_tasks_ map. If the task is not
+                    // retried (aka. it will not go through the task submission path),
+                    // we need to remove it from the map here.
+                    cancelled_tasks_.erase(task_id);
+                  }
+                  failed_tasks_pending_failure_cause_.erase(task_id);
                 };
             auto &cur_lease_entry = worker_to_lease_entry_[addr];
             RAY_CHECK(cur_lease_entry.lease_client);
@@ -649,7 +661,7 @@ void NormalTaskSubmitter::PushNormalTask(
       });
 }
 
-void NormalTaskSubmitter::HandleGetTaskFailureCause(
+bool NormalTaskSubmitter::HandleGetTaskFailureCause(
     const Status &task_execution_status,
     const TaskID &task_id,
     const rpc::Address &addr,
@@ -692,19 +704,12 @@ void NormalTaskSubmitter::HandleGetTaskFailureCause(
     error_info->set_error_message(buffer.str());
     error_info->set_error_type(rpc::ErrorType::NODE_DIED);
   }
-  {
-    absl::MutexLock lock(&mu_);
-    if (!limbo_tasks_.contains(task_id)) {
-      RAY_LOG(INFO) << "Task " << task_id << " is not in limbo. Skip retrying.";
-      return;
-    }
-    RAY_UNUSED(task_manager_.FailOrRetryPendingTask(task_id,
-                                                  task_error_type,
-                                                  &task_execution_status,
-                                                  error_info.get(),
-                                                  /*mark_task_object_failed*/ true,
-                                                  fail_immediately));
-  }
+  return task_manager_.FailOrRetryPendingTask(task_id,
+                                              task_error_type,
+                                              &task_execution_status,
+                                              error_info.get(),
+                                              /*mark_task_object_failed*/ true,
+                                              fail_immediately);
 }
 
 Status NormalTaskSubmitter::CancelTask(TaskSpecification task_spec,
@@ -722,7 +727,6 @@ Status NormalTaskSubmitter::CancelTask(TaskSpecification task_spec,
     absl::MutexLock lock(&mu_);
     auto task_id = task_spec.TaskId();
     generators_to_resubmit_.erase(task_id);
-    limbo_tasks_.erase(task_id);
 
     if (cancelled_tasks_.contains(task_id)) {
       // The task cancel is already in progress. We don't need to do anything.
@@ -758,9 +762,16 @@ Status NormalTaskSubmitter::CancelTask(TaskSpecification task_spec,
 
     if (rpc_client == executing_tasks_.end()) {
       // This case is reached for tasks that have unresolved dependencies.
-      resolver_.CancelDependencyResolution(task_spec.TaskId());
-      RAY_UNUSED(task_manager_.FailPendingTask(task_spec.TaskId(),
-                                               rpc::ErrorType::TASK_CANCELLED));
+      if (failed_tasks_pending_failure_cause_.contains(task_spec.TaskId())) {
+        // The task is in a critical phase between completing execution and determining
+        // whether to retry. During this phase, it must remain as a submissible task -
+        // do not attempt to fail it here. The task will cancel itself once it exits
+        // this critical phase.
+      } else {
+        resolver_.CancelDependencyResolution(task_spec.TaskId());
+        RAY_UNUSED(task_manager_.FailPendingTask(task_spec.TaskId(),
+                                                 rpc::ErrorType::TASK_CANCELLED));
+      }
       if (scheduling_key_entry.CanDelete()) {
         // We can safely remove the entry keyed by scheduling_key from the
         // scheduling_key_entries_ hashmap.

--- a/src/ray/core_worker/transport/normal_task_submitter.cc
+++ b/src/ray/core_worker/transport/normal_task_submitter.cc
@@ -180,7 +180,7 @@ void NormalTaskSubmitter::OnWorkerIdle(
       task_spec.GetMutableMessage().set_lease_grant_timestamp_ms(current_sys_time_ms());
       task_spec.EmitTaskMetrics();
 
-      executing_tasks_.emplace(task_spec.TaskId(), addr);
+      pushed_to_worker_tasks_.emplace(task_spec.TaskId(), addr);
       PushNormalTask(
           addr, client, scheduling_key, std::move(task_spec), assigned_resources);
     }
@@ -578,7 +578,6 @@ void NormalTaskSubmitter::PushNormalTask(
                          << WorkerID::FromBinary(addr.worker_id()) << " of raylet "
                          << NodeID::FromBinary(addr.raylet_id());
           absl::MutexLock lock(&mu_);
-          executing_tasks_.erase(task_id);
 
           resubmit_generator = generators_to_resubmit_.erase(task_id) > 0;
 

--- a/src/ray/core_worker/transport/normal_task_submitter.h
+++ b/src/ray/core_worker/transport/normal_task_submitter.h
@@ -360,9 +360,11 @@ class NormalTaskSubmitter {
   // Tasks that were cancelled while being resolved.
   absl::flat_hash_set<TaskID> cancelled_tasks_ ABSL_GUARDED_BY(mu_);
 
-  // Keeps track of the address of the worker that currently has a task being pushed to
-  // it. This include tasks that are still in the progress of post-pushing handling.
-  absl::flat_hash_map<TaskID, rpc::Address> pushed_to_worker_tasks_ ABSL_GUARDED_BY(mu_);
+  // Keeps track of where currently executing tasks are being run.
+  absl::flat_hash_map<TaskID, rpc::Address> executing_tasks_ ABSL_GUARDED_BY(mu_);
+
+  // Tasks that are in limbo, i.e. they are not being executed but are not completed either.
+  absl::flat_hash_set<TaskID> limbo_tasks_ ABSL_GUARDED_BY(mu_);
 
   // Generators that are currently running and need to be resubmitted.
   absl::flat_hash_set<TaskID> generators_to_resubmit_ ABSL_GUARDED_BY(mu_);

--- a/src/ray/core_worker/transport/normal_task_submitter.h
+++ b/src/ray/core_worker/transport/normal_task_submitter.h
@@ -360,8 +360,9 @@ class NormalTaskSubmitter {
   // Tasks that were cancelled while being resolved.
   absl::flat_hash_set<TaskID> cancelled_tasks_ ABSL_GUARDED_BY(mu_);
 
-  // Keeps track of where currently executing tasks are being run.
-  absl::flat_hash_map<TaskID, rpc::Address> executing_tasks_ ABSL_GUARDED_BY(mu_);
+  // Keeps track of the address of the worker that currently has a task being pushed to
+  // it. This include tasks that are still in the progress of post-pushing handling.
+  absl::flat_hash_map<TaskID, rpc::Address> pushed_to_worker_tasks_ ABSL_GUARDED_BY(mu_);
 
   // Generators that are currently running and need to be resubmitted.
   absl::flat_hash_set<TaskID> generators_to_resubmit_ ABSL_GUARDED_BY(mu_);

--- a/src/ray/core_worker/transport/normal_task_submitter.h
+++ b/src/ray/core_worker/transport/normal_task_submitter.h
@@ -239,7 +239,8 @@ class NormalTaskSubmitter {
                           &assigned_resources);
 
   /// Handles result from GetTaskFailureCause.
-  void HandleGetTaskFailureCause(
+  /// \return true if the task is retried, false otherwise.
+  bool HandleGetTaskFailureCause(
       const Status &task_execution_status,
       const TaskID &task_id,
       const rpc::Address &addr,
@@ -363,8 +364,9 @@ class NormalTaskSubmitter {
   // Keeps track of where currently executing tasks are being run.
   absl::flat_hash_map<TaskID, rpc::Address> executing_tasks_ ABSL_GUARDED_BY(mu_);
 
-  // Tasks that are in limbo, i.e. they are not being executed but are not completed either.
-  absl::flat_hash_set<TaskID> limbo_tasks_ ABSL_GUARDED_BY(mu_);
+  // Tasks that have failed but we are waiting for their error cause to decide if they
+  // should be retried or permanently failed.
+  absl::flat_hash_set<TaskID> failed_tasks_pending_failure_cause_ ABSL_GUARDED_BY(mu_);
 
   // Generators that are currently running and need to be resubmitted.
   absl::flat_hash_set<TaskID> generators_to_resubmit_ ABSL_GUARDED_BY(mu_);


### PR DESCRIPTION
## Problems

This PR fixes the `RAY_CHECK failure:
it != submissible_tasks_.end() Tried to retry task that was not pending`.

This failure occurs when a task cancellation ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L702)) races with the callback from PushNormalTask ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L546)).

Currently, there's a map called `executing_tasks_` that is intended to prevent this race, but it fails to do so. The crash happens via the following sequence:
- The `PushNormalTask` callback removes the task ID from `executing_tasks_` ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L583)).
- This causes the task cancellation to enter the following condition ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L750)), which eventually invokes `TaskManager::FailPendingTask` ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L753)).
- `TaskManager` always removes the task from the `submissible_tasks_ `map when it ends a pending task’s lifecycle (via `FailPendingTask` and others).
- After that, the `PushNormalTask` callback invokes `HandleGetTaskFailureCause` ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L605)), which attempts to retrieve the task’s failure cause. This function asks `TaskManager` to retry the task ([source](https://github.com/ray-project/ray/blob/master/src/ray/core_worker/transport/normal_task_submitter.cc#L694)), but it fails because the task has already been removed from the `submissible_tasks_` map.

## Solutions

This PR introduces a `limbo_tasks_` map to track tasks that have finished execution but haven't been fully processed yet. It ensures that task completion is handled exactly once—either through cancellation or failure handling, but not both.

## Test
- CI
- A test that crashes without this fix and passes with this fix
- Also update normal_task_submitter_test to represent its real implementation