### PR TITLE
[Doc] Update deprecated `evaluation_strategy` parameter to `eval_strategy` in transformers examples

### DIFF
--- a/doc/source/train/doc_code/checkpoints.py
+++ b/doc/source/train/doc_code/checkpoints.py
@@ -311,7 +311,7 @@ def train_func(config):
     # Configure logging, saving, evaluation strategies as usual.
     args = TrainingArguments(
         ...,
-        evaluation_strategy="epoch",
+        eval_strategy="epoch",
         save_strategy="epoch",
         logging_strategy="step",
     )

--- a/doc/source/train/examples/intel_gaudi/llama.ipynb
+++ b/doc/source/train/examples/intel_gaudi/llama.ipynb
@@ -273,7 +273,7 @@
     "                                  learning_rate=config[\"lr\"],\n",
     "                                  save_strategy=\"no\",\n",
     "                                  torch_compile_backend=torch_compile_backend,\n",
-    "                                  evaluation_strategy=\"no\",\n",
+    "                                  eval_strategy=\"no\",\n",
     "                                  lr_scheduler_type=\"cosine\",\n",
     "                                  num_train_epochs=config[\"epochs\"],\n",
     "                                  use_lazy_mode=use_lazy_mode,\n",

--- a/doc/source/train/examples/transformers/huggingface_text_classification.ipynb
+++ b/doc/source/train/examples/transformers/huggingface_text_classification.ipynb
@@ -581,7 +581,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "id": "TlqNaB8jIrJW",
     "tags": []
@@ -662,7 +662,7 @@
     "\n",
     "    args = TrainingArguments(\n",
     "        name,\n",
-    "        evaluation_strategy=\"epoch\",\n",
+    "        eval_strategy=\"epoch\",\n",
     "        save_strategy=\"epoch\",\n",
     "        logging_strategy=\"epoch\",\n",
     "        per_device_train_batch_size=batch_size,\n",

