### PR TITLE
[air] fix `test_wandb_logging_actor_fault_tolerance`

### DIFF
--- a/python/ray/air/tests/test_integration_wandb.py
+++ b/python/ray/air/tests/test_integration_wandb.py
@@ -491,7 +491,10 @@ class TestWandbLogger:
             logger.log_trial_result(4, trial, result={"training_iteration": 4})
             logger.log_trial_result(5, trial, result={"training_iteration": 5})
 
-            queue.put(_QueueItem.END)
+            queue.put((_QueueItem.END, None))
+
+            # Wait for the actor's run method to complete
+            ray.get(logger._trial_logging_futures[trial])
 
             state = ray.get(actor.get_state.remote())
             assert [metrics["training_iteration"] for metrics in state.logs] == [4, 5]


### PR DESCRIPTION
Fixes this flaky unit test by making the following changes:

1. Fix `queue.put` call to use correct tuple format `(_QueueItem.END, None)` .
2. Add blocking `ray.get` call to ensure test assertions run after actor finishes.
