### PR TITLE
[Serve.llm] Make llm serve endpoints compatible with vLLM serve frontend (5/N): Change source of dashboards from ray serve llm metrics to vllm metrics

### DIFF
--- a/python/ray/dashboard/modules/metrics/dashboards/serve_llm_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/serve_llm_dashboard_panels.py
@@ -281,12 +281,12 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="Tokens",
         targets=[
             Target(
-                expr='(sum by (model_id) (delta(ray_serve_llm_tokens_input{{WorkerId=~"$workerid", model_id !~ ".+--.+", {global_filters}}}[1d])))',
-                legend="Input: {{model_id}}",
+                expr='(sum by (model_name) (delta(ray_vllm:prompt_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1d])))',
+                legend="Input: {{model_name}}",
             ),
             Target(
-                expr='(sum by (model_id) (delta(ray_serve_llm_tokens_generated{{WorkerId=~"$workerid", model_id !~ ".+--.+", {global_filters}}}[1d])))',
-                legend="Generated: {{model_id}}",
+                expr='(sum by (model_name) (delta(ray_vllm:generation_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1d])))',
+                legend="Generated: {{model_name}}",
             ),
         ],
         fill=1,
@@ -302,12 +302,12 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="Tokens",
         targets=[
             Target(
-                expr='delta(ray_serve_llm_tokens_input{{WorkerId=~"$workerid", {global_filters}}}[1h])',
-                legend="Input: {{model_id}}",
+                expr='delta(ray_vllm:prompt_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1h])',
+                legend="Input: {{model_name}}",
             ),
             Target(
-                expr='delta(ray_serve_llm_tokens_generated{{WorkerId=~"$workerid", {global_filters}}}[1h])',
-                legend="Generated: {{model_id}}",
+                expr='delta(ray_vllm:generation_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1h])',
+                legend="Generated: {{model_name}}",
             ),
         ],
         fill=1,