--- a/doc/source/train/getting-started-transformers.rst
+++ b/doc/source/train/getting-started-transformers.rst
@@ -98,7 +98,7 @@ Compare a standard Hugging Face Transformers script with its Ray Train equivalen
 
             # Hugging Face Trainer
             training_args = TrainingArguments(
-                output_dir="test_trainer", evaluation_strategy="epoch", report_to="none"
+                output_dir="test_trainer", eval_strategy="epoch", report_to="none"
             )
 
             trainer = Trainer(
@@ -170,7 +170,7 @@ Compare a standard Hugging Face Transformers script with its Ray Train equivalen
                 # Hugging Face Trainer
                 training_args = TrainingArguments(
                     output_dir="test_trainer",
-                    evaluation_strategy="epoch",
+                    eval_strategy="epoch",
                     save_strategy="epoch",
                     report_to="none",
                 )

--- a/doc/source/train/user-guides/checkpoints.rst
+++ b/doc/source/train/user-guides/checkpoints.rst
@@ -136,7 +136,7 @@ Here are a few examples of saving checkpoints with different training frameworks
 
         Note that :class:`~ray.train.huggingface.transformers.RayTrainReportCallback`
         binds the latest metrics and checkpoints together,
-        so users can properly configure ``logging_strategy``, ``save_strategy`` and ``evaluation_strategy``
+        so users can properly configure ``logging_strategy``, ``save_strategy`` and ``eval_strategy``
         to ensure the monitoring metric is logged at the same step as checkpoint saving.
 
         For example, the evaluation metrics (``eval_loss`` in this case) are logged during
@@ -148,13 +148,13 @@ Here are a few examples of saving checkpoints with different training frameworks
 
             args = TrainingArguments(
                 ...,
-                evaluation_strategy="epoch",
+                eval_strategy="epoch",
                 save_strategy="epoch",
             )
 
             args = TrainingArguments(
                 ...,
-                evaluation_strategy="steps",
+                eval_strategy="steps",
                 save_strategy="steps",
                 eval_steps=50,
                 save_steps=100,

--- a/doc/source/tune/examples/pbt_transformers.ipynb
+++ b/doc/source/tune/examples/pbt_transformers.ipynb
@@ -117,7 +117,7 @@
     "        do_train=True,\n",
     "        do_eval=True,\n",
     "        no_cuda=gpus_per_trial <= 0,\n",
-    "        evaluation_strategy=\"epoch\",\n",
+    "        eval_strategy=\"epoch\",\n",
     "        save_strategy=\"epoch\",\n",
     "        load_best_model_at_end=True,\n",
     "        num_train_epochs=2,  # config\n",

--- a/python/ray/train/huggingface/transformers/_transformers_utils.py
+++ b/python/ray/train/huggingface/transformers/_transformers_utils.py
@@ -53,12 +53,12 @@ class RayTrainReportCallback(TrainerCallback):
     Suppose the monitoring metric is reported from evaluation stage:
 
     Some valid configurations:
-        - evaluation_strategy == save_strategy == "epoch"
-        - evaluation_strategy == save_strategy == "steps", save_steps % eval_steps == 0
+        - eval_strategy == save_strategy == "epoch"
+        - eval_strategy == save_strategy == "steps", save_steps % eval_steps == 0
 
     Some invalid configurations:
-        - evaluation_strategy != save_strategy
-        - evaluation_strategy == save_strategy == "steps", save_steps % eval_steps != 0
+        - eval_strategy != save_strategy
+        - eval_strategy == save_strategy == "steps", save_steps % eval_steps != 0
 
     """
 

--- a/python/ray/train/tests/test_torch_transformers_train.py
+++ b/python/ray/train/tests/test_torch_transformers_train.py
@@ -48,7 +48,7 @@ MAX_STEPS = MAX_EPOCHS * STEPS_PER_EPOCH
 # Transformers Traienr Configurations
 CONFIGURATIONS = {
     "epoch_gpu": {
-        "evaluation_strategy": "epoch",
+        "eval_strategy": "epoch",
         "save_strategy": "epoch",
         "logging_strategy": "epoch",
         "eval_steps": None,
@@ -57,7 +57,7 @@ CONFIGURATIONS = {
         "no_cuda": False,
     },
     "steps_gpu": {
-        "evaluation_strategy": "steps",
+        "eval_strategy": "steps",
         "save_strategy": "steps",
         "logging_strategy": "steps",
         "eval_steps": STEPS_PER_EPOCH,
@@ -66,7 +66,7 @@ CONFIGURATIONS = {
         "no_cuda": False,
     },
     "steps_cpu": {
-        "evaluation_strategy": "steps",
+        "eval_strategy": "steps",
         "save_strategy": "steps",
         "logging_strategy": "steps",
         "eval_steps": STEPS_PER_EPOCH,
@@ -103,7 +103,7 @@ def train_func(config):
     # HF Transformers Trainer
     training_args = TrainingArguments(
         f"{MODEL_NAME}-wikitext2",
-        evaluation_strategy=config["evaluation_strategy"],
+        eval_strategy=config["eval_strategy"],
         logging_strategy=config["logging_strategy"],
         save_strategy=config["save_strategy"],
         eval_steps=config["eval_steps"],

--- a/python/ray/train/v2/tests/test_torch_transformers_train.py
+++ b/python/ray/train/v2/tests/test_torch_transformers_train.py
@@ -36,7 +36,7 @@ MAX_STEPS = MAX_EPOCHS * STEPS_PER_EPOCH
 # Transformers Trainer Configurations
 CONFIGURATIONS = {
     "epoch_gpu": {
-        "evaluation_strategy": "epoch",
+        "eval_strategy": "epoch",
         "save_strategy": "epoch",
         "logging_strategy": "epoch",
         "eval_steps": None,
@@ -45,7 +45,7 @@ CONFIGURATIONS = {
         "no_cuda": False,
     },
     "steps_gpu": {
-        "evaluation_strategy": "steps",
+        "eval_strategy": "steps",
         "save_strategy": "steps",
         "logging_strategy": "steps",
         "eval_steps": STEPS_PER_EPOCH,
@@ -54,7 +54,7 @@ CONFIGURATIONS = {
         "no_cuda": False,
     },
     "steps_cpu": {
-        "evaluation_strategy": "steps",
+        "eval_strategy": "steps",
         "save_strategy": "steps",
         "logging_strategy": "steps",
         "eval_steps": STEPS_PER_EPOCH,
@@ -91,7 +91,7 @@ def train_func(config):
     # HF Transformers Trainer
     training_args = TrainingArguments(
         f"{MODEL_NAME}-wikitext2",
-        evaluation_strategy=config["evaluation_strategy"],
+        eval_strategy=config["eval_strategy"],
         logging_strategy=config["logging_strategy"],
         save_strategy=config["save_strategy"],
         eval_steps=config["eval_steps"],
@@ -152,7 +152,7 @@ def test_e2e_hf_data(ray_start_6_cpus_2_gpus, config_id):
         # HF Transformers Trainer
         training_args = TrainingArguments(
             f"{MODEL_NAME}-wikitext2",
-            evaluation_strategy=config["evaluation_strategy"],
+            eval_strategy=config["eval_strategy"],
             logging_strategy=config["logging_strategy"],
             save_strategy=config["save_strategy"],
             eval_steps=config["eval_steps"],
@@ -241,7 +241,7 @@ def test_e2e_ray_data(ray_start_6_cpus_2_gpus, config_id):
         # HF Transformers Trainer
         training_args = TrainingArguments(
             f"{MODEL_NAME}-wikitext2",
-            evaluation_strategy=config["evaluation_strategy"],
+            eval_strategy=config["eval_strategy"],
             logging_strategy=config["logging_strategy"],
             save_strategy=config["save_strategy"],
             eval_steps=config["eval_steps"],

--- a/python/ray/tune/examples/pbt_transformers/pbt_transformers.py
+++ b/python/ray/tune/examples/pbt_transformers/pbt_transformers.py
@@ -80,7 +80,7 @@ def tune_transformer(num_samples=8, gpus_per_trial=0, smoke_test=False):
         do_train=True,
         do_eval=True,
         no_cuda=gpus_per_trial <= 0,
-        evaluation_strategy="epoch",
+        eval_strategy="epoch",
         save_strategy="epoch",
         load_best_model_at_end=True,
         num_train_epochs=2,  # config


### PR DESCRIPTION
## Why are these changes needed?
 The evaluation_strategy parameter in Hugging Face Transformers, TrainingArguments has been deprecated and replaced with eval_strategy.

## Related issue number
https://github.com/huggingface/transformers/pull/30190

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