@@ -318,37 +318,13 @@ SERVE_LLM_GRAFANA_PANELS = [
     ),
     Panel(
         id=16,
-        title="Requests Last Hour",
-        description="",
-        unit="Requests",
-        targets=[
-            Target(
-                expr='(sum by (WorkerId) (delta(ray_serve_llm_requests_errored{{WorkerId=~"$workerid", {global_filters}}}[1h])))',
-                legend="Errored",
-            ),
-            Target(
-                expr='(sum by (WorkerId) (delta(ray_serve_llm_requests_finished{{WorkerId=~"$workerid", {global_filters}}}[1h])))',
-                legend="Finished",
-            ),
-            Target(
-                expr='(sum by (WorkerId) (delta(ray_serve_llm_requests_started{{WorkerId=~"$workerid", {global_filters}}}[1h])))',
-                legend="Started",
-            ),
-        ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(0, 56, 12, 8),
-    ),
-    Panel(
-        id=17,
         title="Distribution of Requests Per Model Last 24 Hours",
         description="",
         unit="Requests",
         targets=[
             Target(
-                expr='sum by (model_id) (delta(ray_serve_llm_requests_started{{WorkerId=~"$workerid", model_id !~ ".+--.+", {global_filters}}}[1d]))',
-                legend="{{model_id}}",
+                expr='sum by (model_name) (delta(ray_vllm:request_success_total{{WorkerId=~"$workerid", {global_filters}}}[1d]))',
+                legend="{{model_name}}",
             ),
         ],
         fill=1,
@@ -364,8 +340,8 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="none",
         targets=[
             Target(
-                expr='sum by (model_id) (delta(ray_serve_llm_tokens_input{{WorkerId=~"$workerid", {global_filters}}}[1d])) / sum by (model_id) (delta(ray_serve_llm_tokens_generated{{WorkerId=~"$workerid", {global_filters}}}[1d]))',
-                legend="{{model_id}}",
+                expr='sum by (model_name) (delta(ray_vllm:prompt_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1d])) / sum by (model_name) (delta(ray_vllm:generation_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1d]))',
+                legend="{{model_name}}",
             ),
         ],
         fill=1,
@@ -381,8 +357,8 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="Tokens",
         targets=[
             Target(
-                expr='sum by (model_id) (delta(ray_serve_llm_tokens_input{{WorkerId=~"$workerid", {global_filters}}}[1d])) + sum by (model_id) (delta(ray_serve_llm_tokens_generated{{WorkerId=~"$workerid", {global_filters}}}[1d]))',
-                legend="{{model_id}}",
+                expr='sum by (model_name) (delta(ray_vllm:prompt_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1d])) + sum by (model_name) (delta(ray_vllm:generation_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1d]))',
+                legend="{{model_name}}",
             ),
         ],
         fill=1,
@@ -398,8 +374,8 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="Tokens/s",
         targets=[
             Target(
-                expr='max_over_time(sum by (model_id) (rate(ray_serve_llm_tokens_generated{{WorkerId=~"$workerid", {global_filters}}}[2m]))[24h:])',
-                legend="{{model_id}}",
+                expr='max_over_time(sum by (model_name) (rate(ray_vllm:generation_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[2m]))[24h:])',
+                legend="{{model_name}}",
             ),
         ],
         fill=1,
@@ -415,8 +391,8 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="Requests",
         targets=[
             Target(
-                expr='sum by (model_id) (delta(ray_serve_llm_requests_started{{WorkerId=~"$workerid",model_id !~ ".+--.+", {global_filters}}}[1w]))',
-                legend="{{ model_id}}",
+                expr='sum by (model_name) (delta(ray_vllm:request_success_total{{WorkerId=~"$workerid", {global_filters}}}[1w]))',
+                legend="{{ model_name}}",
             ),
         ],
         fill=1,
@@ -432,8 +408,8 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="Requests",
         targets=[
             Target(
-                expr='(sum by (model_id) (delta(ray_serve_llm_tokens_input{{WorkerId=~"$workerid",model_id !~ ".+--.+", model_id=~"$ray_llm_model_id", {global_filters}}}[1w])) +\nsum by (model_id) (delta(ray_serve_llm_tokens_generated{{WorkerId=~"$workerid",model_id !~ ".+--.+", model_id=~"$ray_llm_model_id", {global_filters}}}[1w]))) / sum by (model_id) (delta(ray_serve_llm_requests_started{{WorkerId=~"$workerid",model_id !~ ".+--.+", model_id=~"$ray_llm_model_id", {global_filters}}}[1w]))',
-                legend="{{ model_id}}",
+                expr='(sum by (model_name) (delta(ray_vllm:prompt_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1w])) +\nsum by (model_name) (delta(ray_vllm:generation_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1w]))) / sum by (model_name) (delta(ray_vllm:request_success_total{{WorkerId=~"$workerid", {global_filters}}}[1w]))',
+                legend="{{ model_name}}",
             ),
         ],
         fill=1,
@@ -449,8 +425,8 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="Requests",
         targets=[
             Target(
-                expr='(sum by (model_id) (delta(ray_serve_llm_tokens_input{{WorkerId=~"$workerid",model_id !~ ".+--.+", {global_filters}}}[1w])) + sum by (model_id) (delta(ray_serve_llm_tokens_generated{{WorkerId=~"$workerid",model_id !~ ".+--.+", {global_filters}}}[1w])))/ sum by (model_id) (delta(ray_serve_llm_requests_started{{WorkerId=~"$workerid",model_id !~ ".+--.+", {global_filters}}}[1w]))',
-                legend="{{ model_id}}",
+                expr='(sum by (model_name) (delta(ray_vllm:prompt_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1w])) + sum by (model_name) (delta(ray_vllm:generation_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1w])))/ sum by (model_name) (delta(ray_vllm:request_success_total{{WorkerId=~"$workerid", {global_filters}}}[1w]))',
+                legend="{{ model_name}}",
             ),
         ],
         fill=1,
@@ -466,12 +442,12 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="Tokens",
         targets=[
             Target(
-                expr='sum by (model_id) (delta(ray_serve_llm_tokens_input{{WorkerId=~"$workerid",model_id !~ ".+--.+", {global_filters}}}[1w]))',
-                legend="In: {{ model_id}}",
+                expr='sum by (model_name) (delta(ray_vllm:prompt_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1w]))',
+                legend="In: {{ model_name}}",
             ),
             Target(
-                expr='sum by (model_id) (delta(ray_serve_llm_tokens_generated{{WorkerId=~"$workerid",model_id !~ ".+--.+", {global_filters}}}[1w]))',
-                legend="Out: {{ model_id }}",
+                expr='sum by (model_name) (delta(ray_vllm:generation_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1w]))',
+                legend="Out: {{ model_name }}",
             ),
         ],
         fill=1,
@@ -487,12 +463,12 @@ SERVE_LLM_GRAFANA_PANELS = [
         unit="Tokens",
         targets=[
             Target(
-                expr='sum by (model_id) (delta(ray_serve_llm_tokens_input{{WorkerId=~"$workerid",model_id !~ ".+--.+", {global_filters}}}[1w])) / sum by (model_id) (delta(ray_serve_llm_requests_started{{WorkerId=~"$workerid",model_id !~ ".+--.+", {global_filters}}}[1w]))',
-                legend="In: {{ model_id}}",
+                expr='sum by (model_name) (delta(ray_vllm:prompt_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1w])) / sum by (model_name) (delta(ray_vllm:request_success_total{{WorkerId=~"$workerid", {global_filters}}}[1w]))',
+                legend="In: {{ model_name}}",
             ),
             Target(
-                expr='sum by (model_id) (delta(ray_serve_llm_tokens_generated{{WorkerId=~"$workerid",model_id !~ ".+--.+", {global_filters}}}[1w])) / sum by (model_id) (delta(ray_serve_llm_requests_started{{WorkerId=~"$workerid",model_id !~ ".+--.+", {global_filters}}}[1w]))',
-                legend="Out: {{ model_id}}",
+                expr='sum by (model_name) (delta(ray_vllm:generation_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1w])) / sum by (model_name) (delta(ray_vllm:request_success_total{{WorkerId=~"$workerid", {global_filters}}}[1w]))',
+                legend="Out: {{ model_name}}",
             ),
         ],
         fill=1,

--- a/python/ray/dashboard/modules/metrics/dashboards/serve_llm_grafana_dashboard_base.json
+++ b/python/ray/dashboard/modules/metrics/dashboards/serve_llm_grafana_dashboard_base.json
@@ -66,39 +66,14 @@
         }
       },
       {
-        "name": "ray_llm_model_id",
-        "label": "Ray LLM Model ID",
-        "type": "query",
-        "hide": 0,
-        "datasource": "${datasource}",
-        "definition": "label_values(ray_serve_llm_tokens_input_total{{{global_filters}}}, model_id)",
-        "query": {
-          "query": "label_values(ray_serve_llm_tokens_input_total{{{global_filters}}}, model_id)",
-          "refId": "StandardVariableQuery"
-        },
-        "refresh": 1,
-        "includeAll": true,
-        "multi": false,
-        "allValue": ".*",
-        "current": {
-          "selected": true,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
-        }
-      },
-      {
         "name": "workerid",
         "label": "Worker ID",
         "type": "query",
         "hide": 0,
         "datasource": "${datasource}",
-        "definition": "label_values(ray_serve_llm_tokens_input_total{{{global_filters}}}, WorkerId)",
+        "definition": "label_values(ray_vllm:request_prompt_tokens_sum{{{global_filters}}}, WorkerId)",
         "query": {
-          "query": "label_values(ray_serve_llm_tokens_input_total{{{global_filters}}}, WorkerId)",
+          "query": "label_values(ray_vllm:request_prompt_tokens_sum{{{global_filters}}}, WorkerId)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/python/ray/llm/_internal/serve/configs/server_models.py
+++ b/python/ray/llm/_internal/serve/configs/server_models.py
@@ -235,7 +235,7 @@ class LLMConfig(BaseModelExtended):
 
     log_engine_metrics: Optional[bool] = Field(
         False,
-        description="Enable additional engine metrics via Ray Prometheus port. Only compatible with V1 vLLM engine.",
+        description="Enable additional engine metrics via Ray Prometheus port. Only compatible with V1 vLLM engine. NOTE: once v1 is fully rolled out, we will remove this flag and turn it on by default.",
     )
 
     _supports_vision: bool = PrivateAttr(False)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

This PR addresses the metrics handling approach needed to achieve the desired state outlined in PR #54189.
To make the LLM serve endpoint compatible with vLLM's serve frontend, we need to make the serve layer unaware of the internals of streamed objects. This architectural decision invalidates our previous metric handler approach, which intercepted packets and looked for specific fields within the streamed data.

Moreover, we have added RayPrometheusLogger to vLLM so we can easily aggregate engine level metrics across the cluster and rebuild the same dashboards directly using the engine-emitted metrics instead of server-emitted metrics. 

This PR basically restructures the dashboard to use the engine emitted metrics for presenting the same information. 

## Testing Strategy

Built an image from this PR, and started a cluster with this image. 

When log_engine_metrics=False, there are no data on any of the panes which confirms that no panel is using the old metrics anymore.


When log_engine_metrics=True, all panels show data according to the old meaning, which means that the metrics are properly reflected on the dashboards after the change:

<img width="1506" height="952" alt="image" src="https://github.com/user-attachments/assets/ca0006ce-fbbc-45c3-a03f-c7ee4d6b2ed9" />



## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
